### PR TITLE
Add dual-layer event caching + content enrichment

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2967,9 +2967,13 @@ body {
         if (ev.price) metaParts.push(`<span>${escHtml(ev.price)}</span>`);
         if (ev.ages) metaParts.push(`<span>${escHtml(ev.ages)}</span>`);
         if (ev.promoter) metaParts.push(`<span>${escHtml(ev.promoter)}</span>`);
-        const genreHtml = ev.genre
-          ? ev.genre.split(/,\s*/).slice(0, 6).map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('')
-          : '';
+        const allTags = ev.genre ? ev.genre.split(/,\s*/).slice(0, 6) : [];
+        if (ev.enrichedTags && ev.enrichedTags.length > 0) {
+          for (const t of ev.enrichedTags) {
+            if (allTags.length < 6 && !allTags.some(g => g.toLowerCase() === t.toLowerCase())) allTags.push(t);
+          }
+        }
+        const genreHtml = allTags.map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('');
         const descHtml = ev.description ? `<div class="day-detail__desc">${escHtml(ev.description)}</div>` : '';
         const imgHtml = ev.imageUrl ? `<img src="${escHtml(ev.imageUrl)}" class="day-detail__img" alt="" loading="lazy">` : '';
         return `<li class="day-detail__item">

--- a/events/index.html
+++ b/events/index.html
@@ -639,6 +639,33 @@ body {
   padding-top: 4px;
 }
 
+/* Enriched event data */
+.day-detail__desc {
+  font-size: var(--text-2xs);
+  color: var(--fg-subtle);
+  line-height: var(--leading-relaxed);
+  margin-top: var(--space-1);
+  max-height: 3.6em;
+  overflow: hidden;
+}
+
+.day-detail__img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.event-thumb {
+  width: 24px;
+  height: 24px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  vertical-align: middle;
+  margin-right: var(--space-1);
+}
+
 /* Week View */
 .week-view { margin-bottom: var(--space-8); }
 
@@ -1476,6 +1503,66 @@ body {
     } catch (e) { log('Cache save failed: ' + e.message); }
   }
 
+  // --- Supabase L2 Cache ---
+  const SUPABASE_CACHE_TTL = 2 * 60 * 60 * 1000; // 2 hours
+  const CACHE_EVENTS_URL = SUPABASE_URL + '/functions/v1/cache-events';
+
+  async function loadSupabaseCachedEvents() {
+    if (!supabaseClient) { log('L2 cache: client not available'); return null; }
+    try {
+      const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id);
+      if (enabledIds.length === 0) return null;
+      const cutoff = new Date(Date.now() - SUPABASE_CACHE_TTL).toISOString();
+      const today = new Date().toISOString().split('T')[0];
+      log(`L2 cache: querying ${enabledIds.length} source(s)`);
+      const { data, error } = await supabaseClient
+        .from('events')
+        .select('*')
+        .in('source_id', enabledIds)
+        .gte('scraped_at', cutoff)
+        .gte('date', today)
+        .order('date', { ascending: true });
+      if (error) { log('L2 cache: query error — ' + error.message); return null; }
+      if (!data || data.length === 0) { log('L2 cache: empty'); return null; }
+      const events = data.map(row => ({
+        date: row.date, time: row.time || '', name: row.name, venue: row.venue,
+        address: row.address || '', city: row.city || '', genre: row.genre || '',
+        price: row.price || '', ages: row.ages || '', promoter: row.promoter || '',
+        url: row.url, source: row.source_id,
+        contentType: row.content_type || getSourceCategory(row.source_id),
+        description: row.description || '', imageUrl: row.image_url || '',
+        enrichedTags: row.tags || [],
+      }));
+      log(`L2 cache: loaded ${events.length} events`);
+      return events;
+    } catch (e) { log('L2 cache: error — ' + e.message); return null; }
+  }
+
+  async function saveEventsToSupabase(events) {
+    if (!events || events.length === 0) return;
+    try {
+      log(`L2 cache: saving ${events.length} events...`);
+      const payload = events.map(ev => ({
+        source: ev.source, date: ev.date, time: ev.time || '', name: ev.name,
+        venue: ev.venue, address: ev.address || '', city: ev.city || '',
+        genre: ev.genre || '', price: ev.price || '', ages: ev.ages || '',
+        promoter: ev.promoter || '', url: ev.url, contentType: ev.contentType || '',
+      }));
+      const resp = await fetch(CACHE_EVENTS_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+          'apikey': SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ events: payload }),
+      });
+      if (!resp.ok) { log('L2 cache: save failed — ' + resp.status); return; }
+      const result = await resp.json();
+      log(`L2 cache: cached=${result.cached} updated=${result.updated} enrichQueued=${result.enrichQueued}`);
+    } catch (e) { log('L2 cache: save error — ' + e.message); }
+  }
+
   // --- Auto-detect source type from URL ---
   function detectSourceType(url) {
     const u = url.toLowerCase();
@@ -1547,22 +1634,48 @@ body {
     throw new Error('All fetch methods failed for ' + url);
   }
 
-  // --- Fetch All Sources ---
+  // --- Fetch All Sources (three-tier: L1 localStorage → L2 Supabase → scrape) ---
   async function fetchAllSources() {
-    // Try cache first for instant load
-    const cached = loadCachedEvents();
-    if (cached) {
-      state.events = cached;
+    // L1: localStorage (15-min TTL)
+    const cachedL1 = loadCachedEvents();
+    if (cachedL1) {
+      state.events = cachedL1;
       state.events.forEach(ev => { ev.contentType = getSourceCategory(ev.source); });
-      calAutoNavigate();
-      updateFilters();
-      updateContentTypeFilter();
-      render();
-      // Refresh in background
-      fetchAllSourcesNetwork();
+      calAutoNavigate(); updateFilters(); updateContentTypeFilter(); render();
+      log('L1 hit: rendered from localStorage');
+      checkL2OrScrape(); // background
       return;
     }
+    // L2: Supabase (2-hour TTL)
+    log('L1 miss: checking L2 (Supabase)');
+    const cachedL2 = await loadSupabaseCachedEvents();
+    if (cachedL2 && cachedL2.length > 0) {
+      state.events = cachedL2;
+      state.events.forEach(ev => { ev.contentType = getSourceCategory(ev.source); });
+      calAutoNavigate(); updateFilters(); updateContentTypeFilter(); render();
+      saveEventCache(); // populate L1
+      log('L2 hit: rendered from Supabase');
+      return;
+    }
+    // Both miss: scrape
+    log('L1+L2 miss: scraping sources');
     await fetchAllSourcesNetwork();
+  }
+
+  async function checkL2OrScrape() {
+    try {
+      const cachedL2 = await loadSupabaseCachedEvents();
+      if (!cachedL2 || cachedL2.length === 0) {
+        log('L2 stale: background scrape');
+        await fetchAllSourcesNetwork();
+      } else if (cachedL2.length > state.events.length + 5) {
+        log(`L2 fresher (${cachedL2.length} vs ${state.events.length}): updating`);
+        state.events = cachedL2;
+        state.events.forEach(ev => { ev.contentType = getSourceCategory(ev.source); });
+        updateFilters(); updateContentTypeFilter(); render();
+        saveEventCache();
+      }
+    } catch (e) { log('L2 background check failed: ' + e.message); }
   }
 
   async function fetchAllSourcesNetwork() {
@@ -1623,7 +1736,10 @@ body {
     const failedNames = Object.keys(state.sourceErrors).map(id => state.sources.find(s => s.id === id)?.name || id);
     if (failedNames.length > 0) log(`Failed sources: ${failedNames.join(', ')}`);
     el.style.display = 'none';
-    saveEventCache();
+    saveEventCache(); // L1
+    if (state.events.length > 0) {
+      saveEventsToSupabase(state.events).catch(e => log('L2 save failed: ' + e.message)); // L2 async
+    }
     calAutoNavigate();
     updateFilters();
     updateContentTypeFilter();
@@ -2500,17 +2616,25 @@ body {
     tbody.innerHTML = sorted.map(ev => {
       const sourceIds = ev.sources || [ev.source];
       const sourceName = sourceIds.map(sid => state.sources.find(s => s.id === sid)?.name || sid).join(' + ');
+      const titleAttr = ev.description ? ` title="${escHtml(ev.description)}"` : '';
       const nameCell = ev.url && ev.url !== '#'
-        ? `<a href="${escHtml(ev.url)}" class="event-link" target="_blank" rel="noopener">${escHtml(ev.name)}</a>`
-        : escHtml(ev.name);
+        ? `<a href="${escHtml(ev.url)}" class="event-link" target="_blank" rel="noopener"${titleAttr}>${escHtml(ev.name)}</a>`
+        : `<span${titleAttr}>${escHtml(ev.name)}</span>`;
       const dateDisplay = formatDate(ev.date) + (ev.time ? `<small>${escHtml(ev.time)}</small>` : '');
       // Venue + city combined
       const venueHtml = escHtml(ev.venue) + (ev.city ? `<span class="venue-city"> ${escHtml(ev.city)}</span>` : '');
-      // Genre as inline tags
-      const genreHtml = ev.genre ? ev.genre.split(/,\s*/).slice(0, 4).map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('') : '';
+      // Genre + enriched tags
+      const allTags = ev.genre ? ev.genre.split(/,\s*/).slice(0, 4) : [];
+      if (ev.enrichedTags && ev.enrichedTags.length > 0) {
+        for (const t of ev.enrichedTags) {
+          if (allTags.length < 4 && !allTags.some(g => g.toLowerCase() === t.toLowerCase())) allTags.push(t);
+        }
+      }
+      const genreHtml = allTags.map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('');
+      const thumbHtml = ev.imageUrl ? `<img src="${escHtml(ev.imageUrl)}" class="event-thumb" alt="" loading="lazy">` : '';
       return `<tr>
         <td class="col-date">${dateDisplay}</td>
-        <td class="col-name">${nameCell}</td>
+        <td class="col-name">${thumbHtml}${nameCell}</td>
         <td class="col-venue">${venueHtml}</td>
         <td class="col-genre">${genreHtml}</td>
         <td class="col-price">${escHtml(ev.price)}</td>
@@ -2846,11 +2970,15 @@ body {
         const genreHtml = ev.genre
           ? ev.genre.split(/,\s*/).slice(0, 6).map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('')
           : '';
+        const descHtml = ev.description ? `<div class="day-detail__desc">${escHtml(ev.description)}</div>` : '';
+        const imgHtml = ev.imageUrl ? `<img src="${escHtml(ev.imageUrl)}" class="day-detail__img" alt="" loading="lazy">` : '';
         return `<li class="day-detail__item">
+          ${imgHtml}
           <div class="day-detail__time">${escHtml(ev.time || '\u2014')}</div>
           <div class="day-detail__info">
             <div class="day-detail__name">${nameHtml}</div>
             <div class="day-detail__meta">${metaParts.join('')}</div>
+            ${descHtml}
           </div>
           <div class="day-detail__tags">${genreHtml}</div>
         </li>`;

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -22,11 +22,11 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
   })
 }
 
-// Generate MD5 event key matching the DB helper function
+// Generate SHA-256 event key matching the DB helper function
 async function generateEventKey(source: string, date: string, name: string, venue: string): Promise<string> {
   const normalized = `${source}|${date}|${name.trim().toLowerCase()}|${venue.trim().toLowerCase()}`
   const data = new TextEncoder().encode(normalized)
-  const hashBuffer = await crypto.subtle.digest('MD5', data)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   return Array.from(new Uint8Array(hashBuffer))
     .map(b => b.toString(16).padStart(2, '0'))
     .join('')

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -1,0 +1,199 @@
+// Supabase Edge Function: cache-events
+// Accepts scraped events from the client, deduplicates via event_key, upserts to DB.
+// Triggers enrichment for new events that have URLs.
+//
+// POST /functions/v1/cache-events
+// Body: { events: Event[] }
+// Returns: { cached, updated, enrichQueued, errors }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+// Generate MD5 event key matching the DB helper function
+async function generateEventKey(source: string, date: string, name: string, venue: string): Promise<string> {
+  const normalized = `${source}|${date}|${name.trim().toLowerCase()}|${venue.trim().toLowerCase()}`
+  const data = new TextEncoder().encode(normalized)
+  const hashBuffer = await crypto.subtle.digest('MD5', data)
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+interface ScrapedEvent {
+  source: string
+  date: string
+  time?: string
+  name: string
+  venue: string
+  address?: string
+  city?: string
+  genre?: string
+  price?: string
+  ages?: string
+  promoter?: string
+  url: string
+  contentType?: string
+}
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'POST required' }, 405)
+  }
+
+  try {
+    const { events } = await req.json() as { events: ScrapedEvent[] }
+
+    if (!events || !Array.isArray(events) || events.length === 0) {
+      return jsonResponse({ error: 'events array required' }, 400)
+    }
+
+    if (events.length > 500) {
+      return jsonResponse({ error: 'Max 500 events per request' }, 400)
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    let cached = 0
+    let updated = 0
+    const newEventIds: string[] = []
+    const errors: string[] = []
+
+    // Build rows with event keys
+    const rows = await Promise.all(events.map(async (ev) => {
+      if (!ev.source || !ev.date || !ev.name || !ev.venue || !ev.url) return null
+      const eventKey = await generateEventKey(ev.source, ev.date, ev.name, ev.venue)
+      return {
+        event_key: eventKey,
+        source_id: ev.source,
+        date: ev.date,
+        time: ev.time || null,
+        name: ev.name,
+        venue: ev.venue,
+        address: ev.address || null,
+        city: ev.city || null,
+        genre: ev.genre || null,
+        price: ev.price || null,
+        ages: ev.ages || null,
+        promoter: ev.promoter || null,
+        url: ev.url,
+        content_type: ev.contentType || null,
+        scraped_at: new Date().toISOString(),
+      }
+    }))
+
+    const validRows = rows.filter(Boolean) as Record<string, unknown>[]
+
+    if (validRows.length === 0) {
+      return jsonResponse({ cached: 0, updated: 0, enrichQueued: 0, errors: ['No valid events'] })
+    }
+
+    // Check which event_keys already exist
+    const keys = validRows.map(r => r.event_key as string)
+    const { data: existing } = await supabase
+      .from('events')
+      .select('event_key, id, enrichment_status')
+      .in('event_key', keys)
+
+    const existingMap = new Map<string, { id: string; enrichment_status: string }>()
+    if (existing) {
+      for (const row of existing) {
+        existingMap.set(row.event_key, { id: row.id, enrichment_status: row.enrichment_status })
+      }
+    }
+
+    // Split into inserts and updates
+    const toInsert = validRows.filter(r => !existingMap.has(r.event_key as string))
+    const toUpdate = validRows.filter(r => existingMap.has(r.event_key as string))
+
+    // Batch insert new events
+    if (toInsert.length > 0) {
+      const { data: inserted, error: insertErr } = await supabase
+        .from('events')
+        .insert(toInsert)
+        .select('id, url, enrichment_status')
+
+      if (insertErr) {
+        console.error('[cache-events] Insert error:', insertErr.message)
+        errors.push(`Insert: ${insertErr.message}`)
+      } else {
+        cached = inserted?.length || 0
+        if (inserted) {
+          for (const row of inserted) {
+            if (row.url && row.enrichment_status === 'pending') {
+              newEventIds.push(row.id)
+            }
+          }
+        }
+      }
+    }
+
+    // Batch update existing events (refresh scraped_at)
+    if (toUpdate.length > 0) {
+      for (const row of toUpdate) {
+        const { error: updateErr } = await supabase
+          .from('events')
+          .update({ scraped_at: row.scraped_at })
+          .eq('event_key', row.event_key)
+
+        if (updateErr) {
+          errors.push(`Update ${row.event_key}: ${updateErr.message}`)
+        } else {
+          updated++
+        }
+      }
+    }
+
+    // Trigger enrichment for new events (fire-and-forget, batch of up to 10)
+    let enrichQueued = 0
+    if (newEventIds.length > 0) {
+      const batches = []
+      for (let i = 0; i < newEventIds.length; i += 10) {
+        batches.push(newEventIds.slice(i, i + 10))
+      }
+
+      for (const batch of batches) {
+        try {
+          fetch(`${supabaseUrl}/functions/v1/enrich-event`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${supabaseKey}`,
+            },
+            body: JSON.stringify({ eventIds: batch }),
+          }).catch(err => {
+            console.error('[cache-events] Enrich trigger failed:', err.message)
+          })
+          enrichQueued += batch.length
+        } catch (err) {
+          console.error('[cache-events] Failed to trigger enrichment:', err)
+        }
+      }
+    }
+
+    console.log(`[cache-events] cached=${cached} updated=${updated} enrichQueued=${enrichQueued} errors=${errors.length}`)
+
+    return jsonResponse({ cached, updated, enrichQueued, errors: errors.length > 0 ? errors : undefined })
+  } catch (err) {
+    console.error('[cache-events] Error:', err)
+    return jsonResponse({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -1,0 +1,298 @@
+// Supabase Edge Function: enrich-event
+// Fetches event detail URLs to extract description, image, and tags.
+// Called by cache-events for newly cached events.
+//
+// POST /functions/v1/enrich-event
+// Body: { eventIds: string[] }   (batch up to 10)
+// Returns: { processed, succeeded, failed, results }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+// Domains we can safely scrape for enrichment
+const ALLOWED_DOMAINS = [
+  '19hz.info',
+  'roxie.com',
+  'punchlinecomedyclub.com',
+  'cobbscomedy.com',
+  'screenslate.com',
+  'eventbrite.com',
+  'alamodrafthouse.com',
+  'drafthouse.com',
+  'dice.fm',
+  'ra.co',
+  'songkick.com',
+]
+
+function isDomainAllowed(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return ALLOWED_DOMAINS.some(d => hostname === d || hostname.endsWith('.' + d))
+  } catch {
+    return false
+  }
+}
+
+interface EnrichResult {
+  eventId: string
+  success: boolean
+  description?: string | null
+  imageUrl?: string | null
+  tags?: string[]
+  error?: string
+}
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10_000)
+
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!resp.ok) return null
+    const ct = resp.headers.get('content-type') || ''
+    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) return null
+
+    return await resp.text()
+  } catch {
+    return null
+  }
+}
+
+function extractMetadata(html: string, pageUrl: string): {
+  description: string | null
+  imageUrl: string | null
+  tags: string[]
+} {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  if (!doc) return { description: null, imageUrl: null, tags: [] }
+
+  // --- Description ---
+  const metaDesc = doc.querySelector('meta[name="description"]')?.getAttribute('content')?.trim()
+  const ogDesc = doc.querySelector('meta[property="og:description"]')?.getAttribute('content')?.trim()
+  let firstP: string | null = null
+  const pSelectors = [
+    'article p', '.event-description p', '.description p',
+    '.event-detail p', '.event-info p', 'main p', '.content p',
+  ]
+  for (const sel of pSelectors) {
+    const el = doc.querySelector(sel)
+    if (el) {
+      const text = el.textContent?.trim()
+      if (text && text.length > 30) {
+        firstP = text.length > 500 ? text.substring(0, 500) + '...' : text
+        break
+      }
+    }
+  }
+  const description = metaDesc || ogDesc || firstP || null
+
+  // --- Image ---
+  const ogImage = doc.querySelector('meta[property="og:image"]')?.getAttribute('content')?.trim()
+  const twitterImage = doc.querySelector('meta[name="twitter:image"]')?.getAttribute('content')?.trim()
+
+  let eventImage: string | null = null
+  const imgSelectors = [
+    '.event-image img', '.event-hero img', '.hero-image img',
+    '.event-poster img', 'article img', '.event-detail img',
+    'img[src*="event"]', 'img[src*="poster"]', 'img[src*="flyer"]',
+  ]
+  for (const sel of imgSelectors) {
+    const el = doc.querySelector(sel)
+    if (el) {
+      const src = el.getAttribute('src') || el.getAttribute('data-src')
+      if (src) { eventImage = src; break }
+    }
+  }
+
+  let rawImageUrl = ogImage || twitterImage || eventImage
+  let imageUrl: string | null = null
+  if (rawImageUrl) {
+    try {
+      imageUrl = new URL(rawImageUrl, pageUrl).href
+    } catch {
+      imageUrl = rawImageUrl.startsWith('http') ? rawImageUrl : null
+    }
+  }
+
+  // --- Tags ---
+  const tags: string[] = []
+  const keywords = doc.querySelector('meta[name="keywords"]')?.getAttribute('content')
+  if (keywords) {
+    for (const k of keywords.split(',')) {
+      const t = k.trim().toLowerCase()
+      if (t && t.length > 1 && t.length < 50 && !tags.includes(t)) tags.push(t)
+    }
+  }
+
+  const tagSelectors = '.tag, .genre, .category, [rel="tag"], .event-tag, .event-category'
+  doc.querySelectorAll(tagSelectors).forEach((el: Element) => {
+    const t = el.textContent?.trim().toLowerCase()
+    if (t && t.length > 1 && t.length < 50 && !tags.includes(t)) tags.push(t)
+  })
+
+  return {
+    description,
+    imageUrl,
+    tags: tags.slice(0, 10),
+  }
+}
+
+async function enrichSingleEvent(
+  supabase: ReturnType<typeof createClient>,
+  eventId: string,
+  eventUrl: string
+): Promise<EnrichResult> {
+  await supabase
+    .from('events')
+    .update({ enrichment_status: 'processing' })
+    .eq('id', eventId)
+
+  if (!isDomainAllowed(eventUrl)) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'skipped', enrichment_error: 'Domain not in allowlist' })
+      .eq('id', eventId)
+    return { eventId, success: false, error: 'Domain not allowed' }
+  }
+
+  const html = await fetchPage(eventUrl)
+  if (!html) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'failed', enrichment_error: 'Failed to fetch URL' })
+      .eq('id', eventId)
+    return { eventId, success: false, error: 'Failed to fetch' }
+  }
+
+  const metadata = extractMetadata(html, eventUrl)
+
+  const hasData = metadata.description || metadata.imageUrl || metadata.tags.length > 0
+  if (!hasData) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'completed', enriched_at: new Date().toISOString() })
+      .eq('id', eventId)
+    return { eventId, success: true, description: null, imageUrl: null, tags: [] }
+  }
+
+  const { error } = await supabase
+    .from('events')
+    .update({
+      description: metadata.description,
+      image_url: metadata.imageUrl,
+      tags: metadata.tags.length > 0 ? metadata.tags : null,
+      enrichment_status: 'completed',
+      enriched_at: new Date().toISOString(),
+      enrichment_error: null,
+    })
+    .eq('id', eventId)
+
+  if (error) {
+    console.error(`[enrich-event] DB update failed for ${eventId}:`, error.message)
+    return { eventId, success: false, error: error.message }
+  }
+
+  return {
+    eventId,
+    success: true,
+    description: metadata.description,
+    imageUrl: metadata.imageUrl,
+    tags: metadata.tags,
+  }
+}
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'POST required' }, 405)
+  }
+
+  try {
+    const { eventIds } = await req.json() as { eventIds: string[] }
+
+    if (!eventIds || !Array.isArray(eventIds) || eventIds.length === 0) {
+      return jsonResponse({ error: 'eventIds array required' }, 400)
+    }
+
+    if (eventIds.length > 10) {
+      return jsonResponse({ error: 'Max 10 events per request' }, 400)
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    const { data: events, error: fetchErr } = await supabase
+      .from('events')
+      .select('id, url, enrichment_status')
+      .in('id', eventIds)
+      .in('enrichment_status', ['pending', 'failed'])
+
+    if (fetchErr) {
+      console.error('[enrich-event] Failed to fetch events:', fetchErr.message)
+      return jsonResponse({ error: fetchErr.message }, 500)
+    }
+
+    if (!events || events.length === 0) {
+      return jsonResponse({ processed: 0, succeeded: 0, failed: 0, results: [] })
+    }
+
+    console.log(`[enrich-event] Processing ${events.length} events`)
+
+    const results: EnrichResult[] = []
+    let succeeded = 0
+    let failed = 0
+
+    for (const event of events) {
+      const result = await enrichSingleEvent(supabase, event.id, event.url)
+      results.push(result)
+      if (result.success) succeeded++
+      else failed++
+
+      if (events.length > 1) {
+        await new Promise(r => setTimeout(r, 500))
+      }
+    }
+
+    console.log(`[enrich-event] Done: ${succeeded} succeeded, ${failed} failed`)
+
+    return jsonResponse({
+      processed: events.length,
+      succeeded,
+      failed,
+      results,
+    })
+  } catch (err) {
+    console.error('[enrich-event] Error:', err)
+    return jsonResponse({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/migrations/009_events_cache.sql
+++ b/supabase/migrations/009_events_cache.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 
   -- Identity (composite key for deduplication)
-  event_key TEXT UNIQUE NOT NULL,   -- MD5(source_id|date|name|venue)
+  event_key TEXT UNIQUE NOT NULL,   -- SHA256(source_id|date|name|venue)
   source_id TEXT NOT NULL,          -- Source identifier (e.g. '19hz-bayarea')
 
   -- Core scraped data
@@ -84,7 +84,7 @@ CREATE OR REPLACE FUNCTION generate_event_key(
   p_venue TEXT
 ) RETURNS TEXT AS $$
 BEGIN
-  RETURN md5(p_source_id || '|' || p_date::text || '|' || lower(trim(p_name)) || '|' || lower(trim(p_venue)));
+  RETURN encode(sha256(convert_to(p_source_id || '|' || p_date::text || '|' || lower(trim(p_name)) || '|' || lower(trim(p_venue)), 'UTF8')), 'hex');
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/supabase/migrations/009_events_cache.sql
+++ b/supabase/migrations/009_events_cache.sql
@@ -1,0 +1,118 @@
+-- ============================================
+-- Events Cache Schema
+-- Dual-layer caching (localStorage L1 + Supabase L2) with content enrichment
+-- Migration 009
+-- ============================================
+
+-- Events table: shared cache of scraped event data
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Identity (composite key for deduplication)
+  event_key TEXT UNIQUE NOT NULL,   -- MD5(source_id|date|name|venue)
+  source_id TEXT NOT NULL,          -- Source identifier (e.g. '19hz-bayarea')
+
+  -- Core scraped data
+  date DATE NOT NULL,
+  time TEXT,
+  name TEXT NOT NULL,
+  venue TEXT NOT NULL,
+  address TEXT,
+  city TEXT,
+  genre TEXT,
+  price TEXT,
+  ages TEXT,
+  promoter TEXT,
+  url TEXT NOT NULL,
+  content_type TEXT,                -- music|film|comedy|theater|other
+
+  -- Enriched data (from enrich-event function)
+  description TEXT,
+  image_url TEXT,
+  tags TEXT[],
+  enrichment_status TEXT DEFAULT 'pending'
+    CHECK (enrichment_status IN ('pending', 'processing', 'completed', 'failed', 'skipped')),
+  enrichment_error TEXT,
+  enriched_at TIMESTAMPTZ,
+
+  -- Cache metadata
+  scraped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================
+-- Indexes
+-- ============================================
+CREATE INDEX IF NOT EXISTS idx_events_source_date ON events(source_id, date DESC);
+CREATE INDEX IF NOT EXISTS idx_events_date ON events(date DESC);
+CREATE INDEX IF NOT EXISTS idx_events_scraped ON events(scraped_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_enrichment
+  ON events(enrichment_status) WHERE enrichment_status = 'pending';
+
+-- ============================================
+-- Row Level Security
+-- ============================================
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read events (public data)
+CREATE POLICY "Public read access"
+  ON events FOR SELECT
+  USING (true);
+
+-- Anon role can insert (client writes scraped data)
+CREATE POLICY "Anon insert access"
+  ON events FOR INSERT
+  WITH CHECK (true);
+
+-- Anon role can update (client refreshes scraped_at on re-scrape)
+CREATE POLICY "Anon update access"
+  ON events FOR UPDATE
+  USING (true);
+
+-- Service role full access (edge functions)
+CREATE POLICY "Service role full access"
+  ON events FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- ============================================
+-- Helper: generate event_key
+-- ============================================
+CREATE OR REPLACE FUNCTION generate_event_key(
+  p_source_id TEXT,
+  p_date DATE,
+  p_name TEXT,
+  p_venue TEXT
+) RETURNS TEXT AS $$
+BEGIN
+  RETURN md5(p_source_id || '|' || p_date::text || '|' || lower(trim(p_name)) || '|' || lower(trim(p_venue)));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- ============================================
+-- Auto-update updated_at
+-- ============================================
+CREATE OR REPLACE FUNCTION update_events_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER events_updated_at
+  BEFORE UPDATE ON events
+  FOR EACH ROW EXECUTE FUNCTION update_events_timestamp();
+
+-- ============================================
+-- Cleanup: delete events older than 7 days
+-- ============================================
+CREATE OR REPLACE FUNCTION cleanup_stale_events()
+RETURNS INTEGER AS $$
+DECLARE
+  deleted INTEGER;
+BEGIN
+  DELETE FROM events WHERE date < CURRENT_DATE - INTERVAL '7 days';
+  GET DIAGNOSTICS deleted = ROW_COUNT;
+  RETURN deleted;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Add Supabase as shared L2 cache for events (localStorage L1 remains, 15min TTL → L2 2hr TTL → scrape)
- New `cache-events` edge function: batch upsert with SHA-256 dedup keys
- New `enrich-event` edge function: scrape event URLs for description, image, tags
- New `009_events_cache.sql` migration: events table with RLS, indexes, cleanup function
- Frontend three-tier fetch flow: L1 → L2 → scrape, with enriched data display (thumbnails, descriptions, tags)

## Test plan
- [ ] Run migration on Supabase Boards project
- [ ] Deploy `cache-events` and `enrich-event` edge functions
- [ ] Cold load: scrape → events render → verify Supabase table has rows
- [ ] Clear localStorage, reload: should load from Supabase (no scraping)
- [ ] Reload within 15min: should load from localStorage instantly
- [ ] Verify enriched events show description/image/tags in table and day detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)