### PR TITLE
Use SUPABASE_BOARDS_SERVICE_KEY for Discord cron

### DIFF
--- a/.github/workflows/refresh-discord-events.yml
+++ b/.github/workflows/refresh-discord-events.yml
@@ -20,7 +20,7 @@ jobs:
           LOOKBACK="${{ github.event.inputs.lookback_days || '7' }}"
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "${{ secrets.SUPABASE_BOARDS_URL }}/functions/v1/scrape-discord-events" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_KEY }}" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_BOARDS_SERVICE_KEY }}" \
             -H "Content-Type: application/json" \
             -d "{\"action\": \"refresh-all\", \"lookbackDays\": $LOOKBACK}")
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)

--- a/docs/playground/events/strategy/discord-bot-setup.md
+++ b/docs/playground/events/strategy/discord-bot-setup.md
@@ -47,7 +47,7 @@ supabase secrets set DISCORD_BOT_TOKEN="your-bot-token-here"
 The scheduled cache refresh requires two GitHub repository secrets:
 
 - **`SUPABASE_BOARDS_URL`** — `https://yfhudwakpgzswiylhfbh.supabase.co` ✅ Added
-- **`SUPABASE_SERVICE_KEY`** — Service role key from Supabase Dashboard → Settings → API ✅ Already configured
+- **`SUPABASE_BOARDS_SERVICE_KEY`** — Boards service role key from [Supabase Dashboard → Settings → API](https://supabase.com/dashboard/project/yfhudwakpgzswiylhfbh/settings/api) → Reveal `service_role` ⬅️ **Add this**
 
 **Verify:** Go to **Actions** tab → **"Refresh Discord Events Cache"** → click **"Run workflow"** → check output.
 
@@ -177,6 +177,6 @@ Client opens app
 | "DISCORD_BOT_TOKEN not configured" | Secret not set | Run `supabase secrets set DISCORD_BOT_TOKEN=...` |
 | 0 events extracted from many messages | Messages are image-only flyers, or very short | Check debug log — candidates < threshold means messages didn't match heuristic |
 | "MESSAGE_CONTENT intent required" | Intent not enabled in Developer Portal | Go to Bot tab → enable MESSAGE CONTENT INTENT |
-| GitHub Actions cron fails | Missing repo secrets | Verify `SUPABASE_BOARDS_URL` and `SUPABASE_SERVICE_KEY` exist in Settings → Secrets → Actions |
+| GitHub Actions cron fails | Missing repo secrets | Verify `SUPABASE_BOARDS_URL` and `SUPABASE_BOARDS_SERVICE_KEY` exist in Settings → Secrets → Actions |
 | "Unexpected end of JSON input" | Edge Function called with empty body | Fixed — function now returns 400 with clear error message |
 | Cache returns stale events | Cron not running or secrets missing | Check Actions tab → Refresh Discord Events Cache → recent runs |

--- a/docs/playground/events/strategy/prd-discord-channel-source.md
+++ b/docs/playground/events/strategy/prd-discord-channel-source.md
@@ -544,7 +544,7 @@ A cron workflow refreshes all cached channels every 4 hours:
 - **Action:** Calls the Edge Function with `{ "action": "refresh-all" }`
 - **Required GitHub secrets:**
   - `SUPABASE_BOARDS_URL` — Boards project URL (`https://yfhudwakpgzswiylhfbh.supabase.co`)
-  - `SUPABASE_SERVICE_KEY` — Service role key (shared with Notion sync workflow)
+  - `SUPABASE_BOARDS_SERVICE_KEY` — Boards service role key
 
 This means:
 - **Clients always get fast cached responses** (no Discord API latency)


### PR DESCRIPTION
## Summary
- Workflow was using `SUPABASE_SERVICE_KEY` which belongs to the Ops project
- Discord Edge Function is on the Boards project → 401 Invalid JWT
- Now uses `SUPABASE_BOARDS_SERVICE_KEY` (new secret needed)

## Action required
Add repo secret `SUPABASE_BOARDS_SERVICE_KEY` with the Boards service role key from:
https://supabase.com/dashboard/project/yfhudwakpgzswiylhfbh/settings/api

🤖 Generated with [Claude Code](https://claude.com/claude-code)