### PR TITLE
Fix: stop polling on 401, handle expired token

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -8184,6 +8184,18 @@ Return JSON:
         fetch(`${SUPABASE_URL}/rest/v1/expanded_cards?user_id=eq.${currentUser.id}&select=cards&limit=1`, { headers })
       ]);
 
+      // Check for auth failures before parsing JSON
+      if (linksRes.status === 401 || orderRes.status === 401 || expandedRes.status === 401) {
+        console.warn('[fetch] 401 Unauthorized — token expired, stopping polling');
+        stopPolling();
+        return null;
+      }
+
+      if (!linksRes.ok || !orderRes.ok || !expandedRes.ok) {
+        console.warn(`[fetch] HTTP error: links=${linksRes.status} order=${orderRes.status} expanded=${expandedRes.status}`);
+        return null;
+      }
+
       const [linksData, orderData, expandedData] = await Promise.all([
         linksRes.json(),
         orderRes.json(),
@@ -10953,6 +10965,11 @@ Return JSON:
 
       // Process any links saved from shared boards while logged out
       await processPendingSaves();
+    }
+
+    if (event === 'TOKEN_REFRESHED' && currentUser) {
+      // Token was refreshed — restart polling if it was stopped due to 401
+      startPolling();
     }
   }
 


### PR DESCRIPTION
## Summary
- **Boards polling was spamming 401 errors every 30s after session token expired** — 3 unauthorized requests per cycle, indefinitely
- `fetchFromSupabase` now checks HTTP status before parsing JSON, preventing the `TypeError: .map is not a function` crash
- Polling stops on 401 and auto-resumes when `TOKEN_REFRESHED` fires

## Test plan
- [ ] Sign in to Boards, let session sit idle until token expires (~1hr or force via devtools)
- [ ] Verify console shows `[fetch] 401 Unauthorized — token expired, stopping polling` once, then no more poll requests
- [ ] Verify polling resumes after token refresh (look for `[poll] Started polling every 30s` after `TOKEN_REFRESHED`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)