### PR TITLE
fix(listen): openPlayer load() returns object not array

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6894,8 +6894,8 @@ Return JSON:
 
   function openPlayer(linkId) {
     if (currentPlayer.linkId === linkId) { closePlayer(); return; }
-    const links = load();
-    const link = links.find(l => l.id === linkId);
+    const data = load();
+    const link = data.links.find(l => l.id === linkId);
     if (!link) return;
     const music = link.music || {};
     let embedUrl = music.embedUrl;
@@ -6914,7 +6914,7 @@ Return JSON:
         link.music.embedUrl = embedUrl;
         link.music.embedType = embedType;
         link.music.embedHeight = embedHeight;
-        save(links);
+        save(data);
       }
     }
     const platform = getMusicPlatform(link.domain) || '';


### PR DESCRIPTION
## Summary
- `load()` returns `{links:[], categories:{}, linkOrder:[]}` — not an array
- `openPlayer()` was calling `links.find()` on the object, causing `TypeError: links.find is not a function`
- Fixed to `data.links.find()` and `save(data)` instead of `save(links)`

## Test plan
- [ ] Click a listen row → player opens without console error
- [ ] Lazy backfill persists embedUrl correctly to localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)