### PR TITLE
Document Add Pin stability fixes (BUG-017–022)

### DIFF
--- a/docs/execution/BUGS.md
+++ b/docs/execution/BUGS.md
@@ -54,4 +54,9 @@ Active bugs and known issues requiring attention.
 
 | Bug | Description | Fixed | Resolution |
 |-----|-------------|-------|------------|
-| - | - | - | - |
+| BUG-017 | `generateId()` produced short hash strings (e.g. "a1b2c3") but `links` table requires UUID primary key — caused 400 on insert | 2026-02-09 | Changed to `crypto.randomUUID()` (`boards/index.html:7331`) |
+| BUG-018 | `categorizeWithAI()` fetch missing `apikey` header — caused 401 from Supabase edge function | 2026-02-09 | Added `'apikey': SUPABASE_ANON_KEY` to categorize request headers (`boards/index.html:~7675`) |
+| BUG-019 | `syncLinkToSupabase()` payload included `image_scores` column that doesn't exist on live DB (migration 007 never applied) — caused PGRST204 | 2026-02-09 | Removed `image_scores` from sync payload (`boards/index.html:~8079`) |
+| BUG-020 | `syncLinkToSupabase()` only logged HTTP status on failure, not response body — made debugging impossible | 2026-02-09 | Now logs `errBody` via `await res.text()` on non-OK responses |
+| BUG-021 | `validate-image` edge function was never deployed to Supabase — caused CORS preflight failure on image validation calls | 2026-02-09 | Deployed via `supabase functions deploy validate-image` |
+| BUG-022 | `categorize` edge function required JWT verification but client sends anon key — caused 401 | 2026-02-09 | Redeployed with `--no-verify-jwt`; confirmed 200 response 2026-02-13 |

--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -34,6 +34,14 @@
 
 ## Recent Milestones
 
+### Add Pin Stability ✅
+**Completed: 2026-02-09 | Verified: 2026-02-13**
+
+- **3 bugs fixed**: UUID generation for link IDs, missing apikey header on categorize, image_scores column removed from sync payload
+- **2 edge functions**: `validate-image` deployed, `categorize` redeployed with `--no-verify-jwt`
+- **Improved error logging**: `syncLinkToSupabase()` now logs response body on failure
+- **Still open**: Migration 007 (image_scores columns) not yet applied; allorigins.win CORS proxy intermittent
+
 ### Listen Category ✅
 **Completed: 2026-02-09**
 
@@ -122,8 +130,8 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 | Push notifications | FCM/APNs setup required | Human |
 | Run migration `007_image_validation.sql` against Supabase (Phase 10) | Supabase Dashboard → SQL Editor | Human |
 | Deploy `enrich-link` edge function with Tier 2 validation (Phase 10) | `supabase functions deploy enrich-link` | Human |
-| Deploy new `validate-image` edge function for Tier 3 (Phase 10) | `supabase functions deploy validate-image` | Human |
-| Verify `ANTHROPIC_API_KEY` is set in Supabase function secrets (Phase 10) | Dashboard → Edge Functions → Secrets | Human |
+| ~~Deploy new `validate-image` edge function for Tier 3 (Phase 10)~~ | ~~`supabase functions deploy validate-image`~~ | ~~Done 2026-02-09~~ |
+| ~~Verify `ANTHROPIC_API_KEY` is set in Supabase function secrets (Phase 10)~~ | ~~Confirmed working — categorize returns 200~~ | ~~Done 2026-02-13~~ |
 | Backfill Tier 1 scores for existing pins via console script (Phase 10) | Run `imageQualityReport()` after deploy to baseline | Human |
 
 ---


### PR DESCRIPTION
## Summary
- Logs 6 resolved bugs (BUG-017 through BUG-022) in `BUGS.md` Recently Fixed section
- Adds "Add Pin Stability" milestone to project plan with verification date
- Strikes through 2 completed blocked items: `validate-image` deployment and `ANTHROPIC_API_KEY` confirmation

## Context
Three code bugs were fixed on 2026-02-09 (UUID generation, missing apikey header, image_scores in sync payload). Two infrastructure issues were also resolved (validate-image deployed, categorize redeployed with --no-verify-jwt). All verified working via curl on 2026-02-13.

## Test plan
- [x] Verified `categorize` endpoint returns 200 via curl
- [x] Verified `validate-image` endpoint returns 200 via curl
- [x] Confirmed all 3 code fixes present on master
- [ ] Manual: add a pin in Boards and verify it saves to Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)