### PR TITLE
Events: animated fetch phrases, live counter, UI polish

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -136,8 +136,9 @@ body {
 
 /* Table overrides — column widths */
 .data-table-wrap { margin-bottom: var(--space-8); }
+.data-table th { font-size: var(--text-2xs); }
 .data-table .col-date { width: 80px; white-space: nowrap; }
-.data-table .col-time { width: 60px; white-space: nowrap; font-size: var(--text-2xs); color: var(--fg-muted); }
+.data-table .col-time { width: 44px; white-space: nowrap; font-size: var(--text-2xs); color: var(--fg-muted); }
 .data-table .col-name { min-width: 180px; }
 .data-table .col-venue { min-width: 120px; }
 .data-table .col-city { min-width: 80px; white-space: nowrap; }
@@ -146,7 +147,7 @@ body {
 .data-table .col-price { width: 70px; white-space: nowrap; font-size: var(--text-2xs); position: relative; }
 .data-table .col-price[title] { cursor: help; }
 .data-table .col-ages { width: 50px; white-space: nowrap; font-size: var(--text-2xs); text-align: center; }
-.data-table .col-promoter { min-width: 80px; font-size: var(--text-2xs); color: var(--fg-muted); }
+.data-table .col-promoter { display: none; }
 .data-table .col-source { width: 90px; white-space: nowrap; }
 
 /* Source token — color-coded, clickable */
@@ -193,7 +194,7 @@ body {
 }
 
 /* Venue with city subtitle */
-.venue-city { font-size: var(--text-2xs); color: var(--fg-muted); }
+.venue-city { font-size: var(--text-2xs); color: var(--fg-muted); display: block; }
 
 /* Content type filter chips */
 .type-filter {
@@ -879,6 +880,29 @@ body {
   font-size: var(--text-sm);
 }
 
+/* Fetch animation */
+.loading__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+}
+.loading__phrase {
+  font-size: var(--text-sm);
+  color: var(--fg);
+  animation: fadePhrase 0.4s ease;
+}
+.loading__count {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  transition: opacity 0.2s ease;
+}
+@keyframes fadePhrase {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 /* ---- Responsive: Tablet (768px) ---- */
 @media (max-width: 768px) {
   .data-table .col-time,
@@ -1172,7 +1196,10 @@ body {
     <!-- Loading — DS: .loading + .spinner -->
     <div class="loading" id="loadingIndicator" style="display: none;">
       <div class="spinner"></div>
-      <span id="loadingText">Fetching events</span>
+      <div class="loading__content">
+        <span id="loadingText" class="loading__phrase">Fetching events</span>
+        <span id="loadingCount" class="loading__count" style="display: none;"></span>
+      </div>
     </div>
 
     </div><!-- /eventsContent -->
@@ -1813,6 +1840,43 @@ body {
     } catch (e) { log('L2 background check failed: ' + e.message); }
   }
 
+  // --- Fetch animation phrases ---
+  const FETCH_PHRASES = [
+    'Scouring the internet', 'Rounding up events', 'Checking the listings',
+    'Tapping into the scene', 'Scanning the airwaves', 'Digging through flyers',
+    'Asking around town', 'Peeking at calendars', 'Shaking the grapevine',
+    'Tuning into the underground', 'Reading the fine print', 'Following the bass',
+    'Consulting the vibes', 'Hunting down happenings', 'Chasing the lineup',
+    'Surveying the nightlife', 'Decoding the schedule', 'Mapping the culture',
+  ];
+
+  function startFetchAnimation(el) {
+    const textEl = document.getElementById('loadingText');
+    const countEl = document.getElementById('loadingCount');
+    let idx = 0;
+    countEl.style.display = 'none';
+    textEl.textContent = FETCH_PHRASES[0];
+    const interval = setInterval(() => {
+      idx = (idx + 1) % FETCH_PHRASES.length;
+      textEl.style.animation = 'none';
+      void textEl.offsetHeight; // reflow trigger
+      textEl.style.animation = '';
+      textEl.textContent = FETCH_PHRASES[idx];
+    }, 2200);
+    return { interval, countEl };
+  }
+
+  function updateFetchCount(countEl, count) {
+    if (count > 0) {
+      countEl.style.display = '';
+      countEl.textContent = `${count} event${count !== 1 ? 's' : ''} found`;
+    }
+  }
+
+  function stopFetchAnimation(anim) {
+    clearInterval(anim.interval);
+  }
+
   async function fetchAllSourcesNetwork() {
     const el = document.getElementById('loadingIndicator');
     const isBackgroundRefresh = state.events.length > 0;
@@ -1820,9 +1884,13 @@ body {
 
     const enabled = state.sources.filter(s => s.enabled);
     log(`Fetching ${enabled.length} source(s)...${isBackgroundRefresh ? ' (background)' : ''}`);
-    if (!isBackgroundRefresh) document.getElementById('loadingText').textContent = `Fetching ${enabled.length} source(s)...`;
+
+    // Start animated phrases
+    let anim = null;
+    if (!isBackgroundRefresh) anim = startFetchAnimation(el);
 
     const allEvents = [];
+    let runningCount = 0;
     state.sourceErrors = {};
 
     const promises = enabled.map(async (source) => {
@@ -1840,6 +1908,9 @@ body {
         else events = [];
         log(`Source "${source.name}": parsed ${events.length} events`);
         if (events.length > 0) log(`  Sample: ${events[0].name} on ${events[0].date}`);
+        // Update live counter
+        runningCount += events.length;
+        if (anim) updateFetchCount(anim.countEl, runningCount);
         return { source, events, ok: true };
       } catch (err) {
         log(`Source "${source.name}" FAILED: ${err.message}`);
@@ -1855,6 +1926,8 @@ body {
         state.sourceErrors[res.source.id] = classifySourceError(res.error);
       }
     });
+
+    if (anim) stopFetchAnimation(anim);
 
     // Cross-source deduplication: merge duplicates, keep both source tags
     const dedupedEvents = deduplicateAcrossSources(allEvents);

--- a/events/index.html
+++ b/events/index.html
@@ -2644,6 +2644,30 @@ body {
     return { title, venue, city };
   }
 
+  // Strip venue name prefix/suffix from event title (e.g., "Roxie - Film Name" -> "Film Name")
+  function stripVenueFromTitle(name, venue) {
+    if (!name || !venue) return name;
+    const vLower = venue.toLowerCase().trim();
+    const nLower = name.toLowerCase();
+    // "Venue - Event" or "Venue: Event" or "Venue | Event"
+    const prefixPatterns = [' - ', ': ', ' | ', ' — ', ' – '];
+    for (const sep of prefixPatterns) {
+      const prefix = vLower + sep;
+      if (nLower.startsWith(prefix)) return name.substring(prefix.length).trim();
+      // Also check short venue name (first word)
+      const shortVenue = vLower.split(/\s+/)[0];
+      if (shortVenue.length >= 4 && nLower.startsWith(shortVenue + sep)) {
+        return name.substring(shortVenue.length + sep.length).trim();
+      }
+    }
+    // "Event - Venue" or "Event @ Venue" suffix
+    for (const sep of prefixPatterns) {
+      const suffix = sep + vLower;
+      if (nLower.endsWith(suffix)) return name.substring(0, name.length - suffix.length).trim();
+    }
+    return name;
+  }
+
   // --- iCal Parser ---
   async function fetchIcal(source) {
     const text = await proxyFetch(source.url);
@@ -2912,9 +2936,10 @@ body {
       const sourceName = sourceIds.map(sid => state.sources.find(s => s.id === sid)?.name || sid).join(' + ');
       const sourceColor = getSourceColor(sourceIds[0]);
       const titleAttr = ev.description ? ` title="${escHtml(ev.description)}"` : '';
+      const displayName = stripVenueFromTitle(ev.name, ev.venue);
       const nameCell = ev.url && ev.url !== '#'
-        ? `<a href="${escHtml(ev.url)}" class="event-link" target="_blank" rel="noopener"${titleAttr}>${escHtml(ev.name)}</a>`
-        : `<span${titleAttr}>${escHtml(ev.name)}</span>`;
+        ? `<a href="${escHtml(ev.url)}" class="event-link" target="_blank" rel="noopener"${titleAttr}>${escHtml(displayName)}</a>`
+        : `<span${titleAttr}>${escHtml(displayName)}</span>`;
       // Date (no time) and Time (separate)
       const dateDisplay = formatDate(ev.date);
       const timeDisplay = ev.time ? escHtml(ev.time) : '';


### PR DESCRIPTION
## Summary
- **Animated fetch phrases** — rotating fun wordplay during loading: "Scouring the internet", "Following the bass", "Consulting the vibes", etc. Each fades in with a smooth animation every 2.2s
- **Live event counter** — shows running total ("47 events found") as each source returns, so you see progress in real time
- **Time column narrower** — 60px to 44px
- **City on new line** — drops below venue name instead of inline
- **Consistent header sizes** — all `th` use `text-2xs`
- **Promoter column hidden** — removed from view entirely

## Test plan
- [ ] Open events page — see animated phrases cycling during fetch
- [ ] Event count appears and increments as sources complete
- [ ] Time column is narrower
- [ ] Venue shows city on a separate line below
- [ ] All column headers are the same font size
- [ ] Promoter column is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)