### PR TITLE
Fix dedup + cloud sync for user event sources

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2002,10 +2002,13 @@ body {
     const na = normalizeForDedup(a), nb = normalizeForDedup(b);
     if (!na || !nb) return false;
     if (na === nb) return true;
-    if (na.includes(nb) || nb.includes(na)) return true;
-    // Scale threshold with name length: 3 for short names, up to 15% for longer ones
+    // Substring match only when the shorter name is substantial (>= 60% of longer)
+    const shorter = na.length <= nb.length ? na : nb;
+    const longer = na.length > nb.length ? na : nb;
+    if (shorter.length >= 8 && shorter.length >= longer.length * 0.6 && longer.includes(shorter)) return true;
+    // Scale threshold with name length: 2 for short names, up to 12% for longer ones
     const maxLen = Math.max(na.length, nb.length);
-    const threshold = maxLen < 20 ? 3 : Math.floor(maxLen * 0.15);
+    const threshold = maxLen < 15 ? 2 : Math.floor(maxLen * 0.12);
     return levenshtein(na, nb) <= threshold;
   }
 
@@ -2034,6 +2037,8 @@ body {
     for (const ev of events) {
       let found = false;
       for (const existing of merged) {
+        // Never dedup events that lack a date — we can't confirm they're the same day
+        if (!existing.date || !ev.date) continue;
         // Must match on date + name; venue match required if both have venues
         if (existing.date !== ev.date) continue;
         if (!namesMatch(existing.name, ev.name)) continue;

--- a/events/index.html
+++ b/events/index.html
@@ -1520,6 +1520,8 @@ body {
   function saveSources() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state.sources));
     saveSettings();
+    // Cloud sync (fire-and-forget)
+    saveSourcesCloud();
   }
 
   function saveSettings() {
@@ -1540,6 +1542,63 @@ body {
         if (settings.sort) state.sort = settings.sort;
       }
     } catch (e) { /* ignore */ }
+  }
+
+  // --- Cloud Source Sync (Supabase user_event_sources) ---
+  let _cloudSyncDebounce = null;
+
+  async function saveSourcesCloud() {
+    if (!supabaseClient || !currentUser) return;
+    // Debounce: wait 1s after last change before saving
+    clearTimeout(_cloudSyncDebounce);
+    _cloudSyncDebounce = setTimeout(async () => {
+      try {
+        const payload = {
+          user_id: currentUser.id,
+          sources: state.sources,
+          settings: { view: state.view, sort: state.sort },
+          region: localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area',
+          onboarded: state.onboarded,
+        };
+        const { error } = await supabaseClient
+          .from('user_event_sources')
+          .upsert(payload, { onConflict: 'user_id' });
+        if (error) log('Cloud sync save error: ' + error.message);
+        else log('Cloud sync: sources saved for ' + currentUser.email);
+      } catch (e) { log('Cloud sync save failed: ' + e.message); }
+    }, 1000);
+  }
+
+  async function loadSourcesCloud() {
+    if (!supabaseClient || !currentUser) return false;
+    try {
+      const { data, error } = await supabaseClient
+        .from('user_event_sources')
+        .select('*')
+        .eq('user_id', currentUser.id)
+        .single();
+      if (error || !data) {
+        log('Cloud sync: no saved sources found' + (error ? ' (' + error.message + ')' : ''));
+        return false;
+      }
+      const cloudSources = data.sources;
+      if (!Array.isArray(cloudSources) || cloudSources.length === 0) return false;
+
+      // Use cloud sources as the source of truth
+      state.sources = cloudSources;
+      state.onboarded = data.onboarded ?? true;
+      if (data.settings?.view) state.view = data.settings.view;
+      if (data.settings?.sort) state.sort = data.settings.sort;
+      if (data.region) localStorage.setItem('ctrl-rodeo-events-region', data.region);
+
+      // Persist to localStorage so L1 cache works
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.sources));
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify({ sources: state.sources, view: state.view, sort: state.sort }));
+      if (state.onboarded) localStorage.setItem(ONBOARDED_KEY, '1');
+
+      log(`Cloud sync: loaded ${cloudSources.length} sources for ${currentUser.email}`);
+      return true;
+    } catch (e) { log('Cloud sync load failed: ' + e.message); return false; }
   }
 
   // Get category for a source
@@ -3947,6 +4006,20 @@ body {
         if (currentUser && wasLoggedOut) {
           document.getElementById('authModal').classList.remove('auth-modal--visible');
           log('Logged in as ' + currentUser.email);
+          // Sync sources from cloud on login
+          loadSourcesCloud().then(loaded => {
+            if (loaded) {
+              log('Cloud sync: restored sources after login');
+              if (state.onboarded && state.sources.length > 0) {
+                document.getElementById('eventsContent').style.display = '';
+                document.getElementById('onboarding')?.remove();
+                fetchAllSources();
+              }
+            } else {
+              // First login: push current localStorage sources to cloud
+              saveSourcesCloud();
+            }
+          });
         }
       });
     }
@@ -3998,11 +4071,17 @@ body {
   }
 
   // --- Init ---
-  function init() {
+  async function init() {
     loadSettings();
     loadSources();
     bindEvents();
     initAuth();
+
+    // If logged in, try loading sources from cloud (overrides localStorage)
+    if (currentUser && supabaseClient) {
+      const cloudLoaded = await loadSourcesCloud();
+      if (cloudLoaded) log('Init: using cloud sources');
+    }
 
     if (!state.onboarded && state.sources.length === 0) {
       showOnboarding();

--- a/supabase/migrations/011_user_event_sources.sql
+++ b/supabase/migrations/011_user_event_sources.sql
@@ -1,0 +1,47 @@
+-- Migration 011: User Event Sources
+-- Stores event source preferences per user so they persist across browsers/devices.
+-- On login, client syncs localStorage sources to this table and loads from it.
+
+CREATE TABLE user_event_sources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  sources JSONB NOT NULL DEFAULT '[]'::jsonb,      -- full sources array [{id, name, url, type, enabled, category, region, ...}]
+  settings JSONB NOT NULL DEFAULT '{}'::jsonb,      -- user settings (view prefs, filters, etc.)
+  region TEXT DEFAULT 'bay-area',
+  onboarded BOOLEAN DEFAULT false,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id)
+);
+
+-- Index for fast lookup by user
+CREATE INDEX idx_user_event_sources_user ON user_event_sources(user_id);
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_user_event_sources_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_user_event_sources_updated
+  BEFORE UPDATE ON user_event_sources
+  FOR EACH ROW EXECUTE FUNCTION update_user_event_sources_timestamp();
+
+-- RLS: users can only read/write their own row
+ALTER TABLE user_event_sources ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own sources"
+  ON user_event_sources FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own sources"
+  ON user_event_sources FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own sources"
+  ON user_event_sources FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- **Dedup fix**: Events without dates no longer get falsely matched. Tightened fuzzy name matching (substring requires 60%+ overlap + 8 char min, reduced Levenshtein thresholds)
- **Cloud source sync**: New `user_event_sources` table stores sources, settings, region per user. On login, cloud sources restore automatically — opening a new browser with your account shows your past setup
- **Migration 011**: `user_event_sources` with RLS (users read/write own row only)

## Caching note
The three-tier cache (L1 localStorage 15min → L2 Supabase 2hr → scrape) is already implemented in the code. For L2 to work, ensure `cache-events` edge function is deployed and migration 009 (`events` table) has been run.

## Deploy steps after merge
1. Run migration 011: `supabase db push` (or apply `011_user_event_sources.sql` manually)
2. Deploy edge functions: `supabase functions deploy cache-events` and `supabase functions deploy fetch-source`

## Test plan
- [ ] Reload page within 15 min → should load from L1 cache (check Fetch Log for "L1 hit")
- [ ] Login on new browser → sources should sync from cloud
- [ ] Add/remove source while logged in → refreshing on another device shows the change
- [ ] Events on different days with similar names should NOT be deduped
- [ ] Events with missing dates should NOT be deduped with anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)