### PR TITLE
feat(listen): track name primary, BPM/Key always visible

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -1704,21 +1704,21 @@ body {
   min-width: 0;
 }
 
-.listen-row__artist {
+.listen-row__track {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
   color: var(--fg);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.listen-row__track {
+.listen-row__artist {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
   color: var(--muted);
   white-space: nowrap;
   overflow: hidden;
@@ -1923,11 +1923,16 @@ body {
   line-height: 1;
   letter-spacing: 0;
 }
+.listen-row__bpm,
+.listen-row__key {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  color: var(--fg);
+  opacity: 0.7;
+}
 .listen-row__album,
 .listen-row__genre,
 .listen-row__year,
-.listen-row__bpm,
-.listen-row__key,
 .listen-row__label {
   font-size: 8px;
   font-family: var(--font-mono);
@@ -9173,7 +9178,7 @@ Return JSON:
         const bpmMeta = music?.bpm ? `<span class="listen-row__bpm">${music.bpm} BPM</span>` : '';
         const keyMeta = music?.key ? `<span class="listen-row__key">${esc(music.key)}</span>` : '';
         const labelMeta = music?.label ? `<span class="listen-row__label">${esc(music.label)}</span>` : '';
-        const hasSecondary = music?.albumTitle || music?.genre || music?.releaseDate || music?.bpm || music?.key || music?.label;
+        const hasSecondary = fmt || music?.isExplicit || music?.albumTitle || music?.genre || music?.releaseDate || music?.label;
 
         html += `<div class="listen-row${isPlaying ? ' listen-row--playing' : ''}" data-id="${l.id}">
           <div class="listen-row__art-wrapper">
@@ -9181,17 +9186,16 @@ Return JSON:
             <button class="listen-row__play-btn" aria-label="Play">${isPlaying ? '&#9646;&#9646;' : '&#9654;'}</button>
           </div>
           <div class="listen-row__info">
-            <span class="listen-row__artist">${platformDot} ${esc(artistName)}</span>
             <span class="listen-row__track">${esc(trackName)}</span>
+            <span class="listen-row__artist">${platformDot} ${esc(artistName)}</span>
           </div>
           <div class="listen-row__meta listen-row__meta--extended">
             <div class="listen-row__meta-primary">
-              ${fmt ? `<span class="listen-row__format">${esc(fmt)}</span>` : ''}
+              ${bpmMeta}${keyMeta}
               ${dur ? `<span class="listen-row__duration">${dur}</span>` : ''}
-              ${explicitBadge}
             </div>
             ${hasSecondary ? `<div class="listen-row__meta-secondary">
-              ${albumMeta}${genreMeta}${yearMeta}${bpmMeta}${keyMeta}${labelMeta}
+              ${fmt ? `<span class="listen-row__format">${esc(fmt)}</span>` : ''}${explicitBadge}${albumMeta}${genreMeta}${yearMeta}${labelMeta}
             </div>` : ''}
           </div>
         </div>`;

--- a/docs/execution/project-plan/backlog.md
+++ b/docs/execution/project-plan/backlog.md
@@ -375,3 +375,14 @@ Design system analyzer and documentation generator.
 | SPA/JavaScript rendering support | Pending |
 | CSS-in-JS token extraction | Pending |
 | Multi-page crawl depth optimization | Pending |
+
+---
+
+## Listen: Unified Player
+
+| Story | Status |
+|-------|--------|
+| **Replace platform-specific iframe embeds with a single custom audio player** — Consistent UI regardless of source platform | Pending |
+| **Support full track playback across Spotify, SoundCloud, Apple Music, YouTube Music, Bandcamp** — All major music platforms | Pending |
+| **Investigate platform APIs/SDKs for playback** — Spotify Web Playback SDK, SoundCloud Widget API, etc. | Pending |
+| **Related PRs** — #35, #36, #38, #40, #41 | Reference |


### PR DESCRIPTION
## Summary
- **Track name** is now the primary line (bold, 11px, white)
- **Artist name** is secondary below (muted, 9px, uppercase)
- **BPM and Key** always visible on the right side of each list item
- Format, explicit badge, album, genre, year, label → secondary row (hover on desktop, always on mobile)
- Added unified player backlog item to `docs/execution/project-plan/backlog.md`

## Layout
```
[Album Art]  Track Name                    120 BPM · Cm · 3:24
  [▶ hover]  ARTIST NAME                   [Track · E · Album · Genre · 2024 · Label] ← hover
```

## Test plan
- [ ] Track name shows as primary bold line
- [ ] Artist name shows as secondary muted line below
- [ ] BPM and Key visible without hover on right side
- [ ] Hover reveals secondary metadata (format, explicit, album, genre, year, label)
- [ ] Play button overlay still works on art hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)