### PR TITLE
feat(listen): enrich-music edge function — BPM, key, genre, label

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -7912,6 +7912,28 @@ Return JSON:
       }
 
       console.log('%c[music-meta] Extracted:', 'color: #1DB954', meta);
+
+      // ── Step 6: Server-side enrichment for BPM, key, genre, label ──
+      if (meta.artist && meta.trackTitle && (!meta.bpm || !meta.key)) {
+        try {
+          const enrichResp = await fetch(`${SUPABASE_URL}/functions/v1/enrich-music`, {
+            method: 'POST',
+            headers: { 'Authorization': `Bearer ${SUPABASE_ANON_KEY}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ artist: meta.artist, track: meta.trackTitle, album: meta.albumTitle })
+          });
+          if (enrichResp.ok) {
+            const ed = await enrichResp.json();
+            console.log('%c[music-meta] Enriched:', 'color: #1DB954', ed);
+            if (ed.bpm) meta.bpm = ed.bpm;
+            if (ed.key) meta.key = ed.key;
+            if (ed.genre && !meta.genre) meta.genre = ed.genre;
+            if (ed.label) meta.label = ed.label;
+            if (ed.releaseDate && !meta.releaseDate) meta.releaseDate = ed.releaseDate;
+          }
+        } catch (enrichErr) {
+          console.warn('[music-meta] Server enrichment failed:', enrichErr.message);
+        }
+      }
     } catch (e) {
       console.warn('[music-meta] Extraction failed:', e.message);
     }
@@ -9017,30 +9039,63 @@ Return JSON:
   // ============================================
   // Backfills .music property on listen links that were migrated
   // before extractMusicMetadata existed.
-  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v2';
+  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v3';
 
   async function enrichListenLinks() {
     if (localStorage.getItem(LISTEN_ENRICH_KEY)) return;
 
     const allLinks = getAllLinks();
-    // v2: also re-enrich links that have music but missing artist (improved parsing)
-    const needsEnrich = allLinks.filter(l => l.category === 'listen' && (!l.music || !l.music.artist));
+    // v3: re-enrich links missing artist OR missing BPM/key/genre/label
+    const needsEnrich = allLinks.filter(l => {
+      if (l.category !== 'listen') return false;
+      if (!l.music || !l.music.artist) return true;  // Missing basic metadata
+      if (l.music.artist && l.music.trackTitle && (!l.music.bpm || !l.music.key)) return true;  // Missing extended metadata
+      return false;
+    });
     if (needsEnrich.length === 0) {
       localStorage.setItem(LISTEN_ENRICH_KEY, Date.now().toString());
       return;
     }
 
-    console.log(`%c[enrich-listen] Enriching ${needsEnrich.length} listen links with music metadata`, 'color: #1DB954; font-weight: bold');
+    console.log(`%c[enrich-listen] v3: Enriching ${needsEnrich.length} listen links`, 'color: #1DB954; font-weight: bold');
 
     let enriched = 0;
     for (const link of needsEnrich) {
       try {
-        const music = await extractMusicMetadata(link.url, link.title, link.description || '', null);
-        if (music) {
-          updateLink(link.id, { music });
-          enriched++;
-          console.log(`%c[enrich-listen] ✓ ${link.domain}:`, 'color: #1DB954', music.artist || link.title);
+        // Step 1: Re-extract basic metadata (artist, track) if missing
+        let music = link.music;
+        if (!music || !music.artist) {
+          music = await extractMusicMetadata(link.url, link.title, link.description || '', null);
         }
+        if (!music || !music.artist || !music.trackTitle) continue;
+
+        // Step 2: Call enrich-music for BPM/key/genre/label
+        if (!music.bpm || !music.key) {
+          try {
+            const resp = await fetch(`${SUPABASE_URL}/functions/v1/enrich-music`, {
+              method: 'POST',
+              headers: { 'Authorization': `Bearer ${SUPABASE_ANON_KEY}`, 'Content-Type': 'application/json' },
+              body: JSON.stringify({ artist: music.artist, track: music.trackTitle, album: music.albumTitle })
+            });
+            if (resp.ok) {
+              const ed = await resp.json();
+              if (ed.bpm) music.bpm = ed.bpm;
+              if (ed.key) music.key = ed.key;
+              if (ed.genre && !music.genre) music.genre = ed.genre;
+              if (ed.label) music.label = ed.label;
+              if (ed.releaseDate && !music.releaseDate) music.releaseDate = ed.releaseDate;
+            }
+          } catch (e) {
+            console.warn(`[enrich-listen] Server enrichment failed for ${link.domain}:`, e.message);
+          }
+          // Rate limit: 250ms between calls
+          await new Promise(r => setTimeout(r, 250));
+        }
+
+        updateLink(link.id, { music });
+        enriched++;
+        console.log(`%c[enrich-listen] ✓ ${link.domain}:`, 'color: #1DB954',
+          `${music.artist} - ${music.trackTitle}`, music.bpm ? `${music.bpm}BPM` : '', music.key || '');
       } catch (e) {
         console.warn(`[enrich-listen] Failed for ${link.domain}:`, e.message);
       }

--- a/boards/index.html
+++ b/boards/index.html
@@ -13172,5 +13172,8 @@ Return JSON:
 
 })();
   </script>
+  <footer class="attribution" style="position:fixed;bottom:0;left:0;padding:2px 6px;font-size:7px;font-family:var(--font-mono);color:var(--subtle);opacity:0.3;z-index:0;pointer-events:auto;">
+    BPM data by <a href="https://getsongbpm.com" target="_blank" rel="noopener" style="color:inherit;">GetSongBPM</a>
+  </footer>
 </body>
 </html>

--- a/supabase/functions/enrich-music/index.ts
+++ b/supabase/functions/enrich-music/index.ts
@@ -1,0 +1,285 @@
+// Supabase Edge Function: enrich-music
+// Enriches music links with BPM, key, genre, label from external APIs
+//
+// POST /functions/v1/enrich-music
+// Body: { artist: string, track: string, album?: string }
+// Returns: { bpm?, key?, genre?, label?, sources, cached, confidence }
+//
+// APIs used:
+//   - MusicBrainz (free, no key) → genre, label, album
+//   - GetSongBPM (free, key required) → BPM, musical key
+//   - Last.fm (free, key required) → genre tags
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// ── Helpers ──
+
+function normalizeLookupKey(artist: string, track: string): string {
+  const norm = (s: string) => s.toLowerCase().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim()
+  return `${norm(artist)}:${norm(track)}`
+}
+
+// ── Cache ──
+
+async function getCache(supabase: any, artist: string, track: string): Promise<any | null> {
+  const key = normalizeLookupKey(artist, track)
+  const { data, error } = await supabase
+    .from('music_metadata_cache')
+    .select('*')
+    .eq('lookup_key', key)
+    .single()
+
+  if (error || !data) return null
+
+  // Check TTL: 90 days
+  const age = Date.now() - new Date(data.cached_at).getTime()
+  if (age > 90 * 24 * 60 * 60 * 1000) return null
+
+  // Bump hit count (fire and forget)
+  supabase
+    .from('music_metadata_cache')
+    .update({ hit_count: data.hit_count + 1, last_hit_at: new Date().toISOString() })
+    .eq('id', data.id)
+    .then(() => {})
+
+  return data.metadata
+}
+
+async function setCache(supabase: any, artist: string, track: string, metadata: any): Promise<void> {
+  const key = normalizeLookupKey(artist, track)
+  await supabase
+    .from('music_metadata_cache')
+    .upsert({
+      lookup_key: key,
+      artist,
+      track,
+      metadata,
+      cached_at: new Date().toISOString(),
+      last_hit_at: new Date().toISOString(),
+      hit_count: 1,
+    }, { onConflict: 'lookup_key' })
+}
+
+// ── MusicBrainz ──
+// Free, no auth. 50 req/sec. Must send User-Agent.
+// Returns: genre, label, album, releaseDate
+
+async function queryMusicBrainz(artist: string, track: string): Promise<{
+  genre?: string
+  label?: string
+  album?: string
+  releaseDate?: string
+  confidence: number
+} | null> {
+  try {
+    const query = encodeURIComponent(`"${track}" AND artist:"${artist}"`)
+    const url = `https://musicbrainz.org/ws/2/recording/?query=${query}&fmt=json&limit=3`
+
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'ctrl.rodeo/1.0 (https://ctrl.rodeo)',
+        'Accept': 'application/json',
+      },
+    })
+
+    if (!resp.ok) {
+      console.error('[musicbrainz] HTTP', resp.status)
+      return null
+    }
+
+    const data = await resp.json()
+    if (!data.recordings?.length) {
+      console.log('[musicbrainz] No results')
+      return null
+    }
+
+    const rec = data.recordings[0]
+    const confidence = (rec.score || 0) / 100
+    const release = rec.releases?.[0]
+
+    return {
+      genre: rec.tags?.[0]?.name || null,
+      label: release?.['label-info']?.[0]?.label?.name || null,
+      album: release?.title || null,
+      releaseDate: release?.date || null,
+      confidence,
+    }
+  } catch (e) {
+    console.error('[musicbrainz] Error:', e.message)
+    return null
+  }
+}
+
+// ── GetSongBPM ──
+// Free with API key. Returns BPM + musical key.
+
+async function queryGetSongBPM(artist: string, track: string): Promise<{
+  bpm?: number
+  key?: string
+  confidence: number
+} | null> {
+  try {
+    const apiKey = Deno.env.get('GETSONGBPM_API_KEY')
+    if (!apiKey) {
+      console.log('[getsongbpm] No API key')
+      return null
+    }
+
+    // Search by artist + track
+    const query = encodeURIComponent(`${artist} ${track}`)
+    const url = `https://api.getsongbpm.com/search/?api_key=${apiKey}&type=both&lookup=${query}`
+
+    const resp = await fetch(url)
+    if (!resp.ok) {
+      console.error('[getsongbpm] HTTP', resp.status)
+      return null
+    }
+
+    const data = await resp.json()
+    if (!data.search?.length) {
+      console.log('[getsongbpm] No results')
+      return null
+    }
+
+    const hit = data.search[0]
+    return {
+      bpm: hit.tempo ? parseInt(hit.tempo, 10) : undefined,
+      key: hit.key_of || hit.song_key || undefined,
+      confidence: 0.8,
+    }
+  } catch (e) {
+    console.error('[getsongbpm] Error:', e.message)
+    return null
+  }
+}
+
+// ── Last.fm ──
+// Free with API key. 5 req/sec. Returns genre tags.
+
+async function queryLastfm(artist: string, track: string): Promise<{
+  genre?: string
+  genreTags?: string[]
+  confidence: number
+} | null> {
+  try {
+    const apiKey = Deno.env.get('LASTFM_API_KEY')
+    if (!apiKey) {
+      console.log('[lastfm] No API key')
+      return null
+    }
+
+    const url = `https://ws.audioscrobbler.com/2.0/?method=track.getInfo&api_key=${apiKey}&artist=${encodeURIComponent(artist)}&track=${encodeURIComponent(track)}&format=json`
+
+    const resp = await fetch(url)
+    if (!resp.ok) {
+      console.error('[lastfm] HTTP', resp.status)
+      return null
+    }
+
+    const data = await resp.json()
+    if (data.error || !data.track) {
+      console.log('[lastfm] No results')
+      return null
+    }
+
+    const tags = (data.track.toptags?.tag || []).map((t: any) => t.name).slice(0, 5)
+    return {
+      genre: tags[0] || undefined,
+      genreTags: tags.length ? tags : undefined,
+      confidence: 0.9,
+    }
+  } catch (e) {
+    console.error('[lastfm] Error:', e.message)
+    return null
+  }
+}
+
+// ── Main ──
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  const start = Date.now()
+
+  try {
+    const { artist, track, album } = await req.json()
+
+    if (!artist || !track) {
+      return new Response(
+        JSON.stringify({ error: 'artist and track are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('[enrich-music] Query:', artist, '-', track)
+
+    // Init Supabase client with service role for cache writes
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    // Check cache first
+    const cached = await getCache(supabase, artist, track)
+    if (cached) {
+      console.log('[enrich-music] Cache hit:', Date.now() - start, 'ms')
+      return new Response(
+        JSON.stringify({ ...cached, cached: true }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Query all 3 APIs in parallel
+    const [mb, gsb, lfm] = await Promise.all([
+      queryMusicBrainz(artist, track),
+      queryGetSongBPM(artist, track),
+      queryLastfm(artist, track),
+    ])
+
+    // Merge results
+    const result: Record<string, any> = {
+      sources: {},
+      cached: false,
+      confidence: 0,
+    }
+
+    if (gsb?.bpm) { result.bpm = gsb.bpm; result.sources.bpm = 'getsongbpm' }
+    if (gsb?.key) { result.key = gsb.key; result.sources.key = 'getsongbpm' }
+    if (mb?.label) { result.label = mb.label; result.sources.label = 'musicbrainz' }
+    if (mb?.genre) { result.genre = mb.genre; result.sources.genre = 'musicbrainz' }
+    if (lfm?.genre && !result.genre) { result.genre = lfm.genre; result.sources.genre = 'lastfm' }
+    if (lfm?.genreTags) { result.genreTags = lfm.genreTags }
+    if (mb?.album && !album) { result.album = mb.album }
+    if (mb?.releaseDate) { result.releaseDate = mb.releaseDate }
+
+    // Average confidence
+    const scores = [mb?.confidence, gsb?.confidence, lfm?.confidence].filter((c): c is number => c != null)
+    result.confidence = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0
+
+    // Cache merged result
+    if (result.confidence > 0) {
+      await setCache(supabase, artist, track, result)
+    }
+
+    console.log('[enrich-music] Done:', Date.now() - start, 'ms', result)
+
+    return new Response(
+      JSON.stringify(result),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  } catch (error) {
+    console.error('[enrich-music] Error:', error.message)
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})

--- a/supabase/migrations/012_music_metadata_cache.sql
+++ b/supabase/migrations/012_music_metadata_cache.sql
@@ -1,0 +1,28 @@
+-- Music Metadata Cache
+-- Caches enrichment results from MusicBrainz, GetSongBPM, Last.fm
+-- Keyed by normalized "artist:track" to avoid duplicate API calls
+
+CREATE TABLE IF NOT EXISTS music_metadata_cache (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  lookup_key TEXT UNIQUE NOT NULL,
+  artist TEXT NOT NULL,
+  track TEXT NOT NULL,
+  metadata JSONB NOT NULL,
+  cached_at TIMESTAMPTZ DEFAULT NOW(),
+  hit_count INTEGER DEFAULT 1,
+  last_hit_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_music_cache_lookup ON music_metadata_cache(lookup_key);
+CREATE INDEX IF NOT EXISTS idx_music_cache_cached_at ON music_metadata_cache(cached_at);
+
+ALTER TABLE music_metadata_cache ENABLE ROW LEVEL SECURITY;
+
+-- Readable by anyone with anon key (cache is shared)
+CREATE POLICY "Music cache readable by all"
+  ON music_metadata_cache FOR SELECT USING (true);
+
+-- Service role can write (edge function uses service key)
+CREATE POLICY "Service role can write music cache"
+  ON music_metadata_cache FOR ALL
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
New Supabase edge function `enrich-music` that enriches music links with metadata from 3 free APIs:

| API | Data | Auth | Rate Limit |
|-----|------|------|------------|
| MusicBrainz | genre, label, album, releaseDate | None | 50 req/sec |
| GetSongBPM | BPM, musical key | API key (free) | Generous |
| Last.fm | genre tags | API key (free) | 5 req/sec |

All 3 APIs queried in parallel, results merged and cached in `music_metadata_cache` table (90-day TTL).

## Files
- **New:** `supabase/functions/enrich-music/index.ts` — edge function (285 lines)
- **New:** `supabase/migrations/012_music_metadata_cache.sql` — cache table
- **Modified:** `boards/index.html` — client integration (+73 lines)
  - `extractMusicMetadata()` calls enrich-music after basic extraction
  - Backfill v3: re-enriches links missing BPM/key with 250ms rate limiting

## Deployment Steps (before merging)
1. Run migration `012_music_metadata_cache.sql` in Supabase SQL editor
2. Set secrets: `GETSONGBPM_API_KEY`, `LASTFM_API_KEY`
3. Deploy: `supabase functions deploy enrich-music`
4. Test: `curl -X POST .../functions/v1/enrich-music -d '{"artist":"Daft Punk","track":"Get Lucky"}'`

## Test plan
- [ ] Run migration in Supabase dashboard
- [ ] Sign up for GetSongBPM + Last.fm API keys
- [ ] Set secrets in Supabase dashboard
- [ ] Deploy edge function
- [ ] curl test with known track → BPM/key/genre/label returned
- [ ] Hard refresh boards → backfill v3 runs, console shows enrichment
- [ ] List row shows BPM and Key values
- [ ] Add new Spotify link → BPM/key populated immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)