### PR TITLE
Fix: add missing fabScanImage HTML elements causing TypeError

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -4014,6 +4014,10 @@ body {
             <span class="fab-menu__item-icon">◻</span>
             Photo
           </button>
+          <button class="fab-menu__item" id="fabScanImage">
+            <span class="fab-menu__item-icon">⊙</span>
+            Scan Image
+          </button>
           <button class="fab-menu__item" id="fabVideoUpload">
             <span class="fab-menu__item-icon">▶</span>
             Video
@@ -4030,6 +4034,7 @@ body {
 
   <!-- Hidden file inputs for uploads -->
   <input type="file" id="photoInput" class="hidden-input" accept="image/*" multiple>
+  <input type="file" id="scanInput" class="hidden-input" accept="image/*">
   <input type="file" id="videoInput" class="hidden-input" accept="video/*" multiple>
 
   <!-- Add Modal -->


### PR DESCRIPTION
## Summary
- PR #33 added image scanning JS (`fabScanImage.onclick`, `scanInput.onchange`) but forgot to add the corresponding HTML elements
- This caused `Uncaught TypeError: Cannot set properties of null (setting 'onclick')` on every page load at line 10107
- Added `<button id="fabScanImage">` to the FAB menu dropdown and `<input id="scanInput">` hidden file input

## Test plan
- [ ] Load `/boards/` — no console TypeError
- [ ] FAB menu shows "Scan Image" option
- [ ] Clicking "Scan Image" opens file picker for images

🤖 Generated with [Claude Code](https://claude.com/claude-code)