### PR TITLE
Add event recommendation engine based on Boards content

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -3611,6 +3611,121 @@ body {
   margin-top: var(--space-2);
 }
 
+/* Events For You widget */
+.widget-events-for-you {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.widget-events-for-you__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-3);
+}
+
+.widget-events-for-you__title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--fg-default);
+  margin: 0;
+}
+
+.widget-events-for-you__link {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+.widget-events-for-you__link:hover {
+  color: var(--fg-default);
+}
+
+.event-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.event-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.event-card:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.event-card__date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 40px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm, 4px);
+  line-height: 1;
+}
+
+.event-card__month {
+  font-size: var(--text-3xs, 9px);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.event-card__day {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--fg-default);
+}
+
+.event-card__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.event-card__name {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--fg-default);
+  margin: 0 0 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.event-card__venue {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  margin: 0 0 2px;
+}
+
+.event-card__reason {
+  font-size: var(--text-2xs);
+  color: var(--fg-subtle);
+  margin: 0;
+  font-style: italic;
+}
+
+.event-card__action {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  text-decoration: none;
+  white-space: nowrap;
+  align-self: center;
+}
+
+.event-card__action:hover {
+  color: var(--fg-default);
+}
+
 /* Inline widget (injected into grid) */
 .widget-inline {
   grid-column: 1 / -1;
@@ -6721,6 +6836,175 @@ Return JSON:
     );
   }
 
+  // =============================================================================
+  // EVENTS FOR YOU — Profile extraction + widget rendering
+  // Recommends upcoming events based on Boards content
+  // =============================================================================
+
+  const EVENTS_STOPWORDS = new Set([
+    'the', 'and', 'for', 'with', 'from', 'this', 'that', 'have', 'has',
+    'are', 'was', 'were', 'been', 'being', 'will', 'would', 'could',
+    'should', 'may', 'might', 'shall', 'can', 'not', 'but', 'its',
+    'our', 'your', 'his', 'her', 'their', 'which', 'what', 'when',
+    'where', 'how', 'who', 'whom', 'each', 'every', 'all', 'any',
+    'few', 'more', 'most', 'some', 'such', 'than', 'too', 'very',
+    'just', 'about', 'also', 'into', 'over', 'after', 'before',
+    'between', 'through', 'during', 'only', 'then', 'them', 'these',
+    'those', 'other', 'new', 'one', 'two', 'first', 'last', 'long',
+    'great', 'little', 'own', 'old', 'right', 'big', 'high', 'small',
+    'large', 'next', 'early', 'young', 'important', 'public', 'free',
+    'shop', 'buy', 'sale', 'official', 'store', 'home', 'page', 'site',
+    'http', 'https', 'www', 'com', 'org', 'net',
+  ]);
+
+  function extractEventProfile(links) {
+    const profile = {
+      categories: {},
+      artists: [],
+      genres: [],
+      keywords: [],
+      domains: {},
+      contentTypes: {},
+    };
+
+    const wordFreq = {};
+
+    for (const link of links) {
+      // Category distribution
+      if (link.category) {
+        profile.categories[link.category] = (profile.categories[link.category] || 0) + 1;
+      }
+
+      // Content type distribution
+      if (link.content_type) {
+        profile.contentTypes[link.content_type] = (profile.contentTypes[link.content_type] || 0) + 1;
+      }
+
+      // Explicit music metadata
+      if (link.artist) profile.artists.push(link.artist);
+      if (link.music_tags && Array.isArray(link.music_tags)) {
+        profile.genres.push(...link.music_tags);
+      }
+      if (link.music_type) profile.genres.push(link.music_type);
+
+      // Domain tracking
+      if (link.domain) {
+        const d = link.domain.replace(/^www\./, '');
+        profile.domains[d] = (profile.domains[d] || 0) + 1;
+      }
+
+      // Word frequency from titles
+      if (link.title) {
+        const words = link.title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').split(/\s+/);
+        for (const w of words) {
+          if (w.length > 3 && !EVENTS_STOPWORDS.has(w)) {
+            wordFreq[w] = (wordFreq[w] || 0) + 1;
+          }
+        }
+      }
+    }
+
+    // Deduplicate and limit
+    profile.artists = [...new Set(profile.artists)].slice(0, 30);
+    profile.genres = [...new Set(profile.genres)].slice(0, 20);
+
+    // Top keywords by frequency (min 2 occurrences)
+    profile.keywords = Object.entries(wordFreq)
+      .filter(([, count]) => count >= 2)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 20)
+      .map(([word]) => word);
+
+    return profile;
+  }
+
+  function renderEventsWidget(events) {
+    const footerSection = document.getElementById('widgetFooter');
+    const footerContent = document.getElementById('widgetFooterContent');
+    if (!footerSection || !footerContent) return;
+
+    const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    const cardsHtml = events.map(function(evt) {
+      const d = new Date(evt.date + 'T00:00:00');
+      const month = MONTHS[d.getMonth()] || '';
+      const day = d.getDate();
+      const reason = (evt.relevance && evt.relevance.reasons && evt.relevance.reasons[0]) || '';
+      const eventUrl = evt.url ? esc(evt.url) : '#';
+      return '<div class="event-card">' +
+        '<div class="event-card__date">' +
+          '<span class="event-card__month">' + esc(month) + '</span>' +
+          '<span class="event-card__day">' + day + '</span>' +
+        '</div>' +
+        '<div class="event-card__content">' +
+          '<h4 class="event-card__name">' + esc(evt.name) + '</h4>' +
+          '<p class="event-card__venue">' + esc(evt.venue || '') + '</p>' +
+          (reason ? '<p class="event-card__reason">' + esc(reason) + '</p>' : '') +
+        '</div>' +
+        '<a href="' + eventUrl + '" target="_blank" rel="noopener" class="event-card__action">Details</a>' +
+      '</div>';
+    }).join('');
+
+    const widgetHtml =
+      '<div class="widget-events-for-you">' +
+        '<div class="widget-events-for-you__header">' +
+          '<h3 class="widget-events-for-you__title">Events For You</h3>' +
+          '<a href="/events/" class="widget-events-for-you__link">View all events</a>' +
+        '</div>' +
+        '<div class="event-card-list">' + cardsHtml + '</div>' +
+      '</div>';
+
+    // Append to footer zone (don't replace existing widgets)
+    footerSection.classList.add('widget-section--visible');
+    footerContent.insertAdjacentHTML('beforeend', widgetHtml);
+  }
+
+  async function loadEventsForYouWidget() {
+    // Feature flag: skip if widgets disabled
+    if (!widgetDSEnabled) return;
+
+    const items = getAllLinks();
+    if (items.length < 3) return;
+
+    const profile = extractEventProfile(items);
+
+    // Require at least some meaningful signals
+    const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
+    if (signalCount === 0) return;
+
+    console.log('[events-for-you] Profile:', signalCount, 'signals,', Object.keys(profile.categories).length, 'categories');
+
+    try {
+      const response = await fetch(SUPABASE_URL + '/functions/v1/recommend-events', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({
+          profile: profile,
+          filters: { maxResults: 5 },
+        }),
+      });
+
+      if (!response.ok) {
+        console.warn('[events-for-you] API error:', response.status);
+        return;
+      }
+
+      const data = await response.json();
+      if (!data.events || data.events.length === 0) {
+        console.log('[events-for-you] No matching events');
+        return;
+      }
+
+      console.log('[events-for-you] Got', data.events.length, 'events (' + data.meta.algorithm + ')');
+      renderEventsWidget(data.events);
+    } catch (err) {
+      console.warn('[events-for-you] Error:', err);
+    }
+  }
+
   // Store inline widgets for grid injection
   let inlineWidgetHtml = '';
   let inlineWidgets = []; // Array of { id, html } for drag-and-drop support
@@ -6895,6 +7179,9 @@ Return JSON:
     }
 
     widgetGenerationInProgress = false;
+
+    // Load Events For You widget (async, non-blocking)
+    loadEventsForYouWidget();
 
     // If another generateWidgets() was called while we were running, run again
     if (widgetRegenerationNeeded) {

--- a/events/index.html
+++ b/events/index.html
@@ -134,6 +134,91 @@ body {
   align-items: center;
 }
 
+/* Recommended For You section */
+.recommended-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.recommended-title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--fg-default);
+  margin: 0;
+}
+
+.recommended-badge {
+  font-size: var(--text-3xs, 9px);
+  color: var(--fg-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm, 4px);
+  padding: 1px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.recommended-cards {
+  display: flex;
+  gap: var(--space-3);
+  overflow-x: auto;
+  padding-bottom: var(--space-3);
+  margin-bottom: var(--space-6);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.rec-card {
+  flex: 0 0 220px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md, 8px);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.rec-card__date {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+}
+
+.rec-card__name {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--fg-default);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.rec-card__venue {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.rec-card__reason {
+  font-size: var(--text-2xs);
+  color: var(--fg-subtle);
+  margin: 0;
+  font-style: italic;
+  margin-top: auto;
+}
+
+.rec-card__link {
+  font-size: var(--text-2xs);
+  color: var(--fg-muted);
+  text-decoration: none;
+  margin-top: var(--space-1);
+}
+
+.rec-card__link:hover {
+  color: var(--fg-default);
+}
+
 /* Table overrides — column widths */
 .data-table-wrap { margin-bottom: var(--space-8); }
 .data-table th { font-size: var(--text-2xs); }
@@ -1109,6 +1194,15 @@ body {
         <button class="view-toggle__btn" data-view="week">Week</button>
         <button class="view-toggle__btn" data-view="calendar">Month</button>
       </div>
+    </div>
+
+    <!-- Recommended For You (populated by JS if Boards data exists) -->
+    <div id="recommendedSection" style="display:none">
+      <div class="recommended-header">
+        <h3 class="recommended-title">Recommended for you</h3>
+        <span class="recommended-badge">Based on your Boards</span>
+      </div>
+      <div class="recommended-cards" id="recommendedCards"></div>
     </div>
 
     <!-- Table — DS: .data-table-wrap + .data-table -->
@@ -4086,6 +4180,97 @@ body {
     log('Logged out');
   }
 
+  // --- Events For You (Boards integration) ---
+  const BOARDS_STORAGE_KEY = 'things-i-like';
+  const EVENTS_STOPWORDS = new Set([
+    'the', 'and', 'for', 'with', 'from', 'this', 'that', 'have', 'has',
+    'are', 'was', 'were', 'been', 'will', 'would', 'could', 'should',
+    'not', 'but', 'its', 'our', 'your', 'which', 'what', 'when', 'where',
+    'how', 'who', 'each', 'every', 'all', 'any', 'few', 'more', 'most',
+    'some', 'than', 'too', 'very', 'just', 'about', 'also', 'into', 'over',
+    'only', 'then', 'them', 'these', 'those', 'other', 'new', 'one', 'two',
+    'first', 'last', 'free', 'shop', 'buy', 'sale', 'official', 'store',
+    'home', 'page', 'site', 'http', 'https', 'www', 'com',
+  ]);
+
+  async function loadRecommendedEvents() {
+    try {
+      const raw = localStorage.getItem(BOARDS_STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      const links = data.links || [];
+      if (links.length < 3) return;
+
+      // Extract profile from Boards data
+      const profile = { categories: {}, artists: [], genres: [], keywords: [], domains: {}, contentTypes: {} };
+      const wordFreq = {};
+
+      for (const link of links) {
+        if (link.category) profile.categories[link.category] = (profile.categories[link.category] || 0) + 1;
+        if (link.content_type) profile.contentTypes[link.content_type] = (profile.contentTypes[link.content_type] || 0) + 1;
+        if (link.artist) profile.artists.push(link.artist);
+        if (link.music_tags && Array.isArray(link.music_tags)) profile.genres.push(...link.music_tags);
+        if (link.music_type) profile.genres.push(link.music_type);
+        if (link.domain) {
+          const d = link.domain.replace(/^www\./, '');
+          profile.domains[d] = (profile.domains[d] || 0) + 1;
+        }
+        if (link.title) {
+          const words = link.title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').split(/\s+/);
+          for (const w of words) {
+            if (w.length > 3 && !EVENTS_STOPWORDS.has(w)) wordFreq[w] = (wordFreq[w] || 0) + 1;
+          }
+        }
+      }
+
+      profile.artists = [...new Set(profile.artists)].slice(0, 30);
+      profile.genres = [...new Set(profile.genres)].slice(0, 20);
+      profile.keywords = Object.entries(wordFreq)
+        .filter(([, c]) => c >= 2)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 20)
+        .map(([w]) => w);
+
+      const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
+      if (signalCount === 0) return;
+
+      const resp = await fetch(SUPABASE_URL + '/functions/v1/recommend-events', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ profile: profile, filters: { maxResults: 6 } }),
+      });
+
+      if (!resp.ok) return;
+      const result = await resp.json();
+      if (!result.events || result.events.length === 0) return;
+
+      const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+      const container = document.getElementById('recommendedCards');
+      const section = document.getElementById('recommendedSection');
+
+      container.innerHTML = result.events.map(function(evt) {
+        const d = new Date(evt.date + 'T00:00:00');
+        const dateStr = MONTHS[d.getMonth()] + ' ' + d.getDate();
+        const reason = (evt.relevance && evt.relevance.reasons && evt.relevance.reasons[0]) || '';
+        return '<div class="rec-card">' +
+          '<span class="rec-card__date">' + escHtml(dateStr) + '</span>' +
+          '<h4 class="rec-card__name">' + escHtml(evt.name) + '</h4>' +
+          '<p class="rec-card__venue">' + escHtml(evt.venue || '') + '</p>' +
+          (reason ? '<p class="rec-card__reason">' + escHtml(reason) + '</p>' : '') +
+          (evt.url ? '<a href="' + escHtml(evt.url) + '" target="_blank" rel="noopener" class="rec-card__link">Details &rarr;</a>' : '') +
+        '</div>';
+      }).join('');
+
+      section.style.display = '';
+      log('Recommended events loaded: ' + result.events.length);
+    } catch (err) {
+      log('Recommended events error: ' + err);
+    }
+  }
+
   // --- Init ---
   async function init() {
     loadSettings();
@@ -4104,6 +4289,8 @@ body {
     } else {
       document.getElementById('eventsContent').style.display = '';
       fetchAllSources();
+      // Load personalized recommendations (non-blocking)
+      loadRecommendedEvents();
     }
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);

--- a/supabase/functions/generate-widget/config/registry.ts
+++ b/supabase/functions/generate-widget/config/registry.ts
@@ -37,6 +37,7 @@ import { readerIdentity } from './widgets/reader-identity.ts'
 import { upcomingReleases } from './widgets/upcoming-releases.ts'
 import { soundShelf } from './widgets/sound-shelf.ts'
 import { listenNext } from './widgets/listen-next.ts'
+import { eventsForYou } from './widgets/events-for-you.ts'
 
 // =============================================================================
 // WIDGET REGISTRY
@@ -65,6 +66,7 @@ const registry: WidgetRegistry = {
     'upcoming-releases': upcomingReleases,
     'sound-shelf': soundShelf,
     'listen-next': listenNext,
+    'events-for-you': eventsForYou,
   },
 
   defaults: {

--- a/supabase/functions/generate-widget/config/widgets/events-for-you.ts
+++ b/supabase/functions/generate-widget/config/widgets/events-for-you.ts
@@ -1,0 +1,67 @@
+// Widget Definition: Events For You
+// Recommends upcoming events based on patterns in saved Boards content.
+// Uses a dedicated edge function (recommend-events) rather than generate-widget.
+
+import type { WidgetDefinition } from '../schema.ts'
+
+export const eventsForYou: WidgetDefinition = {
+  id: 'events-for-you',
+  name: 'Events For You',
+  description: 'Upcoming events matching your saved interests — music, film, comedy, and more.',
+  version: '1.0.0',
+
+  eligibility: {
+    rules: [
+      {
+        type: 'min_items',
+        weight: 1.0,
+        params: { min: 3 }
+      },
+      {
+        type: 'content_quality',
+        weight: 0.4,
+        params: {
+          minScore: 0.2,
+          weights: { title: 0.6, description: 0.2, image: 0.1, url: 0.1 }
+        }
+      }
+    ],
+    requireAllCritical: true,
+    minOverallScore: 0.3
+  },
+
+  confidence: {
+    threshold: 0.3,
+    fallbackBehavior: 'suppress'
+  },
+
+  generation: {
+    model: 'claude-3-haiku-20240307',
+    maxTokens: 512,
+    // Not used — this widget calls recommend-events directly
+    promptTemplate: ''
+  },
+
+  enrichment: {
+    enabled: false,
+    strategies: [],
+    timeout: 0,
+    fallback: 'none',
+    brandsEnabled: false
+  },
+
+  rendering: {
+    zone: 'footer',
+    template: 'event-card-list',
+    fallbackTemplate: 'list',
+    cssClass: 'widget-events-for-you',
+    priority: 5
+  },
+
+  categories: ['all', 'listen', 'watch', 'go'],
+  tags: ['events', 'recommendations', 'local', 'cross-product'],
+  enabled: true,
+
+  relevanceSignals: ['hasMusicContent', 'hasEventInterest', 'hasArtistData'],
+  noveltyDecay: 0.1
+}

--- a/supabase/functions/recommend-events/index.ts
+++ b/supabase/functions/recommend-events/index.ts
@@ -1,0 +1,516 @@
+// Supabase Edge Function: recommend-events
+// Recommends upcoming events based on a user's Boards profile.
+//
+// Hybrid approach:
+// 1. Query events + discord_event_cache for upcoming events
+// 2. Keyword pre-filter: score events against profile signals
+// 3. AI ranking: Claude Haiku ranks top candidates with relevance explanations
+//
+// POST /functions/v1/recommend-events
+// Body: { profile: { categories, artists, genres, keywords, domains, contentTypes }, filters? }
+// Returns: { events: [...], meta: { eventsScanned, profileSignals, algorithm } }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+// --- Supabase client ---
+
+function getSupabase() {
+  const url = Deno.env.get('SUPABASE_URL')!
+  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  return createClient(url, key)
+}
+
+// --- Types ---
+
+interface EventProfile {
+  categories: Record<string, number>
+  artists: string[]
+  genres: string[]
+  keywords: string[]
+  domains: Record<string, number>
+  contentTypes: Record<string, number>
+}
+
+interface EventFilters {
+  dateRange?: { start: string; end: string }
+  contentTypes?: string[]
+  maxResults?: number
+}
+
+interface CandidateEvent {
+  id: string
+  name: string
+  venue: string
+  date: string
+  time: string | null
+  genre: string | null
+  content_type: string | null
+  url: string
+  image_url: string | null
+  price: string | null
+  city: string | null
+  description: string | null
+  tags: string[] | null
+  source: string
+  keywordScore: number
+}
+
+interface RankedEvent {
+  id: string
+  name: string
+  venue: string
+  date: string
+  time: string | null
+  genre: string | null
+  content_type: string | null
+  url: string
+  image_url: string | null
+  price: string | null
+  city: string | null
+  relevance: {
+    score: number
+    reasons: string[]
+    matchedSignals: string[]
+  }
+}
+
+// --- Fetch upcoming events from both sources ---
+
+async function fetchUpcomingEvents(
+  filters: EventFilters
+): Promise<CandidateEvent[]> {
+  const supabase = getSupabase()
+  const today = new Date().toISOString().split('T')[0]
+  const endDate = filters.dateRange?.end ||
+    new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+  const startDate = filters.dateRange?.start || today
+
+  // Query events table
+  let query = supabase
+    .from('events')
+    .select('id, name, venue, date, time, genre, content_type, url, image_url, price, city, description, tags, source_id')
+    .gte('date', startDate)
+    .lte('date', endDate)
+    .order('date', { ascending: true })
+    .limit(500)
+
+  if (filters.contentTypes?.length) {
+    query = query.in('content_type', filters.contentTypes)
+  }
+
+  const { data: scrapedEvents, error: scrapedError } = await query
+
+  if (scrapedError) {
+    console.error('[recommend-events] Error fetching events:', scrapedError)
+  }
+
+  // Query discord_event_cache
+  const { data: discordCache, error: discordError } = await supabase
+    .from('discord_event_cache')
+    .select('events, guild_id, channel_id')
+    .gt('expires_at', new Date().toISOString())
+
+  if (discordError) {
+    console.error('[recommend-events] Error fetching discord cache:', discordError)
+  }
+
+  // Normalize scraped events
+  const events: CandidateEvent[] = (scrapedEvents || []).map(e => ({
+    id: e.id,
+    name: e.name,
+    venue: e.venue,
+    date: e.date,
+    time: e.time,
+    genre: e.genre,
+    content_type: e.content_type,
+    url: e.url,
+    image_url: e.image_url,
+    price: e.price,
+    city: e.city,
+    description: e.description,
+    tags: e.tags,
+    source: e.source_id || 'scraped',
+    keywordScore: 0,
+  }))
+
+  // Normalize discord events
+  if (discordCache) {
+    for (const row of discordCache) {
+      const discordEvents = (row.events as any[]) || []
+      for (const de of discordEvents) {
+        // Skip past events
+        if (de.date && de.date < startDate) continue
+        if (de.date && de.date > endDate) continue
+
+        events.push({
+          id: `discord-${row.guild_id}-${row.channel_id}-${de.date}-${(de.name || '').slice(0, 20)}`,
+          name: de.name || de.title || '',
+          venue: de.venue || '',
+          date: de.date || '',
+          time: de.time || null,
+          genre: de.genre || null,
+          content_type: de.contentType || de.content_type || 'music',
+          url: de.url || '',
+          image_url: de.image_url || null,
+          price: de.price || null,
+          city: de.city || null,
+          description: de.description || null,
+          tags: de.tags || null,
+          source: 'discord',
+          keywordScore: 0,
+        })
+      }
+    }
+  }
+
+  // Deduplicate by name+date+venue (case-insensitive)
+  const seen = new Set<string>()
+  return events.filter(e => {
+    const key = `${e.name.toLowerCase().trim()}|${e.date}|${e.venue.toLowerCase().trim()}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return e.name.length > 0
+  })
+}
+
+// --- Keyword pre-filter: score events against profile ---
+
+function scoreEventAgainstProfile(
+  event: CandidateEvent,
+  profile: EventProfile
+): number {
+  let score = 0
+  const eventText = [
+    event.name,
+    event.venue,
+    event.genre,
+    event.description,
+    ...(event.tags || []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  // Artist match (highest signal, 10 points per match)
+  for (const artist of profile.artists) {
+    if (artist.length > 2 && eventText.includes(artist.toLowerCase())) {
+      score += 10
+    }
+  }
+
+  // Genre match (5 points per match)
+  for (const genre of profile.genres) {
+    if (genre.length > 2 && eventText.includes(genre.toLowerCase())) {
+      score += 5
+    }
+  }
+
+  // Keyword match (2 points per match)
+  for (const keyword of profile.keywords) {
+    if (keyword.length > 3 && eventText.includes(keyword.toLowerCase())) {
+      score += 2
+    }
+  }
+
+  // Content type affinity (3 points if event type matches user's top content types)
+  if (event.content_type) {
+    const typeMap: Record<string, string[]> = {
+      music: ['music', 'listen'],
+      film: ['video', 'watch'],
+      comedy: ['comedy'],
+      theater: ['theater'],
+    }
+    const eventCategories = typeMap[event.content_type] || []
+    for (const cat of eventCategories) {
+      if (profile.categories[cat] > 0 || profile.contentTypes[cat] > 0) {
+        score += 3
+      }
+    }
+  }
+
+  return score
+}
+
+function preFilterEvents(
+  events: CandidateEvent[],
+  profile: EventProfile,
+  maxCandidates: number = 50
+): CandidateEvent[] {
+  // Score all events
+  for (const event of events) {
+    event.keywordScore = scoreEventAgainstProfile(event, profile)
+  }
+
+  // Sort by score descending, then by date ascending for ties
+  events.sort((a, b) => {
+    if (b.keywordScore !== a.keywordScore) return b.keywordScore - a.keywordScore
+    return a.date.localeCompare(b.date)
+  })
+
+  // Return top candidates (include all with score > 0, up to max)
+  const withScore = events.filter(e => e.keywordScore > 0)
+  if (withScore.length > 0) {
+    return withScore.slice(0, maxCandidates)
+  }
+
+  // If no keyword matches, return the soonest events for AI to evaluate
+  return events.slice(0, Math.min(20, maxCandidates))
+}
+
+// --- AI ranking with Claude Haiku ---
+
+async function rankEventsWithAI(
+  candidates: CandidateEvent[],
+  profile: EventProfile,
+  maxResults: number
+): Promise<{ rankings: Array<{ event_index: number; score: number; reasons: string[] }>, confidence: number }> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.warn('[recommend-events] No ANTHROPIC_API_KEY, falling back to keyword-only')
+    return { rankings: [], confidence: 0 }
+  }
+
+  // Build profile summary
+  const profileSummary = []
+  if (profile.artists.length > 0) {
+    profileSummary.push(`Artists/creators they follow: ${profile.artists.slice(0, 15).join(', ')}`)
+  }
+  if (profile.genres.length > 0) {
+    profileSummary.push(`Genres/tags: ${profile.genres.slice(0, 10).join(', ')}`)
+  }
+  if (profile.keywords.length > 0) {
+    profileSummary.push(`Keywords from saved content: ${profile.keywords.slice(0, 15).join(', ')}`)
+  }
+  const topCategories = Object.entries(profile.categories)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([cat, count]) => `${cat} (${count})`)
+  if (topCategories.length > 0) {
+    profileSummary.push(`Content categories: ${topCategories.join(', ')}`)
+  }
+
+  // Build events list
+  const eventsList = candidates.map((e, i) =>
+    `${i + 1}. "${e.name}" at ${e.venue || 'TBA'} on ${e.date}${e.genre ? ` [${e.genre}]` : ''}${e.content_type ? ` (${e.content_type})` : ''}${e.description ? ` — ${e.description.slice(0, 100)}` : ''}`
+  ).join('\n')
+
+  const prompt = `You are an event recommendation engine. Given a user's interests and upcoming events, rank the events by relevance to the user.
+
+USER INTERESTS:
+${profileSummary.join('\n')}
+
+CANDIDATE EVENTS:
+${eventsList}
+
+Return a JSON object with:
+- "rankings": array of the top ${maxResults} most relevant events, each with:
+  - "event_index": the event number (1-based)
+  - "score": relevance score 0.0-1.0
+  - "reasons": array of 1-2 short reasons referencing specific user interests
+- "confidence": overall confidence in recommendations (0.0-1.0)
+
+RULES:
+- Only include events scoring above 0.3
+- Reasons must reference specific user interests (artist names, genres, keywords)
+- Prefer exact artist/genre matches over vague keyword overlap
+- If no events are relevant, return {"rankings": [], "confidence": 0}
+- Keep each reason under 15 words
+
+Respond with valid JSON only.`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 512,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!response.ok) {
+      console.error('[recommend-events] Anthropic API error:', response.status)
+      return { rankings: [], confidence: 0 }
+    }
+
+    const data = await response.json()
+    const textContent = data.content?.[0]?.text || ''
+
+    // Parse JSON (handle markdown wrapping)
+    let cleaned = textContent
+      .replace(/```json\n?/g, '')
+      .replace(/```\n?/g, '')
+      .trim()
+
+    let parsed: any
+    try {
+      parsed = JSON.parse(cleaned)
+    } catch {
+      const firstBrace = cleaned.indexOf('{')
+      const lastBrace = cleaned.lastIndexOf('}')
+      if (firstBrace >= 0 && lastBrace > firstBrace) {
+        parsed = JSON.parse(cleaned.substring(firstBrace, lastBrace + 1))
+      } else {
+        console.error('[recommend-events] Failed to parse AI response')
+        return { rankings: [], confidence: 0 }
+      }
+    }
+
+    return {
+      rankings: parsed.rankings || [],
+      confidence: parsed.confidence || 0,
+    }
+  } catch (err) {
+    console.error('[recommend-events] AI ranking error:', err)
+    return { rankings: [], confidence: 0 }
+  }
+}
+
+// --- Main handler ---
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { profile, filters = {} } = await req.json() as {
+      profile: EventProfile
+      filters?: EventFilters
+    }
+
+    // Validate profile
+    if (!profile) {
+      return new Response(
+        JSON.stringify({ error: 'profile is required' }),
+        { status: 400, headers: jsonHeaders }
+      )
+    }
+
+    const maxResults = filters.maxResults || 5
+    const startTime = Date.now()
+
+    // Count profile signals
+    const profileSignals =
+      (profile.artists?.length || 0) +
+      (profile.genres?.length || 0) +
+      (profile.keywords?.length || 0)
+
+    console.log(`[recommend-events] Profile: ${profileSignals} signals, ${Object.keys(profile.categories || {}).length} categories`)
+
+    // Step 1: Fetch upcoming events
+    const allEvents = await fetchUpcomingEvents(filters)
+    console.log(`[recommend-events] Fetched ${allEvents.length} upcoming events`)
+
+    if (allEvents.length === 0) {
+      return new Response(
+        JSON.stringify({
+          events: [],
+          meta: { eventsScanned: 0, profileSignals, algorithm: 'none' },
+        }),
+        { headers: jsonHeaders }
+      )
+    }
+
+    // Step 2: Keyword pre-filter
+    const candidates = preFilterEvents(allEvents, profile, 50)
+    const hasKeywordMatches = candidates.some(c => c.keywordScore > 0)
+    console.log(`[recommend-events] Pre-filtered to ${candidates.length} candidates (keyword matches: ${hasKeywordMatches})`)
+
+    // Step 3: AI ranking (if we have signals and API key)
+    let rankedEvents: RankedEvent[] = []
+    let algorithm: 'hybrid' | 'keyword-only' = 'keyword-only'
+
+    if (profileSignals > 0 && candidates.length > 0) {
+      const { rankings, confidence } = await rankEventsWithAI(candidates, profile, maxResults)
+
+      if (rankings.length > 0) {
+        algorithm = 'hybrid'
+        rankedEvents = rankings
+          .filter(r => r.event_index >= 1 && r.event_index <= candidates.length)
+          .map(r => {
+            const event = candidates[r.event_index - 1]
+            return {
+              id: event.id,
+              name: event.name,
+              venue: event.venue,
+              date: event.date,
+              time: event.time,
+              genre: event.genre,
+              content_type: event.content_type,
+              url: event.url,
+              image_url: event.image_url,
+              price: event.price,
+              city: event.city,
+              relevance: {
+                score: r.score,
+                reasons: r.reasons || [],
+                matchedSignals: [],
+              },
+            }
+          })
+
+        console.log(`[recommend-events] AI ranked ${rankedEvents.length} events (confidence: ${confidence})`)
+      }
+    }
+
+    // Fallback: use keyword-scored events if AI didn't produce results
+    if (rankedEvents.length === 0 && hasKeywordMatches) {
+      rankedEvents = candidates
+        .filter(c => c.keywordScore > 0)
+        .slice(0, maxResults)
+        .map(event => ({
+          id: event.id,
+          name: event.name,
+          venue: event.venue,
+          date: event.date,
+          time: event.time,
+          genre: event.genre,
+          content_type: event.content_type,
+          url: event.url,
+          image_url: event.image_url,
+          price: event.price,
+          city: event.city,
+          relevance: {
+            score: Math.min(event.keywordScore / 20, 1),
+            reasons: ['Matches keywords from your saved content'],
+            matchedSignals: [],
+          },
+        }))
+    }
+
+    const elapsed = Date.now() - startTime
+    console.log(`[recommend-events] Done in ${elapsed}ms: ${rankedEvents.length} results (${algorithm})`)
+
+    return new Response(
+      JSON.stringify({
+        events: rankedEvents,
+        meta: {
+          eventsScanned: allEvents.length,
+          profileSignals,
+          algorithm,
+        },
+      }),
+      { headers: jsonHeaders }
+    )
+  } catch (err) {
+    console.error('[recommend-events] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal error', detail: String(err) }),
+      { status: 500, headers: jsonHeaders }
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- New `recommend-events` edge function that analyzes a user's Boards profile (artists, genres, keywords, categories) and matches against upcoming events in Supabase
- Hybrid matching: SQL keyword pre-filter narrows candidates, then Claude Haiku AI ranks top results with personalized relevance explanations
- **Boards widget**: "Events For You" card list in the footer zone, showing up to 5 recommended events with date badges, venue, and match reasons
- **Events page**: "Recommended for you" horizontal scroll section at the top when Boards data exists in localStorage

## Architecture
```
Boards localStorage → extractEventProfile() → POST /recommend-events
                                                      ↓
                                          Query: events + discord_event_cache
                                                      ↓
                                          Keyword pre-filter (~50 candidates)
                                                      ↓
                                          Claude Haiku AI ranking (top 5)
                                                      ↓
                              Boards widget (footer) + Events page (top section)
```

## Files
| File | Change |
|------|--------|
| `supabase/functions/recommend-events/index.ts` | **New** — Core recommendation edge function |
| `supabase/functions/generate-widget/config/widgets/events-for-you.ts` | **New** — Widget definition config |
| `supabase/functions/generate-widget/config/registry.ts` | Register new widget |
| `boards/index.html` | Profile extraction, widget rendering, event card CSS |
| `events/index.html` | "Recommended for you" section with cards + CSS |

## Test plan
- [ ] Deploy edge function: `supabase functions deploy recommend-events`
- [ ] Test endpoint with curl: `POST /functions/v1/recommend-events` with sample profile
- [ ] Open Boards with 3+ saved links — verify widget appears in footer
- [ ] Open Events page with Boards data in localStorage — verify recommended section appears
- [ ] Clear localStorage — verify both surfaces gracefully hide
- [ ] Test with no matching events — verify widget suppresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)