### PR TITLE
Fix TMDB title cleaning for Wikipedia URLs

### DIFF
--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -344,9 +344,12 @@ async function lookupTMDB(rawTitle: string, type: string | null, year: number | 
 
   // Clean title: strip common suffixes
   const cleanTitle = rawTitle
-    .replace(/\s*[\|\-–—]\s*(Netflix|YouTube|Hulu|Disney\+?|HBO|Max|Prime Video|Apple TV\+?|Vimeo|IMDb|Letterboxd|Rotten Tomatoes|Watch|Stream|Official).*$/i, '')
+    .replace(/\s*[\|\-–—]\s*(Netflix|YouTube|Hulu|Disney\+?|HBO|Max|Prime Video|Apple TV\+?|Vimeo|IMDb|Letterboxd|Rotten Tomatoes|Watch|Stream|Official|Wikipedia|Wiki|Fandom).*$/i, '')
     .replace(/\s*\(\d{4}\)\s*$/, '')  // strip trailing (2024)
-    .replace(/\s*-\s*IMDb\s*$/i, '')
+    .replace(/\s*-\s*(IMDb|Wikipedia)\s*$/i, '')
+    .replace(/\s*\(TV series\)\s*$/i, '')  // strip "(TV series)" from Wikipedia titles
+    .replace(/\s*\(film\)\s*$/i, '')  // strip "(film)" from Wikipedia titles
+    .replace(/\s*\(TV programme\)\s*$/i, '')
     .trim()
 
   if (!cleanTitle) return null


### PR DESCRIPTION
## Summary
- TMDB search was returning no results for Wikipedia-sourced watch items because "- Wikipedia" wasn't being stripped from titles
- Added Wikipedia, Wiki, Fandom, (TV series), (film), (TV programme) to the title suffix cleanup regex
- Already redeployed with `--no-verify-jwt` — all 3 existing watch items now return full TMDB data

## Test results
- "Trafficked with mariana van zeller - Wikipedia" → TMDB 113888, IMDB tt10370750, 9 providers ✅
- "Congo (tv series) - Wikipedia" → TMDB 10329, IMDB tt0112715, 7 providers ✅
- "Enter the Void - Wikipedia" → TMDB 34647, IMDB tt1191111, 10 providers ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)