### PR TITLE
Fix: Replace Wikipedia titles with clean TMDB titles

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9048,14 +9048,19 @@ Return JSON:
             creator: existing.creator || result.video.creator || null,
             rating: existing.rating || result.video.rating || null,
             runtime: result.video.runtime || existing.runtime || null,
-            // Preserve client-side fields
-            title: existing.title || null,
+            // Title: prefer TMDB canonical title, then existing client-extracted title
+            title: result.video.title || existing.title || null,
             platform: existing.platform || null,
             platformId: existing.platformId || null,
             contentFormat: existing.contentFormat || null,
             seriesInfo: existing.seriesInfo || null
           };
           console.log('%c[ENRICH] Video metadata merged:', 'color: #E50914', link.video);
+
+          // Update top-level link title with clean TMDB title (removes "- Wikipedia" etc.)
+          if (link.video.title) {
+            link.title = link.video.title;
+          }
 
           // Use TMDB poster for watch items — always prefer it over scraped OG images
           if (link.video.posterPath) {

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -176,6 +176,7 @@ serve(async (req) => {
 
       // 3. Merge: TMDB is primary, AI fills gaps
       videoMeta = {
+        title: tmdbResult?.title || null,  // Clean canonical title from TMDB
         summary: truncSummary(tmdbResult?.overview || aiResult?.summary || null),
         type: aiResult?.type || (tmdbResult ? inferTypeFromTMDB(tmdbResult.mediaType) : null),
         genre: tmdbResult?.genres?.[0] || aiResult?.genre || null,


### PR DESCRIPTION
## Summary
- Server now returns TMDB canonical title in the `videoMeta.title` field
- Client enrichment merge updates `link.video.title` with TMDB title (was preserving stale client-extracted title)
- Client also updates top-level `link.title` so the card heading always shows the clean name

Fixes titles like "Trafficked with mariana van zeller - Wikipedia" → "Trafficked with Mariana Van Zeller"

## Test plan
- [ ] Rerun enrichment on a watch card with a Wikipedia-sourced title
- [ ] Verify card heading shows clean TMDB title (no "- Wikipedia" suffix)
- [ ] Verify title persists after logout/login

🤖 Generated with [Claude Code](https://claude.com/claude-code)