### PR TITLE
Fix: filter event recommendations by region

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -7189,6 +7189,14 @@ Return JSON:
   // Recommends upcoming events based on Boards content
   // =============================================================================
 
+  // Region → source IDs (must stay in sync with STOCK_SOURCES in events/index.html)
+  const EVENT_SOURCE_REGIONS = {
+    'bay-area': ['19hz-bayarea', 'ra-bayarea', 'sf-punchline', 'cobbs-sf', 'roxie-sf', 'screenslate-sf'],
+    'los-angeles': ['19hz-losangeles'],
+    'new-york': ['19hz-newyork', 'screenslate-nyc'],
+    'seattle': ['19hz-seattle'],
+  };
+
   const EVENTS_STOPWORDS = new Set([
     'the', 'and', 'for', 'with', 'from', 'this', 'that', 'have', 'has',
     'are', 'was', 'were', 'been', 'being', 'will', 'would', 'could',
@@ -7320,7 +7328,11 @@ Return JSON:
     const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
     if (signalCount === 0) return;
 
-    console.log('[events-for-you] Profile:', signalCount, 'signals,', Object.keys(profile.categories).length, 'categories');
+    // Region filter: only recommend events from user's region
+    const region = localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area';
+    const sourceIds = EVENT_SOURCE_REGIONS[region] || EVENT_SOURCE_REGIONS['bay-area'];
+
+    console.log('[events-for-you] Profile:', signalCount, 'signals,', Object.keys(profile.categories).length, 'categories, region:', region);
 
     try {
       const response = await fetch(SUPABASE_URL + '/functions/v1/recommend-events', {
@@ -7331,7 +7343,7 @@ Return JSON:
         },
         body: JSON.stringify({
           profile: profile,
-          filters: { maxResults: 5 },
+          filters: { maxResults: 5, sourceIds: sourceIds },
         }),
       });
 

--- a/events/index.html
+++ b/events/index.html
@@ -4234,13 +4234,17 @@ body {
       const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
       if (signalCount === 0) return;
 
+      // Region filter: only recommend events from user's active sources
+      const region = localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area';
+      const sourceIds = STOCK_SOURCES.filter(function(s) { return s.region === region; }).map(function(s) { return s.id; });
+
       const resp = await fetch(SUPABASE_URL + '/functions/v1/recommend-events', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
         },
-        body: JSON.stringify({ profile: profile, filters: { maxResults: 6 } }),
+        body: JSON.stringify({ profile: profile, filters: { maxResults: 6, sourceIds: sourceIds } }),
       });
 
       if (!resp.ok) return;

--- a/supabase/functions/recommend-events/index.ts
+++ b/supabase/functions/recommend-events/index.ts
@@ -42,6 +42,7 @@ interface EventProfile {
 interface EventFilters {
   dateRange?: { start: string; end: string }
   contentTypes?: string[]
+  sourceIds?: string[]
   maxResults?: number
 }
 
@@ -104,6 +105,10 @@ async function fetchUpcomingEvents(
 
   if (filters.contentTypes?.length) {
     query = query.in('content_type', filters.contentTypes)
+  }
+
+  if (filters.sourceIds?.length) {
+    query = query.in('source_id', filters.sourceIds)
   }
 
   const { data: scrapedEvents, error: scrapedError } = await query
@@ -409,7 +414,7 @@ serve(async (req) => {
       (profile.genres?.length || 0) +
       (profile.keywords?.length || 0)
 
-    console.log(`[recommend-events] Profile: ${profileSignals} signals, ${Object.keys(profile.categories || {}).length} categories`)
+    console.log(`[recommend-events] Profile: ${profileSignals} signals, ${Object.keys(profile.categories || {}).length} categories${filters.sourceIds?.length ? `, region filter: ${filters.sourceIds.length} sources` : ''}`)
 
     // Step 1: Fetch upcoming events
     const allEvents = await fetchUpcomingEvents(filters)


### PR DESCRIPTION
## Summary
- Event recommendations were returning events from all regions (NYC movies for a Bay Area user)
- Now filters by user's region preference (`ctrl-rodeo-events-region` localStorage key, defaults to `bay-area`)
- Edge function accepts `sourceIds` filter to restrict events query to matching sources
- Both Boards widget and Events page pass region-appropriate source IDs

## Changes
- `recommend-events/index.ts`: Added `sourceIds` to `EventFilters`, applies `.in('source_id', sourceIds)` to query
- `boards/index.html`: Added `EVENT_SOURCE_REGIONS` map, passes matching source IDs in widget request
- `events/index.html`: Filters `STOCK_SOURCES` by region, passes source IDs in recommendation request

## Test plan
- [ ] Deploy edge function
- [ ] Verify Bay Area user only sees Bay Area events
- [ ] Test with `localStorage.setItem('ctrl-rodeo-events-region', 'new-york')` to confirm NYC filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)