### PR TITLE
Add iOS app with Share Extension

### DIFF
--- a/ios/CtrlRodeo.xcodeproj/project.pbxproj
+++ b/ios/CtrlRodeo.xcodeproj/project.pbxproj
@@ -1,0 +1,490 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2809118237843E1E2049E8DE /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BDECABB0154E8E7FE1A2DF /* Models.swift */; };
+		298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */; };
+		3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBCBB85AA0707A741D4EFA /* ContentView.swift */; };
+		6BB63DB10028F7F640E4F59A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
+		72663FD73C994D268DA29A27 /* QueueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89405C4E8B1D627ACA6871F1 /* QueueService.swift */; };
+		82BB846447A43DF78547DC25 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
+		835320A0E5898A5D1BC08D06 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = FF18623D8E09BE7AE83777BA /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		886C46A480D7A3BCCBB4B450 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BDECABB0154E8E7FE1A2DF /* Models.swift */; };
+		AAFDFA1C77F0973A2BB1A75A /* QueueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89405C4E8B1D627ACA6871F1 /* QueueService.swift */; };
+		AD8C20FBC3481F5DA1734000 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D726CF484741663C8E44F3 /* ShareViewController.swift */; };
+		CAD640C5E7E7ED3DCFBED06D /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9DDCA70DD729557ADB4922 /* SupabaseClient.swift */; };
+		D9D52660B6969013489C222E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BA850935A1BD210899C8BE /* Theme.swift */; };
+		F6FA76D0AD6549E2B174B376 /* SupabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9DDCA70DD729557ADB4922 /* SupabaseClient.swift */; };
+		FBE1EBD7F388E35711BCAAE7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A6015C07711BF1587BCFBA10 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		2B01DF9F6236C1A7B203B0CB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3F4AF139F7AF9D50A2CFEE51 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3BABF9E086A0E249AB2B3CF6;
+			remoteInfo = ShareExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A23FFFA9D9F8B5CC5C8FD1E2 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				835320A0E5898A5D1BC08D06 /* ShareExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		26338682C91C387B8F02C931 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		31FBCBB85AA0707A741D4EFA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		66BDECABB0154E8E7FE1A2DF /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		71BA850935A1BD210899C8BE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlRodeoApp.swift; sourceTree = "<group>"; };
+		89405C4E8B1D627ACA6871F1 /* QueueService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueService.swift; sourceTree = "<group>"; };
+		976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CtrlRodeo.entitlements; sourceTree = "<group>"; };
+		9A112C46BE4BF03936FA33CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		A6015C07711BF1587BCFBA10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B8394AA45211749874523793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CC870C2D6BE9AF4E017479FA /* CtrlRodeo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlRodeo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF9DDCA70DD729557ADB4922 /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
+		F563E6BC27A2E8580BA307F8 /* ShareExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShareExtension.entitlements; sourceTree = "<group>"; };
+		F5D726CF484741663C8E44F3 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		FF18623D8E09BE7AE83777BA /* ShareExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		19DF1BDDA4B3C5B1B447CF01 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				B8394AA45211749874523793 /* Info.plist */,
+				F563E6BC27A2E8580BA307F8 /* ShareExtension.entitlements */,
+				F5D726CF484741663C8E44F3 /* ShareViewController.swift */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+		746E5ACD895662CB0A2FA53B /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				26338682C91C387B8F02C931 /* Constants.swift */,
+				66BDECABB0154E8E7FE1A2DF /* Models.swift */,
+				89405C4E8B1D627ACA6871F1 /* QueueService.swift */,
+				DF9DDCA70DD729557ADB4922 /* SupabaseClient.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		AC8CB60951561FB25DD640AB /* CtrlRodeo */ = {
+			isa = PBXGroup;
+			children = (
+				A6015C07711BF1587BCFBA10 /* Assets.xcassets */,
+				31FBCBB85AA0707A741D4EFA /* ContentView.swift */,
+				976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */,
+				728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */,
+				9A112C46BE4BF03936FA33CE /* Info.plist */,
+				71BA850935A1BD210899C8BE /* Theme.swift */,
+			);
+			path = CtrlRodeo;
+			sourceTree = "<group>";
+		};
+		D7E121D55C33D1EEE199738A = {
+			isa = PBXGroup;
+			children = (
+				AC8CB60951561FB25DD640AB /* CtrlRodeo */,
+				746E5ACD895662CB0A2FA53B /* Shared */,
+				19DF1BDDA4B3C5B1B447CF01 /* ShareExtension */,
+				F22DB2199EF6DC647718E15C /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		F22DB2199EF6DC647718E15C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CC870C2D6BE9AF4E017479FA /* CtrlRodeo.app */,
+				FF18623D8E09BE7AE83777BA /* ShareExtension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		3BABF9E086A0E249AB2B3CF6 /* ShareExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 01C30E24FE9DBFD4DBC50F1D /* Build configuration list for PBXNativeTarget "ShareExtension" */;
+			buildPhases = (
+				96A15EEC7F09B81D17A5637E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ShareExtension;
+			packageProductDependencies = (
+			);
+			productName = ShareExtension;
+			productReference = FF18623D8E09BE7AE83777BA /* ShareExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		EDCF5207659B5090ED08AFC6 /* CtrlRodeo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 324A7CE027D1CA0EC33473FD /* Build configuration list for PBXNativeTarget "CtrlRodeo" */;
+			buildPhases = (
+				F0488E6DB78ECF342603A7FF /* Sources */,
+				77A96274D657316A2D37EDE2 /* Resources */,
+				A23FFFA9D9F8B5CC5C8FD1E2 /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8E6A37DE9E82C230D88DF77E /* PBXTargetDependency */,
+			);
+			name = CtrlRodeo;
+			packageProductDependencies = (
+			);
+			productName = CtrlRodeo;
+			productReference = CC870C2D6BE9AF4E017479FA /* CtrlRodeo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3F4AF139F7AF9D50A2CFEE51 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					3BABF9E086A0E249AB2B3CF6 = {
+						ProvisioningStyle = Automatic;
+					};
+					EDCF5207659B5090ED08AFC6 = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = D953BA3C2ED0C04AAC6D4C01 /* Build configuration list for PBXProject "CtrlRodeo" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = D7E121D55C33D1EEE199738A;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EDCF5207659B5090ED08AFC6 /* CtrlRodeo */,
+				3BABF9E086A0E249AB2B3CF6 /* ShareExtension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		77A96274D657316A2D37EDE2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FBE1EBD7F388E35711BCAAE7 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		96A15EEC7F09B81D17A5637E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6BB63DB10028F7F640E4F59A /* Constants.swift in Sources */,
+				2809118237843E1E2049E8DE /* Models.swift in Sources */,
+				72663FD73C994D268DA29A27 /* QueueService.swift in Sources */,
+				AD8C20FBC3481F5DA1734000 /* ShareViewController.swift in Sources */,
+				CAD640C5E7E7ED3DCFBED06D /* SupabaseClient.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F0488E6DB78ECF342603A7FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				82BB846447A43DF78547DC25 /* Constants.swift in Sources */,
+				3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */,
+				298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */,
+				886C46A480D7A3BCCBB4B450 /* Models.swift in Sources */,
+				AAFDFA1C77F0973A2BB1A75A /* QueueService.swift in Sources */,
+				F6FA76D0AD6549E2B174B376 /* SupabaseClient.swift in Sources */,
+				D9D52660B6969013489C222E /* Theme.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		8E6A37DE9E82C230D88DF77E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3BABF9E086A0E249AB2B3CF6 /* ShareExtension */;
+			targetProxy = 2B01DF9F6236C1A7B203B0CB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		3A2408E8CB67FA6E476EF834 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CtrlRodeo/CtrlRodeo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CtrlRodeo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctrlrodeo.boards;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		4C72DF63D1E812E24070AFC3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Release;
+		};
+		4D369946E98FE72AE34DD607 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctrlrodeo.boards.share;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		5058B5FA863992F1A95EF1E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = ShareExtension/ShareExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = ShareExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctrlrodeo.boards.share;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A8EAEBFC4B0B5333AFCAA233 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CtrlRodeo/CtrlRodeo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = CtrlRodeo/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.ctrlrodeo.boards;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FBF7824BD6006AFE0AEB44FD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		01C30E24FE9DBFD4DBC50F1D /* Build configuration list for PBXNativeTarget "ShareExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5058B5FA863992F1A95EF1E0 /* Debug */,
+				4D369946E98FE72AE34DD607 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		324A7CE027D1CA0EC33473FD /* Build configuration list for PBXNativeTarget "CtrlRodeo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A8EAEBFC4B0B5333AFCAA233 /* Debug */,
+				3A2408E8CB67FA6E476EF834 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D953BA3C2ED0C04AAC6D4C01 /* Build configuration list for PBXProject "CtrlRodeo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FBF7824BD6006AFE0AEB44FD /* Debug */,
+				4C72DF63D1E812E24070AFC3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3F4AF139F7AF9D50A2CFEE51 /* Project object */;
+}

--- a/ios/CtrlRodeo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/CtrlRodeo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/CtrlRodeo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/CtrlRodeo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/CtrlRodeo/Assets.xcassets/Contents.json
+++ b/ios/CtrlRodeo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/CtrlRodeo/ContentView.swift
+++ b/ios/CtrlRodeo/ContentView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+import WebKit
+
+struct ContentView: View {
+    @State private var isRefreshing = false
+
+    var body: some View {
+        WebView(isRefreshing: $isRefreshing)
+            .ignoresSafeArea()
+            .background(Theme.background)
+    }
+}
+
+// MARK: - WebView
+
+struct WebView: UIViewRepresentable {
+    @Binding var isRefreshing: Bool
+
+    func makeUIView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+
+        // Set up message handler for auth bridge
+        config.userContentController.add(context.coordinator, name: "authBridge")
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        webView.isOpaque = false
+        webView.backgroundColor = .black
+
+        // Pull-to-refresh
+        let refreshControl = UIRefreshControl()
+        refreshControl.tintColor = .white
+        refreshControl.addTarget(context.coordinator, action: #selector(Coordinator.refresh), for: .valueChanged)
+        webView.scrollView.addSubview(refreshControl)
+        context.coordinator.refreshControl = refreshControl
+
+        // Load the boards URL
+        if let url = URL(string: AppConstants.boardsURL) {
+            webView.load(URLRequest(url: url))
+        }
+
+        // Listen for deep links
+        NotificationCenter.default.addObserver(
+            context.coordinator,
+            selector: #selector(Coordinator.handleDeepLink(_:)),
+            name: NSNotification.Name("DeepLinkReceived"),
+            object: nil
+        )
+
+        context.coordinator.webView = webView
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        if isRefreshing {
+            context.coordinator.refreshControl?.endRefreshing()
+            isRefreshing = false
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isRefreshing: $isRefreshing)
+    }
+
+    // MARK: - Coordinator
+
+    class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        var webView: WKWebView?
+        var refreshControl: UIRefreshControl?
+        @Binding var isRefreshing: Bool
+
+        private var hasInjectedAuth = false
+        private var hasProcessedQueue = false
+
+        init(isRefreshing: Binding<Bool>) {
+            _isRefreshing = isRefreshing
+        }
+
+        // MARK: - Navigation Delegate
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            injectAuthBridge()
+
+            // Inject stored auth into web localStorage (one-time on first load)
+            if !hasInjectedAuth {
+                injectStoredAuth()
+                hasInjectedAuth = true
+            }
+
+            // Process queued URLs (one-time on first load)
+            if !hasProcessedQueue {
+                processQueuedURLs()
+                hasProcessedQueue = true
+            }
+
+            refreshControl?.endRefreshing()
+        }
+
+        // MARK: - Script Message Handler
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == "authBridge",
+                  let body = message.body as? [String: Any],
+                  let authData = try? JSONSerialization.data(withJSONObject: body) else {
+                return
+            }
+
+            // Parse auth token from web and store in App Group
+            if let auth = try? JSONDecoder().decode(StoredAuth.self, from: authData) {
+                SupabaseClient.shared.storeAuth(auth)
+            }
+        }
+
+        // MARK: - Auth Bridge
+
+        private func injectAuthBridge() {
+            let script = """
+            (function() {
+                // Monitor localStorage changes to auth token
+                const authKey = '\(AppConstants.webAuthStorageKey)';
+                const originalSetItem = localStorage.setItem;
+
+                localStorage.setItem = function(key, value) {
+                    originalSetItem.apply(this, arguments);
+                    if (key === authKey) {
+                        try {
+                            const auth = JSON.parse(value);
+                            window.webkit.messageHandlers.authBridge.postMessage(auth);
+                        } catch (e) {
+                            console.error('Failed to parse auth:', e);
+                        }
+                    }
+                };
+
+                // Also send current auth if it exists
+                const currentAuth = localStorage.getItem(authKey);
+                if (currentAuth) {
+                    try {
+                        const auth = JSON.parse(currentAuth);
+                        window.webkit.messageHandlers.authBridge.postMessage(auth);
+                    } catch (e) {
+                        console.error('Failed to parse existing auth:', e);
+                    }
+                }
+            })();
+            """
+            webView?.evaluateJavaScript(script)
+        }
+
+        private func injectStoredAuth() {
+            guard let auth = SupabaseClient.shared.getStoredAuth(),
+                  let authData = try? JSONEncoder().encode(auth),
+                  let authJSON = String(data: authData, encoding: .utf8) else {
+                return
+            }
+
+            let script = """
+            (function() {
+                const authKey = '\(AppConstants.webAuthStorageKey)';
+                localStorage.setItem(authKey, '\(authJSON.replacingOccurrences(of: "'", with: "\\'"))');
+            })();
+            """
+            webView?.evaluateJavaScript(script)
+        }
+
+        // MARK: - Queue Processing
+
+        private func processQueuedURLs() {
+            let queued = QueueService.shared.dequeueAll()
+            guard !queued.isEmpty else { return }
+
+            Task {
+                for item in queued {
+                    do {
+                        _ = try await SupabaseClient.shared.addLink(url: item.url, title: item.title)
+                    } catch {
+                        print("Failed to add queued link: \(error)")
+                        // Re-queue if failed
+                        QueueService.shared.enqueue(url: item.url, title: item.title)
+                    }
+                }
+
+                // Reload web view to show new links
+                await MainActor.run {
+                    webView?.reload()
+                }
+            }
+        }
+
+        // MARK: - Pull to Refresh
+
+        @objc func refresh() {
+            webView?.reload()
+        }
+
+        // MARK: - Deep Links
+
+        @objc func handleDeepLink(_ notification: Notification) {
+            guard let url = notification.userInfo?["url"] as? URL else { return }
+
+            // Navigate to the deep link URL in the web view
+            // This handles OAuth callbacks from Supabase
+            webView?.load(URLRequest(url: url))
+        }
+    }
+}
+

--- a/ios/CtrlRodeo/CtrlRodeo.entitlements
+++ b/ios/CtrlRodeo/CtrlRodeo.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ios/CtrlRodeo/CtrlRodeoApp.swift
+++ b/ios/CtrlRodeo/CtrlRodeoApp.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+@main
+struct CtrlRodeoApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .preferredColorScheme(.dark)
+                .background(Color.black)
+                .onOpenURL { url in
+                    handleDeepLink(url)
+                }
+        }
+    }
+
+    private func handleDeepLink(_ url: URL) {
+        // Handle ctrlrodeo:// deep links (e.g., auth callbacks)
+        guard url.scheme == AppConstants.urlScheme else { return }
+
+        // Auth callback from Supabase OAuth flow
+        // The web app will handle the actual token exchange
+        // We just need to pass it through to the WebView
+        NotificationCenter.default.post(
+            name: NSNotification.Name("DeepLinkReceived"),
+            object: nil,
+            userInfo: ["url": url]
+        )
+    }
+}

--- a/ios/CtrlRodeo/Info.plist
+++ b/ios/CtrlRodeo/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.ctrlrodeo.boards</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ctrlrodeo</string>
+			</array>
+		</dict>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+</dict>
+</plist>

--- a/ios/CtrlRodeo/Theme.swift
+++ b/ios/CtrlRodeo/Theme.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+enum Theme {
+    // Core colors matching ctrl.rodeo design tokens
+    static let background = Color(hex: "#000000")
+    static let foreground = Color(hex: "#FFFFFF")
+    static let surface = Color(hex: "#111111")
+    static let muted = Color(hex: "#888888")
+}
+
+// MARK: - Color Hex Extension
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+
+        let r, g, b: UInt64
+        switch hex.count {
+        case 6: // RGB (24-bit)
+            (r, g, b) = ((int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        default:
+            (r, g, b) = (0, 0, 0)
+        }
+
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255
+        )
+    }
+}

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/ShareExtension/ShareExtension.entitlements
+++ b/ios/ShareExtension/ShareExtension.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/ios/ShareExtension/ShareViewController.swift
+++ b/ios/ShareExtension/ShareViewController.swift
@@ -1,0 +1,214 @@
+import UIKit
+import UniformTypeIdentifiers
+
+/// Custom Share Extension view controller for ctrl.rodeo Boards
+/// Displays a minimal black/white UI, saves URLs to Supabase or queues them offline
+@objc(ShareViewController)
+class ShareViewController: UIViewController {
+
+    // MARK: - UI Elements
+
+    private let containerView = UIView()
+    private let iconLabel = UILabel()
+    private let statusLabel = UILabel()
+    private let urlLabel = UILabel()
+
+    // MARK: - State
+
+    private var sharedURL: String?
+    private var sharedTitle: String?
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        extractSharedContent()
+    }
+
+    // MARK: - UI Setup
+
+    private func setupUI() {
+        view.backgroundColor = UIColor.black
+
+        // Container for centered content
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(containerView)
+
+        // Icon (SF Symbol checkmark)
+        iconLabel.translatesAutoresizingMaskIntoConstraints = false
+        iconLabel.font = UIFont.systemFont(ofSize: 48, weight: .regular)
+        iconLabel.textColor = .white
+        iconLabel.textAlignment = .center
+        iconLabel.alpha = 0 // Start invisible for fade-in
+        containerView.addSubview(iconLabel)
+
+        // Status text
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        statusLabel.textColor = .white
+        statusLabel.textAlignment = .center
+        statusLabel.alpha = 0
+        containerView.addSubview(statusLabel)
+
+        // URL display
+        urlLabel.translatesAutoresizingMaskIntoConstraints = false
+        urlLabel.font = UIFont.systemFont(ofSize: 12, weight: .regular)
+        urlLabel.textColor = UIColor(white: 0.533, alpha: 1.0) // #888
+        urlLabel.textAlignment = .center
+        urlLabel.numberOfLines = 1
+        urlLabel.lineBreakMode = .byTruncatingMiddle
+        urlLabel.alpha = 0
+        containerView.addSubview(urlLabel)
+
+        NSLayoutConstraint.activate([
+            // Center container
+            containerView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            containerView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -48),
+
+            // Icon at top
+            iconLabel.topAnchor.constraint(equalTo: containerView.topAnchor),
+            iconLabel.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+
+            // Status below icon
+            statusLabel.topAnchor.constraint(equalTo: iconLabel.bottomAnchor, constant: 16),
+            statusLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            statusLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+
+            // URL below status
+            urlLabel.topAnchor.constraint(equalTo: statusLabel.bottomAnchor, constant: 8),
+            urlLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            urlLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            urlLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor)
+        ])
+
+        // Configure presentation style
+        if #available(iOS 15.0, *) {
+            if let sheet = sheetPresentationController {
+                sheet.detents = [.medium()]
+                sheet.prefersGrabberVisible = false
+            }
+        }
+        modalPresentationStyle = .pageSheet
+    }
+
+    // MARK: - Content Extraction
+
+    private func extractSharedContent() {
+        guard let extensionItem = extensionContext?.inputItems.first as? NSExtensionItem else {
+            showError()
+            return
+        }
+
+        // Try to get title from the extension item
+        let titleFromItem = extensionItem.attributedTitle?.string ?? extensionItem.attributedContentText?.string
+
+        guard let attachments = extensionItem.attachments else {
+            showError()
+            return
+        }
+
+        // Try URL type first
+        if let urlAttachment = attachments.first(where: { $0.hasItemConformingToTypeIdentifier(UTType.url.identifier) }) {
+            urlAttachment.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { [weak self] (item, error) in
+                DispatchQueue.main.async {
+                    if let url = item as? URL {
+                        self?.sharedURL = url.absoluteString
+                        self?.sharedTitle = titleFromItem
+                        self?.saveLink()
+                    } else {
+                        self?.showError()
+                    }
+                }
+            }
+        }
+        // Fall back to plain text (some apps share URLs as text)
+        else if let textAttachment = attachments.first(where: { $0.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) }) {
+            textAttachment.loadItem(forTypeIdentifier: UTType.plainText.identifier, options: nil) { [weak self] (item, error) in
+                DispatchQueue.main.async {
+                    if let text = item as? String, self?.isValidURL(text) == true {
+                        self?.sharedURL = text
+                        self?.sharedTitle = titleFromItem
+                        self?.saveLink()
+                    } else {
+                        self?.showError()
+                    }
+                }
+            }
+        } else {
+            showError()
+        }
+    }
+
+    private func isValidURL(_ string: String) -> Bool {
+        guard let url = URL(string: string) else { return false }
+        return url.scheme == "http" || url.scheme == "https"
+    }
+
+    // MARK: - Save Flow
+
+    private func saveLink() {
+        guard let url = sharedURL else {
+            showError()
+            return
+        }
+
+        urlLabel.text = url
+
+        if SupabaseClient.shared.isAuthenticated {
+            // Try to save directly
+            Task {
+                do {
+                    _ = try await SupabaseClient.shared.addLink(url: url, title: sharedTitle)
+                    await showSuccess()
+                } catch {
+                    // Failed to save, queue it
+                    await queueLink(url: url, title: sharedTitle)
+                }
+            }
+        } else {
+            // Not authenticated, queue it
+            Task {
+                await queueLink(url: url, title: sharedTitle)
+            }
+        }
+    }
+
+    @MainActor
+    private func showSuccess() {
+        iconLabel.text = "✓"
+        statusLabel.text = "Saved to Boards"
+        fadeInAndDismiss()
+    }
+
+    @MainActor
+    private func queueLink(url: String, title: String?) {
+        QueueService.shared.enqueue(url: url, title: title)
+        iconLabel.text = "↑"
+        statusLabel.text = "Queued for sync"
+        fadeInAndDismiss()
+    }
+
+    @MainActor
+    private func showError() {
+        iconLabel.text = "✕"
+        statusLabel.text = "Unable to save"
+        urlLabel.text = "Please try again"
+        fadeInAndDismiss(delay: 2.0)
+    }
+
+    // MARK: - Animation & Dismissal
+
+    private func fadeInAndDismiss(delay: TimeInterval = 1.5) {
+        UIView.animate(withDuration: 0.3) {
+            self.iconLabel.alpha = 1.0
+            self.statusLabel.alpha = 1.0
+            self.urlLabel.alpha = 1.0
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+        }
+    }
+}

--- a/ios/Shared/Constants.swift
+++ b/ios/Shared/Constants.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum AppConstants {
+    static let supabaseURL = "https://yfhudwakpgzswiylhfbh.supabase.co"
+    static let supabaseAnonKey = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI"
+
+    static let appGroupID = "group.com.ctrlrodeo.boards"
+    static let authStorageKey = "supabase_auth"
+    static let queueStorageKey = "url_queue"
+
+    static let boardsURL = "https://ctrl.rodeo/boards/"
+    static let urlScheme = "ctrlrodeo"
+
+    // Matches the web app's localStorage key for Supabase auth
+    static let webAuthStorageKey = "sb-yfhudwakpgzswiylhfbh-auth-token"
+}

--- a/ios/Shared/Models.swift
+++ b/ios/Shared/Models.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// MARK: - Auth
+
+struct StoredAuth: Codable {
+    let accessToken: String
+    let refreshToken: String?
+    let user: AuthUser?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case user
+    }
+}
+
+struct AuthUser: Codable {
+    let id: String
+    let email: String?
+}
+
+// MARK: - Link
+
+struct LinkPayload: Codable {
+    let id: String
+    let userId: String
+    let url: String
+    let title: String
+    let description: String
+    let domain: String
+    let category: String
+    let createdAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case url, title, description, domain, category
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - Enrich Request
+
+struct EnrichRequest: Codable {
+    let url: String
+    let title: String?
+    let linkId: String?
+}
+
+// MARK: - Queue
+
+struct QueuedURL: Codable, Identifiable {
+    let id: String
+    let url: String
+    let title: String?
+    let queuedAt: Date
+
+    init(url: String, title: String?) {
+        self.id = UUID().uuidString
+        self.url = url
+        self.title = title
+        self.queuedAt = Date()
+    }
+}

--- a/ios/Shared/QueueService.swift
+++ b/ios/Shared/QueueService.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+final class QueueService {
+    static let shared = QueueService()
+
+    private let defaults: UserDefaults?
+
+    init() {
+        defaults = UserDefaults(suiteName: AppConstants.appGroupID)
+    }
+
+    // MARK: - Enqueue
+
+    func enqueue(url: String, title: String?) {
+        var queue = loadQueue()
+        queue.append(QueuedURL(url: url, title: title))
+        saveQueue(queue)
+    }
+
+    // MARK: - Dequeue
+
+    /// Returns all queued URLs and clears the queue.
+    func dequeueAll() -> [QueuedURL] {
+        let queue = loadQueue()
+        if !queue.isEmpty {
+            saveQueue([])
+        }
+        return queue
+    }
+
+    /// Returns the number of queued URLs without modifying the queue.
+    var count: Int {
+        loadQueue().count
+    }
+
+    // MARK: - Storage
+
+    private func loadQueue() -> [QueuedURL] {
+        guard let data = defaults?.data(forKey: AppConstants.queueStorageKey) else {
+            return []
+        }
+        return (try? JSONDecoder().decode([QueuedURL].self, from: data)) ?? []
+    }
+
+    private func saveQueue(_ queue: [QueuedURL]) {
+        guard let data = try? JSONEncoder().encode(queue) else { return }
+        defaults?.set(data, forKey: AppConstants.queueStorageKey)
+    }
+}

--- a/ios/Shared/SupabaseClient.swift
+++ b/ios/Shared/SupabaseClient.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+final class SupabaseClient {
+    static let shared = SupabaseClient()
+
+    private let session = URLSession.shared
+
+    // MARK: - Auth
+
+    func getStoredAuth() -> StoredAuth? {
+        guard let defaults = UserDefaults(suiteName: AppConstants.appGroupID),
+              let data = defaults.data(forKey: AppConstants.authStorageKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(StoredAuth.self, from: data)
+    }
+
+    func storeAuth(_ auth: StoredAuth) {
+        guard let defaults = UserDefaults(suiteName: AppConstants.appGroupID),
+              let data = try? JSONEncoder().encode(auth) else { return }
+        defaults.set(data, forKey: AppConstants.authStorageKey)
+    }
+
+    func clearAuth() {
+        guard let defaults = UserDefaults(suiteName: AppConstants.appGroupID) else { return }
+        defaults.removeObject(forKey: AppConstants.authStorageKey)
+    }
+
+    var isAuthenticated: Bool {
+        getStoredAuth() != nil
+    }
+
+    var accessToken: String? {
+        getStoredAuth()?.accessToken
+    }
+
+    var userId: String? {
+        getStoredAuth()?.user?.id
+    }
+
+    // MARK: - Add Link
+
+    /// Saves a link to Supabase and triggers enrichment. Returns the link ID.
+    func addLink(url linkURL: String, title: String? = nil) async throws -> String {
+        guard let token = accessToken, let userId = userId else {
+            throw SupabaseError.notAuthenticated
+        }
+
+        let domain = extractDomain(from: linkURL)
+        let linkId = "link_\(Int(Date().timeIntervalSince1970 * 1000))_\(Int.random(in: 1000...9999))"
+
+        let payload = LinkPayload(
+            id: linkId,
+            userId: userId,
+            url: linkURL,
+            title: title ?? domain,
+            description: "",
+            domain: domain,
+            category: "uncategorized",
+            createdAt: ISO8601DateFormatter().string(from: Date())
+        )
+
+        var request = makeRequest(path: "/rest/v1/links", method: "POST")
+        request.setValue("resolution=merge-duplicates", forHTTPHeaderField: "Prefer")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONEncoder().encode(payload)
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw SupabaseError.requestFailed
+        }
+
+        // Fire-and-forget enrichment
+        Task {
+            try? await enrichLink(linkId: linkId, url: linkURL, title: title)
+        }
+
+        return linkId
+    }
+
+    // MARK: - Enrich Link
+
+    func enrichLink(linkId: String, url: String, title: String?) async throws {
+        var request = makeRequest(path: "/functions/v1/enrich-link", method: "POST")
+        // enrich-link uses anon key for Authorization (not user token)
+        request.setValue("Bearer \(AppConstants.supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+
+        let body = EnrichRequest(url: url, title: title, linkId: linkId)
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw SupabaseError.enrichmentFailed
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeRequest(path: String, method: String) -> URLRequest {
+        let url = URL(string: "\(AppConstants.supabaseURL)\(path)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(AppConstants.supabaseAnonKey, forHTTPHeaderField: "apikey")
+        return request
+    }
+
+    private func extractDomain(from urlString: String) -> String {
+        guard let url = URL(string: urlString), let host = url.host else {
+            return urlString
+        }
+        return host.hasPrefix("www.") ? String(host.dropFirst(4)) : host
+    }
+}
+
+enum SupabaseError: LocalizedError {
+    case notAuthenticated
+    case requestFailed
+    case enrichmentFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated: return "Not signed in"
+        case .requestFailed: return "Failed to save link"
+        case .enrichmentFailed: return "Failed to enrich link"
+        }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,56 @@
+name: CtrlRodeo
+options:
+  bundleIdPrefix: com.ctrlrodeo
+  deploymentTarget:
+    iOS: "16.0"
+  xcodeVersion: "15.0"
+  createIntermediateGroups: true
+  defaultConfig: Release
+
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+
+targets:
+  CtrlRodeo:
+    type: application
+    platform: iOS
+    sources:
+      - path: CtrlRodeo
+      - path: Shared
+    info:
+      path: CtrlRodeo/Info.plist
+    entitlements:
+      path: CtrlRodeo/CtrlRodeo.entitlements
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ctrlrodeo.boards
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: ShareExtension
+
+  ShareExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: ShareExtension
+      - path: Shared
+    info:
+      path: ShareExtension/Info.plist
+    entitlements:
+      path: ShareExtension/ShareExtension.entitlements
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.ctrlrodeo.boards.share
+        CODE_SIGN_STYLE: Automatic
+        GENERATE_INFOPLIST_FILE: NO
+        SKIP_INSTALL: YES


### PR DESCRIPTION
## Summary
- Adds a minimal iOS app that wraps ctrl.rodeo/boards in a WKWebView
- Includes an iOS Share Extension so users can save URLs from any app (Safari, Twitter, etc.) directly into Boards
- Auth token bridges from web localStorage → App Group → Share Extension via injected JS bridge
- Offline queue: URLs shared while offline are queued and synced when the app next opens
- ~640 lines of Swift, no external dependencies

## Architecture
- **Main app**: SwiftUI shell with full-screen WKWebView loading the existing web app
- **Share Extension**: Calls Supabase REST API directly (no app launch required) for fast capture
- **Shared layer**: SupabaseClient, QueueService, Models shared between both targets via App Group
- **Auth bridge**: JS monkey-patches `localStorage.setItem` to post auth tokens to native via `messageHandlers`

## Files
```
ios/
├── CtrlRodeo/          # Main app (WKWebView + auth bridge)
├── ShareExtension/     # Share sheet (API call + offline queue)
├── Shared/             # Constants, Models, SupabaseClient, QueueService
└── project.yml         # XcodeGen spec → generates .xcodeproj
```

## Test plan
- [ ] Open `ios/CtrlRodeo.xcodeproj` in Xcode
- [ ] Build and run on iOS Simulator — should load ctrl.rodeo/boards
- [ ] Sign in via magic link in the web view
- [ ] Share a URL from Safari → "Save to Boards" appears in share sheet
- [ ] Verify link appears in Supabase `links` table
- [ ] Test offline: airplane mode → share URL → verify "Queued for sync" → go online → open app → verify sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)