### PR TITLE
Fix iOS entitlements and Share Extension plist

### DIFF
--- a/ios/CtrlRodeo/CtrlRodeo.entitlements
+++ b/ios/CtrlRodeo/CtrlRodeo.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.ctrlrodeo.boards</string>
+	</array>
+</dict>
 </plist>

--- a/ios/ShareExtension/Info.plist
+++ b/ios/ShareExtension/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Save to Boards</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -18,5 +20,22 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
 </dict>
 </plist>

--- a/ios/ShareExtension/ShareExtension.entitlements
+++ b/ios/ShareExtension/ShareExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.ctrlrodeo.boards</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
## Summary
- Restores App Group entitlements (`group.com.ctrlrodeo.boards`) to both targets — XcodeGen stripped them
- Restores `NSExtension` configuration in ShareExtension/Info.plist (activation rules, extension point, principal class)
- Without these, the Share Extension won't appear in the share sheet and auth bridging won't work

## Test plan
- [ ] Build in Xcode — verify no signing errors related to App Groups
- [ ] Share a URL from Safari — verify "Save to Boards" appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)