### PR TITLE
Document events source additions in changelog and project plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ For Notion sync and ops infrastructure changes, see [docs/infrastructure/ops-cha
 
 ---
 
+## [2026-02-14] - Events Aggregator: New Sources, RA GraphQL Fix & Multi-Source Tags
+
+### Added
+- **Gary's Guide event source** — `fetchGarysGuide()` scraper for tech/startup events (SF + NYC). Parses custom table layout with `font.ftitle > a` links, `font.fdescription` venue/address, and day headers. ~63 events per region.
+- **Bonobo Network event source** — `fetchBonobo()` scraper for social/community events (SF). Uses Squarespace JSON API (`?format=json`) with JSON-LD and HTML fallbacks. ~8 upcoming events.
+- **Tech and Social content types** — Added `tech` and `social` to `CONTENT_TYPES` with keyword-based detection in `detectEventType()` (tech: startup, hack, ai, demo day, pitch, etc.; social: mixer, happy hour, brunch, etc.)
+- **Multi-source tags** — Deduped events now show separate color-coded clickable tags per source instead of a single combined tag (e.g. `19hz` `RA` instead of `19hz + RA`)
+
+### Fixed
+- **Resident Advisor scraper** — RA is a SPA returning an empty 765-byte HTML shell. Rewrote `fetchRA()` to use RA's GraphQL API (`ra.co/graphql`, `eventListings` query). Returns ~72 events per area with full metadata. Added `__NEXT_DATA__` fallback.
+- **Edge function POST support** — `fetch-source` now accepts `method`, `body`, and `headers` params for server-side POST proxying (needed for RA GraphQL)
+- **Edge function domain allowlists** — Added `garysguide.com`, `bonobonetwork.com`, and `ra.co` to `fetch-source` and `enrich-event` ALLOWED_DOMAINS. Deployed both functions.
+
+### Changed
+- **CLAUDE.md autonomous operations** — Added rules: always merge PR to master when finished; always deploy updated Supabase edge functions after merge without asking
+
+### PRs
+- #64: Add Gary's Guide and Bonobo Network as event sources
+- #67: Fix Gary's Guide and Bonobo scrapers (parser + edge function deploy)
+- #68: Add auto-merge and auto-deploy rules to CLAUDE.md
+- #70: Fix Resident Advisor: use GraphQL API instead of HTML scraping
+- #78: Show separate source tags for deduped events
+
+---
+
 ## [2026-02-14] - Visual Standards System for Image Quality & Aesthetics
 
 ### Added

--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -1,7 +1,7 @@
 # Project Plan - ctrl.rodeo
 
 > Single source of truth for all features, stories, and tasks.
-> **Last Updated**: 2026-02-14 (Visual Standards System shipped, Phase 11 Instagram Import PRD added)
+> **Last Updated**: 2026-02-14 (Events: RA GraphQL, Gary's Guide, Bonobo sources + multi-source tags)
 
 ---
 
@@ -70,11 +70,17 @@
 - Loads manifest + registry, exposes `validate()`, `auditDOM()`, `annotate()` APIs
 
 ### Events Page ✅
-**Completed: 2026-02-09**
+**Completed: 2026-02-09 | Updated: 2026-02-14**
 
 - **Standalone events aggregator** at `/events/index.html`
 - ScreenSlate JSON API integration with day/week calendar views
 - Location filtering, source filtering with status chips, error handling
+- **Resident Advisor** — GraphQL API scraper (`eventListings` query, ~72 events/area)
+- **Gary's Guide** — Tech/startup events (SF + NYC, ~63 events/region via table parsing)
+- **Bonobo Network** — Social/community events (SF, ~8 events via Squarespace JSON)
+- **Tech & Social content types** with keyword detection
+- **Multi-source dedup tags** — events from multiple sources show separate color-coded tags
+- **Edge function POST proxy** — `fetch-source` supports custom method/body/headers for GraphQL
 
 ### Brand Positioning & Persona Framework ✅
 **Completed: 2026-02-08**


### PR DESCRIPTION
## Summary
- Added changelog entry covering PRs #64, #67, #68, #70, #78 (Gary's Guide, Bonobo, RA GraphQL, multi-source tags, CLAUDE.md rules)
- Updated project plan index Events Page section with new sources, content types, and infrastructure changes

## Test plan
- [ ] Verify CHANGELOG.md and project plan render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)