### PR TITLE
Fix organize modal button (broken function call)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -12904,7 +12904,7 @@ Return JSON:
   organizeModal.querySelector('.modal__close').onclick = () => closeModal(organizeModal);
 
   function renderOrganizeModal(link) {
-    const cats = getCategoryNames();
+    const cats = getCategories();
     const types = ['article', 'product', 'music', 'video', 'image', 'social', 'other'];
     let html = '<div style="padding: var(--space-4);">';
     html += '<label style="font-family: var(--font-mono); font-size: var(--font-size-sm); color: var(--muted); display: block; margin-bottom: var(--space-2);">Category</label>';


### PR DESCRIPTION
## Summary
- The Organize button in the card kebab menu did nothing — clicking it threw a silent `ReferenceError`
- Root cause: `renderOrganizeModal()` called `getCategoryNames()` which doesn't exist
- Fix: Changed to `getCategories()`, matching the pattern used by `openCategorySelect()`

## Test plan
- [ ] Expand a card → click kebab (⋮) → click Organize
- [ ] Verify modal opens showing categories and content types
- [ ] Click a category → verify card moves and toast confirms
- [ ] Click a content type → verify type updates and toast confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)