### PR TITLE
Fix enrichment backfill + Spotify link 404

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -61,7 +61,16 @@
       "Bash(git -C /Users/ian/Documents/GitHub/fikei.github.io push -u origin claude/docs-restructure-v2)",
       "Bash(gh pr close:*)",
       "Bash(git reset:*)",
-      "Bash(git branch:*)"
+      "Bash(supabase secrets set:*)",
+      "Bash(supabase db execute:*)",
+      "Bash(curl:*)",
+      "Bash(supabase functions logs:*)",
+      "WebFetch(domain:getsongbpm.com)",
+      "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon status:*)",
+      "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon add:*)",
+      "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon commit -m \"$\\(cat <<''EOF''\nfix: enrich-music improvements + client-side BPM lookup\n\nEdge function fixes:\n- Remove GetSongBPM from server-side \\(blocked by Cloudflare bot protection\\)\n- Fix MusicBrainz: filter results by artist name match, prefer original\n  album releases over compilations\n- Fix Last.fm: fall back to artist.getTopTags when track tags are empty,\n  also try track.getTopTags as intermediate step\n\nClient-side BPM \\(boards/index.html\\):\n- Add queryGetSongBPM\\(\\) at module scope — calls GetSongBPM API directly\n  from browser, bypassing Cloudflare bot protection\n- Step 6 split: 6a server enrichment \\(genre/label\\), 6b client BPM/key\n- Backfill v4: re-enriches links missing BPM/key/genre/label\n- Backfill Step 2 \\(server\\) + Step 3 \\(client BPM\\) with rate limiting\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
+      "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon push -u origin claude/fix-enrich-music-0dc05)",
+      "Bash(git stash:*)"
     ]
   }
 }

--- a/boards/index.html
+++ b/boards/index.html
@@ -9605,8 +9605,10 @@ Return JSON:
         'fbclid', 'gclid', 'twclid', 'msclkid', 'mc_cid', 'mc_eid', '_ga', '_gid', '_gl',
         'tw_source', 'tw_adid', 'sl_source_ad_platform', 'sl_source_campaign_id',
         'sl_source_placement', 'sl_source_ad_id', 'adset_name', 'ad_name', 'campaign_id', 'ad_id', 'media_type',
-        'ref', 'ref_src', 'ref_url', 'source', 'igshid', 'si', 'feature'];
+        'ref', 'ref_src', 'ref_url', 'source', 'igshid', 'feature'];
       for (const p of dominated) u.searchParams.delete(p);
+      // 'si' is a Spotify share identifier, not tracking - preserve for spotify.com
+      if (!u.hostname.includes('spotify.com')) u.searchParams.delete('si');
       return u.toString();
     } catch { return url; }
   }
@@ -10309,11 +10311,11 @@ Return JSON:
   }
 
   // ============================================
-  // Migration v4: Enrich listen links with music metadata + client-side BPM
+  // Migration v5: Enrich listen links - server genre/label + client-side BPM/key
   // ============================================
   // Backfills .music property on listen links that were migrated
   // before extractMusicMetadata existed.
-  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v4';
+  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v5';
 
   async function enrichListenLinks() {
     if (localStorage.getItem(LISTEN_ENRICH_KEY)) return;
@@ -10323,15 +10325,17 @@ Return JSON:
     const needsEnrich = allLinks.filter(l => {
       if (l.category !== 'listen') return false;
       if (!l.music || !l.music.artist) return true;  // Missing basic metadata
-      if (l.music.artist && l.music.trackTitle && (!l.music.bpm || !l.music.key || !l.music.genre || !l.music.label)) return true;  // Missing extended metadata
+      if (!l.music.trackTitle) return true;  // Has artist but no track title
+      if (!l.music.bpm || !l.music.key || !l.music.genre || !l.music.label) return true;  // Missing extended metadata
       return false;
     });
     if (needsEnrich.length === 0) {
+      console.log('%c[enrich-listen] v5: All listen links up to date', 'color: #1DB954');
       localStorage.setItem(LISTEN_ENRICH_KEY, Date.now().toString());
       return;
     }
 
-    console.log(`%c[enrich-listen] v3: Enriching ${needsEnrich.length} listen links`, 'color: #1DB954; font-weight: bold');
+    console.log(`%c[enrich-listen] v5: Enriching ${needsEnrich.length} listen links`, 'color: #1DB954; font-weight: bold');
 
     let enriched = 0;
     for (const link of needsEnrich) {


### PR DESCRIPTION
## Summary
- **Enrichment not running**: Filter missed links with artist but no trackTitle; silent exit with no log. Widened filter, added logging, bumped to v5
- **Spotify 404**: `cleanUrl()` stripped `si` param which Spotify needs. Now preserved for spotify.com

## Test plan
- [ ] Hard refresh boards — console shows `[enrich-listen] v5:` (enriching or "all up to date")
- [ ] Add Spotify URL `https://open.spotify.com/track/6isTmPPYrPkNmeqKydQm5k?si=15b209da16574f62` — no 404
- [ ] Check for `[getsongbpm]` and `[music-meta]` logs during enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)