### PR TITLE
Add native auth screen + Universal Links for iOS magic link login

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID.com.ctrlrodeo.boards",
+        "paths": [
+          "/boards/*"
+        ]
+      }
+    ]
+  }
+}

--- a/ios/CtrlRodeo.xcodeproj/project.pbxproj
+++ b/ios/CtrlRodeo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2809118237843E1E2049E8DE /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66BDECABB0154E8E7FE1A2DF /* Models.swift */; };
 		298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */; };
 		3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBCBB85AA0707A741D4EFA /* ContentView.swift */; };
+		5676404668741E19652BA07A /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B575A42CA03C308482965518 /* AuthView.swift */; };
 		6BB63DB10028F7F640E4F59A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
 		72663FD73C994D268DA29A27 /* QueueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89405C4E8B1D627ACA6871F1 /* QueueService.swift */; };
 		82BB846447A43DF78547DC25 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
@@ -57,6 +58,7 @@
 		976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CtrlRodeo.entitlements; sourceTree = "<group>"; };
 		9A112C46BE4BF03936FA33CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A6015C07711BF1587BCFBA10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B575A42CA03C308482965518 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
 		B8394AA45211749874523793 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CC870C2D6BE9AF4E017479FA /* CtrlRodeo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CtrlRodeo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF9DDCA70DD729557ADB4922 /* SupabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseClient.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				A6015C07711BF1587BCFBA10 /* Assets.xcassets */,
+				B575A42CA03C308482965518 /* AuthView.swift */,
 				31FBCBB85AA0707A741D4EFA /* ContentView.swift */,
 				976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */,
 				728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */,
@@ -224,6 +227,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5676404668741E19652BA07A /* AuthView.swift in Sources */,
 				82BB846447A43DF78547DC25 /* Constants.swift in Sources */,
 				3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */,
 				298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */,

--- a/ios/CtrlRodeo/AuthView.swift
+++ b/ios/CtrlRodeo/AuthView.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+
+struct AuthView: View {
+    let onAuthenticated: () -> Void
+    let onSkip: () -> Void
+
+    @State private var email = ""
+    @State private var isSending = false
+    @State private var didSend = false
+    @State private var errorMessage: String?
+
+    @FocusState private var emailFocused: Bool
+
+    var body: some View {
+        ZStack {
+            Theme.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                // Logo
+                Text("ctrl.rodeo")
+                    .font(.system(size: 32, weight: .bold, design: .monospaced))
+                    .foregroundColor(Theme.foreground)
+                    .padding(.bottom, 12)
+
+                // Tagline
+                VStack(spacing: 4) {
+                    Text("Your likes. Your saves.")
+                        .font(.system(size: 15))
+                        .foregroundColor(Theme.muted)
+                    Text("Your life \u{2014} organized.")
+                        .font(.system(size: 15))
+                        .foregroundColor(Theme.muted)
+                }
+                .padding(.bottom, 48)
+
+                if didSend {
+                    // Success state
+                    VStack(spacing: 16) {
+                        Image(systemName: "envelope.open")
+                            .font(.system(size: 36))
+                            .foregroundColor(Theme.foreground)
+
+                        Text("Check your email")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundColor(Theme.foreground)
+
+                        Text("We sent a magic link to\n\(email)")
+                            .font(.system(size: 14))
+                            .foregroundColor(Theme.muted)
+                            .multilineTextAlignment(.center)
+
+                        Button("Send again") {
+                            didSend = false
+                        }
+                        .font(.system(size: 14))
+                        .foregroundColor(Theme.muted)
+                        .padding(.top, 8)
+                    }
+                    .padding(.horizontal, 32)
+                } else {
+                    // Email input
+                    VStack(spacing: 16) {
+                        TextField("", text: $email, prompt: Text("email@example.com").foregroundColor(Color(hex: "#555555")))
+                            .textContentType(.emailAddress)
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .foregroundColor(Theme.foreground)
+                            .font(.system(size: 16))
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color(hex: "#333333"), lineWidth: 1)
+                            )
+                            .focused($emailFocused)
+
+                        // Send button
+                        Button(action: sendMagicLink) {
+                            Group {
+                                if isSending {
+                                    ProgressView()
+                                        .tint(Theme.background)
+                                } else {
+                                    Text("SEND MAGIC LINK")
+                                        .font(.system(size: 14, weight: .semibold))
+                                        .tracking(1)
+                                }
+                            }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                        }
+                        .foregroundColor(Theme.background)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(isValidEmail ? Theme.foreground : Color(hex: "#333333"))
+                        )
+                        .disabled(!isValidEmail || isSending)
+
+                        // Error message
+                        if let error = errorMessage {
+                            Text(error)
+                                .font(.system(size: 13))
+                                .foregroundColor(.red)
+                                .multilineTextAlignment(.center)
+                        }
+                    }
+                    .padding(.horizontal, 32)
+                }
+
+                Spacer()
+
+                // Divider
+                HStack(spacing: 12) {
+                    Rectangle()
+                        .fill(Color(hex: "#333333"))
+                        .frame(height: 1)
+                    Text("or")
+                        .font(.system(size: 13))
+                        .foregroundColor(Theme.muted)
+                    Rectangle()
+                        .fill(Color(hex: "#333333"))
+                        .frame(height: 1)
+                }
+                .padding(.horizontal, 32)
+                .padding(.bottom, 20)
+
+                // Skip button
+                Button(action: onSkip) {
+                    Text("CONTINUE WITHOUT LOGIN")
+                        .font(.system(size: 13, weight: .medium))
+                        .tracking(0.5)
+                        .foregroundColor(Theme.muted)
+                }
+                .padding(.bottom, 48)
+            }
+        }
+        .onAppear {
+            emailFocused = false
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isValidEmail: Bool {
+        let pattern = #"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return email.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private func sendMagicLink() {
+        guard isValidEmail else { return }
+
+        isSending = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await SupabaseClient.shared.sendMagicLink(email: email)
+                await MainActor.run {
+                    isSending = false
+                    didSend = true
+                }
+            } catch {
+                await MainActor.run {
+                    isSending = false
+                    errorMessage = "Failed to send. Check your email and try again."
+                }
+            }
+        }
+    }
+}

--- a/ios/CtrlRodeo/ContentView.swift
+++ b/ios/CtrlRodeo/ContentView.swift
@@ -1,7 +1,63 @@
 import SwiftUI
 import WebKit
 
+// MARK: - Root View
+
 struct ContentView: View {
+    @State private var isAuthenticated = SupabaseClient.shared.isAuthenticated
+    @State private var didSkipAuth = false
+    @State private var pendingAuthURL: URL? = nil
+
+    var body: some View {
+        Group {
+            if isAuthenticated || didSkipAuth {
+                BoardsWebView(
+                    isAuthenticated: $isAuthenticated,
+                    pendingAuthURL: $pendingAuthURL
+                )
+            } else {
+                AuthView(
+                    onAuthenticated: {
+                        isAuthenticated = true
+                    },
+                    onSkip: {
+                        didSkipAuth = true
+                    }
+                )
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("DeepLinkReceived"))) { notification in
+            guard let url = notification.userInfo?["url"] as? URL else { return }
+            handleAuthDeepLink(url)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("AuthStateChanged"))) { _ in
+            isAuthenticated = SupabaseClient.shared.isAuthenticated
+        }
+    }
+
+    private func handleAuthDeepLink(_ url: URL) {
+        print("[ContentView] handleAuthDeepLink: \(url)")
+
+        // Check if this is an auth callback (contains access_token in fragment or query)
+        let urlString = url.absoluteString
+        if urlString.contains("access_token") || urlString.contains("token_type") {
+            // Store the URL to pass to WebView for token extraction
+            pendingAuthURL = url
+
+            // If we're on the auth screen, skip to the web view so it can process the token
+            if !isAuthenticated && !didSkipAuth {
+                didSkipAuth = true
+            }
+        }
+    }
+}
+
+// MARK: - BoardsWebView
+
+struct BoardsWebView: View {
+    @Binding var isAuthenticated: Bool
+    @Binding var pendingAuthURL: URL?
+
     @State private var isRefreshing = false
     @State private var isLoading = true
     @State private var errorMessage: String? = nil
@@ -11,7 +67,9 @@ struct ContentView: View {
             WebView(
                 isRefreshing: $isRefreshing,
                 isLoading: $isLoading,
-                errorMessage: $errorMessage
+                errorMessage: $errorMessage,
+                isAuthenticated: $isAuthenticated,
+                pendingAuthURL: $pendingAuthURL
             )
             .ignoresSafeArea()
             .background(Theme.background)
@@ -63,6 +121,8 @@ struct WebView: UIViewRepresentable {
     @Binding var isRefreshing: Bool
     @Binding var isLoading: Bool
     @Binding var errorMessage: String?
+    @Binding var isAuthenticated: Bool
+    @Binding var pendingAuthURL: URL?
 
     func makeUIView(context: Context) -> WKWebView {
         print("[WebView] makeUIView: Creating WKWebView")
@@ -86,8 +146,14 @@ struct WebView: UIViewRepresentable {
         webView.scrollView.addSubview(refreshControl)
         context.coordinator.refreshControl = refreshControl
 
-        // Load the boards URL
-        if let url = URL(string: AppConstants.boardsURL) {
+        // Load the boards URL (or pending auth URL if we have one)
+        if let authURL = pendingAuthURL {
+            print("[WebView] makeUIView: Loading auth URL \(authURL)")
+            webView.load(URLRequest(url: authURL))
+            DispatchQueue.main.async {
+                pendingAuthURL = nil
+            }
+        } else if let url = URL(string: AppConstants.boardsURL) {
             print("[WebView] makeUIView: Loading URL \(url)")
             webView.load(URLRequest(url: url))
         }
@@ -118,13 +184,23 @@ struct WebView: UIViewRepresentable {
                 webView.load(URLRequest(url: url))
             }
         }
+
+        // Load pending auth URL if one arrived
+        if let authURL = pendingAuthURL {
+            print("[WebView] updateUIView: Loading pending auth URL \(authURL)")
+            webView.load(URLRequest(url: authURL))
+            DispatchQueue.main.async {
+                pendingAuthURL = nil
+            }
+        }
     }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
             isRefreshing: $isRefreshing,
             isLoading: $isLoading,
-            errorMessage: $errorMessage
+            errorMessage: $errorMessage,
+            isAuthenticated: $isAuthenticated
         )
     }
 
@@ -138,14 +214,16 @@ struct WebView: UIViewRepresentable {
         @Binding var isRefreshing: Bool
         @Binding var isLoading: Bool
         @Binding var errorMessage: String?
+        @Binding var isAuthenticated: Bool
 
         private var hasInjectedAuth = false
         private var hasProcessedQueue = false
 
-        init(isRefreshing: Binding<Bool>, isLoading: Binding<Bool>, errorMessage: Binding<String?>) {
+        init(isRefreshing: Binding<Bool>, isLoading: Binding<Bool>, errorMessage: Binding<String?>, isAuthenticated: Binding<Bool>) {
             _isRefreshing = isRefreshing
             _isLoading = isLoading
             _errorMessage = errorMessage
+            _isAuthenticated = isAuthenticated
         }
 
         // MARK: - Navigation Delegate
@@ -202,7 +280,12 @@ struct WebView: UIViewRepresentable {
 
             // Parse auth token from web and store in App Group
             if let auth = try? JSONDecoder().decode(StoredAuth.self, from: authData) {
+                print("[WebView] authBridge: Received auth token, storing...")
                 SupabaseClient.shared.storeAuth(auth)
+                isAuthenticated = true
+
+                // Notify other views that auth state changed
+                NotificationCenter.default.post(name: NSNotification.Name("AuthStateChanged"), object: nil)
             }
         }
 
@@ -292,6 +375,8 @@ struct WebView: UIViewRepresentable {
 
         @objc func handleDeepLink(_ notification: Notification) {
             guard let url = notification.userInfo?["url"] as? URL else { return }
+
+            print("[WebView] handleDeepLink: Loading URL \(url)")
 
             // Navigate to the deep link URL in the web view
             // This handles OAuth callbacks from Supabase

--- a/ios/CtrlRodeo/CtrlRodeo.entitlements
+++ b/ios/CtrlRodeo/CtrlRodeo.entitlements
@@ -6,5 +6,9 @@
 	<array>
 		<string>group.com.ctrlrodeo.boards</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:ctrl.rodeo</string>
+	</array>
 </dict>
 </plist>

--- a/ios/CtrlRodeo/CtrlRodeoApp.swift
+++ b/ios/CtrlRodeo/CtrlRodeoApp.swift
@@ -10,16 +10,19 @@ struct CtrlRodeoApp: App {
                 .onOpenURL { url in
                     handleDeepLink(url)
                 }
+                .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+                    // Handle Universal Links (https:// URLs that match apple-app-site-association)
+                    guard let url = activity.webpageURL else { return }
+                    print("[App] onContinueUserActivity: Universal Link received \(url)")
+                    handleDeepLink(url)
+                }
         }
     }
 
     private func handleDeepLink(_ url: URL) {
-        // Handle ctrlrodeo:// deep links (e.g., auth callbacks)
-        guard url.scheme == AppConstants.urlScheme else { return }
+        print("[App] handleDeepLink: \(url)")
 
-        // Auth callback from Supabase OAuth flow
-        // The web app will handle the actual token exchange
-        // We just need to pass it through to the WebView
+        // Post notification for ContentView/WebView to handle
         NotificationCenter.default.post(
             name: NSNotification.Name("DeepLinkReceived"),
             object: nil,

--- a/ios/Shared/SupabaseClient.swift
+++ b/ios/Shared/SupabaseClient.swift
@@ -94,6 +94,26 @@ final class SupabaseClient {
         }
     }
 
+    // MARK: - Magic Link (OTP)
+
+    /// Sends a magic link email via Supabase OTP endpoint
+    func sendMagicLink(email: String) async throws {
+        var request = makeRequest(path: "/auth/v1/otp", method: "POST")
+
+        let body: [String: Any] = [
+            "email": email,
+            "options": [
+                "emailRedirectTo": "\(AppConstants.boardsURL)"
+            ]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (_, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw SupabaseError.magicLinkFailed
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeRequest(path: String, method: String) -> URLRequest {
@@ -117,12 +137,14 @@ enum SupabaseError: LocalizedError {
     case notAuthenticated
     case requestFailed
     case enrichmentFailed
+    case magicLinkFailed
 
     var errorDescription: String? {
         switch self {
         case .notAuthenticated: return "Not signed in"
         case .requestFailed: return "Failed to save link"
         case .enrichmentFailed: return "Failed to enrich link"
+        case .magicLinkFailed: return "Failed to send magic link"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a native SwiftUI auth screen (`AuthView`) shown before the WebView when user is not logged in, with email input and "Send Magic Link" button that calls Supabase OTP endpoint directly
- Adds Universal Links support via `apple-app-site-association` file so magic link emails open in the iOS app instead of Safari
- Updates deep link handling to support both `ctrlrodeo://` URL scheme and `https://` Universal Links via `onContinueUserActivity`
- Adds "Continue without login" option to skip auth and load WebView immediately

## Test plan
- [ ] Launch app without stored auth → should see native auth screen (black bg, email field, send button)
- [ ] Enter email → tap "Send Magic Link" → should see "Check your email" confirmation
- [ ] Tap "Continue without login" → should skip to WebView with welcome screen
- [ ] **Replace `TEAMID` in `.well-known/apple-app-site-association` with actual Apple Developer Team ID**
- [ ] After deploying AASA file: tap magic link email on device → app opens (not Safari)
- [ ] App receives auth callback → transitions to WebView → user is logged in
- [ ] Kill and relaunch → still logged in (token persisted in App Group)
- [ ] Share Extension still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)