### PR TITLE
Revert .filters safe-area padding on desktop viewports

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -798,7 +798,7 @@ body {
   flex-wrap: nowrap;
   gap: var(--space-2);
   padding: var(--space-4);
-  padding-top: calc(48px + var(--safe-top)); /* Space for auth bar above */
+  padding-top: 48px; /* Space for auth bar above */
   padding-right: 120px; /* Space for auth bar - clips filters before profile button */
   border-bottom: 1px solid var(--subtle);
   position: sticky;


### PR DESCRIPTION
## Summary
- Removes `var(--safe-top)` from `.filters` padding-top on desktop (restores original `48px`)
- Keeps safe-area padding on mobile (`calc(52px + var(--safe-top))`) where the iOS app needs it

## Test plan
- [ ] Desktop/large viewport: filters nav height matches original (no extra top padding)
- [ ] iOS app (mobile viewport): filters still account for safe area inset

🤖 Generated with [Claude Code](https://claude.com/claude-code)