### PR TITLE
fix: YouTube links showing generic data

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9461,6 +9461,12 @@ Return JSON:
           }
         }
 
+        // Update title from oEmbed if server resolved a better one (e.g. YouTube)
+        if (result.title && (!link.title || link.title === extractDomain(link.url))) {
+          console.log('%c[ENRICH] Title updated from oEmbed:', 'color: #27ae60', result.title);
+          link.title = result.title;
+        }
+
         save(data);
 
         // Sync enrichment to Supabase (don't await — fire and forget)
@@ -9665,6 +9671,30 @@ Return JSON:
   async function fetchMetadata(url) {
     const domain = extractDomain(url);
     const meta = { url, title: domain, description: '', image: null, domain };
+
+    // YouTube/Vimeo: use noembed.com oEmbed (CORS-friendly) instead of CORS proxy
+    // YouTube blocks CORS proxies and returns generic "YouTube" page data
+    const oembedDomains = ['youtube.com', 'youtu.be', 'vimeo.com'];
+    if (oembedDomains.some(d => domain.includes(d))) {
+      try {
+        console.log('%c[METADATA] Using noembed oEmbed for:', 'color: #e67e22', url);
+        const oembedResp = await fetchWithTimeout(
+          `https://noembed.com/embed?url=${encodeURIComponent(url)}`, FETCH_TIMEOUT
+        );
+        if (oembedResp.ok) {
+          const data = await oembedResp.json();
+          if (data.title && !data.error) {
+            meta.title = data.title;
+            meta.description = data.author_name ? `By ${data.author_name}` : '';
+            if (data.thumbnail_url) meta.image = data.thumbnail_url;
+            console.log('%c[METADATA] oEmbed success:', 'color: #27ae60', meta.title);
+            return meta;
+          }
+        }
+      } catch (e) {
+        console.warn('[METADATA] oEmbed failed, falling back to CORS proxy:', e.message);
+      }
+    }
 
     // Clean URL to remove tracking params (makes fetch faster)
     const fetchUrl = cleanUrl(url);

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -40,7 +40,7 @@ serve(async (req) => {
   }
 
   try {
-    const { url, title, description, linkId, skipClassification, skipImage,
+    let { url, title, description, linkId, skipClassification, skipImage,
             skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, category } = await req.json()
 
     // Support skipIfHasImage: skip image resolution if client already has a valid image
@@ -57,6 +57,24 @@ serve(async (req) => {
 
     const domain = new URL(url).hostname.replace('www.', '')
     const path = new URL(url).pathname
+
+    // ========================================
+    // STEP 0: oEmbed title resolution for platforms that block scraping
+    // YouTube returns generic "YouTube" page data to CORS proxies/scrapers.
+    // Use oEmbed to get real video title, author, and thumbnail.
+    // ========================================
+    const oembedTitle = await resolveOembedMetadata(url, domain)
+    if (oembedTitle) {
+      // Only override if title is missing or generic
+      const genericTitles = ['youtube', 'vimeo', 'watch', '']
+      if (!title || genericTitles.includes(title.toLowerCase().trim())) {
+        console.log('[enrich-link] oEmbed resolved title:', oembedTitle.title)
+        title = oembedTitle.title
+      }
+      if (!description && oembedTitle.author) {
+        description = `By ${oembedTitle.author}`
+      }
+    }
 
     let contentType = 'unknown'
     let typeConfidence = 0
@@ -341,6 +359,10 @@ serve(async (req) => {
         image_source: imageSource,
         image_resolved_at: new Date().toISOString()
       }
+      // Save oEmbed-resolved title to DB (overrides generic "YouTube" etc.)
+      if (oembedTitle) {
+        updatePayload.title = title
+      }
       if (imageScores) {
         updatePayload.image_scores = imageScores
       }
@@ -381,6 +403,11 @@ serve(async (req) => {
       image_resolution_log: imageResolutionLog,
       cached
     }
+    // Include oEmbed-resolved title so client can update its stored data
+    if (oembedTitle) {
+      response.title = title
+      if (oembedTitle.author) response.author = oembedTitle.author
+    }
     if (videoMeta) {
       response.video = videoMeta
     }
@@ -403,6 +430,58 @@ serve(async (req) => {
     )
   }
 })
+
+// ========================================
+// oEmbed Metadata Resolution (YouTube, Vimeo)
+// ========================================
+async function resolveOembedMetadata(
+  url: string,
+  domain: string
+): Promise<{ title: string, author: string | null, thumbnail: string | null } | null> {
+  // YouTube oEmbed (server-side, no CORS issues)
+  if (domain.includes('youtube.com') || domain.includes('youtu.be')) {
+    try {
+      const resp = await fetch(
+        `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        if (data.title) {
+          return {
+            title: data.title,
+            author: data.author_name || null,
+            thumbnail: data.thumbnail_url || null
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[oembed] YouTube oEmbed error:', e)
+    }
+  }
+
+  // Vimeo oEmbed
+  if (domain.includes('vimeo.com')) {
+    try {
+      const resp = await fetch(
+        `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(url)}`
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        if (data.title) {
+          return {
+            title: data.title,
+            author: data.author_name || null,
+            thumbnail: data.thumbnail_url || null
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[oembed] Vimeo oEmbed error:', e)
+    }
+  }
+
+  return null
+}
 
 // ========================================
 // AI Classification using Anthropic


### PR DESCRIPTION
## Summary
- YouTube links were showing generic "YouTube" title, logo, and description instead of actual video metadata
- Root cause: YouTube blocks CORS proxy scraping, returning its generic landing page instead of the actual video page
- Fix: Added oEmbed API integration at both client and server layers

## Changes
- **Client** (`boards/index.html`): For YouTube/Vimeo URLs, call `noembed.com` oEmbed API (CORS-friendly) to get real title, author, and thumbnail before falling back to CORS proxy
- **Server** (`enrich-link/index.ts`): Added `resolveOembedMetadata()` that calls YouTube/Vimeo oEmbed APIs directly to resolve titles when the client passes generic data. Resolved titles are persisted to DB and returned to client.

## Test plan
- [ ] Add a YouTube video link (e.g. `https://www.youtube.com/watch?v=dQw4w9WgXcQ`) — should show actual video title and thumbnail
- [ ] Add a youtu.be short link — should also resolve correctly
- [ ] Add a Vimeo link — should resolve via oEmbed
- [ ] Add a non-video link — should still work via CORS proxy as before
- [ ] Test with a private/deleted YouTube video — should fall back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)