### PR TITLE
Fix URL lowercasing + bump enrichment v6

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9584,12 +9584,17 @@ Return JSON:
 
   function normalizeUrl(url) {
     if (!url) return null;
-    let n = url.trim().toLowerCase();
-    if (!n.startsWith('http://') && !n.startsWith('https://')) {
+    let n = url.trim();
+    // Case-insensitive protocol check (don't lowercase entire URL -- path is case-sensitive per RFC 3986)
+    if (!/^https?:\/\//i.test(n)) {
       n = 'https://' + n;
     }
     n = n.replace(/\/+$/, '');
-    try { new URL(n); return n; } catch { return null; }
+    try {
+      const u = new URL(n);
+      // URL constructor normalizes scheme+host to lowercase, preserves path/query/fragment case
+      return u.toString().replace(/\/+$/, '');
+    } catch { return null; }
   }
 
   function extractDomain(url) {
@@ -10348,11 +10353,11 @@ Return JSON:
   }
 
   // ============================================
-  // Migration v5: Enrich listen links - server genre/label + client-side BPM/key
+  // Migration v6: Enrich listen links - fix URL case preservation + re-trigger enrichment
   // ============================================
   // Backfills .music property on listen links that were migrated
   // before extractMusicMetadata existed.
-  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v5';
+  const LISTEN_ENRICH_KEY = 'boards-listen-enrich-v6';
 
   async function enrichListenLinks() {
     if (localStorage.getItem(LISTEN_ENRICH_KEY)) return;
@@ -10367,12 +10372,12 @@ Return JSON:
       return false;
     });
     if (needsEnrich.length === 0) {
-      console.log('%c[enrich-listen] v5: All listen links up to date', 'color: #1DB954');
+      console.log('%c[enrich-listen] v6: All listen links up to date', 'color: #1DB954');
       localStorage.setItem(LISTEN_ENRICH_KEY, Date.now().toString());
       return;
     }
 
-    console.log(`%c[enrich-listen] v5: Enriching ${needsEnrich.length} listen links`, 'color: #1DB954; font-weight: bold');
+    console.log(`%c[enrich-listen] v6: Enriching ${needsEnrich.length} listen links`, 'color: #1DB954; font-weight: bold');
 
     let enriched = 0;
     for (const link of needsEnrich) {
@@ -10850,8 +10855,9 @@ Return JSON:
   function getCategories() { return load().categories; }
 
   function findByUrl(url) {
-    const n = url.toLowerCase().replace(/\/+$/, '');
-    return getAllLinks().find(l => l.url.toLowerCase().replace(/\/+$/, '') === n);
+    const n = normalizeUrl(url);
+    if (!n) return null;
+    return getAllLinks().find(l => normalizeUrl(l.url) === n);
   }
 
   function addLink(link) {


### PR DESCRIPTION
## Summary
- **Fix `normalizeUrl()` URL lowercasing** — was lowercasing the entire URL including path, breaking case-sensitive URLs like Spotify track IDs (`6isTmPPYrPkNmeqKydQm5k` → `6istmppyrpknmeqkydqm5k`). Now uses `URL` constructor which normalizes only scheme+host per RFC 3986.
- **Fix `findByUrl()` comparison** — uses `normalizeUrl()` for consistent URL comparison instead of ad-hoc `.toLowerCase()`
- **Bump enrichment to v6** — forces re-run of listen link enrichment after URL fix (v5 ran with broken lowercased URLs)

## Context
Console logs showed URLs being stored lowercased, causing Spotify 404s and failed enrichment. The `normalizeUrl()` function was doing `url.trim().toLowerCase()` on the entire URL. Per RFC 3986, only scheme and host are case-insensitive.

## Also needed (deployment)
- Redeploy `enrich-link` with `--no-verify-jwt` to fix 401 Unauthorized

## Test plan
- [ ] Hard refresh ctrl.rodeo/boards/
- [ ] Delete broken Spotify link (lowercased URL)
- [ ] Re-add: `https://open.spotify.com/track/6isTmPPYrPkNmeqKydQm5k?si=15b209da16574f62`
- [ ] Verify URL stored with preserved case
- [ ] Check `[enrich-listen] v6:` log appears
- [ ] Check enrichment succeeds (BPM/Key/Genre appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)