### PR TITLE
Build iOS design system components, rewrite auth screen

### DIFF
--- a/ios/CtrlRodeo.xcodeproj/project.pbxproj
+++ b/ios/CtrlRodeo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */; };
 		3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FBCBB85AA0707A741D4EFA /* ContentView.swift */; };
 		5676404668741E19652BA07A /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B575A42CA03C308482965518 /* AuthView.swift */; };
+		6B23CAC8F28A2018BBC2C35D /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DDE541E441806054DBA9D4 /* DesignSystem.swift */; };
 		6BB63DB10028F7F640E4F59A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
 		72663FD73C994D268DA29A27 /* QueueService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89405C4E8B1D627ACA6871F1 /* QueueService.swift */; };
 		82BB846447A43DF78547DC25 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26338682C91C387B8F02C931 /* Constants.swift */; };
@@ -55,6 +56,7 @@
 		71BA850935A1BD210899C8BE /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlRodeoApp.swift; sourceTree = "<group>"; };
 		89405C4E8B1D627ACA6871F1 /* QueueService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueService.swift; sourceTree = "<group>"; };
+		94DDE541E441806054DBA9D4 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CtrlRodeo.entitlements; sourceTree = "<group>"; };
 		9A112C46BE4BF03936FA33CE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A6015C07711BF1587BCFBA10 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 				31FBCBB85AA0707A741D4EFA /* ContentView.swift */,
 				976FCC7260A1776E53897CC8 /* CtrlRodeo.entitlements */,
 				728A6379CF1F0B47A362A0D1 /* CtrlRodeoApp.swift */,
+				94DDE541E441806054DBA9D4 /* DesignSystem.swift */,
 				9A112C46BE4BF03936FA33CE /* Info.plist */,
 				71BA850935A1BD210899C8BE /* Theme.swift */,
 			);
@@ -231,6 +234,7 @@
 				82BB846447A43DF78547DC25 /* Constants.swift in Sources */,
 				3FFAC662A702D29683D4DA01 /* ContentView.swift in Sources */,
 				298DFAC43025203989E65020 /* CtrlRodeoApp.swift in Sources */,
+				6B23CAC8F28A2018BBC2C35D /* DesignSystem.swift in Sources */,
 				886C46A480D7A3BCCBB4B450 /* Models.swift in Sources */,
 				AAFDFA1C77F0973A2BB1A75A /* QueueService.swift in Sources */,
 				F6FA76D0AD6549E2B174B376 /* SupabaseClient.swift in Sources */,

--- a/ios/CtrlRodeo/AuthView.swift
+++ b/ios/CtrlRodeo/AuthView.swift
@@ -9,8 +9,6 @@ struct AuthView: View {
     @State private var didSend = false
     @State private var errorMessage: String?
 
-    @FocusState private var emailFocused: Bool
-
     var body: some View {
         ZStack {
             Theme.background
@@ -19,143 +17,94 @@ struct AuthView: View {
             VStack(spacing: 0) {
                 Spacer()
 
-                // Logo
-                Text("boards")
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundColor(Theme.foreground)
-                    .padding(.bottom, 8)
+                // Logo — Georgia serif, matching web display text
+                DSText("boards", style: .display)
+                    .padding(.bottom, Theme.space6)
 
-                // Tagline
-                VStack(spacing: 2) {
-                    Text("Your likes. Your saves.")
-                        .textCase(.uppercase)
-                        .tracking(1)
-                    Text("Your life \u{2014} organized.")
-                        .textCase(.uppercase)
-                        .tracking(1)
+                // Tagline — uppercase label style
+                VStack(spacing: Theme.space1) {
+                    DSText("Your likes. Your saves.", style: .label)
+                    DSText("Your life \u{2014} organized.", style: .label)
                 }
-                .font(.system(size: 10))
-                .foregroundColor(Theme.muted)
-                .padding(.bottom, 32)
+                .padding(.bottom, Theme.space10)
 
                 if didSend {
-                    // Success state
-                    VStack(spacing: 12) {
-                        Image(systemName: "envelope.open")
-                            .font(.system(size: 24))
-                            .foregroundColor(Theme.foreground)
-
-                        Text("CHECK YOUR EMAIL")
-                            .font(.system(size: 10))
-                            .tracking(1)
-                            .foregroundColor(Theme.foreground)
-
-                        Text("We sent a magic link to\n\(email)")
-                            .font(.system(size: 10))
-                            .foregroundColor(Theme.muted)
-                            .multilineTextAlignment(.center)
-
-                        Button(action: { didSend = false }) {
-                            Text("SEND AGAIN")
-                                .font(.system(size: 10))
-                                .tracking(0.5)
-                                .foregroundColor(Theme.muted)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(
-                                    Rectangle()
-                                        .stroke(Theme.borderSubtle, lineWidth: 1)
-                                )
-                        }
-                        .padding(.top, 4)
-                    }
-                    .padding(.horizontal, 32)
+                    successState
                 } else {
-                    // Email input
-                    VStack(spacing: 16) {
-                        TextField("", text: $email, prompt: Text("email@example.com").foregroundColor(Theme.placeholder))
-                            .textContentType(.emailAddress)
-                            .keyboardType(.emailAddress)
-                            .autocapitalization(.none)
-                            .disableAutocorrection(true)
-                            .foregroundColor(Theme.foreground)
-                            .font(.system(size: 10))
-                            .padding(12)
-                            .background(
-                                Rectangle()
-                                    .stroke(Theme.foreground, lineWidth: 1)
-                            )
-                            .focused($emailFocused)
-
-                        // Send button
-                        Button(action: sendMagicLink) {
-                            Group {
-                                if isSending {
-                                    ProgressView()
-                                        .tint(isValidEmail ? Theme.background : Theme.subtle)
-                                } else {
-                                    Text("SEND MAGIC LINK")
-                                        .font(.system(size: 10))
-                                        .tracking(0.5)
-                                }
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 8)
-                        }
-                        .foregroundColor(isValidEmail ? Theme.background : Theme.subtle)
-                        .background(
-                            ZStack {
-                                if isValidEmail {
-                                    Rectangle().fill(Theme.foreground)
-                                } else {
-                                    Rectangle().stroke(Theme.borderSubtle, lineWidth: 1)
-                                }
-                            }
-                        )
-                        .disabled(!isValidEmail || isSending)
-
-                        // Error message
-                        if let error = errorMessage {
-                            Text(error)
-                                .font(.system(size: 10))
-                                .foregroundColor(.red)
-                                .multilineTextAlignment(.center)
-                        }
-                    }
-                    .padding(.horizontal, 32)
+                    emailInputState
                 }
 
                 Spacer()
 
                 // Divider
-                HStack(spacing: 12) {
-                    Rectangle()
-                        .fill(Theme.borderSubtle)
-                        .frame(height: 1)
-                    Text("OR")
-                        .font(.system(size: 10))
-                        .tracking(0.5)
-                        .foregroundColor(Theme.muted)
-                    Rectangle()
-                        .fill(Theme.borderSubtle)
-                        .frame(height: 1)
-                }
-                .padding(.horizontal, 32)
-                .padding(.bottom, 16)
+                DSDivider(label: "or")
+                    .padding(.horizontal, Theme.space8)
+                    .padding(.bottom, Theme.space4)
 
-                // Skip button
-                Button(action: onSkip) {
-                    Text("CONTINUE WITHOUT LOGIN")
-                        .font(.system(size: 10))
-                        .tracking(1)
-                        .foregroundColor(Theme.subtle)
-                }
-                .padding(.bottom, 48)
+                // Skip — ghost button, no border
+                DSButton(
+                    title: "Continue without login",
+                    action: onSkip,
+                    variant: .ghost,
+                    size: .small
+                )
+                .padding(.bottom, Theme.space12)
             }
         }
-        .onAppear {
-            emailFocused = false
+    }
+
+    // MARK: - Success State
+
+    private var successState: some View {
+        VStack(spacing: Theme.space3) {
+            Image(systemName: "envelope.open")
+                .font(.system(size: Theme.text3XL))
+                .foregroundColor(Theme.foreground)
+
+            DSText("Check your email", style: .title)
+
+            DSText("We sent a magic link to \(email)", style: .meta)
+                .multilineTextAlignment(.center)
+
+            DSButton(
+                title: "Send again",
+                action: { didSend = false },
+                variant: .outlined,
+                size: .small
+            )
+            .padding(.top, Theme.space1)
         }
+        .padding(.horizontal, Theme.space8)
+    }
+
+    // MARK: - Email Input State
+
+    private var emailInputState: some View {
+        VStack(spacing: Theme.space4) {
+            DSInput(
+                placeholder: "email@example.com",
+                text: $email,
+                keyboardType: .emailAddress,
+                textContentType: .emailAddress
+            )
+
+            DSButton(
+                title: "Send magic link",
+                action: sendMagicLink,
+                variant: .filled,
+                fullWidth: true,
+                disabled: !isValidEmail,
+                loading: isSending
+            )
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.system(size: Theme.textXS))
+                    .foregroundColor(Theme.error)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(.horizontal, Theme.space8)
     }
 
     // MARK: - Helpers

--- a/ios/CtrlRodeo/ContentView.swift
+++ b/ios/CtrlRodeo/ContentView.swift
@@ -91,22 +91,15 @@ struct BoardsWebView: View {
                     Theme.background
                         .ignoresSafeArea()
 
-                    VStack(spacing: 20) {
-                        Text(error)
-                            .foregroundColor(Theme.foreground)
+                    VStack(spacing: Theme.space5) {
+                        DSText(error, style: .meta)
                             .multilineTextAlignment(.center)
                             .padding()
 
-                        Button("Retry") {
-                            errorMessage = nil
-                            // Will trigger reload via binding in WebView
-                        }
-                        .foregroundColor(Theme.foreground)
-                        .padding(.horizontal, 32)
-                        .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .stroke(Theme.foreground, lineWidth: 1)
+                        DSButton(
+                            title: "Retry",
+                            action: { errorMessage = nil },
+                            variant: .outlined
                         )
                     }
                 }

--- a/ios/CtrlRodeo/DesignSystem.swift
+++ b/ios/CtrlRodeo/DesignSystem.swift
@@ -1,0 +1,303 @@
+import SwiftUI
+
+// MARK: - DSText
+
+/// Typography component matching the web design system hierarchy.
+///
+/// Styles map to web CSS:
+/// - `.display` → Georgia 24pt (--text-3xl + --font-serif)
+/// - `.title` → System 12pt bold uppercase (`.w-text--title`)
+/// - `.body` → System 10pt (--text-xs)
+/// - `.label` → System 10pt uppercase muted (`.w-text--label`)
+/// - `.meta` → System 10pt muted (`.w-text--meta`)
+/// - `.tiny` → System 8pt (--text-2xs)
+enum DSTextStyle {
+    case display
+    case title
+    case body
+    case label
+    case meta
+    case tiny
+}
+
+struct DSText: View {
+    let text: String
+    let style: DSTextStyle
+
+    init(_ text: String, style: DSTextStyle = .body) {
+        self.text = text
+        self.style = style
+    }
+
+    var body: some View {
+        switch style {
+        case .display:
+            Text(text)
+                .font(.custom(Theme.fontSerif, size: Theme.text3XL))
+                .foregroundColor(Theme.foreground)
+
+        case .title:
+            Text(text.uppercased())
+                .font(.system(size: Theme.textLG, weight: .bold))
+                .tracking(Theme.trackingWide)
+                .foregroundColor(Theme.foreground)
+
+        case .body:
+            Text(text)
+                .font(.system(size: Theme.textXS))
+                .foregroundColor(Theme.foreground)
+
+        case .label:
+            Text(text.uppercased())
+                .font(.system(size: Theme.textXS))
+                .tracking(Theme.trackingWider)
+                .foregroundColor(Theme.muted)
+
+        case .meta:
+            Text(text)
+                .font(.system(size: Theme.textXS))
+                .foregroundColor(Theme.muted)
+
+        case .tiny:
+            Text(text)
+                .font(.system(size: Theme.text2XS))
+                .foregroundColor(Theme.subtle)
+        }
+    }
+}
+
+// MARK: - DSButton
+
+/// Button component mirroring the web `.btn` class.
+///
+/// Variants:
+/// - `.outlined` → transparent bg, 1px white border (web `.btn`)
+/// - `.filled` → white bg, black text (web `.btn--filled`, `.auth-modal__submit`)
+/// - `.ghost` → no border, text only (web `.btn--ghost`)
+///
+/// All text is uppercase, bold, with 0.05em tracking.
+/// Sharp corners (0 radius). Inverts on press.
+enum DSButtonVariant {
+    case outlined
+    case filled
+    case ghost
+}
+
+enum DSButtonSize {
+    case small    // 4/12 padding, 8pt font — web .btn--sm
+    case regular  // 8/16 padding, 10pt font — web .btn
+    case large    // 12/24 padding, 10pt font — web .btn--lg
+}
+
+struct DSButton: View {
+    let title: String
+    let action: () -> Void
+    var variant: DSButtonVariant = .outlined
+    var size: DSButtonSize = .regular
+    var fullWidth: Bool = false
+    var disabled: Bool = false
+    var loading: Bool = false
+
+    @State private var isPressed = false
+
+    var body: some View {
+        Button(action: {
+            if !disabled && !loading { action() }
+        }) {
+            Group {
+                if loading {
+                    ProgressView()
+                        .tint(textColor)
+                } else {
+                    Text(title.uppercased())
+                        .font(.system(size: fontSize, weight: .bold))
+                        .tracking(Theme.trackingWide)
+                }
+            }
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .foregroundColor(textColor)
+        .background(backgroundColor)
+        .overlay(borderOverlay)
+        .opacity(disabled ? 0.5 : 1.0)
+        .disabled(disabled || loading)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in withAnimation(.easeInOut(duration: Theme.durationFast)) { isPressed = true } }
+                .onEnded { _ in withAnimation(.easeInOut(duration: Theme.durationFast)) { isPressed = false } }
+        )
+    }
+
+    // MARK: - Sizing
+
+    private var fontSize: CGFloat {
+        size == .small ? Theme.text2XS : Theme.textXS
+    }
+
+    private var verticalPadding: CGFloat {
+        switch size {
+        case .small: return Theme.space1
+        case .regular: return Theme.space2
+        case .large: return Theme.space3
+        }
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch size {
+        case .small: return Theme.space3
+        case .regular: return Theme.space4
+        case .large: return Theme.space6
+        }
+    }
+
+    // MARK: - Colors
+
+    private var backgroundColor: Color {
+        switch variant {
+        case .outlined:
+            return isPressed ? Theme.foreground : .clear
+        case .filled:
+            return isPressed ? .clear : Theme.foreground
+        case .ghost:
+            return .clear
+        }
+    }
+
+    private var textColor: Color {
+        switch variant {
+        case .outlined:
+            return isPressed ? Theme.surface : Theme.foreground
+        case .filled:
+            return isPressed ? Theme.foreground : Theme.surface
+        case .ghost:
+            return Theme.foreground
+        }
+    }
+
+    @ViewBuilder
+    private var borderOverlay: some View {
+        switch variant {
+        case .outlined, .filled:
+            Rectangle().stroke(Theme.foreground, lineWidth: 1)
+        case .ghost:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - DSInput
+
+/// Text input matching the web `.auth-modal__input`.
+///
+/// - padding: 12px, font: 10pt
+/// - bg: surface (#111), border: 1px white
+/// - Focus: double-border glow (web `box-shadow: 0 0 0 1px #fff`)
+struct DSInput: View {
+    let placeholder: String
+    @Binding var text: String
+    var keyboardType: UIKeyboardType = .default
+    var textContentType: UITextContentType? = nil
+
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        TextField("", text: $text, prompt:
+            Text(placeholder)
+                .font(.system(size: Theme.textXS))
+                .foregroundColor(Theme.placeholder)
+        )
+        .textContentType(textContentType)
+        .keyboardType(keyboardType)
+        .textInputAutocapitalization(.never)
+        .disableAutocorrection(true)
+        .font(.system(size: Theme.textXS))
+        .foregroundColor(Theme.foreground)
+        .padding(Theme.space3)
+        .background(Theme.surface)
+        .overlay(
+            Rectangle()
+                .stroke(Theme.foreground, lineWidth: isFocused ? 2 : 1)
+        )
+        .focused($isFocused)
+    }
+}
+
+// MARK: - DSDivider
+
+/// Horizontal divider with optional centered label.
+/// Line color: borderSubtle (#333). Label: 10pt uppercase muted.
+struct DSDivider: View {
+    var label: String? = nil
+
+    var body: some View {
+        HStack(spacing: Theme.space3) {
+            Rectangle()
+                .fill(Theme.borderSubtle)
+                .frame(height: 1)
+
+            if let label = label {
+                Text(label.uppercased())
+                    .font(.system(size: Theme.textXS))
+                    .tracking(Theme.trackingWide)
+                    .foregroundColor(Theme.muted)
+            }
+
+            if label != nil {
+                Rectangle()
+                    .fill(Theme.borderSubtle)
+                    .frame(height: 1)
+            }
+        }
+    }
+}
+
+// MARK: - DSSurface
+
+/// Container with background and border matching web surface patterns.
+///
+/// Variants:
+/// - `.standard` → bg #111, 1px white border (web `.modal__content`)
+/// - `.subtle` → bg #1a1a1a, 1px #333 border (web `.grid-item`, `.w-body`)
+/// - `.elevated` → bg #222, 1px #333 border
+enum DSSurfaceVariant {
+    case standard
+    case subtle
+    case elevated
+}
+
+struct DSSurface<Content: View>: View {
+    let variant: DSSurfaceVariant
+    let content: Content
+
+    init(_ variant: DSSurfaceVariant = .standard, @ViewBuilder content: () -> Content) {
+        self.variant = variant
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .background(backgroundColor)
+            .overlay(
+                Rectangle()
+                    .stroke(borderColor, lineWidth: 1)
+            )
+    }
+
+    private var backgroundColor: Color {
+        switch variant {
+        case .standard: return Theme.surface
+        case .subtle: return Theme.surfaceCard
+        case .elevated: return Theme.elevated
+        }
+    }
+
+    private var borderColor: Color {
+        switch variant {
+        case .standard: return Theme.foreground
+        case .subtle, .elevated: return Theme.borderSubtle
+        }
+    }
+}

--- a/ios/CtrlRodeo/Theme.swift
+++ b/ios/CtrlRodeo/Theme.swift
@@ -1,15 +1,65 @@
 import SwiftUI
 
 enum Theme {
-    // Core colors matching ctrl.rodeo design tokens
-    static let background = Color(hex: "#000000")
-    static let foreground = Color(hex: "#FFFFFF")
-    static let surface = Color(hex: "#111111")
-    static let muted = Color(hex: "#888888")
-    static let subtle = Color(hex: "#666666")       // --fg-subtle
-    static let elevated = Color(hex: "#222222")      // --bg-elevated
-    static let borderSubtle = Color(hex: "#333333")  // --border-subtle
-    static let placeholder = Color(hex: "#555555")   // input placeholders
+    // MARK: - Colors
+
+    // Core
+    static let background = Color(hex: "#000000")    // --color-black (app bg)
+    static let foreground = Color(hex: "#FFFFFF")     // --color-white (primary text, borders)
+    static let surface = Color(hex: "#111111")        // --bg / --gray-100 (content bg)
+    static let muted = Color(hex: "#888888")          // --fg-muted / --gray-600
+    static let subtle = Color(hex: "#666666")         // --fg-subtle / --gray-500
+    static let elevated = Color(hex: "#222222")       // --bg-elevated / --gray-300
+    static let borderSubtle = Color(hex: "#333333")   // --border-subtle / --gray-400
+    static let placeholder = Color(hex: "#555555")    // input placeholders
+    static let surfaceCard = Color(hex: "#1A1A1A")    // --bg-surface / --gray-200
+
+    // Status
+    static let error = Color(hex: "#CC0000")          // --color-error
+    static let success = Color(hex: "#00FF00")        // --color-success
+    static let warning = Color(hex: "#FF9900")        // --color-warning
+
+    // MARK: - Typography
+
+    // Font families
+    static let fontSerif = "Georgia"                  // --font-serif (display text)
+    // System font (SF Pro) used for all interface text (Space Grotesk equivalent)
+
+    // Font sizes
+    static let text2XS: CGFloat = 8                   // --text-2xs (badges, tiny labels)
+    static let textXS: CGFloat = 10                   // --text-xs (buttons, labels, body)
+    static let textLG: CGFloat = 12                   // --text-lg (titles)
+    static let textXL: CGFloat = 14                   // --text-xl (section titles)
+    static let text2XL: CGFloat = 18                  // --text-2xl (modal titles)
+    static let text3XL: CGFloat = 24                  // --text-3xl (display text)
+
+    // Letter spacing (em → pt conversion at 10pt base)
+    static let trackingWide: CGFloat = 0.5            // 0.05em — buttons, titles
+    static let trackingWider: CGFloat = 1.0           // 0.1em — labels, filter tokens
+    static let trackingWidest: CGFloat = 3.0          // 0.3em — breadcrumb emphasis
+
+    // Line heights
+    static let leadingTight: CGFloat = 1.2            // --leading-tight (headings)
+    static let leadingNormal: CGFloat = 1.6           // --leading-normal (body)
+
+    // MARK: - Spacing (4px base unit)
+
+    static let space1: CGFloat = 4                    // --space-1
+    static let space2: CGFloat = 8                    // --space-2
+    static let space3: CGFloat = 12                   // --space-3
+    static let space4: CGFloat = 16                   // --space-4
+    static let space5: CGFloat = 20                   // --space-5
+    static let space6: CGFloat = 24                   // --space-6
+    static let space8: CGFloat = 32                   // --space-8
+    static let space10: CGFloat = 40                  // --space-10
+    static let space12: CGFloat = 48                  // --space-12
+    static let space16: CGFloat = 64                  // --space-16
+
+    // MARK: - Animation
+
+    static let durationFast: Double = 0.1             // --duration-fast
+    static let durationNormal: Double = 0.15          // --duration-normal
+    static let durationSlow: Double = 0.2             // --duration-slow
 }
 
 // MARK: - Color Hex Extension


### PR DESCRIPTION
## Summary
- Creates `DesignSystem.swift` with 5 reusable SwiftUI components mirroring the web design system:
  - **DSText** — Typography presets (`.display`/Georgia, `.title`/12pt bold, `.body`/10pt, `.label`/uppercase muted, `.meta`/muted, `.tiny`/8pt)
  - **DSButton** — `.outlined` / `.filled` / `.ghost` variants with press inversion, sizes, fullWidth/disabled/loading props
  - **DSInput** — Text field matching web `.auth-modal__input` (12px padding, 1px border, focus glow)
  - **DSDivider** — 1px line with optional centered label
  - **DSSurface** — Container with `.standard`/`.subtle`/`.elevated` bg+border combinations
- Expands `Theme.swift` with full design token set: typography scale (8-24pt), spacing (4px grid), tracking, line heights, animation durations, additional colors
- Rewrites `AuthView.swift` to compose DSText/DSButton/DSInput/DSDivider instead of inline styling — Georgia serif logo, proper button variants, consistent spacing
- Fixes `ContentView.swift` error overlay: rounded corner retry button → DSButton(.outlined) with sharp corners

## Test plan
- [ ] Auth screen: "boards" in Georgia serif, uppercase muted tagline, sharp-cornered input/button
- [ ] Submit button: white bg when enabled (filled), 50% opacity when disabled, spinner when loading
- [ ] Press any button → colors invert (outlined fills, filled outlines)
- [ ] "SEND AGAIN" is small outlined button, "CONTINUE WITHOUT LOGIN" is ghost (no border)
- [ ] Error overlay: retry button has sharp corners matching design system
- [ ] All spacing on 4px grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)