### PR TITLE
fix: stop re-enriching watch/read items on every page load

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9354,6 +9354,7 @@ Return JSON:
           link.video = {
             ...existing,
             // Server-enriched fields (TMDB + AI) — overwrite with better data
+            server_enriched_at: new Date().toISOString(),
             summary: result.video.summary || existing.summary || null,
             streamingServices: result.video.streamingServices?.length ? result.video.streamingServices : existing.streamingServices || [],
             voteAverage: result.video.voteAverage || existing.voteAverage || null,
@@ -9399,6 +9400,7 @@ Return JSON:
           link.book = {
             ...existing,
             // Server-enriched fields — overwrite with better data
+            server_enriched_at: new Date().toISOString(),
             title: result.book.title || existing.title || null,
             author: result.book.author || existing.author || null,
             isbn: result.book.isbn || existing.isbn || null,
@@ -10064,7 +10066,7 @@ Return JSON:
       },
       summaryField: 'summary',
       enrichFlag: 'enrichWatch',
-      backfillCheck: (link) => link.video && !link.video.tmdbId,
+      backfillCheck: (link) => link.video && !link.video.server_enriched_at,
     },
     read: {
       category: 'read',
@@ -10101,7 +10103,7 @@ Return JSON:
       },
       summaryField: 'summary',
       enrichFlag: 'enrichBook',
-      backfillCheck: (link) => link.book && !link.book.openLibraryKey,
+      backfillCheck: (link) => link.book && !link.book.server_enriched_at,
     },
   };
 


### PR DESCRIPTION
## Summary
- Watch/read items were re-enriched on **every page load** because `backfillCheck` relied on `tmdbId`/`openLibraryKey` — fields that stay null when TMDB/OpenLibrary lookups fail
- Added `server_enriched_at` timestamp to video/book metadata after server enrichment completes
- `backfillCheck` now uses this timestamp instead of optional API-specific fields
- Items get one final enrichment run to receive the stamp, then are permanently skipped

## Impact
- Eliminates 12+ unnecessary `enrich-link` edge function calls per page load
- Fixes the excessive "[BACKFILL] X items need enrichment" + "[sync] Uploaded:" log spam on every load

## Test plan
- [ ] Load boards on mobile — should see one final enrichment run for existing items
- [ ] Reload — should see "[BACKFILL] All watch/read items enriched" (green) with zero re-enrichment
- [ ] New watch/read items should still get enriched on first save

🤖 Generated with [Claude Code](https://claude.com/claude-code)