### PR TITLE
fix: prevent generic YouTube titles from overwriting link data

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9436,7 +9436,9 @@ Return JSON:
         const titleIsGeneric = !link.title
           || link.title === extractDomain(link.url)
           || genericTitles.includes(link.title.toLowerCase().trim());
-        if (result.title && titleIsGeneric) {
+        const serverTitleIsGeneric = !result.title
+          || genericTitles.includes(result.title.toLowerCase().trim());
+        if (result.title && titleIsGeneric && !serverTitleIsGeneric) {
           console.log('%c[ENRICH] Title updated from platform API:', 'color: #27ae60', result.title);
           link.title = result.title;
         }

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -467,8 +467,14 @@ serve(async (req) => {
         image_resolved_at: new Date().toISOString()
       }
       // Save platform-resolved title to DB (overrides generic "YouTube" etc.)
+      // Only save if we actually resolved a meaningful title
       if (oembedTitle) {
-        updatePayload.title = title
+        const genericTitleValues = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+        const titleIsGeneric = !title || genericTitleValues.includes(title.toLowerCase().trim())
+          || title.toLowerCase().trim() === domain
+        if (!titleIsGeneric) {
+          updatePayload.title = title
+        }
         if (youtubeData?.description) {
           updatePayload.description = youtubeData.description.slice(0, 500)
         }
@@ -514,8 +520,14 @@ serve(async (req) => {
       cached
     }
     // Include platform-resolved title so client can update its stored data
+    // Only include if we actually resolved a meaningful title (not empty or generic domain names)
     if (oembedTitle) {
-      response.title = title
+      const genericTitleValues = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+      const titleIsGeneric = !title || genericTitleValues.includes(title.toLowerCase().trim())
+        || title.toLowerCase().trim() === domain
+      if (!titleIsGeneric) {
+        response.title = title
+      }
       if (oembedTitle.author) response.author = oembedTitle.author
       if (youtubeData?.description) response.description = youtubeData.description.slice(0, 500)
     }


### PR DESCRIPTION
## Summary
- Fixes server returning `title: "youtu.be"` for deleted YouTube videos, which the client then accepted as a valid resolved title
- Both server and client now check if a title is generic before writing it

## Root Cause
For deleted/private YouTube videos, oEmbed returns no data. The server fallback correctly constructed a thumbnail URL but the original request `title` param (`"youtu.be"`) leaked through to the response. The client then treated this generic domain name as a resolved platform title.

## Test plan
- [ ] Deleted YouTube video should not have title overwritten with "youtu.be"
- [ ] Valid YouTube video should still get real title from oEmbed/API

🤖 Generated with [Claude Code](https://claude.com/claude-code)