### PR TITLE
Set Apple Team ID for Universal Links

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "TEAMID.com.ctrlrodeo.boards",
+        "appID": "RJ8FB5M6HX.com.ctrlrodeo.boards",
         "paths": [
           "/boards/*"
         ]


### PR DESCRIPTION
## Summary
- Replaces `TEAMID` placeholder in `.well-known/apple-app-site-association` with actual Apple Developer Team ID `RJ8FB5M6HX`
- Enables Universal Links so magic link emails open in the iOS app instead of Safari

## Test plan
- [ ] After deploy: `curl https://ctrl.rodeo/.well-known/apple-app-site-association` returns `RJ8FB5M6HX.com.ctrlrodeo.boards`
- [ ] On physical device: tap magic link in email → app opens (not Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)