### PR TITLE
Add Instagram Reel → Pins import pipeline

### DIFF
--- a/supabase/functions/instagram-import/index.ts
+++ b/supabase/functions/instagram-import/index.ts
@@ -1,0 +1,611 @@
+// Supabase Edge Function: instagram-import
+// Processes Instagram Reel URLs into structured board pins.
+//
+// Pipeline:
+//   1. ScrapeCreators API → caption, video URL, thumbnail, audio track, location
+//   2. Transcription → Instagram auto-transcript, Supadata, or Deepgram Nova-2
+//   3. Claude Haiku → entity extraction from caption + transcript
+//   4. DuckDuckGo → resolve entities to stable primary-source URLs
+//   5. Return source pin + N derived pins
+//
+// POST /functions/v1/instagram-import
+// Body:
+//   Single mode: { url: "https://instagram.com/reel/ABC/" }
+//   Batch mode:  { urls: ["https://...", "https://..."] }
+//   Pre-parsed:  { posts: [{ shortcode, caption, video_url, ... }] }
+//
+// Returns: { source_pin, derived_pins[], transcript?, entities[], cost_estimate }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ReelData {
+  url: string
+  shortcode: string
+  caption: string
+  author_username: string
+  thumbnail_url: string | null
+  video_url: string | null
+  duration: number | null
+  audio_track: string | null
+  tagged_location: string | null
+  tagged_accounts: string[]
+  auto_transcript: string | null
+  view_count: number | null
+  like_count: number | null
+}
+
+interface Entity {
+  type: string
+  name: string
+  location_hint: string | null
+  category: string
+  confidence: number
+  source: string
+  search_query: string
+  resolved_url: string | null
+  resolved_via: string | null
+  status: 'auto' | 'review' | 'discarded'
+}
+
+interface ExtractionResult {
+  entities: Entity[]
+  post_category: string
+  post_summary: string
+}
+
+interface Pin {
+  id: string
+  url: string
+  title: string
+  description: string
+  image: string | null
+  domain: string
+  category: string
+  content_type: string
+  type_confidence: number
+  source: string
+  source_id?: string
+  source_url?: string
+  instagram?: Record<string, unknown>
+  extraction?: Record<string, unknown>
+  addedAt: number
+}
+
+// ---------------------------------------------------------------------------
+// 1. Content Extraction (ScrapeCreators)
+// ---------------------------------------------------------------------------
+
+function parseShortcode(url: string): string | null {
+  const match = url.match(/instagram\.com\/(?:reel|p|tv)\/([A-Za-z0-9_-]+)/)
+  return match ? match[1] : null
+}
+
+async function extractReel(url: string): Promise<ReelData> {
+  const apiKey = Deno.env.get('SCRAPECREATORS_API_KEY')
+  if (!apiKey) {
+    throw new Error('SCRAPECREATORS_API_KEY not configured')
+  }
+
+  const encodedUrl = encodeURIComponent(url)
+  const apiUrl = `https://api.scrapecreators.com/v2/instagram/post?url=${encodedUrl}`
+
+  const resp = await fetch(apiUrl, {
+    headers: {
+      'x-api-key': apiKey,
+      'Accept': 'application/json',
+    },
+  })
+
+  if (!resp.ok) {
+    const text = await resp.text()
+    throw new Error(`ScrapeCreators API error ${resp.status}: ${text}`)
+  }
+
+  const raw = await resp.json()
+  const post = raw.shortcode ? raw : (raw.data || raw)
+
+  // Extract audio track from music metadata
+  let audioTrack: string | null = null
+  const music = post.music_info || post.clips_metadata?.music_info
+  if (music) {
+    const asset = music.music_asset_info || music
+    const trackName = asset.title || asset.track_name
+    const artist = asset.display_artist || asset.artist_name
+    if (trackName) {
+      audioTrack = artist ? `${artist} - ${trackName}` : trackName
+    }
+  }
+
+  // Extract tagged location
+  let taggedLocation: string | null = null
+  if (post.location && typeof post.location === 'object') {
+    taggedLocation = post.location.name || null
+  } else if (typeof post.location === 'string') {
+    taggedLocation = post.location
+  }
+
+  return {
+    url,
+    shortcode: post.shortcode || parseShortcode(url) || 'unknown',
+    caption: post.caption || post.description || '',
+    author_username: post.author_username || post.owner_username || '',
+    thumbnail_url: post.thumbnail_url || post.display_url || null,
+    video_url: post.video_url || null,
+    duration: post.duration || post.video_duration || null,
+    audio_track: audioTrack,
+    tagged_location: taggedLocation,
+    tagged_accounts: post.tagged_users || [],
+    auto_transcript: post.transcript || post.accessibility_caption || null,
+    view_count: post.video_view_count || post.view_count || null,
+    like_count: post.like_count || null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Audio Transcription (Supadata → Deepgram fallback)
+// ---------------------------------------------------------------------------
+
+async function transcribeViaSupadata(url: string): Promise<string | null> {
+  const apiKey = Deno.env.get('SUPADATA_API_KEY')
+  if (!apiKey) return null
+
+  try {
+    const resp = await fetch('https://api.supadata.ai/v1/transcript', {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url }),
+    })
+
+    if (!resp.ok) return null
+
+    const data = await resp.json()
+    return data.content || data.transcript || data.text || null
+  } catch {
+    return null
+  }
+}
+
+async function transcribeViaDeepgram(videoUrl: string): Promise<string | null> {
+  const apiKey = Deno.env.get('DEEPGRAM_API_KEY')
+  if (!apiKey || !videoUrl) return null
+
+  try {
+    // Download video to buffer
+    const videoResp = await fetch(videoUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      },
+    })
+    if (!videoResp.ok) return null
+
+    const videoBuffer = await videoResp.arrayBuffer()
+    console.log(`[instagram-import] Downloaded ${(videoBuffer.byteLength / 1024 / 1024).toFixed(1)} MB for transcription`)
+
+    // Send to Deepgram
+    const dgResp = await fetch(
+      'https://api.deepgram.com/v1/listen?model=nova-2&smart_format=true&detect_language=true',
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Token ${apiKey}`,
+          'Content-Type': 'video/mp4',
+        },
+        body: videoBuffer,
+      }
+    )
+
+    if (!dgResp.ok) return null
+
+    const result = await dgResp.json()
+    return result.results?.channels?.[0]?.alternatives?.[0]?.transcript || null
+  } catch {
+    return null
+  }
+}
+
+async function transcribeAudio(reel: ReelData): Promise<string | null> {
+  // 1. Instagram's own auto-transcript (free)
+  if (reel.auto_transcript) {
+    console.log('[instagram-import] Using Instagram auto-transcript')
+    return reel.auto_transcript
+  }
+
+  // 2. Supadata (URL -> transcript in one call)
+  const supadataResult = await transcribeViaSupadata(reel.url)
+  if (supadataResult) {
+    console.log('[instagram-import] Got Supadata transcript')
+    return supadataResult
+  }
+
+  // 3. Deepgram (download video + transcribe)
+  if (reel.video_url) {
+    const deepgramResult = await transcribeViaDeepgram(reel.video_url)
+    if (deepgramResult) {
+      console.log('[instagram-import] Got Deepgram transcript')
+      return deepgramResult
+    }
+  }
+
+  console.log('[instagram-import] No transcription available')
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// 3. Entity Extraction (Claude Haiku)
+// ---------------------------------------------------------------------------
+
+const EXTRACTION_PROMPT = `Analyze this Instagram Reel post. Extract every real-world entity mentioned or referenced — places, products, brands, songs, restaurants, events, people, recipes, tools, etc.
+
+For each entity:
+- type: place | product | brand | song | food | event | person | generic
+- name: canonical name (e.g., "Blue Bottle Coffee" not "this coffee spot")
+- location_hint: any geographic context (e.g., "Valencia St, San Francisco")
+- category: which board category (eat, go, wear, watch, listen, use, follow, read)
+- confidence: 0.0-1.0
+- source: which input it came from ("caption" | "transcript" | "audio_track" | "tagged_location" | "tagged_account")
+- search_query: a search query to find this entity's primary website or listing
+
+Be aggressive about extraction. If someone says "this place" while tagged at a location, that's a place entity. If a song is playing, that's a song entity. If they mention a brand, that's a brand entity.
+
+Return ONLY valid JSON, no markdown fences:
+{
+  "entities": [...],
+  "post_category": "eat|go|wear|watch|listen|use|follow|read",
+  "post_summary": "one sentence summary"
+}`
+
+async function extractEntities(reel: ReelData, transcript: string | null): Promise<ExtractionResult> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY not configured')
+  }
+
+  // Build context
+  const parts: string[] = []
+  parts.push(`Author: @${reel.author_username}`)
+  if (reel.caption) parts.push(`Caption: ${reel.caption}`)
+  if (transcript) parts.push(`Transcript (spoken audio): ${transcript}`)
+  if (reel.audio_track) parts.push(`Audio track playing: ${reel.audio_track}`)
+  if (reel.tagged_location) parts.push(`Tagged location: ${reel.tagged_location}`)
+  if (reel.tagged_accounts.length > 0) {
+    parts.push(`Tagged accounts: ${reel.tagged_accounts.map(a => '@' + a).join(', ')}`)
+  }
+
+  const userMessage = parts.join('\n\n')
+  console.log(`[instagram-import] Entity extraction input: ${userMessage.length} chars`)
+
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 2048,
+      messages: [
+        { role: 'user', content: `${EXTRACTION_PROMPT}\n\n---\n\n${userMessage}` }
+      ],
+    }),
+  })
+
+  if (!resp.ok) {
+    const text = await resp.text()
+    throw new Error(`Claude API error ${resp.status}: ${text}`)
+  }
+
+  const result = await resp.json()
+  let text = result.content[0].text.trim()
+
+  // Strip markdown fences if present
+  if (text.startsWith('```')) {
+    text = text.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '')
+  }
+
+  return JSON.parse(text) as ExtractionResult
+}
+
+// ---------------------------------------------------------------------------
+// 4. Entity Resolution (DuckDuckGo search)
+// ---------------------------------------------------------------------------
+
+async function searchDuckDuckGo(query: string): Promise<string | null> {
+  const encoded = encodeURIComponent(query)
+  const url = `https://html.duckduckgo.com/html/?q=${encoded}`
+
+  try {
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+      },
+    })
+
+    const html = await resp.text()
+    const match = html.match(/class="result__a"[^>]*href="([^"]+)"/)
+    if (match) {
+      const resultUrl = match[1]
+      // DuckDuckGo wraps URLs in a redirect
+      try {
+        const parsed = new URL(resultUrl)
+        const uddg = parsed.searchParams.get('uddg')
+        if (uddg) return uddg
+      } catch { /* not a redirect URL */ }
+      return resultUrl
+    }
+  } catch {
+    // Search failed — return null
+  }
+
+  return null
+}
+
+async function resolveEntity(entity: Entity): Promise<Entity> {
+  const searchQuery = entity.search_query || (() => {
+    switch (entity.type) {
+      case 'place': return `${entity.name} ${entity.location_hint || ''} Google Maps`.trim()
+      case 'song': return `${entity.name} Spotify`
+      case 'brand': return `${entity.name} official site`
+      case 'product': return `${entity.name} buy`
+      case 'person': return `${entity.name} Instagram`
+      default: return entity.name
+    }
+  })()
+
+  const url = await searchDuckDuckGo(searchQuery)
+  entity.resolved_url = url
+  entity.resolved_via = url ? 'duckduckgo-search' : null
+  return entity
+}
+
+async function resolveAllEntities(entities: Entity[]): Promise<Entity[]> {
+  const results: Entity[] = []
+
+  for (const entity of entities) {
+    if (entity.confidence < 0.5) {
+      entity.resolved_url = null
+      entity.status = 'discarded'
+      results.push(entity)
+      continue
+    }
+
+    entity.status = entity.confidence >= 0.7 ? 'auto' : 'review'
+    const resolved = await resolveEntity(entity)
+    results.push(resolved)
+
+    console.log(`[instagram-import] Resolved: ${entity.name} -> ${resolved.resolved_url || 'NOT FOUND'}`)
+
+    // Rate limit: 500ms between searches
+    await new Promise(r => setTimeout(r, 500))
+  }
+
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// 5. Pin Creation
+// ---------------------------------------------------------------------------
+
+function generateId(): string {
+  const ts = Date.now()
+  const rand = Math.random().toString(36).substring(2, 8)
+  return `link_${ts}_${rand}`
+}
+
+function createPins(
+  reel: ReelData,
+  extraction: ExtractionResult,
+  transcript: string | null
+): { source_pin: Pin; derived_pins: Pin[] } {
+  const now = Math.floor(Date.now() / 1000)
+
+  // Source pin
+  const source_pin: Pin = {
+    id: generateId(),
+    url: reel.url,
+    title: `Reel by @${reel.author_username}`,
+    description: (reel.caption || '').slice(0, 200),
+    image: reel.thumbnail_url,
+    domain: 'instagram.com',
+    category: 'follow',
+    content_type: 'social',
+    type_confidence: 1.0,
+    source: 'social',
+    source_id: 'instagram',
+    instagram: {
+      shortcode: reel.shortcode,
+      media_type: 'reel',
+      author_username: reel.author_username,
+      audio_track: reel.audio_track,
+      tagged_location: reel.tagged_location,
+      tagged_accounts: reel.tagged_accounts,
+      transcript,
+      extracted_entities_count: extraction.entities.length,
+    },
+    addedAt: now,
+  }
+
+  // Derived pins
+  const derived_pins: Pin[] = extraction.entities
+    .filter(e => e.status !== 'discarded' && e.resolved_url)
+    .map(entity => {
+      let domain = ''
+      try { domain = new URL(entity.resolved_url!).hostname.replace('www.', '') } catch {}
+
+      return {
+        id: generateId(),
+        url: entity.resolved_url!,
+        title: entity.name,
+        description: `From @${reel.author_username}: ${extraction.post_summary}`,
+        image: null,
+        domain,
+        category: entity.category || 'uncategorized',
+        content_type: entity.type || 'generic',
+        type_confidence: entity.confidence,
+        source: 'social',
+        source_url: reel.url,
+        extraction: {
+          method: transcript ? 'ai-caption+transcript' : 'ai-caption',
+          source_platform: 'instagram',
+          source_shortcode: reel.shortcode,
+          confidence: entity.confidence,
+          entity_type: entity.type,
+          resolved_via: entity.resolved_via,
+        },
+        addedAt: now,
+      }
+    })
+
+  return { source_pin, derived_pins }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  const headers = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+  try {
+    const body = await req.json()
+    const { url, urls, posts } = body
+
+    // Single URL mode
+    if (url) {
+      // Validate
+      if (!url.includes('instagram.com')) {
+        return new Response(
+          JSON.stringify({ error: 'URL must be an Instagram URL' }),
+          { status: 400, headers }
+        )
+      }
+
+      console.log(`[instagram-import] Processing: ${url}`)
+      const startTime = Date.now()
+
+      // Step 1: Extract reel metadata
+      const reel = await extractReel(url)
+      console.log(`[instagram-import] Extracted: @${reel.author_username}, caption ${reel.caption.length} chars`)
+
+      // Step 2: Transcribe audio
+      const transcript = await transcribeAudio(reel)
+
+      // Step 3: Extract entities
+      const extraction = await extractEntities(reel, transcript)
+      console.log(`[instagram-import] Found ${extraction.entities.length} entities`)
+
+      // Step 4: Resolve entities
+      extraction.entities = await resolveAllEntities(extraction.entities)
+
+      // Step 5: Create pins
+      const { source_pin, derived_pins } = createPins(reel, extraction, transcript)
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1)
+      console.log(`[instagram-import] Done in ${elapsed}s: 1 source + ${derived_pins.length} derived pins`)
+
+      return new Response(
+        JSON.stringify({
+          source_pin,
+          derived_pins,
+          transcript,
+          entities: extraction.entities,
+          post_category: extraction.post_category,
+          post_summary: extraction.post_summary,
+          stats: {
+            elapsed_seconds: parseFloat(elapsed),
+            entities_found: extraction.entities.length,
+            entities_resolved: derived_pins.length,
+            entities_review: extraction.entities.filter(e => e.status === 'review').length,
+            entities_discarded: extraction.entities.filter(e => e.status === 'discarded').length,
+          },
+        }),
+        { status: 200, headers }
+      )
+    }
+
+    // Batch URL mode
+    if (urls && Array.isArray(urls)) {
+      const results = []
+      for (const u of urls) {
+        try {
+          const reel = await extractReel(u)
+          const transcript = await transcribeAudio(reel)
+          const extraction = await extractEntities(reel, transcript)
+          extraction.entities = await resolveAllEntities(extraction.entities)
+          const pins = createPins(reel, extraction, transcript)
+          results.push({ url: u, ...pins, entities: extraction.entities, status: 'ok' })
+        } catch (err) {
+          results.push({ url: u, status: 'error', error: String(err) })
+        }
+        // Rate limit between posts
+        await new Promise(r => setTimeout(r, 1000))
+      }
+
+      return new Response(JSON.stringify({ results }), { status: 200, headers })
+    }
+
+    // Pre-parsed batch mode (from browser extension)
+    if (posts && Array.isArray(posts)) {
+      const results = []
+      for (const post of posts) {
+        try {
+          // Build reel data from pre-parsed extension data
+          const reel: ReelData = {
+            url: post.url || `https://instagram.com/reel/${post.shortcode}/`,
+            shortcode: post.shortcode,
+            caption: post.caption || '',
+            author_username: post.author_username || '',
+            thumbnail_url: post.media_urls?.thumbnail || post.display_url || null,
+            video_url: post.media_urls?.video || post.video_url || null,
+            duration: post.duration || null,
+            audio_track: post.audio_track || null,
+            tagged_location: post.tagged_location || null,
+            tagged_accounts: post.tagged_accounts || [],
+            auto_transcript: null,
+            view_count: post.view_count || null,
+            like_count: post.like_count || null,
+          }
+
+          const transcript = await transcribeAudio(reel)
+          const extraction = await extractEntities(reel, transcript)
+          extraction.entities = await resolveAllEntities(extraction.entities)
+          const pins = createPins(reel, extraction, transcript)
+          results.push({ url: reel.url, ...pins, entities: extraction.entities, status: 'ok' })
+        } catch (err) {
+          results.push({ url: post.url || post.shortcode, status: 'error', error: String(err) })
+        }
+        await new Promise(r => setTimeout(r, 1000))
+      }
+
+      return new Response(JSON.stringify({ results }), { status: 200, headers })
+    }
+
+    return new Response(
+      JSON.stringify({ error: 'Provide "url", "urls", or "posts" in request body' }),
+      { status: 400, headers }
+    )
+
+  } catch (err) {
+    console.error('[instagram-import] Error:', err)
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 500, headers }
+    )
+  }
+})

--- a/tools/reel-to-pins.py
+++ b/tools/reel-to-pins.py
@@ -3,20 +3,26 @@
 reel-to-pins.py — Extract an Instagram Reel into structured board pins.
 
 Pipeline:
-  1. yt-dlp extracts video, caption, metadata from Instagram URL
-  2. Deepgram Nova-2 transcribes spoken audio (optional, needs API key)
+  1. Extract reel metadata + video URL (ScrapeCreators API or yt-dlp fallback)
+  2. Transcribe audio (Supadata API, Deepgram Nova-2, or yt-dlp local)
   3. Claude Haiku extracts entities (places, products, music, brands)
   4. Web search resolves each entity to a stable primary-source URL
   5. Outputs structured pin JSON matching the boards schema
 
 Usage:
-  pip install yt-dlp anthropic httpx
-  export ANTHROPIC_API_KEY=sk-ant-...
-  export DEEPGRAM_API_KEY=...          # optional, for audio transcription
-  export SUPABASE_URL=...              # optional, for direct pin creation
-  export SUPABASE_ANON_KEY=...         # optional, for direct pin creation
+  # Production mode (recommended — API-based, no local tools needed):
+  export SCRAPECREATORS_API_KEY=...   # metadata extraction
+  export SUPADATA_API_KEY=...         # audio transcription (or DEEPGRAM_API_KEY)
+  export ANTHROPIC_API_KEY=sk-ant-... # entity extraction
 
   python tools/reel-to-pins.py https://www.instagram.com/reel/DUuIXvviek-/
+
+  # Local mode (uses yt-dlp + Deepgram — requires pip install yt-dlp):
+  python tools/reel-to-pins.py --backend=ytdlp https://www.instagram.com/reel/DUuIXvviek-/
+
+  # Extraction backends (--backend flag):
+  #   scrapecreators  — ScrapeCreators API (default, needs SCRAPECREATORS_API_KEY)
+  #   ytdlp           — yt-dlp local tool (needs yt-dlp installed)
 """
 
 import argparse
@@ -33,23 +39,75 @@ from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
-# 1. CONTENT EXTRACTION (yt-dlp)
+# 1. CONTENT EXTRACTION
 # ---------------------------------------------------------------------------
 
-def extract_reel(url: str, download_video: bool = True) -> dict:
-    """Use yt-dlp to extract metadata and optionally download video."""
-    print(f"\n{'='*60}")
-    print(f"  STEP 1: Extracting reel content")
-    print(f"{'='*60}")
-    print(f"  URL: {url}")
+def parse_shortcode(url: str) -> str | None:
+    """Extract Instagram shortcode from a URL."""
+    match = re.search(r'instagram\.com/(?:reel|p|tv)/([A-Za-z0-9_-]+)', url)
+    return match.group(1) if match else None
 
-    # First pass: metadata only
+
+def extract_via_scrapecreators(url: str) -> dict:
+    """Use ScrapeCreators API to extract reel metadata and video URL."""
+    api_key = os.environ.get("SCRAPECREATORS_API_KEY")
+    if not api_key:
+        raise RuntimeError("SCRAPECREATORS_API_KEY not set")
+
+    encoded_url = urllib.parse.quote(url, safe='')
+    api_url = f"https://api.scrapecreators.com/v2/instagram/post?url={encoded_url}"
+
+    req = urllib.request.Request(api_url, headers={
+        "x-api-key": api_key,
+        "Accept": "application/json",
+    })
+
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+
+    # ScrapeCreators returns nested data — normalize to our format
+    post = data if "shortcode" in data else data.get("data", data)
+
+    reel = {
+        "url": url,
+        "shortcode": post.get("shortcode") or parse_shortcode(url),
+        "title": post.get("title", ""),
+        "caption": post.get("caption") or post.get("description") or "",
+        "author": post.get("author_name") or post.get("owner_username") or "",
+        "author_id": post.get("author_username") or post.get("owner_username") or "",
+        "thumbnail": post.get("thumbnail_url") or post.get("display_url"),
+        "duration": post.get("duration") or post.get("video_duration"),
+        "view_count": post.get("video_view_count") or post.get("view_count"),
+        "like_count": post.get("like_count"),
+        "comment_count": post.get("comment_count"),
+        "timestamp": post.get("taken_at") or post.get("timestamp"),
+        "audio_track": None,
+        "video_url": post.get("video_url"),
+        "video_path": None,
+        "tagged_location": post.get("location", {}).get("name") if isinstance(post.get("location"), dict) else post.get("location"),
+        "tagged_accounts": post.get("tagged_users") or [],
+        "auto_transcript": post.get("transcript") or post.get("accessibility_caption"),
+    }
+
+    # Extract audio/music track
+    music = post.get("music_info") or post.get("clips_metadata", {}).get("music_info", {})
+    if isinstance(music, dict):
+        asset = music.get("music_asset_info", music)
+        track_name = asset.get("title") or asset.get("track_name")
+        artist = asset.get("display_artist") or asset.get("artist_name")
+        if track_name:
+            reel["audio_track"] = f"{artist} - {track_name}" if artist else track_name
+
+    return reel
+
+
+def extract_via_ytdlp(url: str, download_video: bool = True) -> dict:
+    """Use yt-dlp to extract metadata and optionally download video."""
     cmd = ["yt-dlp", "--dump-json", "--no-download", url]
     print(f"  Running: {' '.join(cmd)}")
 
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
-        # Try with cookies from browser
         for browser in ["chrome", "firefox", "safari"]:
             print(f"  Retrying with {browser} cookies...")
             cmd_cookies = ["yt-dlp", "--dump-json", "--no-download",
@@ -58,8 +116,7 @@ def extract_reel(url: str, download_video: bool = True) -> dict:
             if result.returncode == 0:
                 break
         if result.returncode != 0:
-            print(f"  ERROR: yt-dlp failed: {result.stderr}")
-            sys.exit(1)
+            raise RuntimeError(f"yt-dlp failed: {result.stderr}")
 
     meta = json.loads(result.stdout)
 
@@ -77,29 +134,24 @@ def extract_reel(url: str, download_video: bool = True) -> dict:
         "comment_count": meta.get("comment_count"),
         "timestamp": meta.get("timestamp"),
         "audio_track": None,
+        "video_url": None,
         "video_path": None,
+        "tagged_location": None,
+        "tagged_accounts": [],
+        "auto_transcript": None,
     }
 
-    # Extract audio/music track info if available
+    # Extract audio/music track info
     track = meta.get("track")
     artist = meta.get("artist") or meta.get("creator")
     if track:
         reel["audio_track"] = f"{artist} - {track}" if artist else track
-    elif meta.get("music_track"):
-        reel["audio_track"] = meta["music_track"]
 
-    print(f"\n  Author:    @{reel['author_id']}")
-    print(f"  Caption:   {reel['caption'][:120]}{'...' if len(reel['caption']) > 120 else ''}")
-    print(f"  Duration:  {reel['duration']}s")
-    print(f"  Audio:     {reel['audio_track'] or 'none detected'}")
-    print(f"  Thumbnail: {reel['thumbnail'][:80]}..." if reel['thumbnail'] else "  Thumbnail: none")
-
-    # Second pass: download video for transcription
+    # Download video for transcription
     if download_video:
         tmpdir = tempfile.mkdtemp(prefix="reel_")
         video_path = os.path.join(tmpdir, "reel.mp4")
         dl_cmd = ["yt-dlp", "-o", video_path, "--format", "mp4", url]
-        # Try with cookies if plain download fails
         dl_result = subprocess.run(dl_cmd, capture_output=True, text=True, timeout=120)
         if dl_result.returncode != 0:
             for browser in ["chrome", "firefox", "safari"]:
@@ -118,30 +170,109 @@ def extract_reel(url: str, download_video: bool = True) -> dict:
     return reel
 
 
+def extract_reel(url: str, backend: str = "scrapecreators", download_video: bool = True) -> dict:
+    """Extract reel content using the specified backend."""
+    print(f"\n{'='*60}")
+    print(f"  STEP 1: Extracting reel content ({backend})")
+    print(f"{'='*60}")
+    print(f"  URL: {url}")
+
+    if backend == "scrapecreators":
+        try:
+            reel = extract_via_scrapecreators(url)
+        except Exception as e:
+            print(f"  ScrapeCreators failed: {e}")
+            print(f"  Falling back to yt-dlp...")
+            reel = extract_via_ytdlp(url, download_video=download_video)
+    elif backend == "ytdlp":
+        reel = extract_via_ytdlp(url, download_video=download_video)
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+
+    print(f"\n  Author:    @{reel['author_id']}")
+    print(f"  Caption:   {reel['caption'][:120]}{'...' if len(reel['caption']) > 120 else ''}")
+    if reel.get("duration"):
+        print(f"  Duration:  {reel['duration']}s")
+    print(f"  Audio:     {reel['audio_track'] or 'none detected'}")
+    if reel.get("tagged_location"):
+        print(f"  Location:  {reel['tagged_location']}")
+    if reel.get("thumbnail"):
+        print(f"  Thumbnail: {reel['thumbnail'][:80]}...")
+    if reel.get("video_url"):
+        print(f"  Video URL: available (CDN, ~48h expiry)")
+    if reel.get("auto_transcript"):
+        print(f"  IG Transcript: available ({len(reel['auto_transcript'])} chars)")
+
+    return reel
+
+
 # ---------------------------------------------------------------------------
-# 2. AUDIO TRANSCRIPTION (Deepgram Nova-2)
+# 2. AUDIO TRANSCRIPTION
 # ---------------------------------------------------------------------------
 
-def transcribe_audio(video_path: str) -> str | None:
-    """Transcribe video audio using Deepgram Nova-2 REST API."""
-    api_key = os.environ.get("DEEPGRAM_API_KEY")
+def transcribe_via_supadata(url: str) -> str | None:
+    """Transcribe using Supadata API — URL to transcript in one call."""
+    api_key = os.environ.get("SUPADATA_API_KEY")
     if not api_key:
-        print("\n  STEP 2: Skipping transcription (no DEEPGRAM_API_KEY)")
-        print("  Set DEEPGRAM_API_KEY to enable audio transcription.")
         return None
 
-    print(f"\n{'='*60}")
-    print(f"  STEP 2: Transcribing audio (Deepgram Nova-2)")
-    print(f"{'='*60}")
+    print(f"  Trying Supadata API...")
 
-    with open(video_path, "rb") as f:
-        video_data = f.read()
-
-    print(f"  Sending {len(video_data) / (1024*1024):.1f} MB to Deepgram...")
-
-    url = "https://api.deepgram.com/v1/listen?model=nova-2&smart_format=true&detect_language=true"
+    payload = json.dumps({"url": url}).encode()
     req = urllib.request.Request(
-        url,
+        "https://api.supadata.ai/v1/transcript",
+        data=payload,
+        headers={
+            "x-api-key": api_key,
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            result = json.loads(resp.read().decode())
+        transcript = result.get("content") or result.get("transcript") or result.get("text")
+        if transcript:
+            lang = result.get("lang", "unknown")
+            print(f"  Supadata transcript ({lang}):")
+            print(f"  \"{transcript[:200]}{'...' if len(transcript) > 200 else ''}\"")
+            return transcript
+    except Exception as e:
+        print(f"  Supadata failed: {e}")
+
+    return None
+
+
+def transcribe_via_deepgram(video_source: str) -> str | None:
+    """Transcribe using Deepgram Nova-2 REST API.
+
+    video_source can be a local file path or a CDN video URL.
+    """
+    api_key = os.environ.get("DEEPGRAM_API_KEY")
+    if not api_key:
+        return None
+
+    print(f"  Trying Deepgram Nova-2...")
+
+    # Load video data from file or URL
+    if os.path.exists(video_source):
+        with open(video_source, "rb") as f:
+            video_data = f.read()
+        print(f"  Sending {len(video_data) / (1024*1024):.1f} MB to Deepgram...")
+    else:
+        # Download from CDN URL first
+        print(f"  Downloading video from CDN...")
+        dl_req = urllib.request.Request(video_source, headers={
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+        })
+        with urllib.request.urlopen(dl_req, timeout=60) as resp:
+            video_data = resp.read()
+        print(f"  Downloaded {len(video_data) / (1024*1024):.1f} MB")
+
+    api_url = "https://api.deepgram.com/v1/listen?model=nova-2&smart_format=true&detect_language=true"
+    req = urllib.request.Request(
+        api_url,
         data=video_data,
         headers={
             "Authorization": f"Token {api_key}",
@@ -155,13 +286,47 @@ def transcribe_audio(video_path: str) -> str | None:
             result = json.loads(resp.read().decode())
         transcript = result["results"]["channels"][0]["alternatives"][0]["transcript"]
         confidence = result["results"]["channels"][0]["alternatives"][0]["confidence"]
-        print(f"  Transcript ({confidence:.0%} confidence):")
+        print(f"  Deepgram transcript ({confidence:.0%} confidence):")
         print(f"  \"{transcript[:200]}{'...' if len(transcript) > 200 else ''}\"")
         return transcript
     except Exception as e:
-        print(f"  Transcription failed: {e}")
-        print("  Continuing with caption-only extraction.")
-        return None
+        print(f"  Deepgram failed: {e}")
+
+    return None
+
+
+def transcribe_audio(reel: dict) -> str | None:
+    """Transcribe reel audio using the best available method.
+
+    Priority:
+      1. Instagram's own auto-transcript (free, already in metadata)
+      2. Supadata API (one call, URL -> transcript)
+      3. Deepgram Nova-2 (needs video file or CDN URL)
+    """
+    print(f"\n{'='*60}")
+    print(f"  STEP 2: Transcribing audio")
+    print(f"{'='*60}")
+
+    # 1. Check for Instagram's own auto-transcript
+    if reel.get("auto_transcript"):
+        print(f"  Using Instagram auto-transcript (free)")
+        return reel["auto_transcript"]
+
+    # 2. Try Supadata (URL -> transcript in one call)
+    transcript = transcribe_via_supadata(reel["url"])
+    if transcript:
+        return transcript
+
+    # 3. Try Deepgram with video file or CDN URL
+    video_source = reel.get("video_path") or reel.get("video_url")
+    if video_source:
+        transcript = transcribe_via_deepgram(video_source)
+        if transcript:
+            return transcript
+
+    print(f"  No transcription available.")
+    print(f"  Set SUPADATA_API_KEY or DEEPGRAM_API_KEY to enable.")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -179,7 +344,7 @@ For each entity:
 - location_hint: any geographic context (e.g., "Valencia St, San Francisco")
 - category: which board category (eat, go, wear, watch, listen, use, follow, read)
 - confidence: 0.0-1.0
-- source: which input it came from ("caption" | "transcript" | "audio_track")
+- source: which input it came from ("caption" | "transcript" | "audio_track" | "tagged_location" | "tagged_account")
 - search_query: a Google search query that would find this entity's primary \
   website or listing (e.g., "Blue Bottle Coffee Valencia St San Francisco \
   Google Maps" or "Khruangbin Maria También Spotify")
@@ -218,6 +383,12 @@ def extract_entities(reel: dict, transcript: str | None) -> dict:
         context_parts.append(f"Transcript (spoken audio): {transcript}")
     if reel["audio_track"]:
         context_parts.append(f"Audio track playing: {reel['audio_track']}")
+    if reel.get("tagged_location"):
+        context_parts.append(f"Tagged location: {reel['tagged_location']}")
+    if reel.get("tagged_accounts"):
+        accounts = reel["tagged_accounts"]
+        if isinstance(accounts, list) and accounts:
+            context_parts.append(f"Tagged accounts: {', '.join('@' + a for a in accounts)}")
 
     user_message = "\n\n".join(context_parts)
     print(f"  Input length: {len(user_message)} chars")
@@ -274,7 +445,6 @@ def extract_entities(reel: dict, transcript: str | None) -> dict:
 
 def search_duckduckgo(query: str) -> str | None:
     """Search DuckDuckGo and return the first result URL."""
-    # Use DuckDuckGo HTML search (no API key needed)
     encoded = urllib.parse.quote_plus(query)
     url = f"https://html.duckduckgo.com/html/?q={encoded}"
     req = urllib.request.Request(url, headers={
@@ -285,12 +455,9 @@ def search_duckduckgo(query: str) -> str | None:
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             html = resp.read().decode("utf-8", errors="replace")
-        # Extract first result URL from DuckDuckGo HTML
-        # Results are in <a class="result__a" href="...">
         match = re.search(r'class="result__a"[^>]*href="([^"]+)"', html)
         if match:
             result_url = match.group(1)
-            # DuckDuckGo wraps URLs in a redirect; extract the actual URL
             parsed = urllib.parse.urlparse(result_url)
             params = urllib.parse.parse_qs(parsed.query)
             if "uddg" in params:
@@ -308,7 +475,6 @@ def resolve_entity(entity: dict) -> dict:
     location = entity.get("location_hint", "")
     search_query = entity.get("search_query", "")
 
-    # Build targeted search queries by entity type
     if etype == "place" or entity.get("category") == "eat":
         query = search_query or f"{name} {location} Google Maps".strip()
     elif etype == "song":
@@ -390,6 +556,8 @@ def create_pins(reel: dict, extraction: dict, transcript: str | None) -> list[di
             "media_type": "reel",
             "author_username": reel["author_id"],
             "audio_track": reel["audio_track"],
+            "tagged_location": reel.get("tagged_location"),
+            "tagged_accounts": reel.get("tagged_accounts", []),
             "transcript": transcript,
             "extracted_entities_count": len(extraction.get("entities", [])),
         },
@@ -411,13 +579,13 @@ def create_pins(reel: dict, extraction: dict, transcript: str | None) -> list[di
             "url": entity["resolved_url"],
             "title": entity["name"],
             "description": f"From @{reel['author_id']}: {extraction.get('post_summary', '')}",
-            "image": None,  # Will be enriched by standard pipeline
+            "image": None,
             "domain": urllib.parse.urlparse(entity["resolved_url"]).netloc.replace("www.", ""),
             "category": entity.get("category", "uncategorized"),
             "content_type": entity.get("type", "generic"),
             "type_confidence": entity.get("confidence", 0.5),
             "source": "social",
-            "source_url": reel["url"],  # BACKLINK to source reel
+            "source_url": reel["url"],
             "extraction": {
                 "method": "ai-caption" + ("+transcript" if transcript else ""),
                 "source_platform": "instagram",
@@ -458,7 +626,6 @@ def output_pins(pins: list[dict], output_path: str | None = None):
 
     print(f"\n  1 reel -> {len(source)} source pin + {len(derived)} derived pins\n")
 
-    # Category breakdown
     categories = {}
     for p in derived:
         cat = p["category"]
@@ -466,7 +633,6 @@ def output_pins(pins: list[dict], output_path: str | None = None):
     for cat, count in sorted(categories.items()):
         print(f"    {cat}: {count}")
 
-    # Write JSON
     if output_path:
         path = output_path
     else:
@@ -489,14 +655,25 @@ def output_pins(pins: list[dict], output_path: str | None = None):
 def main():
     parser = argparse.ArgumentParser(
         description="Convert an Instagram Reel into structured board pins.",
-        epilog="Requires: pip install yt-dlp\n"
-               "Optional: DEEPGRAM_API_KEY for audio transcription\n"
+        epilog="Backends:\n"
+               "  scrapecreators  ScrapeCreators API (default, needs SCRAPECREATORS_API_KEY)\n"
+               "  ytdlp           yt-dlp local tool (needs pip install yt-dlp)\n\n"
+               "Transcription (checked in order):\n"
+               "  1. Instagram auto-transcript (free, when available)\n"
+               "  2. SUPADATA_API_KEY   Supadata API (URL -> transcript)\n"
+               "  3. DEEPGRAM_API_KEY   Deepgram Nova-2 (video -> transcript)\n\n"
                "Required: ANTHROPIC_API_KEY for entity extraction",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("url", help="Instagram Reel URL")
     parser.add_argument("-o", "--output", help="Output JSON file path")
+    parser.add_argument("--backend", choices=["scrapecreators", "ytdlp"],
+                        default="scrapecreators",
+                        help="Extraction backend (default: scrapecreators)")
     parser.add_argument("--no-video", action="store_true",
-                        help="Skip video download (caption-only extraction)")
+                        help="Skip video download (caption-only extraction, yt-dlp only)")
+    parser.add_argument("--no-transcribe", action="store_true",
+                        help="Skip audio transcription")
     parser.add_argument("--no-resolve", action="store_true",
                         help="Skip entity resolution (extraction only)")
     parser.add_argument("--dry-run", action="store_true",
@@ -508,18 +685,25 @@ def main():
         print("ERROR: URL must be an Instagram URL")
         sys.exit(1)
 
+    # Auto-detect backend: fall back to ytdlp if no ScrapeCreators key
+    backend = args.backend
+    if backend == "scrapecreators" and not os.environ.get("SCRAPECREATORS_API_KEY"):
+        print("  Note: SCRAPECREATORS_API_KEY not set, falling back to yt-dlp")
+        backend = "ytdlp"
+
     print("\n" + "="*60)
     print("  REEL TO PINS")
     print("  Instagram Reel -> Structured Board Pins")
     print("="*60)
 
     # Step 1: Extract reel content
-    reel = extract_reel(args.url, download_video=not args.no_video)
+    reel = extract_reel(args.url, backend=backend,
+                        download_video=not args.no_video)
 
     # Step 2: Transcribe audio
     transcript = None
-    if reel.get("video_path") and not args.no_video:
-        transcript = transcribe_audio(reel["video_path"])
+    if not args.no_transcribe:
+        transcript = transcribe_audio(reel)
 
     # Step 3: Extract entities
     extraction = extract_entities(reel, transcript)


### PR DESCRIPTION
## Summary
- **CLI tool** (`tools/reel-to-pins.py`): Python script that takes an Instagram Reel URL and extracts structured board pins. Pipeline: ScrapeCreators API → audio transcription (Supadata/Deepgram) → Claude Haiku entity extraction → DuckDuckGo URL resolution → pin JSON output.
- **Edge function** (`supabase/functions/instagram-import/`): TypeScript Deno function mirroring the same pipeline for server-side use. Supports single URL, batch URL, and pre-parsed post modes.

## Test plan
- [ ] Verify `python tools/reel-to-pins.py --help` runs without errors
- [ ] Test with a real Instagram Reel URL (requires API keys)
- [ ] Deploy edge function and test via curl
- [ ] Verify entity extraction produces valid pin JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)