### PR TITLE
Categorization Cleanup MVP + Lookback Phase 1 MVP

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -925,6 +925,134 @@ body {
 }
 
 /* ============================================
+   Lookback Card
+   ============================================ */
+.lookback-card {
+  grid-column: 1 / -1;
+  background: var(--surface);
+  border: 1px solid var(--fg);
+  padding: var(--space-4);
+  margin-bottom: var(--grid-gap);
+}
+
+.lookback-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.lookback-card__label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.lookback-card__dismiss {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s;
+}
+
+.lookback-card__dismiss:hover {
+  color: var(--fg);
+}
+
+.lookback-card__items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.lookback-card__item {
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.lookback-card__item:hover {
+  opacity: 0.7;
+}
+
+.lookback-card__img {
+  width: 100%;
+  aspect-ratio: 16/9;
+  object-fit: cover;
+  background: var(--subtle);
+  border: 1px solid var(--subtle);
+  margin-bottom: var(--space-2);
+}
+
+.lookback-card__placeholder {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: var(--subtle);
+  border: 1px solid var(--subtle);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-2xl);
+  color: var(--muted);
+  margin-bottom: var(--space-2);
+}
+
+.lookback-card__title {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
+  margin-bottom: var(--space-1);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--fg);
+}
+
+.lookback-card__context {
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+.lookback-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.lookback-card__see-all {
+  background: transparent;
+  border: 1px solid var(--fg);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: var(--space-2) var(--space-4);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.lookback-card__see-all:hover {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+@media (max-width: 640px) {
+  .lookback-card__items {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============================================
    Grid Item
    ============================================ */
 .grid-item {
@@ -10870,6 +10998,98 @@ Return JSON:
   function getAllLinks() { return load().links; }
   function getCategories() { return load().categories; }
 
+  // ============================================
+  // Categorization Cleanup (Epic 3.6)
+  // ============================================
+
+  // Compute adaptive threshold: 25th percentile of confidence distribution, floored at 0.50, capped at 0.80
+  function computeAdaptiveThreshold(links) {
+    const confidences = links
+      .map(l => l.confidence || 0)
+      .filter(c => c > 0)
+      .sort((a, b) => a - b);
+
+    if (confidences.length === 0) return 0.50;
+
+    const p25Index = Math.floor(confidences.length * 0.25);
+    const percentile = confidences[p25Index] || 0.50;
+
+    return Math.max(0.50, Math.min(0.80, percentile));
+  }
+
+  // Get cleanup queue - pins that need human attention
+  function getCleanupQueue(links) {
+    if (links.length < 10) return []; // Feature activation gate
+
+    const adaptiveThreshold = computeAdaptiveThreshold(links);
+
+    // Helper to check if image is missing or poor quality
+    function hasPoOrMissingImage(link) {
+      if (!link.image) return true;
+      if (link.image_scores && typeof link.image_scores === 'object') {
+        const composite = parseFloat(link.image_scores.composite);
+        if (!isNaN(composite) && composite < 0.15) return true;
+      }
+      return false;
+    }
+
+    // Helper to check for missing structured metadata based on category
+    function hasMissingStructuredMetadata(link) {
+      if (link.category === 'watch' && !link.video) return true;
+      if (link.category === 'listen' && !link.music) return true;
+      if (link.category === 'read' && !link.book) return true;
+      return false;
+    }
+
+    // Helper to determine priority tier
+    function getPriority(link) {
+      if (link.category === 'uncategorized') return 0; // High
+      if ((link.confidence || 0) < adaptiveThreshold) return 1; // High
+      if ((link.type_confidence || 0) < 0.50) return 2; // Medium
+      if (hasPoOrMissingImage(link)) return 2; // Medium
+      if (!link.title || link.title === link.domain || link.title === '') return 2; // Medium
+      if (link.enrichment_failed) return 3; // Low
+      if (hasMissingStructuredMetadata(link)) return 3; // Low
+      return 4; // Everything else
+    }
+
+    // Filter pins that qualify for cleanup (7 criteria)
+    const queue = links.filter(link => {
+      // Exclude if already reviewed by user
+      if (link.user_reviewed_at) return false;
+
+      // Qualification criteria (ANY of these):
+      return (
+        (link.confidence || 0) < adaptiveThreshold ||                    // 1. Low category confidence
+        link.category === 'uncategorized' ||                             // 2. Uncategorized
+        (link.type_confidence || 0) < 0.50 ||                           // 3. Low content type confidence
+        hasPoOrMissingImage(link) ||                                     // 4. Missing/poor image
+        !link.title || link.title === link.domain || link.title === '' || // 5. Missing title
+        link.enrichment_failed ||                                        // 6. Enrichment failure
+        hasMissingStructuredMetadata(link)                               // 7. Missing structured metadata
+      );
+    });
+
+    // Sort by priority, then recency
+    queue.sort((a, b) => {
+      const priorityA = getPriority(a);
+      const priorityB = getPriority(b);
+      if (priorityA !== priorityB) return priorityA - priorityB;
+      // Secondary sort: newest first (created_at or addedAt)
+      const dateA = new Date(a.addedAt || a.created_at || 0);
+      const dateB = new Date(b.addedAt || b.created_at || 0);
+      return dateB - dateA;
+    });
+
+    // Cap at 25 items
+    return queue.slice(0, 25);
+  }
+
+  // Cleanup view state
+  let cleanupViewActive = false;
+  let cleanupQueueCache = [];
+  let currentCleanupIndex = 0;
+
   function findByUrl(url) {
     const n = normalizeUrl(url);
     if (!n) return null;
@@ -11199,6 +11419,15 @@ Return JSON:
       html += `<button class="filter-token ${activeClass}" data-category="${name}" role="tab" aria-selected="${active}">${cap(name)}${badge}</button>`;
     }
 
+    // Add cleanup pill if queue has 3+ items
+    cleanupQueueCache = getCleanupQueue(links);
+    if (cleanupQueueCache.length >= 3) {
+      const cleanupActive = cleanupViewActive;
+      const activeClass = cleanupActive ? 'filter-token--active' : '';
+      const count = cleanupQueueCache.length > 25 ? '25+' : cleanupQueueCache.length;
+      html += `<button class="filter-token filter-token--cleanup ${activeClass}" data-category="cleanup" role="tab" aria-selected="${cleanupActive}">⚑ Review (${count})</button>`;
+    }
+
     filters.innerHTML = html;
 
     // --- Design Constraints: annotate filter components ---
@@ -11421,6 +11650,9 @@ Return JSON:
 
     let html = '';
     let cardCount = 0;
+
+    // Inject Lookback card at top of grid (before any pins)
+    html += renderLookbackCard(allLinks);
 
     // Build a map of widget positions for injection
     const widgetsByPosition = {};
@@ -12391,7 +12623,23 @@ Return JSON:
   filters.onclick = (e) => {
     const t = e.target.closest('.filter-token');
     if (t) {
-      currentFilter = t.dataset.category;
+      const category = t.dataset.category;
+
+      // Handle cleanup view
+      if (category === 'cleanup') {
+        cleanupViewActive = true;
+        currentCleanupIndex = 0;
+        renderFilters();
+        renderCleanupView();
+        return;
+      }
+
+      // Exit cleanup view if active
+      if (cleanupViewActive) {
+        cleanupViewActive = false;
+      }
+
+      currentFilter = category;
       currentSubTag = null; // Reset sub-tag when changing category
       if (currentPlayer.linkId && currentFilter !== 'listen') closePlayer();
       localStorage.setItem(FILTER_KEY, currentFilter);
@@ -12496,6 +12744,38 @@ Return JSON:
   });
 
   grid.onclick = async (e) => {
+    // Handle Lookback card interactions
+    const lookbackItem = e.target.closest('.lookback-card__item');
+    if (lookbackItem) {
+      e.preventDefault();
+      const linkId = lookbackItem.dataset.linkId;
+      if (linkId) {
+        const link = getAllLinks().find(l => l.id === linkId);
+        if (link) {
+          trackPinInteraction(linkId, 'lookback_view');
+          window.open(link.url, '_blank');
+        }
+      }
+      return;
+    }
+
+    const dismissBtn = e.target.closest('[data-action="dismiss-lookback"]');
+    if (dismissBtn) {
+      e.preventDefault();
+      localStorage.setItem(LOOKBACK_DISMISSED_KEY, new Date().toISOString());
+      renderGrid();
+      return;
+    }
+
+    const seeAllBtn = e.target.closest('[data-action="see-all-lookback"]');
+    if (seeAllBtn) {
+      e.preventDefault();
+      // For MVP, just scroll to show all lookback pins in grid
+      // Full Lookback View is post-MVP
+      toast('Full Lookback view coming soon!');
+      return;
+    }
+
     // Handle listen row click → open player
     const lr = e.target.closest('.listen-row');
     if (lr) { e.preventDefault(); const id = lr.dataset.id; if (id) openPlayer(id); return; }
@@ -12528,6 +12808,8 @@ Return JSON:
       if (openMenu) openMenu.classList.remove('grid-item__menu--visible');
 
       if (actionType === 'visit') {
+        // Track interaction when visiting a pin
+        trackPinInteraction(id, 'click');
         // Let the link handle itself
         return;
       } else if (actionType === 'resize') {
@@ -15021,6 +15303,267 @@ Return JSON:
   };
 
   init();
+
+  // ============================================
+  // Lookback Feature - Phase 1 MVP
+  // ============================================
+
+  const LOOKBACK_CACHE_KEY = 'ctrl-rodeo-lookback-cache';
+  const LOOKBACK_DISMISSED_KEY = 'ctrl-rodeo-lookback-dismissed';
+  const LOOKBACK_SURFACED_KEY = 'ctrl-rodeo-lookback-surfaced';
+
+  // Get season from date
+  function getSeason(date) {
+    const month = date.getMonth();
+    if (month >= 2 && month <= 4) return 'spring';
+    if (month >= 5 && month <= 7) return 'summer';
+    if (month >= 8 && month <= 10) return 'fall';
+    return 'winter';
+  }
+
+  // Compute lookback score for a pin
+  function computeLookbackScore(pin, now) {
+    let score = 0;
+    const signals = [];
+    const createdAt = new Date(pin.addedAt || pin.created_at);
+    const age = now - createdAt;
+    const daysSinceSave = age / (24 * 60 * 60 * 1000);
+
+    // Anniversary (within 3-day window, pin must be 300+ days old)
+    if (daysSinceSave > 300) {
+      const savedMD = `${createdAt.getMonth()}-${createdAt.getDate()}`;
+      for (let offset = -1; offset <= 1; offset++) {
+        const checkDate = new Date(now.getTime() + offset * 86400000);
+        const checkMD = `${checkDate.getMonth()}-${checkDate.getDate()}`;
+        if (savedMD === checkMD) {
+          score += 0.9;
+          const yearsAgo = Math.round(daysSinceSave / 365);
+          signals.push({ type: 'anniversary', label: `Saved ${yearsAgo} year${yearsAgo > 1 ? 's' : ''} ago` });
+          break;
+        }
+      }
+    }
+
+    // Seasonal match (pin 180+ days old, same season)
+    if (daysSinceSave > 180 && getSeason(createdAt) === getSeason(now)) {
+      score += 0.5;
+      const season = getSeason(createdAt);
+      signals.push({ type: 'seasonal', label: `From last ${season}` });
+    }
+
+    // Never clicked (7+ days old, no interaction)
+    if (!pin.last_interacted_at && daysSinceSave > 7) {
+      score += 0.7;
+      signals.push({ type: 'never_clicked', label: 'Never opened' });
+    }
+
+    // Consumption gap
+    if (pin.category === 'watch' && !pin.watched) {
+      score += 0.6;
+      signals.push({ type: 'unwatched', label: 'Still unwatched' });
+    }
+    if (pin.category === 'read' && !pin.read) {
+      score += 0.6;
+      signals.push({ type: 'unread', label: 'Still unread' });
+    }
+
+    // Staleness bonus (90+ days, no interaction)
+    if (daysSinceSave > 90 && !pin.last_interacted_at) {
+      score += Math.min(0.3, daysSinceSave / 1000);
+      signals.push({ type: 'stale', label: 'Forgotten save' });
+    }
+
+    return { score, signals };
+  }
+
+  // Get daily lookback pins
+  function getDailyLookback(links, today) {
+    // Activation gate: need at least 20 pins AND collection at least 30 days old
+    if (links.length < 20) return [];
+
+    const oldestPin = links.reduce((oldest, pin) => {
+      const pinDate = new Date(pin.addedAt || pin.created_at);
+      return !oldest || pinDate < oldest ? pinDate : oldest;
+    }, null);
+
+    if (!oldestPin) return [];
+
+    const collectionAge = (today - oldestPin) / (24 * 60 * 60 * 1000);
+    if (collectionAge < 30) return [];
+
+    // Load surfaced history for recency decay
+    let surfaced = {};
+    try {
+      surfaced = JSON.parse(localStorage.getItem(LOOKBACK_SURFACED_KEY) || '{}');
+    } catch {}
+
+    const now = new Date(today);
+    const scored = [];
+
+    for (const pin of links) {
+      const result = computeLookbackScore(pin, now);
+      if (result.score > 0) {
+        // Apply recency decay
+        let finalScore = result.score;
+        const lastSurfaced = surfaced[pin.id];
+        if (lastSurfaced) {
+          const daysSinceSurfaced = (today - new Date(lastSurfaced)) / (24 * 60 * 60 * 1000);
+          if (daysSinceSurfaced < 14) {
+            // Exponential decay with 14-day half-life
+            const decayFactor = Math.pow(0.5, (14 - daysSinceSurfaced) / 14);
+            finalScore *= decayFactor;
+          }
+        }
+
+        scored.push({ ...pin, lookbackScore: finalScore, lookbackSignals: result.signals });
+      }
+    }
+
+    // Sort by score descending
+    scored.sort((a, b) => b.lookbackScore - a.lookbackScore);
+
+    // Apply daily budget constraints
+    let selected = [];
+    let consumptionGapCount = 0;
+    const categories = new Set();
+
+    for (const pin of scored) {
+      if (selected.length >= 5) break;
+
+      // Max 1 consumption gap pin per day
+      const hasConsumptionGap = pin.lookbackSignals.some(s => s.type === 'unwatched' || s.type === 'unread');
+      if (hasConsumptionGap) {
+        if (consumptionGapCount >= 1) continue;
+        consumptionGapCount++;
+      }
+
+      selected.push(pin);
+      categories.add(pin.category);
+    }
+
+    // Category diversity bonus: if top results are all one category, boost others
+    if (selected.length >= 3 && categories.size === 1) {
+      // Find pins from different categories in the scored list
+      const otherCategories = scored.filter(p =>
+        p.category !== selected[0].category &&
+        !selected.find(s => s.id === p.id)
+      );
+
+      if (otherCategories.length > 0) {
+        // Replace last item with top different-category pin
+        selected[selected.length - 1] = otherCategories[0];
+      }
+    }
+
+    return selected.slice(0, 5); // Return 3-5 pins
+  }
+
+  // Track interaction with a pin
+  function trackPinInteraction(linkId, interactionType) {
+    const link = getAllLinks().find(l => l.id === linkId);
+    if (!link) return;
+
+    // Update last_interacted_at in localStorage
+    const now = new Date().toISOString();
+    updateLink(linkId, { last_interacted_at: now });
+
+    // TODO: Async insert into pin_interactions via Supabase (non-blocking)
+    // For MVP, just localStorage is sufficient
+  }
+
+  // Render lookback card at top of grid
+  function renderLookbackCard(links) {
+    // Only show when viewing all categories
+    if (currentFilter !== 'all') return '';
+
+    // Check if dismissed
+    try {
+      const dismissed = localStorage.getItem(LOOKBACK_DISMISSED_KEY);
+      if (dismissed) {
+        const dismissedDate = new Date(dismissed);
+        const now = new Date();
+        const hoursSinceDismiss = (now - dismissedDate) / (1000 * 60 * 60);
+        if (hoursSinceDismiss < 24) return '';
+      }
+    } catch {}
+
+    // Get today's lookback pins
+    const today = new Date();
+    const todayKey = today.toISOString().split('T')[0];
+
+    // Check cache
+    let cached = null;
+    try {
+      const cacheData = JSON.parse(localStorage.getItem(LOOKBACK_CACHE_KEY) || '{}');
+      if (cacheData.date === todayKey) {
+        cached = cacheData.pins;
+      }
+    } catch {}
+
+    let lookbackPins = cached;
+    if (!cached) {
+      lookbackPins = getDailyLookback(links, today);
+
+      // Cache for the day
+      try {
+        localStorage.setItem(LOOKBACK_CACHE_KEY, JSON.stringify({
+          date: todayKey,
+          pins: lookbackPins.map(p => p.id) // Store only IDs
+        }));
+
+        // Update surfaced history
+        const surfaced = JSON.parse(localStorage.getItem(LOOKBACK_SURFACED_KEY) || '{}');
+        for (const pin of lookbackPins) {
+          surfaced[pin.id] = today.toISOString();
+        }
+        localStorage.setItem(LOOKBACK_SURFACED_KEY, JSON.stringify(surfaced));
+      } catch {}
+    } else {
+      // Reconstruct pins from cached IDs
+      lookbackPins = cached.map(id => links.find(l => l.id === id)).filter(Boolean);
+      // Re-score to get signals
+      lookbackPins = lookbackPins.map(pin => {
+        const result = computeLookbackScore(pin, today);
+        return { ...pin, lookbackScore: result.score, lookbackSignals: result.signals };
+      });
+    }
+
+    // Need at least 3 pins to show card
+    if (lookbackPins.length < 3) return '';
+
+    // Render 3 mini-cards
+    const miniCards = lookbackPins.slice(0, 3).map(pin => {
+      const hasImg = pin.image && pin.image.length > 0;
+      const initial = pin.title ? pin.title.charAt(0).toUpperCase() : '?';
+      const contextLabel = pin.lookbackSignals[0]?.label || 'Worth revisiting';
+
+      return `
+        <div class="lookback-card__item" data-link-id="${pin.id}">
+          ${hasImg
+            ? `<img src="${esc(pin.image)}" alt="" class="lookback-card__img">`
+            : `<div class="lookback-card__placeholder">${initial}</div>`
+          }
+          <div class="lookback-card__title">${esc(pin.title || pin.url)}</div>
+          <div class="lookback-card__context">${esc(contextLabel)}</div>
+        </div>
+      `;
+    }).join('');
+
+    return `
+      <div class="lookback-card">
+        <div class="lookback-card__header">
+          <div class="lookback-card__label">LOOKBACK</div>
+          <button class="lookback-card__dismiss" data-action="dismiss-lookback">×</button>
+        </div>
+        <div class="lookback-card__items">
+          ${miniCards}
+        </div>
+        <div class="lookback-card__footer">
+          <button class="lookback-card__see-all" data-action="see-all-lookback">See all →</button>
+        </div>
+      </div>
+    `;
+  }
 
   // ============================================
   // Mobile Paste Button

--- a/boards/index.html
+++ b/boards/index.html
@@ -1053,6 +1053,229 @@ body {
 }
 
 /* ============================================
+   Cleanup View — Review Card
+   ============================================ */
+.cleanup-view {
+  grid-column: 1 / -1;
+  max-width: 640px;
+  margin: 0 auto;
+  padding: var(--space-4) 0;
+}
+
+.cleanup-view__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.cleanup-view__title {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.05em;
+  color: var(--fg);
+}
+
+.cleanup-view__progress {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+}
+
+.cleanup-view__back {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  padding: 0;
+}
+
+.cleanup-view__back:hover {
+  color: var(--fg);
+}
+
+.review-card {
+  border: 1px solid var(--fg);
+  background: var(--surface);
+}
+
+.review-card__image-wrap {
+  width: 100%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  background: var(--subtle);
+  position: relative;
+}
+
+.review-card__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.review-card__placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  color: var(--muted);
+}
+
+.review-card__body {
+  padding: var(--space-4);
+}
+
+.review-card__domain {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+  margin-bottom: var(--space-2);
+}
+
+.review-card__title-input,
+.review-card__desc-input {
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--fg);
+  font-family: var(--font-sans);
+  padding: var(--space-2);
+  border-radius: 0;
+  transition: border-color 0.15s;
+}
+
+.review-card__title-input {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.review-card__desc-input {
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-3);
+  resize: vertical;
+  min-height: 48px;
+}
+
+.review-card__title-input:focus,
+.review-card__desc-input:focus {
+  outline: none;
+  border-color: var(--fg);
+}
+
+.review-card__ai-context {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+  margin-bottom: var(--space-3);
+}
+
+.review-card__ai-context strong {
+  color: var(--fg);
+}
+
+.review-card__categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.review-card__cat-chip {
+  background: transparent;
+  border: 1px solid var(--muted);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.review-card__cat-chip:hover {
+  border-color: var(--fg);
+  color: var(--fg);
+}
+
+.review-card__cat-chip--active {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+
+.review-card__cat-chip--active:hover {
+  opacity: 0.85;
+}
+
+.review-card__actions {
+  display: flex;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--subtle);
+}
+
+.review-card__btn {
+  flex: 1;
+  background: transparent;
+  border: 1px solid var(--fg);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: var(--space-3);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.review-card__btn:hover {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+.review-card__btn--confirm {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+.review-card__btn--confirm:hover {
+  opacity: 0.85;
+}
+
+.review-card__btn--delete {
+  border-color: #c00;
+  color: #c00;
+  flex: 0.5;
+}
+
+.review-card__btn--delete:hover {
+  background: #c00;
+  color: var(--bg);
+}
+
+.cleanup-view__empty {
+  text-align: center;
+  padding: var(--space-8) var(--space-4);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 640px) {
+  .cleanup-view {
+    padding: var(--space-2) 0;
+  }
+  .review-card__actions {
+    flex-wrap: wrap;
+  }
+  .review-card__btn--delete {
+    flex: 1;
+  }
+}
+
+/* ============================================
    Grid Item
    ============================================ */
 .grid-item {
@@ -11089,6 +11312,184 @@ Return JSON:
   let cleanupViewActive = false;
   let cleanupQueueCache = [];
   let currentCleanupIndex = 0;
+  let selectedCleanupCategory = null;
+
+  // Render the cleanup review view — replaces the grid when active
+  function renderCleanupView() {
+    if (!cleanupViewActive) return;
+
+    // Refresh queue
+    cleanupQueueCache = getCleanupQueue(getAllLinks());
+
+    if (cleanupQueueCache.length === 0) {
+      grid.innerHTML = `
+        <div class="cleanup-view">
+          <div class="cleanup-view__header">
+            <button class="cleanup-view__back" onclick="exitCleanupView()">← Back</button>
+          </div>
+          <div class="cleanup-view__empty">All caught up — no pins need review right now.</div>
+        </div>`;
+      return;
+    }
+
+    // Clamp index
+    if (currentCleanupIndex >= cleanupQueueCache.length) {
+      currentCleanupIndex = 0;
+    }
+
+    const pin = cleanupQueueCache[currentCleanupIndex];
+    const hasImg = pin.image && pin.image.length > 0;
+    const initial = pin.title ? pin.title.charAt(0).toUpperCase() : '?';
+    const confPct = pin.confidence ? Math.round(pin.confidence * 100) : 0;
+
+    // Pre-select current category
+    selectedCleanupCategory = pin.category || 'uncategorized';
+
+    const catChips = CATEGORIES.map(cat => {
+      const active = cat === selectedCleanupCategory ? ' review-card__cat-chip--active' : '';
+      return `<button class="review-card__cat-chip${active}" data-cleanup-cat="${cat}">${cap(cat)}</button>`;
+    }).join('');
+
+    grid.innerHTML = `
+      <div class="cleanup-view">
+        <div class="cleanup-view__header">
+          <button class="cleanup-view__back" onclick="exitCleanupView()">← Back</button>
+          <span class="cleanup-view__title">Review</span>
+          <span class="cleanup-view__progress">${currentCleanupIndex + 1} of ${cleanupQueueCache.length}</span>
+        </div>
+        <div class="review-card" data-cleanup-pin-id="${pin.id}">
+          <div class="review-card__image-wrap">
+            ${hasImg
+              ? `<img src="${esc(pin.image)}" alt="" class="review-card__image">`
+              : `<div class="review-card__placeholder">${initial}</div>`
+            }
+          </div>
+          <div class="review-card__body">
+            <div class="review-card__domain">${esc(pin.domain || '')}</div>
+            <input class="review-card__title-input" value="${esc(pin.title || '')}" placeholder="Title" data-cleanup-field="title">
+            <textarea class="review-card__desc-input" placeholder="Description" data-cleanup-field="description">${esc(pin.description || '')}</textarea>
+            <div class="review-card__ai-context">AI says: <strong>${esc(cap(pin.category || 'uncategorized'))}</strong> (${confPct}%)</div>
+            <div class="review-card__categories">${catChips}</div>
+            <div class="review-card__actions">
+              <button class="review-card__btn review-card__btn--confirm" data-cleanup-action="confirm">Confirm</button>
+              <button class="review-card__btn" data-cleanup-action="skip">Skip</button>
+              <button class="review-card__btn review-card__btn--delete" data-cleanup-action="delete">Delete</button>
+            </div>
+          </div>
+        </div>
+      </div>`;
+
+    // Attach event listeners for category chips and action buttons
+    attachCleanupHandlers();
+  }
+
+  function attachCleanupHandlers() {
+    // Category chip selection
+    const chips = grid.querySelectorAll('[data-cleanup-cat]');
+    chips.forEach(chip => {
+      chip.onclick = () => {
+        chips.forEach(c => c.classList.remove('review-card__cat-chip--active'));
+        chip.classList.add('review-card__cat-chip--active');
+        selectedCleanupCategory = chip.dataset.cleanupCat;
+      };
+    });
+
+    // Action buttons
+    const actions = grid.querySelectorAll('[data-cleanup-action]');
+    actions.forEach(btn => {
+      btn.onclick = () => handleCleanupAction(btn.dataset.cleanupAction);
+    });
+  }
+
+  function handleCleanupAction(action) {
+    const pin = cleanupQueueCache[currentCleanupIndex];
+    if (!pin) return;
+
+    if (action === 'confirm') {
+      // Read inline edits
+      const titleInput = grid.querySelector('[data-cleanup-field="title"]');
+      const descInput = grid.querySelector('[data-cleanup-field="description"]');
+
+      const updates = {
+        user_reviewed_at: new Date().toISOString(),
+        confidence: 1.0,
+        category: selectedCleanupCategory
+      };
+
+      if (titleInput && titleInput.value !== pin.title) {
+        updates.title = titleInput.value;
+      }
+      if (descInput && descInput.value !== pin.description) {
+        updates.description = descInput.value;
+      }
+
+      updateLink(pin.id, updates);
+      toast(`Confirmed as ${cap(selectedCleanupCategory)}`);
+
+      // Remove from queue and advance
+      cleanupQueueCache.splice(currentCleanupIndex, 1);
+      if (currentCleanupIndex >= cleanupQueueCache.length) currentCleanupIndex = 0;
+
+      if (cleanupQueueCache.length === 0) {
+        exitCleanupView();
+        toast('All done — queue cleared!');
+        return;
+      }
+      renderCleanupView();
+
+    } else if (action === 'skip') {
+      // Move current to end of queue
+      const skipped = cleanupQueueCache.splice(currentCleanupIndex, 1)[0];
+      cleanupQueueCache.push(skipped);
+      if (currentCleanupIndex >= cleanupQueueCache.length) currentCleanupIndex = 0;
+      renderCleanupView();
+
+    } else if (action === 'delete') {
+      const deletedPin = { ...pin };
+      deleteLink(pin.id);
+      cleanupQueueCache.splice(currentCleanupIndex, 1);
+      if (currentCleanupIndex >= cleanupQueueCache.length) currentCleanupIndex = 0;
+
+      // Show undo toast
+      const toastEl = document.createElement('div');
+      toastEl.className = 'toast toast--success';
+      toastEl.innerHTML = `Deleted "${esc(deletedPin.title || deletedPin.url)}" <button style="margin-left:8px;background:transparent;border:1px solid var(--fg);color:var(--fg);cursor:pointer;padding:2px 8px;font-family:var(--font-mono);font-size:12px" id="undoDelete">Undo</button>`;
+      const container = document.querySelector('.toasts') || document.body;
+      container.appendChild(toastEl);
+      setTimeout(() => toastEl.remove(), 6000);
+
+      toastEl.querySelector('#undoDelete').onclick = () => {
+        // Re-add the pin
+        const data = load();
+        data.links.push(deletedPin);
+        save(data);
+        syncLinkToSupabase(deletedPin);
+        toastEl.remove();
+        toast('Restored');
+        renderCleanupView();
+        renderFilters();
+      };
+
+      if (cleanupQueueCache.length === 0) {
+        exitCleanupView();
+        return;
+      }
+      renderCleanupView();
+    }
+
+    // Update the badge count in filters
+    renderFilters();
+  }
+
+  // Exit cleanup view and return to normal grid
+  window.exitCleanupView = function() {
+    cleanupViewActive = false;
+    currentCleanupIndex = 0;
+    currentFilter = 'all';
+    localStorage.setItem(FILTER_KEY, currentFilter);
+    renderFilters();
+    renderGrid();
+  };
 
   function findByUrl(url) {
     const n = normalizeUrl(url);
@@ -11542,6 +11943,12 @@ Return JSON:
   }
 
   function renderGrid(newIds = []) {
+    // If cleanup view is active, render that instead
+    if (cleanupViewActive) {
+      renderCleanupView();
+      return;
+    }
+
     // Toggle listen grid/list override
     const isListenList = currentFilter === 'listen' && listenView === 'list';
     grid.classList.toggle('grid--listen', currentFilter === 'listen' && listenView === 'grid');

--- a/docs/execution/project-plan/backlog.md
+++ b/docs/execution/project-plan/backlog.md
@@ -8,18 +8,9 @@
 
 ## Taste & Pattern Intelligence
 
-Surfaces connections and patterns in what users collect. Directly supports brand principle #1: **Input shapes output.**
+→ Moved to [Phase 12: Lookback](./phase-12-lookback.md).
 
-> Personas: Visual Collector, Sound & Scene Curator, DJ, Researcher, Cultural Omnivore
-
-| Story | Status |
-|-------|--------|
-| **Taste profile** — Auto-generated summary of what a user collects most (domains, categories, content types) | Pending |
-| **"You save a lot of X" insights** — Surface collection patterns via widget or dashboard card | Pending |
-| **Trend detection** — Identify emerging themes across recent saves (e.g. "3 brutalist architecture links this week") | Pending |
-| **Cross-category connections** — Surface related pins across categories ("these pins share a theme") | Pending |
-| **Collection timeline** — Visual timeline of saves over time, filterable by category | Pending |
-| **Monthly digest widget** — Auto-generated summary of that month's curation activity | Pending |
+Items absorbed: taste profile (Epic 12.3), "you save a lot of X" insights (Epic 12.3), trend detection (Epic 12.3), cross-category connections (Epic 12.3), collection timeline (Epic 12.2), monthly digest (Epic 12.2).
 
 ---
 
@@ -471,10 +462,10 @@ Deepening engagement through install prompts and discovery features.
 | **PWA install prompt** (#68) — Show install prompt after repeated visits with "Add to Home Screen" flow | Pending |
 | **Keyboard shortcuts reference** (#69) — Press `?` to show keyboard shortcuts overlay | Pending |
 | **Unread / Read Later tracking** (#44) — Track read/unread state on article pins, filter by unread | Pending |
-| **Recently viewed tracking** (#57) — Track which pins were recently opened/visited, show as a filter or view | Pending |
+| ~~**Recently viewed tracking** (#57)~~ → Moved to [Phase 12: Lookback](./phase-12-lookback.md) Prerequisites (interaction tracking) | Moved |
 | **Widget preference granularity** (#45) — Per-category or per-widget-type enable/disable instead of all-or-nothing | Pending |
 | **Smart auto-boards** (#46) — Rule-based auto-organization (e.g. "all Nike links → Sneakers board") | Pending |
-| **Streaming availability notifications** (#61) — Notify when a Watch pin becomes available on a subscribed streaming service | Pending |
+| ~~**Streaming availability notifications** (#61)~~ → Moved to [Phase 12: Lookback](./phase-12-lookback.md) Epic 12.2 (release calendar) | Moved |
 | **Widget suggestion preview on hover** (#77) — Preview widget content on hover before committing to view | Pending |
 
 ---

--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -1,7 +1,7 @@
 # Project Plan - ctrl.rodeo
 
 > Single source of truth for all features, stories, and tasks.
-> **Last Updated**: 2026-02-14 (Events: RA GraphQL, Gary's Guide, Bonobo sources + multi-source tags)
+> **Last Updated**: 2026-02-19 (Categorization Cleanup + Lookback PRDs → project plan entries)
 
 ---
 
@@ -20,7 +20,7 @@
 |-------|--------|----------|
 | [Phase 1: Foundation](./phase-1-foundation.md) | SHIPPED | 24/24 |
 | [Phase 2: Core Experience](./phase-2-core-experience.md) | SHIPPED | 15/15 |
-| [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md) | IN PROGRESS | 151/413 |
+| [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md) | IN PROGRESS | 151/502 |
 | [Phase 4: Sharing & Collaboration](./phase-4-sharing-collaboration.md) | IN PROGRESS | 11/140 |
 | [Phase 5: UX Polish](./phase-5-ux-polish.md) | Pending | 3/60 |
 | [Phase 6: Performance & Scale](./phase-6-performance.md) | Pending | 1/15 |
@@ -29,7 +29,8 @@
 | [Phase 9: Bulk Import](./phase-9-bulk-import.md) | Pending | 0/132 |
 | [Phase 10: Image Validation & Enrichment](./phase-10-image-validation.md) | IN PROGRESS | 68/126 |
 | [Phase 11: Instagram Import](./phase-11-instagram-import.md) | Pending | 0/73 |
-| [Backlog](./backlog.md) | Future | 1/110 |
+| [Phase 12: Lookback](./phase-12-lookback.md) | Pending | 0/236 |
+| [Backlog](./backlog.md) | Future | 1/102 |
 
 ---
 
@@ -115,7 +116,7 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 |----------|----------|-------------|---------|---------|
 | Phase 1: Foundation | 24 | 0 | 0 | 0 |
 | Phase 2: Core Experience | 15 | 0 | 0 | 0 |
-| Phase 3: AI Intelligence | 151 | 4 | 257 | 0 |
+| Phase 3: AI Intelligence | 151 | 4 | 345 | 1 |
 | Phase 4: Sharing & Collaboration | 11 | 1 | 128 | 0 |
 | Phase 5: UX Polish | 3 | 0 | 57 | 0 |
 | Phase 6: Performance | 1 | 0 | 14 | 0 |
@@ -124,8 +125,9 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 | Phase 9: Bulk Import | 0 | 0 | 132 | 0 |
 | Phase 10: Image Validation | 68 | 0 | 58 | 0 |
 | Phase 11: Instagram Import | 0 | 0 | 73 | 0 |
-| Backlog | 1 | 0 | 108 | 0 |
-| **TOTAL** | **295** | **5** | **898** | **0** |
+| Phase 12: Lookback | 0 | 0 | 231 | 5 |
+| Backlog | 1 | 0 | 100 | 0 |
+| **TOTAL** | **295** | **5** | **1217** | **6** |
 
 ---
 
@@ -148,6 +150,10 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 | Item | Blocker | Owner |
 |------|---------|-------|
 | Push notifications | FCM/APNs setup required | Human |
+| Run migration `016_categorization_cleanup.sql` (Phase 3, Epic 3.6) | Supabase Dashboard → SQL Editor | Human |
+| Run migration `017_lookback_prerequisites.sql` (Phase 12) | Supabase Dashboard → SQL Editor | Human |
+| Run migration `018_lookback_external.sql` (Phase 12, Epic 12.2) | Supabase Dashboard → SQL Editor | Human |
+| Add `RESEND_API_KEY` for digest emails (Phase 12, Epic 12.2) | Supabase Dashboard → Edge Functions → Secrets | Human |
 | Run migration `007_image_validation.sql` against Supabase (Phase 10) | Supabase Dashboard → SQL Editor | Human |
 | Deploy `enrich-link` edge function with Tier 2 validation (Phase 10) | `supabase functions deploy enrich-link` | Human |
 | Deploy new `validate-image` edge function for Tier 3 (Phase 10) | `supabase functions deploy validate-image` | Human |

--- a/docs/execution/project-plan/phase-12-lookback.md
+++ b/docs/execution/project-plan/phase-12-lookback.md
@@ -1,0 +1,375 @@
+# Phase 12: Lookback (Pending)
+
+> Back to [Project Plan](./index.md)
+>
+> **Reference**: [PRD: Lookback](/docs/strategy/prds/lookback.md)
+>
+> **Vision**: A system that resurfaces the right past pins at the right time — using temporal patterns, interaction signals, external context, and collection intelligence. Lookback transforms a static archive into a living asset and gives users a reason to open ctrl.rodeo on days when they have nothing new to save.
+>
+> **Why a new phase**: Lookback is a three-phase rollout with its own data model prerequisites and conceptually distinct purpose (retention/re-engagement vs. Phase 3's capture/classification focus). It absorbs the backlog's "Taste & Pattern Intelligence" section.
+
+---
+
+## Prerequisites (Before Any Lookback Work)
+
+These tasks must be complete before Epic 12.1 can begin.
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Interaction Tracking Schema** | | Pending |
+| | Write migration `017_lookback_prerequisites.sql` | Pending |
+| | Add `last_interacted_at TIMESTAMPTZ DEFAULT NULL` to `links` table | Pending |
+| | Add index `idx_links_last_interacted` on `(user_id, last_interacted_at)` | Pending |
+| | Create `pin_interactions` table: `id UUID PK`, `user_id UUID`, `link_id UUID`, `interaction_type TEXT`, `created_at TIMESTAMPTZ` | Pending |
+| | Add index `idx_pin_interactions_link` on `(link_id)` | Pending |
+| | Add index `idx_pin_interactions_user_date` on `(user_id, created_at DESC)` | Pending |
+| | Enable RLS on `pin_interactions`; policy: `FOR ALL USING (auth.uid() = user_id)` | Pending |
+| | Run migration against Boards Supabase project | Blocked |
+| | Update `database-schema.md` via `/arch` | Pending |
+| **Client-Side Interaction Tracking** | | Pending |
+| | Instrument `click` event: fires when user opens a pin URL (new tab) | Pending |
+| | Instrument `expand` event: fires when user expands a pin card | Pending |
+| | Instrument `share` event: fires when user shares a pin or board | Pending |
+| | On each interaction: update `links[id].last_interacted_at = now` in localStorage | Pending |
+| | On each interaction: async insert into `pin_interactions` via Supabase (non-blocking) | Pending |
+| | Verify tracking overhead < 10ms per event | Pending |
+| | Note: `lookback_view` and `lookback_dismiss` types added in Epic 12.1 | Pending |
+
+---
+
+## Epic 12.1: Lookback MVP — Temporal + Interaction Signals
+
+> **Surfaces**: Lookback Card (main board), Time Machine (basic browse)
+> **Signals**: Anniversary, seasonal match, never clicked, consumption gap, staleness
+> **Scoring**: Client-side only — zero infrastructure cost
+> **Personas**: All (these signals apply universally)
+
+### Story 1: Client-Side Lookback Scoring Engine
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **computeLookbackScore() function** | | Pending |
+| | Implement `computeLookbackScore(pin, now)` — returns `{ score, signals }` | Pending |
+| | Anniversary signal: match month-day within 3-day window, pin 300+ days old, score += 0.9 | Pending |
+| | Seasonal match: compare saved season to current season, pin 180+ days old, score += 0.5 | Pending |
+| | Never clicked: `last_interacted_at IS NULL` and pin 7+ days old, score += 0.7 | Pending |
+| | Consumption gap — watch: `category === 'watch' && !pin.watched`, score += 0.6 | Pending |
+| | Consumption gap — read: `category === 'read' && !pin.read`, score += 0.6 | Pending |
+| | Staleness bonus: pin > 90 days old with no interaction, score += min(0.3, age_days/1000) | Pending |
+| | `getSeason(date)` helper: returns 'winter', 'spring', 'summer', 'fall' from month | Pending |
+| **Lookback selection algorithm** | | Pending |
+| | `getDailyLookback(links, today)` — scores all pins, selects qualifying set | Pending |
+| | Activation gate: return empty if user has < 20 pins OR collection < 30 days old | Pending |
+| | Recency decay: pins surfaced in last 14 days get score * 0.5^(days_ago/14) | Pending |
+| | Category diversity bonus: if top 5 are all same category, boost underrepresented categories | Pending |
+| | Select top 3-5 pins by composite score | Pending |
+| | Daily budget: max 1 consumption gap pin per day | Pending |
+| | Cache daily set in localStorage with `lookback_date` key (avoid recomputation on re-render) | Pending |
+| | Invalidate cache if user adds new pin or calendar day changes | Pending |
+| **Lookback interaction events** | | Pending |
+| | Instrument `lookback_view` event: user views a surfaced pin via Lookback | Pending |
+| | Instrument `lookback_dismiss` event: user dismisses the Lookback card | Pending |
+
+### Story 2: Lookback Card Component (Main Board)
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Lookback card layout** | | Pending |
+| | Render at top of board grid, above pins, below filter bar | Pending |
+| | "LOOKBACK" label (small caps, muted) | Pending |
+| | 3 mini-cards: image, title (truncated 2 lines), context label | Pending |
+| | Context labels per signal: "Saved 1 year ago", "Never opened", "Still unwatched", etc. | Pending |
+| | "See all" link — opens Lookback view | Pending |
+| | "Dismiss" button (X) — hides for 24 hours | Pending |
+| **Lookback card behavior** | | Pending |
+| | Only render if `getDailyLookback()` returns 3+ pins | Pending |
+| | Tapping mini-card: open pin URL or expand card | Pending |
+| | Dismissal: set `lookback_dismissed_at` in localStorage, suppress 24 hours | Pending |
+| | New set each day: cache resets at midnight (user local time) | Pending |
+| | Only show when `currentFilter === 'all'` (not in category-filtered views) | Pending |
+
+### Story 3: Time Machine View
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Time Machine entry point** | | Pending |
+| | Accessible from Lookback card "See all" and from Lookback nav | Pending |
+| | Activation: 10+ pins AND collection 14+ days old | Pending |
+| **Time period filters** | | Pending |
+| | Year tabs: one per year present in collection | Pending |
+| | Season filters: Winter, Spring, Summer, Fall (by month) | Pending |
+| | Category filter: reuse existing 9-category chips | Pending |
+| | Filters compose with AND logic | Pending |
+| **Time Machine grid** | | Pending |
+| | Render filtered pins in standard board grid (reuse card components) | Pending |
+| | Sort: `created_at` descending within filtered set | Pending |
+| | Count: "12 pins from Summer 2025" above grid | Pending |
+| | Empty state: "No pins from [filter combination]" | Pending |
+| **Navigation** | | Pending |
+| | URL hash routing: `#lookback/time-machine?year=2025&season=summer` | Pending |
+| | Back button returns to Lookback card or board grid | Pending |
+
+### Story 4: Lookback View Shell
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Lookback view layout** | | Pending |
+| | "LOOKBACK" header with back-to-board navigation | Pending |
+| | "Today" section: featured large card (highest score) + 2-3 supporting mini-cards | Pending |
+| | "Time Machine" section below Today (from Story 3) | Pending |
+| | Empty state: "Come back tomorrow" if daily budget exhausted | Pending |
+| **Today section — featured card** | | Pending |
+| | Full image, title, domain, multi-signal context sentence | Pending |
+| | Action buttons: "Open link", "Re-categorize", "Archive" | Pending |
+| | Supporting mini-cards below featured card | Pending |
+| **Nav integration** | | Pending |
+| | Lookback accessible from dedicated nav icon or filter item | Pending |
+| | Deep link: `#lookback` opens Lookback view | Pending |
+
+### Story 5: Phase 1 Testing
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Functional testing** | | Pending |
+| | Test scoring: verify anniversary window, seasonal match, staleness decay | Pending |
+| | Test daily budget: verify max 5 pins, max 1 consumption gap | Pending |
+| | Test cache: same set on reload within day, new set after midnight | Pending |
+| | Test thresholds: no card for <20 pins or <30 day collections | Pending |
+| | Test Time Machine: 10+ pin threshold, filter composition | Pending |
+| | Test dismissal: 24-hour suppression, new set overrides next day | Pending |
+| **Performance verification** | | Pending |
+| | `computeLookbackScore()` runs < 200ms for 1,000 pins | Pending |
+| | Interaction tracking overhead < 10ms per event | Pending |
+| | Lookback card renders < 500ms after board load | Pending |
+
+---
+
+## Epic 12.2: External Context + Full Lookback View
+
+> **New signals**: Dead link detection, release calendar, creator activity, seasonal commerce
+> **New surfaces**: Full Lookback View (This Week, Monthly Review, Collection Timeline), weekly digest
+> **Scoring**: Edge function with external data
+> **Personas**: The DJ (new releases), The Visual Collector (price drops), The Researcher (dead links)
+>
+> **Absorbs backlog**: "Monthly digest widget", "Collection timeline", "Streaming availability notifications" (#61)
+
+### Story 1: Lookback Edge Function
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Create `lookback` edge function** | | Pending |
+| | Create `supabase/functions/lookback/index.ts` with action router | Pending |
+| | Action: `score` — accepts `{ user_id, limit, exclude_ids[] }`, returns ranked pins with signals | Pending |
+| | Action: `monthly-review` — accepts `{ user_id, month }`, returns AI-generated summary | Pending |
+| | Action: `check-dead-links` — accepts `{ user_id }`, runs HEAD checks, updates `link_status` | Pending |
+| | Migrate client-side scoring to edge function (temporal + interaction server-side) | Pending |
+| | Client falls back to client-side scoring if edge function unavailable | Pending |
+
+### Story 2: Dead Link Detection
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Schema for link health** | | Pending |
+| | Write migration `018_lookback_external.sql` | Pending |
+| | Add `link_status TEXT DEFAULT 'alive'` to `links` ('alive', 'dead', 'redirect', 'unknown') | Pending |
+| | Add `link_checked_at TIMESTAMPTZ DEFAULT NULL` to `links` | Pending |
+| | Run migration against Boards Supabase project | Blocked |
+| **Dead link checker** | | Pending |
+| | HTTP HEAD requests to pin URLs with 5-second timeout | Pending |
+| | Mark `link_status = 'dead'` for 404, 410, 5xx | Pending |
+| | Mark `link_status = 'redirect'` for 301/302 with different final domain | Pending |
+| | Rate limit: max 100 URLs per user per run | Pending |
+| | Prioritize oldest-checked pins (`link_checked_at ASC NULLS FIRST`) | Pending |
+| | Respect `Retry-After` headers | Pending |
+| | Cache results 7 days: skip recently-checked pins | Pending |
+| **Scheduled execution** | | Pending |
+| | GitHub Actions workflow: run `check-dead-links` weekly (Sunday midnight) | Pending |
+| | Log results: checked count, newly dead count, errors | Pending |
+| **Dead link as Lookback signal** | | Pending |
+| | Score boost for `link_status = 'dead'`, label "Link may be dead" | Pending |
+| | Max 1 dead link pin per daily budget | Pending |
+
+### Story 3: Release Calendar Integration
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **TMDB for watch pins** | | Pending |
+| | Query TMDB API for upcoming seasons/episodes on `category = 'watch'` pins | Pending |
+| | Fuzzy title match (0.8+ similarity) | Pending |
+| | Lookback signal: release within 30 days → "New season available" | Pending |
+| **Open Library for read pins** | | Pending |
+| | Query Open Library for author's latest work on `category = 'read'` pins with book metadata | Pending |
+| | Lookback signal: new release within 60 days → "New book from this author" | Pending |
+| **YouTube creator activity** | | Pending |
+| | Check latest upload on YouTube channels for follow/listen pins | Pending |
+| | Lookback signal: new upload within 7 days → "Just posted something new" | Pending |
+| | YouTube Data API v3 key required (add to edge function secrets) | Pending |
+| **Seasonal commerce rules** | | Pending |
+| | Calendar-based rules: month ranges → category boosts | Pending |
+| | Nov-Dec: boost eat recipes + go gift guides; Jun-Aug: boost wear + go travel | Pending |
+| | Pure calendar logic — no external API | Pending |
+
+### Story 4: Full Lookback View — Additional Sections
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **"This Week" section** | | Pending |
+| | Show pins surfaced earlier this week, not acted on (not clicked, not dismissed) | Pending |
+| | Max 4 pins | Pending |
+| | Disappears if all were acted on | Pending |
+| **Monthly Review section** | | Pending |
+| | Claude Haiku generates 2-3 sentence summary of month's saving activity | Pending |
+| | Input: category counts, new categories, total pins, milestones | Pending |
+| | Cache per month; regenerate only if pin count changes by 3+ | Pending |
+| | Fallback: simple stats ("You saved 23 pins across 6 categories") | Pending |
+| **Collection Timeline section** | | Pending |
+| | Visual timeline of saves by month — bar chart or sparkline (CSS/SVG, no library) | Pending |
+| | Filterable by category | Pending |
+| | Tapping a month bar filters Time Machine to that month | Pending |
+
+### Story 5: Weekly Digest Email
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Email infrastructure** | | Pending |
+| | Select email provider (Resend recommended) | Pending |
+| | Add `RESEND_API_KEY` to Ops Supabase function secrets | Blocked |
+| | Create `send-digest` edge function in Ops project | Pending |
+| **Digest content** | | Pending |
+| | Top 3 lookback pins by composite score for the week | Pending |
+| | Pin title, domain, context label, age | Pending |
+| | Footer: week's save count, most-saved category | Pending |
+| | Deep link: "Open Lookback" → `#lookback` | Pending |
+| **Digest scheduling** | | Pending |
+| | GitHub Actions workflow: weekly (Monday 9am) | Pending |
+| | Only send if 30+ pins AND collection 60+ days old AND 3+ qualifying pins | Pending |
+| | Unsubscribe link in footer (set preference on user profile) | Pending |
+
+### Story 6: Phase 2 Testing
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Edge function testing** | | Pending |
+| | Test `lookback` edge function `score` action with real data | Pending |
+| | Test dead link checker: mock 404 responses, verify status update | Pending |
+| | Test TMDB integration: fuzzy matching, signal generation | Pending |
+| | Test monthly review: verify <3 sentences, verify caching | Pending |
+| **Digest testing** | | Pending |
+| | Send test digest, verify formatting | Pending |
+| | Verify unsubscribe works | Pending |
+| | Verify threshold logic (no digest for small/new collections) | Pending |
+| **Deployment** | | Pending |
+| | Deploy `lookback` edge function to Boards project | Pending |
+| | Deploy `send-digest` edge function to Ops project | Pending |
+
+---
+
+## Epic 12.3: Collection Intelligence + Re-engagement
+
+> **New signals**: Cross-category connections, taste drift, emerging themes, trending topics
+> **New surfaces**: Re-engagement push notification, smart grouping
+> **Scoring**: AI-powered (Claude Haiku for theme extraction)
+> **Personas**: The Cultural Omnivore (taste drift), The Multidisciplinary Maker (cross-category), The Researcher (trending)
+>
+> **Absorbs backlog**: "Taste profile", "You save a lot of X insights", "Trend detection", "Cross-category connections"
+
+### Story 1: Taste Profile
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Taste profile computation** | | Pending |
+| | `computeTasteProfile(links)` — returns `{ topCategories, topDomains, topContentTypes, saveVelocity, mostActivePeriod }` | Pending |
+| | Top categories: distribution as percentages, ranked | Pending |
+| | Top domains: most frequently saved (top 5) | Pending |
+| | Save velocity: pins per week (4-week average vs. prior 4-week) | Pending |
+| | Most active period: time-of-day and day-of-week distributions | Pending |
+| **"Your taste at a glance" surface** | | Pending |
+| | Section in Lookback View with top 3 insights in plain language | Pending |
+| | Refresh weekly (cached in localStorage) | Pending |
+
+### Story 2: Trend Detection and Emerging Themes
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Burst detection** | | Pending |
+| | Analyze `created_at` clustering: 3+ pins in 2-week window with similar category/domain | Pending |
+| | Label: "Your architecture phase, March 2025 (8 pins)" | Pending |
+| | Surface as markers on collection timeline | Pending |
+| **Emerging theme detection** | | Pending |
+| | Claude Haiku: send last 30 days of pin titles/domains, ask for themes beyond existing categories | Pending |
+| | Output: `{ theme, pin_count, confidence, sample_pins }` | Pending |
+| | Surface: "Emerging in your collection: [theme]" | Pending |
+| | Minimum: 3+ pins, confidence > 0.7 | Pending |
+| | Compute monthly, cache — one Haiku call per user per month | Pending |
+| **Trending topic matching** | | Pending |
+| | Query Google Trends or X trending topics daily | Pending |
+| | Cross-reference against pin titles/descriptions/domains | Pending |
+| | Signal: "Trending right now" label, max 1 per daily budget | Pending |
+| | Degrade gracefully if API unavailable | Pending |
+
+### Story 3: Cross-Category Connections
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Semantic similarity** | | Pending |
+| | Claude Haiku: identify thematic connections across categories | Pending |
+| | Input: pin titles, descriptions, domains across categories | Pending |
+| | Output: `{ pin_a_id, pin_b_id, connection_type, reason }` | Pending |
+| | Compute monthly, cache | Pending |
+| **Connection surface** | | Pending |
+| | Lookback signal: "These pins connect across categories" — surface pair with reason | Pending |
+| | "Connections" subsection in Lookback View | Pending |
+| | Minimum: confidence > 0.75 | Pending |
+
+### Story 4: Taste Drift
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Taste drift computation** | | Pending |
+| | Compare category distribution: last 90 days vs. prior 90 days | Pending |
+| | Detect categories that grew or shrank by 10%+ | Pending |
+| | Summary: "You're saving more [listen] and less [watch] lately" | Pending |
+| **Taste drift surface** | | Pending |
+| | Add to "Your taste at a glance" section | Pending |
+| | Only surface when 10%+ shift in at least one category | Pending |
+
+### Story 5: Re-engagement Push Notification
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Push notification prerequisite** | | Blocked |
+| | FCM/APNs setup required (existing blocker) | Blocked |
+| **Re-engagement trigger** | | Pending |
+| | Trigger: user inactive 14+ days | Pending |
+| | Select pin: highest composite lookback score | Pending |
+| | Cadence: max 1 nudge per 30 days per user | Pending |
+| | Only for opted-in users | Pending |
+| **Measurement** | | Pending |
+| | Track: app open within 48 hours of nudge | Pending |
+| | Target: 15% conversion rate | Pending |
+
+### Story 6: Smart Grouping
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Group by signal type** | | Pending |
+| | Group Today's pins: "Anniversaries", "Unfinished business", "New from creators", "Trending" | Pending |
+| | Group headers when 2+ pins share signal type | Pending |
+| | Ungrouped pins render without header | Pending |
+| **Group actions** | | Pending |
+| | "Open all" — open all URLs in group in new tabs | Pending |
+| | "Dismiss group" — dismiss all pins in group for 48 hours | Pending |
+
+### Story 7: Phase 3 Testing
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **AI signal testing** | | Pending |
+| | Test emerging themes: quality of Haiku output on real boards | Pending |
+| | Test cross-category: at least 1 meaningful connection per 50-pin collection | Pending |
+| | Test trending topics: graceful degradation when API unavailable | Pending |
+| | Test taste drift: accurate period comparison | Pending |
+| **Cost verification** | | Pending |
+| | Monthly review + emerging theme + cross-category: combined ≤ 2 Haiku calls per user per month | Pending |
+| | Total Claude cost at 1,000 users: verify < $10/month | Pending |
+| | Trending API cost: verify < $10/month at 1,000 users | Pending |

--- a/docs/execution/project-plan/phase-3-ai-intelligence.md
+++ b/docs/execution/project-plan/phase-3-ai-intelligence.md
@@ -768,3 +768,143 @@ Replace "Refresh Image" button with a full image management interface. Users get
 | **Upload tab**: Drag-and-drop or file picker for custom image | Pending |
 | Image history: show previous images for this pin, one-click revert | Pending |
 | Keyboard shortcut: `i` on selected pin opens image editor | Pending |
+
+---
+
+## Epic 3.6: Categorization Cleanup (Pending)
+
+> **Vision**: A persistent utility queue that surfaces pins with low-confidence AI categorization or missing metadata, lets users fast-correct them, and feeds corrections back into the classification system. Not a widget — a drain-to-zero task queue with a badge count.
+>
+> **Reference**: [PRD: Categorization Cleanup](/docs/strategy/prds/categorization-cleanup.md)
+>
+> **Prerequisite**: Requires `confidence` and `type_confidence` fields from Epic 3.1. Requires `image_scores` from Phase 10.
+
+### Story 1: Schema Migration
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Schema: user_reviewed_at** | | Pending |
+| | Write migration `016_categorization_cleanup.sql`: add `user_reviewed_at TIMESTAMPTZ DEFAULT NULL` to `links` table | Pending |
+| | Add index `idx_links_user_reviewed` on `(user_id, user_reviewed_at)` for queue query performance | Pending |
+| | Run migration against Boards Supabase project | Blocked |
+| | Update `database-schema.md` to document new column | Pending |
+
+### Story 2: Cleanup Queue — Client-Side Computation
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Adaptive threshold computation** | | Pending |
+| | Implement `computeAdaptiveThreshold(links)`: 25th percentile of confidence distribution, floor 0.50, ceiling 0.80 | Pending |
+| | Cache threshold per session (recompute on page load, not per render) | Pending |
+| **getCleanupQueue() function** | | Pending |
+| | Implement `getCleanupQueue(links)` — filter by: confidence < adaptive threshold, uncategorized, type_confidence < 0.50, missing image (null or composite < 0.15), enrichment_failed, missing structured metadata (watch w/o video, listen w/o music, read w/o book) | Pending |
+| | Exclude pins where `user_reviewed_at` is set | Pending |
+| | Priority sort: uncategorized (0), confidence < threshold (1), type_confidence < 0.50 (2), everything else (3) | Pending |
+| | Secondary sort: `created_at` descending within each priority tier | Pending |
+| | Cap queue at 25 items | Pending |
+| | Feature activation gate: return empty queue if user has fewer than 10 pins total | Pending |
+| **Queue badge count** | | Pending |
+| | Compute badge count from `getCleanupQueue()` result length | Pending |
+| | Render badge on cleanup nav item (count, max display "25+") | Pending |
+| | Refresh badge on page load and after each review action | Pending |
+
+### Story 3: Cleanup View — Navigation Entry Point
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Cleanup nav item** | | Pending |
+| | Add cleanup entry to `renderFilters()` after existing category pills | Pending |
+| | Show only if queue has 3+ items | Pending |
+| | Active state styling consistent with other filter pills | Pending |
+| | Tapping nav item activates cleanup view (replaces grid with cleanup UI) | Pending |
+| **Cleanup view shell** | | Pending |
+| | Empty state: "All clear" messaging with return-to-board CTA | Pending |
+| | Header: "Review (N)" with count decrementing as items are resolved | Pending |
+| | Exit cleanup: back button or tapping any category nav returns to board grid | Pending |
+
+### Story 4: Review Card UI
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Review card layout** | | Pending |
+| | Full-width hero image (or placeholder with "No image" label if missing) | Pending |
+| | Inline-editable title field (tap to edit, tap away to save) | Pending |
+| | Inline-editable description field (collapsed to 2 lines, expandable) | Pending |
+| | Domain label below title | Pending |
+| | "AI says: [category] (N%)" context line | Pending |
+| | 9 category chips (horizontally scrollable) with AI suggestion pre-selected | Pending |
+| | Three action buttons: Confirm (primary), Skip (secondary), Delete (destructive) | Pending |
+| **Review card behavior** | | Pending |
+| | Confirm: apply current state, set `user_reviewed_at`, slide card out, show next | Pending |
+| | Skip: move pin to end of queue, excluded from current session | Pending |
+| | Delete: remove pin with undo toast (3-second window) | Pending |
+| | Progress indicator: "3 of 12" counter | Pending |
+| | Keyboard shortcuts: `c` confirm, `s` skip, `d` delete (desktop) | Pending |
+| **Re-fetch image action** | | Pending |
+| | Show "Re-fetch image" button on cards with missing/poor image | Pending |
+| | Calls existing image resolution pipeline, updates card inline | Pending |
+
+### Story 5: Inline Queue Banner
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Banner component** | | Pending |
+| | Render banner at top of board grid when cleanup queue has 3+ items | Pending |
+| | Content: "[flag icon] N pins need review" with "Review now" CTA | Pending |
+| | Tapping CTA activates cleanup view | Pending |
+| | Dismiss button hides banner for current session | Pending |
+| **Banner suppression logic** | | Pending |
+| | Track `cleanup_banner_dismissed_at` in localStorage | Pending |
+| | Suppress if dismissed within 24 hours AND no new queue items since dismissal | Pending |
+| | Re-show if new pins added and queue grew after dismissal | Pending |
+
+### Story 6: Batch Actions
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Multi-select mode** | | Pending |
+| | Long-press on review card enters multi-select mode | Pending |
+| | Checkbox on each card, tap to toggle selection | Pending |
+| | Selection count in floating action bar | Pending |
+| | "Done" button exits multi-select | Pending |
+| **Batch operations** | | Pending |
+| | "Move to category" — category picker, applies to all selected | Pending |
+| | "Delete" — confirmation dialog with count, bulk delete with undo | Pending |
+| | "Re-enrich" — re-trigger server enrichment for selected pins | Pending |
+| | After batch: deselect all, update queue and badge count | Pending |
+
+### Story 7: Feedback Loop
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **On confirm / re-categorize** | | Pending |
+| | Update pin `category`, set `confidence` to 1.0 (user-confirmed) | Pending |
+| | Set `user_reviewed_at` to current timestamp | Pending |
+| | Write `classification_log` entry: `user_override = true`, original + corrected category, original confidence | Pending |
+| | Sync changes to Supabase | Pending |
+| **Domain profile boosting** | | Pending |
+| | On correction: call `updateDomainProfile(domain, correctedCategory)` | Pending |
+| | Increment corrected-category count in `domain_profiles` | Pending |
+| | At 3+ overrides to same category for a domain: boost cached confidence | Pending |
+| **On title / description edit** | | Pending |
+| | Update `title`/`description` in localStorage and sync to Supabase | Pending |
+| | If content type derived from title keywords, re-evaluate `content_type` client-side | Pending |
+
+### Story 8: Testing & Polish
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Functional testing** | | Pending |
+| | Test queue computation: various confidence levels, verify sorting and cap | Pending |
+| | Test adaptive threshold: verify percentile computation, floor, ceiling | Pending |
+| | Test review card: confirm, skip, delete flows with localStorage and Supabase sync | Pending |
+| | Test batch operations: multi-select, category move, bulk delete | Pending |
+| | Test feedback loop: verify `classification_log` entries and `domain_profiles` updates | Pending |
+| | Test banner: appearance at 3+ items, dismissal, 24-hour suppression | Pending |
+| **Edge cases** | | Pending |
+| | Queue with 0 items: no nav badge, no banner, empty state in cleanup view | Pending |
+| | Queue with 1-2 items: no banner, nav badge appears, cleanup view works | Pending |
+| | User reviews all items: badge disappears, "All clear" state shown | Pending |
+| | Offline: queue computed from localStorage, sync queued for reconnection | Pending |
+| | Undo delete: 3-second toast, pin restored to queue on undo | Pending |
+| | Feature gate: verify no UI appears below 10 pins | Pending |

--- a/docs/strategy/prds/categorization-cleanup.md
+++ b/docs/strategy/prds/categorization-cleanup.md
@@ -76,7 +76,7 @@ This is not a widget. Widgets are ephemeral AI-generated recommendations — the
 
 | Signal | Threshold | Priority |
 |--------|-----------|----------|
-| Category confidence | < 0.65 | High |
+| Category confidence | Below adaptive threshold (see Threshold Framework below) | High |
 | Content in `uncategorized` | Any | High |
 | Content type confidence | < 0.50 | Medium |
 | Missing image (no image or composite score < 0.15) | Any | Medium |
@@ -86,7 +86,40 @@ This is not a widget. Widgets are ephemeral AI-generated recommendations — the
 
 **Sorting:** High priority first, then by `created_at` descending (newest uncertain pins first — they're freshest in memory).
 
-**Badge count:** Total pins in the queue. Displayed on the cleanup nav item. Refreshed on page load and after each action.
+**Badge count:** Total pins in the queue (capped at 25). Displayed on the cleanup nav item. Refreshed on page load and after each action.
+
+### Threshold Framework
+
+The cleanup queue uses an adaptive threshold model rather than a fixed cutoff. This ensures the queue is useful for both users whose AI performs well (most confidence scores > 0.80) and users whose AI struggles (scores clustered around 0.50-0.60).
+
+**Category confidence threshold:**
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Method | 25th percentile of user's confidence distribution | Adapts to each user's AI accuracy |
+| Floor | 0.50 | Below 0.50 the AI is essentially guessing — always flag |
+| Ceiling | 0.80 | Above 0.80 the AI is confident — never flag |
+
+Computed on each queue refresh: `threshold = max(0.50, min(0.80, percentile(user_confidences, 0.25)))`. If a user's 25th percentile is 0.72, only pins below 0.72 are flagged. If it's 0.45, the floor kicks in at 0.50.
+
+**Activation gates:**
+
+| Gate | Condition | Behavior |
+|------|-----------|----------|
+| Feature activation | User has < 10 pins total | Cleanup queue returns empty; no badge, no banner, no nav item |
+| Dedicated view | Queue has < 3 items | Nav badge hidden; banner hidden; cleanup view accessible only via direct URL |
+| Badge + banner | Queue has 3+ items | Nav badge visible with count; inline banner appears on board |
+| Queue cap | Queue exceeds 25 items | Show only the top 25 by priority; remaining items are deferred |
+
+**Sub-signal thresholds** (unchanged from qualification table above):
+
+| Signal | Threshold | Notes |
+|--------|-----------|-------|
+| Content type confidence | < 0.50 | Fixed — type classification has different accuracy profile |
+| Image composite score | < 0.15 | Fixed — below this threshold, image is unusable |
+| Enrichment failure | `enrichment_failed = true` | Binary — no threshold |
+| Missing structured metadata | Category-specific null check | Binary — no threshold |
+| Uncategorized | `category = 'uncategorized'` | Binary — always flagged |
 
 ---
 
@@ -188,11 +221,12 @@ The cleanup queue is **computed, not stored**. Qualification is derived from exi
 
 ```sql
 -- Cleanup queue query
+-- Note: :adaptive_threshold is computed client-side as max(0.50, percentile(user_confidences, 0.25))
 SELECT * FROM links
 WHERE user_id = :user_id
   AND user_reviewed_at IS NULL
   AND (
-    confidence < 0.65
+    confidence < :adaptive_threshold
     OR category = 'uncategorized'
     OR type_confidence < 0.50
     OR image IS NULL
@@ -205,11 +239,12 @@ WHERE user_id = :user_id
 ORDER BY
   CASE
     WHEN category = 'uncategorized' THEN 0
-    WHEN confidence < 0.65 THEN 1
+    WHEN confidence < :adaptive_threshold THEN 1
     WHEN type_confidence < 0.50 THEN 2
     ELSE 3
   END,
-  created_at DESC;
+  created_at DESC
+LIMIT 25; -- Queue cap
 ```
 
 ### Schema Changes
@@ -243,9 +278,16 @@ For the local-first architecture, the cleanup queue is also computed client-side
 
 ```javascript
 function getCleanupQueue(links) {
+  if (links.length < 10) return []; // Feature activation gate
+
+  // Adaptive threshold: 25th percentile of confidence distribution, floored at 0.50, capped at 0.80
+  const confidences = links.map(l => l.confidence || 0).filter(c => c > 0).sort((a, b) => a - b);
+  const p25Index = Math.floor(confidences.length * 0.25);
+  const adaptiveThreshold = Math.max(0.50, Math.min(0.80, confidences[p25Index] || 0.50));
+
   return links.filter(link =>
     !link.user_reviewed_at && (
-      (link.confidence || 0) < 0.65 ||
+      (link.confidence || 0) < adaptiveThreshold ||
       link.category === 'uncategorized' ||
       (link.type_confidence || 0) < 0.50 ||
       !link.image ||
@@ -257,7 +299,7 @@ function getCleanupQueue(links) {
     const priorityB = getPriority(b);
     if (priorityA !== priorityB) return priorityA - priorityB;
     return new Date(b.addedAt) - new Date(a.addedAt);
-  });
+  }).slice(0, 25); // Queue cap
 }
 ```
 
@@ -347,7 +389,7 @@ Widgets are the wrong abstraction for cleanup because:
 
 ## Open Questions
 
-1. **Threshold tuning** — Is 0.65 the right category confidence cutoff for flagging? Should it be configurable per user or learn from their correction rate?
+1. ~~**Threshold tuning**~~ **Resolved** — Using adaptive percentile-based threshold (25th percentile of user's confidence distribution, floored at 0.50, capped at 0.80). See Threshold Framework section above. The system adapts per-user automatically; no manual configuration needed.
 2. **Re-flagging** — If the enrichment system re-processes a pin and lowers its confidence after the user reviewed it, should it re-enter the queue? Currently `user_reviewed_at` prevents this permanently.
 3. **Gamification** — Should there be any reward for emptying the queue (streak counter, "all clear" animation)? Risk of making it feel like a chore vs. a satisfying micro-task.
 4. **Image review** — Should "bad image" pins get a different review card with image selection options (choose from alternatives, upload, or accept template)?

--- a/docs/strategy/prds/categorization-cleanup.md
+++ b/docs/strategy/prds/categorization-cleanup.md
@@ -1,0 +1,376 @@
+# PRD: Categorization Cleanup
+
+**Version:** 1.0
+**Date:** 2026-02-19
+**Status:** Draft
+
+---
+
+## Overview
+
+Every AI categorization system makes mistakes. ctrl.rodeo currently assigns categories and content types with confidence scores, but pins with low or medium confidence silently live in the wrong place — or pile up in `uncategorized`. There's no mechanism for a user to review, correct, or confirm what the AI decided.
+
+Categorization Cleanup is a dedicated review surface that identifies pins with weak, suspect, or missing metadata and presents them for fast human correction. It turns the AI's uncertainty into an invitation: "I'm not sure about these — take a look?" The result is a cleaner, more trustworthy collection that improves over time as user corrections feed back into the system's domain knowledge.
+
+This is not a widget. Widgets are ephemeral AI-generated recommendations — they appear and disappear. Cleanup is a persistent utility: a queue of work that drains as you act on it. It deserves its own surface, accessible from the main board navigation, with a badge count that communicates "N items need attention" without being noisy.
+
+---
+
+## Goals
+
+1. Surface pins the AI is uncertain about, so users can correct mistakes before they compound
+2. Improve collection quality without requiring users to manually audit every pin
+3. Feed user corrections back into the categorization system to improve future accuracy
+4. Keep the experience fast and low-friction — reviewing a pin should take 2-3 seconds
+5. Reduce the `uncategorized` backlog by giving users an easy path to resolve it
+
+---
+
+## Who This Serves
+
+### Primary Personas
+
+| Persona | Why This Matters |
+|---------|-----------------|
+| **The Visual Collector** | Saves 40+ links across design, fashion, architecture. Miscategorized pins break the visual browsing flow — a furniture link in `wear` is jarring. Needs fast bulk correction. |
+| **The Multidisciplinary Maker** | Content spans materials, code, design tools, suppliers. AI struggles with cross-domain links. Needs to correct "is this `use` or `read`?" decisions. |
+| **The DJ** | Music links from obscure platforms (Bandcamp subdomains, SoundCloud sets) often get miscategorized. Quick re-sort keeps the dig organized. |
+
+### Secondary Personas
+
+| Persona | Why This Matters |
+|---------|-----------------|
+| **The Researcher** | Article quality depends on correct categorization for later retrieval. A misplaced article is a lost connection. |
+| **The Deep-Dive Enthusiast** | Curates recommendations for friends — accuracy matters because they share from categories. |
+
+### Jobs To Be Done
+
+| When I... | I want to... | So I can... |
+|-----------|-------------|-------------|
+| Open my board and see the cleanup badge | Quickly review flagged pins | Trust that my collection is accurate |
+| See a pin the AI put in the wrong category | Re-categorize it with one tap | Keep my board organized without hunting for mistakes |
+| Notice pins stuck in uncategorized | Assign them to the right place | Eliminate the junk drawer feeling |
+| See a pin with a bad title or missing image | Fix the metadata inline | Maintain a clean, browsable collection |
+| Finish reviewing all flagged pins | See the badge disappear | Feel a sense of completion and trust in the system |
+
+---
+
+## Design Principles
+
+| Brand Principle | Application |
+|-----------------|-------------|
+| **Organize as you go** | Cleanup is not a chore — it's a 30-second check-in that keeps the system honest |
+| **Show, don't decorate** | The pin's own content (image, title, domain) is the UI. Minimal chrome around it. |
+| **Expand with the user** | Badge only appears when there's work. New users won't see it until they have enough pins for the AI to be uncertain about something. |
+| **Input shapes output** | User corrections make the AI smarter — every cleanup action improves future categorization |
+
+---
+
+## Core Features
+
+### 1. Cleanup Queue
+
+**What it is:** A filtered view of pins that need human attention, ranked by urgency.
+
+**Qualification criteria** — a pin enters the queue if ANY of these are true:
+
+| Signal | Threshold | Priority |
+|--------|-----------|----------|
+| Category confidence | < 0.65 | High |
+| Content in `uncategorized` | Any | High |
+| Content type confidence | < 0.50 | Medium |
+| Missing image (no image or composite score < 0.15) | Any | Medium |
+| Missing title (title is URL slug or empty) | Any | Medium |
+| Enrichment failure | `enrichment_failed = true` | Low |
+| Missing structured metadata | e.g., `category = 'watch'` but `video` is null | Low |
+
+**Sorting:** High priority first, then by `created_at` descending (newest uncertain pins first — they're freshest in memory).
+
+**Badge count:** Total pins in the queue. Displayed on the cleanup nav item. Refreshed on page load and after each action.
+
+---
+
+### 2. Review Card
+
+**What it is:** An expanded pin card optimized for fast decision-making.
+
+```
+┌─────────────────────────────────────────────┐
+│  [image]                                    │
+│                                             │
+│  Title (editable)                           │
+│  domain.com                                 │
+│  "Description text..." (editable)           │
+│                                             │
+│  AI says: watch (62% confident)             │
+│  ┌─────┬───────┬────────┬───────┬─────────┐ │
+│  │ wear│ watch │ listen │ read  │ follow  │ │ ← category chips
+│  └─────┴───────┴────────┴───────┴─────────┘ │
+│  AI suggested category is pre-selected      │
+│                                             │
+│  [Confirm]              [Skip]    [Delete]  │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+
+- **Image**: Full-width hero. If missing/poor, show a placeholder with "No image" and an optional "Re-fetch image" action.
+- **Title**: Inline editable. Tap to edit, tap away to save. Pre-filled with current title.
+- **Description**: Inline editable. Collapsed to 2 lines, expandable.
+- **Category chips**: All 9 categories displayed as tappable chips. AI's suggestion pre-selected. Tap another to re-categorize. The AI confidence is shown as context ("AI says: watch (62%)") but doesn't constrain the choice.
+- **Confirm**: Accept current state (category, title, description). Marks pin as reviewed. Advances to next.
+- **Skip**: Move to end of queue. Pin remains flagged.
+- **Delete**: Remove pin entirely (with undo toast).
+
+---
+
+### 3. Batch Actions
+
+**What it is:** Multi-select mode for power users who want to process many pins at once.
+
+**Behavior:**
+
+- Long-press or checkbox toggle enters multi-select mode
+- Select multiple pins from the queue list view
+- Available batch actions:
+  - **Move to category** — assign all selected to one category
+  - **Delete** — remove all selected (with count confirmation)
+  - **Re-enrich** — re-trigger server-side enrichment for all selected (useful for enrichment failures)
+- Exit multi-select with "Done" or by tapping outside
+
+---
+
+### 4. Inline Queue (Alternative Entry Point)
+
+**What it is:** A compact banner within the main board view that surfaces when cleanup items exist.
+
+```
+┌─────────────────────────────────────────────┐
+│  ⚑ 7 pins need review                      │
+│  [Review now →]                             │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+
+- Appears at the top of the grid when there are 3+ items in the cleanup queue
+- Tapping opens the full cleanup view
+- Dismissible per session (reappears next visit if items remain)
+- Does not appear if the user has dismissed it within the last 24 hours and no new items have been added
+
+This is NOT a widget — it's a system notification banner. It doesn't use the widget infrastructure, doesn't call `generate-widget`, and doesn't have AI-generated content. It's a static prompt.
+
+---
+
+### 5. Feedback Loop
+
+**What it is:** User corrections feed back into the categorization system to improve future accuracy.
+
+**On confirm or re-categorize:**
+
+1. Update the pin's `category`, `confidence` (set to 1.0 for user-confirmed), and `updated_at`
+2. Write to `classification_log` with `user_override = true`, recording both the AI's original prediction and the user's correction
+3. Update `domain_profiles` if the user's choice differs from the cached domain classification — increment the user-chosen type's count
+4. When a domain accumulates 3+ user overrides to the same category, boost that domain's cached confidence for future pins
+
+**On title/description edit:**
+
+1. Update the pin's `title` and/or `description` in both localStorage and Supabase
+2. If content type was derived from title keywords, re-evaluate content type classification
+
+---
+
+## Data Model
+
+### No New Tables Required
+
+The cleanup queue is **computed, not stored**. Qualification is derived from existing fields:
+
+```sql
+-- Cleanup queue query
+SELECT * FROM links
+WHERE user_id = :user_id
+  AND user_reviewed_at IS NULL
+  AND (
+    confidence < 0.65
+    OR category = 'uncategorized'
+    OR type_confidence < 0.50
+    OR image IS NULL
+    OR (image_scores->>'composite')::float < 0.15
+    OR enrichment_failed = true
+    OR (category = 'watch' AND video IS NULL)
+    OR (category = 'listen' AND music IS NULL)
+    OR (category = 'read' AND book IS NULL)
+  )
+ORDER BY
+  CASE
+    WHEN category = 'uncategorized' THEN 0
+    WHEN confidence < 0.65 THEN 1
+    WHEN type_confidence < 0.50 THEN 2
+    ELSE 3
+  END,
+  created_at DESC;
+```
+
+### Schema Changes
+
+One new column on the `links` table:
+
+```sql
+ALTER TABLE links ADD COLUMN user_reviewed_at TIMESTAMPTZ DEFAULT NULL;
+```
+
+**Purpose:** Tracks when a user explicitly confirmed or corrected a pin. Pins with `user_reviewed_at IS NOT NULL` are excluded from the cleanup queue regardless of confidence. This prevents the system from re-flagging pins the user has already approved.
+
+**Why not a boolean?** A timestamp is more useful — it enables future queries like "pins reviewed in the last 30 days" and doesn't lose information.
+
+### Existing Fields Used
+
+| Field | Role in Cleanup |
+|-------|----------------|
+| `confidence` | Category confidence score — primary cleanup signal |
+| `type_confidence` | Content type confidence — secondary signal |
+| `category` | Current category assignment — `uncategorized` is a trigger |
+| `image` | Null = missing image trigger |
+| `image_scores->>'composite'` | Low composite = poor image trigger |
+| `enrichment_failed` | Enrichment failure trigger |
+| `video`, `music`, `book` | Missing structured metadata trigger |
+| `classification_log.user_override` | Existing field — used to record corrections |
+
+### Client-Side Queue
+
+For the local-first architecture, the cleanup queue is also computed client-side from localStorage:
+
+```javascript
+function getCleanupQueue(links) {
+  return links.filter(link =>
+    !link.user_reviewed_at && (
+      (link.confidence || 0) < 0.65 ||
+      link.category === 'uncategorized' ||
+      (link.type_confidence || 0) < 0.50 ||
+      !link.image ||
+      link.enrichment_failed
+    )
+  ).sort((a, b) => {
+    // Priority sort, then recency
+    const priorityA = getPriority(a);
+    const priorityB = getPriority(b);
+    if (priorityA !== priorityB) return priorityA - priorityB;
+    return new Date(b.addedAt) - new Date(a.addedAt);
+  });
+}
+```
+
+---
+
+## User Flows
+
+### Flow 1: Badge-Driven Review
+
+```
+1. User opens Boards
+2. Category nav shows: [All] [wear] [watch] ... [⚑ 7]
+3. User taps cleanup badge
+4. Cleanup view opens — first review card displayed
+5. User sees pin: "Brutalist Building Tour" — AI says: go (58%)
+6. User taps "watch" chip instead (it's a video tour)
+7. Taps [Confirm]
+8. Pin saved as watch (confidence: 1.0), user_reviewed_at set
+9. classification_log entry written with user_override
+10. Next card appears — badge count decrements to 6
+11. After 3 reviews, user taps back — returns to board
+```
+
+### Flow 2: Uncategorized Triage
+
+```
+1. User pastes 10 links from various sources
+2. AI categorizes 7 with high confidence, 3 land in uncategorized
+3. After loading, inline banner appears: "3 pins need review"
+4. User taps "Review now"
+5. First uncategorized pin shown with all 9 category chips
+6. User assigns categories to all 3 pins
+7. Banner disappears — uncategorized count drops to 0
+```
+
+### Flow 3: Batch Cleanup
+
+```
+1. User enters cleanup view — sees 15 items
+2. Long-presses to enter multi-select mode
+3. Selects 5 pins that are all fashion items miscategorized as "follow"
+4. Taps "Move to category" → selects "wear"
+5. All 5 updated, removed from queue — count drops to 10
+```
+
+---
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| Review card load time | < 200ms (all data is local) |
+| Queue computation | < 50ms for 1,000 pins |
+| Confirm action feedback | Immediate — card slides out, next slides in |
+| Offline support | Full — queue computed from localStorage, synced when online |
+| Badge accuracy | Exact count, not approximate |
+
+---
+
+## Why Not a Widget?
+
+Widgets are the wrong abstraction for cleanup because:
+
+1. **Persistence** — Widgets are ephemeral suggestions with 1-hour cache TTLs. Cleanup items persist until resolved. A widget that says "7 pins need review" would regenerate every hour, burning AI tokens to say the same thing.
+
+2. **No AI generation needed** — The cleanup queue is a deterministic computation (confidence < threshold). There's no creative or analytical work for the AI to do. Widget generation calls Claude Haiku to produce recommendations — cleanup just needs a database query.
+
+3. **Editing UX** — Widgets display content; they don't support inline editing of pin metadata. The review card needs editable title, description, and category — that's a form, not a widget.
+
+4. **Counting** — The badge count needs to be exact and update on every action. Widget eligibility scores are approximate and cached.
+
+5. **Completion semantics** — Cleanup has a "done" state (queue empty). Widgets are infinite — there's always another recommendation. The psychological reward of emptying the cleanup queue is part of the feature's value.
+
+**The inline banner** (Feature 4) is the bridge — it's a lightweight prompt within the board view that points to the full cleanup surface. It occupies the same visual space a widget might, but it's static HTML with a count, not an AI-generated card.
+
+---
+
+## Future Considerations
+
+1. **Smart re-enrichment** — When a user changes a pin's category (e.g., `follow` → `watch`), automatically trigger watch-specific enrichment (TMDB lookup, video metadata)
+2. **Confidence calibration** — Track the rate at which users override AI decisions per category. If `go` has a 40% override rate, lower its confidence threshold for cleanup flagging.
+3. **Suggested corrections** — Instead of just showing all 9 categories, show "Did you mean: watch?" when the AI's #2 prediction was close. Uses the classification model's runner-up.
+4. **Collaborative cleanup** — On shared boards, allow collaborators to review and correct pins they didn't add.
+5. **Bulk import triage** — When Instagram import (or similar) adds 50+ pins at once, trigger a dedicated triage flow optimized for high-volume review.
+
+---
+
+## Open Questions
+
+1. **Threshold tuning** — Is 0.65 the right category confidence cutoff for flagging? Should it be configurable per user or learn from their correction rate?
+2. **Re-flagging** — If the enrichment system re-processes a pin and lowers its confidence after the user reviewed it, should it re-enter the queue? Currently `user_reviewed_at` prevents this permanently.
+3. **Gamification** — Should there be any reward for emptying the queue (streak counter, "all clear" animation)? Risk of making it feel like a chore vs. a satisfying micro-task.
+4. **Image review** — Should "bad image" pins get a different review card with image selection options (choose from alternatives, upload, or accept template)?
+5. **Notification cadence** — Should the inline banner be more aggressive for new users (who benefit most from a clean collection early) and quieter for power users?
+
+---
+
+## Success Metrics
+
+| Metric | Target | How Measured |
+|--------|--------|-------------|
+| Cleanup queue engagement | 60% of users with flagged pins interact with cleanup | `user_reviewed_at` set / users with queue > 0 |
+| Override rate | < 25% of reviewed pins get re-categorized (meaning AI was mostly right) | `classification_log` where `user_override = true` / total reviews |
+| Uncategorized reduction | 80% reduction in uncategorized pins per user within 30 days of feature launch | Count of `category = 'uncategorized'` over time |
+| Review speed | Median < 3 seconds per pin | Time between card display and confirm action |
+| Return rate | Users return to cleanup within 7 days if new items appear | Session tracking |
+
+---
+
+## Related Documents
+
+- [PRD: Boards MVP](./boards-mvp.md) — Core categorization system and confidence model
+- [AI Widget System](../../infrastructure/technical-design/ai-widget-system.md) — Widget architecture (for contrast with why cleanup is not a widget)
+- [User Personas](../../ux/personas.md) — Persona definitions and JTBD
+- [Brand Positioning](../brand-positioning.md) — Brand principles guiding UX decisions
+- [Database Schema](../../infrastructure/technical-design/database-schema.md) — Current `links` table schema

--- a/docs/strategy/prds/lookback.md
+++ b/docs/strategy/prds/lookback.md
@@ -161,6 +161,37 @@ lookback_score = (
 - At least 1 pin with an external signal (when available)
 - Never more than 1 "dead link" pin per day (negative signals are draining)
 
+### Surface Activation Thresholds
+
+Each Lookback surface and signal activates independently based on minimum collection requirements. This prevents the feature from feeling empty or repetitive on new/small collections.
+
+**Progressive unlock model:**
+
+| Surface / Signal | Min Pins | Min Age | Rationale |
+|-----------------|----------|---------|-----------|
+| **Anniversary signal** | 1 | 365 days | Lowest bar — if any pin is a year old, this fires |
+| **Time Machine** (manual browse) | 10 | 14 days | Light utility that works even with small collections |
+| **Lookback Card** (main board) | 20 | 30 days | Needs enough pins for meaningful daily rotation |
+| **Lookback View** (full page) | 20 | 30 days | Same threshold as Lookback Card |
+| **Seasonal match signal** | 10 | 180 days | Needs at least a half-year of saves for seasonal patterns |
+| **Burst detection signal** | 15 | 60 days | Needs enough saves to form detectable clusters |
+| **Weekly Digest** (email) | 30 | 60 days | Higher bar — email is intrusive; needs strong signal quality |
+| **Monthly Review** | 20 | 30 days | Needs a month of data to summarize meaningfully |
+| **Re-engagement Nudge** (push) | 20 | 30 days | Same as Lookback Card — nudge references specific pins |
+
+**Why not a single threshold?** Different surfaces have different quality requirements. Time Machine works fine with 10 pins — it's just a filtered browse. But a weekly email with 10 pins would resurface the same ones every week. The progressive model lets users discover Lookback gradually as their collection grows.
+
+**Daily budget constraints:**
+
+| Constraint | Value | Rationale |
+|------------|-------|-----------|
+| Total pins per day | 3-5 | Enough to be interesting, not overwhelming |
+| Minimum categories | 2 | Reflects "one place, whole life" — prevents single-category monotony |
+| Max dead link pins | 1 | Negative signals are draining — limit exposure |
+| Max consumption gap pins | 1 | Prevents guilt pile-up ("you never watched these 5 videos") |
+| Max external signal pins | 2 | External signals are noisy — keep them minority |
+| Recency decay half-life | 14 days | Pin surfaced today is dampened for 2 weeks before re-eligible |
+
 ---
 
 ## Surfaces
@@ -537,7 +568,7 @@ This section maps how Lookback specifically drives retention for each segment �
 
 ## Open Questions
 
-1. **Signal cold start** — Lookback needs history to work. What's the minimum collection size/age before Lookback activates? 20 pins? 30 days? Should there be a "preview" mode that shows what Lookback will do once you have enough data?
+1. ~~**Signal cold start**~~ **Resolved** — Using progressive unlock model with per-surface minimums. Lookback Card requires 20 pins + 30 days. Time Machine is lighter at 10 pins + 14 days. Digest requires 30 pins + 60 days. No preview mode — the feature simply doesn't appear until thresholds are met, consistent with "expand with the user" principle. See Surface Activation Thresholds section above.
 2. **Negative signals** — Should Lookback ever surface a pin the user explicitly dismissed? Current design says no (14-day decay). But what about pins dismissed 6 months ago? Relevance can change.
 3. **Emotional tone** — "On this day" features can surface painful memories (a restaurant from a past relationship, a trip that got cancelled). Should there be a "hide this memory" option that permanently suppresses a pin from Lookback?
 4. **Scoring transparency** — Should users see WHY a pin was surfaced ("Because you never opened it" / "Because it's trending")? Current design shows context labels. But should the composite score be visible to power users?

--- a/docs/strategy/prds/lookback.md
+++ b/docs/strategy/prds/lookback.md
@@ -1,0 +1,576 @@
+# PRD: Lookback
+
+**Version:** 1.0
+**Date:** 2026-02-19
+**Status:** Draft
+
+---
+
+## Overview
+
+People save things because they matter in the moment. But most saved content dies on arrival — bookmarked and forgotten, buried under the next wave of input. The gap between "I saved this" and "I used this" is where curation tools fail. ctrl.rodeo is built on the premise that **input shapes output**. Lookback is the feature that closes the loop.
+
+Lookback is a system that resurfaces the right past pins at the right time, using a layered signal model that combines temporal patterns, interaction decay, external context, and collection intelligence. It's not a nostalgia feature — it's a utility. It answers: "What in my collection is relevant *right now*, and what have I forgotten that I shouldn't have?"
+
+This is the golden ticket for long-term retention. The first 30 days of a curation tool are driven by the excitement of adding. Day 31+ is driven by the value of what you already have. Lookback makes the collection a living asset instead of a growing archive. It gives users a reason to open ctrl.rodeo when they have nothing to save — which is most days.
+
+---
+
+## Goals
+
+1. Give users a reason to return to ctrl.rodeo daily, even when they have nothing new to save
+2. Surface forgotten, stale, or newly-relevant pins at moments when they're most useful
+3. Build a signal infrastructure that makes the collection smarter the longer it exists
+4. Create persona-specific value: different users need different things resurfaced for different reasons
+5. Establish the foundation for notifications, digests, and proactive recommendations
+
+---
+
+## Who This Serves
+
+### Primary Personas
+
+| Persona | Why Lookback Matters | Key Trigger |
+|---------|---------------------|-------------|
+| **The Cultural Omnivore** | Their value is in the breadth of what they've consumed. "What did I experience this year?" is a question they already ask. Lookback answers it automatically. | Anniversaries, seasonal context, annual reviews |
+| **The DJ** | Tracks saved months ago resurface when building a set for a specific vibe or season. "What was I digging last summer?" is a real workflow question. | Seasonal relevance, genre drift, forgotten digs |
+| **The Researcher** | Threads started but never finished. An article saved 6 months ago becomes relevant when its topic trends. Lookback connects the dots across time. | Topic resurgence, depth tracking, citation recall |
+| **The Visual Collector** | Design references from past projects resurface when starting a new project with similar aesthetic needs. | Style recurrence, project kickoff, portfolio review |
+
+### Secondary Personas
+
+| Persona | Why Lookback Matters |
+|---------|---------------------|
+| **The Deep-Dive Enthusiast** | "Remember when you were obsessed with pour-over coffee?" — Lookback maps hobby phases and resurfaces expertise. |
+| **The Multidisciplinary Maker** | Cross-domain connections only emerge over time. A material saved for one project becomes relevant to another 3 months later. |
+| **The Sound & Scene Curator** | Album releases from saved artists, venue events near saved locations, label connections across time. |
+
+### Jobs To Be Done
+
+| When I... | I want to... | So I can... |
+|-----------|-------------|-------------|
+| Open ctrl.rodeo with nothing to save | See something interesting from my past collection | Feel like my collection is alive and worth maintaining |
+| Start a new creative project | Resurface relevant references I saved months ago | Build on my own past research instead of starting from scratch |
+| Notice a topic trending in my world | See my own saves related to that topic | Contribute to the conversation with things I've already curated |
+| Reach a personal milestone (1 year of saving) | See a retrospective of my collection | Appreciate the breadth and evolution of my interests |
+| Wonder "what was I into last [season/month/year]?" | Browse a time-filtered view of my saves | Reconnect with past interests and rediscover forgotten gems |
+| Haven't opened the app in a while | Get pulled back by something relevant | Re-engage without the guilt of a neglected archive |
+
+---
+
+## Design Principles
+
+| Brand Principle | Application |
+|-----------------|-------------|
+| **Input shapes output** | Lookback is the literal manifestation: your past input resurfaces to shape your current output. |
+| **One place, whole life** | Cross-category resurfacing is the point. A listen pin and a go pin from the same trip resurface together. |
+| **Show, don't decorate** | The resurfaced pins ARE the content. No wrapping, no editorial voice beyond a one-line context label. |
+| **Expand with the user** | Lookback doesn't exist until you have enough history. It grows richer and more specific as the collection deepens. |
+| **Organize as you go** | Lookback is passive — it works without user configuration. No "set a reminder" or "flag for later." |
+
+---
+
+## The Signal Model
+
+Lookback's intelligence comes from layering multiple signal types. No single signal is sufficient — the power is in combining them to surface the *right* pin at the *right* moment.
+
+### Signal Layer 1: Temporal
+
+Signals derived from when pins were saved and how time has passed.
+
+| Signal | Description | Data Source | Strength |
+|--------|-------------|-------------|----------|
+| **Anniversary** | "You saved this 1 year ago today" | `created_at` | High — emotional resonance, proven by Apple Photos/Facebook memories |
+| **Seasonal match** | "Last winter you saved these" | `created_at` month + category heuristics | High — seasonal interests recur (winter fashion, summer travel, holiday recipes) |
+| **Recency decay** | Pins not interacted with in 30/60/90 days | `last_interacted_at` vs now | Medium — staleness is a signal but not always actionable |
+| **Burst detection** | "You saved 8 architecture links in March 2025" | `created_at` clustering analysis | Medium — identifies interest phases worth revisiting |
+| **Day-of-week patterns** | "You save music on Fridays" | `created_at` day-of-week distribution | Low — useful for notification timing, not content selection |
+
+### Signal Layer 2: Interaction
+
+Signals derived from how (or whether) the user has engaged with pins after saving them.
+
+| Signal | Description | Data Source | Strength |
+|--------|-------------|-------------|----------|
+| **Never clicked** | Saved but never opened the original URL | `last_interacted_at IS NULL` | High — the "saved and forgot" pattern, core use case |
+| **Consumption gap** | `watched = false` on a watch pin, `read = false` on a read pin | `watched`, `read` booleans | High — explicit unfinished business |
+| **Interaction cliff** | Was frequently accessed, then dropped off | `interaction_log` frequency analysis | Medium — abandoned interest or completed interest? Context-dependent. |
+| **Widget engagement** | User engaged with a widget about this pin/category | `widget_events` (future) | Low (until instrumentation ships) |
+
+### Signal Layer 3: External Context
+
+Signals derived from the world outside the user's collection. This is where Lookback gets powerful — and differentiated.
+
+| Signal | Description | Data Source | Implementation |
+|--------|-------------|-------------|----------------|
+| **Dead link detection** | The URL returns 404/5xx | HTTP HEAD check on saved URLs | Periodic background job (weekly). Resurface with "this link may be dead — archive or find alternative?" |
+| **Price change** | Product pin's price dropped or item back in stock | Periodic scrape of product pages | Phase 2+. Requires `pin_price_history` table. High-value for product-heavy collectors. |
+| **Creator activity** | An artist/creator you saved has new work | RSS/API monitoring of saved domains | Phase 2+. Start with YouTube (subscriptions), expand to Bandcamp, personal sites. |
+| **Cultural moment** | A topic related to your saves is trending | Trending topics API (Google Trends, X/Twitter trending) cross-referenced with pin categories/keywords | Phase 3. Requires keyword extraction from pins. "Brutalism is trending — you saved 12 brutalist links." |
+| **Seasonal commerce** | Fashion seasons, holiday periods, back-to-school | Calendar-based rules + category matching | Phase 1. Simple rules: Nov-Dec → resurface `eat` recipes and `go` gift guides. |
+| **Geographic proximity** | User is near a saved location (restaurant, store, venue) | Device location (opt-in) cross-referenced with pin URLs containing addresses | Phase 3. Mobile-only. Requires location extraction from pins. |
+| **Release calendar** | A saved show has a new season, a saved book author has a new release | TMDB API (shows), Open Library (books), MusicBrainz (albums) | Phase 2. Leverages existing enrichment metadata. |
+
+### Signal Layer 4: Collection Intelligence
+
+Signals derived from analyzing the collection itself — patterns, gaps, and relationships.
+
+| Signal | Description | Data Source | Strength |
+|--------|-------------|-------------|----------|
+| **Taste drift** | "You used to save a lot of X, now you save Y" | Category distribution over time | Medium — interesting for reflection, not always actionable |
+| **Cross-category connection** | "This restaurant is in the same neighborhood as that hotel you saved" | Semantic/geographic similarity across pins | High — the "one place, whole life" principle in action |
+| **Collection milestone** | "You've saved 100 pins" / "Your collection is 1 year old" | Count + time thresholds | Medium — gamification-adjacent, but genuine markers |
+| **Depth vs. breadth** | "You have 50 wear pins but only 2 eat pins" | Category distribution analysis | Low — interesting but not urgently actionable |
+| **Emerging theme** | 3+ recent saves share a topic not captured by category | AI clustering of recent pin titles/descriptions | High — surfaces nascent interests before they're obvious |
+
+---
+
+## Signal Prioritization Framework
+
+Not all signals should fire at once. Lookback needs a scoring model to rank which pins to surface on a given day.
+
+### Composite Score
+
+```
+lookback_score = (
+  temporal_weight   × temporal_signal   +
+  interaction_weight × interaction_signal +
+  external_weight   × external_signal   +
+  collection_weight × collection_signal
+) × recency_decay_modifier × category_diversity_bonus
+```
+
+**Weights (initial, tunable):**
+
+| Weight | Value | Rationale |
+|--------|-------|-----------|
+| `temporal_weight` | 0.30 | Time-based signals are reliable and emotionally resonant |
+| `interaction_weight` | 0.35 | "Never clicked" and "never watched" are the strongest engagement signals |
+| `external_weight` | 0.25 | External context is high-value but noisy — weight grows as data quality improves |
+| `collection_weight` | 0.10 | Collection intelligence is insightful but low-urgency |
+
+**Modifiers:**
+
+- `recency_decay_modifier`: Pins resurfaced recently get dampened (exponential decay, half-life 14 days). Prevents the same pin from appearing every day.
+- `category_diversity_bonus`: If the day's lookback set is all one category, boost pins from underrepresented categories. Reflects "one place, whole life."
+
+### Daily Budget
+
+- **3-5 pins per day** — enough to be interesting, not enough to overwhelm
+- At least 2 different categories represented
+- At least 1 pin with an external signal (when available)
+- Never more than 1 "dead link" pin per day (negative signals are draining)
+
+---
+
+## Surfaces
+
+Lookback is not one screen — it's a system that manifests across multiple surfaces, each with different depth.
+
+### Surface 1: Lookback Card (Main Board)
+
+**Where:** Top of the board grid, above pins. Appears on page load.
+
+```
+┌─────────────────────────────────────────────┐
+│  LOOKBACK                                   │
+│                                             │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐       │
+│  │ [image] │ │ [image] │ │ [image] │       │
+│  │         │ │         │ │         │       │
+│  │ Title   │ │ Title   │ │ Title   │       │
+│  │ 1y ago  │ │ unwatched│ │ trending│       │
+│  └─────────┘ └─────────┘ └─────────┘       │
+│                                             │
+│  [See all →]                    [Dismiss]   │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+
+- Shows 3 pins as mini-cards with image, title, and a one-line context label (the signal that triggered resurfacing)
+- Tapping a pin opens it (link click) or expands it (card expand)
+- "See all" opens the full Lookback view
+- "Dismiss" hides for 24 hours
+- Rotates daily — new set each day
+- Only appears if there are 3+ qualifying pins
+
+**Context labels** (one per pin, from highest-priority signal):
+
+| Signal | Label |
+|--------|-------|
+| Anniversary | "Saved 1 year ago" |
+| Seasonal | "From last winter" |
+| Never clicked | "Never opened" |
+| Consumption gap | "Still unwatched" / "Still unread" |
+| Dead link | "Link may be dead" |
+| Burst | "Part of your architecture phase" |
+| Trending | "Trending right now" |
+| Price drop | "Price dropped" |
+| New release | "New season available" |
+| Milestone | "Your 100th save" |
+
+### Surface 2: Lookback View (Full Page)
+
+**Where:** Dedicated view, accessible from nav and "See all" on the card.
+
+```
+┌─────────────────────────────────────────────┐
+│  LOOKBACK                                   │
+│                                             │
+│  Today                                      │
+│  ┌─────────────────────────────────────────┐│
+│  │ [Full review card — pin + context]      ││
+│  │ "You saved this 1 year ago today.       ││
+│  │  It's a video you never watched."       ││
+│  │ [Open link]  [Re-categorize]  [Archive] ││
+│  └─────────────────────────────────────────┘│
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│  │ pin 2    │ │ pin 3    │ │ pin 4    │    │
+│  └──────────┘ └──────────┘ └──────────┘    │
+│                                             │
+│  This Week                                  │
+│  ┌──────────┐ ┌──────────┐                  │
+│  │ earlier  │ │ earlier  │                  │
+│  └──────────┘ └──────────┘                  │
+│                                             │
+│  Your [Month] in Review                     │
+│  "You saved 23 pins across 6 categories.   │
+│   Most-saved: wear (9). New interest:      │
+│   ceramics (3 pins, first time)."          │
+│                                             │
+│  Time Machine                               │
+│  [2026] [2025] [Winter] [Summer] [All]     │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│  │ filtered │ │ pins     │ │ here     │    │
+│  └──────────┘ └──────────┘ └──────────┘    │
+└─────────────────────────────────────────────┘
+```
+
+**Sections:**
+
+1. **Today** — The day's 3-5 lookback pins, with the highest-scored pin featured large
+2. **This Week** — Pins surfaced earlier this week that weren't acted on (gives a second chance)
+3. **Monthly Review** — AI-generated 2-3 sentence summary of the month's saving activity (category distribution, new interests, milestones). Generated once per month, cached.
+4. **Time Machine** — Filterable browse of the full collection by time period. Year tabs, season filters, category filters. This is the "your year in review" and "what was I into last summer" interface.
+
+### Surface 3: Digest (Push/Email — Phase 2)
+
+**Where:** Outside the app. Weekly email or push notification.
+
+```
+Subject: Your week in ctrl.rodeo
+
+3 pins worth revisiting:
+- [Title] — saved 6 months ago, never opened
+- [Title] — the artist just released a new album
+- [Title] — this link may be dead
+
++ You saved 8 new pins this week (most: listen)
+
+[Open Lookback →]
+```
+
+**Behavior:**
+
+- Weekly cadence (configurable: daily/weekly/off)
+- Top 3 lookback pins by composite score
+- Brief collection activity summary
+- Deep link to Lookback view
+- Only sent if there are 3+ qualifying pins that week
+- Unsubscribe respected, re-engagement nudge after 30 days of no opens
+
+### Surface 4: Re-engagement Nudge (Phase 3)
+
+**Where:** Push notification for users who haven't opened the app in 14+ days.
+
+```
+"You saved a restaurant in Lisbon 3 months ago.
+Still planning that trip?"
+```
+
+**Behavior:**
+
+- Triggers after 14 days of inactivity
+- Uses the single highest-scored lookback pin
+- Personal, specific — references actual content, not generic "come back!"
+- Maximum 1 nudge per 30-day period
+- Only for users who opted into notifications
+- Measured by re-engagement rate (did they open the app within 48 hours?)
+
+---
+
+## Technical Architecture
+
+### Interaction Tracking (Prerequisite)
+
+Before Lookback can use interaction signals, the system needs to track engagement:
+
+```sql
+-- New column on links table
+ALTER TABLE links ADD COLUMN last_interacted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Interaction log for richer analysis
+CREATE TABLE pin_interactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users NOT NULL,
+  link_id UUID REFERENCES links NOT NULL,
+  interaction_type TEXT NOT NULL, -- 'click', 'expand', 'share', 'lookback_view', 'lookback_dismiss'
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_pin_interactions_link ON pin_interactions(link_id);
+CREATE INDEX idx_pin_interactions_user_date ON pin_interactions(user_id, created_at DESC);
+
+-- RLS
+ALTER TABLE pin_interactions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pin_interactions_user ON pin_interactions
+  FOR ALL USING (auth.uid() = user_id);
+```
+
+**Client-side tracking:**
+
+- `click`: User clicks the pin's URL (opens in new tab)
+- `expand`: User expands a card to see details
+- `share`: User shares a pin or board
+- `lookback_view`: User views a pin via Lookback
+- `lookback_dismiss`: User dismisses a lookback suggestion
+
+On each interaction, update `links.last_interacted_at = NOW()` and insert into `pin_interactions`.
+
+### Lookback Score Computation
+
+**Option A: Client-side (Phase 1)** — Compute scores in the browser from localStorage data. Fast, offline-capable, but limited to temporal and interaction signals.
+
+**Option B: Edge function (Phase 2+)** — Supabase edge function computes scores server-side with access to external signals (dead link checks, price changes, trending topics). Returns a ranked list of lookback pins.
+
+```typescript
+// POST /functions/v1/lookback
+// Request: { user_id, limit: 5, exclude_ids: [...] }
+// Response: { pins: [{ link_id, score, signals: [{ type, label, weight }] }] }
+```
+
+**Phase 1 client-side scoring:**
+
+```javascript
+function computeLookbackScore(pin, now) {
+  let score = 0;
+  const signals = [];
+  const age = now - new Date(pin.created_at).getTime();
+  const daysSinceSave = age / (24 * 60 * 60 * 1000);
+
+  // Anniversary (within 3-day window)
+  const savedDate = new Date(pin.created_at);
+  const todayMD = `${now.getMonth()}-${now.getDate()}`;
+  const savedMD = `${savedDate.getMonth()}-${savedDate.getDate()}`;
+  if (todayMD === savedMD && daysSinceSave > 300) {
+    score += 0.9;
+    signals.push({ type: 'anniversary', label: `Saved ${Math.round(daysSinceSave/365)} year(s) ago` });
+  }
+
+  // Seasonal match
+  const savedSeason = getSeason(savedDate);
+  const currentSeason = getSeason(now);
+  if (savedSeason === currentSeason && daysSinceSave > 180) {
+    score += 0.5;
+    signals.push({ type: 'seasonal', label: `From last ${savedSeason}` });
+  }
+
+  // Never interacted
+  if (!pin.last_interacted_at && daysSinceSave > 7) {
+    score += 0.7;
+    signals.push({ type: 'never_clicked', label: 'Never opened' });
+  }
+
+  // Consumption gap
+  if (pin.category === 'watch' && !pin.watched) {
+    score += 0.6;
+    signals.push({ type: 'unwatched', label: 'Still unwatched' });
+  }
+  if (pin.category === 'read' && !pin.read) {
+    score += 0.6;
+    signals.push({ type: 'unread', label: 'Still unread' });
+  }
+
+  // Staleness bonus (older forgotten pins get boosted)
+  if (daysSinceSave > 90 && !pin.last_interacted_at) {
+    score += Math.min(0.3, daysSinceSave / 1000);
+    signals.push({ type: 'stale', label: 'Forgotten save' });
+  }
+
+  return { score, signals };
+}
+```
+
+### Dead Link Detection (Phase 2)
+
+```typescript
+// Scheduled edge function — runs weekly
+// POST /functions/v1/check-dead-links
+// Iterates user's links, sends HEAD requests, marks dead ones
+
+ALTER TABLE links ADD COLUMN link_status TEXT DEFAULT 'alive';
+-- 'alive', 'dead', 'redirect', 'unknown'
+ALTER TABLE links ADD COLUMN link_checked_at TIMESTAMPTZ;
+```
+
+**Rate limiting:** Max 100 URLs per user per run. Prioritize oldest-checked links. Respect `Retry-After` headers. Cache results for 7 days.
+
+### Monthly Review Generation (Phase 2)
+
+```typescript
+// POST /functions/v1/lookback
+// { action: "monthly-review", user_id, month: "2026-02" }
+// Uses Claude Haiku to generate a 2-3 sentence summary
+// Prompt includes: category counts, new categories, total pins, notable patterns
+// Cached for the month — regenerated only if pin count changes significantly
+```
+
+---
+
+## Phasing
+
+### Phase 1: Temporal + Interaction (MVP)
+
+**Prerequisites:** `last_interacted_at` column, client-side interaction tracking
+
+**Signals:** Anniversary, seasonal match, never clicked, consumption gap, staleness
+
+**Surfaces:** Lookback Card (main board), Time Machine (basic year/season filter)
+
+**Scoring:** Client-side only
+
+**Personas served:** All — these signals work for every user type
+
+### Phase 2: External Context + Digest
+
+**New signals:** Dead link detection, price tracking (products), release calendar (TMDB, Open Library), creator activity (YouTube)
+
+**New surfaces:** Full Lookback View with monthly review, weekly digest (email)
+
+**Scoring:** Edge function with external data
+
+**Personas served:** The DJ (new releases), The Visual Collector (price drops), The Researcher (dead links)
+
+### Phase 3: Collection Intelligence + Re-engagement
+
+**New signals:** Cross-category connections, taste drift, emerging themes, trending topic matching, geographic proximity
+
+**New surfaces:** Re-engagement nudge (push notification), smart grouping in Lookback View
+
+**Scoring:** AI-powered analysis (Claude Haiku for theme extraction, cross-reference)
+
+**Personas served:** The Cultural Omnivore (taste drift), The Multidisciplinary Maker (cross-category), The Researcher (trending topics)
+
+---
+
+## Retention Mechanics by Persona
+
+This section maps how Lookback specifically drives retention for each segment — because a generic "memories" feature won't work. Different people need different things resurfaced.
+
+| Persona | Retention Driver | Lookback Mechanic | Frequency |
+|---------|-----------------|-------------------|-----------|
+| **The DJ** | "What was I digging last summer?" — seasonal set building | Seasonal filter + burst detection ("your techno phase, June 2025") | Weekly — when planning sets |
+| **The Visual Collector** | "I need references for this new project" — past research is future ammo | Cross-category connections + keyword matching to current saves | On-demand — triggered by new saves |
+| **The Cultural Omnivore** | "What did I experience this year?" — reflection and sharing | Annual/monthly review + collection timeline | Monthly — digest cadence |
+| **The Researcher** | "This topic I saved about is in the news" — relevance resurgence | Trending topic matching + "never opened" flags | Daily — when topics trend |
+| **The Deep-Dive Enthusiast** | "Remember when I was obsessed with X?" — interest archaeology | Burst detection + taste drift visualization | Monthly — hobby phase reflection |
+| **The Multidisciplinary Maker** | "That material I found for Project A works for Project B" — cross-pollination | Cross-category connections + semantic similarity | On-demand — during active projects |
+| **The Sound & Scene Curator** | "This artist released something new" — creator following | Release calendar monitoring + creator activity | Real-time — as releases happen |
+
+---
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| Lookback card load time | < 500ms (client-side scoring in Phase 1) |
+| Score computation for 1,000 pins | < 200ms client-side |
+| Dead link check latency | < 5s per URL (HEAD request with timeout) |
+| Monthly review generation | < 3s (Claude Haiku) |
+| Digest email delivery | Within 1 hour of scheduled time |
+| Lookback card freshness | New set daily (midnight user-local-time) |
+| Interaction tracking overhead | < 10ms per event (async, non-blocking) |
+
+---
+
+## Privacy & Data Handling
+
+| Data | Storage | Retention | Access |
+|------|---------|-----------|--------|
+| Pin interaction events | `pin_interactions` table, Supabase | 1 year | User only (RLS) |
+| Lookback scores | Computed, not stored (Phase 1). Cached 24h (Phase 2+) | 24 hours | User only |
+| Dead link status | `links.link_status` column | Updated weekly | User only (RLS) |
+| Monthly reviews | Cached in edge function response store | 30 days | User only |
+| Location data (Phase 3) | Never stored — used transiently for proximity matching | Session only | Not transmitted to server |
+| Digest email address | Supabase auth | Account lifetime | System + user |
+
+---
+
+## Cost Model
+
+| Component | Per-User Cost | At 1,000 Users |
+|-----------|--------------|----------------|
+| Client-side scoring (Phase 1) | $0 | $0 |
+| Dead link checks (100 URLs/week) | ~$0.001 (compute) | $1/week |
+| Monthly review (Claude Haiku) | ~$0.002/month | $2/month |
+| Digest email (SendGrid/Resend) | ~$0.001/email | $4/month (weekly) |
+| TMDB/Open Library API | Free tier | $0 |
+| Trending topics API | ~$0.01/day | $10/month |
+
+**Total Phase 1:** $0 (all client-side)
+**Total Phase 2:** ~$7/month at 1,000 users
+**Total Phase 3:** ~$17/month at 1,000 users
+
+---
+
+## Future Considerations
+
+1. **Shared Lookback** — "Here's what we were both into last year" for collaborative board members. Social reminiscing.
+2. **Lookback as content** — Export your monthly/annual review as a shareable page. The Cultural Omnivore persona explicitly wants this.
+3. **AI journaling** — "Based on what you saved this month, here's what seems to be on your mind." Claude generates a reflective paragraph. High emotional value, low utility.
+4. **Lookback-driven collections** — Auto-generate smart boards from Lookback patterns ("Your Architecture Phase", "Summer 2025 Travel"). Read-only, always up to date.
+5. **Predictive surfacing** — Instead of "here's what you saved," flip to "here's what you'll probably want to save next" based on patterns. The line between Lookback and recommendation blurs.
+6. **Platform integrations** — Import watch history from Netflix, listen history from Spotify, reading list from Kindle. Lookback becomes "your whole cultural life" not just "your ctrl.rodeo saves."
+
+---
+
+## Open Questions
+
+1. **Signal cold start** — Lookback needs history to work. What's the minimum collection size/age before Lookback activates? 20 pins? 30 days? Should there be a "preview" mode that shows what Lookback will do once you have enough data?
+2. **Negative signals** — Should Lookback ever surface a pin the user explicitly dismissed? Current design says no (14-day decay). But what about pins dismissed 6 months ago? Relevance can change.
+3. **Emotional tone** — "On this day" features can surface painful memories (a restaurant from a past relationship, a trip that got cancelled). Should there be a "hide this memory" option that permanently suppresses a pin from Lookback?
+4. **Scoring transparency** — Should users see WHY a pin was surfaced ("Because you never opened it" / "Because it's trending")? Current design shows context labels. But should the composite score be visible to power users?
+5. **Cannibalization** — Does Lookback compete with the existing widget system? Widgets like Archaeologist (#20) and Persuade (#3) overlap with Lookback signals. Should those widgets be retired in favor of Lookback, or should they coexist?
+6. **External API reliability** — Dead link checking, price monitoring, and release calendar all depend on external APIs. What's the degradation strategy when they fail? Fall back to temporal signals only?
+7. **Notification permission** — Digests and re-engagement nudges require email/push permission. How aggressive should the opt-in prompt be? Should it be tied to a milestone ("You have 50 pins — want weekly lookback emails?")?
+
+---
+
+## Success Metrics
+
+| Metric | Target | How Measured |
+|--------|--------|-------------|
+| DAU/MAU ratio improvement | +15% within 3 months of launch | Analytics — daily active / monthly active |
+| Lookback card engagement | 40% of daily visitors interact with the card | Click/expand events on lookback pins |
+| Return visits driven by Lookback | 20% of sessions start from a digest/notification deep link | Referrer tracking on Lookback view |
+| Pin re-engagement | 30% of lookback-surfaced pins get clicked through | `pin_interactions` where source = 'lookback' |
+| Collection longevity | 50% of users with 6+ month collections are monthly active | Cohort analysis — retention by collection age |
+| Digest open rate | 35% (industry avg for personal tools is ~25%) | Email analytics |
+| Re-engagement nudge conversion | 15% open app within 48 hours of nudge | Push notification + session tracking |
+| "Never opened" resolution | 25% of "never opened" pins get clicked after Lookback surfaces them | `last_interacted_at` transitions from NULL |
+
+---
+
+## Related Documents
+
+- [PRD: Boards MVP](./boards-mvp.md) — Core pin data model and categorization system
+- [PRD: AI Widgets](./ai-widgets.md) — Widget system including staleness and time-based widgets (Phase 4-5)
+- [PRD: Widget Instrumentation](./widget-instrumentation.md) — Engagement tracking architecture (future signal source)
+- [AI Widget System](../../infrastructure/technical-design/ai-widget-system.md) — Widget generation architecture
+- [User Personas](../../ux/personas.md) — Full persona definitions with JTBD
+- [Brand Positioning](../brand-positioning.md) — Brand principles and voice
+- [Database Schema](../../infrastructure/technical-design/database-schema.md) — Current data model
+- [Taste & Pattern Surfacing](../../ux/widgets/taste-patterns.md) — Related planned features (monthly digest, collection timeline)
+- [Cross-Category Features](../../ux/boards/cross-category.md) — Dynamic collections concept
+- [Backlog](../../execution/project-plan/backlog.md) — Related backlog items (#57 recently viewed tracking, taste profile, trend detection)

--- a/supabase/migrations/016_categorization_cleanup.sql
+++ b/supabase/migrations/016_categorization_cleanup.sql
@@ -1,0 +1,8 @@
+-- Epic 3.6: Categorization Cleanup
+-- Add user_reviewed_at column to track when users explicitly confirmed or corrected a pin
+-- Pins with user_reviewed_at set are excluded from the cleanup queue
+
+ALTER TABLE links ADD COLUMN user_reviewed_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Index for cleanup queue performance
+CREATE INDEX idx_links_user_reviewed ON links(user_id, user_reviewed_at);

--- a/supabase/migrations/017_lookback_prerequisites.sql
+++ b/supabase/migrations/017_lookback_prerequisites.sql
@@ -1,0 +1,30 @@
+-- Phase 12 Prerequisites: Lookback Interaction Tracking Schema
+--
+-- Adds columns and tables to support tracking user interactions with pins
+-- for the Lookback feature's scoring algorithms.
+
+-- Add last_interacted_at column to links table
+ALTER TABLE links ADD COLUMN last_interacted_at TIMESTAMPTZ DEFAULT NULL;
+
+-- Index for efficient lookback queries (user's pins with no interaction)
+CREATE INDEX idx_links_last_interacted ON links(user_id, last_interacted_at);
+
+-- Interaction log for detailed analytics (future use)
+CREATE TABLE pin_interactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users NOT NULL,
+  link_id UUID REFERENCES links NOT NULL,
+  interaction_type TEXT NOT NULL, -- 'click', 'expand', 'share', 'lookback_view', 'lookback_dismiss'
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes for efficient queries
+CREATE INDEX idx_pin_interactions_link ON pin_interactions(link_id);
+CREATE INDEX idx_pin_interactions_user_date ON pin_interactions(user_id, created_at DESC);
+
+-- Enable RLS
+ALTER TABLE pin_interactions ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see their own interactions
+CREATE POLICY pin_interactions_user ON pin_interactions
+  FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- **Categorization Cleanup (Epic 3.6)**: Review queue surfacing low-confidence AI categorization. Adaptive threshold (25th percentile, floor 0.50, ceiling 0.80). Full review card with inline editing, category reassignment, confirm/skip/delete. Activation: 10+ pins, 3+ flagged items for nav pill.
- **Lookback Phase 1 (Epic 12.1)**: Pin resurfacing system using temporal + interaction signals (anniversary, seasonal, never-clicked, consumption gap, staleness). Lookback Card at top of board grid with 3 mini-cards. Daily cache, 24h dismiss, category diversity. Activation: 20+ pins, 30+ day collection.
- **Documentation**: Both PRDs updated with threshold frameworks. Phase 3 updated with Epic 3.6 (89 items). New Phase 12 created (236 items). Backlog cross-references updated.

## Files Changed
- `boards/index.html` — Both features implemented (scoring engines, UI components, CSS)
- `supabase/migrations/016_categorization_cleanup.sql` — `user_reviewed_at` column + index
- `supabase/migrations/017_lookback_prerequisites.sql` — `last_interacted_at` column, `pin_interactions` table + RLS
- `docs/strategy/prds/categorization-cleanup.md` — Threshold framework section
- `docs/strategy/prds/lookback.md` — Surface activation thresholds section
- `docs/execution/project-plan/phase-3-ai-intelligence.md` — Epic 3.6 appended
- `docs/execution/project-plan/phase-12-lookback.md` — New file (3 epics)
- `docs/execution/project-plan/index.md` — Phase 12 row + updated stats
- `docs/execution/project-plan/backlog.md` — Absorbed items cross-referenced

## Test plan
- [ ] Verify cleanup pill appears in filter bar when 3+ pins qualify (low confidence, uncategorized, missing data)
- [ ] Tap cleanup pill → review card renders with pin image, title, AI context, category chips
- [ ] Edit title/description inline → confirm → verify updates in localStorage and category changes
- [ ] Skip → pin moves to end of queue, next pin shows
- [ ] Delete → pin removed, undo toast appears, undo restores pin
- [ ] Verify Lookback card appears at top of "All" view when 20+ pins and collection is 30+ days old
- [ ] Click Lookback mini-card → pin URL opens in new tab, interaction tracked
- [ ] Dismiss Lookback card → hidden for 24 hours
- [ ] Run migrations 016 + 017 via Supabase SQL Editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)