### PR TITLE
fix: resolve instagram-import 401 and is_merged column errors

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9789,11 +9789,19 @@ Return JSON:
   // Instagram Import
   // ============================================
   async function importInstagramContent(url) {
-    const { data, error } = await supabase.functions.invoke('instagram-import', {
-      body: { url }
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/instagram-import`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ url })
     });
-    if (error) throw new Error(error.message || 'Instagram import failed');
-    return data;
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Import failed (${resp.status}): ${text}`);
+    }
+    return resp.json();
   }
 
   function normalizeImportedPin(pin) {

--- a/supabase/migrations/018_pin_merge_columns.sql
+++ b/supabase/migrations/018_pin_merge_columns.sql
@@ -1,0 +1,6 @@
+-- Pin Merge System
+-- Adds columns for tracking merged/duplicate pins
+
+ALTER TABLE links ADD COLUMN IF NOT EXISTS is_merged BOOLEAN DEFAULT FALSE;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS sources JSONB DEFAULT NULL;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS merged_at TIMESTAMPTZ DEFAULT NULL;


### PR DESCRIPTION
## Summary
- **instagram-import 401 fix**: Switched from `supabase.functions.invoke()` to direct `fetch` with anon key, matching how all other edge functions are called. Also redeployed with `--no-verify-jwt`.
- **is_merged column fix**: Added migration 018 with `is_merged`, `sources`, and `merged_at` columns that the pin-merging feature writes but were missing from the database schema. Migration already applied.

## Test plan
- [ ] Refresh an Instagram reel pin — should no longer 401
- [ ] Verify `syncLinkToSupabase` no longer logs `Could not find the 'is_merged' column` errors
- [ ] Normal pin operations (add, update, delete) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)