### PR TITLE
feat: enable sub-tag filters by default

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -10868,7 +10868,7 @@ Return JSON:
 
   let currentSubTag = null; // Current sub-tag filter (legacy single-dimension categories)
   let currentFilters = {}; // Multi-dimension filter state: { format: 'movies', genre: 'action' }
-  let showSubTagsBar = false; // Beta feature - enable via: window.enableSubTagsBar()
+  let showSubTagsBar = true; // Sub-tag filters visible by default
 
   // Detect sub-tag from link title/description (legacy single-dimension categories)
   function detectSubTag(link) {


### PR DESCRIPTION
## Summary
- Removes the beta flag on the sub-tags bar so subcategory filters are visible by default
- When viewing watch: two filter rows (Type + Genre) appear automatically
- When viewing wear, listen, home, use: single row of sub-tag filters appears
- `enableSubTagsBar()`/`disableSubTagsBar()` console functions still work for toggling

## Test plan
- [ ] Open Boards, click **watch** — two filter rows visible without console commands
- [ ] Click **wear** — single row of sub-tags visible
- [ ] Click **all** — no sub-tag bar
- [ ] Run `window.disableSubTagsBar()` — bar hides, `enableSubTagsBar()` brings it back

🤖 Generated with [Claude Code](https://claude.com/claude-code)