### PR TITLE
design: restyle sub-tag filters as visually secondary

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -829,13 +829,12 @@ body {
   color: var(--bg);
 }
 
-/* Sub-tag filter bar */
+/* Sub-tag filter bar — visually secondary to category filters */
 .sub-tags {
   display: none;
   flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-4);
-  background: var(--surface);
+  gap: 0;
+  padding: var(--space-1) var(--space-4);
   border-bottom: 1px solid var(--subtle);
 }
 
@@ -843,11 +842,12 @@ body {
   display: flex;
 }
 
-/* Multi-dimension row */
+/* Dimension row */
 .sub-tags__dimension {
   display: flex;
-  gap: var(--space-2);
+  gap: 0;
   align-items: center;
+  padding: var(--space-1) 0;
 }
 
 .sub-tags__label {
@@ -855,48 +855,56 @@ body {
   font-size: 9px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: var(--muted);
+  color: var(--fg-subtle);
   flex-shrink: 0;
   min-width: 44px;
+  padding-right: var(--space-2);
 }
 
 .sub-tags__buttons {
   display: flex;
-  gap: var(--space-2);
+  gap: var(--space-1);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
   flex: 1;
 }
 
+.sub-tags__buttons::-webkit-scrollbar {
+  display: none;
+}
+
+/* Sub-tag: small, borderless text links — secondary to main category tokens */
 .sub-tag {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 9px;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  padding: var(--space-1) var(--space-2);
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
   background: transparent;
-  color: var(--muted);
-  border: 1px solid var(--subtle);
+  color: var(--fg-subtle);
+  border: none;
+  border-radius: 2px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: color 0.15s, background 0.15s;
   flex-shrink: 0;
   white-space: nowrap;
+  line-height: 1.4;
 }
 
 .sub-tag:hover {
   color: var(--fg);
-  border-color: var(--fg);
 }
 
 .sub-tag--active {
-  background: var(--fg);
-  color: var(--bg);
-  border-color: var(--fg);
+  color: var(--fg);
+  background: var(--subtle);
 }
 
 .sub-tag__count {
-  opacity: 0.6;
-  margin-left: 4px;
+  opacity: 0.4;
+  margin-left: 3px;
+  font-size: 8px;
 }
 
 /* Search input */


### PR DESCRIPTION
## Summary
Redesigns the sub-tag filter bars to be clearly secondary to the main category tokens:

**Before:** Sub-tags had same visual weight as categories — bordered buttons, same font size, full-inversion active state. Looked like two competing nav bars.

**After:** Sub-tags are quiet, text-link style:
- **Smaller** — 9px font (vs 10px categories), 8px counts
- **Borderless** — no border, just text; active state uses subtle bg tint (`--subtle`) instead of full white/black inversion
- **Muted** — `--fg-subtle` color (#666), counts at 0.4 opacity
- **Compact** — tighter padding (2px 6px), minimal gaps
- **Clean** — hidden scrollbars on dimension rows

Creates a clear hierarchy: **Categories** (bold, bordered, 44px) → **Sub-tags** (quiet, inline, compact)

## Test plan
- [ ] Open Boards → Watch — sub-tags should feel visually secondary, not competing with categories
- [ ] Active sub-tag should use subtle background tint, not full inversion
- [ ] Hover should brighten text without adding borders
- [ ] Mobile: horizontal scroll works, scrollbar hidden
- [ ] Other categories (wear, listen) — same secondary treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)