### PR TITLE
Create a Board MVP: user-created boards + library suggestions

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -1516,6 +1516,234 @@ body {
   opacity: 0.9;
 }
 
+/* ============================================
+   Create Board Form
+   ============================================ */
+.create-board-form {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.create-board-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.create-board-form__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg);
+}
+.create-board-form__optional {
+  color: var(--muted);
+  font-weight: normal;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.create-board-form__input,
+.create-board-form__textarea {
+  width: 100%;
+  padding: var(--space-3);
+  font-family: var(--font-primary);
+  font-size: var(--font-size-base);
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--fg);
+  outline: none;
+  resize: none;
+  box-sizing: border-box;
+}
+.create-board-form__input:focus,
+.create-board-form__textarea:focus {
+  outline: 2px solid var(--fg);
+  outline-offset: 1px;
+}
+.create-board-form__error {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: #c00;
+  margin: 0;
+}
+.create-board-form__submit {
+  width: 100%;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: var(--fg);
+  color: var(--bg);
+  border: 1px solid var(--fg);
+  cursor: pointer;
+}
+.create-board-form__submit:hover {
+  opacity: 0.85;
+}
+.create-board-form__submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ============================================
+   Filter Token — User Board Indicator
+   ============================================ */
+.filter-token--new-board {
+  color: var(--muted);
+  border-color: rgba(255,255,255,0.2);
+  border-style: dashed;
+}
+.filter-token--new-board:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+  border-style: solid;
+  background: var(--bg);
+}
+
+/* ============================================
+   Board Seed Panel (Library Suggestions)
+   ============================================ */
+.board-seed-panel {
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+  background: var(--bg);
+  padding: var(--space-3) 0;
+}
+.board-seed-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--space-4) var(--space-2);
+}
+.board-seed-panel__label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+.board-seed-panel__dismiss {
+  font-size: 16px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+.board-seed-panel__dismiss:hover {
+  color: var(--fg);
+}
+.board-seed-panel__body {
+  display: flex;
+  gap: var(--space-2);
+  overflow-x: auto;
+  padding: 0 var(--space-4);
+  scrollbar-width: none;
+}
+.board-seed-panel__body::-webkit-scrollbar {
+  display: none;
+}
+.board-seed-panel__empty {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+  padding: var(--space-2) 0;
+}
+.board-seed-panel__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-2) var(--space-4) 0;
+}
+.board-seed-panel__add-all {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  background: none;
+  border: 1px solid var(--fg);
+  color: var(--fg);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+}
+.board-seed-panel__add-all:hover {
+  background: var(--fg);
+  color: var(--bg);
+}
+
+/* Seed Card */
+.seed-card {
+  display: flex;
+  flex-direction: column;
+  width: 120px;
+  min-width: 120px;
+  border: 1px solid rgba(255,255,255,0.15);
+  flex-shrink: 0;
+  background: var(--bg);
+  position: relative;
+  transition: opacity 0.2s, border-color 0.15s;
+}
+.seed-card:hover {
+  border-color: var(--fg);
+}
+.seed-card--added {
+  opacity: 0.3;
+  pointer-events: none;
+}
+.seed-card__img {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+  display: block;
+}
+.seed-card__placeholder {
+  width: 100%;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,0.05);
+  font-family: var(--font-mono);
+  font-size: 18px;
+  color: var(--muted);
+}
+.seed-card__info {
+  padding: var(--space-2);
+  flex: 1;
+}
+.seed-card__title {
+  font-family: var(--font-primary);
+  font-size: 10px;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.seed-card__domain {
+  font-family: var(--font-mono);
+  font-size: 8px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+.seed-card__add {
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--fg);
+  color: var(--bg);
+  border: none;
+  cursor: pointer;
+  text-align: center;
+}
+.seed-card__add:hover {
+  opacity: 0.85;
+}
+
 /* New item animation */
 @keyframes slideIn {
   from {
@@ -5140,6 +5368,18 @@ body {
     </button>
   </div>
 
+  <!-- Board Seed Panel — suggestions for user-created boards -->
+  <section class="board-seed-panel" id="boardSeedPanel" hidden>
+    <div class="board-seed-panel__header">
+      <span class="board-seed-panel__label">From your library</span>
+      <button class="board-seed-panel__dismiss" id="boardSeedDismiss" aria-label="Dismiss">&times;</button>
+    </div>
+    <div class="board-seed-panel__body" id="boardSeedBody"></div>
+    <div class="board-seed-panel__footer" id="boardSeedFooter" hidden>
+      <button class="board-seed-panel__add-all" id="boardSeedAddAll">Add All</button>
+    </div>
+  </section>
+
   <!-- AI Widget Section - Hero Zone -->
   <section class="widget-section widget-zone widget-zone--hero" id="widgetSection" data-zone="hero">
     <div class="widget-section__content" id="widgetContent"></div>
@@ -5198,6 +5438,10 @@ body {
           <button class="fab-menu__item" id="fabVideoUpload">
             <span class="fab-menu__item-icon">▶</span>
             Video
+          </button>
+          <button class="fab-menu__item" id="fabCreateBoard">
+            <span class="fab-menu__item-icon">✦</span>
+            New Board
           </button>
           <button class="fab-menu__item" id="fabTools">
             <span class="fab-menu__item-icon">⚙</span>
@@ -5742,6 +5986,36 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
           <button id="mergeCancelBtn">Cancel</button>
           <button class="merge-preview__confirm" id="mergeConfirmBtn">Merge</button>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Create Board Modal -->
+  <div class="modal" id="createBoardModal" role="dialog" aria-modal="true" aria-labelledby="createBoardModalTitle">
+    <div class="modal__backdrop" data-close></div>
+    <div class="modal__content">
+      <div class="modal__header">
+        <h2 class="modal__title" id="createBoardModalTitle">New Board</h2>
+        <button class="modal__close" data-close>&times;</button>
+      </div>
+      <div class="create-board-form" id="createBoardForm">
+        <div class="create-board-form__field">
+          <label class="create-board-form__label" for="createBoardName">Name</label>
+          <input type="text" id="createBoardName" class="create-board-form__input"
+                 placeholder="e.g. Summer Looks, Studio Gear" autocomplete="off" maxlength="40">
+          <p class="create-board-form__error" id="createBoardError" hidden></p>
+        </div>
+        <div class="create-board-form__field">
+          <label class="create-board-form__label" for="createBoardPrompt">
+            Context <span class="create-board-form__optional">(optional)</span>
+          </label>
+          <textarea id="createBoardPrompt" class="create-board-form__textarea"
+                    placeholder="What is this board for? Helps surface better suggestions."
+                    rows="2" maxlength="200"></textarea>
+        </div>
+        <button class="create-board-form__submit" id="createBoardSubmit" type="button">
+          Create Board
+        </button>
       </div>
     </div>
   </div>
@@ -12077,11 +12351,18 @@ Return JSON:
     syncOrderToSupabase(data.linkOrder); // Background sync
   }
 
-  function createCategory(name) {
+  function createCategory(name, opts = {}) {
     const data = load();
-    const n = name.toLowerCase().replace(/\s+/g, '-');
+    const n = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    if (!n) throw new Error('Invalid name');
     if (data.categories[n]) throw new Error('Category exists');
-    data.categories[n] = { pinned: false };
+    data.categories[n] = {
+      pinned: false,
+      isUserBoard: opts.isUserBoard || false,
+      displayName: opts.isUserBoard ? name : null,
+      prompt: opts.prompt || null,
+      createdAt: new Date().toISOString()
+    };
     save(data);
     return n;
   }
@@ -12416,16 +12697,33 @@ Return JSON:
     html += `<button class="filter-token ${allActive ? 'filter-token--active' : ''}" data-category="all" role="tab" aria-selected="${allActive}">All</button>`;
 
     const sorted = Object.entries(cats)
-      .filter(([n]) => counts[n] > 0 && n !== 'uncategorized')
-      .sort((a, b) => (b[1].pinned ? 1 : 0) - (a[1].pinned ? 1 : 0) || (counts[b[0]] || 0) - (counts[a[0]] || 0));
+      .filter(([n, meta]) => (counts[n] > 0 || meta.isUserBoard) && n !== 'uncategorized')
+      .sort((a, b) => {
+        const aM = a[1], bM = b[1];
+        // Pinned AI categories first
+        const aPinned = aM.pinned && !aM.isUserBoard ? 1 : 0;
+        const bPinned = bM.pinned && !bM.isUserBoard ? 1 : 0;
+        if (aPinned !== bPinned) return bPinned - aPinned;
+        // User boards second group
+        const aUser = aM.isUserBoard ? 1 : 0;
+        const bUser = bM.isUserBoard ? 1 : 0;
+        if (aUser !== bUser) return aUser - bUser;
+        // Within group, sort by pin count
+        return (counts[b[0]] || 0) - (counts[a[0]] || 0);
+      });
 
-    for (const [name] of sorted) {
+    for (const [name, meta] of sorted) {
       const c = counts[name] || 0;
       const active = currentFilter === name;
       const activeClass = active ? 'filter-token--active' : '';
+      const userClass = meta.isUserBoard ? ' filter-token--user-board' : '';
+      const label = meta.isUserBoard ? `✦ ${meta.displayName || cap(name)}` : cap(name);
       const badge = name === 'uncategorized' && c > 0 ? ` (${c})` : '';
-      html += `<button class="filter-token ${activeClass}" data-category="${name}" role="tab" aria-selected="${active}">${cap(name)}${badge}</button>`;
+      html += `<button class="filter-token${userClass} ${activeClass}" data-category="${name}" role="tab" aria-selected="${active}">${label}${badge}</button>`;
     }
+
+    // Add "New Board" button in filter bar
+    html += `<button class="filter-token filter-token--new-board" id="createBoardBtn" aria-label="Create new board">+ Board</button>`;
 
     // Add cleanup pill if queue has 3+ items
     cleanupQueueCache = getCleanupQueue(links);
@@ -13067,6 +13365,15 @@ Return JSON:
     videoInput.click();
   };
 
+  // FAB Create Board
+  const fabCreateBoard = document.getElementById('fabCreateBoard');
+  if (fabCreateBoard) {
+    fabCreateBoard.onclick = () => {
+      fabMenu.classList.remove('fab-menu--open');
+      openCreateBoardModal();
+    };
+  }
+
   // ============================================
   // Tools Modal — Tabs + Extension / Bookmarklet Install
   // ============================================
@@ -13686,6 +13993,12 @@ Return JSON:
     if (t) {
       const category = t.dataset.category;
 
+      // Handle "Create Board" button in filter bar
+      if (t.id === 'createBoardBtn') {
+        openCreateBoardModal();
+        return;
+      }
+
       // Handle cleanup view
       if (category === 'cleanup') {
         cleanupViewActive = true;
@@ -13710,6 +14023,8 @@ Return JSON:
       updateShareButton();
       // Onboarding: show search hint when first filtering to a category
       showCategoryHint();
+      // Show seed panel for user-created boards
+      renderBoardSeedPanel(category);
     }
   };
 
@@ -14915,7 +15230,7 @@ Return JSON:
     if (m._trapHandler) { m.removeEventListener('keydown', m._trapHandler); m._trapHandler = null; }
     if (m._previousFocus) { m._previousFocus.focus(); m._previousFocus = null; }
   }
-  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal].forEach(closeModal); }
+  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal, createBoardModal].forEach(closeModal); }
 
   // Custom confirm dialog (native confirm() is blocked in some contexts)
   const confirmModal = $('confirmModal');
@@ -14939,6 +15254,229 @@ Return JSON:
       confirmOkBtn.onclick = () => { cleanup(); resolve(true); };
       confirmCancelBtn.onclick = () => { cleanup(); resolve(false); };
     });
+  }
+
+  // ============================================
+  // Create Board Modal Logic
+  // ============================================
+  const createBoardModal = $('createBoardModal');
+  const createBoardNameInput = $('createBoardName');
+  const createBoardPromptInput = $('createBoardPrompt');
+  const createBoardError = $('createBoardError');
+  const createBoardSubmitBtn = $('createBoardSubmit');
+
+  if (createBoardModal) {
+    createBoardModal.querySelectorAll('[data-close]').forEach(el => {
+      el.onclick = () => closeModal(createBoardModal);
+    });
+  }
+
+  function openCreateBoardModal() {
+    if (!createBoardModal) return;
+    createBoardNameInput.value = '';
+    createBoardPromptInput.value = '';
+    createBoardError.hidden = true;
+    createBoardError.textContent = '';
+    createBoardSubmitBtn.disabled = false;
+    openModal(createBoardModal);
+  }
+
+  if (createBoardSubmitBtn) {
+    createBoardSubmitBtn.onclick = () => {
+      const name = createBoardNameInput.value.trim();
+      if (!name) {
+        createBoardError.textContent = 'Board name is required.';
+        createBoardError.hidden = false;
+        createBoardNameInput.focus();
+        return;
+      }
+      const prompt = createBoardPromptInput.value.trim();
+      try {
+        const slug = createCategory(name, { isUserBoard: true, prompt: prompt || null });
+        closeModal(createBoardModal);
+        currentFilter = slug;
+        localStorage.setItem(FILTER_KEY, currentFilter);
+        renderFilters();
+        renderGrid();
+        generateWidgets();
+        updateShareButton();
+        renderBoardSeedPanel(slug);
+        toast(`Board "${name}" created`);
+      } catch (e) {
+        if (e.message === 'Category exists') {
+          createBoardError.textContent = `A board named "${name}" already exists.`;
+        } else {
+          createBoardError.textContent = e.message || 'Could not create board.';
+        }
+        createBoardError.hidden = false;
+      }
+    };
+  }
+
+  // Enter key submits the create board form
+  if (createBoardNameInput) {
+    createBoardNameInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter') createBoardSubmitBtn.click();
+    });
+  }
+
+  // ============================================
+  // Board Seed Panel — Library Suggestions
+  // ============================================
+  const BOARD_SEED_THRESHOLD = 5;
+  const BOARD_SEED_DISMISSED_KEY = 'boards-seed-dismissed';
+  const boardSeedPanel = $('boardSeedPanel');
+  const boardSeedBody = $('boardSeedBody');
+  const boardSeedFooter = $('boardSeedFooter');
+  const boardSeedDismiss = $('boardSeedDismiss');
+  const boardSeedAddAll = $('boardSeedAddAll');
+
+  function getLibrarySuggestions(boardSlug, limit = 12) {
+    const data = load();
+    const meta = data.categories[boardSlug];
+    if (!meta) return [];
+
+    const boardName = (meta.displayName || boardSlug.replace(/-/g, ' ')).toLowerCase();
+    const prompt = (meta.prompt || '').toLowerCase();
+    const allText = boardName + ' ' + prompt;
+    const tokens = allText.split(/\s+/).filter(t => t.length > 2);
+    if (tokens.length === 0) return [];
+
+    const boardPinIds = new Set(data.links.filter(l => l.category === boardSlug).map(l => l.id));
+
+    return data.links
+      .filter(l => !boardPinIds.has(l.id) && !l.loading && l.category !== 'uncategorized')
+      .map(link => {
+        let score = 0;
+        const titleLower = (link.title || '').toLowerCase();
+        const descLower = (link.description || '').toLowerCase();
+        const catLower = (link.category || '').toLowerCase();
+        const domainLower = (link.domain || '').toLowerCase();
+
+        for (const token of tokens) {
+          if (titleLower.includes(token)) score += 3;
+          if (descLower.includes(token)) score += 1;
+          if (catLower.includes(token)) score += 2;
+          if (domainLower.includes(token)) score += 1;
+        }
+
+        // Image quality bonus
+        if (link.image) score += 1;
+
+        return { link, score };
+      })
+      .filter(r => r.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map(r => r.link);
+  }
+
+  function renderBoardSeedPanel(slug) {
+    if (!boardSeedPanel) return;
+
+    const data = load();
+    const meta = data.categories[slug];
+
+    // Only show for user-created boards
+    if (!meta || !meta.isUserBoard) {
+      boardSeedPanel.hidden = true;
+      return;
+    }
+
+    // Check if dismissed
+    try {
+      const dismissed = JSON.parse(localStorage.getItem(BOARD_SEED_DISMISSED_KEY) || '{}');
+      if (dismissed[slug]) { boardSeedPanel.hidden = true; return; }
+    } catch {}
+
+    // Check seeding threshold
+    const boardPinCount = data.links.filter(l => l.category === slug).length;
+    if (boardPinCount >= BOARD_SEED_THRESHOLD) {
+      boardSeedPanel.hidden = true;
+      return;
+    }
+
+    const suggestions = getLibrarySuggestions(slug);
+    if (suggestions.length === 0) {
+      boardSeedPanel.hidden = true;
+      return;
+    }
+
+    boardSeedBody.innerHTML = suggestions.map(pin => {
+      const hasImg = pin.image && pin.image.length > 0;
+      const initial = pin.title ? pin.title.charAt(0).toUpperCase() : '?';
+      return `<div class="seed-card" data-seed-id="${esc(pin.id)}">
+        ${hasImg
+          ? `<img class="seed-card__img" src="${secureImg(pin.image)}" alt="" loading="lazy">`
+          : `<div class="seed-card__placeholder">${initial}</div>`}
+        <div class="seed-card__info">
+          <div class="seed-card__title">${esc(pin.title || pin.url)}</div>
+          <div class="seed-card__domain">${esc(pin.domain || '')}</div>
+        </div>
+        <button class="seed-card__add" data-seed-add="${esc(pin.id)}">Add</button>
+      </div>`;
+    }).join('');
+
+    boardSeedPanel.dataset.suggestions = JSON.stringify(suggestions.map(p => p.id));
+    boardSeedFooter.hidden = suggestions.length === 0;
+    boardSeedPanel.hidden = false;
+  }
+
+  // Seed panel event: Add individual pin
+  if (boardSeedBody) {
+    boardSeedBody.addEventListener('click', e => {
+      const addBtn = e.target.closest('[data-seed-add]');
+      if (addBtn) {
+        e.stopPropagation();
+        const pinId = addBtn.dataset.seedAdd;
+        updateLink(pinId, { category: currentFilter });
+        const card = addBtn.closest('.seed-card');
+        if (card) card.classList.add('seed-card--added');
+        renderFilters();
+        renderGrid();
+        generateWidgets();
+        // Re-evaluate panel after a brief delay for animation
+        setTimeout(() => renderBoardSeedPanel(currentFilter), 300);
+        toast('Added to board');
+        return;
+      }
+
+      // Card click — open pin detail
+      const card = e.target.closest('[data-seed-id]');
+      if (card) {
+        const pinId = card.dataset.seedId;
+        openDetail(pinId);
+      }
+    });
+  }
+
+  // Seed panel event: Dismiss
+  if (boardSeedDismiss) {
+    boardSeedDismiss.onclick = () => {
+      try {
+        const dismissed = JSON.parse(localStorage.getItem(BOARD_SEED_DISMISSED_KEY) || '{}');
+        dismissed[currentFilter] = new Date().toISOString();
+        localStorage.setItem(BOARD_SEED_DISMISSED_KEY, JSON.stringify(dismissed));
+      } catch {}
+      boardSeedPanel.hidden = true;
+    };
+  }
+
+  // Seed panel event: Add All
+  if (boardSeedAddAll) {
+    boardSeedAddAll.onclick = async () => {
+      let ids;
+      try { ids = JSON.parse(boardSeedPanel.dataset.suggestions || '[]'); } catch { ids = []; }
+      if (ids.length === 0) return;
+      const confirmed = await showConfirm(`Move ${ids.length} pins to this board?`, 'Add All');
+      if (!confirmed) return;
+      bulkMove(ids, currentFilter);
+      renderFilters();
+      renderGrid();
+      generateWidgets();
+      boardSeedPanel.hidden = true;
+      toast(`Added ${ids.length} pins to board`);
+    };
   }
 
   // ============================================
@@ -16505,6 +17043,7 @@ Return JSON:
     // Stale-while-revalidate: render from localStorage immediately
     renderFilters();
     renderGrid();
+    renderBoardSeedPanel(currentFilter);
     initWidgetSystem();
     generateWidgets();
     console.log(`[perf] init: ${(performance.now() - initStart).toFixed(0)}ms`);


### PR DESCRIPTION
## Summary
- Users can now create custom boards with a name and optional context prompt
- User-created boards appear in navigation with ✦ prefix, visible even at 0 pins
- Library suggestions surface existing pins that match the board's theme
- Seed panel with Add/Add All functionality, auto-hides after 5+ pins
- Two entry points: FAB menu "New Board" + filter bar "+ Board" button

Implements Phase 1 + Phase 2 of the [Create a Board PRD](docs/strategy/prds/create-a-board.md). Internet suggestions (Phase 3) deferred.

## Test plan
- [ ] Click "+ Board" in filter bar → modal opens with name + prompt fields
- [ ] Create board → navigates to empty board with ✦ prefix in filters
- [ ] Library suggestions appear if matching pins exist
- [ ] Add individual pin from suggestions → moves to board, card fades
- [ ] Add All → confirms then bulk moves all suggestions
- [ ] Dismiss (×) → panel hidden, stays hidden on revisit
- [ ] Create board named "wear" → shows collision error
- [ ] Board with 5+ pins → seed panel auto-hides
- [ ] FAB menu → "New Board" → opens same modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)