### PR TITLE
Smart banner: magic link email → iOS app redirect

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -4278,6 +4278,13 @@ body {
   }
 }
 
+/* Auth deep link banner: stack above capture promo on mobile */
+@media (max-width: 600px) {
+  #authDeepLinkBanner {
+    bottom: 160px;
+  }
+}
+
 /* Mobile Paste Button — clipboard-aware full-width paste action */
 .mobile-paste {
   display: none;
@@ -5164,6 +5171,19 @@ body {
       </div>
       <button class="capture-promo__cta" id="promoShowTools">Install</button>
       <button class="capture-promo__dismiss" id="promoDismiss" aria-label="Dismiss">&times;</button>
+    </div>
+  </div>
+
+  <!-- iOS Magic Link Auth Banner -->
+  <div class="capture-promo" id="authDeepLinkBanner" style="display:none;z-index:1001;">
+    <div class="capture-promo__inner">
+      <div class="capture-promo__icon">📱</div>
+      <div class="capture-promo__body">
+        <div class="capture-promo__text">Open in Boards app</div>
+        <div class="capture-promo__subtext">Tap to sign in to the app</div>
+      </div>
+      <button class="capture-promo__cta" id="authBannerOpen">Open App</button>
+      <button class="capture-promo__dismiss" id="authBannerDismiss" aria-label="Dismiss">&times;</button>
     </div>
   </div>
 
@@ -17286,6 +17306,64 @@ Return JSON:
 
 })();
   </script>
+
+  <!-- iOS Magic Link Auth Banner Script -->
+  <script>
+(function() {
+  'use strict';
+
+  // Skip if inside the native WKWebView (authBridge injected by the app)
+  if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.authBridge) return;
+
+  // Only show on iOS (iPhone/iPad in Safari or Chrome)
+  if (!/iPhone|iPad/.test(navigator.userAgent)) return;
+
+  // Only show when there's an auth callback in the URL hash
+  var hash = window.location.hash;
+  if (!hash || hash.indexOf('access_token') === -1) return;
+
+  // Parse tokens from hash fragment
+  var params = {};
+  hash.slice(1).split('&').forEach(function(part) {
+    var kv = part.split('=');
+    if (kv[0]) params[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1] || '');
+  });
+
+  var accessToken = params['access_token'];
+  var refreshToken = params['refresh_token'] || '';
+  var tokenType = params['token_type'] || 'bearer';
+  if (!accessToken) return;
+
+  // Build deep link URL using the custom URL scheme
+  var deepLink = 'ctrlrodeo://auth#access_token=' + encodeURIComponent(accessToken)
+    + '&refresh_token=' + encodeURIComponent(refreshToken)
+    + '&token_type=' + encodeURIComponent(tokenType);
+
+  var banner = document.getElementById('authDeepLinkBanner');
+  var openBtn = document.getElementById('authBannerOpen');
+  var dismissBtn = document.getElementById('authBannerDismiss');
+  if (!banner || !openBtn || !dismissBtn) return;
+
+  function hideBanner() { banner.style.display = 'none'; }
+
+  var autoDismiss = setTimeout(hideBanner, 10000);
+
+  openBtn.addEventListener('click', function() {
+    clearTimeout(autoDismiss);
+    hideBanner();
+    window.location.href = deepLink;
+  });
+
+  dismissBtn.addEventListener('click', function() {
+    clearTimeout(autoDismiss);
+    hideBanner();
+  });
+
+  // Show after 300ms delay to let Supabase SDK start processing the hash
+  setTimeout(function() { banner.style.display = 'block'; }, 300);
+})();
+  </script>
+
   <footer class="attribution" style="position:fixed;bottom:0;left:0;padding:2px 6px;font-size:7px;font-family:var(--font-mono);color:var(--subtle);opacity:0.3;z-index:0;pointer-events:auto;">
     BPM data by <a href="https://getsongbpm.com" target="_blank" rel="noopener" style="color:inherit;">GetSongBPM</a>
   </footer>

--- a/ios/CtrlRodeo/ContentView.swift
+++ b/ios/CtrlRodeo/ContentView.swift
@@ -40,14 +40,28 @@ struct ContentView: View {
 
         // Check if this is an auth callback (contains access_token in fragment or query)
         let urlString = url.absoluteString
-        if urlString.contains("access_token") || urlString.contains("token_type") {
-            // Store the URL to pass to WebView for token extraction
-            pendingAuthURL = url
+        guard urlString.contains("access_token") || urlString.contains("token_type") else { return }
 
-            // If we're on the auth screen, skip to the web view so it can process the token
-            if !isAuthenticated && !didSkipAuth {
-                didSkipAuth = true
-            }
+        // If it's a custom scheme URL (ctrlrodeo://), WKWebView can't load it.
+        // Extract the fragment and build a proper HTTPS URL.
+        let loadURL: URL
+        if url.scheme == AppConstants.urlScheme {
+            let fragment = url.fragment ?? ""
+            let httpsURLString = fragment.isEmpty
+                ? AppConstants.boardsURL
+                : AppConstants.boardsURL + "#" + fragment
+            loadURL = URL(string: httpsURLString) ?? url
+            print("[ContentView] handleAuthDeepLink: translated custom scheme to \(loadURL)")
+        } else {
+            loadURL = url
+        }
+
+        // Store the URL to pass to WebView for token extraction
+        pendingAuthURL = loadURL
+
+        // If we're on the auth screen, skip to the web view so it can process the token
+        if !isAuthenticated && !didSkipAuth {
+            didSkipAuth = true
         }
     }
 }
@@ -150,14 +164,6 @@ struct WebView: UIViewRepresentable {
             print("[WebView] makeUIView: Loading URL \(url)")
             webView.load(URLRequest(url: url))
         }
-
-        // Listen for deep links
-        NotificationCenter.default.addObserver(
-            context.coordinator,
-            selector: #selector(Coordinator.handleDeepLink(_:)),
-            name: NSNotification.Name("DeepLinkReceived"),
-            object: nil
-        )
 
         context.coordinator.webView = webView
         return webView
@@ -364,16 +370,5 @@ struct WebView: UIViewRepresentable {
             webView?.reload()
         }
 
-        // MARK: - Deep Links
-
-        @objc func handleDeepLink(_ notification: Notification) {
-            guard let url = notification.userInfo?["url"] as? URL else { return }
-
-            print("[WebView] handleDeepLink: Loading URL \(url)")
-
-            // Navigate to the deep link URL in the web view
-            // This handles OAuth callbacks from Supabase
-            webView?.load(URLRequest(url: url))
-        }
     }
 }


### PR DESCRIPTION
## Summary
- When magic link email opens in a mobile browser (Gmail → Chrome iOS), shows an "Open in Boards app" banner
- Banner deep links to the native app via `ctrlrodeo://` custom URL scheme with auth tokens
- Web auth still works normally regardless of banner interaction (Supabase SDK processes hash first)
- Fixes `handleAuthDeepLink` to translate `ctrlrodeo://` URLs to `https://` before loading in WKWebView
- Removes duplicate NotificationCenter observer that could load raw custom scheme URLs

## How it works
1. User taps magic link in email → browser loads `ctrl.rodeo/boards/#access_token=...`
2. Supabase SDK processes hash → user logged in on web
3. JS detects iOS + auth callback + not in WKWebView → shows banner after 300ms
4. User taps "Open App" → `ctrlrodeo://auth#access_token=...` → iOS opens native app
5. Swift translates to HTTPS URL → WebView loads → auth bridge captures token → done

## Test plan
- [ ] Send magic link → open in Gmail on iPhone → Chrome loads → banner appears
- [ ] Tap "Open App" → native app opens and authenticates
- [ ] Dismiss banner → web auth works, stays in browser
- [ ] Wait 10s → banner auto-hides
- [ ] Load in native WKWebView → banner does NOT appear
- [ ] Load on desktop → banner does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)