### PR TITLE
Fix iOS auth: button taps, deep link overlay, keyboard

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -10,6 +10,27 @@
   <link rel="icon" type="image/x-icon" href="/images/icons/favicons/favicon.ico">
   <link rel="manifest" href="/images/icons/favicons/site.webmanifest">
 
+  <!-- iOS Auth Token Capture — MUST run before Supabase clears the hash -->
+  <script>
+  (function() {
+    var h = window.location.hash;
+    if (h && h.indexOf('access_token') !== -1) {
+      var p = {};
+      h.slice(1).split('&').forEach(function(s) {
+        var kv = s.split('=');
+        if (kv[0]) p[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1] || '');
+      });
+      if (p['access_token']) {
+        window.__iosAuthCapture = {
+          accessToken: p['access_token'],
+          refreshToken: p['refresh_token'] || '',
+          tokenType: p['token_type'] || 'bearer'
+        };
+      }
+    }
+  })();
+  </script>
+
   <!-- Space Grotesk Font -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -4639,13 +4660,6 @@ body {
   }
 }
 
-/* Auth deep link banner: stack above capture promo on mobile */
-@media (max-width: 600px) {
-  #authDeepLinkBanner {
-    bottom: 160px;
-  }
-}
-
 /* Mobile Paste Button — clipboard-aware full-width paste action */
 .mobile-paste {
   display: none;
@@ -5563,16 +5577,14 @@ body {
     </div>
   </div>
 
-  <!-- iOS Magic Link Auth Banner -->
-  <div class="capture-promo" id="authDeepLinkBanner" style="display:none;z-index:1001;">
-    <div class="capture-promo__inner">
-      <div class="capture-promo__icon">📱</div>
-      <div class="capture-promo__body">
-        <div class="capture-promo__text">Open in Boards app</div>
-        <div class="capture-promo__subtext">Tap to sign in to the app</div>
-      </div>
-      <button class="capture-promo__cta" id="authBannerOpen">Open App</button>
-      <button class="capture-promo__dismiss" id="authBannerDismiss" aria-label="Dismiss">&times;</button>
+  <!-- iOS App Redirect Overlay -->
+  <div id="iosAppOverlay" style="display:none;position:fixed;inset:0;z-index:9999;background:#000;color:#fff;font-family:var(--font-mono);flex-direction:column;align-items:center;justify-content:center;padding:var(--space-8);text-align:center;-webkit-font-smoothing:antialiased;">
+    <div style="max-width:320px;width:100%;">
+      <div style="font-family:'Georgia',serif;font-size:40px;margin-bottom:var(--space-8);letter-spacing:-0.02em;">boards</div>
+      <div style="font-size:var(--font-size-xs);text-transform:uppercase;letter-spacing:0.1em;color:#999;margin-bottom:var(--space-3);">Open in the app</div>
+      <div style="font-size:var(--font-size-xs);color:#666;margin-bottom:var(--space-8);line-height:1.6;" id="iosOverlaySubtext">Continue to the full Boards experience</div>
+      <button id="iosOverlayOpen" style="display:block;width:100%;padding:var(--space-3) var(--space-6);background:#fff;color:#000;border:1px solid #fff;font-family:var(--font-mono);font-size:var(--font-size-xs);text-transform:uppercase;letter-spacing:0.05em;font-weight:700;cursor:pointer;margin-bottom:var(--space-4);">Open Boards App</button>
+      <button id="iosOverlayDismiss" style="display:block;width:100%;padding:var(--space-3) var(--space-6);background:transparent;color:#666;border:1px solid #333;font-family:var(--font-mono);font-size:var(--font-size-xs);text-transform:uppercase;letter-spacing:0.05em;cursor:pointer;">Continue in Browser</button>
     </div>
   </div>
 
@@ -19262,7 +19274,7 @@ Return JSON:
 })();
   </script>
 
-  <!-- iOS Magic Link Auth Banner Script -->
+  <!-- iOS App Redirect Overlay Script -->
   <script>
 (function() {
   'use strict';
@@ -19270,52 +19282,54 @@ Return JSON:
   // Skip if inside the native WKWebView (authBridge injected by the app)
   if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.authBridge) return;
 
-  // Only show on iOS (iPhone/iPad in Safari or Chrome)
+  // Only show on iOS
   if (!/iPhone|iPad/.test(navigator.userAgent)) return;
 
-  // Only show when there's an auth callback in the URL hash
-  var hash = window.location.hash;
-  if (!hash || hash.indexOf('access_token') === -1) return;
+  var overlay = document.getElementById('iosAppOverlay');
+  var openBtn = document.getElementById('iosOverlayOpen');
+  var dismissBtn = document.getElementById('iosOverlayDismiss');
+  var subtext = document.getElementById('iosOverlaySubtext');
+  if (!overlay || !openBtn || !dismissBtn) return;
 
-  // Parse tokens from hash fragment
-  var params = {};
-  hash.slice(1).split('&').forEach(function(part) {
-    var kv = part.split('=');
-    if (kv[0]) params[decodeURIComponent(kv[0])] = decodeURIComponent(kv[1] || '');
-  });
+  // Check for captured auth tokens (from head-level script, before Supabase cleared the hash)
+  var capturedAuth = window.__iosAuthCapture || null;
 
-  var accessToken = params['access_token'];
-  var refreshToken = params['refresh_token'] || '';
-  var tokenType = params['token_type'] || 'bearer';
-  if (!accessToken) return;
+  // Check for existing session in localStorage
+  var hasExistingSession = false;
+  try {
+    var stored = localStorage.getItem('sb-yfhudwakpgzswiylhfbh-auth-token');
+    if (stored) {
+      var parsed = JSON.parse(stored);
+      if (parsed && parsed.access_token) hasExistingSession = true;
+    }
+  } catch (e) {}
 
-  // Build deep link URL using the custom URL scheme
-  var deepLink = 'ctrlrodeo://auth#access_token=' + encodeURIComponent(accessToken)
-    + '&refresh_token=' + encodeURIComponent(refreshToken)
-    + '&token_type=' + encodeURIComponent(tokenType);
+  // Show overlay if we have fresh auth tokens OR an existing session
+  if (!capturedAuth && !hasExistingSession) return;
 
-  var banner = document.getElementById('authDeepLinkBanner');
-  var openBtn = document.getElementById('authBannerOpen');
-  var dismissBtn = document.getElementById('authBannerDismiss');
-  if (!banner || !openBtn || !dismissBtn) return;
+  // Build deep link
+  var deepLink;
+  if (capturedAuth) {
+    deepLink = 'ctrlrodeo://auth#access_token=' + encodeURIComponent(capturedAuth.accessToken)
+      + '&refresh_token=' + encodeURIComponent(capturedAuth.refreshToken)
+      + '&token_type=' + encodeURIComponent(capturedAuth.tokenType);
+    if (subtext) subtext.textContent = 'Tap to sign in to the app';
+  } else {
+    deepLink = 'ctrlrodeo://open';
+    if (subtext) subtext.textContent = 'Continue to the full Boards experience';
+  }
 
-  function hideBanner() { banner.style.display = 'none'; }
-
-  var autoDismiss = setTimeout(hideBanner, 10000);
+  function hideOverlay() { overlay.style.display = 'none'; }
 
   openBtn.addEventListener('click', function() {
-    clearTimeout(autoDismiss);
-    hideBanner();
     window.location.href = deepLink;
+    setTimeout(hideOverlay, 2500);
   });
 
-  dismissBtn.addEventListener('click', function() {
-    clearTimeout(autoDismiss);
-    hideBanner();
-  });
+  dismissBtn.addEventListener('click', hideOverlay);
 
-  // Show after 300ms delay to let Supabase SDK start processing the hash
-  setTimeout(function() { banner.style.display = 'block'; }, 300);
+  // Show overlay immediately
+  overlay.style.display = 'flex';
 })();
   </script>
 

--- a/ios/CtrlRodeo/AuthView.swift
+++ b/ios/CtrlRodeo/AuthView.swift
@@ -117,6 +117,12 @@ struct AuthView: View {
     private func sendMagicLink() {
         guard isValidEmail else { return }
 
+        // Dismiss keyboard immediately
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+
         isSending = true
         errorMessage = nil
 

--- a/ios/CtrlRodeo/ContentView.swift
+++ b/ios/CtrlRodeo/ContentView.swift
@@ -56,12 +56,15 @@ struct ContentView: View {
             loadURL = url
         }
 
-        // Store the URL to pass to WebView for token extraction
+        // Store the URL to pass to WebView for token extraction.
+        // Set pendingAuthURL first, then defer the view transition to the next runloop tick.
+        // This ensures the binding value is committed before BoardsWebView's makeUIView reads it.
         pendingAuthURL = loadURL
 
-        // If we're on the auth screen, skip to the web view so it can process the token
         if !isAuthenticated && !didSkipAuth {
-            didSkipAuth = true
+            DispatchQueue.main.async {
+                didSkipAuth = true
+            }
         }
     }
 }
@@ -153,15 +156,10 @@ struct WebView: UIViewRepresentable {
         webView.scrollView.addSubview(refreshControl)
         context.coordinator.refreshControl = refreshControl
 
-        // Load the boards URL (or pending auth URL if we have one)
-        if let authURL = pendingAuthURL {
-            print("[WebView] makeUIView: Loading auth URL \(authURL)")
-            webView.load(URLRequest(url: authURL))
-            DispatchQueue.main.async {
-                pendingAuthURL = nil
-            }
-        } else if let url = URL(string: AppConstants.boardsURL) {
-            print("[WebView] makeUIView: Loading URL \(url)")
+        // Always load the base boards URL here.
+        // If a pendingAuthURL exists, updateUIView will load it immediately after.
+        if let url = URL(string: AppConstants.boardsURL) {
+            print("[WebView] makeUIView: Loading base URL \(url)")
             webView.load(URLRequest(url: url))
         }
 

--- a/ios/CtrlRodeo/DesignSystem.swift
+++ b/ios/CtrlRodeo/DesignSystem.swift
@@ -89,52 +89,24 @@ enum DSButtonSize {
     case large    // 12/24 padding, 10pt font — web .btn--lg
 }
 
-struct DSButton: View {
-    let title: String
-    let action: () -> Void
-    var variant: DSButtonVariant = .outlined
-    var size: DSButtonSize = .regular
-    var fullWidth: Bool = false
-    var disabled: Bool = false
-    var loading: Bool = false
+/// Custom ButtonStyle that drives press-state visuals via `configuration.isPressed`.
+/// This replaces the DragGesture approach which interfered with tap delivery.
+struct DSButtonStyle: ButtonStyle {
+    let variant: DSButtonVariant
+    let size: DSButtonSize
+    let fullWidth: Bool
 
-    @State private var isPressed = false
+    func makeBody(configuration: Configuration) -> some View {
+        let pressed = configuration.isPressed
 
-    var body: some View {
-        Button(action: {
-            if !disabled && !loading { action() }
-        }) {
-            Group {
-                if loading {
-                    ProgressView()
-                        .tint(textColor)
-                } else {
-                    Text(title.uppercased())
-                        .font(.system(size: fontSize, weight: .bold))
-                        .tracking(Theme.trackingWide)
-                }
-            }
+        configuration.label
             .frame(maxWidth: fullWidth ? .infinity : nil)
             .padding(.vertical, verticalPadding)
             .padding(.horizontal, horizontalPadding)
-        }
-        .buttonStyle(PlainButtonStyle())
-        .foregroundColor(textColor)
-        .background(backgroundColor)
-        .overlay(borderOverlay)
-        .opacity(disabled ? 0.5 : 1.0)
-        .disabled(disabled || loading)
-        .simultaneousGesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in withAnimation(.easeInOut(duration: Theme.durationFast)) { isPressed = true } }
-                .onEnded { _ in withAnimation(.easeInOut(duration: Theme.durationFast)) { isPressed = false } }
-        )
-    }
-
-    // MARK: - Sizing
-
-    private var fontSize: CGFloat {
-        size == .small ? Theme.text2XS : Theme.textXS
+            .foregroundColor(textColor(pressed: pressed))
+            .background(backgroundColor(pressed: pressed))
+            .overlay(borderOverlay)
+            .animation(.easeInOut(duration: Theme.durationFast), value: pressed)
     }
 
     private var verticalPadding: CGFloat {
@@ -153,27 +125,19 @@ struct DSButton: View {
         }
     }
 
-    // MARK: - Colors
-
-    private var backgroundColor: Color {
+    private func backgroundColor(pressed: Bool) -> Color {
         switch variant {
-        case .outlined:
-            return isPressed ? Theme.foreground : .clear
-        case .filled:
-            return isPressed ? .clear : Theme.foreground
-        case .ghost:
-            return .clear
+        case .outlined: return pressed ? Theme.foreground : .clear
+        case .filled:   return pressed ? .clear : Theme.foreground
+        case .ghost:    return .clear
         }
     }
 
-    private var textColor: Color {
+    private func textColor(pressed: Bool) -> Color {
         switch variant {
-        case .outlined:
-            return isPressed ? Theme.surface : Theme.foreground
-        case .filled:
-            return isPressed ? Theme.foreground : Theme.surface
-        case .ghost:
-            return Theme.foreground
+        case .outlined: return pressed ? Theme.surface : Theme.foreground
+        case .filled:   return pressed ? Theme.foreground : Theme.surface
+        case .ghost:    return Theme.foreground
         }
     }
 
@@ -184,6 +148,47 @@ struct DSButton: View {
             Rectangle().stroke(Theme.foreground, lineWidth: 1)
         case .ghost:
             EmptyView()
+        }
+    }
+}
+
+struct DSButton: View {
+    let title: String
+    let action: () -> Void
+    var variant: DSButtonVariant = .outlined
+    var size: DSButtonSize = .regular
+    var fullWidth: Bool = false
+    var disabled: Bool = false
+    var loading: Bool = false
+
+    var body: some View {
+        Button(action: {
+            if !disabled && !loading { action() }
+        }) {
+            Group {
+                if loading {
+                    ProgressView()
+                        .tint(labelColor)
+                } else {
+                    Text(title.uppercased())
+                        .font(.system(size: fontSize, weight: .bold))
+                        .tracking(Theme.trackingWide)
+                }
+            }
+        }
+        .buttonStyle(DSButtonStyle(variant: variant, size: size, fullWidth: fullWidth))
+        .opacity(disabled ? 0.5 : 1.0)
+        .disabled(disabled || loading)
+    }
+
+    private var fontSize: CGFloat {
+        size == .small ? Theme.text2XS : Theme.textXS
+    }
+
+    private var labelColor: Color {
+        switch variant {
+        case .outlined, .ghost: return Theme.foreground
+        case .filled: return Theme.surface
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Fix DSButton tap handling** — `DragGesture(minimumDistance: 0)` was eating all button taps. Replaced with a proper `ButtonStyle` using `configuration.isPressed`. This was the critical blocker — no buttons worked in the app.
- **Add keyboard dismiss** — keyboard now hides when "Send magic link" is tapped
- **Fix deep link timing** — `pendingAuthURL` now commits before `didSkipAuth` triggers re-render, preventing the auth URL from being dropped
- **Replace broken banner with full-screen iOS overlay** — tokens are captured in `<head>` before Supabase clears the hash. Overlay shows on iOS when auth tokens are present OR when an existing session exists. Skips inside WKWebView and on desktop.

## What was broken
1. ALL DSButtons (login, skip, retry) — taps did nothing
2. Deep link banner never appeared — Supabase cleared the URL hash before the banner script ran
3. Banner didn't show when already logged in — only checked for hash tokens
4. `pendingAuthURL` could be nil when `makeUIView` ran — race condition dropped auth URLs

## Test plan
- [ ] Open app → auth screen → enter email → tap "Send magic link" → spinner + success message
- [ ] Keyboard dismisses on submit
- [ ] Send magic link → open in Gmail/Safari on iPhone → full-screen overlay → tap "Open App" → app authenticates
- [ ] Visit `ctrl.rodeo/boards/` on iOS while logged in → overlay shows → tap → app opens
- [ ] Visit on desktop → no overlay
- [ ] Inside native WKWebView → no overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)