### PR TITLE
fix: remove image_scores from sync payload

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -12078,7 +12078,8 @@ Return JSON:
         type_confidence: link.type_confidence || null,
         type_signals: link.type_signals || null,
         image_source: link.image_source || null,
-        image_scores: link.image_scores || null,
+        // image_scores intentionally omitted — client-only field, DB column exists but
+        // PostgREST schema cache may be stale. Scores live in localStorage and are recomputed.
         // Structured metadata (JSONB columns)
         video: link.video || null,
         music: link.music || null,
@@ -12135,7 +12136,12 @@ Return JSON:
           errBody = await retry.text();
         }
         console.error('[sync] Upload failed:', res.status, errBody);
-        toast('Sync failed — changes saved locally', true);
+        // Throttle toast — show at most once per 30s
+        const now = Date.now();
+        if (!syncLinkToSupabase._lastToast || now - syncLinkToSupabase._lastToast > 30000) {
+          syncLinkToSupabase._lastToast = now;
+          toast('Sync failed — changes saved locally', true);
+        }
         // Queue for retry on next sync
         if (!syncRetryQueue.find(l => l.id === link.id)) {
           syncRetryQueue.push(link);
@@ -12147,7 +12153,11 @@ Return JSON:
       }
     } catch (e) {
       console.error('[sync] Error:', e);
-      toast('Sync failed — changes saved locally', true);
+      const now = Date.now();
+      if (!syncLinkToSupabase._lastToast || now - syncLinkToSupabase._lastToast > 30000) {
+        syncLinkToSupabase._lastToast = now;
+        toast('Sync failed — changes saved locally', true);
+      }
       // Queue for retry on next sync
       if (!syncRetryQueue.find(l => l.id === link.id)) {
         syncRetryQueue.push(link);


### PR DESCRIPTION
## Summary
- Remove `image_scores` from `syncLinkToSupabase` payload — the DB column exists but PostgREST schema cache is stale, causing every sync to fail with 400
- Throttle "Sync failed" toast to max once per 30s to prevent flooding when multiple syncs fail

## Context
After recent DDL changes (adding `tags` column), PostgREST's schema cache became stale and stopped recognizing `image_scores`. `NOTIFY pgrst, 'reload schema'` was run but didn't take effect. Since image scores are client-computed and stored in localStorage, they don't need to be in the sync payload.

## Test plan
- [ ] Load boards app, verify syncs complete without 400 errors
- [ ] Verify image scores still appear in pin cards (from localStorage)
- [ ] Trigger multiple sync failures — verify toast shows max once per 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)