### PR TITLE
Replace SVG logo marks with text-only Livongo branding

### DIFF
--- a/registration-flows/index.html
+++ b/registration-flows/index.html
@@ -69,9 +69,10 @@
       gap: 10px;
       text-decoration: none;
       flex-shrink: 0;
+      font-size: 22px;
+      font-weight: 700;
+      color: #333;
     }
-
-    .logo-svg { display: block; }
 
     .header-divider {
       width: 1px;
@@ -658,16 +659,7 @@
 
 <!-- ────────────────────────────────────────── HEADER -->
 <header class="site-header">
-  <a href="#" class="logo-mark">
-    <svg class="logo-svg" width="110" height="32" viewBox="0 0 110 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <!-- Green leaf / health icon -->
-      <circle cx="16" cy="16" r="15" fill="#4CAF50"/>
-      <path d="M10 20 C10 14 14 10 22 10 C22 18 18 22 10 22 Z" fill="white" opacity="0.9"/>
-      <path d="M16 22 L16 16" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-      <!-- Wordmark -->
-      <text x="36" y="21" font-family="Roboto, sans-serif" font-size="14" font-weight="700" fill="#333">Livongo</text>
-    </svg>
-  </a>
+  <a href="#" class="logo-mark">Livongo</a>
   <div class="header-divider"></div>
   <div class="header-text">
     <div class="header-title">Onboarding Flow Comparison</div>

--- a/registration-flows/prereg.html
+++ b/registration-flows/prereg.html
@@ -13,7 +13,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 /* Header */
 .header { display: flex; align-items: center; justify-content: space-between; padding: 16px 32px; border-bottom: 1px solid #e0e0e0; position: sticky; top: 0; background: #fff; z-index: 100; }
 .logo { display: flex; align-items: center; gap: 8px; font-size: 22px; font-weight: 700; color: #333; text-decoration: none; }
-.logo-icon { width: 28px; height: 28px; }
 .header-center { flex: 1; max-width: 400px; margin: 0 40px; }
 .header-right { display: flex; align-items: center; gap: 16px; font-size: 14px; color: #666; }
 .live-chat { color: #1976D2; font-weight: 500; cursor: pointer; }
@@ -430,13 +429,7 @@ input.error, select.error { border-color: #d32f2f; }
 
 <!-- Header -->
 <div class="header">
-  <a class="logo" href="#">
-    <svg class="logo-icon" viewBox="0 0 32 32">
-      <rect x="2" y="14" width="12" height="12" fill="#4caf50" rx="1"/>
-      <polygon points="8,2 20,14 8,14" fill="#1976D2"/>
-    </svg>
-    Livongo
-  </a>
+  <a class="logo" href="#">Livongo</a>
   <div class="header-center">
     <div class="progress-sections" id="progressSections">
       <div class="progress-section">

--- a/registration-flows/standard.html
+++ b/registration-flows/standard.html
@@ -13,7 +13,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 /* Header */
 .header { display: flex; align-items: center; justify-content: space-between; padding: 16px 32px; border-bottom: 1px solid #e0e0e0; position: sticky; top: 0; background: #fff; z-index: 100; }
 .logo { display: flex; align-items: center; gap: 8px; font-size: 22px; font-weight: 700; color: #333; text-decoration: none; }
-.logo-icon { width: 28px; height: 28px; }
 .header-right { display: flex; align-items: center; gap: 16px; font-size: 14px; color: #666; }
 .live-chat { color: #1976D2; font-weight: 500; cursor: pointer; }
 .live-chat::before { content: "💬 "; }
@@ -171,10 +170,7 @@ input.error, select.error { border-color: #d32f2f; }
 
 <!-- Header -->
 <div class="header">
-  <a class="logo" href="#">
-    <svg class="logo-icon" viewBox="0 0 32 32"><rect x="2" y="14" width="12" height="12" fill="#4caf50" rx="1"/><polygon points="8,2 20,14 8,14" fill="#1976D2"/></svg>
-    Livongo
-  </a>
+  <a class="logo" href="#">Livongo</a>
   <div class="progress-wrap" style="flex:1; max-width: 400px; margin: 0 40px;">
     <div class="progress-bar"><div class="progress-fill" id="progressFill" style="width:10%"></div></div>
   </div>


### PR DESCRIPTION
## Summary
- Removed all SVG logo icons from index.html, prereg.html, and standard.html
- Replaced with plain text "Livongo" (22px bold Roboto) — clean type-only branding
- Removed unused `.logo-icon` and `.logo-svg` CSS

## Test plan
- [ ] Open all three pages — verify "Livongo" renders as clean bold text in header
- [ ] No broken icon/SVG artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)