### PR TITLE
Header: ctrl.rodeo logo, new subtitle, buttons into cards

### DIFF
--- a/reg/index.html
+++ b/reg/index.html
@@ -670,11 +670,11 @@
 
 <!-- ────────────────────────────────────────── HEADER -->
 <header class="site-header">
-  <a href="#" class="logo-mark">Livongo</a>
+  <a href="/" class="logo-mark">ctrl.rodeo</a>
   <div class="header-divider"></div>
   <div class="header-text">
     <div class="header-title">Onboarding Flow Comparison</div>
-    <div class="header-subtitle">Original Flow vs. Optimized Flow: Reducing friction through upstream data</div>
+    <div class="header-subtitle">Reshaping onboarding to build trust &amp; feel like partnership.</div>
   </div>
 </header>
 
@@ -708,12 +708,6 @@
     <div class="section-label">Side-by-Side Comparison</div>
     <div class="section-title">Two Paths, One Goal</div>
     <div class="section-desc">The optimized flow moves data collection upstream — from employer HR, health plan records, and carrier APIs — so the user arrives already known to the system.</div>
-
-    <!-- View buttons above the grid -->
-    <div class="flow-buttons-row">
-      <a href="standard.html" target="_blank" class="btn btn--blue">View Original Flow →</a>
-      <a href="prereg.html" target="_blank" class="btn btn--green">View Optimized Flow →</a>
-    </div>
 
     <div class="flow-grid">
 
@@ -792,6 +786,7 @@
               </div>
             </li>
           </ol>
+          <a href="standard.html" target="_blank" class="btn btn--blue" style="margin-top: 16px;">View Original Flow →</a>
         </div>
       </div>
 
@@ -875,6 +870,7 @@
               </div>
             </li>
           </ol>
+          <a href="prereg.html" target="_blank" class="btn btn--green" style="margin-top: 16px;">View Optimized Flow →</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Logo → **ctrl.rodeo** (links to /)
- Subtitle → "Reshaping onboarding to build trust & feel like partnership."
- View flow buttons moved from above the grid to the bottom of each respective card

## Test plan
- [ ] Header shows "ctrl.rodeo" not "Livongo"
- [ ] Subtitle reads new copy
- [ ] "View Original Flow →" button at bottom of Original card
- [ ] "View Optimized Flow →" button at bottom of Optimized card
- [ ] No buttons above the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)