### PR TITLE
Remove chat icon from Live Chat label

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -16,7 +16,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .header-center { flex: 1; max-width: 400px; margin: 0 40px; }
 .header-right { display: flex; align-items: center; gap: 16px; font-size: 14px; color: #666; }
 .live-chat { color: #1976D2; font-weight: 500; cursor: pointer; }
-.live-chat::before { content: "💬 "; }
 
 /* Sectioned Progress Bar */
 .progress-sections {

--- a/reg/standard.html
+++ b/reg/standard.html
@@ -15,7 +15,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .logo { display: flex; align-items: center; gap: 8px; font-size: 22px; font-weight: 700; color: #333; text-decoration: none; }
 .header-right { display: flex; align-items: center; gap: 16px; font-size: 14px; color: #666; }
 .live-chat { color: #1976D2; font-weight: 500; cursor: pointer; }
-.live-chat::before { content: "💬 "; }
 
 /* Progress Bar */
 .progress-wrap { padding: 0 32px; }


### PR DESCRIPTION
## Summary
- Removed `💬` pseudo-element from `.live-chat::before` in prereg.html and standard.html

## Test plan
- [ ] "LIVE CHAT" shows as plain text with no emoji icon in both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)