### PR TITLE
Skip Gender & A1C, enhance records section, rename Step 4

### DIFF
--- a/reg/index.html
+++ b/reg/index.html
@@ -829,14 +829,14 @@
                   <a href="prereg.html#step-3" target="_blank">Supporting Your Diabetes</a>
                   <span class="badge badge--green" style="font-size:0.6rem; padding:2px 6px;">Confirm</span>
                 </div>
-                <div class="step-subtitle">Gender, A1C, CGM, blood glucose — skippable fields auto-confirmed</div>
+                <div class="step-subtitle">CGM, blood glucose — 7 fields in From Your Records</div>
               </div>
             </li>
             <li class="step-item">
               <span class="step-num step-num--green">4</span>
               <div class="step-content">
                 <div class="step-title">
-                  <a href="prereg.html#step-4" target="_blank">A Little More About You</a>
+                  <a href="prereg.html#step-4" target="_blank">Health History</a>
                   <span class="badge badge--green" style="font-size:0.6rem; padding:2px 6px;">Confirm</span>
                 </div>
                 <div class="step-subtitle">Height, weight, conditions, lifestyle — some from records, some user-entered</div>
@@ -991,15 +991,15 @@
     <!-- Filter bar -->
     <div class="filter-bar" id="filterBar">
       <button class="filter-pill active" data-filter="all">All <span class="count">(35)</span></button>
-      <button class="filter-pill" data-filter="confirm">🟢 Confirm <span class="count">(16)</span></button>
+      <button class="filter-pill" data-filter="confirm">🟢 Confirm <span class="count">(14)</span></button>
       <button class="filter-pill" data-filter="user">🔴 User enters <span class="count">(7)</span></button>
-      <button class="filter-pill" data-filter="skipped">⚠ Skipped <span class="count">(10)</span></button>
+      <button class="filter-pill" data-filter="skipped">⚠ Skipped <span class="count">(12)</span></button>
       <button class="filter-pill" data-filter="partial">🟡 Partial <span class="count">(2)</span></button>
     </div>
 
     <div class="table-section">
       <div class="table-section-header">
-        <div class="section-label" style="margin-bottom:2px;">35 Fields — 16 Confirm, 7 User-Entered, 10 Skipped, 2 Partial</div>
+        <div class="section-label" style="margin-bottom:2px;">35 Fields — 14 Confirm, 7 User-Entered, 12 Skipped, 2 Partial</div>
         <div style="font-size:0.8125rem; color: var(--gray-600);">Scroll horizontally on small screens to see all columns.</div>
       </div>
 
@@ -1107,12 +1107,12 @@
             <tr class="table-group-row" data-group="careplan">
               <td colspan="5">Step 3 — Supporting Your Diabetes</td>
             </tr>
-            <tr data-status="confirm">
+            <tr data-status="skipped">
               <td class="field-name">Gender</td>
               <td class="field-standard">Manual entry</td>
-              <td><span class="status-chip status-chip--green">🟢 Confirm</span></td>
+              <td><span class="status-chip status-chip--black">⚠ Skipped</span></td>
               <td class="field-source"><span class="source-pill source-pill--employer">🏢 Employer HR</span></td>
-              <td class="field-notes">User confirms on Diabetes Care Plan</td>
+              <td class="field-notes">Auto-confirmed from employer records</td>
             </tr>
             <tr data-status="skipped">
               <td class="field-name">Diabetes Type</td>
@@ -1128,12 +1128,12 @@
               <td class="field-source"><span class="source-pill source-pill--health">🏥 Health Records</span></td>
               <td class="field-notes">Auto-confirmed from health records</td>
             </tr>
-            <tr data-status="confirm">
+            <tr data-status="skipped">
               <td class="field-name">A1C Check</td>
               <td class="field-standard">Manual entry</td>
-              <td><span class="status-chip status-chip--green">🟢 Confirm</span></td>
+              <td><span class="status-chip status-chip--black">⚠ Skipped</span></td>
               <td class="field-source"><span class="source-pill source-pill--health">🏥 Health Records</span></td>
-              <td class="field-notes">Most recent lab result</td>
+              <td class="field-notes">Auto-confirmed from health records</td>
             </tr>
             <tr data-status="skipped">
               <td class="field-name">Medications</td>
@@ -1192,7 +1192,7 @@
 
             <!-- Health Profile -->
             <tr class="table-group-row" data-group="health">
-              <td colspan="5">Step 4 — A Little More About You</td>
+              <td colspan="5">Step 4 — Health History</td>
             </tr>
             <tr data-status="confirm">
               <td class="field-name">Height</td>

--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -148,10 +148,15 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .records-summary summary::after { content: "▸"; float: right; transition: transform 0.2s; }
 .records-summary[open] summary::after { transform: rotate(90deg); }
 .records-summary-body { padding: 16px 18px; border-top: 1px solid #e0e0e0; }
-.records-item { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid #f0f0f0; font-size: 14px; }
+.records-source-heading { display: flex; align-items: center; gap: 8px; font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: #888; margin: 12px 0 6px; padding-top: 8px; border-top: 1px solid #f0f0f0; }
+.records-source-heading:first-child { margin-top: 0; padding-top: 0; border-top: none; }
+.records-item { display: flex; align-items: center; padding: 8px 0; border-bottom: 1px solid #f0f0f0; font-size: 14px; }
 .records-item:last-child { border-bottom: none; }
-.records-label { color: #777; }
+.records-label { color: #777; flex: 1; }
 .records-value { font-weight: 500; color: #333; }
+.records-edit { font-size: 12px; color: #1976D2; cursor: pointer; margin-left: 12px; text-decoration: none; }
+.records-edit:hover { text-decoration: underline; }
+.records-privacy { font-size: 12px; color: #999; padding-top: 12px; margin-top: 8px; border-top: 1px solid #eee; }
 
 /* Welcome Card + Data Disclosure Card */
 .welcome-card,
@@ -593,63 +598,7 @@ input.error, select.error { border-color: #d32f2f; }
 <div class="step" data-step="3">
 
   <h1>Supporting Your Diabetes</h1>
-  <p class="subtitle">Review your diabetes history so we can support you from day one.</p>
-
-  <div class="data-disclosure-card">
-    <div class="wc-greeting">📋 Where Your Information Comes From</div>
-    <div class="wc-body">
-      To save you time, we've combined information from a few sources. Review what we have and correct anything that's changed.
-    </div>
-    <div class="wc-sources">
-      <div class="wc-source-row">
-        <span class="wc-icon">🏢</span>
-        <strong>Employer</strong>
-        <span class="wc-fields">Address</span>
-      </div>
-      <div class="wc-source-row">
-        <span class="wc-icon">🏥</span>
-        <strong>Health Records</strong>
-        <span class="wc-fields">Diabetes history, Clinical data</span>
-      </div>
-      <div class="wc-source-row">
-        <span class="wc-icon">✏️</span>
-        <strong>You provided</strong>
-        <span class="wc-fields">Name, DOB, Email, Phone</span>
-      </div>
-    </div>
-    <div class="wc-privacy">
-      🔒 Your data is encrypted and never shared outside of your care team.
-    </div>
-  </div>
-
-  <div class="source-banner source-banner--records">
-    <span class="sb-icon">🏥</span>
-    <span>Your diabetes history was sourced from health plan records. Review each item and correct anything that's changed.</span>
-  </div>
-
-  <div class="question-group">
-    <div class="question">What is your gender?</div>
-    <label class="radio-card preselected selected" onclick="selectRadioCard(this)">
-      <input type="radio" name="gender" value="male" checked>
-      Male    </label>
-    <label class="radio-card" onclick="selectRadioCard(this)"><input type="radio" name="gender" value="female"> Female</label>
-    <label class="radio-card" onclick="selectRadioCard(this)"><input type="radio" name="gender" value="other"> Prefer to self-describe</label>
-    <label class="radio-card" onclick="selectRadioCard(this)"><input type="radio" name="gender" value="nodisclose"> Prefer not to disclose</label>
-  </div>
-
-
-  <div class="question-group">
-    <div class="question">Have you ever had an A1C check? <span class="info-icon" title="A1C measures your average blood sugar over 2-3 months">ⓘ</span></div>
-    <label class="radio-card preselected selected" onclick="selectRadioCard(this)">
-      <input type="radio" name="a1c" value="yes" checked>
-      Yes    </label>
-    <label class="radio-card" onclick="selectRadioCard(this)"><input type="radio" name="a1c" value="no"> No</label>
-    <div class="checkbox-row" style="margin-top: 8px;">
-      <input type="checkbox" id="a1cUnsure">
-      <label for="a1cUnsure">I don't know if I have had an A1C check.</label>
-    </div>
-  </div>
-
+  <p class="subtitle">Answer a few questions about how you manage your blood sugar. We've already confirmed the rest from your records.</p>
 
   <div class="question-group">
     <div class="question">Do you use a Continuous Glucose Monitor (CGM) to help monitor your blood glucose?</div>
@@ -700,30 +649,50 @@ input.error, select.error { border-color: #d32f2f; }
   <details class="records-summary">
     <summary>From Your Records</summary>
     <div class="records-summary-body">
+      <div class="records-source-heading">🏢 Employer</div>
+      <div class="records-item">
+        <span class="records-label">Gender</span>
+        <span class="records-value">Male</span>
+        <a class="records-edit" onclick="return false">Edit</a>
+      </div>
+
+      <div class="records-source-heading">🏥 Health Records</div>
       <div class="records-item">
         <span class="records-label">Diabetes Type</span>
         <span class="records-value">Type 2</span>
+        <a class="records-edit" onclick="return false">Edit</a>
       </div>
       <div class="records-item">
         <span class="records-label">Diagnosed</span>
         <span class="records-value">2019</span>
+        <a class="records-edit" onclick="return false">Edit</a>
+      </div>
+      <div class="records-item">
+        <span class="records-label">A1C Check</span>
+        <span class="records-value">Yes</span>
+        <a class="records-edit" onclick="return false">Edit</a>
       </div>
       <div class="records-item">
         <span class="records-label">Medications</span>
         <span class="records-value">Oral Medications</span>
+        <a class="records-edit" onclick="return false">Edit</a>
       </div>
       <div class="records-item">
         <span class="records-label">Diabetes Eye Exam</span>
         <span class="records-value">March 2024</span>
+        <a class="records-edit" onclick="return false">Edit</a>
       </div>
       <div class="records-item">
         <span class="records-label">Foot Exam</span>
         <span class="records-value">November 2024</span>
+        <a class="records-edit" onclick="return false">Edit</a>
       </div>
+
+      <div class="records-privacy">🔒 Your data is encrypted and never shared outside of your care team.</div>
     </div>
   </details>
 
-  <button class="btn-next" onclick="goTo(4)"><span class="label-bold">Next:</span> A Little More About You</button>
+  <button class="btn-next" onclick="goTo(4)"><span class="label-bold">Next:</span> Health History</button>
 
   <div class="footer">
     <span>&copy; Livongo Health, All Rights Reserved.</span>
@@ -731,9 +700,9 @@ input.error, select.error { border-color: #d32f2f; }
   </div>
 </div>
 
-<!-- ========== STEP 4: A Little More About You ========== -->
+<!-- ========== STEP 4: Health History ========== -->
 <div class="step" data-step="4">
-  <h1>A Little More About You</h1>
+  <h1>Health History</h1>
   <p class="subtitle">These answers help your coach personalize your experience. Answer what you can — you can always update later.</p>
 
   <div class="data-disclosure-card">
@@ -1027,7 +996,7 @@ const totalSteps = 6;
 
 // Progress bar section mapping
 // Steps 1-2 = Sign Up section (Confirm Identity + Create Account)
-// Steps 3-5 = About You section (Diabetes Care Plan, Health Profile, Shipping)
+// Steps 3-5 = About You section (Diabetes Care Plan, Health History, Shipping)
 // Step 6 = Welcome section
 const stepSections = {
   1: { section: 'signup', progress: 50 },


### PR DESCRIPTION
## Summary
- **Skip Gender & A1C**: Remove from Step 3 visible questions, add to "From Your Records" collapsed section
- **Enhanced records section**: Merge disclosure card content into records section — source group headings (Employer / Health Records), Edit links per item, privacy note. Remove standalone disclosure card and source banner.
- **Rename Step 4**: "A Little More About You" → "Health History"
- **index.html**: Gender & A1C → Skipped status, counts updated to 14 Confirm / 12 Skipped, Step 3 subtitle and Step 4 name updated

## Test plan
- [ ] Step 3 shows only 3 questions: CGM, BG frequency, Doctor BG rec
- [ ] "From Your Records" collapsed section expands to show 7 items grouped by source
- [ ] Each item has an Edit link (non-functional prototype — `onclick="return false"`)
- [ ] Privacy note appears inside the records section
- [ ] No standalone disclosure card or source banner in Step 3
- [ ] Step 4 heading reads "Health History" everywhere (h1, Next button on Step 3, index.html)
- [ ] index.html: Gender & A1C show as Skipped, counts are 14/7/12/2
- [ ] Navigate all 6 steps — no broken layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)