### PR TITLE
Program value card: restyle to match welcome card, reframe content

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -471,41 +471,17 @@ input.error, select.error { border-color: #d32f2f; }
   line-height: 1.5;
 }
 
-/* Program value explanation card — Step 3 */
+/* Program value card — Step 3, matches welcome-card divider treatment */
 .program-value-card {
-  background: #f0f7ff;
-  border: 1px solid #d0e3f8;
-  border-radius: 10px;
-  padding: 18px 20px;
-  margin-bottom: 28px;
-  font-size: 14px;
-  color: #444;
-  line-height: 1.65;
-}
-.program-value-card .pvc-heading {
-  font-size: 14px;
-  font-weight: 600;
-  color: #1565c0;
-  margin-bottom: 10px;
-}
-.program-value-card .pvc-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-.program-value-card .pvc-list li {
-  padding: 4px 0;
-  padding-left: 20px;
-  position: relative;
-  color: #555;
-  font-size: 13px;
-}
-.program-value-card .pvc-list li::before {
-  content: "\2192";
-  position: absolute;
-  left: 0;
-  color: #1976D2;
-  font-weight: 700;
+  background: #fff;
+  border: none;
+  border-radius: 0;
+  padding: 20px 0 24px;
+  margin-top: 16px;
+  margin-bottom: 32px;
+  box-shadow: none;
+  border-top: 1px solid #e8e8e8;
+  border-bottom: 1px solid #e8e8e8;
 }
 
 /* Context card at top of From Your Records expansion */
@@ -689,13 +665,10 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">Tell us about your current monitoring routine. This helps us personalize your program from day one.</p>
 
   <div class="program-value-card">
-    <div class="pvc-heading">What's included in your Livongo program</div>
-    <ul class="pvc-list">
-      <li>A connected glucose meter with unlimited strip refills</li>
-      <li>A dedicated certified health coach</li>
-      <li>Personalized insights after every reading</li>
-      <li>Your answers here help us tailor your coaching from the start</li>
-    </ul>
+    <div class="wc-greeting">What to expect from your program</div>
+    <div class="wc-body">
+      Livongo is built around you. A dedicated health coach will use your answers to create a plan that fits your life — not the other way around. You'll also receive a connected glucose meter, unlimited strips, and real-time insights after every reading.
+    </div>
   </div>
 
   <div class="question-group">


### PR DESCRIPTION
## Summary

- Restyled the Step 3 program value card from a blue-tinted box to the same divider-separated treatment used by the Welcome to Livongo card on Step 1
- Reframed heading from "What's included in your Livongo program" → "What to expect from your program"
- Replaced bullet list with supportive paragraph copy that emphasizes personalization and coaching
- Reuses `.wc-greeting` / `.wc-body` typography classes for visual consistency

## Test plan

- [ ] Step 3: Program value card uses top/bottom dividers (not a blue box)
- [ ] Card heading and body text match the visual weight of Step 1's welcome card
- [ ] Content reads as warm/editorial rather than a feature list

🤖 Generated with [Claude Code](https://claude.com/claude-code)