### PR TITLE
Restore program-value-card to bordered card design

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -471,17 +471,27 @@ input.error, select.error { border-color: #d32f2f; }
   line-height: 1.5;
 }
 
-/* Program value card — Step 3, matches welcome-card divider treatment */
+/* Program value card — Step 3, card treatment matching original welcome-card style */
 .program-value-card {
   background: #fff;
-  border: none;
-  border-radius: 0;
-  padding: 20px 0 24px;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 24px;
   margin-top: 16px;
-  margin-bottom: 32px;
-  box-shadow: none;
-  border-top: 1px solid #e8e8e8;
-  border-bottom: 1px solid #e8e8e8;
+  margin-bottom: 28px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+.program-value-card .wc-greeting {
+  font-size: 18px;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 10px;
+}
+.program-value-card .wc-body {
+  font-size: 14px;
+  color: #555;
+  line-height: 1.65;
+  margin-bottom: 0;
 }
 
 /* Context card at top of From Your Records expansion */


### PR DESCRIPTION
## Summary
- Restores the Step 3 program value card from flat divider treatment to a proper bordered card container
- Matches the original Welcome to Livongo card style: `border: 1px solid #e0e0e0`, `border-radius: 10px`, `padding: 24px`, subtle `box-shadow`
- Adds scoped `.wc-greeting` and `.wc-body` typography rules under `.program-value-card` to prevent override by welcome-card divider selectors

## Test plan
- [ ] Open Step 3 (Set Up Your Diabetes Program) and verify the "What to expect from your program" card appears as a proper bordered card with rounded corners and subtle shadow
- [ ] Verify content displays correctly: heading + paragraph body text
- [ ] Compare visual feel to the Welcome to Livongo card on Step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)