### PR TITLE
Add emojis before card headers

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -689,7 +689,7 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">Tell us about your current monitoring routine. This helps us personalize your program from day one.</p>
 
   <div class="program-value-card">
-    <div class="wc-greeting">What to expect from your program</div>
+    <div class="wc-greeting">🌟 What to expect from your program</div>
     <div class="wc-body">
       Livongo is built around you. A dedicated health coach will use your answers to create a plan that fits your life — not the other way around. You'll also receive a connected glucose meter, unlimited strips, and real-time insights after every reading.
     </div>
@@ -808,7 +808,7 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">These answers help your coach personalize your experience. Answer what you can — you can always update later.</p>
 
   <div class="data-disclosure-card">
-    <div class="wc-greeting">A little about your health</div>
+    <div class="wc-greeting">💚 A little about your health</div>
     <div class="wc-body">
       The more your coach knows, the better they can support you. Nothing here is required — share what feels right, skip what doesn't, and come back to update anytime.
     </div>


### PR DESCRIPTION
## Summary
- Adds emojis before card-level headers for visual warmth and consistency:
  - Step 3: 🌟 What to expect from your program
  - Step 4: 💚 A little about your health
  - Step 1 already had 👋 Welcome to Livongo

## Test plan
- [ ] Step 1: "👋 Welcome to Livongo" still displays correctly
- [ ] Step 3: "🌟 What to expect from your program" shows emoji before heading
- [ ] Step 4: "💚 A little about your health" shows emoji before heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)