### PR TITLE
Add warm cream background to program value card

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -487,8 +487,8 @@ input.error, select.error { border-color: #d32f2f; }
 
 /* Program value card — Step 3, card treatment matching original welcome-card style */
 .program-value-card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: #faf8f5;
+  border: 1px solid #ede8e1;
   border-radius: 10px;
   padding: 24px;
   margin-top: 16px;


### PR DESCRIPTION
## Summary
- Changes the "What to expect from your program" card background from white (`#fff`) to a subtle warm cream (`#faf8f5`)
- Updates border from neutral gray (`#e0e0e0`) to matching warm tone (`#ede8e1`)
- Follows 2026 design trends toward warm neutrals — feels premium and approachable without introducing a new accent color

## Test plan
- [ ] Step 3: Program value card has a subtle warm cream tint (barely perceptible but distinct from pure white)
- [ ] Card border blends naturally with the warm background
- [ ] Text remains highly readable against the cream background

🤖 Generated with [Claude Code](https://claude.com/claude-code)