### PR TITLE
Add more breathing room below cream card titles

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -180,7 +180,7 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   font-size: 17px;
   font-weight: 600;
   color: #222;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 .welcome-card .wc-body,
 .data-disclosure-card .wc-body,


### PR DESCRIPTION
## Summary
- Increases `.wc-greeting` margin-bottom from `8px` to `12px` in all three warm cream cards
- Gives a touch more separation between heading and body text

## Test plan
- [ ] Steps 1, 3, 4: Card titles have slightly more space below them before the body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)