### PR TITLE
Shift confirmation banner to calmer blue-sage

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -228,11 +228,11 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   border-top: 1px solid #eee;
 }
 
-/* Coverage verified box — sage confirmation */
+/* Coverage verified box — blue-sage confirmation */
 .coverage-verified {
-  background: #f5f9f5;
-  border: 1px solid #dde8dd;
-  border-left: 4px solid #4caf50;
+  background: #f2f8f6;
+  border: 1px solid #d5e4de;
+  border-left: 4px solid #3d9e6e;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 24px;
@@ -240,8 +240,8 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   align-items: flex-start;
   gap: 12px;
 }
-.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #43a047; }
-.coverage-verified .cv-text { font-size: 14px; color: #2e7d32; line-height: 1.6; }
+.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #3d9e6e; }
+.coverage-verified .cv-text { font-size: 14px; color: #2d7a5a; line-height: 1.6; }
 .coverage-verified .cv-text strong { font-weight: 700; }
 
 /* Step legend */


### PR DESCRIPTION
## Summary
- Adds a touch of blue to the sage confirmation banner for a calmer, cooler feel
- Background: `#f5f9f5` → `#f2f8f6` (blue-green tint)
- Border: `#dde8dd` → `#d5e4de` (cooler sage)
- Accent/icon: `#4caf50` → `#3d9e6e` (teal-green)
- Text: `#2e7d32` → `#2d7a5a` (teal-green)

## Test plan
- [ ] Step 2: "We found you!" banner has a slightly cooler, calmer sage tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)