### PR TITLE
Match sage card border with cream card style

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -232,7 +232,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .coverage-verified {
   background: #f2f8f6;
   border: 1px solid #d5e4de;
-  border-left: 4px solid #3d9e6e;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 24px;


### PR DESCRIPTION
## Summary
- Removes the 4px left accent stripe from the "We found you!" confirmation banner
- Now uses uniform `1px solid #d5e4de` border all around, matching the cream card `1px solid #ede8e1` pattern

## Test plan
- [ ] Step 2: "We found you!" banner has a clean uniform border (no thick left accent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)