### PR TITLE
Lighten sage confirmation banner, dark text

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -228,10 +228,10 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   border-top: 1px solid #eee;
 }
 
-/* Coverage verified box — blue-sage confirmation */
+/* Coverage verified box — light sage, dark text (Radix sage scale) */
 .coverage-verified {
-  background: #f2f8f6;
-  border: 1px solid #d5e4de;
+  background: #f7f9f8;
+  border: 1px solid #d7dad9;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 24px;
@@ -239,8 +239,8 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   align-items: flex-start;
   gap: 12px;
 }
-.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #3d9e6e; }
-.coverage-verified .cv-text { font-size: 14px; color: #2d7a5a; line-height: 1.6; }
+.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #43a047; }
+.coverage-verified .cv-text { font-size: 14px; color: #333; line-height: 1.6; }
 .coverage-verified .cv-text strong { font-weight: 700; }
 
 /* Step legend */


### PR DESCRIPTION
## Summary
Lightens the "We found you!" confirmation banner using the [Radix UI sage color scale](https://www.radix-ui.com/colors) — a best-in-class design system used by Vercel, Linear, and others.

- **Background**: `#f2f8f6` → `#f7f9f8` (Radix sage-2 — very light, barely tinted)
- **Border**: `#d5e4de` → `#d7dad9` (Radix sage-6 — subtle neutral)
- **Icon**: `#43a047` (green checkmark for success semantics)
- **Text**: `#2d7a5a` → `#333` (near-black for maximum readability)

Follows Radix convention: step 2 for subtle backgrounds, step 6 for borders, dark text for contrast.

## Test plan
- [ ] Step 2: "We found you!" banner is very light sage with dark readable text
- [ ] Green checkmark icon still visible and clearly success-coded
- [ ] Text is crisp and high-contrast against the light background

🤖 Generated with [Claude Code](https://claude.com/claude-code)