### PR TITLE
Records banner → sage card, warm text, card polish & title updates

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -109,11 +109,6 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   border: 1px solid #d0e3f8;
   border-left: 3px solid #1976D2;
 }
-.source-banner--records {
-  background: #f0f9f8;
-  border: 1px solid #c8e6c5;
-  border-left: 3px solid #00897B;
-}
 .source-banner .sb-icon { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
 
 /* Prefilled indicator — polished dot on right side */
@@ -169,7 +164,7 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   background: #faf8f5;
   border: 1px solid #ede8e1;
   border-radius: 10px;
-  padding: 24px;
+  padding: 14px 24px 24px;
   margin-top: 16px;
   margin-bottom: 24px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
@@ -179,14 +174,14 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .program-value-card .wc-greeting {
   font-size: 17px;
   font-weight: 600;
-  color: #222;
+  color: #2d2a26;
   margin-bottom: 12px;
 }
 .welcome-card .wc-body,
 .data-disclosure-card .wc-body,
 .program-value-card .wc-body {
   font-size: 14px;
-  color: #555;
+  color: #4a4540;
   line-height: 1.6;
   margin-bottom: 0;
 }
@@ -228,10 +223,10 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   border-top: 1px solid #eee;
 }
 
-/* Coverage verified box — light sage, dark text (Radix sage scale) */
+/* Confirmation / attribution card — blue-sage, dark text */
 .coverage-verified {
-  background: #f7f9f8;
-  border: 1px solid #d7dad9;
+  background: #f5f9f9;
+  border: 1px solid #d3d9d9;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 24px;
@@ -493,7 +488,7 @@ input.error, select.error { border-color: #d32f2f; }
   background: #faf8f5;
   border: 1px solid #ede8e1;
   border-radius: 10px;
-  padding: 24px;
+  padding: 14px 24px 24px;
   margin-top: 16px;
   margin-bottom: 24px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
@@ -614,7 +609,7 @@ input.error, select.error { border-color: #d32f2f; }
 <!-- ========== STEP 2: Create Account ========== -->
 <div class="step" data-step="2">
 
-  <h1>Set Up Your Account</h1>
+  <h1>Create Your Account</h1>
   <p class="subtitle">Create your email and password so you can access Livongo anytime.</p>
 
   <div class="coverage-verified">
@@ -679,7 +674,7 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">Tell us about your current monitoring routine. This helps us personalize your program from day one.</p>
 
   <div class="program-value-card">
-    <div class="wc-greeting">🌟 A program made for you.</div>
+    <div class="wc-greeting">✨ A program made for you.</div>
     <div class="wc-body">
       Your coach will use these answers to create a plan that fits your schedule, your goals, and your routine — backed by a connected meter and unlimited strips.
     </div>
@@ -798,15 +793,17 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">These answers help your coach personalize your experience. Answer what you can — you can always update later.</p>
 
   <div class="data-disclosure-card">
-    <div class="wc-greeting">💚 Personal to you from day one.</div>
+    <div class="wc-greeting">🤝 Personal to you from day one.</div>
     <div class="wc-body">
       Every answer here helps your coach understand what matters to you — so your plan reflects your life, not a one-size-fits-all checklist.
     </div>
   </div>
 
-  <div class="source-banner source-banner--records">
-    <span class="sb-icon">🏥</span>
-    <span>Some answers are filled in from your health records. Update anything that's changed.</span>
+  <div class="coverage-verified">
+    <span class="cv-icon">🏥</span>
+    <div class="cv-text">
+      <strong>Filled in from your records.</strong> Some answers below come from your health records to save you time. Review and update anything that's changed.
+    </div>
   </div>
 
   <div class="question-group">

--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -228,10 +228,10 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   border-top: 1px solid #eee;
 }
 
-/* Coverage verified box — blue-sage confirmation */
+/* Coverage verified box — light sage, dark text (Radix sage scale) */
 .coverage-verified {
-  background: #f2f8f6;
-  border: 1px solid #d5e4de;
+  background: #f7f9f8;
+  border: 1px solid #d7dad9;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 24px;
@@ -239,8 +239,8 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   align-items: flex-start;
   gap: 12px;
 }
-.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #3d9e6e; }
-.coverage-verified .cv-text { font-size: 14px; color: #2d7a5a; line-height: 1.6; }
+.coverage-verified .cv-icon { font-size: 20px; flex-shrink: 0; color: #43a047; }
+.coverage-verified .cv-text { font-size: 14px; color: #333; line-height: 1.6; }
 .coverage-verified .cv-text strong { font-weight: 700; }
 
 /* Step legend */


### PR DESCRIPTION
## Summary
- Converts Step 4 records banner from `.source-banner` to `.coverage-verified` sage card design (matching "We found you!" card)
- Removes unused `.source-banner--records` CSS
- Shifts sage background toward blue (`#f5f9f9`, border `#d3d9d9`)
- Updates info card text to warm off-black (`#2d2a26` headings, `#4a4540` body) to complement cream background
- Reduces top padding to 14px on all three info cards (welcome, program-value, data-disclosure)
- Updates Step 3 emoji 🌟 → ✨, Step 4 emoji 💚 → 🤝
- Renames Step 2 title: "Set Up Your Account" → "Create Your Account"

## Test plan
- [ ] Step 2: Verify h1 reads "Create Your Account"
- [ ] Step 3: Verify ✨ emoji on program-value-card, reduced top padding
- [ ] Step 4: Verify 🤝 emoji on data-disclosure-card, records banner uses sage card design
- [ ] All cream cards: Warm off-black text, 14px top padding
- [ ] Both sage cards (Step 2 + Step 4): Matching blue-sage background

🤖 Generated with [Claude Code](https://claude.com/claude-code)