### PR TITLE
Reduce Next button label weight from 700 to 600

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -355,7 +355,7 @@ input.error, select.error { border-color: #d32f2f; }
 /* Buttons */
 .btn-next { display: block; width: 100%; padding: 18px; background: #1976D2; color: #fff; border: none; border-radius: 10px; font-size: 17px; font-weight: 500; cursor: pointer; transition: background 0.2s; font-family: 'Roboto', sans-serif; margin-top: 24px; box-shadow: 0 2px 8px rgba(25,118,210,0.25); min-height: 56px; }
 .btn-next:hover { background: #1565c0; }
-.btn-next .label-bold { font-weight: 700; }
+.btn-next .label-bold { font-weight: 600; }
 
 /* Supplies showcase */
 .supplies-showcase { display: flex; align-items: center; justify-content: center; gap: 24px; margin: 24px 0; padding: 24px; background: #fff; border: 1px solid #e0e0e0; border-radius: 10px; }


### PR DESCRIPTION
## Summary
- Softens the `.label-bold` weight on Next buttons from 700 → 600
- Base button text stays at 500; label still reads as bolder but less heavy

## Test plan
- [ ] Verify "Next:" label appears slightly bolder than step name but not heavy/bold
- [ ] Check all 4 Next buttons (Steps 1-4) and Finish Setup button

🤖 Generated with [Claude Code](https://claude.com/claude-code)