### PR TITLE
Revert card top padding from 14px to 16px

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -164,7 +164,7 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
   background: #faf8f5;
   border: 1px solid #ede8e1;
   border-radius: 10px;
-  padding: 14px 24px 24px;
+  padding: 16px 24px 24px;
   margin-top: 16px;
   margin-bottom: 24px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
@@ -488,7 +488,7 @@ input.error, select.error { border-color: #d32f2f; }
   background: #faf8f5;
   border: 1px solid #ede8e1;
   border-radius: 10px;
-  padding: 14px 24px 24px;
+  padding: 16px 24px 24px;
   margin-top: 16px;
   margin-bottom: 24px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);


### PR DESCRIPTION
## Summary
- Reverts top padding on info cards (welcome, program-value, data-disclosure) from 14px back to 16px

## Test plan
- [ ] Verify top spacing above card headings feels balanced at 16px

🤖 Generated with [Claude Code](https://claude.com/claude-code)