### PR TITLE
Update Step 4 card title to 'Personal from day one'

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -793,7 +793,7 @@ input.error, select.error { border-color: #d32f2f; }
   <p class="subtitle">These answers help your coach personalize your experience. Answer what you can — you can always update later.</p>
 
   <div class="data-disclosure-card">
-    <div class="wc-greeting">🤝 Personal to you from day one.</div>
+    <div class="wc-greeting">🤝 Personal from day one.</div>
     <div class="wc-body">
       Every answer here helps your coach understand what matters to you — so your plan reflects your life, not a one-size-fits-all checklist.
     </div>


### PR DESCRIPTION
## Summary
- Shortens Step 4 data-disclosure card title from "Personal to you from day one." to "Personal from day one."

## Test plan
- [ ] Step 4: Verify card heading reads "🤝 Personal from day one."

🤖 Generated with [Claude Code](https://claude.com/claude-code)