### PR TITLE
Change Review badge to gray '7 Found' count badge

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -505,11 +505,11 @@ input.error, select.error { border-color: #d32f2f; }
   line-height: 1.6;
 }
 
-/* Review badge on From Your Records summary — pushed to the right */
+/* Count badge on From Your Records summary — pushed to the right */
 .records-summary summary .review-badge {
   display: inline-block;
-  background: #fff3e0;
-  color: #e65100;
+  background: #f0f0f0;
+  color: #555;
   font-size: 10px;
   font-weight: 700;
   text-transform: uppercase;
@@ -728,7 +728,7 @@ input.error, select.error { border-color: #d32f2f; }
   </div>
 
   <details class="records-summary">
-    <summary>From Your Records <span class="review-badge">Review</span></summary>
+    <summary>From Your Records <span class="review-badge">7 Found</span></summary>
     <div class="records-summary-body">
       <div class="records-context-card">
         We pulled these details from your employer and health records to save you time. Review the information below and edit anything that's changed.


### PR DESCRIPTION
## Summary
- Changes the "From Your Records" dropdown badge from orange "Review" to gray "7 Found"
- Badge now reflects the count of prefilled items in the dropdown
- Gray color scheme: `#f0f0f0` background, `#555` text

## Test plan
- [ ] Step 4: Verify "From Your Records" dropdown shows gray "7 Found" badge
- [ ] Badge should appear subtle/neutral (not attention-grabbing orange)

🤖 Generated with [Claude Code](https://claude.com/claude-code)