### PR TITLE
Improve progress bar spacing around labels

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -21,12 +21,12 @@ body { font-family: 'Roboto', sans-serif; background: #fff; color: #333; min-hei
 .progress-sections {
   display: flex;
   align-items: center;
-  gap: 0;
+  gap: 12px;
 }
 .progress-section {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 10px;
   flex: 1;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- Increases gap between progress bar segments from 0 → 12px
- Increases gap between label text and fill bar from 6px → 10px
- Gives the progress bar more breathing room after dot removal

## Test plan
- [ ] Progress bar labels have comfortable spacing from their bars
- [ ] Segments have visible separation without dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)