### PR TITLE
Pre-select flu vaccine as Yes from health records

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -854,8 +854,8 @@ input.error, select.error { border-color: #d32f2f; }
 
   <div class="question-group">
     <div class="question">Have you had a flu vaccine within the last year? <span class="info-icon">ⓘ</span></div>
-    <label class="radio-card" onclick="selectRadioCard(this)">
-      <input type="radio" name="flu" value="yes">
+    <label class="radio-card preselected selected" onclick="selectRadioCard(this)">
+      <input type="radio" name="flu" value="yes" checked>
       Yes
     </label>
     <label class="radio-card" onclick="selectRadioCard(this)"><input type="radio" name="flu" value="no"> No</label>


### PR DESCRIPTION
## Summary
- Flu vaccine question on Step 4 now pre-selected as "Yes" with blue preselected indicator dot
- Matches existing pattern for record-sourced prefilled fields

## Test plan
- [ ] Step 4: Flu vaccine "Yes" is selected with blue highlight and dot indicator
- [ ] Clicking "No" clears the selection and removes preselected styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)