### PR TITLE
Remove prefilled dot when user changes a pre-filled field

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -1199,6 +1199,7 @@ function selectRadioCard(el) {
   var name = el.querySelector('input').name;
   document.querySelectorAll('input[name="' + name + '"]').forEach(function(i) {
     i.closest('.radio-card').classList.remove('selected');
+    i.closest('.radio-card').classList.remove('preselected');
   });
   el.classList.add('selected');
   el.querySelector('input').checked = true;
@@ -1208,7 +1209,20 @@ function selectRadioCard(el) {
 function toggleCheckCard(el) {
   var cb = el.querySelector('input');
   el.classList.toggle('selected', cb.checked);
+  if (!cb.checked) el.classList.remove('preselected');
 }
+
+// Remove prefilled dot when user edits a prefilled text input or select
+document.querySelectorAll('.field-wrap.prefilled input, .field-wrap.prefilled select').forEach(function(field) {
+  field.addEventListener('input', function() {
+    var wrap = this.closest('.field-wrap');
+    if (wrap) wrap.classList.remove('prefilled', 'prefilled--select');
+  });
+  field.addEventListener('change', function() {
+    var wrap = this.closest('.field-wrap');
+    if (wrap) wrap.classList.remove('prefilled', 'prefilled--select');
+  });
+});
 
 // Language modal
 function openLangModal() {


### PR DESCRIPTION
## Summary
- When a user modifies any pre-filled field, the blue indicator dot disappears
- Covers all three field types: radio cards, checkbox cards, and text/select inputs
- Dot only clears on user interaction, not on page load

## Test plan
- [ ] Click a different radio option on a preselected radio card → blue dot disappears
- [ ] Uncheck a preselected checkbox card → blue dot disappears
- [ ] Type in a prefilled text input → blue dot disappears
- [ ] Change a prefilled select dropdown → blue dot disappears
- [ ] Fields that haven't been touched still show their dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)