### PR TITLE
Add autocomplete attributes to password and email fields

### DIFF
--- a/reg/prereg.html
+++ b/reg/prereg.html
@@ -610,7 +610,7 @@ input.error, select.error { border-color: #d32f2f; }
   <div class="form-row single">
     <div class="form-group">
       <label for="email">Email Address <span class="req">*</span></label>
-      <input type="email" id="email" placeholder="your@email.com" required>
+      <input type="email" id="email" name="email" placeholder="your@email.com" autocomplete="email" required>
       <span class="error-msg" id="emailErr">Please enter a valid email address</span>
     </div>
   </div>
@@ -627,7 +627,7 @@ input.error, select.error { border-color: #d32f2f; }
     <div class="form-group">
       <label for="password">Password <span class="req">*</span></label>
       <div class="password-wrap">
-        <input type="password" id="password" placeholder="Create a password" required>
+        <input type="password" id="password" name="password" placeholder="Create a password" autocomplete="new-password" required>
         <button type="button" class="toggle-pw" onclick="togglePassword()">👁</button>
       </div>
       <div class="pw-rules" id="pwRules">


### PR DESCRIPTION
## Summary
- Adds `name="password"` and `autocomplete="new-password"` to the password input
- Adds `name="email"` and `autocomplete="email"` to the email input
- Enables browser password managers to recognize and prefill these fields

## Test plan
- [ ] Browser offers to save/generate password on the Create Account step
- [ ] Email field triggers browser email autofill suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)