### PR TITLE
Move flow links to card headers on reg index

### DIFF
--- a/reg/index.html
+++ b/reg/index.html
@@ -719,6 +719,7 @@
             <span class="badge badge--blue">9 Steps</span>
           </div>
           <div class="flow-card-desc">User enters all information manually from scratch. Every field requires input.</div>
+          <a href="standard.html" target="_blank" class="btn btn--blue" style="margin-top: 12px;">View Original Flow →</a>
         </div>
         <div class="flow-card-body">
           <ol class="step-list">
@@ -786,7 +787,6 @@
               </div>
             </li>
           </ol>
-          <a href="standard.html" target="_blank" class="btn btn--blue" style="margin-top: 16px;">View Original Flow →</a>
         </div>
       </div>
 
@@ -799,6 +799,7 @@
             <span class="badge badge--savings">−3 Steps</span>
           </div>
           <div class="flow-card-desc">Employer, health records, and carrier data source 20 of 35 fields for confirmation. Coverage verified server-side; coaching moved to on-device setup.</div>
+          <a href="prereg.html" target="_blank" class="btn btn--green" style="margin-top: 12px;">View Optimized Flow →</a>
         </div>
         <div class="flow-card-body">
           <ol class="step-list">
@@ -880,7 +881,6 @@
               </div>
             </li>
           </ol>
-          <a href="prereg.html" target="_blank" class="btn btn--green" style="margin-top: 16px;">View Optimized Flow →</a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Moved "View Original Flow" and "View Optimized Flow" buttons from the bottom of each card body to below the subhead text in the card header, above the separator line

## Test plan
- [ ] Open `/reg/index.html` and verify both buttons appear below the description text and above the separator on each card
- [ ] Verify links still open `standard.html` and `prereg.html` in new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)