### PR TITLE
Language cleanup: reg index copy tightened and aligned to prototypes

### DIFF
--- a/reg/index.html
+++ b/reg/index.html
@@ -674,7 +674,7 @@
   <div class="header-divider"></div>
   <div class="header-text">
     <div class="header-title">Onboarding Flow Comparison</div>
-    <div class="header-subtitle">Reshaping onboarding to build trust &amp; feel like partnership.</div>
+    <div class="header-subtitle">From data entry to data confirmation — fewer steps, less friction, same outcome.</div>
   </div>
 </header>
 
@@ -707,7 +707,7 @@
   <div class="section">
     <div class="section-label">Side-by-Side Comparison</div>
     <div class="section-title">Two Paths, One Goal</div>
-    <div class="section-desc">The optimized flow moves data collection upstream — from employer HR, health plan records, and carrier APIs — so the user arrives already known to the system.</div>
+    <div class="section-desc">The optimized flow sources data upstream so the user arrives already known to the system.</div>
 
     <div class="flow-grid">
 
@@ -727,7 +727,7 @@
               <span class="step-num step-num--blue">1</span>
               <div class="step-content">
                 <div class="step-title"><a href="standard.html#step-1" target="_blank">Personal Information</a></div>
-                <div class="step-subtitle">All fields empty — name, email, DOB, phone</div>
+                <div class="step-subtitle">Name, email, password, DOB, phone — all blank</div>
               </div>
             </li>
             <li class="step-item">
@@ -798,7 +798,7 @@
             <span class="badge badge--green">6 Steps</span>
             <span class="badge badge--savings">−3 Steps</span>
           </div>
-          <div class="flow-card-desc">Employer, health records, and carrier data source 20 of 35 fields for confirmation. Coverage verified server-side; coaching moved to on-device setup.</div>
+          <div class="flow-card-desc">20 of 35 fields pre-populated from employer, health plan, and carrier data. Coverage verified server-side; coaching moved to on-device setup.</div>
           <a href="prereg.html" target="_blank" class="btn btn--green" style="margin-top: 12px;">View Optimized Flow →</a>
         </div>
         <div class="flow-card-body">
@@ -827,10 +827,10 @@
               <span class="step-num step-num--green">3</span>
               <div class="step-content">
                 <div class="step-title">
-                  <a href="prereg.html#step-3" target="_blank">Supporting Your Diabetes</a>
+                  <a href="prereg.html#step-3" target="_blank">Diabetes Program Setup</a>
                   <span class="badge badge--green" style="font-size:0.6rem; padding:2px 6px;">Confirm</span>
                 </div>
-                <div class="step-subtitle">CGM, blood glucose — 7 fields in From Your Records</div>
+                <div class="step-subtitle">Monitoring routine — CGM, blood glucose, meds from records</div>
               </div>
             </li>
             <li class="step-item">
@@ -847,10 +847,10 @@
               <span class="step-num step-num--green">5</span>
               <div class="step-content">
                 <div class="step-title">
-                  <a href="prereg.html#step-5" target="_blank">Your Welcome Kit</a>
+                  <a href="prereg.html#step-5" target="_blank">Receiving Your Device</a>
                   <span class="badge badge--green" style="font-size:0.6rem; padding:2px 6px;">Confirm</span>
                 </div>
-                <div class="step-subtitle">Address from employer records — user confirms</div>
+                <div class="step-subtitle">Shipping address from employer records — confirm or edit</div>
               </div>
             </li>
             <li class="step-item">
@@ -867,7 +867,7 @@
                   Coverage Search / Verification / Insurance
                   <span class="badge badge--yellow" style="font-size:0.6rem; padding:2px 6px;">Skipped</span>
                 </div>
-                <div class="step-subtitle step-subtitle--eliminated">Skipped — employer sponsorship verified server-side</div>
+                <div class="step-subtitle step-subtitle--eliminated">Employer sponsorship verified server-side</div>
               </div>
             </li>
             <li class="step-item">
@@ -877,7 +877,7 @@
                   Coaching &amp; Alerts
                   <span class="badge badge--yellow" style="font-size:0.6rem; padding:2px 6px;">Skipped</span>
                 </div>
-                <div class="step-subtitle step-subtitle--eliminated">Moved to on-device setup — better cost-to-value moment</div>
+                <div class="step-subtitle step-subtitle--eliminated">Deferred to on-device setup after first use</div>
               </div>
             </li>
           </ol>
@@ -888,7 +888,7 @@
 
     <div class="prototype-tip">
       <span>💡</span>
-      <span><strong>Tip:</strong> Click any step name to jump directly to that screen in the prototype. Links open in a new tab — navigate using the arrow keys or step buttons within each flow.</span>
+      <span><strong>Tip:</strong> Click any step name to jump to that screen in the prototype. Use arrow keys or step buttons to navigate within each flow.</span>
     </div>
   </div><!-- /section -->
 
@@ -896,29 +896,29 @@
   <!-- ── INSIGHTS ── -->
   <div class="section">
     <div class="section-label">Design Rationale</div>
-    <div class="section-title">What the Redesign Changes</div>
-    <div class="section-desc">Four key shifts in the user experience when upstream data is available.</div>
+    <div class="section-title">What Changed</div>
+    <div class="section-desc">Four shifts in the experience when upstream data is available.</div>
 
     <div class="insights-grid">
       <div class="insight-card">
         <div class="insight-icon">✔</div>
         <div class="insight-title">From Data Entry to Data Confirmation</div>
-        <div class="insight-body">When upstream data is available — from employer HR, health plan records, and carrier APIs — the user's role shifts from typing to confirming. 24 of 36 fields arrive pre-populated, each labeled with its source. The user reviews, edits if needed, and moves on. Cognitive load drops sharply because recognition is easier than recall.</div>
+        <div class="insight-body">20 of 35 fields arrive pre-populated from employer HR, health plan records, and carrier APIs. Each field is labeled with its source. The user reviews, edits if needed, and moves on — recognition instead of recall.</div>
       </div>
       <div class="insight-card">
         <div class="insight-icon" style="background: var(--red-light);">✕</div>
         <div class="insight-title">Coverage Steps Skipped</div>
-        <div class="insight-body">The 3-step coverage flow is handled server-side. Employer sponsorship and insurance eligibility are verified before the user sees their first screen. Zero user effort — no searching for employers, no member IDs, no group codes. Three friction-heavy steps become invisible infrastructure.</div>
+        <div class="insight-body">Employer sponsorship and insurance eligibility are verified server-side before the user sees their first screen. No searching for employers, no member IDs, no group codes — three steps removed entirely.</div>
       </div>
       <div class="insight-card">
         <div class="insight-icon" style="background: var(--teal-light);">⊞</div>
         <div class="insight-title">Multi-Source Data Integration</div>
-        <div class="insight-body">Pre-registration draws from three distinct data sources: employer HR systems (identity, address), health plan claims data (clinical history, exams, conditions), and carrier APIs (phone type detection). Each source is visually distinguished with a colored badge — blue for employer, teal for health records, purple for carrier — building user trust through transparency about where each data point originated.</div>
+        <div class="insight-body">Three data sources feed the flow: employer HR (identity, address), health plan claims (clinical history, conditions), and carrier APIs (device detection). Each source is color-coded — blue for employer, teal for health records, purple for carrier — so users see exactly where each data point came from.</div>
       </div>
       <div class="insight-card">
         <div class="insight-icon" style="background: var(--yellow-light);">⚐</div>
         <div class="insight-title">Partnership, Not Paperwork</div>
-        <div class="insight-body">Each step opens with a brief narrative explaining why it matters and where the data came from. Instead of a clinical form, the experience feels like a guided conversation — the system shows what it knows, the user fills in what only they can share, and together they build a complete health picture. The result is a registration that feels personal, not procedural.</div>
+        <div class="insight-body">Each step explains why it matters and where the data came from. The system shows what it knows, the user fills in what only they can share, and together they build a complete health picture.</div>
       </div>
     </div>
   </div>
@@ -928,14 +928,14 @@
   <div class="section">
     <div class="section-label">System Architecture</div>
     <div class="section-title">How the Optimized Flow Works</div>
-    <div class="section-desc">Three backend services power the optimized experience — each responsible for a different layer of data resolution.</div>
+    <div class="section-desc">Three services resolve member data before the first screen loads.</div>
 
     <div class="insights-grid" style="grid-template-columns: repeat(3, 1fr);">
 
       <div class="insight-card" style="border-top: 3px solid var(--blue);">
         <div class="insight-icon" style="background: var(--blue-light); font-size: 1.25rem;">🔍</div>
         <div class="insight-title">User Lookup</div>
-        <div class="insight-body" style="margin-bottom: 12px;">Takes a UUID or basic identifiers (first name, last name, DOB, zip code) and resolves to a unique member record. This is the entry point — before any data can be sourced, the system must know who the user is.</div>
+        <div class="insight-body" style="margin-bottom: 12px;">Resolves a UUID or basic identifiers (name, DOB, zip) to a unique member record. Entry point for all downstream data sourcing.</div>
         <div style="font-size: 0.75rem; color: var(--gray-500); border-top: 1px solid var(--gray-200); padding-top: 10px; margin-top: auto;">
           <strong>Inputs:</strong> UUID <em>or</em> First + Last + DOB + Zip<br>
           <strong>Output:</strong> Canonical member ID
@@ -945,7 +945,7 @@
       <div class="insight-card" style="border-top: 3px solid var(--teal);">
         <div class="insight-icon" style="background: var(--teal-light); font-size: 1.25rem;">📋</div>
         <div class="insight-title">Profiler</div>
-        <div class="insight-body" style="margin-bottom: 12px;">Centralizes known data for a member from multiple upstream sources — employer HR, health plan claims, pharmacy records, and carrier APIs. Merges and deduplicates into a single profile that the registration flow consumes.</div>
+        <div class="insight-body" style="margin-bottom: 12px;">Aggregates data from employer HR, health plan claims, pharmacy records, and carrier APIs into a single member profile.</div>
         <div style="font-size: 0.75rem; color: var(--gray-500); border-top: 1px solid var(--gray-200); padding-top: 10px; margin-top: auto;">
           <strong>Sources:</strong> Employer HR, Health Plan, Pharmacy, Carrier<br>
           <strong>Output:</strong> Unified member profile (24 fields)
@@ -955,7 +955,7 @@
       <div class="insight-card" style="border-top: 3px solid var(--purple);">
         <div class="insight-icon" style="background: var(--purple-light); font-size: 1.25rem;">🧠</div>
         <div class="insight-title">Question Engine</div>
-        <div class="insight-body" style="margin-bottom: 12px;">For each question in the registration flow, provides a confidence score and a suggested answer based on available data. High-confidence fields are sourced for confirmation; low-confidence fields are left for the user to fill in.</div>
+        <div class="insight-body" style="margin-bottom: 12px;">Scores each field against available data. High-confidence fields are pre-filled for confirmation; low-confidence fields are left for the user.</div>
         <div style="font-size: 0.75rem; color: var(--gray-500); border-top: 1px solid var(--gray-200); padding-top: 10px; margin-top: auto;">
           <strong>Input:</strong> Question ID + Member Profile<br>
           <strong>Output:</strong> Answer + Confidence Score
@@ -985,7 +985,7 @@
   <div class="section">
     <div class="section-label">Detailed Field Analysis</div>
     <div class="section-title">Breakdown by Field</div>
-    <div class="section-desc">Every field across the full onboarding flow, mapped to its optimized treatment and data source.</div>
+    <div class="section-desc">Every field in the flow — how it's handled in each version and where the data comes from.</div>
 
 
     <!-- Filter bar -->


### PR DESCRIPTION
## Summary
- Changed "What the Redesign Changes" → "What Changed"
- Fixed data inconsistency (insight card said "24 of 36" → corrected to "20 of 35")
- Tightened all section descriptions, insight card bodies, and architecture copy
- Aligned step names and subtitles with actual prototype content
- Removed redundant phrasing throughout

## Test plan
- [ ] Open `/reg/index.html` and read through — copy should be concise and match the prototypes
- [ ] Click step links to verify names match prototype screen titles
- [ ] Check "What Changed" section for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)