### PR TITLE
Only show iOS app redirect on login attempts

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -19350,30 +19350,14 @@ Return JSON:
   // Check for captured auth tokens (from head-level script, before Supabase cleared the hash)
   var capturedAuth = window.__iosAuthCapture || null;
 
-  // Check for existing session in localStorage
-  var hasExistingSession = false;
-  try {
-    var stored = localStorage.getItem('sb-yfhudwakpgzswiylhfbh-auth-token');
-    if (stored) {
-      var parsed = JSON.parse(stored);
-      if (parsed && parsed.access_token) hasExistingSession = true;
-    }
-  } catch (e) {}
+  // Only show overlay on fresh login (auth tokens in URL), not on every page refresh
+  if (!capturedAuth) return;
 
-  // Show overlay if we have fresh auth tokens OR an existing session
-  if (!capturedAuth && !hasExistingSession) return;
-
-  // Build deep link
-  var deepLink;
-  if (capturedAuth) {
-    deepLink = 'ctrlrodeo://auth#access_token=' + encodeURIComponent(capturedAuth.accessToken)
-      + '&refresh_token=' + encodeURIComponent(capturedAuth.refreshToken)
-      + '&token_type=' + encodeURIComponent(capturedAuth.tokenType);
-    if (subtext) subtext.textContent = 'Tap to sign in to the app';
-  } else {
-    deepLink = 'ctrlrodeo://open';
-    if (subtext) subtext.textContent = 'Continue to the full Boards experience';
-  }
+  // Build deep link with auth tokens
+  var deepLink = 'ctrlrodeo://auth#access_token=' + encodeURIComponent(capturedAuth.accessToken)
+    + '&refresh_token=' + encodeURIComponent(capturedAuth.refreshToken)
+    + '&token_type=' + encodeURIComponent(capturedAuth.tokenType);
+  if (subtext) subtext.textContent = 'Tap to sign in to the app';
 
   function hideOverlay() { overlay.style.display = 'none'; }
 


### PR DESCRIPTION
## Summary
- The iOS app redirect overlay was appearing on every mobile page refresh because it checked for an existing Supabase session in localStorage
- Now it only shows when fresh OAuth tokens are present in the URL hash (i.e., the user just completed a login flow)
- Removes the `hasExistingSession` localStorage check and the `ctrlrodeo://open` fallback deep link

## Test plan
- [ ] On iOS Safari, refresh the page while logged in — overlay should NOT appear
- [ ] On iOS Safari, complete a login flow — overlay SHOULD appear with "Tap to sign in to the app"
- [ ] On desktop, verify no change in behavior (overlay never shows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)