### PR TITLE
Board-aware categorization with AI board suggestions

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -1758,6 +1758,22 @@ body {
   border-style: solid;
   background: var(--bg);
 }
+.filter-token--board-suggest {
+  color: #10b981;
+  border-color: rgba(16,185,129,0.4);
+  border-style: dashed;
+  animation: board-suggest-pulse 2s ease-in-out 1;
+}
+.filter-token--board-suggest:hover {
+  color: #fff;
+  border-color: #10b981;
+  border-style: solid;
+  background: rgba(16,185,129,0.15);
+}
+@keyframes board-suggest-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
 /* ============================================
    Board Seed Panel (Library Suggestions)
    ============================================ */
@@ -11117,6 +11133,29 @@ Return JSON:
   const CATEGORY_CACHE_KEY = 'boards-category-cache';
   const CATEGORIES = ['home', 'wear', 'watch', 'listen', 'use', 'eat', 'go', 'follow', 'read'];
 
+  // Get user-created boards formatted for the categorize API
+  function getUserBoardsForCategorizer() {
+    try {
+      const cats = load().categories;
+      const boards = [];
+      for (const [slug, meta] of Object.entries(cats)) {
+        if (meta.isUserBoard) {
+          boards.push({
+            slug,
+            name: meta.displayName || slug.replace(/-/g, ' '),
+            prompt: meta.prompt || undefined
+          });
+        }
+      }
+      // Cap at 15, most recent first
+      return boards.sort((a, b) => {
+        const ca = cats[a.slug]?.createdAt || '';
+        const cb = cats[b.slug]?.createdAt || '';
+        return cb.localeCompare(ca);
+      }).slice(0, 15);
+    } catch { return []; }
+  }
+
   // Genre normalization — maps variant spellings to canonical tag IDs
   // Used by TF-IDF ranker, detectTags, and computeLinkTags
   const GENRE_NORMALIZE = {
@@ -11581,7 +11620,8 @@ Return JSON:
           title: link.title || '',
           description: link.description || '',
           domain: domain,
-          categories: CATEGORIES
+          categories: CATEGORIES,
+          userBoards: getUserBoardsForCategorizer()
         })
       });
 
@@ -11598,13 +11638,14 @@ Return JSON:
         `\n  💭 ${data.reason || data.error || 'no reason'}`,
         `\n  ⏱ ${ms}ms`);
 
-      // Cache the result by domain (skip multi-topic domains)
-      if (data.category && data.category !== 'uncategorized' && !isMultiTopicDomain(domain)) {
+      // Cache the result by domain (skip multi-topic domains and user board results)
+      const isUserBoardResult = data.category && !CATEGORIES.includes(data.category) && data.category !== 'uncategorized';
+      if (data.category && data.category !== 'uncategorized' && !isMultiTopicDomain(domain) && !isUserBoardResult) {
         categoryCache[domain] = data.category;
         saveCategoryCache(categoryCache);
       }
 
-      return { category: data.category, confidence: data.confidence ?? 0.9, cached: false, source: 'ai', reason: data.reason };
+      return { category: data.category, confidence: data.confidence ?? 0.9, cached: false, source: 'ai', reason: data.reason, suggestedBoard: data.suggestedBoard || null };
     } catch (e) {
       console.warn('[categorize] AI failed:', e.message);
       return null; // Fall back to rule-based
@@ -11909,6 +11950,22 @@ Return JSON:
       score = Math.min(score, 1);
       if (score > maxScore) { maxScore = score; best = cat; }
     }
+
+    // Score against user-created boards (name + prompt keywords)
+    try {
+      const cats = getCategories();
+      for (const [slug, meta] of Object.entries(cats)) {
+        if (!meta.isUserBoard) continue;
+        const boardText = `${meta.displayName || ''} ${meta.prompt || ''}`.toLowerCase();
+        const boardTokens = boardText.split(/\s+/).filter(t => t.length > 3);
+        let score = 0;
+        for (const token of boardTokens) {
+          if (text.includes(token)) score += 0.2;
+        }
+        score = Math.min(score, 0.7); // Cap below strong built-in matches
+        if (score > maxScore) { maxScore = score; best = slug; }
+      }
+    } catch { /* getCategories may fail before data is loaded */ }
 
     // Lower threshold to 0.15 (single keyword match is enough)
     return { category: maxScore >= 0.15 ? best : 'uncategorized', confidence: maxScore };
@@ -14806,6 +14863,11 @@ Return JSON:
           renderGrid();
           console.log('%c[LINK FLOW] ✓ Card updated:', 'color: #27ae60; font-weight: bold', meta.title);
 
+          // Suggest new board if AI couldn't categorize but has a suggestion
+          if (cat.category === 'uncategorized' && cat.suggestedBoard) {
+            showNewBoardChip(id, cat.suggestedBoard);
+          }
+
           // Auto-assign to prompt-based dimensions (fire-and-forget)
           autoAssignNewPin({ id, url, title: meta.title, description: meta.description, domain: meta.domain || domain, category: cat.category })
             .catch(err => console.warn('[dimensions] autoAssign error:', err));
@@ -16383,9 +16445,9 @@ Return JSON:
     });
   }
 
-  function openCreateBoardModal() {
+  function openCreateBoardModal(prefillName = '') {
     if (!createBoardModal) return;
-    createBoardNameInput.value = '';
+    createBoardNameInput.value = prefillName;
     createBoardPromptInput.value = '';
     createBoardError.hidden = true;
     createBoardError.textContent = '';
@@ -16414,6 +16476,22 @@ Return JSON:
         updateShareButton();
         renderBoardSeedPanel(slug);
         toast(`Board "${name}" created`);
+        // If a pin triggered this board suggestion, offer to move it
+        if (_pendingBoardSuggestPin) {
+          const pendingId = _pendingBoardSuggestPin;
+          _pendingBoardSuggestPin = null;
+          const pin = getAllLinks().find(l => l.id === pendingId);
+          if (pin) {
+            setTimeout(() => {
+              if (confirm(`Move "${pin.title || pin.domain}" to "${name}"?`)) {
+                updateLink(pendingId, { category: slug, previousCategory: pin.category });
+                renderFilters();
+                renderGrid();
+                toast(`Moved to "${name}"`);
+              }
+            }, 300);
+          }
+        }
         if (!localStorage.getItem('board-ctx-hint-shown')) {
           localStorage.setItem('board-ctx-hint-shown', '1');
           setTimeout(() => toast('Tip: right-click or long-press a board for options'), 2000);
@@ -16434,6 +16512,53 @@ Return JSON:
     createBoardNameInput.addEventListener('keydown', e => {
       if (e.key === 'Enter') createBoardSubmitBtn.click();
     });
+  }
+
+  // ============================================
+  // Suggest New Board — chip UX for uncategorized pins
+  // ============================================
+  let _pendingBoardSuggestPin = null;
+
+  function showNewBoardChip(pinId, suggestedName) {
+    const filtersEl = document.getElementById('filters');
+    if (!filtersEl) return;
+
+    // Only one suggestion at a time
+    const existing = filtersEl.querySelector('.filter-token--board-suggest');
+    if (existing) existing.remove();
+
+    const chip = document.createElement('button');
+    chip.className = 'filter-token filter-token--board-suggest';
+    chip.setAttribute('aria-label', `Create "${suggestedName}" board`);
+
+    const label = document.createElement('span');
+    label.textContent = `+ "${suggestedName}" board?`;
+    chip.appendChild(label);
+
+    const dismiss = document.createElement('span');
+    dismiss.textContent = '\u00d7';
+    dismiss.style.marginLeft = '6px';
+    dismiss.style.cursor = 'pointer';
+    dismiss.onclick = (e) => {
+      e.stopPropagation();
+      _pendingBoardSuggestPin = null;
+      chip.remove();
+    };
+    chip.appendChild(dismiss);
+
+    chip.onclick = () => {
+      _pendingBoardSuggestPin = pinId;
+      chip.remove();
+      openCreateBoardModal(suggestedName);
+    };
+
+    // Insert before the "+ Board" button
+    const createBtn = filtersEl.querySelector('#createBoardBtn');
+    if (createBtn) {
+      filtersEl.insertBefore(chip, createBtn);
+    } else {
+      filtersEl.appendChild(chip);
+    }
   }
 
   // ============================================

--- a/supabase/functions/categorize/index.ts
+++ b/supabase/functions/categorize/index.ts
@@ -7,6 +7,18 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
+const BUILTIN_DESCRIPTIONS: Record<string, string> = {
+  home: 'Furniture, home decor, interior design, lighting, rugs, ceramics',
+  wear: 'Clothing, shoes, accessories, jewelry, fashion',
+  watch: 'Videos, films, shows, documentaries, streaming video content',
+  listen: 'Music, podcasts, audio content, songs, albums, playlists, DJ mixes, radio',
+  use: 'Apps, software, tools, code, developer resources, products',
+  eat: 'Restaurants, cafes, recipes, food, cooking, dining',
+  go: 'Travel, hotels, destinations, maps, places to visit',
+  follow: 'People, profiles, portfolios, social media accounts, creators',
+  read: 'Articles, essays, blogs, news, books, tutorials, guides',
+}
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -18,7 +30,7 @@ serve(async (req) => {
       throw new Error('ANTHROPIC_API_KEY not configured')
     }
 
-    const { url, title, description, domain, categories } = await req.json()
+    const { url, title, description, domain, categories, userBoards } = await req.json()
 
     if (!url) {
       throw new Error('URL is required')
@@ -26,22 +38,33 @@ serve(async (req) => {
 
     const categoryList = categories || ['home', 'wear', 'watch', 'listen', 'use', 'eat', 'go', 'follow', 'read']
 
+    // Build category descriptions block
+    const builtinBlock = categoryList
+      .map((c: string) => `- ${c}: ${BUILTIN_DESCRIPTIONS[c] || c}`)
+      .join('\n')
+
+    // Build user boards block (cap at 15 to keep prompt reasonable)
+    const boards: Array<{ slug: string; name: string; prompt?: string }> = Array.isArray(userBoards)
+      ? userBoards.slice(0, 15)
+      : []
+    const userBoardSlugs = boards.map(b => b.slug)
+    const allValidSlugs = [...categoryList, ...userBoardSlugs]
+
+    const userBoardBlock = boards.length > 0
+      ? '\n\nUser-created boards (prefer these when they clearly match):\n' +
+        boards.map(b => `- ${b.slug}: ${b.name}${b.prompt ? ` — ${b.prompt}` : ''}`).join('\n')
+      : ''
+
+    const suggestBoardInstruction = '\n\nIf uncategorized, also suggest a short board name (2-3 words max) in a "suggestedBoard" field. If the link fits an existing category, set "suggestedBoard" to null.'
+
     const prompt = `You are a link categorizer. Given information about a webpage, categorize it into exactly ONE of these categories:
 
 Categories:
-- home: Furniture, home decor, interior design, lighting, rugs, ceramics
-- wear: Clothing, shoes, accessories, jewelry, fashion
-- watch: Videos, films, shows, documentaries, streaming video content
-- listen: Music, podcasts, audio content, songs, albums, playlists, DJ mixes, radio
-- use: Apps, software, tools, code, developer resources, products
-- eat: Restaurants, cafes, recipes, food, cooking, dining
-- go: Travel, hotels, destinations, maps, places to visit
-- follow: People, profiles, portfolios, social media accounts, creators
-- read: Articles, essays, blogs, news, books, tutorials, guides
+${builtinBlock}${userBoardBlock}
 
 IMPORTANT: Music platforms (Spotify, SoundCloud, Bandcamp, Apple Music, Tidal, etc.) should ALWAYS be "listen", never "watch".
 
-If the link doesn't clearly fit any category, respond with "uncategorized".
+If the link doesn't clearly fit any category, respond with "uncategorized".${suggestBoardInstruction}
 
 Webpage information:
 - URL: ${url}
@@ -50,7 +73,7 @@ Webpage information:
 - Description: ${description || 'No description'}
 
 Respond with ONLY a JSON object in this exact format, no other text:
-{"category": "category_name", "confidence": 0.95, "reason": "brief reason"}`
+{"category": "category_name", "confidence": 0.95, "reason": "brief reason", "suggestedBoard": null}`
 
     const response = await fetch('https://api.anthropic.com/v1/messages', {
       method: 'POST',
@@ -61,7 +84,7 @@ Respond with ONLY a JSON object in this exact format, no other text:
       },
       body: JSON.stringify({
         model: 'claude-3-haiku-20240307',
-        max_tokens: 150,
+        max_tokens: 200,
         messages: [
           { role: 'user', content: prompt }
         ]
@@ -87,14 +110,20 @@ Respond with ONLY a JSON object in this exact format, no other text:
       result = {
         category: match ? match[1] : 'uncategorized',
         confidence: 0.5,
-        reason: 'Parsed from text'
+        reason: 'Parsed from text',
+        suggestedBoard: null
       }
     }
 
-    // Validate category
-    if (!categoryList.includes(result.category)) {
+    // Validate category against all valid slugs (built-in + user boards)
+    if (!allValidSlugs.includes(result.category) && result.category !== 'uncategorized') {
       result.category = 'uncategorized'
       result.confidence = 0.3
+    }
+
+    // Ensure suggestedBoard is only set when uncategorized
+    if (result.category !== 'uncategorized') {
+      result.suggestedBoard = null
     }
 
     return new Response(JSON.stringify(result), {
@@ -107,7 +136,8 @@ Respond with ONLY a JSON object in this exact format, no other text:
       JSON.stringify({
         category: 'uncategorized',
         confidence: 0,
-        error: error.message
+        error: error.message,
+        suggestedBoard: null
       }),
       {
         status: 200, // Return 200 so client can fall back gracefully


### PR DESCRIPTION
## Summary
- AI categorizer now considers user-created boards alongside the 9 built-in categories
- When a pin doesn't fit any category, the AI suggests a board name (e.g., "Art", "Photography")
- A green suggestion chip appears in the filter bar — clicking it pre-fills the create-board modal
- Rule-based fallback also scores against user board names and prompts
- Edge function is fully backward compatible (no `userBoards` = same behavior as before)

## Test plan
- [ ] Add a pin that matches a built-in category — confirm it still categorizes correctly
- [ ] Create a user board (e.g., "Art" with prompt "paintings, galleries"), add an art pin — confirm it lands in the Art board
- [ ] Add a pin from an obscure site that doesn't match anything — confirm green suggestion chip appears
- [ ] Click the suggestion chip — confirm create-board modal opens pre-filled with AI-suggested name
- [ ] Create the board from the pre-filled modal — confirm pin is offered to be moved
- [ ] Dismiss the chip with × — confirm it disappears
- [ ] Bulk import — confirm no per-pin chips appear (bulk uses existing `checkClusters`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)