### PR TITLE
Fix mobile redirect screen appearing on refresh

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -19992,6 +19992,9 @@ Return JSON:
   // Show overlay if we have fresh auth tokens OR an existing session
   if (!capturedAuth && !hasExistingSession) return;
 
+  // If user already dismissed this session, don't show again (unless fresh auth redirect)
+  if (!capturedAuth && sessionStorage.getItem('iosOverlayDismissed')) return;
+
   // Build deep link
   var deepLink;
   if (capturedAuth) {
@@ -20004,8 +20007,10 @@ Return JSON:
     if (subtext) subtext.textContent = 'Continue to the full Boards experience';
   }
 
-
-  function hideOverlay() { overlay.style.display = 'none'; }
+  function hideOverlay() {
+    overlay.style.display = 'none';
+    sessionStorage.setItem('iosOverlayDismissed', '1');
+  }
 
   openBtn.addEventListener('click', function() {
     window.location.href = deepLink;


### PR DESCRIPTION
## Summary
- iOS app redirect overlay was showing on **every page refresh** after being dismissed
- Root cause: clicking "Continue in Browser" hid the overlay but didn't persist the choice
- Fix: use `sessionStorage` to remember dismissal for the current browser session
- Fresh auth redirects (login flow) still always show the overlay as intended

## Test plan
- [ ] On iOS Safari with an existing session, load Boards — overlay appears once
- [ ] Click "Continue in Browser" — overlay hides
- [ ] Refresh the page — overlay should NOT reappear
- [ ] Close the tab and reopen — overlay shows again (new session)
- [ ] Auth redirect from login — overlay always shows regardless of prior dismissal

🤖 Generated with [Claude Code](https://claude.com/claude-code)