### PR TITLE
Pin supabase-js to v2.97.0 — fix login persistence

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -5565,7 +5565,7 @@ body {
   .ig-entity--unresolved-resolved { border-color: var(--fg) !important; opacity: 1; }
   #igEntities { max-height: 50vh; overflow-y: auto; }
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="../js/image-validation.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- `@supabase/supabase-js@2` (unpinned) started serving v2.98.0 yesterday (Feb 26)
- v2.98.0 changed navigator lock behavior: lowered `lockAcquireTimeout` to 5s and added orphaned lock recovery with steal fallback
- This broke session restoration on page refresh — login doesn't persist
- Fix: pin to v2.97.0 (Feb 18) which was the last stable version before the lock changes

## Test plan
- [ ] Log in via magic link on web
- [ ] Refresh the page — should remain logged in
- [ ] Close and reopen tab — should remain logged in
- [ ] Log out — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)