### PR TITLE
Fix lookback TDZ runtime error

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -19311,8 +19311,6 @@ Return JSON:
     return issues;
   };
 
-  init();
-
   // ============================================
   // Lookback Feature - Phase 1 MVP
   // ============================================
@@ -19742,6 +19740,9 @@ Return JSON:
       </div>
     `;
   }
+
+  // Initialize the app (must be after all const declarations above)
+  init();
 
   // ============================================
   // Mobile Paste Button


### PR DESCRIPTION
## Summary
- Fixes `Uncaught ReferenceError: Cannot access 'LOOKBACK_STOPWORDS' before initialization` crash on page load
- Root cause: `init()` was called before lookback `const` declarations due to JavaScript's Temporal Dead Zone
- Fix: moved `init()` from line 19314 to after all lookback code (line 19745)

## Test plan
- [ ] Load boards page — no console errors
- [ ] Lookback card renders at bottom of feed
- [ ] Click a lookback pin — opens link and fades card

🤖 Generated with [Claude Code](https://claude.com/claude-code)