### PR TITLE
Add boards version bump rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,7 @@ Claude Code is authorized to perform the following operations **without asking f
 - **Assign all PRs to `fikei`** so they appear in the GitHub mobile app for quick merge
 - **Create and push branches** for feature work
 - **Close stale branches** after successful merges
+- **Bump the boards version on every push** — increment `const VERSION` in `boards/index.html` (line ~6354) and update the console.log description on the next line. Use semver: patch (Z) for fixes/small changes, minor (Y) for new features or behavioral changes, major (X) for breaking/structural changes. Include the version bump in the same commit as your changes
 
 ### Supabase Deployment
 - **Always deploy any updated Supabase edge functions after merge** — if any files in `supabase/functions/` changed, run `supabase functions deploy <function-name>` immediately after merging without asking

--- a/boards/index.html
+++ b/boards/index.html
@@ -6351,8 +6351,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.1.0';
-  console.log('[boards] v' + VERSION + ' - Navigation Redesign');
+  const VERSION = '2.1.1';
+  console.log('[boards] v' + VERSION + ' - Add version bump rule');
 
   // ============================================
   // Supabase Setup


### PR DESCRIPTION
## Summary
- Adds rule to CLAUDE.md: bump `const VERSION` in `boards/index.html` on every push
- Uses semver (patch/minor/major) with updated console.log description
- Bumps boards version 2.1.0 → 2.1.1 for this change

## Test plan
- [ ] Open boards page, check console shows `[boards] v2.1.1 - Add version bump rule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)