### PR TITLE
Show full email in menu when no username set

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6351,8 +6351,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.1.1';
-  console.log('[boards] v' + VERSION + ' - Add version bump rule');
+  const VERSION = '2.1.2';
+  console.log('[boards] v' + VERSION + ' - Show full email when no username set');
 
   // ============================================
   // Supabase Setup
@@ -17917,11 +17917,9 @@ Return JSON:
     if (currentUsername) {
       return '@' + currentUsername;
     }
-    // Otherwise show first name from email (capitalized)
+    // Otherwise show full email
     if (currentUser?.email) {
-      const emailPrefix = currentUser.email.split('@')[0];
-      // Capitalize first letter
-      return emailPrefix.charAt(0).toUpperCase() + emailPrefix.slice(1);
+      return currentUser.email;
     }
     return 'User';
   }


### PR DESCRIPTION
## Summary
- `getDisplayName()` now returns full email (e.g. `ian@example.com`) instead of capitalized prefix (e.g. `Ian`) when no @username is set
- @username display unchanged — still shows `@username` when set
- Bumped to v2.1.2

## Test plan
- [ ] Log in without a username set — top-right menu shows full email
- [ ] Set a username — menu shows `@username`

🤖 Generated with [Claude Code](https://claude.com/claude-code)