### PR TITLE
Fix listen row menu showing uuid-like text

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -3530,10 +3530,11 @@ body {
   background: var(--subtle);
 }
 .listen-row__menu-btn::before {
-  content: '\u2022\u2022\u2022';
+  content: '•••';
   color: var(--muted);
   font-size: 12px;
   letter-spacing: 1px;
+  transform: rotate(90deg);
 }
 .listen-row__menu {
   position: absolute;


### PR DESCRIPTION
## Summary
- Fixed CSS `content` property using JavaScript escape `\u2022` instead of literal `•••`
- This caused the menu button to render `u2022u2022u2022` (looks like a UUID) instead of three dots
- Added `rotate(90deg)` to match the vertical triple-dot style of grid card menus

## Test plan
- [ ] Open Listen view — each row should show a vertical triple-dot (⋮) button on the right
- [ ] No "u2022" text visible anywhere
- [ ] Click the dots — menu opens with Share, Refresh, Organize, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)