### PR TITLE
Show format & duration in listen row metadata

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -14302,7 +14302,7 @@ Return JSON:
             <span class="listen-row__artist">${platformDot} ${esc(artistName)}</span>
           </div>
           <div class="listen-row__meta listen-row__meta--extended">
-            ${explicitBadge}${bpmMeta}${keyMeta}
+            ${fmt ? `<span class="listen-row__format">${esc(fmt)}</span>` : ''}${explicitBadge}${bpmMeta}${keyMeta}
             ${dur ? `<span class="listen-row__duration">${dur}</span>` : ''}
           </div>
           <div class="listen-row__menu-container">


### PR DESCRIPTION
## Summary
- Added content format badge (Track, Album, Playlist, etc.) back to listen row metadata
- BPM/key were the only fields showing but are rarely populated (third-party lookup)
- Format is commonly available from URL parsing, so rows now show useful data
- Layout: format badge | explicit badge | BPM | key | duration — all inline, no overlap

## Test plan
- [ ] Open Listen view — rows should show format badge (e.g. "TRACK") and duration when available
- [ ] Verify no layout issues with the metadata + menu button

🤖 Generated with [Claude Code](https://claude.com/claude-code)