### PR TITLE
Wire up full music enrichment pipeline for listen links

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -10431,7 +10431,8 @@ Return JSON:
             forceRefresh: forceRefresh,
             category: item.category || null,
             enrichWatch: item.enrichWatch || false,
-            enrichBook: item.enrichBook || false
+            enrichBook: item.enrichBook || false,
+            enrichListen: item.enrichListen || false
           })
         });
 
@@ -10715,6 +10716,41 @@ Return JSON:
               link.image = olCover;
               link.image_source = 'openlibrary';
             }
+          }
+        }
+
+        // Merge server-enriched music metadata (MusicBrainz + Last.fm + oEmbed) into existing music field
+        if (result.music) {
+          const existing = link.music || {};
+          link.music = {
+            ...existing,
+            server_enriched_at: new Date().toISOString(),
+            artist: result.music.artist || existing.artist || null,
+            trackTitle: result.music.trackTitle || existing.trackTitle || null,
+            albumTitle: result.music.albumTitle || existing.albumTitle || null,
+            genre: result.music.genre || existing.genre || null,
+            genreTags: result.music.genreTags || existing.genreTags || null,
+            label: result.music.label || existing.label || null,
+            releaseDate: result.music.releaseDate || existing.releaseDate || null,
+            duration: existing.duration || result.music.duration || null,
+            contentFormat: existing.contentFormat || result.music.contentFormat || null,
+            isExplicit: existing.isExplicit ?? result.music.isExplicit ?? null,
+            // Preserve client-side fields (BPM/key from GetSongBPM, embed from URL parsing)
+            bpm: existing.bpm || null,
+            key: existing.key || null,
+            embedUrl: result.music.embedUrl || existing.embedUrl || null,
+            embedType: result.music.embedType || existing.embedType || null,
+            embedHeight: result.music.embedHeight || existing.embedHeight || null,
+            platformId: existing.platformId || null,
+          };
+          console.log('%c[ENRICH] Music metadata merged:', 'color: #1db954', link.music);
+          // Recompute unified tags with new music data
+          delete link._tags;
+          link.tags = computeLinkTags(link);
+
+          // Update top-level title with artist - track if we have both
+          if (link.music.artist && link.music.trackTitle) {
+            link.title = `${link.music.artist} – ${link.music.trackTitle}`;
           }
         }
 
@@ -11585,6 +11621,39 @@ Return JSON:
       summaryField: 'summary',
       enrichFlag: 'enrichBook',
       backfillCheck: (link) => link.book && !link.book.server_enriched_at,
+    },
+    listen: {
+      category: 'listen',
+      metaField: 'music',
+      doneField: 'listened',
+      doneLabel: 'Listened',
+      cssClass: 'listen',
+      doneClass: 'listened',
+      getPlatform: getMusicPlatform,
+      overlay: {
+        titleField: 'trackTitle',
+        metaField: 'artist',
+        metaFallback: (meta) => meta.albumTitle || null,
+        titleClass: 'music-title',
+        metaClass: 'music-meta',
+      },
+      metaLine: [
+        { field: 'genre' },
+        { field: 'label' },
+        { field: 'contentFormat', format: (f) => cap(f.replace('-', ' ')) },
+      ],
+      badge: { typeField: 'contentFormat', durationField: 'duration' },
+      externalLink: (meta) => {
+        if (meta.artist && meta.trackTitle) {
+          const q = encodeURIComponent(`${meta.artist} ${meta.trackTitle}`);
+          return { url: `https://www.last.fm/search?q=${q}`, label: 'Last.fm', cssClass: '' };
+        }
+        return null;
+      },
+      extras: () => '',
+      summaryField: null,
+      enrichFlag: 'enrichListen',
+      backfillCheck: (link) => link.music && !link.music.server_enriched_at,
     },
   };
 
@@ -15067,12 +15136,14 @@ Return JSON:
           // Queue for server enrichment if needed (server handles scrape + Tier 2 + Tier 3 quality gate)
           const isWatchItem = cat.category === 'watch' || contentType.type === 'video';
           const isBookItem = cat.category === 'read' || contentType.type === 'book';
-          const needsEnrichment = contentType.confidence < 0.7 || !meta.image || isWatchItem || isBookItem;
+          const isListenItem = cat.category === 'listen' || contentType.type === 'music';
+          const needsEnrichment = contentType.confidence < 0.7 || !meta.image || isWatchItem || isBookItem || isListenItem;
           if (needsEnrichment) {
             queueServerEnrichment(id, url, meta.title, meta.description, {
               category: cat.category,
               enrichWatch: isWatchItem,
-              enrichBook: isBookItem
+              enrichBook: isBookItem,
+              enrichListen: isListenItem
             });
           }
 

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -2,8 +2,8 @@
 // Handles AI classification, image resolution, and watch enrichment for links
 //
 // POST /functions/v1/enrich-link
-// Body: { url, title?, description?, linkId?, skipClassification?, skipImage?, enrichWatch?, enrichBook?, category? }
-// Returns: { content_type, type_confidence, type_source, image_url, image_source, cached, video?, book? }
+// Body: { url, title?, description?, linkId?, skipClassification?, skipImage?, enrichWatch?, enrichBook?, enrichListen?, category? }
+// Returns: { content_type, type_confidence, type_source, image_url, image_source, cached, video?, book?, music? }
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -41,7 +41,7 @@ serve(async (req) => {
 
   try {
     let { url, title, description, linkId, skipClassification, skipImage,
-            skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, category } = await req.json()
+            skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, enrichListen, category } = await req.json()
 
     // Support skipIfHasImage: skip image resolution if client already has a valid image
     const shouldSkipImage = skipImage || (skipIfHasImage && !!currentImage)
@@ -479,6 +479,137 @@ serve(async (req) => {
     }
 
     // ========================================
+    // STEP 2.7: Music Enrichment — oEmbed + URL parsing + MusicBrainz/Last.fm
+    // ========================================
+    let musicMeta: Record<string, any> | null = null
+    if (enrichListen || category === 'listen' || contentType === 'music') {
+      console.log('[enrich-link] Step 2.7: Music enrichment for:', url)
+
+      const musicResult: Record<string, any> = {
+        artist: null,
+        trackTitle: null,
+        albumTitle: null,
+        genre: null,
+        duration: null,
+        contentFormat: null,
+        releaseDate: null,
+        label: null,
+        isExplicit: null,
+        embedUrl: null,
+        embedType: null,
+        embedHeight: null,
+        server_enriched_at: new Date().toISOString(),
+      }
+
+      // 1. Infer contentFormat from URL
+      if (/\/track[\/s]/.test(path)) musicResult.contentFormat = 'track'
+      else if (/\/album[\/s]/.test(path)) musicResult.contentFormat = 'album'
+      else if (/\/playlist[\/s]/.test(path)) musicResult.contentFormat = 'playlist'
+      else if (/\/episode[\/s]/.test(path) || /\/podcast/.test(path)) musicResult.contentFormat = 'podcast-episode'
+      else if (/\/artist[\/s]/.test(path)) musicResult.contentFormat = 'artist'
+      else if (/\/sets?[\/]/.test(path) && domain.includes('soundcloud.com')) musicResult.contentFormat = 'mix'
+
+      // 2. Spotify oEmbed (no CORS issues server-side)
+      if (domain.includes('spotify.com')) {
+        try {
+          const oembedResp = await fetch(`https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`)
+          if (oembedResp.ok) {
+            const oe = await oembedResp.json()
+            musicResult.trackTitle = oe.title || null
+            if (oe.provider_name === 'Spotify' && oe.author_name) {
+              musicResult.artist = oe.author_name
+            }
+            if (oe.html) {
+              const m = oe.html.match(/src=["']([^"']+)["']/)
+              if (m) { musicResult.embedUrl = m[1]; musicResult.embedType = 'iframe'; musicResult.embedHeight = oe.height || 152 }
+            }
+            console.log('[enrich-link] Spotify oEmbed:', oe.title, '-', oe.author_name)
+          }
+        } catch (e) { console.warn('[enrich-link] Spotify oEmbed failed:', (e as Error).message) }
+      }
+
+      // 3. SoundCloud oEmbed
+      if (domain.includes('soundcloud.com')) {
+        try {
+          const oembedResp = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(url)}`)
+          if (oembedResp.ok) {
+            const oe = await oembedResp.json()
+            musicResult.trackTitle = musicResult.trackTitle || oe.title || null
+            musicResult.artist = musicResult.artist || oe.author_name || null
+            if (oe.html) {
+              const m = oe.html.match(/src=["']([^"']+)["']/)
+              if (m) { musicResult.embedUrl = m[1]; musicResult.embedType = 'iframe'; musicResult.embedHeight = oe.height || 166 }
+            }
+          }
+        } catch (e) { console.warn('[enrich-link] SoundCloud oEmbed failed:', (e as Error).message) }
+      }
+
+      // 4. Title-based fallback for artist/track
+      if (!musicResult.artist && title) {
+        // "Track - song and lyrics by Artist | Spotify"
+        const spTitle = title.match(/^(.+?)\s*-\s*(?:song and lyrics by|Song by|Album by)\s+(.+?)\s*\|/i)
+        if (spTitle) {
+          musicResult.trackTitle = musicResult.trackTitle || spTitle[1].trim()
+          musicResult.artist = spTitle[2].trim()
+        }
+        // "Artist - Track" or "Track by Artist"
+        if (!musicResult.artist) {
+          const dashSplit = title.match(/^(.+?)\s*[-–—]\s+(.+?)(?:\s*\|.*)?$/)
+          if (dashSplit) {
+            musicResult.artist = musicResult.artist || dashSplit[1].trim()
+            musicResult.trackTitle = musicResult.trackTitle || dashSplit[2].trim()
+          }
+        }
+      }
+
+      // 5. Description-based fallback (Spotify: "Listen to Track on Spotify. Type · Artist · Year")
+      if (!musicResult.artist && description) {
+        const spDesc = description.match(/(?:Song|Album|Playlist|EP)\s*[·]\s*(.+?)\s*[·]\s*(\d{4})/i)
+        if (spDesc) {
+          musicResult.artist = spDesc[1].trim()
+          musicResult.releaseDate = musicResult.releaseDate || spDesc[2]
+        }
+      }
+
+      // 6. MusicBrainz + Last.fm for genre/label (if we have artist + track)
+      if (musicResult.artist && musicResult.trackTitle) {
+        try {
+          // Call our own enrich-music function internally
+          const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+          const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+          const enrichResp = await fetch(`${supabaseUrl}/functions/v1/enrich-music`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${supabaseServiceKey}`,
+            },
+            body: JSON.stringify({
+              artist: musicResult.artist,
+              track: musicResult.trackTitle,
+              album: musicResult.albumTitle,
+            }),
+          })
+          if (enrichResp.ok) {
+            const enrichData = await enrichResp.json()
+            if (enrichData.genre) musicResult.genre = enrichData.genre
+            if (enrichData.label) musicResult.label = enrichData.label
+            if (enrichData.album) musicResult.albumTitle = musicResult.albumTitle || enrichData.album
+            if (enrichData.releaseDate) musicResult.releaseDate = musicResult.releaseDate || enrichData.releaseDate
+            console.log('[enrich-link] enrich-music result:', enrichData)
+          }
+        } catch (e) { console.warn('[enrich-link] enrich-music call failed:', (e as Error).message) }
+      }
+
+      // Return if we got anything useful
+      const hasData = musicResult.artist || musicResult.trackTitle || musicResult.contentFormat
+      if (hasData) {
+        musicMeta = musicResult
+      }
+
+      console.log('[enrich-link] Music enrichment result:', musicMeta)
+    }
+
+    // ========================================
     // STEP 3: Update link in database (if linkId provided)
     // ========================================
     if (linkId) {
@@ -512,6 +643,9 @@ serve(async (req) => {
       }
       if (bookMeta) {
         updatePayload.book = bookMeta
+      }
+      if (musicMeta) {
+        updatePayload.music = musicMeta
       }
       await supabase
         .from('links')
@@ -561,6 +695,9 @@ serve(async (req) => {
     }
     if (bookMeta) {
       response.book = bookMeta
+    }
+    if (musicMeta) {
+      response.music = musicMeta
     }
 
     console.log('[enrich-link] Complete:', response)


### PR DESCRIPTION
## Summary
- **Server-side**: Added Step 2.7 to `enrich-link` edge function — extracts music metadata via URL pattern parsing, Spotify/SoundCloud oEmbed, and internal `enrich-music` call (MusicBrainz + Last.fm) for genre, label, album, releaseDate
- **Client-side**: Added `result.music` merge handler in `processEnrichmentQueue`, `enrichListen` flag in API calls, listen items now queued for server enrichment on add
- **Backfill**: Added `listen` entry to `RICH_CONTENT` config so existing listen links without `server_enriched_at` are automatically re-enriched on page load

Fixes 7 compounding gaps that prevented music metadata (genre, label, artist, track, format) from being populated for listen links.

## Test plan
- [ ] Add a Spotify track link — verify artist, track, genre, label populate in metadata
- [ ] Add a SoundCloud link — verify oEmbed extracts artist/track
- [ ] Check existing listen links get backfilled on page load (console: `[BACKFILL] N listen items need enrichment`)
- [ ] Verify listen row displays format badge, BPM, key when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)