### PR TITLE
Fix Instagram Reel import trigger + improve extraction thoroughness

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6460,7 +6460,7 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
 
   // Instagram reel/post detection
   function isInstagramContent(url) {
-    return /instagram\.com\/(reel|p)\//i.test(url || '');
+    return /instagram\.com\/(reels?|p|tv)\//i.test(url || '');
   }
 
   // Classify content type using rules (fast, free)
@@ -14978,203 +14978,8 @@ Return JSON:
     closeModal(addModal);
     showStatus('');
 
-    let added = 0, updated = 0;
-    const total = urls.length;
-
-    // STEP 1: Create placeholder cards immediately for all URLs
-    const placeholders = [];
-    for (const url of urls) {
-      const domain = extractDomain(url);
-      const id = generateId(url);
-
-      // Check if already exists
-      if (findByUrl(url)) {
-        console.log('%c[LINK FLOW] URL already exists, skipping placeholder:', 'color: #f39c12', url);
-        updated++;
-        continue;
-      }
-
-      // Create skeleton link with minimal data
-      const skeleton = {
-        id,
-        url,
-        title: generateTitleFromUrl(url),
-        description: '',
-        image: null,
-        domain,
-        category: 'uncategorized',
-        confidence: 0,
-        content_type: null,
-        type_confidence: 0,
-        loading: true // Mark as loading
-      };
-
-      console.log('%c[LINK FLOW] Creating placeholder card:', 'color: #1abc9c; font-weight: bold', domain);
-      const result = addLink(skeleton);
-      if (result.success && !result.updated) {
-        placeholders.push({ id, url, domain });
-        added++;
-      }
-    }
-
-    // Render placeholders immediately
-    if (placeholders.length > 0) {
-      renderFilters();
-      renderGrid();
-      toast(`Adding ${placeholders.length} link${placeholders.length > 1 ? 's' : ''}...`, { level: 'info', id: 'add-links' });
-    }
-
-    // STEP 2: Fetch metadata and update cards progressively (in background)
-    for (let i = 0; i < placeholders.length; i++) {
-      const { id, url, domain } = placeholders[i];
-
-      // Process each link asynchronously but with a small delay to not overwhelm
-      (async () => {
-        try {
-          console.log(`%c[LINK FLOW] (${i+1}/${placeholders.length}) Fetching metadata:`, 'color: #1abc9c', url);
-          const meta = await fetchMetadata(url);
-          console.log('%c[LINK FLOW] Metadata received:', 'color: #1abc9c', {
-            title: meta.title,
-            image: meta.image ? 'YES' : 'NO'
-          });
-
-          // Categorize
-          const cat = await smartCategorize(meta);
-          console.log('%c[LINK FLOW] Category:', 'color: #1abc9c', cat.category);
-
-          // Content type classification
-          const contentType = classifyByRules(url, meta.title, meta.description);
-          console.log('%c[LINK FLOW] Content type:', 'color: #1abc9c', contentType.type);
-
-          // Extract music metadata if categorized as listen or content_type is music
-          let music = null;
-          if (cat.category === 'listen' || contentType.type === 'music') {
-            music = await extractMusicMetadata(url, meta.title, meta.description, meta.musicTags);
-          }
-
-          // Extract video metadata if categorized as watch or content_type is video
-          let video = null;
-          if (cat.category === 'watch' || contentType.type === 'video') {
-            video = await extractVideoMetadata(url, meta.title, meta.description, meta.videoTags);
-          }
-
-          // Extract book metadata if categorized as read or content_type is book
-          let book = null;
-          if (cat.category === 'read' || contentType.type === 'book') {
-            book = extractBookMetadata(url, meta.title, meta.description);
-          }
-
-          // Initialize image resolution log
-          const clientLog = [{
-            strategy: 'client_cors_proxy',
-            result: meta.image ? 'found_og_image' : 'no_image',
-            reason: meta.image ? 'og:image extracted from HTML' : 'No og:image found or CORS proxy failed',
-            image_url: meta.image || null
-          }];
-
-          // Update the link with full data
-          const linkUpdate = {
-            title: meta.title,
-            description: meta.description,
-            image: meta.image,
-            category: cat.category,
-            confidence: cat.confidence,
-            content_type: contentType.type,
-            type_confidence: contentType.confidence,
-            type_signals: contentType.signals,
-            image_resolution_log: { attempts: clientLog, retry_count: 0 },
-            loading: false // Mark as loaded
-          };
-          if (music) linkUpdate.music = music;
-          if (video) linkUpdate.video = video;
-          if (book) linkUpdate.book = book;
-          updateLink(id, linkUpdate);
-
-          renderFilters();
-          renderGrid();
-          console.log('%c[LINK FLOW] ✓ Card updated:', 'color: #27ae60; font-weight: bold', meta.title);
-
-          // Suggest new board if AI couldn't categorize but has a suggestion
-          if (cat.category === 'uncategorized' && cat.suggestedBoard) {
-            showNewBoardChip(id, cat.suggestedBoard);
-          }
-
-          // Queue for batch auto-assign to prompt-based dimensions
-          queueAutoAssign({ id, url, title: meta.title, description: meta.description, domain: meta.domain || domain, category: cat.category });
-
-          // Try fast platform resolution if no image from CORS proxy
-          if (!meta.image) {
-            const platformResult = await resolvePlatformImage(url);
-            if (platformResult?.imageUrl) {
-              let accepted = false;
-              if (typeof ImageValidation !== 'undefined') {
-                const v = ImageValidation.tier1(platformResult.imageUrl, { title: meta.title, domain: meta.domain });
-                if (v.pass) {
-                  meta.image = platformResult.imageUrl;
-                  meta.image_source = platformResult.source;
-                  meta.image_scores = v.scores;
-                  accepted = true;
-                }
-              } else {
-                meta.image = platformResult.imageUrl;
-                meta.image_source = platformResult.source;
-                accepted = true;
-              }
-              if (accepted) {
-                clientLog.push({ strategy: 'client_platform', result: 'accepted', source: platformResult.source, image_url: meta.image });
-                updateLink(id, { image: meta.image, image_source: meta.image_source, image_scores: meta.image_scores,
-                  image_resolution_log: { attempts: clientLog, retry_count: 0 } });
-                renderGrid();
-              } else {
-                clientLog.push({ strategy: 'client_platform', result: 'rejected', reason: 'Tier 1 validation failed' });
-              }
-            } else {
-              clientLog.push({ strategy: 'client_platform', result: 'skipped', reason: 'Not a known platform domain' });
-            }
-          }
-
-          // Queue for server enrichment if needed (server handles scrape + Tier 2 + Tier 3 quality gate)
-          const isWatchItem = cat.category === 'watch' || contentType.type === 'video';
-          const isBookItem = cat.category === 'read' || contentType.type === 'book';
-          const isListenItem = cat.category === 'listen' || contentType.type === 'music';
-          const needsEnrichment = contentType.confidence < 0.7 || !meta.image || isWatchItem || isBookItem || isListenItem;
-          if (needsEnrichment) {
-            queueServerEnrichment(id, url, meta.title, meta.description, {
-              category: cat.category,
-              enrichWatch: isWatchItem,
-              enrichBook: isBookItem,
-              enrichListen: isListenItem
-            });
-          }
-
-          // Sync to Supabase (has its own auth guards)
-          const data2 = load();
-          const link2 = data2.links.find(l => l.id === id);
-          if (link2) syncLinkToSupabase(link2);
-        } catch (err) {
-          console.error('%c[LINK FLOW] ✗ Metadata fetch failed:', 'color: #e74c3c', err.message);
-          // Update link to remove loading state, keep placeholder title
-          updateLink(id, { loading: false });
-          renderGrid();
-        }
-      })();
-
-      // Small delay between starting each fetch to avoid overwhelming proxies
-      if (i < placeholders.length - 1) {
-        await new Promise(r => setTimeout(r, 200));
-      }
-    }
-
-    // Show summary
-    const parts = [];
-    if (added > 0) parts.push(`Added ${added}`);
-    if (updated > 0) parts.push(`${updated} already existed`);
-    if (parts.length > 0 && added > 0) {
-      // Toast already shown above
-    }
-
-    checkClusters();
-    // Image queue removed — server handles image resolution via queueServerEnrichment
+    // Delegate to processLinks — same path as paste, clipboard, deep link
+    processLinks(text);
   };
 
   filters.onclick = (e) => {
@@ -17930,6 +17735,11 @@ Return JSON:
           renderFilters();
           renderGrid();
 
+          // Suggest new board if AI couldn't categorize but has a suggestion
+          if (cat.category === 'uncategorized' && cat.suggestedBoard) {
+            showNewBoardChip(id, cat.suggestedBoard);
+          }
+
           // Queue for batch auto-assign to prompt-based dimensions
           queueAutoAssign({ id, url, title: meta.title, description: meta.description, domain: meta.domain || (new URL(url)).hostname.replace('www.', ''), category: cat.category });
 
@@ -17967,12 +17777,14 @@ Return JSON:
           // Queue for server enrichment if needed (server handles scrape + Tier 2 + Tier 3 quality gate)
           const isWatchItem2 = cat.category === 'watch' || contentType.type === 'video';
           const isBookItem2 = cat.category === 'read' || contentType.type === 'book';
-          const needsEnrichment2 = contentType.confidence < 0.7 || !meta.image || isWatchItem2 || isBookItem2;
+          const isListenItem2 = cat.category === 'listen' || contentType.type === 'music';
+          const needsEnrichment2 = contentType.confidence < 0.7 || !meta.image || isWatchItem2 || isBookItem2 || isListenItem2;
           if (needsEnrichment2) {
             queueServerEnrichment(id, url, meta.title, meta.description, {
               category: cat.category,
               enrichWatch: isWatchItem2,
-              enrichBook: isBookItem2
+              enrichBook: isBookItem2,
+              enrichListen: isListenItem2
             });
           }
 

--- a/supabase/functions/instagram-import/index.ts
+++ b/supabase/functions/instagram-import/index.ts
@@ -257,25 +257,38 @@ async function transcribeAudio(reel: ReelData): Promise<string | null> {
 // 3. Entity Extraction (Claude Haiku)
 // ---------------------------------------------------------------------------
 
-const EXTRACTION_PROMPT = `Analyze this Instagram Reel post. Extract every real-world entity mentioned or referenced — places, products, brands, songs, restaurants, events, people, recipes, tools, etc.
+const EXTRACTION_PROMPT = `Analyze this Instagram Reel post. Your job is to find EVERY real-world entity the creator mentions or recommends — places, restaurants, products, brands, songs, events, people, recipes, tools, etc.
 
-For each entity:
+## Step 1: Count expected items
+Before extracting, read the caption and transcript carefully. Does the creator say "my top 8 restaurants", "5 things you need", "these 3 spots", etc.? If so, note that number — you MUST find that many entities. If no explicit count is given, estimate how many distinct things are being recommended based on the content.
+
+## Step 2: Extract all entities
+For each entity extract:
 - type: place | product | brand | song | food | event | person | generic
-- name: canonical name (e.g., "Blue Bottle Coffee" not "this coffee spot")
+- name: the CORRECT canonical spelling of the entity name. The transcript is speech-to-text and may contain misspellings or phonetic errors (e.g. "Bouchon Bistrow" → "Bouchon Bistro", "Nobu Malibu" may be transcribed as "Nobu Maleebu"). Use context clues from the caption, location tags, and surrounding words to determine the correct real-world name. Always output the corrected canonical name.
 - location_hint: any geographic context (e.g., "Valencia St, San Francisco")
-- category: which board category (eat, go, wear, watch, listen, use, follow, read)
-- confidence: 0.0-1.0
+- category: which board category fits best (eat, go, wear, watch, listen, use, follow, read)
+- confidence: 0.0-1.0 (use 0.5+ for anything plausible, not just certain items)
 - source: which input it came from ("caption" | "transcript" | "audio_track" | "tagged_location" | "tagged_account" | "screen_text")
-- search_query: a search query to find this SPECIFIC piece of content — not the creator's channel or homepage, unless the entity IS the creator/channel itself
+- search_query: a search query to find this SPECIFIC entity — use the CORRECTED canonical name, not the misspelled transcript version. For places include city/neighborhood. For products include brand name. For songs include artist.
 
-Be aggressive about extraction. If someone says "this place" while tagged at a location, that's a place entity. If a song is playing, that's a song entity. If they mention a brand, that's a brand entity.
+## Step 3: Cross-check
+Compare your extracted list against the caption AND transcript independently:
+- Did you find everything mentioned in the caption?
+- Did you find everything mentioned in the transcript?
+- If the creator mentioned a count (Step 1), does your list match that count? If not, look again — you may have missed an item or merged two distinct entities into one.
 
-If a thumbnail image is provided, also extract any text visible on screen in the video thumbnail — overlaid text, signs, labels, product names, captions. Use source "screen_text" for these entities.
+## Step 4: Screen text
+If a thumbnail image is provided, extract any text visible on screen — overlaid text, signs, labels, product names. Use source "screen_text". These may reveal items not mentioned in the audio.
 
-Specificity: when someone references a specific piece of content (article, video, recipe, tutorial, podcast episode, product listing, course, etc.), extract the specific content as the entity — not the creator, channel, or website. But if the entity IS the creator/channel itself, that's fine.
+## Key rules
+- Be aggressive: if someone says "this place" while tagged at a location, that's a place entity. Vague references backed by context still count.
+- Specificity: extract the specific piece of content, not the creator's channel/homepage — unless the entity IS the creator.
+- Do NOT discard entities just because the transcript spelling looks odd — correct the spelling and include them with confidence >= 0.5.
 
 Return ONLY valid JSON, no markdown fences:
 {
+  "expected_count": 8,
   "entities": [...],
   "post_category": "eat|go|wear|watch|listen|use|follow|read",
   "post_summary": "one sentence summary"
@@ -477,7 +490,7 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
   // Phase 1: Classify entities
   const toResolve: Entity[] = []
   for (const entity of entities) {
-    if (entity.confidence < 0.5) {
+    if (entity.confidence < 0.35) {
       entity.resolved_url = null
       entity.resolved_via = null
       entity.match_quality = 0
@@ -936,7 +949,11 @@ serve(async (req) => {
 
       // Step 3: Extract entities
       const extraction = await extractEntities(reel, transcript)
-      console.log(`[instagram-import] Found ${extraction.entities.length} entities`)
+      const expectedCount = (extraction as Record<string, unknown>).expected_count as number | undefined
+      if (expectedCount && extraction.entities.length < expectedCount) {
+        console.warn(`[instagram-import] Extraction gap: expected ${expectedCount}, found ${extraction.entities.length} entities`)
+      }
+      console.log(`[instagram-import] Found ${extraction.entities.length} entities (expected: ${expectedCount ?? 'unknown'})`)
 
       // Step 4: Resolve entities
       extraction.entities = await resolveAllEntities(extraction.entities, reel)


### PR DESCRIPTION
## Summary
- **Unified URL submission paths**: `addForm.onsubmit` now delegates to `processLinks()` instead of duplicating ~200 lines of enrichment logic. Instagram Reel URLs now trigger the import pipeline from both the Add modal and paste/clipboard paths.
- **Widened Instagram URL detection**: regex now matches `reels/` (plural) and `tv/` in addition to `reel/` and `p/`
- **Improved extraction prompt**: structured 4-step prompt that counts expected items, corrects transcript misspellings using context clues, and cross-checks caption vs transcript for completeness
- **Lower discard threshold**: entities with confidence 0.35-0.49 now appear in the review modal instead of being silently dropped
- **Backfilled missing features**: `enrichListen` and `showNewBoardChip` added to `processLinks` (previously only in the now-removed duplicate code)

## Test plan
- [ ] Open Add modal → paste Instagram Reel URL → submit → should see "Importing Instagram content..." toast and review modal
- [ ] Direct page paste of Reel URL → same behavior (regression check)
- [ ] Test with a Reel that says "top N" something → verify N entities extracted
- [ ] Verify low-confidence entities (0.35-0.49) appear in review modal
- [ ] Check Supabase function logs for expected_count diagnostics
- [ ] Test non-Instagram URLs via Add modal still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)