### PR TITLE
fix: Wikipedia + Barnes & Noble book enrichment

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -9729,6 +9729,14 @@ Return JSON:
       if (ogTitle) meta.title = decodeEntities(ogTitle[1]);
       else if (title) meta.title = decodeEntities(title[1]);
 
+      // Clean Wikipedia titles: strip " - Wikipedia" suffix and book disambiguation
+      if (meta.title && domain.includes('wikipedia.org')) {
+        meta.title = meta.title
+          .replace(/\s*-\s*Wikipedia\s*$/i, '')
+          .replace(/\s*\([^)]*(?:novel|book|story|memoir|essay|anthology|series|autobiography|biography|poem|play|novella|collection|treatise|manuscript)[^)]*\)\s*/gi, '')
+          .trim();
+      }
+
       // Description
       const ogDesc = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']*)["']/i) ||
                      html.match(/<meta[^>]*content=["']([^"']*)["'][^>]*property=["']og:description["']/i);
@@ -9919,6 +9927,26 @@ Return JSON:
   function generateTitleFromUrl(url) {
     try {
       const u = new URL(url);
+
+      // Wikipedia: extract clean article title from /wiki/Article_Name
+      if (u.hostname.includes('wikipedia.org')) {
+        const wikiPath = u.pathname.match(/\/wiki\/(.+)/);
+        if (wikiPath) {
+          return decodeURIComponent(wikiPath[1])
+            .replace(/_/g, ' ')
+            .replace(/\s*\([^)]*(?:novel|book|story|memoir|essay|anthology|series|autobiography|biography|poem|play|novella|collection|treatise|manuscript)[^)]*\)\s*/gi, '')
+            .trim();
+        }
+      }
+
+      // Barnes & Noble: extract from URL slug
+      if (u.hostname.includes('barnesandnoble.com')) {
+        const bnPath = u.pathname.match(/\/w\/([^\/]+)/);
+        if (bnPath) {
+          return bnPath[1].replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        }
+      }
+
       const p = u.pathname.replace(/^\/|\/$/g, '').replace(/[-_]/g, ' ').replace(/\.[^.]+$/, '');
       if (p) return p.split('/').pop().replace(/\b\w/g, c => c.toUpperCase());
       return u.hostname.replace(/^www\./, '');

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -419,7 +419,16 @@ serve(async (req) => {
       console.log('[enrich-link] Step 2.6: Book enrichment (Open Library → AI)')
 
       // 1. Try Open Library first (free, structured data)
-      const olResult = await lookupOpenLibrary(title || '')
+      // For blocked sites (B&N, etc.), extract search title from URL path
+      let bookSearchTitle = title || ''
+      if (url.includes('barnesandnoble.com/w/')) {
+        const bnMatch = url.match(/barnesandnoble\.com\/w\/([^\/]+)/)
+        if (bnMatch && (!bookSearchTitle || bookSearchTitle === domain)) {
+          bookSearchTitle = bnMatch[1].replace(/-/g, ' ')
+          console.log('[enrich-link] B&N title from URL slug:', bookSearchTitle)
+        }
+      }
+      const olResult = await lookupOpenLibrary(bookSearchTitle)
 
       // 2. Only call AI if Open Library left gaps
       const needsAI = !olResult
@@ -451,6 +460,15 @@ serve(async (req) => {
       }
 
       console.log('[enrich-link] Book enrichment result:', bookMeta)
+
+      // Prefer stable book cover (Open Library) over scraped og:image
+      if (bookMeta?.coverPath) {
+        const olCoverUrl = `https://covers.openlibrary.org/b/id/${bookMeta.coverPath}-L.jpg`
+        console.log('[enrich-link] Book cover from Open Library, overriding scraped image:', olCoverUrl)
+        imageUrl = olCoverUrl
+        imageSource = 'openlibrary'
+        imageScores = { evaluation_method: 'known_good_source', tier: 'trusted' }
+      }
     }
 
     // ========================================
@@ -1094,6 +1112,9 @@ async function lookupOpenLibrary(rawTitle: string): Promise<{
 
   // Clean title: strip common suffixes
   const cleanTitle = rawTitle
+    .replace(/\s*-\s*Wikipedia\s*$/i, '')  // "Hyperion (novel) - Wikipedia"
+    .replace(/\s*[\|\-–—]\s*Wikipedia\s*$/i, '')  // "Hyperion | Wikipedia"
+    .replace(/\s*\([^)]*(?:novel|book|story|memoir|essay|anthology|series|autobiography|biography|poem|play|novella|collection|treatise|manuscript)[^)]*\)\s*/gi, '')  // "(Simmons novel)"
     .replace(/\s*[\|\-–—]\s*(Goodreads|Amazon|Barnes & Noble|Bookshop|Book|Read|Review|Buy|Kindle|Audible|Open Library).*$/i, '')
     .replace(/\s*by\s+.+$/i, '')
     .replace(/\s*\(\d{4}\)\s*$/, '')
@@ -1518,7 +1539,8 @@ const LOGO_PATTERNS = [
   /placeholder/i, /default/i, /blank/i, /spacer/i,
   /pixel/i, /1x1/i, /transparent/i, /sprite/i,
   /tracking/i, /beacon/i, /badge/i, /button/i,
-  /banner-ad/i, /ad-banner/i, /widget-icon/i
+  /banner-ad/i, /ad-banner/i, /widget-icon/i,
+  /static\/images\/project-logos\//i  // Wikipedia project logos (globe icon)
 ]
 
 // Known CDN placeholder URL patterns
@@ -1528,7 +1550,9 @@ const PLACEHOLDER_URL_PATTERNS = [
   /fallback/i,
   /placeholder\.(jpg|png|gif|svg|webp)/i,
   /default\.(jpg|png|gif|svg|webp)/i,
-  /blank\.(jpg|png|gif|svg|webp)/i
+  /blank\.(jpg|png|gif|svg|webp)/i,
+  /Wikipedia-logo/i,  // Wikipedia logo files
+  /Wiki-logo/i        // Variant wiki logos
 ]
 
 function isLikelyLogo(url: string): boolean {


### PR DESCRIPTION
## Summary
- Strip Wikipedia suffixes and book disambiguation from titles before Open Library search
- Reject Wikipedia logo images (project-logos, Wikipedia-logo patterns) so books get OL covers instead
- Extract book title from Barnes & Noble URL slugs when scraping is blocked by Cloudflare
- Override scraped og:image with Open Library cover for all books (stable source priority)
- Client-side: clean Wikipedia titles in `fetchMetadata()` and `generateTitleFromUrl()`

## Test plan
- [ ] Paste Wikipedia book URL → title cleaned, OL cover shown (not Wikipedia logo)
- [ ] Paste B&N URL → title extracted from URL slug, OL metadata populated
- [ ] Existing watch items unaffected
- [ ] `supabase functions logs enrich-link` shows OL cover override for book enrichments

🤖 Generated with [Claude Code](https://claude.com/claude-code)