### PR TITLE
Fix suggestion infinite retry loop + deploy edge function

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6401,8 +6401,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.2.0';
-  console.log('[boards] v' + VERSION + ' - AI-powered dimension suggestions replace built-in keyword filters');
+  const VERSION = '2.2.2';
+  console.log('[boards] v' + VERSION + ' - Fix suggestion infinite retry loop + cache errors');
 
   // ============================================
   // Supabase Setup
@@ -13949,7 +13949,16 @@ Return JSON:
       const data = await res.json();
       console.log('[suggestions] Response for', category, ':', data);
 
-      if (data.error || !data.suggestions) return [];
+      if (data.error || !data.suggestions) {
+        console.warn('[suggestions] Error for', category, ':', data.error || 'no suggestions');
+        // Cache empty result with 5-min TTL to prevent infinite retry loop
+        localStorage.setItem(cacheKey, JSON.stringify({
+          suggestions: [],
+          pinCount: pins.length,
+          ts: Date.now() - 86400000 + 300000 // expires in 5 minutes
+        }));
+        return [];
+      }
 
       localStorage.setItem(cacheKey, JSON.stringify({
         suggestions: data.suggestions,
@@ -13959,6 +13968,12 @@ Return JSON:
       return data.suggestions;
     } catch (err) {
       console.error('[suggestions] Fetch failed for', category, ':', err);
+      // Cache empty result with 5-min TTL to prevent infinite retry loop
+      localStorage.setItem(cacheKey, JSON.stringify({
+        suggestions: [],
+        pinCount: pins.length,
+        ts: Date.now() - 86400000 + 300000
+      }));
       return [];
     }
   }


### PR DESCRIPTION
## Summary
- **Root cause**: The `generate-subcategories` edge function was never deployed with the `action: "suggest"` mode, so every suggestion request returned `"A prompt is required"` error
- **Infinite loop**: On error, `suggestDimensions()` returned `[]`, the `.then()` handler called `renderSubTags()`, which saw no cached suggestions and started a new fetch — endlessly
- **Fix**: Cache empty results on error with 5-minute TTL so the next render sees cached empty and stops retrying
- **Deploy**: Edge function with suggest mode now deployed to Supabase

## Test plan
- [ ] Hard refresh boards — no more infinite `[suggestions]` log spam
- [ ] After 5 minutes, suggestions auto-retry with working edge function
- [ ] Suggestion chips should appear for boards with 5+ pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)