### PR TITLE
Fix Other classification overload in filter dimensions

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6409,8 +6409,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.4.3';
-  console.log('[boards] v' + VERSION + ' - Add Clear Filter Dimensions to dev menu');
+  const VERSION = '2.4.4';
+  console.log('[boards] v' + VERSION + ' - Fix Other classification: auto-heal partial dims, clear caches on merge');
 
   // ============================================
   // Supabase Setup
@@ -13372,6 +13372,17 @@ Return JSON:
 
     save(data);
 
+    // Invalidate dimension caches — merged pin has new ID not in cached assignments
+    const cat = merged.category;
+    if (cat) {
+      clearPrecomputedDims(cat);
+      clearSuggestionCache(cat);
+      // Remove persisted dimensions (assignments reference deleted source IDs)
+      const dims = loadPromptDimensions(cat);
+      for (const d of dims) removePromptDimension(cat, d.id);
+      console.log('[merge] Cleared dimension caches for', cat);
+    }
+
     // Sync: delete sources, upload merged
     for (const id of sourceIds) {
       deleteLinkFromSupabase(id);
@@ -14163,13 +14174,16 @@ Return JSON:
       return;
     }
 
-    // Auto-heal broken persisted dims
+    // Auto-heal broken or partial persisted dims
     const promptDims = loadPromptDimensions(currentFilter);
     for (const pd of promptDims) {
+      if (!pd.prompt || healedDimIds.has(pd.id)) continue;
       const assigned = Object.values(pd.assignments || {}).filter(v => v);
-      if (assigned.length === 0 && pd.prompt && !healedDimIds.has(pd.id)) {
+      const totalPins = allCategoryLinks.length;
+      // Heal if: zero assignments, OR fewer than 50% of pins are assigned (truncated response)
+      if (assigned.length === 0 || (totalPins > 5 && assigned.length < totalPins * 0.5)) {
         healedDimIds.add(pd.id);
-        console.log('[dimensions] Auto-healing broken dimension:', pd.label);
+        console.log('[dimensions] Auto-healing dimension:', pd.label, '| assigned:', assigned.length, '/', totalPins);
         reanalyzeDimension(currentFilter, pd.id)
           .catch(err => console.warn('[dimensions] Auto-heal failed:', err));
       }

--- a/supabase/functions/generate-subcategories/index.ts
+++ b/supabase/functions/generate-subcategories/index.ts
@@ -222,7 +222,7 @@ Rules:
       },
       body: JSON.stringify({
         model: 'claude-3-haiku-20240307',
-        max_tokens: 1024,
+        max_tokens: 4096,
         messages: [
           { role: 'user', content: claudePrompt }
         ]
@@ -275,16 +275,28 @@ Rules:
       )
     }
 
-    // Ensure assignments only use valid tags
+    // Ensure assignments only use valid tags (with fuzzy matching)
     const validTags = new Set(result.tags)
+    // Build normalized lookup: "running shoes" / "Running Shoes" / "running-shoes" all match "running-shoes"
+    const normalizedTagMap: Record<string, string> = {}
+    for (const tag of result.tags) {
+      normalizedTagMap[tag] = tag
+      normalizedTagMap[tag.toLowerCase()] = tag
+      normalizedTagMap[tag.toLowerCase().replace(/[\s_]+/g, '-')] = tag
+      normalizedTagMap[tag.toLowerCase().replace(/[-_]+/g, ' ')] = tag
+    }
     const cleanAssignments: Record<string, string | null> = {}
     if (result.assignments && typeof result.assignments === 'object') {
       for (const [pinId, tag] of Object.entries(result.assignments)) {
-        if (typeof tag === 'string' && validTags.has(tag)) {
-          cleanAssignments[pinId] = tag
-        } else {
+        if (typeof tag !== 'string') {
           cleanAssignments[pinId] = null
+          continue
         }
+        // Try exact match first, then normalized variants
+        const matched = validTags.has(tag)
+          ? tag
+          : normalizedTagMap[tag] || normalizedTagMap[tag.toLowerCase()] || normalizedTagMap[tag.toLowerCase().replace(/[\s_]+/g, '-')] || normalizedTagMap[tag.toLowerCase().replace(/[-_]+/g, ' ')] || null
+        cleanAssignments[pinId] = matched
       }
     }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `max_tokens: 1024` in edge function truncated AI JSON response for boards with >20 pins, leaving most pins unassigned → all classified as "Other"
- Edge function: `max_tokens` 1024→4096 so the full classification response fits
- Edge function: case-insensitive fuzzy tag matching (normalizes hyphens, spaces, underscores, casing)
- Client: auto-heal now detects partial assignments (<50% assigned), not just zero
- Client: clears all dimension caches on pin merge (merged pins get new IDs not in cached assignments)

## Test plan
- [ ] Open a board with 10+ pins, click a filter suggestion → pins distributed across tags (not all "Other")
- [ ] Clear stale caches via Ctrl+Shift+D → "Clear Filter Dimensions"
- [ ] Merge two pins → verify dimension caches are cleared and re-classify on next filter use
- [ ] Verify edge function deployed: `supabase functions deploy generate-subcategories`

🤖 Generated with [Claude Code](https://claude.com/claude-code)