### PR TITLE
feat: add generate-podcast edge function for Echo app

### DIFF
--- a/supabase/functions/generate-podcast/index.ts
+++ b/supabase/functions/generate-podcast/index.ts
@@ -1,5 +1,5 @@
 // Supabase Edge Function: generate-podcast
-// 4-stage AI pipeline: source aggregation → bias classification → script generation → TTS synthesis
+// 4-stage AI pipeline: source aggregation → bias classification → script generation → ElevenLabs TTS
 //
 // POST /functions/v1/generate-podcast
 // Body: { topic: string, mode: "news" | "deep-dive" | "debate", userId?: string }
@@ -386,13 +386,28 @@ Respond with ONLY a JSON array of transcript cues:
 }
 
 // ============================================================
-// Stage 4: TTS Synthesis via OpenAI
+// Stage 4: TTS Synthesis via ElevenLabs
 // ============================================================
 
-const VOICE_MAP: Record<string, string> = {
-  synthesizer: 'alloy',
-  challenger: 'echo',
-  expert: 'fable',
+// ElevenLabs voice IDs — distinct characters for the podcast
+// These are pre-made voices from the ElevenLabs library.
+// Replace with custom/cloned voice IDs for a unique show identity.
+const VOICE_MAP: Record<string, { voiceId: string; stability: number; similarity: number }> = {
+  synthesizer: {
+    voiceId: 'pNInz6obpgDQGcFmaJgB',  // Adam — warm, measured, authoritative
+    stability: 0.6,
+    similarity: 0.8,
+  },
+  challenger: {
+    voiceId: 'ErXwobaYiN019PkySvjV',  // Antoni — direct, probing, energetic
+    stability: 0.4,                      // lower stability = more expressive/skeptical
+    similarity: 0.75,
+  },
+  expert: {
+    voiceId: 'VR6AewLTigWG4xSOukaG',  // Arnold — deep, precise, gravitas
+    stability: 0.7,
+    similarity: 0.85,
+  },
 }
 
 async function synthesizeCue(
@@ -401,28 +416,37 @@ async function synthesizeCue(
   episodeId: string,
   supabase: ReturnType<typeof createClient>
 ): Promise<string | null> {
-  const openaiKey = Deno.env.get('OPENAI_API_KEY')
-  if (!openaiKey) return null
+  const elevenLabsKey = Deno.env.get('ELEVENLABS_API_KEY')
+  if (!elevenLabsKey) return null
 
-  const voice = VOICE_MAP[cue.speaker] ?? 'alloy'
+  const voiceConfig = VOICE_MAP[cue.speaker] ?? VOICE_MAP.synthesizer
+  const { voiceId, stability, similarity } = voiceConfig
 
   try {
-    const res = await fetch('https://api.openai.com/v1/audio/speech', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${openaiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'tts-1',
-        voice,
-        input: cue.text,
-        response_format: 'mp3',
-      }),
-    })
+    const res = await fetch(
+      `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+      {
+        method: 'POST',
+        headers: {
+          'xi-api-key': elevenLabsKey,
+          'Content-Type': 'application/json',
+          'Accept': 'audio/mpeg',
+        },
+        body: JSON.stringify({
+          text: cue.text,
+          model_id: 'eleven_multilingual_v2',
+          voice_settings: {
+            stability,
+            similarity_boost: similarity,
+            style: 0.3,
+            use_speaker_boost: true,
+          },
+        }),
+      }
+    )
 
     if (!res.ok) {
-      console.error(`[generate-podcast] TTS failed for cue ${index}:`, res.status)
+      console.error(`[generate-podcast] ElevenLabs TTS failed for cue ${index}:`, res.status, await res.text())
       return null
     }
 
@@ -454,7 +478,7 @@ async function synthesizeAll(
   episodeId: string,
   supabase: ReturnType<typeof createClient>
 ): Promise<string[]> {
-  const BATCH_SIZE = 5
+  const BATCH_SIZE = 3  // ElevenLabs rate limits are tighter than OpenAI
   const audioUrls: (string | null)[] = new Array(transcript.length).fill(null)
 
   for (let i = 0; i < transcript.length; i += BATCH_SIZE) {


### PR DESCRIPTION
## Summary
- Adds `supabase/functions/generate-podcast/index.ts` — 4-stage AI pipeline for the Echo iOS app
- Stage 1: Source aggregation via SerpAPI (8-12 real sources per episode)
- Stage 2: Bias classification via Claude Haiku (left/center/right spectrum)
- Stage 3: Script generation via Claude Haiku (3 voices: Synthesizer, Challenger, Expert)
- Stage 4: TTS synthesis via OpenAI API (parallel batched, uploaded to Supabase Storage)

## Test plan
- [ ] Set `OPENAI_API_KEY` secret in Supabase dashboard
- [ ] Create `echo-audio` storage bucket in Supabase
- [ ] Deploy: `supabase functions deploy generate-podcast`
- [ ] Test via curl:
  ```bash
  curl -X POST "https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/generate-podcast" \
    -H "Authorization: Bearer $SUPABASE_ANON_KEY" \
    -H "Content-Type: application/json" \
    -d '{"topic": "AI regulation", "mode": "news"}'
  ```
- [ ] Verify response contains transcript, sources, bias distribution, and audio URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)