### PR TITLE
feat: Rodeo extension v2 — popup UI, context menus, direct saves

### DIFF
--- a/docs/strategy/prds/extension-v1.md
+++ b/docs/strategy/prds/extension-v1.md
@@ -1,0 +1,316 @@
+# Rodeo Browser Extension PRD
+
+**Version:** v1
+**Owner:** Rodeo
+**Status:** Draft
+
+---
+
+## 1. Overview
+
+### Objective
+
+Build a privacy-first browser extension that:
+
+1. Captures high-intent Pins (explicit saves) — click, context menu, text selection
+2. Captures low-intent History exhaust (behavioral signal) — Phase 2+
+3. Persists both to Rodeo backend (Supabase)
+4. Powers Rodeo's Taste Graph and Insight Engine
+5. Maintains strict separation between declared identity and behavioral signal
+
+The extension is Rodeo's primary ingestion layer.
+
+### Relationship to Existing Data Model
+
+| PRD Concept | Existing Infrastructure | Changes Needed |
+|-------------|------------------------|----------------|
+| Pin (explicit save) | `links` table (30+ columns) | Add `source`, `selected_text`, `device_id` columns |
+| Pin enrichment | `enrich-link` edge function | None — called as-is from extension |
+| History event | None | New `browsing_history` table (Phase 3) |
+| Taste Graph | `taste-graph` edge function + Taste Map | Extend to accept history signals (Phase 4) |
+| Signal weighting | `pin_interactions` table | New `domain_affinity`, `session_clusters` tables (Phase 4) |
+| User settings | None | `extension_settings` table + `chrome.storage.sync` (Phase 2) |
+
+---
+
+## 2. Product Vision
+
+Rodeo is a personal signal vault.
+
+The extension transforms browsing into:
+- **Declared Taste** (Pins) — high-intent, explicit saves to the `links` table
+- **Behavioral Signal** (History) — low-intent, passive browsing data
+- **Derived Intelligence** (Taste Graph) — AI-labeled clusters, motifs, bridges
+
+History (Phase 3+) is stored server-side to enable:
+- Cross-device unification
+- Pattern analysis / drift detection
+- Aggregated signal intelligence
+
+Raw browsing data must be minimized before persistence.
+
+---
+
+## 3. Scope
+
+### Phase 1 (This Release)
+- Chrome desktop, MV3
+- Enhanced pin capture (popup, context menu, text selection)
+- Direct-to-Supabase saves with async enrichment
+
+### Phase 2
+- Privacy & settings infrastructure (pause toggle, domain blocklist, deletion controls)
+
+### Phase 3
+- History capture & ingestion (backfill + live navigation events)
+- Safari Web Extension (macOS + iOS forward capture)
+
+### Phase 4
+- Taste graph integration (signal weighting, rabbit hole detection, gap analysis)
+
+---
+
+## 4. Core Features
+
+### 4.1 Pin Capture (High Intent) — Phase 1
+
+**Functional Requirements:**
+- Click extension icon → popup shows page info → SAVE button writes to `links` table
+- Right-click → "Save to Rodeo" context menu → saves directly
+- Highlight text → right-click → "Save to Rodeo" → saves with `selected_text`
+
+**Pin Data Model (maps to `links` table):**
+
+| Field | Column | Source |
+|-------|--------|--------|
+| user_id | `user_id` | From Supabase auth session |
+| pin_id | `id` | `crypto.randomUUID()` |
+| canonical_url | `url` | `normalizeUrl()` — same as boards |
+| title | `title` | From `tab.title`, enriched later |
+| description | `description` | Empty initially, enriched by `enrich-link` |
+| selected_text | `selected_text` | NEW — user-highlighted text (nullable) |
+| timestamp | `created_at` | ISO 8601 |
+| device_id | `device_id` | NEW — stable per chrome.storage.local |
+| source | `source` | NEW — 'explicit', 'context_menu', 'text_selection' |
+
+**Behavior:**
+- Immediately visible in Boards Library
+- Deduplication via URL match before insert
+- Indexed for search (existing `links` indexes)
+- `enrich-link` called async (fire-and-forget) for content type, image, metadata
+- Uses `Prefer: resolution=merge-duplicates` for safe upserts
+
+### 4.2 History Capture (Low Intent) — Phase 3
+
+Extension:
+- Reads local browser history (initial backfill, configurable window, default 30 days)
+- Listens to new navigation events via `chrome.webNavigation.onCompleted`
+- Processes events client-side before sending (sanitization pipeline)
+- Batches events and sends to `ingest-history` edge function
+
+---
+
+## 5. History Persistence (Backend) — Phase 3
+
+### 5.1 Why Persist
+
+History must be stored server-side to enable:
+- Cross-device merging
+- Longitudinal trend analysis via `domain_affinity` scores
+- Session clustering ("rabbit holes") via `session_clusters`
+- Integration with existing `taste-graph` edge function
+
+### 5.2 Data Minimization (Client-Side)
+
+Before transmission:
+- Strip query parameters with auth/session tokens
+- Hash sensitive URL paths (numeric segments > 5 digits → `:id`)
+- Remove PII
+- Exclude incognito sessions
+- Exclude domains in blocklist (default + user-editable)
+
+### 5.3 History Event Schema
+
+Stored in `browsing_history` table:
+
+| Column | Type | Notes |
+|--------|------|-------|
+| event_id | UUID | PK |
+| user_id | UUID | FK to auth.users |
+| device_id | TEXT | Matches `links.device_id` |
+| visited_at | TIMESTAMPTZ | When the page was visited |
+| canonical_domain | TEXT | e.g. 'github.com' |
+| url_hash | TEXT | SHA-256 of canonical URL, never raw URL |
+| page_title | TEXT | Truncated to 100 chars |
+| referrer_domain | TEXT | Domain only |
+| session_id | TEXT | Client-generated, gap-based (30min inactivity) |
+| source | TEXT | 'history' (backfill) or 'navigation' (live) |
+
+**UNIQUE constraint:** (user_id, url_hash, date_trunc('day', visited_at)) — one event per URL per day.
+
+### 5.4 Storage Architecture
+
+History is stored **separately from Pins** (different tables in the same Supabase project):
+
+| Store | Table | Optimization |
+|-------|-------|-------------|
+| Pins | `links` | Durable, rich metadata, indexed for search |
+| History | `browsing_history` | Append-only, write-heavy, time-indexed |
+| Derived Intelligence | `domain_affinity`, `session_clusters` | Computed periodically from history + pins |
+
+History database must not expose raw browsing logs in user UI.
+
+---
+
+## 6. Retention & Lifecycle — Phase 3
+
+### Default Policy
+- History: rolling 12 months (pg_cron daily cleanup)
+- Derived signals (`domain_affinity`, `session_clusters`): retained indefinitely unless user deletes
+- User may configure shorter retention window (future)
+
+### Deletion Requirements
+
+Cascade-delete on user request:
+- `browsing_history` events in time window
+- Related `domain_affinity` rows
+- Related `session_clusters` rows
+
+---
+
+## 7. Privacy Architecture — Phase 2
+
+### 7.1 User Controls (Mandatory)
+
+Extension popup settings tab:
+- Pause history capture toggle
+- Domain exclusion editor (one domain per line)
+- Delete last hour / last day / full purge buttons
+- View signal summary (aggregated only — top domains by affinity)
+
+No raw timeline viewer.
+
+### 7.2 Sensitive Domain Blocking
+
+Default blocklist (hardcoded in extension, merged with user list at runtime):
+- Email: mail.google.com, outlook.live.com, mail.yahoo.com
+- Banking: chase.com, bankofamerica.com, wellsfargo.com
+- Health: mychart.com, myhealth.kaiserpermanente.org
+- Government: irs.gov, ssa.gov, usa.gov
+- Work SaaS: okta.com, workday.com, adp.com (suffix match)
+
+Enforced client-side before transmission. User-editable.
+
+---
+
+## 8. Taste Graph Integration — Phase 4
+
+### Signal Weighting
+
+| Signal | Weight | Half-Life | Notes |
+|--------|--------|-----------|-------|
+| Explicit pin | 1.0 | 180 days | High signal, intentional |
+| History (5+ visit days) | 0.4 | 60 days | Strong passive interest |
+| History (2-4 visit days) | 0.15 | 30 days | Weak signal |
+| History (1 visit) | 0 | N/A | Excluded — too noisy |
+
+### Derived Outputs (from `browsing_history` + `links`)
+
+- **Session clustering**: "rabbit holes" — detected from `session_clusters` table
+- **Topic emergence**: new domains appearing in history that weren't there before
+- **Taste drift**: change in `domain_affinity` scores over time
+- **Domain affinity scores**: computed daily, stored in `domain_affinity`
+- **Gap detection**: high-affinity domains with zero pins → "You browse X but haven't saved from it"
+
+Raw history never directly surfaces in UI.
+
+---
+
+## 9. Security Architecture
+
+### Transport
+- HTTPS/TLS only (Supabase enforces)
+- All requests use Supabase JWT (user's `access_token`)
+
+### Storage
+- Supabase encryption at rest (default)
+- RLS policies on all tables: `auth.uid() = user_id`
+- No staff access to raw browsing data
+
+### Extension Security
+- Supabase anon key is public (same as in boards/index.html)
+- User access token never logged, never in URLs
+- `scripting` permission scoped to `https://ctrl.rodeo/*` via host_permissions
+- Raw browsing URLs never leave the device (only hashed)
+
+---
+
+## 10. Permissions (Chrome MV3)
+
+### Phase 1
+- `activeTab` — read current tab info
+- `storage` — cache auth session, device ID
+- `contextMenus` — "Save to Rodeo" right-click menu
+- `scripting` — read auth from ctrl.rodeo localStorage
+- `host_permissions: ["https://ctrl.rodeo/*"]`
+
+### Phase 3 (Additional)
+- `history` — read browser history for backfill
+- `tabs` — detect tab navigation, check incognito
+- `webNavigation` — listen for navigation events
+
+Permission justification: "Rodeo uses browsing history to build your private taste graph. History is private, encrypted, and never shared."
+
+---
+
+## 11. UX Principles
+
+1. Transparent about persistence
+2. User-controlled
+3. Reversible
+4. Minimal
+5. Non-invasive
+
+Never surprise the user with inferred sensitive insights.
+
+---
+
+## 12. Non-Goals (v1)
+
+- Social graph
+- Public browsing visualization
+- Feed-style discovery
+- Selling behavioral data
+- Raw history viewer
+
+---
+
+## 13. Success Metrics
+
+### Activation
+- % install → first pin saved via extension
+- % users enabling history capture (Phase 3)
+
+### Depth
+- Avg pins per week via extension
+- Avg clusters per user (Phase 4)
+- % users with 3+ recurring themes (Phase 4)
+
+### Trust
+- History opt-out rate (Phase 3)
+- Domain exclusion edits (Phase 2)
+- Deletion requests (Phase 2)
+
+Healthy trust = high usage + low opt-out + moderate control engagement.
+
+---
+
+## 14. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Breach blast radius (history storage) | Minimize raw data, hash URLs, encrypt at rest |
+| Regulatory scrutiny (GDPR/CCPA) | Clear deletion tools, no ad monetization |
+| User perception of surveillance | Transparent controls, pause toggle, no raw viewer |
+| App Store review friction (Safari) | Phase 3 — clear privacy justification |
+| Schema cache miss on new columns | Retry with column stripping (matches boards pattern) |

--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -1,22 +1,237 @@
-// Boards — Save Links
-// Service worker: handles toolbar button click
+// Rodeo — Save & Discover
+// Service worker: context menus, message routing, pin save flow
+
+importScripts('lib/sanitize.js', 'lib/supabase.js', 'lib/auth.js');
 
 const BOARDS_URL = 'https://ctrl.rodeo/boards/';
 
-chrome.action.onClicked.addListener(async (tab) => {
-  if (!tab.url || tab.url.startsWith('chrome://') || tab.url.startsWith('chrome-extension://')) {
-    return;
+// ============================================
+// Device ID (stable per install)
+// ============================================
+async function getOrCreateDeviceId() {
+  const data = await chrome.storage.local.get('rodeo_device_id');
+  if (data.rodeo_device_id) return data.rodeo_device_id;
+  const id = crypto.randomUUID();
+  await chrome.storage.local.set({ rodeo_device_id: id });
+  return id;
+}
+
+// ============================================
+// Context Menu Setup
+// ============================================
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'save-to-rodeo',
+    title: 'Save to Rodeo',
+    contexts: ['page', 'link', 'selection']
+  });
+});
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId !== 'save-to-rodeo') return;
+
+  let url, title, selectedText, source;
+
+  if (info.selectionText) {
+    // Text selection — save current page with the selected text
+    url = tab.url;
+    title = tab.title;
+    selectedText = info.selectionText.trim().slice(0, 2000);
+    source = 'text_selection';
+  } else if (info.linkUrl) {
+    // Right-click on a link — save the link URL
+    url = info.linkUrl;
+    title = info.linkUrl; // will be enriched later
+    selectedText = null;
+    source = 'context_menu';
+  } else {
+    // Right-click on page — save current page
+    url = tab.url;
+    title = tab.title;
+    selectedText = null;
+    source = 'context_menu';
   }
 
-  const addUrl = `${BOARDS_URL}?add=${encodeURIComponent(tab.url)}`;
+  const result = await savePin({ url, title, selectedText, source });
 
-  // Check if Boards is already open in this window
-  const tabs = await chrome.tabs.query({ url: `${BOARDS_URL}*`, currentWindow: true });
-
-  if (tabs.length > 0) {
-    // Reuse the existing Boards tab
-    chrome.tabs.update(tabs[0].id, { url: addUrl, active: true });
+  // Show badge feedback
+  if (result.success) {
+    showBadge(tab.id, 'OK', '#0f0');
+  } else if (result.error === 'duplicate') {
+    showBadge(tab.id, 'DUP', '#f90');
+  } else if (result.error === 'not_authenticated') {
+    showBadge(tab.id, '!', '#c00');
   } else {
-    chrome.tabs.create({ url: addUrl });
+    showBadge(tab.id, 'ERR', '#c00');
   }
 });
+
+// ============================================
+// Badge Feedback (context menu saves)
+// ============================================
+function showBadge(tabId, text, color) {
+  chrome.action.setBadgeText({ text, tabId });
+  chrome.action.setBadgeBackgroundColor({ color, tabId });
+  setTimeout(() => {
+    chrome.action.setBadgeText({ text: '', tabId }).catch(() => {});
+  }, 2000);
+}
+
+// ============================================
+// Message Routing
+// ============================================
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'auth_token') {
+    // Content script on ctrl.rodeo relaying auth session
+    handleAuthRelay(msg.session);
+    sendResponse({ ok: true });
+    return false;
+  }
+
+  if (msg.action === 'save') {
+    // Popup requesting a save
+    savePin(msg.data).then(sendResponse);
+    return true; // async response
+  }
+
+  if (msg.action === 'get_session') {
+    // Popup checking auth state
+    getSession().then(sendResponse);
+    return true;
+  }
+
+  if (msg.action === 'get_tab_info') {
+    // Popup requesting current tab info
+    chrome.tabs.query({ active: true, currentWindow: true }).then(tabs => {
+      const tab = tabs[0];
+      if (!tab || !tab.url || tab.url.startsWith('chrome://') || tab.url.startsWith('chrome-extension://')) {
+        sendResponse({ error: 'unsupported_page' });
+      } else {
+        sendResponse({
+          url: tab.url,
+          title: tab.title || '',
+          domain: extractDomain(tab.url)
+        });
+      }
+    });
+    return true;
+  }
+
+  if (msg.action === 'selection_update') {
+    // Content script reporting text selection
+    chrome.storage.session.set({
+      rodeo_selection: msg.text,
+      rodeo_selection_url: msg.url,
+      rodeo_selection_at: Date.now()
+    });
+    return false;
+  }
+
+  if (msg.action === 'get_selection') {
+    // Popup checking for recent text selection
+    chrome.storage.session.get(
+      ['rodeo_selection', 'rodeo_selection_url', 'rodeo_selection_at']
+    ).then(data => {
+      // Only return selection if it's recent (< 30s) and from the same URL
+      if (data.rodeo_selection && data.rodeo_selection_at &&
+          Date.now() - data.rodeo_selection_at < 30000 &&
+          data.rodeo_selection_url === msg.url) {
+        sendResponse({ text: data.rodeo_selection });
+      } else {
+        sendResponse({ text: null });
+      }
+    });
+    return true;
+  }
+
+  if (msg.action === 'open_boards') {
+    chrome.tabs.create({ url: BOARDS_URL });
+    return false;
+  }
+});
+
+// ============================================
+// Save Pin Flow
+// ============================================
+async function savePin({ url, title, selectedText, source }) {
+  // Validate URL
+  const canonical = normalizeUrl(url);
+  if (!canonical) return { error: 'invalid_url' };
+
+  // Get auth
+  const session = await getSession();
+  if (!session || !session.access_token || !session.user) {
+    return { error: 'not_authenticated' };
+  }
+
+  const accessToken = session.access_token;
+  const userId = session.user.id;
+
+  // Check for duplicate (GET /rest/v1/links?url=eq.<url>&user_id=eq.<id>&select=id)
+  try {
+    const checkRes = await supabaseGet(
+      `/rest/v1/links?url=eq.${encodeURIComponent(canonical)}&user_id=eq.${userId}&select=id`,
+      accessToken
+    );
+    if (checkRes.ok) {
+      const existing = await checkRes.json();
+      if (existing.length > 0) {
+        return { error: 'duplicate', pinId: existing[0].id };
+      }
+    }
+  } catch (e) {
+    console.warn('[rodeo] dedup check failed, proceeding with save:', e.message);
+  }
+
+  // Build payload (matches syncLinkToSupabase shape)
+  const deviceId = await getOrCreateDeviceId();
+  const pinId = crypto.randomUUID();
+  const domain = extractDomain(canonical);
+  const pinTitle = title || titleFromUrl(canonical);
+
+  const payload = {
+    id: pinId,
+    user_id: userId,
+    url: canonical,
+    title: pinTitle,
+    description: '',
+    domain: domain,
+    category: 'uncategorized',
+    confidence: 0,
+    source: source || 'explicit',
+    selected_text: selectedText || null,
+    device_id: deviceId,
+    created_at: new Date().toISOString()
+  };
+
+  // Insert with merge-duplicates (same Prefer header as boards/index.html:12441)
+  const res = await supabasePost('/rest/v1/links', payload, accessToken, {
+    'Prefer': 'resolution=merge-duplicates'
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    console.error('[rodeo] save failed:', res.status, errBody);
+
+    // If a column is unrecognized (schema cache), retry without it
+    if (errBody.includes('schema cache')) {
+      const colMatch = errBody.match(/Could not find the '(\w+)' column/);
+      if (colMatch) {
+        delete payload[colMatch[1]];
+        const retry = await supabasePost('/rest/v1/links', payload, accessToken, {
+          'Prefer': 'resolution=merge-duplicates'
+        });
+        if (retry.ok) {
+          triggerEnrichment({ url: canonical, title: pinTitle, linkId: pinId });
+          return { success: true, pinId };
+        }
+      }
+    }
+    return { error: 'save_failed', status: res.status };
+  }
+
+  // Fire-and-forget enrichment
+  triggerEnrichment({ url: canonical, title: pinTitle, linkId: pinId });
+
+  return { success: true, pinId };
+}

--- a/extension/chrome/content-selection.js
+++ b/extension/chrome/content-selection.js
@@ -1,0 +1,16 @@
+// Rodeo — Content script for all pages
+// Tracks text selection for contextual pin capture
+
+document.addEventListener('mouseup', () => {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  const text = selection.toString().trim();
+  if (text.length >= 10 && text.length <= 2000) {
+    chrome.runtime.sendMessage({
+      action: 'selection_update',
+      text: text,
+      url: window.location.href
+    });
+  }
+});

--- a/extension/chrome/content.js
+++ b/extension/chrome/content.js
@@ -1,4 +1,33 @@
-// Boards — Save Links
-// Content script: marks extension as installed for the web app to detect
+// Rodeo — Content script for ctrl.rodeo pages
+// 1. Marks extension as installed (backward compat with boards/index.html detection)
+// 2. Relays auth session to background service worker
 
 document.documentElement.setAttribute('data-boards-extension', 'installed');
+
+// Relay Supabase auth session to the background service worker
+// so the extension can make authenticated API calls
+const AUTH_KEY = 'sb-yfhudwakpgzswiylhfbh-auth-token';
+
+function relayAuth() {
+  try {
+    const raw = localStorage.getItem(AUTH_KEY);
+    if (raw) {
+      const session = JSON.parse(raw);
+      chrome.runtime.sendMessage({ action: 'auth_token', session });
+    }
+  } catch {}
+}
+
+// Relay immediately and on storage changes
+relayAuth();
+
+window.addEventListener('storage', (e) => {
+  if (e.key === AUTH_KEY) {
+    relayAuth();
+  }
+});
+
+// Re-relay periodically in case session was refreshed
+// (Supabase auto-refresh updates localStorage without firing storage events
+//  when the update happens in the same tab)
+setInterval(relayAuth, 60000);

--- a/extension/chrome/lib/auth.js
+++ b/extension/chrome/lib/auth.js
@@ -1,0 +1,115 @@
+// Rodeo Extension — Auth session management
+// Reads Supabase session from ctrl.rodeo localStorage via content script relay
+
+const AUTH_STORAGE_KEY = 'sb-yfhudwakpgzswiylhfbh-auth-token';
+const SESSION_CACHE_KEY = 'rodeo_session';
+const SESSION_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// Get the cached session from chrome.storage.session (fast, in-memory)
+async function getCachedSession() {
+  try {
+    const data = await chrome.storage.session.get([SESSION_CACHE_KEY, 'rodeo_session_at']);
+    if (!data[SESSION_CACHE_KEY]) return null;
+
+    // Check TTL
+    const cachedAt = data.rodeo_session_at || 0;
+    if (Date.now() - cachedAt > SESSION_TTL_MS) return null;
+
+    return data[SESSION_CACHE_KEY];
+  } catch {
+    return null;
+  }
+}
+
+// Cache a session in chrome.storage.session
+async function cacheSession(session) {
+  try {
+    await chrome.storage.session.set({
+      [SESSION_CACHE_KEY]: session,
+      rodeo_session_at: Date.now()
+    });
+  } catch (e) {
+    console.warn('[rodeo] failed to cache session:', e.message);
+  }
+}
+
+// Clear the cached session
+async function clearCachedSession() {
+  try {
+    await chrome.storage.session.remove([SESSION_CACHE_KEY, 'rodeo_session_at']);
+  } catch {}
+}
+
+// Try to read auth from a ctrl.rodeo tab via scripting API
+async function readSessionFromTab() {
+  try {
+    const tabs = await chrome.tabs.query({ url: 'https://ctrl.rodeo/*' });
+    if (tabs.length === 0) return null;
+
+    const [result] = await chrome.scripting.executeScript({
+      target: { tabId: tabs[0].id },
+      func: (key) => {
+        const raw = localStorage.getItem(key);
+        return raw ? JSON.parse(raw) : null;
+      },
+      args: [AUTH_STORAGE_KEY]
+    });
+
+    return result?.result || null;
+  } catch (e) {
+    console.warn('[rodeo] failed to read session from tab:', e.message);
+    return null;
+  }
+}
+
+// Get a valid session — checks cache first, then tries tab injection
+async function getSession() {
+  // 1. Check cache
+  const cached = await getCachedSession();
+  if (cached) return cached;
+
+  // 2. Check chrome.storage.local (set by content script relay)
+  try {
+    const local = await chrome.storage.local.get(SESSION_CACHE_KEY);
+    if (local[SESSION_CACHE_KEY]) {
+      const session = local[SESSION_CACHE_KEY];
+      // Validate token is not expired (JWT exp claim)
+      if (isTokenValid(session.access_token)) {
+        await cacheSession(session);
+        return session;
+      }
+    }
+  } catch {}
+
+  // 3. Try reading from an open ctrl.rodeo tab
+  const tabSession = await readSessionFromTab();
+  if (tabSession) {
+    await cacheSession(tabSession);
+    // Also persist to local storage for future use
+    try {
+      await chrome.storage.local.set({ [SESSION_CACHE_KEY]: tabSession });
+    } catch {}
+    return tabSession;
+  }
+
+  return null;
+}
+
+// Basic JWT expiry check (decode payload, check exp)
+function isTokenValid(token) {
+  if (!token) return false;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    // Allow 30s buffer
+    return payload.exp && (payload.exp * 1000) > (Date.now() - 30000);
+  } catch {
+    return false;
+  }
+}
+
+// Handle auth token relayed from content script on ctrl.rodeo
+async function handleAuthRelay(session) {
+  if (!session) return;
+  await cacheSession(session);
+  await chrome.storage.local.set({ [SESSION_CACHE_KEY]: session });
+}

--- a/extension/chrome/lib/sanitize.js
+++ b/extension/chrome/lib/sanitize.js
@@ -1,0 +1,44 @@
+// Rodeo Extension — URL canonicalization and domain extraction
+// Matches normalizeUrl() and extractDomain() from boards/index.html:10980-10996
+
+function normalizeUrl(url) {
+  if (!url) return null;
+  let n = url.trim();
+  if (!/^https?:\/\//i.test(n)) {
+    n = 'https://' + n;
+  }
+  n = n.replace(/\/+$/, '');
+  try {
+    const u = new URL(n);
+    return u.toString().replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
+
+function extractDomain(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
+// Generate a title from URL when page title is unavailable
+function titleFromUrl(url) {
+  try {
+    const u = new URL(url);
+    const path = u.pathname.replace(/^\/|\/$/g, '');
+    if (path) {
+      // /some/page-name → "Some Page Name"
+      return path.split('/').pop()
+        .replace(/[-_]/g, ' ')
+        .replace(/\.\w+$/, '')
+        .replace(/\b\w/g, c => c.toUpperCase())
+        .trim() || u.hostname;
+    }
+    return u.hostname;
+  } catch {
+    return url;
+  }
+}

--- a/extension/chrome/lib/supabase.js
+++ b/extension/chrome/lib/supabase.js
@@ -1,0 +1,58 @@
+// Rodeo Extension — Minimal Supabase REST client
+// Matches raw fetch pattern from boards/index.html:12435
+
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+
+async function supabasePost(path, body, accessToken, extraHeaders = {}) {
+  return fetch(`${SUPABASE_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': SUPABASE_ANON_KEY,
+      'Authorization': `Bearer ${accessToken}`,
+      ...extraHeaders
+    },
+    body: JSON.stringify(body)
+  });
+}
+
+async function supabaseGet(path, accessToken) {
+  return fetch(`${SUPABASE_URL}${path}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': SUPABASE_ANON_KEY,
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+}
+
+async function supabaseDelete(path, accessToken) {
+  return fetch(`${SUPABASE_URL}${path}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': SUPABASE_ANON_KEY,
+      'Authorization': `Bearer ${accessToken}`
+    }
+  });
+}
+
+// Fire-and-forget enrichment trigger
+// Uses anon key auth (matches boards/index.html:10477-10481)
+async function triggerEnrichment({ url, title, description, linkId }) {
+  try {
+    await fetch(`${SUPABASE_URL}/functions/v1/enrich-link`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+      },
+      body: JSON.stringify({ url, title, description, linkId })
+    });
+  } catch (e) {
+    // Enrichment is best-effort from extension — swallow errors
+    console.warn('[rodeo] enrichment trigger failed:', e.message);
+  }
+}

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Boards — Save Links",
-  "version": "1.0.0",
-  "description": "Save links to your Boards collection with one click",
+  "name": "Rodeo — Save & Discover",
+  "version": "2.0.0",
+  "description": "Save links, highlight text, and build your taste library",
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",
@@ -10,7 +10,8 @@
     "128": "icons/icon-128.png"
   },
   "action": {
-    "default_title": "Save to Boards",
+    "default_popup": "popup.html",
+    "default_title": "Save to Rodeo",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",
@@ -25,9 +26,16 @@
       "matches": ["https://ctrl.rodeo/*"],
       "js": ["content.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-selection.js"],
+      "run_at": "document_idle",
+      "exclude_matches": ["chrome://*/*", "chrome-extension://*/*"]
     }
   ],
-  "permissions": ["activeTab"],
+  "permissions": ["activeTab", "storage", "contextMenus", "scripting"],
+  "host_permissions": ["https://ctrl.rodeo/*"],
   "externally_connectable": {
     "matches": ["https://ctrl.rodeo/*"]
   }

--- a/extension/chrome/popup.css
+++ b/extension/chrome/popup.css
@@ -1,0 +1,291 @@
+/* Rodeo Extension — Popup Styles
+   Design system tokens ported from design-system/tokens.css
+   Dark-first, Space Grotesk, minimal */
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --color-black: #000;
+  --color-white: #fff;
+  --gray-100: #111;
+  --gray-200: #1a1a1a;
+  --gray-300: #222;
+  --gray-400: #333;
+  --gray-500: #666;
+  --gray-600: #999;
+  --color-success: #0f0;
+  --color-error: #c00;
+  --color-warning: #f90;
+
+  --bg: var(--gray-100);
+  --bg-surface: var(--gray-200);
+  --fg: var(--color-white);
+  --fg-muted: var(--gray-600);
+  --fg-subtle: var(--gray-500);
+  --border: var(--color-white);
+  --border-subtle: var(--gray-400);
+
+  --font-primary: "Space Grotesk", sans-serif;
+  --text-xs: 10px;
+  --text-sm: 10px;
+  --text-lg: 12px;
+  --text-xl: 14px;
+  --text-2xl: 18px;
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+
+  --radius-sm: 2px;
+  --duration-fast: 0.1s;
+  --duration-normal: 0.15s;
+}
+
+body {
+  width: 320px;
+  min-height: 120px;
+  max-height: 480px;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-primary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  overflow: hidden;
+}
+
+/* ============================================
+   States
+   ============================================ */
+.state {
+  padding: var(--space-4);
+}
+
+.state[hidden] {
+  display: none;
+}
+
+/* ============================================
+   Logo
+   ============================================ */
+.logo {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.3em;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-3);
+}
+
+/* ============================================
+   Buttons (matches design-system .btn patterns)
+   ============================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-primary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: all var(--duration-normal) ease;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.btn--filled {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+
+.btn--filled:hover {
+  background: transparent;
+  color: var(--fg);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--fg);
+  border-color: var(--border-subtle);
+}
+
+.btn--outline:hover {
+  border-color: var(--fg);
+}
+
+.btn--block {
+  width: 100%;
+}
+
+/* ============================================
+   Loading
+   ============================================ */
+#state-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.loading-spinner {
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border-subtle);
+  border-top-color: var(--fg);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ============================================
+   Auth State
+   ============================================ */
+.auth-container {
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.auth-message {
+  color: var(--fg-muted);
+  margin-bottom: var(--space-4);
+}
+
+/* ============================================
+   Unsupported State
+   ============================================ */
+.unsupported-container {
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.unsupported-message {
+  color: var(--fg-subtle);
+}
+
+/* ============================================
+   Save State
+   ============================================ */
+.save-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.save-preview {
+  margin-bottom: var(--space-4);
+}
+
+.save-domain {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+  margin-bottom: var(--space-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.save-title {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ============================================
+   Selection Preview
+   ============================================ */
+.selection-preview {
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-left: 2px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+
+.selection-label {
+  font-size: 8px;
+  letter-spacing: 0.2em;
+  color: var(--fg-subtle);
+  margin-bottom: var(--space-1);
+}
+
+.selection-text {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-style: italic;
+}
+
+/* ============================================
+   Saving State
+   ============================================ */
+.saving-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6) 0;
+  gap: var(--space-3);
+}
+
+.saving-message {
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* ============================================
+   Saved State
+   ============================================ */
+.saved-container {
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.saved-check {
+  font-size: var(--text-2xl);
+  color: var(--color-success);
+  margin-bottom: var(--space-2);
+}
+
+.duplicate-check {
+  color: var(--color-warning);
+}
+
+.saved-message {
+  color: var(--fg-muted);
+  margin-bottom: var(--space-4);
+}
+
+/* ============================================
+   Error State
+   ============================================ */
+.error-container {
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.error-message {
+  color: var(--color-error);
+  margin-bottom: var(--space-4);
+}

--- a/extension/chrome/popup.html
+++ b/extension/chrome/popup.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=360">
+  <title>Rodeo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+
+  <!-- State: Loading -->
+  <div id="state-loading" class="state">
+    <div class="loading-spinner"></div>
+  </div>
+
+  <!-- State: Not signed in -->
+  <div id="state-auth" class="state" hidden>
+    <div class="auth-container">
+      <div class="logo">RODEO</div>
+      <p class="auth-message">Sign in to start saving</p>
+      <button id="btn-signin" class="btn btn--filled btn--block">
+        Open ctrl.rodeo
+      </button>
+    </div>
+  </div>
+
+  <!-- State: Unsupported page -->
+  <div id="state-unsupported" class="state" hidden>
+    <div class="unsupported-container">
+      <div class="logo">RODEO</div>
+      <p class="unsupported-message">Can't save this page</p>
+    </div>
+  </div>
+
+  <!-- State: Ready to save -->
+  <div id="state-save" class="state" hidden>
+    <div class="save-header">
+      <div class="logo">RODEO</div>
+    </div>
+
+    <div class="save-preview">
+      <div class="save-domain" id="save-domain"></div>
+      <div class="save-title" id="save-title"></div>
+      <div id="selection-preview" class="selection-preview" hidden>
+        <div class="selection-label">SELECTED TEXT</div>
+        <div class="selection-text" id="selection-text"></div>
+      </div>
+    </div>
+
+    <button id="btn-save" class="btn btn--filled btn--block">
+      Save to Rodeo
+    </button>
+  </div>
+
+  <!-- State: Saving -->
+  <div id="state-saving" class="state" hidden>
+    <div class="saving-container">
+      <div class="loading-spinner"></div>
+      <p class="saving-message">Saving...</p>
+    </div>
+  </div>
+
+  <!-- State: Saved -->
+  <div id="state-saved" class="state" hidden>
+    <div class="saved-container">
+      <div class="saved-check">&#10003;</div>
+      <p class="saved-message">Saved</p>
+      <button id="btn-view" class="btn btn--outline btn--block">
+        View in Library
+      </button>
+    </div>
+  </div>
+
+  <!-- State: Already saved (duplicate) -->
+  <div id="state-duplicate" class="state" hidden>
+    <div class="saved-container">
+      <div class="saved-check duplicate-check">&#9679;</div>
+      <p class="saved-message">Already in your library</p>
+      <button id="btn-view-dup" class="btn btn--outline btn--block">
+        View in Library
+      </button>
+    </div>
+  </div>
+
+  <!-- State: Error -->
+  <div id="state-error" class="state" hidden>
+    <div class="error-container">
+      <p class="error-message" id="error-message">Something went wrong</p>
+      <button id="btn-retry" class="btn btn--outline btn--block">
+        Try Again
+      </button>
+    </div>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/chrome/popup.js
+++ b/extension/chrome/popup.js
@@ -1,0 +1,168 @@
+// Rodeo Extension — Popup controller
+// Manages UI state: loading → auth → save → saving → saved
+
+const BOARDS_URL = 'https://ctrl.rodeo/boards/';
+
+// UI elements
+const states = {
+  loading: document.getElementById('state-loading'),
+  auth: document.getElementById('state-auth'),
+  unsupported: document.getElementById('state-unsupported'),
+  save: document.getElementById('state-save'),
+  saving: document.getElementById('state-saving'),
+  saved: document.getElementById('state-saved'),
+  duplicate: document.getElementById('state-duplicate'),
+  error: document.getElementById('state-error')
+};
+
+// Current page data (set during init)
+let currentTab = null;
+let currentSelection = null;
+
+// ============================================
+// State Management
+// ============================================
+function showState(name) {
+  Object.entries(states).forEach(([key, el]) => {
+    el.hidden = key !== name;
+  });
+}
+
+// ============================================
+// Init — runs when popup opens
+// ============================================
+async function init() {
+  showState('loading');
+
+  // Get current tab info + auth session in parallel
+  const [tabInfo, session] = await Promise.all([
+    sendMessage({ action: 'get_tab_info' }),
+    sendMessage({ action: 'get_session' })
+  ]);
+
+  // Check tab
+  if (!tabInfo || tabInfo.error) {
+    showState('unsupported');
+    return;
+  }
+
+  currentTab = tabInfo;
+
+  // Check auth
+  if (!session || !session.access_token || !session.user) {
+    showState('auth');
+    return;
+  }
+
+  // Check for text selection on this page
+  const selResult = await sendMessage({
+    action: 'get_selection',
+    url: tabInfo.url
+  });
+
+  if (selResult && selResult.text) {
+    currentSelection = selResult.text;
+  }
+
+  // Populate save state
+  document.getElementById('save-domain').textContent = tabInfo.domain;
+  document.getElementById('save-title').textContent = tabInfo.title || tabInfo.url;
+
+  if (currentSelection) {
+    document.getElementById('selection-text').textContent = currentSelection;
+    document.getElementById('selection-preview').hidden = false;
+  }
+
+  showState('save');
+}
+
+// ============================================
+// Save Flow
+// ============================================
+async function handleSave() {
+  showState('saving');
+
+  const result = await sendMessage({
+    action: 'save',
+    data: {
+      url: currentTab.url,
+      title: currentTab.title,
+      selectedText: currentSelection,
+      source: currentSelection ? 'text_selection' : 'explicit'
+    }
+  });
+
+  if (!result) {
+    showError('No response from extension');
+    return;
+  }
+
+  if (result.success) {
+    showState('saved');
+    return;
+  }
+
+  if (result.error === 'duplicate') {
+    showState('duplicate');
+    return;
+  }
+
+  if (result.error === 'not_authenticated') {
+    showState('auth');
+    return;
+  }
+
+  showError(result.error === 'save_failed'
+    ? `Save failed (${result.status})`
+    : result.error || 'Unknown error');
+}
+
+function showError(message) {
+  document.getElementById('error-message').textContent = message;
+  showState('error');
+}
+
+// ============================================
+// Event Listeners
+// ============================================
+document.getElementById('btn-signin').addEventListener('click', () => {
+  chrome.runtime.sendMessage({ action: 'open_boards' });
+  window.close();
+});
+
+document.getElementById('btn-save').addEventListener('click', handleSave);
+
+document.getElementById('btn-view').addEventListener('click', () => {
+  chrome.tabs.create({ url: BOARDS_URL });
+  window.close();
+});
+
+document.getElementById('btn-view-dup').addEventListener('click', () => {
+  chrome.tabs.create({ url: BOARDS_URL });
+  window.close();
+});
+
+document.getElementById('btn-retry').addEventListener('click', () => {
+  handleSave();
+});
+
+// ============================================
+// Messaging Helper
+// ============================================
+function sendMessage(msg) {
+  return new Promise(resolve => {
+    chrome.runtime.sendMessage(msg, response => {
+      if (chrome.runtime.lastError) {
+        console.warn('[rodeo popup]', chrome.runtime.lastError.message);
+        resolve(null);
+      } else {
+        resolve(response);
+      }
+    });
+  });
+}
+
+// ============================================
+// Start
+// ============================================
+init();

--- a/supabase/migrations/022_extension_capture_columns.sql
+++ b/supabase/migrations/022_extension_capture_columns.sql
@@ -1,0 +1,13 @@
+-- Migration 022: Extension capture columns
+-- Adds source tracking, text selection capture, and device identification
+-- for the enhanced Rodeo browser extension (Phase 1)
+
+-- Capture source: how the pin was created
+-- Values: 'explicit' (default/toolbar), 'context_menu', 'text_selection', 'bookmarklet'
+ALTER TABLE links ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'explicit';
+
+-- User-highlighted text when pin was created via text selection
+ALTER TABLE links ADD COLUMN IF NOT EXISTS selected_text TEXT;
+
+-- Stable per-device identifier from chrome.storage.local
+ALTER TABLE links ADD COLUMN IF NOT EXISTS device_id TEXT;


### PR DESCRIPTION
## Summary

- Upgrades the Chrome extension from a minimal tab-redirect (v1.0) to a full pin capture layer (v2.0)
- Adds popup UI with auth detection, page preview, and one-click save flow
- Adds "Save to Rodeo" context menu for pages, links, and text selections
- Writes pins directly to Supabase REST API (matching boards/index.html syncLinkToSupabase pattern)
- Triggers async enrichment via enrich-link edge function
- Adds migration 022: `source`, `selected_text`, `device_id` columns on `links` table
- Creates Extension PRD at `docs/strategy/prds/extension-v1.md` with full 4-phase roadmap

## Architecture

```
Extension (MV3 service worker)
  ├── popup.html/js/css — Save UI (auth → save → success states)
  ├── background.js — Context menus, message routing, savePin() flow
  ├── content.js — Auth relay from ctrl.rodeo localStorage
  ├── content-selection.js — Text selection tracking on all pages
  └── lib/
      ├── supabase.js — Minimal REST client (no SDK)
      ├── auth.js — Session cache (chrome.storage.session, 5-min TTL)
      └── sanitize.js — URL normalization, domain extraction
```

## New Files
| File | Purpose |
|------|---------|
| `extension/chrome/popup.html` | Extension popup (360px wide, dark-first) |
| `extension/chrome/popup.css` | Design system tokens ported to popup |
| `extension/chrome/popup.js` | Auth detection, save flow, UI state |
| `extension/chrome/content-selection.js` | Text selection tracking |
| `extension/chrome/lib/supabase.js` | Raw fetch client matching boards pattern |
| `extension/chrome/lib/auth.js` | Session cache + ctrl.rodeo token relay |
| `extension/chrome/lib/sanitize.js` | normalizeUrl(), extractDomain() |
| `supabase/migrations/022_extension_capture_columns.sql` | 3 new columns on links |
| `docs/strategy/prds/extension-v1.md` | Full PRD with Phase 1-4 roadmap |

## Test plan
- [ ] Load unpacked extension in chrome://extensions (developer mode)
- [ ] Click extension icon on any page → popup shows page title + domain
- [ ] Not signed in → shows "Sign in to Rodeo" prompt
- [ ] Sign in at ctrl.rodeo/boards/ → popup shows save button
- [ ] Click SAVE → pin appears in success state
- [ ] Open ctrl.rodeo/boards/ → new pin visible in library
- [ ] Right-click on page → "Save to Rodeo" → badge shows OK
- [ ] Right-click on link → "Save to Rodeo" → saves linked URL
- [ ] Highlight text → right-click → "Save to Rodeo" → saves with selected_text
- [ ] Save same URL twice → shows "Already in your library"
- [ ] Run migration 022 against Boards Supabase project
- [ ] Verify links table has source, selected_text, device_id columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)