### PR TITLE
chore: bump boards version to 2.8.0

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6480,8 +6480,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.7.1';
-  console.log('[boards] v' + VERSION + ' - Echo voice quality: natural pauses, breaths, cadence');
+  const VERSION = '2.8.0';
+  console.log('[boards] v' + VERSION + ' - Extension v2: popup UI, context menus, direct-to-Supabase saves');
 
   // ============================================
   // Supabase Setup


### PR DESCRIPTION
## Summary
- Bumps boards version 2.7.1 → 2.8.0 for extension v2 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)