### PR TITLE
fix: extension popup spinner CSS specificity

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6480,8 +6480,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.8.0';
-  console.log('[boards] v' + VERSION + ' - Extension v2: popup UI, context menus, direct-to-Supabase saves');
+  const VERSION = '2.8.1';
+  console.log('[boards] v' + VERSION + ' - Fix extension popup spinner CSS specificity');
 
   // ============================================
   // Supabase Setup

--- a/extension/chrome/popup.css
+++ b/extension/chrome/popup.css
@@ -68,7 +68,7 @@ body {
 }
 
 .state[hidden] {
-  display: none;
+  display: none !important;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- Fixed CSS specificity bug where `#state-loading { display: flex }` (ID selector, specificity 1,0,0) overrode `.state[hidden] { display: none }` (class+attribute, specificity 0,2,0)
- Added `!important` to `.state[hidden]` rule so the loading spinner properly hides when switching popup states
- Bumps boards version to 2.8.1

## Test plan
- [ ] Load extension in chrome://extensions (developer mode)
- [ ] Click extension icon on any page — spinner should briefly appear then transition to save state
- [ ] Verify spinner is not visible alongside save content

🤖 Generated with [Claude Code](https://claude.com/claude-code)