### PR TITLE
Move BPM/key lookup server-side to fix CORS

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6480,8 +6480,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.8.3';
-  console.log('[boards] v' + VERSION + ' - Fix pin deletion resurrection, enrichment persistence, and duplicate detection');
+  const VERSION = '2.8.4';
+  console.log('[boards] v' + VERSION + ' - Move BPM/key lookup server-side, fix merge handler');
 
   // ============================================
   // Supabase Setup
@@ -10848,9 +10848,8 @@ Return JSON:
             duration: existing.duration || result.music.duration || null,
             contentFormat: existing.contentFormat || result.music.contentFormat || null,
             isExplicit: existing.isExplicit ?? result.music.isExplicit ?? null,
-            // Preserve client-side fields (BPM/key from GetSongBPM, embed from URL parsing)
-            bpm: existing.bpm || null,
-            key: existing.key || null,
+            bpm: existing.bpm || result.music.bpm || null,
+            key: existing.key || result.music.key || null,
             embedUrl: result.music.embedUrl || existing.embedUrl || null,
             embedType: result.music.embedType || existing.embedType || null,
             embedHeight: result.music.embedHeight || existing.embedHeight || null,

--- a/supabase/functions/enrich-link/index.ts
+++ b/supabase/functions/enrich-link/index.ts
@@ -722,6 +722,31 @@ serve(async (req) => {
         } catch (e) { console.warn('[enrich-link] enrich-music call failed:', (e as Error).message) }
       }
 
+      // 7. GetSongBPM for BPM + musical key (server-side to avoid CORS)
+      if (musicResult.artist && musicResult.trackTitle) {
+        try {
+          const bpmApiKey = Deno.env.get('GETSONGBPM_API_KEY') || '2309ca61f21b623b59ee2f734e67a456'
+          const query = encodeURIComponent(`${musicResult.artist} ${musicResult.trackTitle}`)
+          const bpmResp = await fetch(
+            `https://api.getsongbpm.com/search/?api_key=${bpmApiKey}&type=both&lookup=${query}`,
+            { headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ctrl.rodeo/1.0)' } }
+          )
+          if (bpmResp.ok) {
+            const bpmData = await bpmResp.json()
+            if (bpmData.search?.length) {
+              const hit = bpmData.search[0]
+              if (hit.tempo) musicResult.bpm = parseInt(hit.tempo, 10)
+              if (hit.key_of || hit.song_key) musicResult.key = hit.key_of || hit.song_key
+              console.log('[enrich-link] GetSongBPM result:', { bpm: musicResult.bpm, key: musicResult.key })
+            } else {
+              console.log('[enrich-link] GetSongBPM: no results for', musicResult.artist, musicResult.trackTitle)
+            }
+          } else {
+            console.warn('[enrich-link] GetSongBPM HTTP', bpmResp.status)
+          }
+        } catch (e) { console.warn('[enrich-link] GetSongBPM failed:', (e as Error).message) }
+      }
+
       // Return if we got anything useful
       const hasData = musicResult.artist || musicResult.trackTitle || musicResult.contentFormat
       if (hasData) {


### PR DESCRIPTION
## Summary
- GetSongBPM API blocks browser requests (no CORS headers) — every BPM/key lookup was failing
- Moved the lookup into the `enrich-link` edge function (step 7), which has no CORS restrictions
- Fixed client merge handler that was ignoring server-sent `bpm` and `key` fields

## Root Cause
`api.getsongbpm.com` returns 301 → CORS error from browser origin `ctrl.rodeo`. The API works fine server-side.

The client merge handler also had a bug: `bpm: existing.bpm || null` never read from `result.music.bpm`.

## Test plan
- [ ] Deploy `enrich-link` and re-enrich a Spotify track
- [ ] Verify BPM and musical key appear in listen item metadata
- [ ] Check server logs show `[enrich-link] GetSongBPM result: { bpm: X, key: "Y" }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)