### PR TITLE
fix: AudD fingerprinting gate blocks song discovery in music-only reels

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6480,8 +6480,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.8.4';
-  console.log('[boards] v' + VERSION + ' - Move BPM/key lookup server-side, fix merge handler');
+  const VERSION = '2.8.5';
+  console.log('[boards] v' + VERSION + ' - Fix AudD fingerprinting gate for reels with unmentioned songs');
 
   // ============================================
   // Supabase Setup

--- a/supabase/functions/instagram-import/index.ts
+++ b/supabase/functions/instagram-import/index.ts
@@ -562,20 +562,28 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
   }
 
   // Phase 5: Enhanced music resolution (Spotify + AudD multi-track)
+  // AudD fingerprinting runs for ANY reel with a video URL and non-original audio,
+  // even when no music entities were extracted from text. This handles reels where
+  // songs play without being verbally mentioned or named in the caption.
   const musicEntities = toResolve.filter(e => isMusicEntity(e))
-  if (musicEntities.length > 0) {
-    console.log(`[instagram-import] Phase 5: Enhanced music resolution for ${musicEntities.length} entities`)
+  const streamingRegex = /spotify\.com|music\.apple\.com|soundcloud\.com|beatport\.com|bandcamp\.com|tidal\.com|deezer\.com|audiomack\.com|youtube\.com\/watch|music\.youtube\.com/
 
-    // Tier 2 prep: fingerprint ALL tracks in one call (before entity loop)
-    let fingerprints: FingerprintResult[] = []
-    const streamingRegex = /spotify\.com|music\.apple\.com|soundcloud\.com|beatport\.com|bandcamp\.com|tidal\.com|deezer\.com|audiomack\.com|youtube\.com\/watch|music\.youtube\.com/
-    const anyNeedFingerprint = musicEntities.some(e => {
+  // Always fingerprint when there's a video with non-original audio
+  let fingerprints: FingerprintResult[] = []
+  if (reel.video_url && !isOriginalAudio(reel)) {
+    // Skip fingerprinting only if ALL music entities are already resolved to streaming URLs
+    const allResolved = musicEntities.length > 0 && musicEntities.every(e => {
       const isStreaming = e.resolved_url && streamingRegex.test(e.resolved_url)
-      return !(isStreaming && e.match_quality >= 0.7)
+      return isStreaming && e.match_quality >= 0.7
     })
-    if (anyNeedFingerprint && reel.video_url) {
+
+    if (!allResolved) {
       fingerprints = await fingerprintAllTracks(reel.video_url)
     }
+  }
+
+  if (musicEntities.length > 0) {
+    console.log(`[instagram-import] Phase 5: Enhanced music resolution for ${musicEntities.length} entities`)
 
     for (const entity of musicEntities) {
       // Check if Tier 0 already resolved to a streaming service with high quality
@@ -623,19 +631,35 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
         }
       }
     }
+  }
 
-    // Create entities for unmatched fingerprints (tracks not in caption/transcript)
+  // Create entities for unmatched fingerprints (tracks not in caption/transcript).
+  // This runs regardless of whether music entities existed — it's the primary
+  // discovery mechanism for songs that aren't mentioned in text.
+  if (fingerprints.length > 0) {
     for (const fp of fingerprints) {
       if (fp._matched) continue
       console.log(`[instagram-import] AudD new track: ${fp.artist} - ${fp.track} (offset: ${fp.offset}s)`)
+
+      // Try Spotify search for a proper URL if AudD didn't return one
+      let resolvedUrl = fp.spotifyUrl || null
+      let resolvedVia = 'audd-fingerprint'
+      if (!resolvedUrl && fp.artist && fp.track) {
+        const spotifyResult = await searchSpotify(fp.artist, fp.track)
+        if (spotifyResult) {
+          resolvedUrl = spotifyResult.url
+          resolvedVia = 'audd-fingerprint+spotify'
+        }
+      }
+
       entities.push({
         type: 'song',
         name: `${fp.artist} - ${fp.track}`,
         category: 'listen',
         confidence: 0.8,
         source: 'audio_fingerprint',
-        resolved_url: fp.spotifyUrl || null,
-        resolved_via: 'audd-fingerprint',
+        resolved_url: resolvedUrl,
+        resolved_via: resolvedVia,
         match_quality: 0.85,
         status: 'review',
         location_hint: null,


### PR DESCRIPTION
## Summary
- **Bug**: When an Instagram reel contains songs that aren't verbally mentioned or named in the caption, AudD audio fingerprinting never runs because it was gated behind `musicEntities.length > 0`
- **Root cause**: Claude's entity extraction creates `person`/`brand` entities for artists mentioned in captions, not `song` entities. Since no music entities exist, the fingerprinting gate at line 566 blocks AudD entirely
- **Fix**: Run AudD fingerprinting for any reel with a `video_url` and non-original audio, regardless of whether music entities were extracted from text. Uses the existing `isOriginalAudio()` function that was defined but never called

## Test plan
- [ ] Re-import the reel at `ctrl.rodeo/p/94o5eiyx` — should now discover all 5 songs via AudD fingerprinting
- [ ] Test a reel with songs mentioned in caption — existing behavior should be unchanged
- [ ] Test a reel with "Original Audio" — fingerprinting should still be skipped
- [ ] Verify unmatched fingerprints create new song entities with Spotify URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)