### PR TITLE
feat: switch recommendation suggestions to list view

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6480,8 +6480,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.8.5';
-  console.log('[boards] v' + VERSION + ' - Fix AudD fingerprinting gate for reels with unmentioned songs');
+  const VERSION = '2.8.6';
+  console.log('[boards] v' + VERSION + ' - Switch recommendation suggestions to list view layout');
 
   // ============================================
   // Supabase Setup
@@ -8189,31 +8189,31 @@ Return JSON:
         ? `<img src="${secureImg(sug.productImage)}" alt="${esc(sug.name)}" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><div class="w-img__placeholder" style="display:none">${icon}</div>`
         : `<div class="w-img__placeholder">${icon}</div>`;
 
-      // Render as link only if we have a valid URL, otherwise render as non-clickable card
+      // Render as list row — link if URL available, div otherwise
       if (hasUrl) {
-        // Phase 1: Track click for instrumentation
         const trackClick = `trackWidgetEvent('click', 'complete-the-look', {brand:'${esc(sug.brand)}',name:'${esc(sug.name).replace(/'/g, "\\'")}',hasImage:${hasProductImage}})`;
         suggestionsHtml += `
           <a href="${esc(sug.productUrl)}" target="_blank" rel="noopener" class="w-item" onclick="${trackClick}">
             <div class="w-img" style="border:var(--border-thin) solid var(--border-subtle)">
               ${imageContent}
             </div>
-            ${brandDisplay}
-            <span class="w-text">${esc(sug.name)}</span>
-            <span class="w-text w-text--note">${esc(sug.reason || '')} ${priceDisplay}</span>
-            <span class="w-btn w-btn--sm">Shop Now →</span>
+            <div class="w-item__text">
+              <span class="w-text">${esc(sug.name)}</span>
+              ${brandDisplay}
+              <span class="w-text w-text--note">${esc(sug.reason || '')} ${priceDisplay}</span>
+            </div>
           </a>`;
       } else {
-        // No valid URL - render as non-clickable suggestion
         suggestionsHtml += `
           <div class="w-item">
             <div class="w-img" style="border:var(--border-thin) solid var(--border-subtle)">
               ${imageContent}
             </div>
-            ${brandDisplay}
-            <span class="w-text">${esc(sug.name)}</span>
-            <span class="w-text w-text--note">${esc(sug.reason || '')} ${priceDisplay}</span>
-            <span class="w-btn w-btn--sm" style="opacity:0.5">Search for this item</span>
+            <div class="w-item__text">
+              <span class="w-text">${esc(sug.name)}</span>
+              ${brandDisplay}
+              <span class="w-text w-text--note">${esc(sug.reason || '')} ${priceDisplay}</span>
+            </div>
           </div>`;
       }
     }
@@ -8224,7 +8224,7 @@ Return JSON:
         <div class="w-body">
           <div class="w-items">${userItemsHtml}</div>
           <div class="w-divider"><span class="w-divider__label">+</span></div>
-          <div class="w-items">${suggestionsHtml}</div>
+          <div class="w-items w-items--list">${suggestionsHtml}</div>
         </div>
       </div>`;
   }

--- a/design-system/widgets.css
+++ b/design-system/widgets.css
@@ -696,6 +696,45 @@
   flex-wrap: wrap;
 }
 
+/* List modifier — stacked rows instead of card grid */
+.w-items--list {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0;
+}
+
+.w-items--list .w-item {
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.w-items--list .w-item + .w-item {
+  border-top: var(--border-thin) solid var(--border-subtle);
+}
+
+.w-items--list .w-item .w-img {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  aspect-ratio: 1;
+}
+
+.w-items--list .w-item__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.w-items--list .w-item:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 /* --- w-item --- */
 .w-item {
   flex: 0 0 auto;
@@ -778,6 +817,8 @@
   .w-item { width: 60px; }
   .w-item .w-img { height: 60px; }
   .w-items { gap: var(--space-2); }
+  .w-items--list .w-item .w-img { width: 32px; height: 32px; }
+  .w-items--list .w-item { gap: var(--space-2); }
 
   .w-body--list > .w-row { gap: var(--space-2); }
   .w-row__indicator { display: none; }


### PR DESCRIPTION
## Summary
- Changed the Complete the Look widget's suggestion items from a card grid layout to a stacked list view
- Each suggestion now shows as a horizontal row with thumbnail, name, brand, and reason
- Added `w-items--list` CSS modifier to the design system for reusable list-style item layouts

## Test plan
- [ ] Open a board with enough fashion items to trigger the Complete the Look widget
- [ ] Verify suggestions render as stacked rows (not thumbnail cards)
- [ ] Check responsive behavior at small widget sizes
- [ ] Verify clickable suggestions still open links in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)