### PR TITLE
feat: taste-graph context in event recommendations

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -8767,6 +8767,10 @@ Return JSON:
   // Recommends upcoming events based on Boards content
   // =============================================================================
 
+  // Taste context cache for enriching event recommendations
+  const TASTE_CACHE_KEY = 'ctrl-rodeo-taste-cache';
+  const TASTE_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours
+
   // Region → source IDs (must stay in sync with STOCK_SOURCES in events/index.html)
   const EVENT_SOURCE_REGIONS = {
     'bay-area': ['19hz-bayarea', 'ra-bayarea', 'sf-punchline', 'cobbs-sf', 'roxie-sf', 'screenslate-sf'],
@@ -8852,6 +8856,121 @@ Return JSON:
     return profile;
   }
 
+  function buildClustersFromLinks(links) {
+    var groups = {};
+    for (var i = 0; i < links.length; i++) {
+      var cat = links[i].category || 'uncategorized';
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat].push(links[i]);
+    }
+
+    var clusters = [];
+    var idx = 0;
+    var cats = Object.keys(groups);
+    for (var c = 0; c < cats.length; c++) {
+      var cat = cats[c];
+      var items = groups[cat];
+      if (items.length < 3) continue;
+
+      var wordFreq = {};
+      for (var j = 0; j < items.length; j++) {
+        if (!items[j].title) continue;
+        var words = items[j].title.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/);
+        for (var w = 0; w < words.length; w++) {
+          if (words[w].length > 3 && !EVENTS_STOPWORDS.has(words[w])) {
+            wordFreq[words[w]] = (wordFreq[words[w]] || 0) + 1;
+          }
+        }
+      }
+
+      var topTokens = Object.entries(wordFreq)
+        .sort(function(a, b) { return b[1] - a[1]; })
+        .slice(0, 8)
+        .map(function(e) { return e[0]; });
+
+      var sampleTitles = items.slice(0, 3)
+        .map(function(l) { return l.title || ''; })
+        .filter(Boolean);
+
+      clusters.push({
+        id: 'c' + idx,
+        topTokens: topTokens,
+        sampleTitles: sampleTitles,
+        dominantCategory: cat,
+        pinCount: items.length,
+      });
+      idx++;
+    }
+    return clusters;
+  }
+
+  async function loadTasteContext(links) {
+    // Check cache
+    try {
+      var raw = localStorage.getItem(TASTE_CACHE_KEY);
+      if (raw) {
+        var cached = JSON.parse(raw);
+        var age = Date.now() - (cached.timestamp || 0);
+        var pinDrift = Math.abs((cached.pinCount || 0) - links.length);
+        if (age < TASTE_CACHE_TTL && pinDrift <= 5) {
+          console.log('[taste-context] Cache hit (' + cached.tasteContext.clusters.length + ' clusters)');
+          return cached.tasteContext;
+        }
+      }
+    } catch (e) { /* ignore cache errors */ }
+
+    // Build clusters
+    var clusters = buildClustersFromLinks(links);
+    if (clusters.length < 2) {
+      console.log('[taste-context] Not enough clusters (' + clusters.length + '), skipping');
+      return null;
+    }
+
+    // Call taste-graph
+    try {
+      var resp = await fetch(SUPABASE_URL + '/functions/v1/taste-graph', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ clusters: clusters }),
+      });
+      if (!resp.ok) return null;
+
+      var data = await resp.json();
+      if (!data.clusters || data.clusters.length === 0) return null;
+
+      var tasteContext = {
+        clusters: data.clusters.map(function(c) {
+          var orig = clusters.find(function(cl) { return cl.id === c.id; });
+          return {
+            label: c.label,
+            domain: c.domain,
+            pinCount: orig ? orig.pinCount : 0,
+          };
+        }),
+        bridges: (data.insights && data.insights.bridges) || [],
+        motifs: (data.insights && data.insights.motifs) || [],
+      };
+
+      // Cache result
+      try {
+        localStorage.setItem(TASTE_CACHE_KEY, JSON.stringify({
+          tasteContext: tasteContext,
+          timestamp: Date.now(),
+          pinCount: links.length,
+        }));
+      } catch (e) { /* ignore storage errors */ }
+
+      console.log('[taste-context] Loaded ' + tasteContext.clusters.length + ' clusters, ' + tasteContext.bridges.length + ' bridges');
+      return tasteContext;
+    } catch (err) {
+      console.warn('[taste-context] Error:', err);
+      return null;
+    }
+  }
+
   function renderEventsWidget(events) {
     const footerSection = document.getElementById('widgetFooter');
     const footerContent = document.getElementById('widgetFooterContent');
@@ -8905,6 +9024,12 @@ Return JSON:
     // Require at least some meaningful signals
     const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
     if (signalCount === 0) return;
+
+    // Enrich with taste context (cached, non-blocking on failure)
+    var tasteContext = await loadTasteContext(items);
+    if (tasteContext) {
+      profile.tasteContext = tasteContext;
+    }
 
     // Region filter: only recommend events from user's region
     const region = localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area';

--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -29,7 +29,7 @@
 | [Phase 9: Bulk Import](./phase-9-bulk-import.md) | Pending | 0/132 |
 | [Phase 10: Image Validation & Enrichment](./phase-10-image-validation.md) | IN PROGRESS | 68/126 |
 | [Phase 11: Instagram Import](./phase-11-instagram-import.md) | Pending | 0/73 |
-| [Phase 12: Lookback](./phase-12-lookback.md) | IN PROGRESS | 34/236 |
+| [Phase 12: Lookback](./phase-12-lookback.md) | IN PROGRESS | 47/249 |
 | [Backlog](./backlog.md) | Future | 1/102 |
 
 ---
@@ -134,9 +134,9 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 | Phase 9: Bulk Import | 0 | 0 | 132 | 0 |
 | Phase 10: Image Validation | 68 | 0 | 58 | 0 |
 | Phase 11: Instagram Import | 0 | 0 | 73 | 0 |
-| Phase 12: Lookback | 34 | 0 | 197 | 5 |
+| Phase 12: Lookback | 47 | 0 | 197 | 5 |
 | Backlog | 1 | 0 | 100 | 0 |
-| **TOTAL** | **343** | **5** | **1225** | **9** |
+| **TOTAL** | **356** | **5** | **1225** | **9** |
 
 ---
 

--- a/docs/execution/project-plan/phase-12-lookback.md
+++ b/docs/execution/project-plan/phase-12-lookback.md
@@ -325,6 +325,27 @@ These tasks must be complete before Epic 12.1 can begin.
 | | "Connections" subsection in Lookback View | Pending |
 | | Minimum: confidence > 0.75 | Pending |
 
+### Story 3a: Taste-Graph Enhanced Event Recommendations
+
+<!-- Reference: PRD at docs/strategy/prds/event-connections.md -->
+
+| Story | Tasks | Status |
+|-------|-------|--------|
+| **Server: TasteContext in recommend-events** | | Complete |
+| | Add `TasteContext`, `TasteCluster`, `TasteBridge` types to `recommend-events` | Complete |
+| | Extend `EventProfile` with optional `tasteContext` field | Complete |
+| | Inject taste identities, bridges, motifs into AI ranking prompt | Complete |
+| | Add taste-aware rule to prompt RULES block | Complete |
+| | Trim `topCategories` from 5→3 to offset token budget | Complete |
+| | Version bump to 1.1.0 | Complete |
+| **Client: taste pipeline in Boards** | | Complete |
+| | `buildClustersFromLinks()` — group pins by category, extract topTokens | Complete |
+| | `loadTasteContext()` — call taste-graph with 6h localStorage cache | Complete |
+| | Wire into `loadEventsForYouWidget()` — attach tasteContext to profile | Complete |
+| **Client: taste pipeline in Events** | | Complete |
+| | Duplicate `buildClustersFromLinks` + `loadTasteContext` in events/index.html | Complete |
+| | Wire into `loadRecommendedEvents()` — attach tasteContext to profile | Complete |
+
 ### Story 4: Taste Drift
 
 | Story | Tasks | Status |

--- a/docs/strategy/prds/event-connections.md
+++ b/docs/strategy/prds/event-connections.md
@@ -1,0 +1,153 @@
+# PRD: Taste-Graph Enhanced Event Recommendations
+
+**Version:** 1.0
+**Date:** 2026-03-05
+**Status:** Active
+
+---
+
+## Overview
+
+Event recommendations in ctrl.rodeo match on literal strings — artist names, genre keywords, title words. This works for direct hits ("you saved DJ Shadow → here's a DJ Shadow show") but misses the deeper signal: *taste identity*.
+
+The `taste-graph` edge function already computes rich taste labels (e.g. "Grimy New Wave", "Utilitarian Uniform") and cross-domain bridges (e.g. "your brutalism interest connects to your techno saves"). But this output **never reaches the event recommendation pipeline**. The two systems are completely disconnected.
+
+This PRD defines how to feed taste-graph context into the `recommend-events` AI prompt, so Claude can reason about aesthetic and cultural fit — not just keyword overlap.
+
+---
+
+## Goals
+
+1. **Enrich the AI ranking prompt** with taste identities, cross-domain bridges, and recurring motifs
+2. **Improve recommendation quality** — surface events that match a user's aesthetic posture, not just their literal search terms
+3. **Zero additional AI cost** — reuse the existing `taste-graph` call (cached client-side), inject output into the existing `recommend-events` Haiku call
+
+---
+
+## Non-Goals (Backlog)
+
+- New database tables or connection storage
+- New edge functions
+- User-created event↔pin links (blocked on Pin Type Abstraction)
+- Visual graph exploration of taste connections
+- Changes to the `taste-graph` edge function itself
+
+---
+
+## Who This Serves
+
+| Persona | Job To Be Done | How This Helps |
+|---------|----------------|----------------|
+| Sound & Scene Curator | "Find events that match my vibe, not just my playlist" | Taste labels like "Grimy New Wave" match events by cultural fit, not just genre tags |
+| DJ | "Discover shows aligned with the aesthetic I'm building" | Cross-domain bridges reveal event connections a keyword search would miss |
+| Cultural Omnivore | "Get recommendations that understand my taste across categories" | Motifs and bridges surface events matching cross-category patterns |
+
+---
+
+## Design Principles
+
+| Brand Principle | Application |
+|----------------|-------------|
+| Input shapes output | Taste-graph transforms raw saves into taste identity → that identity shapes event discovery |
+| Organize as you go | No user action required — taste context computed and cached automatically |
+| One place, whole life | Cross-domain bridges mean your fashion saves can inform your event recommendations |
+| Show, don't decorate | Recommendation reasons reference taste labels directly ("matches your Grimy New Wave identity") |
+| Expand with the user | More saves → richer clusters → better event matching — quality improves with use |
+
+---
+
+## Technical Approach
+
+### Data Flow
+
+```
+User's pins (localStorage)
+  → buildClustersFromLinks()     [client, sync]
+    → POST /taste-graph           [1 Haiku call, cached 6h]
+      → { clusters, bridges, motifs }
+        → attached to EventProfile.tasteContext
+          → POST /recommend-events  [existing Haiku call, enriched prompt]
+            → events ranked by taste fit + keyword match
+```
+
+### Server Change: `recommend-events`
+
+Add optional `tasteContext` field to `EventProfile`. When present, inject 2-3 lines into the AI prompt:
+
+- **Taste identities**: top 6 cluster labels with domains (e.g. "Grimy New Wave (music), Scandinavian Silence (design)")
+- **Cross-domain connections**: top 2 bridges with reasons
+- **Recurring themes**: top 3 motifs
+
+Add one rule: "Use taste identity labels to reason about aesthetic and cultural fit, not just literal keyword overlap."
+
+Backward-compatible — when `tasteContext` is absent, behavior is identical to today.
+
+### Client Change: Both Apps
+
+Add `buildClustersFromLinks(links)` — groups pins by category, extracts `topTokens` from title word frequencies, returns cluster input array.
+
+Add `loadTasteContext(links)` — checks localStorage cache (6h TTL, 5-pin drift tolerance), calls `taste-graph` on cache miss, returns `{ clusters, bridges, motifs }` or `null` on failure.
+
+Wire into `loadEventsForYouWidget()` (boards) and `loadRecommendedEvents()` (events) — inject `tasteContext` onto `profile` before the `recommend-events` call.
+
+---
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| Additional AI calls | 0 (taste-graph already called, cached client-side) |
+| Token budget increase | ~80 tokens added to ranking prompt |
+| Cache TTL | 6 hours |
+| Minimum pins for taste context | 2+ clusters with 3+ pins each |
+| Graceful degradation | If taste-graph fails, recommend-events works identically to today |
+
+---
+
+## Cost Model
+
+| Component | Per User/Month | At 1,000 Users |
+|-----------|---------------|----------------|
+| Additional Haiku calls | $0 | $0 |
+| Additional prompt tokens (~80/call) | ~$0.001 | ~$1/month |
+| **Total incremental cost** | **~$0.001** | **~$1/month** |
+
+The `taste-graph` call cost is already budgeted separately. This feature only adds ~80 tokens to the existing `recommend-events` prompt.
+
+---
+
+## Success Metrics
+
+| Metric | Target | How Measured |
+|--------|--------|-------------|
+| Recommendation click-through | +20% over keyword-only baseline | Client event tracking on event card clicks |
+| Taste-label references in reasons | 30%+ of AI reasons mention a taste label | Parse `relevance.reasons` for cluster label strings |
+| Algorithm distribution | 80%+ of calls use `hybrid` (vs `keyword-only`) | `meta.algorithm` field in responses |
+| Cache hit rate | 70%+ of `loadTasteContext` calls served from cache | Console log analysis |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Token budget increase degrades ranking | AI has less room for event evaluation | Trim `topCategories` from 5 to 3; keep taste lines concise |
+| Taste labels add noise for small collections | Bad cluster labels mislead AI | Require 2+ clusters with 3+ pins each; skip gracefully |
+| Both apps race to populate cache | Duplicate `taste-graph` calls | Same cache key in both apps; second write is harmless |
+| `taste-graph` latency on cold path (~800ms) | Delays event widget appearance | Both callers are already async/non-blocking; no UX regression |
+
+---
+
+## Open Questions
+
+1. ~~Should the client call taste-graph first and pass results, or should recommend-events call taste-graph internally?~~ **Resolved:** Client-side with cache. Avoids server fan-out and stays within cost budget.
+
+---
+
+## Related Documents
+
+- [Cross-Category Connections UX](../../ux/boards/cross-category.md)
+- [Phase 12: Lookback](../../execution/project-plan/phase-12-lookback.md) — Epic 12.3
+- [Database Schema](../../infrastructure/technical-design/database-schema.md)
+- [Brand Positioning](../brand-positioning.md)
+- [User Personas](../../ux/personas.md)

--- a/events/index.html
+++ b/events/index.html
@@ -4892,6 +4892,8 @@ body {
 
   // --- Events For You (Boards integration) ---
   const BOARDS_STORAGE_KEY = 'things-i-like';
+  const TASTE_CACHE_KEY = 'ctrl-rodeo-taste-cache';
+  const TASTE_CACHE_TTL = 6 * 60 * 60 * 1000; // 6 hours
   const EVENTS_STOPWORDS = new Set([
     'the', 'and', 'for', 'with', 'from', 'this', 'that', 'have', 'has',
     'are', 'was', 'were', 'been', 'will', 'would', 'could', 'should',
@@ -4902,6 +4904,110 @@ body {
     'first', 'last', 'free', 'shop', 'buy', 'sale', 'official', 'store',
     'home', 'page', 'site', 'http', 'https', 'www', 'com',
   ]);
+
+  function buildClustersFromLinks(links) {
+    var groups = {};
+    for (var i = 0; i < links.length; i++) {
+      var cat = links[i].category || 'uncategorized';
+      if (!groups[cat]) groups[cat] = [];
+      groups[cat].push(links[i]);
+    }
+
+    var clusters = [];
+    var idx = 0;
+    var cats = Object.keys(groups);
+    for (var c = 0; c < cats.length; c++) {
+      var cat = cats[c];
+      var items = groups[cat];
+      if (items.length < 3) continue;
+
+      var wordFreq = {};
+      for (var j = 0; j < items.length; j++) {
+        if (!items[j].title) continue;
+        var words = items[j].title.toLowerCase().replace(/[^a-z0-9\s]/g, '').split(/\s+/);
+        for (var w = 0; w < words.length; w++) {
+          if (words[w].length > 3 && !EVENTS_STOPWORDS.has(words[w])) {
+            wordFreq[words[w]] = (wordFreq[words[w]] || 0) + 1;
+          }
+        }
+      }
+
+      var topTokens = Object.entries(wordFreq)
+        .sort(function(a, b) { return b[1] - a[1]; })
+        .slice(0, 8)
+        .map(function(e) { return e[0]; });
+
+      var sampleTitles = items.slice(0, 3)
+        .map(function(l) { return l.title || ''; })
+        .filter(Boolean);
+
+      clusters.push({
+        id: 'c' + idx,
+        topTokens: topTokens,
+        sampleTitles: sampleTitles,
+        dominantCategory: cat,
+        pinCount: items.length,
+      });
+      idx++;
+    }
+    return clusters;
+  }
+
+  async function loadTasteContext(links) {
+    try {
+      var raw = localStorage.getItem(TASTE_CACHE_KEY);
+      if (raw) {
+        var cached = JSON.parse(raw);
+        var age = Date.now() - (cached.timestamp || 0);
+        var pinDrift = Math.abs((cached.pinCount || 0) - links.length);
+        if (age < TASTE_CACHE_TTL && pinDrift <= 5) {
+          log('Taste context cache hit (' + cached.tasteContext.clusters.length + ' clusters)');
+          return cached.tasteContext;
+        }
+      }
+    } catch (e) { /* ignore cache errors */ }
+
+    var clusters = buildClustersFromLinks(links);
+    if (clusters.length < 2) return null;
+
+    try {
+      var resp = await fetch(SUPABASE_URL + '/functions/v1/taste-graph', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ clusters: clusters }),
+      });
+      if (!resp.ok) return null;
+
+      var data = await resp.json();
+      if (!data.clusters || data.clusters.length === 0) return null;
+
+      var tasteContext = {
+        clusters: data.clusters.map(function(c) {
+          var orig = clusters.find(function(cl) { return cl.id === c.id; });
+          return { label: c.label, domain: c.domain, pinCount: orig ? orig.pinCount : 0 };
+        }),
+        bridges: (data.insights && data.insights.bridges) || [],
+        motifs: (data.insights && data.insights.motifs) || [],
+      };
+
+      try {
+        localStorage.setItem(TASTE_CACHE_KEY, JSON.stringify({
+          tasteContext: tasteContext,
+          timestamp: Date.now(),
+          pinCount: links.length,
+        }));
+      } catch (e) { /* ignore storage errors */ }
+
+      log('Taste context loaded: ' + tasteContext.clusters.length + ' clusters, ' + tasteContext.bridges.length + ' bridges');
+      return tasteContext;
+    } catch (err) {
+      log('Taste context error: ' + err);
+      return null;
+    }
+  }
 
   async function loadRecommendedEvents() {
     try {
@@ -4943,6 +5049,12 @@ body {
 
       const signalCount = profile.artists.length + profile.genres.length + profile.keywords.length;
       if (signalCount === 0) return;
+
+      // Enrich with taste context (cached, non-blocking on failure)
+      var tasteContext = await loadTasteContext(links);
+      if (tasteContext) {
+        profile.tasteContext = tasteContext;
+      }
 
       // Region filter: only recommend events from user's active sources
       const region = localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area';

--- a/supabase/functions/recommend-events/index.ts
+++ b/supabase/functions/recommend-events/index.ts
@@ -7,8 +7,11 @@
 // 3. AI ranking: Claude Haiku ranks top candidates with relevance explanations
 //
 // POST /functions/v1/recommend-events
-// Body: { profile: { categories, artists, genres, keywords, domains, contentTypes }, filters? }
+// Body: { profile: { categories, artists, genres, keywords, domains, contentTypes, tasteContext? }, filters? }
 // Returns: { events: [...], meta: { eventsScanned, profileSignals, algorithm } }
+
+const VERSION = '1.1.0'
+console.log(`[recommend-events] v${VERSION} — taste-graph context`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -30,6 +33,24 @@ function getSupabase() {
 
 // --- Types ---
 
+interface TasteCluster {
+  label: string       // e.g. "Grimy New Wave"
+  domain: string      // e.g. "music"
+  pinCount: number
+}
+
+interface TasteBridge {
+  clusterA: string
+  clusterB: string
+  reason: string
+}
+
+interface TasteContext {
+  clusters: TasteCluster[]
+  bridges: TasteBridge[]
+  motifs: string[]
+}
+
 interface EventProfile {
   categories: Record<string, number>
   artists: string[]
@@ -37,6 +58,7 @@ interface EventProfile {
   keywords: string[]
   domains: Record<string, number>
   contentTypes: Record<string, number>
+  tasteContext?: TasteContext
 }
 
 interface EventFilters {
@@ -296,10 +318,31 @@ async function rankEventsWithAI(
   }
   const topCategories = Object.entries(profile.categories)
     .sort((a, b) => b[1] - a[1])
-    .slice(0, 5)
+    .slice(0, 3)
     .map(([cat, count]) => `${cat} (${count})`)
   if (topCategories.length > 0) {
     profileSummary.push(`Content categories: ${topCategories.join(', ')}`)
+  }
+
+  // Inject taste context if available (from taste-graph)
+  if (profile.tasteContext?.clusters?.length) {
+    const labels = profile.tasteContext.clusters
+      .sort((a, b) => b.pinCount - a.pinCount)
+      .slice(0, 6)
+      .map(c => `${c.label} (${c.domain})`)
+      .join(', ')
+    profileSummary.push(`Taste identities: ${labels}`)
+
+    if (profile.tasteContext.bridges?.length) {
+      const bridgeText = profile.tasteContext.bridges.slice(0, 2)
+        .map(b => `"${b.clusterA}" connects to "${b.clusterB}" — ${b.reason}`)
+        .join('; ')
+      profileSummary.push(`Cross-domain connections: ${bridgeText}`)
+    }
+
+    if (profile.tasteContext.motifs?.length) {
+      profileSummary.push(`Recurring themes: ${profile.tasteContext.motifs.slice(0, 3).join(', ')}`)
+    }
   }
 
   // Build events list
@@ -326,6 +369,7 @@ RULES:
 - Only include events scoring above 0.3
 - Reasons must reference specific user interests (artist names, genres, keywords)
 - Prefer exact artist/genre matches over vague keyword overlap
+- Use taste identity labels to reason about aesthetic and cultural fit, not just literal keyword overlap
 - If no events are relevant, return {"rankings": [], "confidence": 0}
 - Keep each reason under 15 words
 
@@ -414,7 +458,10 @@ serve(async (req) => {
       (profile.genres?.length || 0) +
       (profile.keywords?.length || 0)
 
-    console.log(`[recommend-events] Profile: ${profileSignals} signals, ${Object.keys(profile.categories || {}).length} categories${filters.sourceIds?.length ? `, region filter: ${filters.sourceIds.length} sources` : ''}`)
+    const tasteInfo = profile.tasteContext?.clusters?.length
+      ? `, taste: ${profile.tasteContext.clusters.length} clusters`
+      : ''
+    console.log(`[recommend-events] Profile: ${profileSignals} signals, ${Object.keys(profile.categories || {}).length} categories${tasteInfo}${filters.sourceIds?.length ? `, region filter: ${filters.sourceIds.length} sources` : ''}`)
 
     // Step 1: Fetch upcoming events
     const allEvents = await fetchUpcomingEvents(filters)


### PR DESCRIPTION
## Summary
- Adds taste-graph cluster/bridge/motif context to the recommend-events AI ranking prompt
- Client-side orchestration in both Boards and Events pages with 6-hour localStorage cache
- Graceful degradation when taste-graph is unavailable or collection is too small
- PRD at docs/strategy/prds/event-connections.md

## Test plan
- [ ] Open Boards with 10+ pins, verify `ctrl-rodeo-taste-cache` in localStorage
- [ ] Check event recommendation reasons reference taste identity labels
- [ ] Verify cold path (clear cache) and warm path (cached) both work
- [ ] Confirm graceful fallback with <3 clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)