### PR TITLE
feat: add source health tracking for events pipeline

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -81,6 +81,17 @@ body {
   border-color: var(--border-subtle);
 }
 
+.token--warning {
+  border-color: #663300;
+  color: #eab308;
+}
+
+.token--warning.token--active {
+  background: #1a0a00;
+  color: #eab308;
+  border-color: #663300;
+}
+
 .source-chip__error {
   margin-left: var(--space-1);
   font-size: var(--text-2xs);
@@ -1556,6 +1567,9 @@ body {
 (function() {
   'use strict';
 
+  const VERSION = '1.1.0';
+  console.log(`[events] v${VERSION} - source health tracking`);
+
   // ============================================
   // Stock Sources Catalog
   // ============================================
@@ -1663,6 +1677,7 @@ body {
     events: [],
     sources: [],
     sourceErrors: {},  // { sourceId: { reason: 'timeout'|'blocked'|'offline'|'empty'|'unknown', message: '...' } }
+    sourceHealth: {},  // { sourceId: { status, consecutive_failures, success_rate, last_failure_reason, ... } }
     filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', contentType: '' },
     sort: { key: 'date', dir: 'asc' },
     view: 'table',
@@ -1990,10 +2005,9 @@ body {
     } catch (e) { log('L2 cache: error — ' + e.message); return null; }
   }
 
-  async function saveEventsToSupabase(events) {
-    if (!events || events.length === 0) return;
+  async function saveEventsToSupabase(events, sourceOutcomes = []) {
     try {
-      const all = events.map(ev => ({
+      const all = (events || []).map(ev => ({
         source: ev.source, date: ev.date, time: ev.time || '', name: ev.name,
         venue: ev.venue, address: ev.address || '', city: ev.city || '',
         genre: ev.genre || '', price: ev.price || '', ages: ev.ages || '',
@@ -2003,9 +2017,9 @@ body {
       const BATCH = 400;
       const batches = [];
       for (let i = 0; i < all.length; i += BATCH) batches.push(all.slice(i, i + BATCH));
-      log(`L2 cache: saving ${all.length} events in ${batches.length} batch(es)...`);
-      let totalCached = 0, totalUpdated = 0, totalEnriched = 0;
-      for (const batch of batches) {
+
+      // If no events but have outcomes, send health-only request
+      if (all.length === 0 && sourceOutcomes.length > 0) {
         const resp = await fetch(CACHE_EVENTS_URL, {
           method: 'POST',
           headers: {
@@ -2013,15 +2027,39 @@ body {
             'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
             'apikey': SUPABASE_ANON_KEY,
           },
-          body: JSON.stringify({ events: batch }),
+          body: JSON.stringify({ events: [], sourceOutcomes }),
+        });
+        if (resp.ok) {
+          const result = await resp.json();
+          log(`L2 cache: health-only — ${result.healthUpdated || 0} sources updated`);
+        }
+        return;
+      }
+
+      if (all.length === 0) return;
+      log(`L2 cache: saving ${all.length} events in ${batches.length} batch(es)...`);
+      let totalCached = 0, totalUpdated = 0, totalEnriched = 0, totalHealth = 0;
+      for (let i = 0; i < batches.length; i++) {
+        const body = { events: batches[i] };
+        // Attach sourceOutcomes to the first batch only
+        if (i === 0 && sourceOutcomes.length > 0) body.sourceOutcomes = sourceOutcomes;
+        const resp = await fetch(CACHE_EVENTS_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+            'apikey': SUPABASE_ANON_KEY,
+          },
+          body: JSON.stringify(body),
         });
         if (!resp.ok) { log('L2 cache: batch save failed — ' + resp.status); continue; }
         const result = await resp.json();
         totalCached += result.cached || 0;
         totalUpdated += result.updated || 0;
         totalEnriched += result.enrichQueued || 0;
+        totalHealth += result.healthUpdated || 0;
       }
-      log(`L2 cache: cached=${totalCached} updated=${totalUpdated} enrichQueued=${totalEnriched}`);
+      log(`L2 cache: cached=${totalCached} updated=${totalUpdated} enrichQueued=${totalEnriched} health=${totalHealth}`);
     } catch (e) { log('L2 cache: save error — ' + e.message); }
   }
 
@@ -2241,11 +2279,30 @@ body {
     });
 
     const results = await Promise.allSettled(promises);
+    const sourceOutcomes = [];
     results.forEach(r => {
       const res = r.status === 'fulfilled' ? r.value : { source: null, events: [], ok: false, error: r.reason?.message || String(r.reason) };
       if (res.events.length > 0) allEvents.push(...res.events);
       if (!res.ok && res.source) {
         state.sourceErrors[res.source.id] = classifySourceError(res.error);
+      }
+      // Collect outcome for health reporting (every source, not just failures)
+      if (res.source) {
+        const evCount = res.events ? res.events.length : 0;
+        const classified = !res.ok ? classifySourceError(res.error) : null;
+        sourceOutcomes.push({
+          sourceId: res.source.id,
+          sourceName: res.source.name,
+          sourceUrl: res.source.url || '',
+          sourceType: res.source.type || 'html',
+          eventCount: evCount,
+          ok: res.ok,
+          errorReason: classified ? classified.reason : (res.ok && evCount === 0 ? 'zero_results' : undefined),
+        });
+        // Log zero-result sources that didn't throw (previously silent)
+        if (res.ok && evCount === 0) {
+          log(`Source "${res.source.name}": 0 events returned (no error)`);
+        }
       }
     });
 
@@ -2269,9 +2326,10 @@ body {
     if (failedNames.length > 0) log(`Failed sources: ${failedNames.join(', ')}`);
     el.style.display = 'none';
     saveEventCache(); // L1
-    if (state.events.length > 0) {
-      saveEventsToSupabase(state.events).catch(e => log('L2 save failed: ' + e.message)); // L2 async
-    }
+    // L2 async — send events + health outcomes
+    saveEventsToSupabase(state.events, sourceOutcomes).catch(e => log('L2 save failed: ' + e.message));
+    // Reload health from DB after reporting (async, updates UI once loaded)
+    loadSourceHealth().catch(e => log('Health load failed: ' + e.message));
     calAutoNavigate();
     updateFilters();
     updateContentTypeFilter();
@@ -2295,6 +2353,85 @@ body {
     if (msg.includes('all fetch methods failed'))
       return { reason: 'unreachable', message: 'Couldn\'t connect to this source through any method. The site may be down or blocking automated access.' };
     return { reason: 'unknown', message: 'Something went wrong loading this source. Try refreshing the page.' };
+  }
+
+  // --- Source Health Loading ---
+  async function loadSourceHealth() {
+    if (!supabaseClient) return;
+    const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id);
+    if (enabledIds.length === 0) return;
+
+    try {
+      const { data: healthRows } = await supabaseClient
+        .from('source_health')
+        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes')
+        .in('source_id', enabledIds);
+
+      if (!healthRows) return;
+
+      state.sourceHealth = {};
+      healthRows.forEach(row => {
+        state.sourceHealth[row.source_id] = row;
+      });
+
+      log(`Source health loaded: ${healthRows.length} sources — ` +
+        `${healthRows.filter(r => r.status === 'healthy').length} healthy, ` +
+        `${healthRows.filter(r => r.status === 'degraded').length} degraded, ` +
+        `${healthRows.filter(r => r.status === 'broken').length} broken`);
+
+      // Surface broken/degraded sources
+      const broken = healthRows.filter(r => r.status === 'broken');
+      const degraded = healthRows.filter(r => r.status === 'degraded');
+      if (broken.length > 0 || degraded.length > 0) {
+        showSourceHealthWarning(broken, degraded);
+      } else {
+        // Clear any existing warning
+        const existing = document.getElementById('sourceHealthWarning');
+        if (existing) existing.remove();
+      }
+
+      // Re-render source chips with health info
+      renderSourceChips();
+    } catch (e) {
+      log('Source health load error: ' + e.message);
+    }
+  }
+
+  function showSourceHealthWarning(broken, degraded) {
+    const existing = document.getElementById('sourceHealthWarning');
+    if (existing) existing.remove();
+    if (broken.length === 0 && degraded.length === 0) return;
+
+    const brokenNames = broken.map(r => {
+      const src = state.sources.find(s => s.id === r.source_id);
+      return src ? src.name : r.source_id;
+    });
+    const degradedNames = degraded.map(r => {
+      const src = state.sources.find(s => s.id === r.source_id);
+      return src ? src.name : r.source_id;
+    });
+
+    let msg = '';
+    if (broken.length > 0) {
+      msg += `Broken: ${brokenNames.join(', ')} (${broken[0].consecutive_failures}+ consecutive failures)`;
+    }
+    if (degraded.length > 0) {
+      if (msg) msg += ' · ';
+      msg += `Degraded: ${degradedNames.join(', ')}`;
+    }
+
+    const warn = document.createElement('div');
+    warn.id = 'sourceHealthWarning';
+    warn.style.cssText = 'background:#1a0a00;border:1px solid #663300;color:#ff9944;padding:8px 12px;margin:0 0 12px;border-radius:6px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:8px;';
+    warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Source Health</span> — ${msg}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#ff9944;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
+
+    const container = document.querySelector('.container');
+    const cal = document.getElementById('calendarView');
+    const chips = document.getElementById('sourceChips');
+    const insertBefore = chips || cal || container?.firstChild;
+    if (insertBefore && container) {
+      container.insertBefore(warn, insertBefore);
+    }
   }
 
   // --- Cross-Source Deduplication ---
@@ -3962,6 +4099,19 @@ body {
     document.querySelectorAll('.calendar__cell--selected').forEach(c => c.classList.remove('calendar__cell--selected'));
   }
 
+  function getHealthDot(sourceId) {
+    const health = state.sourceHealth[sourceId];
+    if (!health || health.status === 'unknown') return '';
+    const symbols = { healthy: '●', degraded: '◐', broken: '✕' };
+    const colors = { healthy: '#22c55e', degraded: '#eab308', broken: '#ef4444' };
+    const titles = {
+      healthy: `Healthy (${Math.round(health.success_rate * 100)}% success)`,
+      degraded: `Degraded (${health.consecutive_failures} consecutive failures)`,
+      broken: `Broken (${health.consecutive_failures} consecutive failures)`,
+    };
+    return `<span style="color:${colors[health.status]};font-size:8px;margin-left:3px;vertical-align:middle;" title="${titles[health.status]}">${symbols[health.status]}</span>`;
+  }
+
   function renderSourceChips() {
     const container = document.getElementById('sourceChips');
     const activeSource = state.filters.source;
@@ -3973,9 +4123,13 @@ body {
       const count = state.events.filter(e => e.source === s.id || (e.sources && e.sources.includes(s.id))).length;
       const isActive = activeSource === s.id;
       const hasError = state.sourceErrors[s.id];
-      const errorClass = hasError ? ' token--error' : '';
+      const health = state.sourceHealth[s.id];
+      const isBroken = health && health.status === 'broken';
+      const isDegraded = health && health.status === 'degraded';
+      const errorClass = (hasError || isBroken) ? ' token--error' : (isDegraded ? ' token--warning' : '');
       const errorMark = hasError ? '<span class="source-chip__error" title="Couldn\'t load">!</span>' : '';
-      return `<button class="token ${isActive ? 'token--active' : ''}${errorClass}" data-source-id="${escHtml(s.id)}">${escHtml(s.name)}<span class="source-chip__count">${count}</span>${errorMark}</button>`;
+      const healthDot = getHealthDot(s.id);
+      return `<button class="token ${isActive ? 'token--active' : ''}${errorClass}" data-source-id="${escHtml(s.id)}">${escHtml(s.name)}<span class="source-chip__count">${count}</span>${errorMark}${healthDot}</button>`;
     }).join('');
     container.innerHTML = html;
 
@@ -4063,10 +4217,22 @@ body {
     }
     list.innerHTML = active.map(s => {
       const catLabel = CONTENT_TYPES[s.category] || s.category || '';
+      const health = state.sourceHealth[s.id];
+      let healthHtml = '';
+      if (health && health.status !== 'unknown') {
+        const colors = { healthy: '#22c55e', degraded: '#eab308', broken: '#ef4444' };
+        const labels = {
+          healthy: `${Math.round(health.success_rate * 100)}% success`,
+          degraded: `${health.consecutive_failures} failures`,
+          broken: `Broken — ${health.consecutive_failures} failures`,
+        };
+        const lastOk = health.last_success_at ? new Date(health.last_success_at).toLocaleDateString() : 'never';
+        healthHtml = `<span style="font-size:10px;color:${colors[health.status]};margin-left:6px;" title="Last success: ${lastOk}">${labels[health.status]}</span>`;
+      }
       return `<div style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-3); border-bottom: var(--border-thin) solid var(--border-subtle);">
         <div style="flex: 1; min-width: 0;">
           <span style="font-size: var(--text-xs);">${escHtml(s.name)}</span>
-          <span class="onboarding__cat-tag">${escHtml(catLabel)}</span>
+          <span class="onboarding__cat-tag">${escHtml(catLabel)}</span>${healthHtml}
         </div>
         <button class="btn btn--ghost btn--sm remove-source-btn" data-source-id="${escHtml(s.id)}" style="flex-shrink: 0; font-size: var(--text-2xs); color: var(--fg-subtle);">
           &times;
@@ -5002,6 +5168,8 @@ body {
       showOnboarding();
     } else {
       document.getElementById('eventsContent').style.display = '';
+      // Load health from DB first (non-blocking) so UI shows status immediately
+      loadSourceHealth().catch(e => log('Init health load: ' + e.message));
       fetchAllSources();
       // Load personalized recommendations (non-blocking)
       loadRecommendedEvents();

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -1,10 +1,14 @@
 // Supabase Edge Function: cache-events
 // Accepts scraped events from the client, deduplicates via event_key, upserts to DB.
 // Triggers enrichment for new events that have URLs.
+// Also accepts sourceOutcomes for persistent health tracking.
 //
 // POST /functions/v1/cache-events
-// Body: { events: Event[] }
-// Returns: { cached, updated, enrichQueued, errors }
+// Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
+// Returns: { cached, updated, enrichQueued, healthUpdated, errors }
+
+const VERSION = '1.1.0'
+console.log(`[cache-events] v${VERSION} - event caching with source health tracking`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -48,6 +52,96 @@ interface ScrapedEvent {
   contentType?: string
 }
 
+interface SourceOutcome {
+  sourceId: string
+  sourceName: string
+  sourceUrl: string
+  sourceType: string
+  eventCount: number
+  ok: boolean
+  errorReason?: string
+  durationMs?: number
+}
+
+// --- Source Health Upsert (mirrors domain_profiles pattern from enrich-link) ---
+
+function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number): string {
+  if (totalScrapes < 3) return 'unknown'
+  if (consecutiveFailures >= 6 || (totalScrapes >= 5 && successRate < 0.3)) return 'broken'
+  if (consecutiveFailures >= 3 || (totalScrapes >= 5 && successRate < 0.65)) return 'degraded'
+  if (successRate >= 0.8 && consecutiveFailures < 3) return 'healthy'
+  return 'unknown'
+}
+
+async function upsertSourceHealth(
+  supabase: ReturnType<typeof createClient>,
+  outcome: SourceOutcome,
+): Promise<void> {
+  const isSuccess = outcome.ok && outcome.eventCount > 0
+  const outcomeKey = isSuccess ? 'success'
+    : (outcome.ok && outcome.eventCount === 0) ? 'zero_results'
+    : (outcome.errorReason || 'unknown')
+
+  const { data: existing } = await supabase
+    .from('source_health')
+    .select('*')
+    .eq('source_id', outcome.sourceId)
+    .single()
+
+  if (existing) {
+    const outcomesSeen = existing.outcomes_seen || {}
+    outcomesSeen[outcomeKey] = (outcomesSeen[outcomeKey] || 0) + 1
+
+    const total = existing.total_scrapes + 1
+    const successCount = existing.success_count + (isSuccess ? 1 : 0)
+    const zeroCount = existing.zero_result_count + (outcomeKey === 'zero_results' ? 1 : 0)
+    const errorCount = existing.error_count + (!outcome.ok ? 1 : 0)
+    const successRate = total > 0 ? successCount / total : 1.0
+    const consecutiveFailures = isSuccess ? 0 : existing.consecutive_failures + 1
+    const status = deriveStatus(successRate, consecutiveFailures, total)
+
+    await supabase.from('source_health').update({
+      source_name: outcome.sourceName,
+      source_url: outcome.sourceUrl,
+      source_type: outcome.sourceType,
+      outcomes_seen: outcomesSeen,
+      total_scrapes: total,
+      success_count: successCount,
+      zero_result_count: zeroCount,
+      error_count: errorCount,
+      success_rate: successRate,
+      consecutive_failures: consecutiveFailures,
+      last_failure_reason: isSuccess ? existing.last_failure_reason : (outcome.errorReason || outcomeKey),
+      last_failure_at: isSuccess ? existing.last_failure_at : new Date().toISOString(),
+      last_success_at: isSuccess ? new Date().toISOString() : existing.last_success_at,
+      last_success_event_count: isSuccess ? outcome.eventCount : existing.last_success_event_count,
+      status,
+      last_scraped_at: new Date().toISOString(),
+    }).eq('source_id', outcome.sourceId)
+  } else {
+    const outcomesSeen = { [outcomeKey]: 1 }
+    await supabase.from('source_health').insert({
+      source_id: outcome.sourceId,
+      source_name: outcome.sourceName,
+      source_url: outcome.sourceUrl,
+      source_type: outcome.sourceType,
+      outcomes_seen: outcomesSeen,
+      total_scrapes: 1,
+      success_count: isSuccess ? 1 : 0,
+      zero_result_count: outcomeKey === 'zero_results' ? 1 : 0,
+      error_count: !outcome.ok ? 1 : 0,
+      success_rate: isSuccess ? 1.0 : 0.0,
+      consecutive_failures: isSuccess ? 0 : 1,
+      last_failure_reason: isSuccess ? null : (outcome.errorReason || outcomeKey),
+      last_failure_at: isSuccess ? null : new Date().toISOString(),
+      last_success_at: isSuccess ? new Date().toISOString() : null,
+      last_success_event_count: isSuccess ? outcome.eventCount : null,
+      status: 'unknown',
+      last_scraped_at: new Date().toISOString(),
+    })
+  }
+}
+
 serve(async (req: Request) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
@@ -58,19 +152,40 @@ serve(async (req: Request) => {
   }
 
   try {
-    const { events } = await req.json() as { events: ScrapedEvent[] }
+    const body = await req.json() as { events?: ScrapedEvent[]; sourceOutcomes?: SourceOutcome[] }
+    const events = body.events
+    const sourceOutcomes = body.sourceOutcomes
 
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseKey)
+
+    // --- Process source health outcomes (if provided) ---
+    let healthUpdated = 0
+    if (sourceOutcomes && Array.isArray(sourceOutcomes) && sourceOutcomes.length > 0) {
+      for (const outcome of sourceOutcomes) {
+        if (!outcome.sourceId) continue
+        try {
+          await upsertSourceHealth(supabase, outcome)
+          healthUpdated++
+        } catch (err) {
+          console.error(`[cache-events] Health upsert failed for ${outcome.sourceId}:`, (err as Error).message)
+        }
+      }
+      console.log(`[cache-events] Health: updated ${healthUpdated}/${sourceOutcomes.length} sources`)
+    }
+
+    // --- If no events, return health-only result ---
     if (!events || !Array.isArray(events) || events.length === 0) {
+      if (healthUpdated > 0) {
+        return jsonResponse({ cached: 0, updated: 0, enrichQueued: 0, healthUpdated })
+      }
       return jsonResponse({ error: 'events array required' }, 400)
     }
 
     if (events.length > 500) {
       return jsonResponse({ error: 'Max 500 events per request' }, 400)
     }
-
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-    const supabase = createClient(supabaseUrl, supabaseKey)
 
     let cached = 0
     let updated = 0
@@ -103,7 +218,7 @@ serve(async (req: Request) => {
     const validRows = rows.filter(Boolean) as Record<string, unknown>[]
 
     if (validRows.length === 0) {
-      return jsonResponse({ cached: 0, updated: 0, enrichQueued: 0, errors: ['No valid events'] })
+      return jsonResponse({ cached: 0, updated: 0, enrichQueued: 0, healthUpdated, errors: ['No valid events'] })
     }
 
     // Check which event_keys already exist
@@ -189,9 +304,9 @@ serve(async (req: Request) => {
       }
     }
 
-    console.log(`[cache-events] cached=${cached} updated=${updated} enrichQueued=${enrichQueued} errors=${errors.length}`)
+    console.log(`[cache-events] cached=${cached} updated=${updated} enrichQueued=${enrichQueued} healthUpdated=${healthUpdated} errors=${errors.length}`)
 
-    return jsonResponse({ cached, updated, enrichQueued, errors: errors.length > 0 ? errors : undefined })
+    return jsonResponse({ cached, updated, enrichQueued, healthUpdated, errors: errors.length > 0 ? errors : undefined })
   } catch (err) {
     console.error('[cache-events] Error:', err)
     return jsonResponse({ error: (err as Error).message }, 500)

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -6,6 +6,9 @@
 // Body: { eventIds: string[] }   (batch up to 10)
 // Returns: { processed, succeeded, failed, results }
 
+const VERSION = '1.1.0'
+console.log(`[enrich-event] v${VERSION} - event enrichment with stuck-state recovery`)
+
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts'
@@ -362,6 +365,18 @@ serve(async (req: Request) => {
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     )
+
+    // Recover events stuck in 'processing' for > 15 minutes (timed out)
+    const fifteenMinAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString()
+    const { data: stuckEvents } = await supabase
+      .from('events')
+      .update({ enrichment_status: 'failed', enrichment_error: 'Timed out in processing state' })
+      .eq('enrichment_status', 'processing')
+      .lt('updated_at', fifteenMinAgo)
+      .select('id')
+    if (stuckEvents && stuckEvents.length > 0) {
+      console.log(`[enrich-event] Recovered ${stuckEvents.length} stuck events from processing → failed`)
+    }
 
     const { data: events, error: fetchErr } = await supabase
       .from('events')

--- a/supabase/migrations/024_source_health.sql
+++ b/supabase/migrations/024_source_health.sql
@@ -1,0 +1,89 @@
+-- ============================================
+-- Source Health Tracking
+-- Migration 024
+-- Tracks per-source scrape outcomes to detect degraded or broken sources.
+-- Pattern mirrors domain_profiles: accumulate outcomes, compute success rate.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS source_health (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Identity
+  source_id TEXT UNIQUE NOT NULL,
+  source_name TEXT,
+  source_url TEXT,
+  source_type TEXT,
+
+  -- Rolling outcome accumulator (mirrors types_seen in domain_profiles)
+  -- Structure: { "success": 42, "zero_results": 8, "timeout": 2, "blocked": 1, ... }
+  outcomes_seen JSONB DEFAULT '{}',
+
+  -- Derived metrics (recomputed on each upsert)
+  total_scrapes INTEGER DEFAULT 0,
+  success_count INTEGER DEFAULT 0,
+  zero_result_count INTEGER DEFAULT 0,
+  error_count INTEGER DEFAULT 0,
+  success_rate REAL DEFAULT 1.0,
+
+  -- Consecutive failure tracking (resets on any successful scrape with >0 events)
+  consecutive_failures INTEGER DEFAULT 0,
+  last_failure_reason TEXT,
+  last_failure_at TIMESTAMPTZ,
+
+  -- Last known good state
+  last_success_at TIMESTAMPTZ,
+  last_success_event_count INTEGER,
+
+  -- Status (derived, stored for fast querying)
+  status TEXT DEFAULT 'unknown'
+    CHECK (status IN ('healthy', 'degraded', 'broken', 'unknown')),
+
+  -- Repair tracking (for future auto-repair phases)
+  repair_attempted_at TIMESTAMPTZ,
+  repair_strategy TEXT,
+  repair_result TEXT,
+
+  -- Timestamps
+  first_seen_at TIMESTAMPTZ DEFAULT NOW(),
+  last_scraped_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_source_health_status
+  ON source_health(status) WHERE status IN ('degraded', 'broken');
+
+CREATE INDEX IF NOT EXISTS idx_source_health_source_id
+  ON source_health(source_id);
+
+CREATE INDEX IF NOT EXISTS idx_source_health_consecutive_failures
+  ON source_health(consecutive_failures DESC);
+
+ALTER TABLE source_health ENABLE ROW LEVEL SECURITY;
+
+-- Anyone can read health data
+CREATE POLICY "Public read source health"
+  ON source_health FOR SELECT USING (true);
+
+-- Anon can insert/update (client reports outcomes after each scrape)
+CREATE POLICY "Anon insert source health"
+  ON source_health FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "Anon update source health"
+  ON source_health FOR UPDATE USING (true);
+
+-- Service role full access
+CREATE POLICY "Service role full access to source health"
+  ON source_health FOR ALL USING (auth.role() = 'service_role');
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_source_health_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER source_health_updated_at
+  BEFORE UPDATE ON source_health
+  FOR EACH ROW EXECUTE FUNCTION update_source_health_timestamp();


### PR DESCRIPTION
## Summary
- **New `source_health` table** (migration 024) — tracks per-source scrape outcomes, success rates, consecutive failures, and derived status (`healthy`/`degraded`/`broken`/`unknown`)
- **`cache-events` extended** — accepts optional `sourceOutcomes` field alongside events, upserts health data using the `domain_profiles` accumulation pattern
- **Frontend outcome collection** — every source's result (including zero-result sources that were previously silent) is reported to the health system
- **Health UI** — colored status dots on source chips, warning banner for broken/degraded sources, health info in the manage sources modal
- **Stuck enrichment recovery** — `enrich-event` now recovers events stuck in `processing` state for >15 minutes

## Test plan
- [ ] Run migration 024 against Boards Supabase project
- [ ] Deploy `cache-events` and `enrich-event` edge functions
- [ ] Load events page, verify `source_health` table gets populated after scrape
- [ ] Check source chips show health dots (green/yellow/red) after first scrape cycle
- [ ] Verify zero-result sources log "0 events returned (no error)" in debug console
- [ ] Verify broken/degraded sources trigger warning banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)