### PR TITLE
feat: source auto-repair system (Phases 4-5)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1059,6 +1059,10 @@ body {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
 
 /* ---- Responsive: Tablet (768px) ---- */
 @media (max-width: 768px) {
@@ -1567,8 +1571,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.1.0';
-  console.log(`[events] v${VERSION} - source health tracking`);
+  const VERSION = '1.2.0';
+  console.log(`[events] v${VERSION} - source auto-repair`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1678,6 +1682,8 @@ body {
     sources: [],
     sourceErrors: {},  // { sourceId: { reason: 'timeout'|'blocked'|'offline'|'empty'|'unknown', message: '...' } }
     sourceHealth: {},  // { sourceId: { status, consecutive_failures, success_rate, last_failure_reason, ... } }
+    repairedThisSession: new Set(),  // sourceIds repaired this page load (avoid loops)
+    repairInProgress: false,  // true while auto-repair is running
     filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', contentType: '' },
     sort: { key: 'date', dir: 'asc' },
     view: 'table',
@@ -2078,6 +2084,7 @@ body {
 
   // --- Fetch via Edge Function (primary) then CORS proxies (fallback) ---
   const FETCH_SOURCE_URL = SUPABASE_URL + '/functions/v1/fetch-source';
+  const VALIDATE_SOURCE_URL = SUPABASE_URL + '/functions/v1/validate-source';
 
   async function proxyFetch(url) {
     log(`Fetching: ${url}`);
@@ -2364,7 +2371,7 @@ body {
     try {
       const { data: healthRows } = await supabaseClient
         .from('source_health')
-        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes')
+        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes, repair_attempted_at, repair_strategy, repair_result')
         .in('source_id', enabledIds);
 
       if (!healthRows) return;
@@ -2384,6 +2391,10 @@ body {
       const degraded = healthRows.filter(r => r.status === 'degraded');
       if (broken.length > 0 || degraded.length > 0) {
         showSourceHealthWarning(broken, degraded);
+        // Trigger auto-repair for broken sources (non-blocking)
+        if (broken.length > 0 && !state.repairInProgress) {
+          attemptAutoRepair(broken).catch(e => log('Auto-repair error: ' + e.message));
+        }
       } else {
         // Clear any existing warning
         const existing = document.getElementById('sourceHealthWarning');
@@ -2431,6 +2442,340 @@ body {
     const insertBefore = chips || cal || container?.firstChild;
     if (insertBefore && container) {
       container.insertBefore(warn, insertBefore);
+    }
+  }
+
+  // --- Auto-Repair System ---
+  // When broken/degraded sources are detected, attempt autonomous repair:
+  // 1. Probe via validate-source edge function (structural analysis)
+  // 2. Try alternative parser types if structure changed
+  // 3. Report results to source_health table
+
+  const MAX_REPAIRS_PER_SESSION = 3;
+  const REPAIR_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours between repair attempts per source
+
+  async function callValidateSource(sourceId, url, currentType, includeAiAnalysis = false) {
+    try {
+      const resp = await fetch(VALIDATE_SOURCE_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ' + SUPABASE_ANON_KEY,
+          'apikey': SUPABASE_ANON_KEY,
+        },
+        body: JSON.stringify({ sourceId, url, currentType, includeAiAnalysis }),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text();
+        log(`validate-source error: ${resp.status} ${errText}`);
+        return null;
+      }
+      return await resp.json();
+    } catch (e) {
+      log(`validate-source call failed: ${e.message}`);
+      return null;
+    }
+  }
+
+  async function fetchSingleSource(source) {
+    const type = source.type === 'auto' ? detectSourceType(source.url) : source.type;
+    if (type === 'screenslate') return await fetchScreenSlate(source);
+    if (type === 'ra') return await fetchRA(source);
+    if (type === 'garysguide') return await fetchGarysGuide(source);
+    if (type === 'bonobo') return await fetchBonobo(source);
+    if (type === 'html') return await fetchHtml(source);
+    if (type === 'ical') return await fetchIcal(source);
+    if (type === 'json') return await fetchJson(source);
+    if (type === 'rss') return await fetchRss(source);
+    if (type === 'discord') return await fetchDiscord(source);
+    return [];
+  }
+
+  async function tryAlternativeParser(source, newType) {
+    const originalType = source.type;
+    log(`Auto-repair: trying "${source.name}" with type="${newType}" (was "${originalType}")`);
+    source.type = newType;
+    try {
+      const events = await fetchSingleSource(source);
+      if (events && events.length > 0) {
+        log(`Auto-repair: SUCCESS! "${source.name}" returned ${events.length} events with type="${newType}"`);
+        // Keep the new type for this session
+        return { success: true, events, newType, eventCount: events.length };
+      }
+      log(`Auto-repair: "${source.name}" with type="${newType}" returned 0 events`);
+    } catch (e) {
+      log(`Auto-repair: "${source.name}" with type="${newType}" threw: ${e.message}`);
+    }
+    // Restore original type on failure
+    source.type = originalType;
+    return { success: false, events: [], newType, eventCount: 0 };
+  }
+
+  async function reportRepairResult(sourceId, strategy, result) {
+    if (!supabaseClient) return;
+    try {
+      await supabaseClient.from('source_health').update({
+        repair_attempted_at: new Date().toISOString(),
+        repair_strategy: strategy,
+        repair_result: JSON.stringify(result),
+      }).eq('source_id', sourceId);
+      log(`Auto-repair: reported result for "${sourceId}": strategy=${strategy} success=${result.success}`);
+    } catch (e) {
+      log(`Auto-repair: failed to report result: ${e.message}`);
+    }
+  }
+
+  function selectRepairStrategy(validation) {
+    if (!validation) return { strategy: 'probe-failed', action: 'none' };
+    if (!validation.reachable) {
+      if (validation.httpStatus === 403 || validation.httpStatus === 429) {
+        return { strategy: 'blocked', action: 'none' };
+      }
+      if (validation.httpStatus === 404) {
+        return { strategy: 'url-changed', action: 'none' };
+      }
+      return { strategy: 'unreachable', action: 'none' };
+    }
+
+    const sr = validation.structureReport || {};
+
+    // Reachable — check if detected type differs from current
+    if (validation.detectedType && validation.detectedType !== validation.currentType) {
+      return { strategy: 'type-mismatch', action: 'try-type', newType: validation.detectedType };
+    }
+
+    // Same type, but has structure signals → probably transient
+    const hasSignals = sr.eventSignals && sr.eventSignals.length > 0;
+    const hasContent = sr.hasTable || sr.hasEventSchema || sr.hasRssItems || sr.hasIcalEvents || sr.hasJsonArray;
+    if (hasSignals || hasContent) {
+      return { strategy: 'transient', action: 'retry' };
+    }
+
+    // No structure found — need AI analysis
+    return { strategy: 'structure-changed', action: 'ai-diagnose' };
+  }
+
+  async function attemptAutoRepair(brokenSources) {
+    if (state.repairInProgress) return;
+    if (brokenSources.length === 0) return;
+
+    state.repairInProgress = true;
+    let repairsAttempted = 0;
+    const results = [];
+
+    log(`Auto-repair: starting for ${brokenSources.length} source(s)`);
+
+    for (const healthRow of brokenSources) {
+      if (repairsAttempted >= MAX_REPAIRS_PER_SESSION) {
+        log(`Auto-repair: hit session limit (${MAX_REPAIRS_PER_SESSION})`);
+        break;
+      }
+
+      const sourceId = healthRow.source_id;
+
+      // Skip if already repaired this session
+      if (state.repairedThisSession.has(sourceId)) {
+        log(`Auto-repair: skipping "${sourceId}" — already attempted this session`);
+        continue;
+      }
+
+      // Skip if repair was attempted recently (read from health row)
+      if (healthRow.repair_attempted_at) {
+        const lastRepair = new Date(healthRow.repair_attempted_at).getTime();
+        if (Date.now() - lastRepair < REPAIR_COOLDOWN_MS) {
+          log(`Auto-repair: skipping "${sourceId}" — repaired ${Math.round((Date.now() - lastRepair) / 3600000)}h ago`);
+          continue;
+        }
+      }
+
+      const source = state.sources.find(s => s.id === sourceId);
+      if (!source || !source.url) {
+        log(`Auto-repair: skipping "${sourceId}" — source not found or no URL`);
+        continue;
+      }
+
+      state.repairedThisSession.add(sourceId);
+      repairsAttempted++;
+
+      // Show repair-in-progress UI
+      updateRepairBanner(source.name, 'probing');
+
+      // Step 1: Probe via validate-source
+      const validation = await callValidateSource(sourceId, source.url, source.type);
+      if (!validation) {
+        const result = { success: false, diagnosis: 'validate-source call failed', timestamp: new Date().toISOString() };
+        await reportRepairResult(sourceId, 'probe-failed', result);
+        results.push({ sourceId, ...result });
+        continue;
+      }
+
+      // Step 2: Select strategy
+      let decision = selectRepairStrategy({ ...validation, currentType: source.type });
+      log(`Auto-repair: "${source.name}" → strategy="${decision.strategy}" action="${decision.action}"`);
+
+      let repairResult = { success: false, oldType: source.type, newType: null, eventsFound: 0, diagnosis: null, timestamp: new Date().toISOString() };
+
+      // Step 3: Execute strategy
+      if (decision.action === 'try-type') {
+        updateRepairBanner(source.name, 'trying', decision.newType);
+        const tryResult = await tryAlternativeParser(source, decision.newType);
+        if (tryResult.success) {
+          repairResult.success = true;
+          repairResult.newType = decision.newType;
+          repairResult.eventsFound = tryResult.eventCount;
+          repairResult.diagnosis = `Switched from ${repairResult.oldType} to ${decision.newType}`;
+          // Merge new events into state
+          if (tryResult.events.length > 0) {
+            tryResult.events.forEach(ev => {
+              ev.contentType = getSourceCategory(ev.source);
+              ev.contentType = detectEventType(ev);
+            });
+            state.events = deduplicateAcrossSources([...state.events, ...tryResult.events]);
+            render();
+          }
+        }
+      } else if (decision.action === 'retry') {
+        updateRepairBanner(source.name, 'retrying');
+        try {
+          const events = await fetchSingleSource(source);
+          if (events && events.length > 0) {
+            repairResult.success = true;
+            repairResult.eventsFound = events.length;
+            repairResult.diagnosis = 'Transient failure — retry succeeded';
+            events.forEach(ev => {
+              ev.contentType = getSourceCategory(ev.source);
+              ev.contentType = detectEventType(ev);
+            });
+            state.events = deduplicateAcrossSources([...state.events, ...events]);
+            render();
+          } else {
+            repairResult.diagnosis = 'Retry returned 0 events — may be seasonal or structural';
+          }
+        } catch (e) {
+          repairResult.diagnosis = `Retry failed: ${e.message}`;
+        }
+      } else if (decision.action === 'ai-diagnose') {
+        updateRepairBanner(source.name, 'analyzing');
+        const aiValidation = await callValidateSource(sourceId, source.url, source.type, true);
+        if (aiValidation?.aiAnalysis) {
+          repairResult.diagnosis = aiValidation.aiAnalysis.diagnosis;
+          log(`Auto-repair: AI diagnosis for "${source.name}": ${aiValidation.aiAnalysis.diagnosis}`);
+
+          // If AI suggests a different type with decent confidence, try it
+          if (aiValidation.aiAnalysis.suggestedType &&
+              aiValidation.aiAnalysis.suggestedType !== source.type &&
+              aiValidation.aiAnalysis.confidence >= 0.5) {
+            updateRepairBanner(source.name, 'trying', aiValidation.aiAnalysis.suggestedType);
+            const tryResult = await tryAlternativeParser(source, aiValidation.aiAnalysis.suggestedType);
+            if (tryResult.success) {
+              repairResult.success = true;
+              repairResult.newType = aiValidation.aiAnalysis.suggestedType;
+              repairResult.eventsFound = tryResult.eventCount;
+              repairResult.diagnosis = `AI suggested ${aiValidation.aiAnalysis.suggestedType}: ${aiValidation.aiAnalysis.diagnosis}`;
+              if (tryResult.events.length > 0) {
+                tryResult.events.forEach(ev => {
+                  ev.contentType = getSourceCategory(ev.source);
+                  ev.contentType = detectEventType(ev);
+                });
+                state.events = deduplicateAcrossSources([...state.events, ...tryResult.events]);
+                render();
+              }
+            }
+          }
+        } else {
+          repairResult.diagnosis = 'AI analysis unavailable';
+        }
+      } else {
+        // action === 'none' — no repair possible
+        repairResult.diagnosis = `Source is ${decision.strategy} — no automatic repair available`;
+      }
+
+      await reportRepairResult(sourceId, decision.strategy, repairResult);
+      results.push({ sourceId, ...repairResult });
+
+      // Delay between sources to avoid hammering
+      if (brokenSources.indexOf(healthRow) < brokenSources.length - 1) {
+        await new Promise(r => setTimeout(r, 1500));
+      }
+    }
+
+    state.repairInProgress = false;
+    showRepairResults(results);
+    // Reload health to get updated status after repairs
+    await loadSourceHealth();
+    log(`Auto-repair: complete — ${results.filter(r => r.success).length}/${results.length} succeeded`);
+  }
+
+  function updateRepairBanner(sourceName, phase, detail) {
+    let warn = document.getElementById('sourceHealthWarning');
+    if (!warn) {
+      warn = document.createElement('div');
+      warn.id = 'sourceHealthWarning';
+      warn.style.cssText = 'background:#0a0a1a;border:1px solid #334466;color:#6699cc;padding:8px 12px;margin:0 0 12px;border-radius:6px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:8px;';
+      const container = document.querySelector('.container');
+      const chips = document.getElementById('sourceChips');
+      const cal = document.getElementById('calendarView');
+      const insertBefore = chips || cal || container?.firstChild;
+      if (insertBefore && container) container.insertBefore(warn, insertBefore);
+    }
+
+    const phases = {
+      probing: `Probing ${sourceName}...`,
+      trying: `Trying ${sourceName} with ${detail || 'alternative'} parser...`,
+      retrying: `Retrying ${sourceName}...`,
+      analyzing: `AI analyzing ${sourceName}...`,
+    };
+    const msg = phases[phase] || `Repairing ${sourceName}...`;
+    warn.style.background = '#0a0a1a';
+    warn.style.borderColor = '#334466';
+    warn.style.color = '#6699cc';
+    warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Auto-Repair</span> — ${msg} <span style="display:inline-block;animation:pulse 1s infinite;">⟳</span></span>`;
+  }
+
+  function showRepairResults(results) {
+    if (results.length === 0) return;
+    const warn = document.getElementById('sourceHealthWarning');
+    if (!warn) return;
+
+    const successes = results.filter(r => r.success);
+    const failures = results.filter(r => !r.success);
+
+    if (successes.length > 0 && failures.length === 0) {
+      // All succeeded
+      const names = successes.map(r => {
+        const src = state.sources.find(s => s.id === r.sourceId);
+        return src ? `${src.name} (${r.eventsFound} events)` : r.sourceId;
+      });
+      warn.style.background = '#0a1a0a';
+      warn.style.borderColor = '#336633';
+      warn.style.color = '#66cc66';
+      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Repaired</span> — ${names.join(', ')}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#66cc66;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
+      // Auto-dismiss after 10 seconds
+      setTimeout(() => { if (warn.parentElement) warn.remove(); }, 10000);
+    } else if (successes.length === 0) {
+      // All failed
+      const names = failures.map(r => {
+        const src = state.sources.find(s => s.id === r.sourceId);
+        return src ? src.name : r.sourceId;
+      });
+      warn.style.background = '#1a0a00';
+      warn.style.borderColor = '#663300';
+      warn.style.color = '#ff9944';
+      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Repair Failed</span> — ${names.join(', ')}. ${failures[0].diagnosis || 'Unknown issue.'}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#ff9944;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
+    } else {
+      // Mixed results
+      const successNames = successes.map(r => {
+        const src = state.sources.find(s => s.id === r.sourceId);
+        return src ? src.name : r.sourceId;
+      });
+      const failNames = failures.map(r => {
+        const src = state.sources.find(s => s.id === r.sourceId);
+        return src ? src.name : r.sourceId;
+      });
+      warn.style.background = '#0a0a1a';
+      warn.style.borderColor = '#334466';
+      warn.style.color = '#6699cc';
+      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Partial Repair</span> — Fixed: ${successNames.join(', ')} · Still broken: ${failNames.join(', ')}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#6699cc;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
     }
   }
 
@@ -4227,7 +4572,14 @@ body {
           broken: `Broken — ${health.consecutive_failures} failures`,
         };
         const lastOk = health.last_success_at ? new Date(health.last_success_at).toLocaleDateString() : 'never';
-        healthHtml = `<span style="font-size:10px;color:${colors[health.status]};margin-left:6px;" title="Last success: ${lastOk}">${labels[health.status]}</span>`;
+        let repairInfo = '';
+        if (health.repair_attempted_at) {
+          const repairDate = new Date(health.repair_attempted_at).toLocaleDateString();
+          let repairDetail = '';
+          try { repairDetail = health.repair_result ? JSON.parse(health.repair_result).success ? ' ✓' : ' ✗' : ''; } catch {}
+          repairInfo = ` · Repair: ${repairDate}${repairDetail}`;
+        }
+        healthHtml = `<span style="font-size:10px;color:${colors[health.status]};margin-left:6px;" title="Last success: ${lastOk}${repairInfo}">${labels[health.status]}</span>`;
       }
       return `<div style="display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-3); border-bottom: var(--border-thin) solid var(--border-subtle);">
         <div style="flex: 1; min-width: 0;">

--- a/supabase/functions/validate-source/index.ts
+++ b/supabase/functions/validate-source/index.ts
@@ -1,0 +1,486 @@
+// Supabase Edge Function: validate-source
+// Server-side structural probe for event source URLs.
+// Fetches the page, analyzes content structure, detects source type,
+// and optionally uses Claude Haiku to diagnose parsing failures.
+// Used by the auto-repair system to determine why a source is broken
+// and suggest a repair strategy.
+//
+// POST /functions/v1/validate-source
+// Body: { sourceId, url, currentType, includeAiAnalysis? }
+// Returns: { sourceId, reachable, httpStatus, contentType, detectedType, structureReport, htmlSnippet?, aiAnalysis? }
+
+const VERSION = '1.0.0'
+console.log(`[validate-source] v${VERSION} - source structural probe with AI diagnosis`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+// Domain allowlist — same as fetch-source
+const ALLOWED_DOMAINS = [
+  '19hz.info',
+  'ra.co', 'www.ra.co',
+  'punchlinecomedyclub.com', 'www.punchlinecomedyclub.com',
+  'cobbscomedy.com', 'www.cobbscomedy.com',
+  'roxie.com', 'www.roxie.com',
+  'screenslate.com', 'www.screenslate.com',
+  'alamodrafthouse.com', 'drafthouse.com', 'www.drafthouse.com',
+  'eventbrite.com', 'www.eventbrite.com',
+  'garysguide.com', 'www.garysguide.com',
+  'bonobonetwork.com', 'www.bonobonetwork.com',
+  'hyperallergic.com', 'www.hyperallergic.com',
+  'sfmoma.org', 'www.sfmoma.org',
+  'famsf.org', 'www.famsf.org',
+  'sfdesignweek.org', 'www.sfdesignweek.org',
+  'citylights.com', 'www.citylights.com',
+  'sfpl.org', 'www.sfpl.org',
+  'commonwealthclub.org', 'www.commonwealthclub.org',
+  'dice.fm', 'www.dice.fm',
+  'songkick.com', 'www.songkick.com',
+]
+
+function isDomainAllowed(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return ALLOWED_DOMAINS.some(d => hostname === d || hostname.endsWith('.' + d))
+  } catch {
+    return false
+  }
+}
+
+// --- Content type detection ---
+
+type SourceType = 'html' | 'rss' | 'json' | 'ical' | null
+
+function detectContentType(contentTypeHeader: string, body: string): SourceType {
+  const ct = contentTypeHeader.toLowerCase()
+
+  // Check headers first
+  if (ct.includes('application/json')) return 'json'
+  if (ct.includes('application/rss+xml') || ct.includes('application/atom+xml')) return 'rss'
+  if (ct.includes('text/calendar')) return 'ical'
+
+  // Content sniffing for ambiguous content-types
+  const trimmed = body.trimStart()
+  if (trimmed.startsWith('BEGIN:VCALENDAR')) return 'ical'
+  if (trimmed.startsWith('<?xml') || trimmed.startsWith('<rss') || trimmed.startsWith('<feed')) return 'rss'
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+    try {
+      JSON.parse(body)
+      return 'json'
+    } catch { /* not valid JSON */ }
+  }
+
+  if (ct.includes('text/html') || ct.includes('application/xhtml')) return 'html'
+  if (ct.includes('text/xml') || ct.includes('application/xml')) {
+    // Could be RSS or generic XML
+    if (body.includes('<item>') || body.includes('<entry>')) return 'rss'
+    return 'html' // treat as HTML for table parsing
+  }
+
+  return null
+}
+
+// --- Structural analysis ---
+
+interface StructureReport {
+  hasTable: boolean
+  tableRowCount: number
+  hasEventSchema: boolean
+  hasIcalEvents: boolean
+  hasRssItems: boolean
+  hasJsonArray: boolean
+  hasDatePatterns: boolean
+  eventSignals: string[]
+}
+
+function analyzeStructure(body: string, detectedType: SourceType): StructureReport {
+  const report: StructureReport = {
+    hasTable: false,
+    tableRowCount: 0,
+    hasEventSchema: false,
+    hasIcalEvents: false,
+    hasRssItems: false,
+    hasJsonArray: false,
+    hasDatePatterns: false,
+    eventSignals: [],
+  }
+
+  // Date pattern detection (applies to all types)
+  const datePatterns = [
+    /\d{4}-\d{2}-\d{2}/g,                     // ISO dates
+    /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}/gi,  // Month Day
+    /\d{1,2}\/\d{1,2}\/\d{2,4}/g,             // MM/DD/YYYY
+  ]
+  for (const pattern of datePatterns) {
+    const matches = body.match(pattern)
+    if (matches && matches.length >= 2) {
+      report.hasDatePatterns = true
+      report.eventSignals.push(`date-patterns-found:${matches.length}`)
+      break
+    }
+  }
+
+  // iCal analysis
+  const veventCount = (body.match(/BEGIN:VEVENT/g) || []).length
+  if (veventCount > 0) {
+    report.hasIcalEvents = true
+    report.eventSignals.push(`ical-events:${veventCount}`)
+  }
+
+  // RSS analysis
+  const itemCount = (body.match(/<item[\s>]/g) || []).length
+  const entryCount = (body.match(/<entry[\s>]/g) || []).length
+  if (itemCount > 0 || entryCount > 0) {
+    report.hasRssItems = true
+    report.eventSignals.push(`rss-items:${itemCount + entryCount}`)
+  }
+
+  // JSON analysis
+  if (detectedType === 'json') {
+    try {
+      const parsed = JSON.parse(body)
+      if (Array.isArray(parsed)) {
+        report.hasJsonArray = true
+        report.eventSignals.push(`json-array:${parsed.length}`)
+      } else if (typeof parsed === 'object') {
+        // Check for common event wrapper keys
+        const wrapperKeys = ['events', 'items', 'results', 'data', 'listings']
+        for (const key of wrapperKeys) {
+          if (parsed[key] && Array.isArray(parsed[key])) {
+            report.hasJsonArray = true
+            report.eventSignals.push(`json-wrapper:${key}:${parsed[key].length}`)
+            break
+          }
+        }
+      }
+    } catch { /* already handled by detectedType check */ }
+  }
+
+  // HTML analysis (most complex)
+  if (detectedType === 'html' || detectedType === null) {
+    try {
+      const doc = new DOMParser().parseFromString(body, 'text/html')
+      if (doc) {
+        // Table analysis
+        const tables = doc.querySelectorAll('table')
+        if (tables.length > 0) {
+          report.hasTable = true
+          let maxRows = 0
+          tables.forEach((table: Element) => {
+            const rows = table.querySelectorAll('tr')
+            if (rows.length > maxRows) maxRows = rows.length
+          })
+          report.tableRowCount = maxRows
+          report.eventSignals.push(`table-rows:${maxRows}`)
+
+          // Check for 19hz-style 11-column tables
+          const firstTable = tables[0]
+          if (firstTable) {
+            const firstRow = firstTable.querySelector('tr')
+            const cells = firstRow?.querySelectorAll('td, th')
+            if (cells) {
+              const colCount = cells.length
+              if (colCount >= 10) report.eventSignals.push(`table-${colCount}-col`)
+              else if (colCount >= 6) report.eventSignals.push(`table-${colCount}-col`)
+              else if (colCount >= 4) report.eventSignals.push(`table-${colCount}-col`)
+            }
+          }
+        }
+
+        // JSON-LD Event schema
+        const scripts = doc.querySelectorAll('script[type="application/ld+json"]')
+        scripts.forEach((script: Element) => {
+          const text = script.textContent || ''
+          if (text.includes('"Event"') || text.includes('"MusicEvent"') || text.includes('"ComedyEvent"')) {
+            report.hasEventSchema = true
+            report.eventSignals.push('json-ld-event')
+          }
+        })
+
+        // Event-specific CSS classes
+        const eventSelectors = [
+          '.event', '.event-item', '.event-card', '.event-listing',
+          '.eventlist-event', '[data-type="events"]',
+          '.event-row', '.event-entry', '.listing',
+          '.show', '.performance', '.screening',
+        ]
+        for (const sel of eventSelectors) {
+          const elements = doc.querySelectorAll(sel)
+          if (elements.length > 0) {
+            report.eventSignals.push(`css-class:${sel}:${elements.length}`)
+          }
+        }
+
+        // Squarespace event indicators
+        if (body.includes('squarespace') || body.includes('sqs-block')) {
+          report.eventSignals.push('squarespace-detected')
+          const sqsEvents = doc.querySelectorAll('.eventlist-event, [data-type="events"] article')
+          if (sqsEvents.length > 0) {
+            report.eventSignals.push(`squarespace-events:${sqsEvents.length}`)
+          }
+        }
+
+        // Gary's Guide specific
+        if (body.includes('ftitle') || body.includes('fblack')) {
+          report.eventSignals.push('garysguide-structure')
+          const titles = doc.querySelectorAll('.ftitle')
+          if (titles.length > 0) {
+            report.eventSignals.push(`garysguide-titles:${titles.length}`)
+          }
+        }
+      }
+    } catch (e) {
+      report.eventSignals.push(`html-parse-error:${(e as Error).message.substring(0, 50)}`)
+    }
+  }
+
+  return report
+}
+
+// --- AI Diagnosis (Claude Haiku) ---
+
+interface AiAnalysis {
+  diagnosis: string
+  suggestedType: string
+  suggestedStrategy: string
+  confidence: number
+}
+
+async function diagnoseWithAI(
+  sourceId: string,
+  url: string,
+  currentType: string,
+  htmlSnippet: string,
+  structureReport: StructureReport,
+): Promise<AiAnalysis | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.log('[validate-source] ANTHROPIC_API_KEY not set, skipping AI diagnosis')
+    return null
+  }
+
+  const prompt = `You are diagnosing a broken event source. This web page was being scraped for events using a "${currentType}" parser, but it's returning 0 results.
+
+Source ID: ${sourceId}
+URL: ${url}
+Current parser type: ${currentType}
+Available parser types: html (table-based), rss, json, ical, ra (Resident Advisor GraphQL), screenslate, garysguide, bonobo (Squarespace)
+
+Structural analysis found these signals:
+${structureReport.eventSignals.length > 0 ? structureReport.eventSignals.join('\n') : 'No event signals detected'}
+
+Has tables: ${structureReport.hasTable} (${structureReport.tableRowCount} rows)
+Has JSON-LD Event schema: ${structureReport.hasEventSchema}
+Has RSS items: ${structureReport.hasRssItems}
+Has iCal events: ${structureReport.hasIcalEvents}
+Has JSON array: ${structureReport.hasJsonArray}
+Has date patterns: ${structureReport.hasDatePatterns}
+
+First 1500 chars of page content:
+${htmlSnippet.substring(0, 1500)}
+
+Analyze why parsing is failing and suggest a fix. Return JSON only:
+{
+  "diagnosis": "brief explanation of what's wrong",
+  "suggestedType": "the parser type that would work (html|rss|json|ical|ra|screenslate|garysguide|bonobo) or empty string if unknown",
+  "suggestedStrategy": "one of: retry (transient failure), switch-type (wrong parser), url-changed (page moved), structure-changed (DOM changed), seasonal-empty (no events right now), blocked (access denied), unknown",
+  "confidence": 0.0 to 1.0
+}`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 300,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!response.ok) {
+      console.error('[validate-source] AI API error:', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const text = data.content?.[0]?.text || ''
+    const match = text.match(/\{[\s\S]*\}/)
+
+    if (match) {
+      const result = JSON.parse(match[0])
+      return {
+        diagnosis: typeof result.diagnosis === 'string' ? result.diagnosis : 'Unknown issue',
+        suggestedType: typeof result.suggestedType === 'string' ? result.suggestedType : '',
+        suggestedStrategy: typeof result.suggestedStrategy === 'string' ? result.suggestedStrategy : 'unknown',
+        confidence: typeof result.confidence === 'number' ? Math.max(0, Math.min(1, result.confidence)) : 0.5,
+      }
+    }
+  } catch (e) {
+    console.error('[validate-source] AI diagnosis error:', e)
+  }
+
+  return null
+}
+
+// --- Fetch page with detailed status ---
+
+interface FetchResult {
+  body: string | null
+  status: number
+  contentType: string
+  error: string | null
+}
+
+async function fetchWithDetails(url: string): Promise<FetchResult> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 15_000)
+
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,application/json,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Accept-Encoding': 'identity',
+        'Cache-Control': 'no-cache',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    const body = await resp.text()
+    return {
+      body,
+      status: resp.status,
+      contentType: resp.headers.get('content-type') || '',
+      error: null,
+    }
+  } catch (e) {
+    const msg = (e as Error).message || 'Unknown fetch error'
+    return {
+      body: null,
+      status: 0,
+      contentType: '',
+      error: msg.includes('abort') ? 'timeout' : msg,
+    }
+  }
+}
+
+// --- Main handler ---
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'POST required' }, 405)
+  }
+
+  try {
+    const { sourceId, url, currentType, includeAiAnalysis } = await req.json() as {
+      sourceId: string
+      url: string
+      currentType: string
+      includeAiAnalysis?: boolean
+    }
+
+    if (!sourceId || !url) {
+      return jsonResponse({ error: 'sourceId and url are required' }, 400)
+    }
+
+    // Domain check
+    if (!isDomainAllowed(url)) {
+      return jsonResponse({
+        sourceId,
+        reachable: false,
+        httpStatus: 0,
+        contentType: '',
+        detectedType: null,
+        structureReport: {
+          hasTable: false, tableRowCount: 0, hasEventSchema: false,
+          hasIcalEvents: false, hasRssItems: false, hasJsonArray: false,
+          hasDatePatterns: false, eventSignals: [],
+        },
+        htmlSnippet: null,
+        aiAnalysis: null,
+        error: 'Domain not in allowlist',
+      })
+    }
+
+    console.log(`[validate-source] Probing ${sourceId}: ${url} (type=${currentType})`)
+
+    // Fetch the page
+    const fetchResult = await fetchWithDetails(url)
+
+    if (!fetchResult.body || fetchResult.error) {
+      console.log(`[validate-source] ${sourceId}: fetch failed — ${fetchResult.error || `HTTP ${fetchResult.status}`}`)
+      return jsonResponse({
+        sourceId,
+        reachable: false,
+        httpStatus: fetchResult.status,
+        contentType: fetchResult.contentType,
+        detectedType: null,
+        structureReport: {
+          hasTable: false, tableRowCount: 0, hasEventSchema: false,
+          hasIcalEvents: false, hasRssItems: false, hasJsonArray: false,
+          hasDatePatterns: false, eventSignals: [],
+        },
+        htmlSnippet: null,
+        aiAnalysis: null,
+        error: fetchResult.error || `HTTP ${fetchResult.status}`,
+      })
+    }
+
+    const reachable = fetchResult.status >= 200 && fetchResult.status < 400
+    const detectedType = detectContentType(fetchResult.contentType, fetchResult.body)
+    const structureReport = analyzeStructure(fetchResult.body, detectedType)
+    const htmlSnippet = fetchResult.body.substring(0, 2000)
+
+    console.log(`[validate-source] ${sourceId}: reachable=${reachable} status=${fetchResult.status} detected=${detectedType} signals=[${structureReport.eventSignals.join(', ')}]`)
+
+    // AI diagnosis (optional)
+    let aiAnalysis: AiAnalysis | null = null
+    if (includeAiAnalysis && reachable) {
+      aiAnalysis = await diagnoseWithAI(sourceId, url, currentType || 'unknown', htmlSnippet, structureReport)
+      if (aiAnalysis) {
+        console.log(`[validate-source] AI: ${sourceId} → diagnosis="${aiAnalysis.diagnosis}" suggested="${aiAnalysis.suggestedType}" strategy="${aiAnalysis.suggestedStrategy}" confidence=${aiAnalysis.confidence}`)
+      }
+    }
+
+    return jsonResponse({
+      sourceId,
+      reachable,
+      httpStatus: fetchResult.status,
+      contentType: fetchResult.contentType,
+      detectedType,
+      structureReport,
+      htmlSnippet,
+      aiAnalysis,
+      error: null,
+    })
+  } catch (err) {
+    console.error('[validate-source] Error:', err)
+    return jsonResponse({ error: (err as Error).message }, 500)
+  }
+})


### PR DESCRIPTION
## Summary
- **New `validate-source` edge function** (v1.0.0) — server-side structural probe for event source URLs. Fetches the page, analyzes content type (HTML/JSON/RSS/iCal), checks for expected patterns (tables, JSON-LD Event schema, RSS items, iCal events), and optionally uses Claude Haiku to diagnose why parsing fails.
- **Auto-repair loop in `events/index.html`** (v1.1.0 → v1.2.0) — when broken sources are detected via source_health, automatically attempts repair: probe → strategy selection → alternative parser testing → AI diagnosis fallback → result reporting.
- **Real-time UI** — repair progress banner with animated states (probing, trying, analyzing), success/failure results, and auto-dismiss on success.

## How it works
1. `loadSourceHealth()` finds sources with `status='broken'`
2. Triggers `attemptAutoRepair(brokenSources)` (non-blocking)
3. For each broken source, calls `validate-source` edge function
4. Selects repair strategy based on probe results (type-mismatch → try detected type, transient → retry, structure-changed → AI diagnosis)
5. On success: merges recovered events into state, updates UI
6. Reports all results to `source_health.repair_*` columns

## Guard rails
- Max 3 repairs per page load
- 24h cooldown between repair attempts per source
- AI analysis only for `structure-changed` cases (cost control)
- Session dedup via `state.repairedThisSession` Set
- Parser type changes are session-level only (don't persist to code)

## Test plan
- [ ] Deploy `validate-source` function
- [ ] Verify probe returns correct `detectedType` for known sources
- [ ] Verify repair triggers when broken sources exist in `source_health`
- [ ] Verify 24h cooldown prevents repeated repair attempts
- [ ] Verify UI banner shows progress states and results

🤖 Generated with [Claude Code](https://claude.com/claude-code)