### PR TITLE
fix: deploy cache-events v1.1.0 + debug logging for sourceOutcomes

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.3.0';
-  console.log(`[events] v${VERSION} - source auto-repair + force refresh`);
+  const VERSION = '1.3.1';
+  console.log(`[events] v${VERSION} - source auto-repair + force refresh + health debug`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2048,12 +2048,15 @@ body {
       }
 
       if (all.length === 0) return;
-      log(`L2 cache: saving ${all.length} events in ${batches.length} batch(es)...`);
+      log(`L2 cache: saving ${all.length} events in ${batches.length} batch(es), ${sourceOutcomes.length} source outcomes`);
       let totalCached = 0, totalUpdated = 0, totalEnriched = 0, totalHealth = 0;
       for (let i = 0; i < batches.length; i++) {
         const body = { events: batches[i] };
         // Attach sourceOutcomes to the first batch only
-        if (i === 0 && sourceOutcomes.length > 0) body.sourceOutcomes = sourceOutcomes;
+        if (i === 0 && sourceOutcomes.length > 0) {
+          body.sourceOutcomes = sourceOutcomes;
+          log(`L2 cache: batch 0 includes ${sourceOutcomes.length} sourceOutcomes: ${sourceOutcomes.map(o => o.sourceId + '(' + (o.ok ? o.eventCount : 'ERR') + ')').join(', ')}`);
+        }
         const resp = await fetch(CACHE_EVENTS_URL, {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary
- **Root cause found**: `cache-events` v1.1.0 (with sourceOutcomes/health tracking support) was merged to master in PR #275 but **never deployed** to Supabase. The deployed version was still the old one without sourceOutcomes processing, causing `health=0` in every response.
- **Fix**: Deployed cache-events v1.1.0 to Supabase (done manually this session)
- Added debug logging to `saveEventsToSupabase()` that shows exactly which sourceOutcomes are being sent in each request
- Bumped events/index.html to v1.3.1

## Test plan
- [ ] Force refresh events page (⟳ button or Shift+R)
- [ ] Check console for `L2 cache: batch 0 includes N sourceOutcomes: ...` log
- [ ] Verify `health=N` (N > 0) in the `L2 cache:` summary line
- [ ] Check source_health table has rows after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)