### PR TITLE
feat: responsive health status + degraded auto-repair

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.3.1';
-  console.log(`[events] v${VERSION} - source auto-repair + force refresh + health debug`);
+  const VERSION = '1.3.2';
+  console.log(`[events] v${VERSION} - responsive health status + degraded auto-repair`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2392,16 +2392,18 @@ body {
       log(`Source health loaded: ${healthRows.length} sources — ` +
         `${healthRows.filter(r => r.status === 'healthy').length} healthy, ` +
         `${healthRows.filter(r => r.status === 'degraded').length} degraded, ` +
-        `${healthRows.filter(r => r.status === 'broken').length} broken`);
+        `${healthRows.filter(r => r.status === 'broken').length} broken, ` +
+        `${healthRows.filter(r => r.status === 'unknown').length} unknown`);
 
       // Surface broken/degraded sources
       const broken = healthRows.filter(r => r.status === 'broken');
       const degraded = healthRows.filter(r => r.status === 'degraded');
       if (broken.length > 0 || degraded.length > 0) {
         showSourceHealthWarning(broken, degraded);
-        // Trigger auto-repair for broken sources (non-blocking)
-        if (broken.length > 0 && !state.repairInProgress) {
-          attemptAutoRepair(broken).catch(e => log('Auto-repair error: ' + e.message));
+        // Trigger auto-repair for broken and degraded sources (non-blocking)
+        const repairTargets = [...broken, ...degraded];
+        if (repairTargets.length > 0 && !state.repairInProgress) {
+          attemptAutoRepair(repairTargets).catch(e => log('Auto-repair error: ' + e.message));
         }
       } else {
         // Clear any existing warning

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.1.0'
-console.log(`[cache-events] v${VERSION} - event caching with source health tracking`)
+const VERSION = '1.2.0'
+console.log(`[cache-events] v${VERSION} - responsive status derivation`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -66,10 +66,18 @@ interface SourceOutcome {
 // --- Source Health Upsert (mirrors domain_profiles pattern from enrich-link) ---
 
 function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number): string {
-  if (totalScrapes < 3) return 'unknown'
-  if (consecutiveFailures >= 6 || (totalScrapes >= 5 && successRate < 0.3)) return 'broken'
-  if (consecutiveFailures >= 3 || (totalScrapes >= 5 && successRate < 0.65)) return 'degraded'
-  if (successRate >= 0.8 && consecutiveFailures < 3) return 'healthy'
+  if (totalScrapes === 0) return 'unknown'
+  // Broken: persistent failure pattern
+  if (consecutiveFailures >= 6) return 'broken'
+  if (totalScrapes >= 5 && successRate < 0.3) return 'broken'
+  if (totalScrapes >= 2 && successRate === 0) return 'broken' // never worked after 2+ scrapes
+  // Degraded: concerning failure pattern
+  if (consecutiveFailures >= 3) return 'degraded'
+  if (totalScrapes >= 3 && successRate < 0.65) return 'degraded'
+  if (consecutiveFailures >= 1 && successRate < 0.5) return 'degraded' // early warning
+  // Healthy: consistent success
+  if (successRate >= 0.8 && consecutiveFailures === 0) return 'healthy'
+  if (totalScrapes === 1 && successRate === 1.0) return 'healthy' // first scrape succeeded
   return 'unknown'
 }
 


### PR DESCRIPTION
## Summary
- **cache-events v1.2.0**: `deriveStatus()` now responds after 1 scrape instead of requiring 3+
  - 1 failed scrape → `degraded` (was `unknown`)
  - 2 consecutive failures, never succeeded → `broken` (was still `unknown`)
  - 1 successful scrape → `healthy` (was `unknown`)
- **events v1.3.2**: Auto-repair triggers for both `broken` AND `degraded` sources
- Health log now shows `unknown` count for visibility

## Why
After deploying cache-events v1.1.0 (PR #280), health data populated correctly (4 sources), but all showed `status='unknown'` because the old threshold required 3+ scrapes. RA returning 0 events wasn't flagged as degraded despite clearly failing.

## Test plan
- [ ] Force refresh → RA should now show as `degraded` (1 failed scrape) 
- [ ] Force refresh again → RA should show as `broken` (2 consecutive failures, 0% success)
- [ ] Auto-repair should trigger for RA on first detection of degraded status
- [ ] 19hz/ScreenSlate/Bonobo should show as `healthy` after 1 successful scrape

🤖 Generated with [Claude Code](https://claude.com/claude-code)