### PR TITLE
feat: event count degradation detection for source health

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.3.2';
-  console.log(`[events] v${VERSION} - responsive health status + degraded auto-repair`);
+  const VERSION = '1.3.3';
+  console.log(`[events] v${VERSION} - event count degradation detection`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2379,7 +2379,7 @@ body {
     try {
       const { data: healthRows } = await supabaseClient
         .from('source_health')
-        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes, repair_attempted_at, repair_strategy, repair_result')
+        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes, outcomes_seen, repair_attempted_at, repair_strategy, repair_result')
         .in('source_id', enabledIds);
 
       if (!healthRows) return;
@@ -2438,7 +2438,17 @@ body {
     }
     if (degraded.length > 0) {
       if (msg) msg += ' · ';
-      msg += `Degraded: ${degradedNames.join(', ')}`;
+      const degradedDetails = degraded.map(r => {
+        const src = state.sources.find(s => s.id === r.source_id);
+        const name = src ? src.name : r.source_id;
+        const peak = r.outcomes_seen?.peak_event_count;
+        const last = r.last_success_event_count;
+        if (peak && last && last < peak * 0.5) {
+          return `${name} (${last}/${peak} events)`;
+        }
+        return name;
+      });
+      msg += `Degraded: ${degradedDetails.join(', ')}`;
     }
 
     const warn = document.createElement('div');

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.2.0'
-console.log(`[cache-events] v${VERSION} - responsive status derivation`)
+const VERSION = '1.3.0'
+console.log(`[cache-events] v${VERSION} - event count degradation detection`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -65,7 +65,7 @@ interface SourceOutcome {
 
 // --- Source Health Upsert (mirrors domain_profiles pattern from enrich-link) ---
 
-function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number): string {
+function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number, countDegraded = false): string {
   if (totalScrapes === 0) return 'unknown'
   // Broken: persistent failure pattern
   if (consecutiveFailures >= 6) return 'broken'
@@ -75,6 +75,8 @@ function deriveStatus(successRate: number, consecutiveFailures: number, totalScr
   if (consecutiveFailures >= 3) return 'degraded'
   if (totalScrapes >= 3 && successRate < 0.65) return 'degraded'
   if (consecutiveFailures >= 1 && successRate < 0.5) return 'degraded' // early warning
+  // Event count degradation: source works but returns far fewer events than peak
+  if (countDegraded) return 'degraded'
   // Healthy: consistent success
   if (successRate >= 0.8 && consecutiveFailures === 0) return 'healthy'
   if (totalScrapes === 1 && successRate === 1.0) return 'healthy' // first scrape succeeded
@@ -100,13 +102,28 @@ async function upsertSourceHealth(
     const outcomesSeen = existing.outcomes_seen || {}
     outcomesSeen[outcomeKey] = (outcomesSeen[outcomeKey] || 0) + 1
 
+    // Track peak event count (stored in JSONB to avoid migration)
+    const previousPeak = outcomesSeen.peak_event_count || 0
+    if (isSuccess && outcome.eventCount > previousPeak) {
+      outcomesSeen.peak_event_count = outcome.eventCount
+    }
+    const peakCount = outcomesSeen.peak_event_count || 0
+
+    // Detect event count degradation: source returns >0 events but far fewer than peak
+    // Threshold: >50% drop from peak, and peak must be meaningful (>20 events)
+    const countDegraded = isSuccess && peakCount > 20 && outcome.eventCount < peakCount * 0.5
+    if (countDegraded) {
+      outcomesSeen.count_drop = (outcomesSeen.count_drop || 0) + 1
+      console.log(`[cache-events] Count degradation: ${outcome.sourceId} returned ${outcome.eventCount} vs peak ${peakCount} (${Math.round(outcome.eventCount / peakCount * 100)}%)`)
+    }
+
     const total = existing.total_scrapes + 1
     const successCount = existing.success_count + (isSuccess ? 1 : 0)
     const zeroCount = existing.zero_result_count + (outcomeKey === 'zero_results' ? 1 : 0)
     const errorCount = existing.error_count + (!outcome.ok ? 1 : 0)
     const successRate = total > 0 ? successCount / total : 1.0
     const consecutiveFailures = isSuccess ? 0 : existing.consecutive_failures + 1
-    const status = deriveStatus(successRate, consecutiveFailures, total)
+    const status = deriveStatus(successRate, consecutiveFailures, total, countDegraded)
 
     await supabase.from('source_health').update({
       source_name: outcome.sourceName,
@@ -127,7 +144,11 @@ async function upsertSourceHealth(
       last_scraped_at: new Date().toISOString(),
     }).eq('source_id', outcome.sourceId)
   } else {
-    const outcomesSeen = { [outcomeKey]: 1 }
+    const outcomesSeen: Record<string, unknown> = { [outcomeKey]: 1 }
+    // Track peak event count from first scrape
+    if (isSuccess && outcome.eventCount > 0) {
+      outcomesSeen.peak_event_count = outcome.eventCount
+    }
     await supabase.from('source_health').insert({
       source_id: outcome.sourceId,
       source_name: outcome.sourceName,


### PR DESCRIPTION
## Summary
- **cache-events v1.3.0**: Tracks `peak_event_count` in the `outcomes_seen` JSONB field (no migration needed). When a source returns >0 events but >50% fewer than its peak (and peak > 20), it's flagged as `degraded` even though the scrape technically succeeded.
  - Example: 19hz returning 71 events when peak is 473 → 85% drop → `degraded`
- **events v1.3.3**: Health query now includes `outcomes_seen`, warning banner shows "Source (71/473 events)" for count-degraded sources

## Why
19hz intermittently drops from 400+ results to ~71 — this is meaningful degradation that wasn't detected because the scrape returned >0 events with no error. The health system only checked binary success/failure.

## Test plan
- [ ] Deploy cache-events v1.3.0
- [ ] Force refresh → verify peak_event_count populates in outcomes_seen
- [ ] If 19hz drops on a subsequent refresh, verify it shows as degraded with count info

🤖 Generated with [Claude Code](https://claude.com/claude-code)