### PR TITLE
fix: health load race condition

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.3.3';
-  console.log(`[events] v${VERSION} - event count degradation detection`);
+  const VERSION = '1.3.4';
+  console.log(`[events] v${VERSION} - fix health load race condition`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2341,10 +2341,10 @@ body {
     if (failedNames.length > 0) log(`Failed sources: ${failedNames.join(', ')}`);
     el.style.display = 'none';
     saveEventCache(); // L1
-    // L2 async — send events + health outcomes
-    saveEventsToSupabase(state.events, sourceOutcomes).catch(e => log('L2 save failed: ' + e.message));
-    // Reload health from DB after reporting (async, updates UI once loaded)
-    loadSourceHealth().catch(e => log('Health load failed: ' + e.message));
+    // L2 async — send events + health outcomes, then reload health
+    saveEventsToSupabase(state.events, sourceOutcomes)
+      .then(() => loadSourceHealth())
+      .catch(e => log('L2 save/health error: ' + e.message));
     calAutoNavigate();
     updateFilters();
     updateContentTypeFilter();


### PR DESCRIPTION
## Summary
- `loadSourceHealth()` was firing in parallel with `saveEventsToSupabase()`, reading stale `status='unknown'` before the save wrote new statuses
- Now chains: save events → then load health
- This is why health showed `4 unknown` despite `health=4` in the response

## Test plan
- [ ] Force refresh → check that `Source health loaded` log appears AFTER `L2 cache: cached=...` log
- [ ] RA should show as `degraded` (or `broken` if 2nd scrape)
- [ ] 19hz/ScreenSlate/Bonobo should show as `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)