### PR TITLE
Fix auto-repair infinite loop (events v1.3.6)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.3.5';
-  console.log(`[events] v${VERSION} - fix DOM insertBefore for warning banners`);
+  const VERSION = '1.3.6';
+  console.log(`[events] v${VERSION} - fix auto-repair infinite loop`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2371,7 +2371,7 @@ body {
   }
 
   // --- Source Health Loading ---
-  async function loadSourceHealth() {
+  async function loadSourceHealth(skipRepair = false) {
     if (!supabaseClient) return;
     const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id);
     if (enabledIds.length === 0) return;
@@ -2401,8 +2401,9 @@ body {
       if (broken.length > 0 || degraded.length > 0) {
         showSourceHealthWarning(broken, degraded);
         // Trigger auto-repair for broken and degraded sources (non-blocking)
+        // skipRepair=true when called from attemptAutoRepair() to avoid infinite loop
         const repairTargets = [...broken, ...degraded];
-        if (repairTargets.length > 0 && !state.repairInProgress) {
+        if (!skipRepair && repairTargets.length > 0 && !state.repairInProgress) {
           attemptAutoRepair(repairTargets).catch(e => log('Auto-repair error: ' + e.message));
         }
       } else {
@@ -2718,8 +2719,8 @@ body {
 
     state.repairInProgress = false;
     showRepairResults(results);
-    // Reload health to get updated status after repairs
-    await loadSourceHealth();
+    // Reload health to get updated status after repairs (skipRepair=true to avoid infinite loop)
+    await loadSourceHealth(true);
     log(`Auto-repair: complete — ${results.filter(r => r.success).length}/${results.length} succeeded`);
   }
 


### PR DESCRIPTION
## Summary
- `attemptAutoRepair()` → `loadSourceHealth()` → `attemptAutoRepair()` created an infinite loop when a source remained broken after repair
- Added `skipRepair` parameter to `loadSourceHealth()` — post-repair health reload skips re-triggering repair

## Test plan
- [ ] Force refresh → auto-repair runs once, not infinitely
- [ ] Console shows single "Auto-repair: complete" message
- [ ] Health dots/warning banner still update correctly after repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)