### PR TITLE
Fix status recovery + parser-error reachable bug

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.5.0';
-  console.log(`[events] v${VERSION} - parser-level auto-repair with AI config overrides`);
+  const VERSION = '1.5.1';
+  console.log(`[events] v${VERSION} - fix: parser-error strategy doesn't require reachable probe`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2588,9 +2588,10 @@ body {
     if (!validation) return { strategy: 'probe-failed', action: 'none' };
 
     // NEW: Parser-level errors get ai-param-fix before URL-level strategies
-    // When the source is reachable but the parser captured specific errors,
-    // send those to AI for parameter override suggestions
-    if (validation.reachable && parserContext?.errors?.length > 0) {
+    // When the parser captured specific errors, send those to AI for parameter
+    // override suggestions. Don't require validation.reachable — SPAs like RA
+    // return 403 to server-side probes but work fine through our fetch proxy.
+    if (parserContext?.errors?.length > 0) {
       return { strategy: 'parser-error', action: 'ai-param-fix' };
     }
 

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.3.0'
-console.log(`[cache-events] v${VERSION} - event count degradation detection`)
+const VERSION = '1.3.1'
+console.log(`[cache-events] v${VERSION} - fix status recovery: consecutive_failures=0 should never be broken`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -67,6 +67,14 @@ interface SourceOutcome {
 
 function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number, countDegraded = false): string {
   if (totalScrapes === 0) return 'unknown'
+  // Most recent scrape succeeded — recovering or healthy
+  // This prevents a source from staying "broken" indefinitely after being fixed
+  if (consecutiveFailures === 0) {
+    if (countDegraded) return 'degraded'
+    if (successRate >= 0.8) return 'healthy'
+    // Low historical rate but currently working — recovering, not broken
+    return successRate >= 0.5 ? 'healthy' : 'degraded'
+  }
   // Broken: persistent failure pattern
   if (consecutiveFailures >= 6) return 'broken'
   if (totalScrapes >= 5 && successRate < 0.3) return 'broken'
@@ -77,9 +85,9 @@ function deriveStatus(successRate: number, consecutiveFailures: number, totalScr
   if (consecutiveFailures >= 1 && successRate < 0.5) return 'degraded' // early warning
   // Event count degradation: source works but returns far fewer events than peak
   if (countDegraded) return 'degraded'
-  // Healthy: consistent success
-  if (successRate >= 0.8 && consecutiveFailures === 0) return 'healthy'
-  if (totalScrapes === 1 && successRate === 1.0) return 'healthy' // first scrape succeeded
+  // Healthy
+  if (successRate >= 0.8) return 'healthy'
+  if (totalScrapes === 1 && successRate === 1.0) return 'healthy'
   return 'unknown'
 }
 


### PR DESCRIPTION
## Summary
- **deriveStatus recovery**: If `consecutive_failures === 0` (most recent scrape succeeded), the source should never be "broken". RA had `success_rate=0.125` from old failures but was working — stayed broken forever.
- **parser-error reachable**: `selectRepairStrategy` no longer requires `validation.reachable` for the `parser-error` path. SPAs like RA return 403 to server-side probes but work fine through our fetch proxy.

## Version bumps
- cache-events: 1.3.0 → 1.3.1
- events: 1.5.0 → 1.5.1

## Test plan
- [ ] Force refresh → RA scrapes 100 events → next health load shows "healthy" (not "broken")
- [ ] Verify broken sources with parser diagnostics trigger `ai-param-fix` even when probe returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)