### PR TITLE
Move health banners to fetch log + test ai-param-fix

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1576,8 +1576,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.5.1';
-  console.log(`[events] v${VERSION} - fix: parser-error strategy doesn't require reachable probe`);
+  const VERSION = '1.5.2';
+  console.log(`[events] v${VERSION} - move health banners to fetch log, revert pageSize to 200 for ai-param-fix test`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2422,17 +2422,13 @@ body {
       const broken = healthRows.filter(r => r.status === 'broken');
       const degraded = healthRows.filter(r => r.status === 'degraded');
       if (broken.length > 0 || degraded.length > 0) {
-        showSourceHealthWarning(broken, degraded);
+        logSourceHealthWarning(broken, degraded);
         // Trigger auto-repair for broken and degraded sources (non-blocking)
         // skipRepair=true when called from attemptAutoRepair() to avoid infinite loop
         const repairTargets = [...broken, ...degraded];
         if (!skipRepair && repairTargets.length > 0 && !state.repairInProgress) {
           attemptAutoRepair(repairTargets).catch(e => log('Auto-repair error: ' + e.message));
         }
-      } else {
-        // Clear any existing warning
-        const existing = document.getElementById('sourceHealthWarning');
-        if (existing) existing.remove();
       }
 
       // Re-render source chips with health info
@@ -2442,11 +2438,8 @@ body {
     }
   }
 
-  function showSourceHealthWarning(broken, degraded) {
-    const existing = document.getElementById('sourceHealthWarning');
-    if (existing) existing.remove();
+  function logSourceHealthWarning(broken, degraded) {
     if (broken.length === 0 && degraded.length === 0) return;
-
     const brokenNames = broken.map(r => {
       const src = state.sources.find(s => s.id === r.source_id);
       return src ? src.name : r.source_id;
@@ -2455,35 +2448,8 @@ body {
       const src = state.sources.find(s => s.id === r.source_id);
       return src ? src.name : r.source_id;
     });
-
-    let msg = '';
-    if (broken.length > 0) {
-      msg += `Broken: ${brokenNames.join(', ')} (${broken[0].consecutive_failures}+ consecutive failures)`;
-    }
-    if (degraded.length > 0) {
-      if (msg) msg += ' · ';
-      const degradedDetails = degraded.map(r => {
-        const src = state.sources.find(s => s.id === r.source_id);
-        const name = src ? src.name : r.source_id;
-        const peak = r.outcomes_seen?.peak_event_count;
-        const last = r.last_success_event_count;
-        if (peak && last && last < peak * 0.5) {
-          return `${name} (${last}/${peak} events)`;
-        }
-        return name;
-      });
-      msg += `Degraded: ${degradedDetails.join(', ')}`;
-    }
-
-    const warn = document.createElement('div');
-    warn.id = 'sourceHealthWarning';
-    warn.style.cssText = 'background:#1a0a00;border:1px solid #663300;color:#ff9944;padding:8px 12px;margin:0 0 12px;border-radius:6px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:8px;';
-    warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Source Health</span> — ${msg}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#ff9944;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
-
-    const eventsContent = document.getElementById('eventsContent');
-    if (eventsContent) {
-      eventsContent.insertBefore(warn, eventsContent.firstChild);
-    }
+    if (broken.length > 0) log(`Source health: BROKEN — ${brokenNames.join(', ')}`);
+    if (degraded.length > 0) log(`Source health: DEGRADED — ${degradedNames.join(', ')}`);
   }
 
   // --- Parser Diagnostics Store (session-scoped) ---
@@ -2818,73 +2784,27 @@ body {
   }
 
   function updateRepairBanner(sourceName, phase, detail) {
-    let warn = document.getElementById('sourceHealthWarning');
-    if (!warn) {
-      warn = document.createElement('div');
-      warn.id = 'sourceHealthWarning';
-      warn.style.cssText = 'background:#0a0a1a;border:1px solid #334466;color:#6699cc;padding:8px 12px;margin:0 0 12px;border-radius:6px;font-size:12px;display:flex;align-items:center;justify-content:space-between;gap:8px;';
-      const eventsContent = document.getElementById('eventsContent');
-      if (eventsContent) eventsContent.insertBefore(warn, eventsContent.firstChild);
-    }
-
     const phases = {
       probing: `Probing ${sourceName}...`,
       trying: `Trying ${sourceName} with ${detail || 'alternative'} parser...`,
       retrying: `Retrying ${sourceName}...`,
       analyzing: `AI analyzing ${sourceName}...`,
     };
-    const msg = phases[phase] || `Repairing ${sourceName}...`;
-    warn.style.background = '#0a0a1a';
-    warn.style.borderColor = '#334466';
-    warn.style.color = '#6699cc';
-    warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Auto-Repair</span> — ${msg} <span style="display:inline-block;animation:pulse 1s infinite;">⟳</span></span>`;
+    log(`Auto-repair: ${phases[phase] || `Repairing ${sourceName}...`}`);
   }
 
   function showRepairResults(results) {
     if (results.length === 0) return;
-    const warn = document.getElementById('sourceHealthWarning');
-    if (!warn) return;
-
     const successes = results.filter(r => r.success);
     const failures = results.filter(r => !r.success);
-
-    if (successes.length > 0 && failures.length === 0) {
-      // All succeeded
-      const names = successes.map(r => {
-        const src = state.sources.find(s => s.id === r.sourceId);
-        return src ? `${src.name} (${r.eventsFound} events)` : r.sourceId;
-      });
-      warn.style.background = '#0a1a0a';
-      warn.style.borderColor = '#336633';
-      warn.style.color = '#66cc66';
-      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Repaired</span> — ${names.join(', ')}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#66cc66;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
-      // Auto-dismiss after 10 seconds
-      setTimeout(() => { if (warn.parentElement) warn.remove(); }, 10000);
-    } else if (successes.length === 0) {
-      // All failed
-      const names = failures.map(r => {
-        const src = state.sources.find(s => s.id === r.sourceId);
-        return src ? src.name : r.sourceId;
-      });
-      warn.style.background = '#1a0a00';
-      warn.style.borderColor = '#663300';
-      warn.style.color = '#ff9944';
-      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Repair Failed</span> — ${names.join(', ')}. ${failures[0].diagnosis || 'Unknown issue.'}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#ff9944;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
-    } else {
-      // Mixed results
-      const successNames = successes.map(r => {
-        const src = state.sources.find(s => s.id === r.sourceId);
-        return src ? src.name : r.sourceId;
-      });
-      const failNames = failures.map(r => {
-        const src = state.sources.find(s => s.id === r.sourceId);
-        return src ? src.name : r.sourceId;
-      });
-      warn.style.background = '#0a0a1a';
-      warn.style.borderColor = '#334466';
-      warn.style.color = '#6699cc';
-      warn.innerHTML = `<span style="flex:1;min-width:0;"><span style="font-weight:600;">Partial Repair</span> — Fixed: ${successNames.join(', ')} · Still broken: ${failNames.join(', ')}</span><button onclick="this.parentElement.remove()" style="background:none;border:none;color:#6699cc;cursor:pointer;font-size:16px;padding:0;flex-shrink:0;line-height:1;">&times;</button>`;
-    }
+    successes.forEach(r => {
+      const src = state.sources.find(s => s.id === r.sourceId);
+      log(`Auto-repair: REPAIRED "${src?.name || r.sourceId}" — ${r.eventsFound} events found`);
+    });
+    failures.forEach(r => {
+      const src = state.sources.find(s => s.id === r.sourceId);
+      log(`Auto-repair: FAILED "${src?.name || r.sourceId}" — ${r.diagnosis || 'Unknown issue'}`);
+    });
   }
 
   // --- Cross-Source Deduplication ---
@@ -3037,7 +2957,7 @@ body {
     const variables = {
       filters: { areas: { eq: source.overrides?.areaId || areaId }, listingDate: { gte: today, lte: endDate } },
       filterOptions: { eventType: true, genre: true },
-      page: 1, pageSize: source.overrides?.pageSize || 100,
+      page: 1, pageSize: source.overrides?.pageSize || 200,
     };
 
     // Strategy 1: GraphQL via edge function (server-side POST proxy)


### PR DESCRIPTION
## Summary
- Health warnings and auto-repair status now log to the fetch log panel instead of DOM banners
- Reverted RA pageSize default to 200 to test the ai-param-fix flow end-to-end
- Fixed parser-error strategy to work when probe returns 403 (SPAs like RA)

events v1.5.1 → v1.5.2, cache-events v1.3.0 → v1.3.1

## Test plan
- [ ] Force refresh → RA breaks with "Limit must not be greater than 100"
- [ ] Auto-repair triggers `ai-param-fix` → AI suggests `pageSize: 100` → retry succeeds
- [ ] Source health warnings appear in fetch log, not as banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)