### PR TITLE
fix: SyntaxError from duplicate const declaration in loadRecommendedEvents

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1612,7 +1612,7 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.5.5';
+  const VERSION = '1.5.6';
   console.log(`[events] v${VERSION} - repaired sources show green, AI runs for unreachable sources`);
 
   // ============================================
@@ -5760,8 +5760,6 @@ body {
       if (!result.events || result.events.length === 0) return;
 
       const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      const container = document.getElementById('recommendedCards');
-      const section = document.getElementById('recommendedSection');
 
       container.innerHTML = result.events.map(function(evt) {
         const d = new Date(evt.date + 'T00:00:00');


### PR DESCRIPTION
## Summary
- Merge conflict resolution introduced duplicate `const container` and `const section` declarations in `loadRecommendedEvents()`, causing `SyntaxError: Identifier 'container' has already been declared` which broke the entire page
- Removed the duplicate declarations (lines 5763-5764) since they were already declared at lines 5685-5686

Events v1.5.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)