### PR TITLE
fix: repaired sources stay green, RA pageSize 100

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1612,8 +1612,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.5.7';
-  console.log(`[events] v${VERSION} - repaired sources show green, AI runs for unreachable sources`);
+  const VERSION = '1.5.8';
+  console.log(`[events] v${VERSION} - repaired sources stay green after health reload, RA pageSize default 100`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2811,13 +2811,6 @@ body {
       await reportRepairResult(sourceId, decision.strategy, repairResult);
       results.push({ sourceId, ...repairResult });
 
-      // If repair succeeded, immediately update local health status to show green
-      if (repairResult.success && state.sourceHealth[sourceId]) {
-        state.sourceHealth[sourceId].status = 'healthy';
-        state.sourceHealth[sourceId].consecutive_failures = 0;
-        renderSourceChips();
-      }
-
       // Delay between sources to avoid hammering
       if (brokenSources.indexOf(healthRow) < brokenSources.length - 1) {
         await new Promise(r => setTimeout(r, 1500));
@@ -2828,6 +2821,20 @@ body {
     showRepairResults(results);
     // Reload health to get updated status after repairs (skipRepair=true to avoid infinite loop)
     await loadSourceHealth(true);
+
+    // Override DB status for sources that were just repaired — DB hasn't processed
+    // the successful scrape yet, so it still says "broken". Apply green locally.
+    const repairedIds = results.filter(r => r.success).map(r => r.sourceId);
+    if (repairedIds.length > 0) {
+      repairedIds.forEach(id => {
+        if (state.sourceHealth[id]) {
+          state.sourceHealth[id].status = 'healthy';
+          state.sourceHealth[id].consecutive_failures = 0;
+        }
+      });
+      renderSourceChips();
+      log(`Auto-repair: marked ${repairedIds.length} repaired source(s) as healthy`);
+    }
     log(`Auto-repair: complete — ${results.filter(r => r.success).length}/${results.length} succeeded`);
   }
 
@@ -3023,7 +3030,7 @@ body {
     const variables = {
       filters: { areas: { eq: source.overrides?.areaId || areaId }, listingDate: { gte: today, lte: endDate } },
       filterOptions: { eventType: true, genre: true },
-      page: 1, pageSize: source.overrides?.pageSize || 200,
+      page: 1, pageSize: source.overrides?.pageSize || 100,
     };
 
     // Strategy 1: GraphQL via edge function (server-side POST proxy)


### PR DESCRIPTION
## Summary
- Repaired sources now stay green after health reload — the local healthy status override is applied AFTER `loadSourceHealth(true)` so the DB value doesn't overwrite it
- Reverted RA default pageSize from 200 to 100 (the confirmed working value — auto-repair no longer needs the intentional failure)
- Events v1.5.8

## Test plan
- [ ] Force refresh → RA scrapes successfully with pageSize=100
- [ ] If RA fails → auto-repair applies override → source chip turns green and stays green
- [ ] Reset Repairs → source health reloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)