### PR TITLE
feat: permanent config_overrides for AI-suggested fixes

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1612,8 +1612,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.5.8';
-  console.log(`[events] v${VERSION} - repaired sources stay green after health reload, RA pageSize default 100`);
+  const VERSION = '1.5.9';
+  console.log(`[events] v${VERSION} - permanent config_overrides for AI-suggested fixes`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2424,7 +2424,7 @@ body {
     try {
       const { data: healthRows } = await supabaseClient
         .from('source_health')
-        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes, outcomes_seen, repair_attempted_at, repair_strategy, repair_result')
+        .select('source_id, status, consecutive_failures, success_rate, last_failure_reason, last_failure_at, last_success_at, last_success_event_count, zero_result_count, total_scrapes, outcomes_seen, repair_attempted_at, repair_strategy, repair_result, config_overrides')
         .in('source_id', enabledIds);
 
       if (!healthRows) return;
@@ -2434,18 +2434,13 @@ body {
         state.sourceHealth[row.source_id] = row;
       });
 
-      // Restore successful overrides from previous repair results
+      // Restore permanent config overrides from previous successful repairs
       state.sources.forEach(source => {
         const health = state.sourceHealth[source.id];
-        if (!health?.repair_result) return;
-        try {
-          const repairData = JSON.parse(health.repair_result);
-          const age = Date.now() - new Date(repairData.timestamp).getTime();
-          if (age < 30 * 86400000 && repairData.success && repairData.appliedOverrides) {
-            source.overrides = repairData.appliedOverrides;
-            log(`Restored overrides for "${source.name}": ${JSON.stringify(source.overrides)}`);
-          }
-        } catch (e) { /* ignore malformed repair_result */ }
+        if (health?.config_overrides && typeof health.config_overrides === 'object') {
+          source.overrides = health.config_overrides;
+          log(`Restored config overrides for "${source.name}": ${JSON.stringify(source.overrides)}`);
+        }
       });
 
       log(`Source health loaded: ${healthRows.length} sources — ` +
@@ -2575,11 +2570,17 @@ body {
   async function reportRepairResult(sourceId, strategy, result) {
     if (!supabaseClient) return;
     try {
-      await supabaseClient.from('source_health').update({
+      const updateData = {
         repair_attempted_at: new Date().toISOString(),
         repair_strategy: strategy,
         repair_result: JSON.stringify(result),
-      }).eq('source_id', sourceId);
+      };
+      // Persist successful overrides permanently in config_overrides
+      if (result.success && result.appliedOverrides) {
+        updateData.config_overrides = result.appliedOverrides;
+        log(`Auto-repair: saving config_overrides for "${sourceId}": ${JSON.stringify(result.appliedOverrides)}`);
+      }
+      await supabaseClient.from('source_health').update(updateData).eq('source_id', sourceId);
       log(`Auto-repair: reported result for "${sourceId}": strategy=${strategy} success=${result.success}`);
     } catch (e) {
       log(`Auto-repair: failed to report result: ${e.message}`);
@@ -2866,7 +2867,7 @@ body {
     if (!supabaseClient) { log('Reset repairs: no Supabase client'); return; }
     try {
       const { error } = await supabaseClient.from('source_health')
-        .update({ repair_attempted_at: null, repair_result: null, repair_strategy: null })
+        .update({ repair_attempted_at: null, repair_result: null, repair_strategy: null, config_overrides: null })
         .not('repair_attempted_at', 'is', null);
       if (error) throw error;
       state.repairedThisSession.clear();

--- a/supabase/migrations/026_config_overrides.sql
+++ b/supabase/migrations/026_config_overrides.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- Config Overrides for Auto-Repair
+-- Migration 026
+-- Stores AI-suggested parameter overrides permanently until manually cleared.
+-- When auto-repair diagnoses a parser parameter issue (e.g. pageSize too large),
+-- the fix is saved here so it persists across page loads without expiry.
+-- ============================================
+
+ALTER TABLE source_health
+  ADD COLUMN IF NOT EXISTS config_overrides JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN source_health.config_overrides IS
+  'Permanent AI-suggested parameter overrides (e.g. {"pageSize": 100}). Persists until manually cleared via Reset Repairs.';


### PR DESCRIPTION
## Summary
- Added `config_overrides` JSONB column to `source_health` (migration 026)
- AI-suggested parameter overrides now persist permanently until manually cleared via Reset Repairs
- Replaces the old 30-day expiry approach that parsed `repair_result` JSON
- Reset Repairs clears `config_overrides` along with other repair state

## How it works
1. AI repair suggests `{pageSize: 100}` → repair succeeds
2. `reportRepairResult()` writes overrides to `config_overrides` column
3. Next page load → `loadSourceHealth()` reads `config_overrides` → applies to `source.overrides`
4. Parser uses `source.overrides?.pageSize || 100` → works permanently
5. Reset Repairs → clears `config_overrides` back to null

## Test plan
- [ ] Trigger RA repair → verify `config_overrides` is written to DB
- [ ] Reload page → verify overrides are restored from `config_overrides`
- [ ] Reset Repairs → verify `config_overrides` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)