### PR TITLE
feat: YouTube import + taste map source visualization

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -375,6 +375,64 @@
   word-break: break-all;
 }
 
+/* YouTube import */
+.yt-import-section {
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-4);
+  margin-top: var(--space-4);
+}
+
+.yt-import-section__header {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  margin-bottom: var(--space-2);
+}
+
+.yt-import-section__status {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--fg);
+  margin-bottom: var(--space-3);
+}
+
+.yt-import-section__note {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--muted);
+  margin-top: var(--space-2);
+  line-height: 1.4;
+}
+
+.yt-import-section__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.yt-import-section__actions .auth-bar__btn {
+  width: 100%;
+  font-size: var(--font-size-xs);
+}
+
+.yt-import-section__progress {
+  margin-top: var(--space-2);
+}
+
+.yt-import-section__progress-bar {
+  height: 2px;
+  background: var(--border);
+  margin-top: var(--space-1);
+}
+
+.yt-import-section__progress-fill {
+  height: 100%;
+  background: var(--fg);
+  transition: width 0.3s ease;
+}
+
 /* Settings row */
 .settings-row {
   display: flex;
@@ -6051,6 +6109,31 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
           <label class="account-label">Logged In From</label>
           <div class="account-value account-value--mono" id="accountDevice"></div>
         </div>
+        <!-- YouTube Import -->
+        <div class="yt-import-section" id="yt-import-section">
+          <div class="yt-import-section__header">YouTube</div>
+          <div class="yt-import-section__status" id="yt-import-status">Not connected</div>
+          <div id="yt-connect-controls">
+            <button class="auth-bar__btn" id="yt-connect-btn" style="width: 100%;">Connect YouTube</button>
+            <div class="yt-import-section__note">
+              Imports liked videos and playlists into your taste map.
+            </div>
+          </div>
+          <div id="yt-import-controls" style="display:none">
+            <div class="yt-import-section__actions">
+              <button class="auth-bar__btn" id="yt-import-liked-btn">Import Liked Videos</button>
+              <button class="auth-bar__btn" id="yt-import-playlists-btn">Import Playlists</button>
+              <button class="auth-bar__btn" id="yt-disconnect-btn" style="color: var(--muted);">Disconnect</button>
+            </div>
+          </div>
+          <div class="yt-import-section__progress" id="yt-import-progress" style="display:none">
+            <div class="yt-import-section__note" id="yt-progress-label">Importing...</div>
+            <div class="yt-import-section__progress-bar">
+              <div class="yt-import-section__progress-fill" id="yt-progress-fill" style="width:0%"></div>
+            </div>
+          </div>
+        </div>
+
         <div class="account-section" style="margin-top: var(--space-6);">
           <button class="auth-bar__btn" id="accountLogout" style="width: 100%;">Logout</button>
         </div>
@@ -6449,8 +6532,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.9.2';
-  console.log('[boards] v' + VERSION + ' - shared auth module');
+  const VERSION = '2.10.0';
+  console.log('[boards] v' + VERSION + ' - youtube import integration');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -10548,6 +10631,151 @@ Return JSON:
       id: crypto.randomUUID(),
       addedAt: new Date().toISOString()
     };
+  }
+
+  // ============================================
+  // YouTube Import
+  // ============================================
+  const YOUTUBE_CLIENT_ID = ''; // Set via Google Cloud Console
+  const YOUTUBE_REDIRECT_URI = window.location.origin + '/boards/';
+
+  function connectYouTube() {
+    if (!YOUTUBE_CLIENT_ID) {
+      toast('YouTube OAuth not configured', { level: 'error' });
+      return;
+    }
+    const params = new URLSearchParams({
+      client_id: YOUTUBE_CLIENT_ID,
+      redirect_uri: YOUTUBE_REDIRECT_URI,
+      response_type: 'code',
+      scope: 'https://www.googleapis.com/auth/youtube.readonly',
+      access_type: 'offline',
+      prompt: 'consent',
+      state: 'youtube-connect',
+    });
+    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+  }
+
+  async function handleYouTubeOAuthCallback() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+    const state = urlParams.get('state');
+    if (!code || state !== 'youtube-connect') return;
+
+    // Clean URL
+    window.history.replaceState({}, '', window.location.pathname);
+
+    toast('Connecting YouTube...', { level: 'info', id: 'yt-connect' });
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session?.data?.session?.access_token;
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/youtube-import`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token || SUPABASE_ANON_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'connect', code, redirect_uri: YOUTUBE_REDIRECT_URI })
+      });
+      const result = await resp.json();
+      if (!resp.ok) throw new Error(result.error || 'Connection failed');
+      toast(`Connected: ${result.channel_title}`, { level: 'success', id: 'yt-connect' });
+      updateYouTubeConnectionUI(true, result.channel_title);
+    } catch (err) {
+      toast('YouTube connection failed', { level: 'error', id: 'yt-connect' });
+      console.error('[youtube-connect]', err);
+    }
+  }
+
+  async function importYouTubeContent(importType) {
+    const progressEl = document.getElementById('yt-import-progress');
+    const labelEl = document.getElementById('yt-progress-label');
+    const fillEl = document.getElementById('yt-progress-fill');
+    progressEl.style.display = 'block';
+    labelEl.textContent = `Importing ${importType === 'liked' ? 'liked videos' : 'playlists'}...`;
+    fillEl.style.width = '30%';
+
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session?.data?.session?.access_token;
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/youtube-import`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token || SUPABASE_ANON_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'import', import_type: importType })
+      });
+      fillEl.style.width = '90%';
+      const result = await resp.json();
+      if (!resp.ok) throw new Error(result.error || 'Import failed');
+
+      fillEl.style.width = '100%';
+      toast(result.message || `Imported ${result.imported} videos`, { level: 'success' });
+
+      // Reload the board to show new pins
+      if (result.imported > 0) {
+        await loadLinks();
+        renderGrid();
+      }
+    } catch (err) {
+      toast('YouTube import failed', { level: 'error' });
+      console.error('[youtube-import]', err);
+    } finally {
+      setTimeout(() => { progressEl.style.display = 'none'; fillEl.style.width = '0%'; }, 1500);
+    }
+  }
+
+  async function disconnectYouTube() {
+    if (!confirm('Disconnect YouTube? Your imported videos will remain in your board.')) return;
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session?.data?.session?.access_token;
+      await fetch(`${SUPABASE_URL}/functions/v1/youtube-import`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token || SUPABASE_ANON_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'disconnect' })
+      });
+      updateYouTubeConnectionUI(false);
+      toast('YouTube disconnected');
+    } catch (err) {
+      console.error('[youtube-disconnect]', err);
+    }
+  }
+
+  function updateYouTubeConnectionUI(isConnected, channelTitle) {
+    const connectControls = document.getElementById('yt-connect-controls');
+    const importControls = document.getElementById('yt-import-controls');
+    const statusEl = document.getElementById('yt-import-status');
+    if (connectControls) connectControls.style.display = isConnected ? 'none' : 'block';
+    if (importControls) importControls.style.display = isConnected ? 'block' : 'none';
+    if (statusEl) statusEl.textContent = isConnected ? `Connected: ${channelTitle}` : 'Not connected';
+  }
+
+  async function initYouTubeSection() {
+    await handleYouTubeOAuthCallback();
+    try {
+      const session = await supabase.auth.getSession();
+      const token = session?.data?.session?.access_token;
+      if (!token) return;
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/youtube-import`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ action: 'status' })
+      });
+      const result = await resp.json();
+      if (result.connected) {
+        updateYouTubeConnectionUI(true, result.channel);
+      }
+    } catch (err) {
+      console.error('[youtube-init]', err);
+    }
   }
 
   // ============================================
@@ -19657,6 +19885,12 @@ Return JSON:
     CtrlAuth.signOut();
   };
 
+  // YouTube import button handlers
+  document.getElementById('yt-connect-btn')?.addEventListener('click', connectYouTube);
+  document.getElementById('yt-import-liked-btn')?.addEventListener('click', () => importYouTubeContent('liked'));
+  document.getElementById('yt-import-playlists-btn')?.addEventListener('click', () => importYouTubeContent('playlists'));
+  document.getElementById('yt-disconnect-btn')?.addEventListener('click', disconnectYouTube);
+
   accountModal.querySelector('[data-close]')?.addEventListener('click', () => closeModal(accountModal));
   accountModal.querySelector('.modal__backdrop')?.addEventListener('click', () => closeModal(accountModal));
 
@@ -19745,6 +19979,7 @@ Return JSON:
       if (currentUsername) localStorage.setItem(USERNAME_KEY, currentUsername);
       updateAuthUI();
       loadAllShares();
+      initYouTubeSection();
 
       // Fetch from Supabase and update if different
       const t2 = performance.now();

--- a/supabase/functions/youtube-import/index.ts
+++ b/supabase/functions/youtube-import/index.ts
@@ -1,0 +1,561 @@
+// Supabase Edge Function: youtube-import
+// Handles YouTube OAuth connection and imports liked videos + playlists
+// as second-class pins (import_source = 'youtube') for taste map visualization.
+//
+// POST /functions/v1/youtube-import
+// Body:
+//   { action: 'connect', code: string, redirect_uri: string }
+//   { action: 'import', import_type: 'liked' | 'playlists' | 'all' }
+//   { action: 'disconnect' }
+//   { action: 'status' }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const VERSION = '1.0.0'
+console.log(`[youtube-import] v${VERSION} - liked videos and playlists`)
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const YOUTUBE_API_BASE = 'https://www.googleapis.com/youtube/v3'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const MAX_LIKED_VIDEOS = 500
+const MAX_PLAYLISTS = 50
+const PAGE_SIZE = 50
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface YouTubePlaylistItem {
+  snippet: {
+    title: string
+    description: string
+    channelTitle: string
+    publishedAt: string
+    resourceId: { videoId: string }
+    thumbnails?: { high?: { url: string }; medium?: { url: string }; default?: { url: string } }
+    position: number
+  }
+  contentDetails?: {
+    videoId: string
+    videoPublishedAt?: string
+  }
+}
+
+interface YouTubePlaylist {
+  id: string
+  snippet: {
+    title: string
+    description: string
+    publishedAt: string
+    channelTitle: string
+    thumbnails?: { high?: { url: string } }
+  }
+  contentDetails?: {
+    itemCount: number
+  }
+}
+
+interface ConnectedAccount {
+  id: string
+  user_id: string
+  platform: string
+  access_token: string
+  refresh_token: string | null
+  token_expires_at: string | null
+  scopes: string[]
+  platform_user_id: string | null
+  platform_username: string | null
+  status: string
+  last_import_at: string | null
+  last_import_count: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+function err(message: string, status = 400) {
+  return json({ error: message }, status)
+}
+
+/** Extract user_id from the Authorization header JWT */
+async function getUserId(req: Request): Promise<string | null> {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return null
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: authHeader } } }
+  )
+
+  const { data: { user } } = await supabase.auth.getUser()
+  return user?.id ?? null
+}
+
+/** Get a service-role Supabase client for DB operations */
+function getServiceClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+}
+
+/** Fetch from YouTube API with access token */
+async function ytFetch(path: string, accessToken: string): Promise<Response> {
+  const resp = await fetch(`${YOUTUBE_API_BASE}${path}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  })
+  if (!resp.ok) {
+    const body = await resp.text()
+    throw new Error(`YouTube API ${resp.status}: ${body}`)
+  }
+  return resp
+}
+
+/** Refresh an expired Google OAuth token */
+async function refreshToken(account: ConnectedAccount, db: ReturnType<typeof createClient>): Promise<string> {
+  if (!account.refresh_token) {
+    throw new Error('No refresh token available — user must reconnect')
+  }
+
+  const resp = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: Deno.env.get('YOUTUBE_CLIENT_ID')!,
+      client_secret: Deno.env.get('YOUTUBE_CLIENT_SECRET')!,
+      refresh_token: account.refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  })
+
+  if (!resp.ok) {
+    const body = await resp.text()
+    console.error(`[youtube-import] Token refresh failed: ${resp.status} ${body}`)
+    await db.from('connected_accounts').update({ status: 'expired' }).eq('id', account.id)
+    throw new Error('Token refresh failed — user must reconnect')
+  }
+
+  const tokens = await resp.json()
+  const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+
+  await db.from('connected_accounts').update({
+    access_token: tokens.access_token,
+    token_expires_at: expiresAt,
+    status: 'active',
+  }).eq('id', account.id)
+
+  return tokens.access_token
+}
+
+/** Get a valid access token, refreshing if needed */
+async function getValidToken(account: ConnectedAccount, db: ReturnType<typeof createClient>): Promise<string> {
+  if (account.token_expires_at) {
+    const expiresAt = new Date(account.token_expires_at)
+    const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000)
+    if (expiresAt < fiveMinFromNow) {
+      return await refreshToken(account, db)
+    }
+  }
+  return account.access_token
+}
+
+/** Normalize a YouTube URL to a canonical form */
+function normalizeYouTubeUrl(videoId: string): string {
+  return `https://www.youtube.com/watch?v=${videoId}`
+}
+
+/** Get the best available thumbnail URL */
+function getBestThumbnail(thumbnails?: { high?: { url: string }; medium?: { url: string }; default?: { url: string } }): string | null {
+  if (!thumbnails) return null
+  return thumbnails.high?.url ?? thumbnails.medium?.url ?? thumbnails.default?.url ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Action handlers
+// ---------------------------------------------------------------------------
+
+async function handleConnect(body: { code: string; redirect_uri: string }, userId: string) {
+  const clientId = Deno.env.get('YOUTUBE_CLIENT_ID')
+  const clientSecret = Deno.env.get('YOUTUBE_CLIENT_SECRET')
+
+  if (!clientId || !clientSecret) {
+    return err('YouTube OAuth not configured', 500)
+  }
+
+  // Exchange authorization code for tokens
+  const tokenResp = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code: body.code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: body.redirect_uri,
+      grant_type: 'authorization_code',
+    }),
+  })
+
+  if (!tokenResp.ok) {
+    const errBody = await tokenResp.text()
+    console.error(`[youtube-import] Token exchange failed: ${tokenResp.status} ${errBody}`)
+    return err('OAuth token exchange failed')
+  }
+
+  const tokens = await tokenResp.json()
+  const accessToken = tokens.access_token
+  const refreshTk = tokens.refresh_token ?? null
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+    : null
+
+  // Fetch channel info
+  const channelResp = await ytFetch('/channels?part=snippet&mine=true', accessToken)
+  const channelData = await channelResp.json()
+  const channel = channelData.items?.[0]
+  const channelTitle = channel?.snippet?.title ?? 'Unknown'
+  const channelId = channel?.id ?? null
+
+  // Upsert connected_accounts
+  const db = getServiceClient()
+  const { error: upsertError } = await db.from('connected_accounts').upsert({
+    user_id: userId,
+    platform: 'youtube',
+    access_token: accessToken,
+    refresh_token: refreshTk,
+    token_expires_at: expiresAt,
+    scopes: ['youtube.readonly'],
+    platform_user_id: channelId,
+    platform_username: channelTitle,
+    status: 'active',
+    connected_at: new Date().toISOString(),
+  }, { onConflict: 'user_id,platform' })
+
+  if (upsertError) {
+    console.error('[youtube-import] Upsert error:', upsertError)
+    return err('Failed to save connection')
+  }
+
+  console.log(`[youtube-import] Connected: ${channelTitle} (${channelId})`)
+  return json({ success: true, channel_title: channelTitle, channel_id: channelId })
+}
+
+async function handleImport(body: { import_type?: string }, userId: string) {
+  const importType = body.import_type ?? 'all'
+  const db = getServiceClient()
+
+  // Get connected account
+  const { data: account, error: acctErr } = await db
+    .from('connected_accounts')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('platform', 'youtube')
+    .eq('status', 'active')
+    .single()
+
+  if (acctErr || !account) {
+    return err('YouTube not connected. Please connect first.')
+  }
+
+  const accessToken = await getValidToken(account as ConnectedAccount, db)
+
+  // Collect all video items to import
+  const items: Array<{
+    videoId: string
+    title: string
+    channelTitle: string
+    description: string
+    thumbnail: string | null
+    publishedAt: string
+    playlistId: string | null
+    playlistName: string | null
+  }> = []
+
+  // --- Liked videos ---
+  if (importType === 'liked' || importType === 'all') {
+    console.log('[youtube-import] Fetching liked videos...')
+
+    // Get the likes playlist ID
+    const channelResp = await ytFetch('/channels?part=contentDetails&mine=true', accessToken)
+    const channelData = await channelResp.json()
+    const likesPlaylistId = channelData.items?.[0]?.contentDetails?.relatedPlaylists?.likes
+
+    if (likesPlaylistId) {
+      let pageToken: string | undefined
+      let totalFetched = 0
+
+      do {
+        const pageParam = pageToken ? `&pageToken=${pageToken}` : ''
+        const resp = await ytFetch(
+          `/playlistItems?part=snippet,contentDetails&playlistId=${likesPlaylistId}&maxResults=${PAGE_SIZE}${pageParam}`,
+          accessToken
+        )
+        const data = await resp.json()
+        const pageItems: YouTubePlaylistItem[] = data.items ?? []
+
+        for (const item of pageItems) {
+          const videoId = item.snippet?.resourceId?.videoId ?? item.contentDetails?.videoId
+          if (!videoId) continue
+          items.push({
+            videoId,
+            title: item.snippet.title,
+            channelTitle: item.snippet.channelTitle,
+            description: (item.snippet.description ?? '').slice(0, 500),
+            thumbnail: getBestThumbnail(item.snippet.thumbnails),
+            publishedAt: item.contentDetails?.videoPublishedAt ?? item.snippet.publishedAt,
+            playlistId: null,
+            playlistName: null,
+          })
+        }
+
+        totalFetched += pageItems.length
+        pageToken = data.nextPageToken
+      } while (pageToken && totalFetched < MAX_LIKED_VIDEOS)
+
+      console.log(`[youtube-import] Fetched ${totalFetched} liked videos`)
+    }
+  }
+
+  // --- User playlists ---
+  if (importType === 'playlists' || importType === 'all') {
+    console.log('[youtube-import] Fetching playlists...')
+
+    let playlistPageToken: string | undefined
+    const playlists: YouTubePlaylist[] = []
+
+    do {
+      const pageParam = playlistPageToken ? `&pageToken=${playlistPageToken}` : ''
+      const resp = await ytFetch(
+        `/playlists?part=snippet,contentDetails&mine=true&maxResults=${PAGE_SIZE}${pageParam}`,
+        accessToken
+      )
+      const data = await resp.json()
+      playlists.push(...(data.items ?? []))
+      playlistPageToken = data.nextPageToken
+    } while (playlistPageToken && playlists.length < MAX_PLAYLISTS)
+
+    console.log(`[youtube-import] Found ${playlists.length} playlists`)
+
+    for (const playlist of playlists) {
+      let pageToken: string | undefined
+      let playlistItemCount = 0
+      const maxPerPlaylist = 200
+
+      do {
+        const pageParam = pageToken ? `&pageToken=${pageToken}` : ''
+        const resp = await ytFetch(
+          `/playlistItems?part=snippet,contentDetails&playlistId=${playlist.id}&maxResults=${PAGE_SIZE}${pageParam}`,
+          accessToken
+        )
+        const data = await resp.json()
+        const pageItems: YouTubePlaylistItem[] = data.items ?? []
+
+        for (const item of pageItems) {
+          const videoId = item.snippet?.resourceId?.videoId ?? item.contentDetails?.videoId
+          if (!videoId) continue
+          items.push({
+            videoId,
+            title: item.snippet.title,
+            channelTitle: item.snippet.channelTitle,
+            description: (item.snippet.description ?? '').slice(0, 500),
+            thumbnail: getBestThumbnail(item.snippet.thumbnails),
+            publishedAt: item.contentDetails?.videoPublishedAt ?? item.snippet.publishedAt,
+            playlistId: playlist.id,
+            playlistName: playlist.snippet.title,
+          })
+        }
+
+        playlistItemCount += pageItems.length
+        pageToken = data.nextPageToken
+      } while (pageToken && playlistItemCount < maxPerPlaylist)
+    }
+
+    console.log(`[youtube-import] Total items from playlists: ${items.length}`)
+  }
+
+  if (items.length === 0) {
+    return json({ imported: 0, skipped: 0, total: 0, message: 'No videos found to import' })
+  }
+
+  // Deduplicate within batch (same videoId can appear in liked + playlist)
+  const seen = new Map<string, typeof items[0]>()
+  for (const item of items) {
+    if (!seen.has(item.videoId)) {
+      seen.set(item.videoId, item)
+    }
+  }
+  const uniqueItems = Array.from(seen.values())
+
+  // Check existing URLs to avoid duplicates
+  const urls = uniqueItems.map(i => normalizeYouTubeUrl(i.videoId))
+  const { data: existing } = await db
+    .from('links')
+    .select('url')
+    .eq('user_id', userId)
+    .in('url', urls)
+
+  const existingUrls = new Set((existing ?? []).map((r: { url: string }) => r.url))
+
+  // Build pin rows for new items
+  const newPins = uniqueItems
+    .filter(item => !existingUrls.has(normalizeYouTubeUrl(item.videoId)))
+    .map(item => ({
+      user_id: userId,
+      url: normalizeYouTubeUrl(item.videoId),
+      title: item.title,
+      description: `${item.channelTitle} — ${item.description.slice(0, 200)}`,
+      image: item.thumbnail ?? `https://img.youtube.com/vi/${item.videoId}/hqdefault.jpg`,
+      domain: 'youtube.com',
+      category: inferCategory(item.playlistName),
+      content_type: 'video',
+      import_source: 'youtube',
+      tags: item.playlistName ? [item.playlistName] : [],
+      video: {
+        title: item.title,
+        creator: item.channelTitle,
+        year: new Date(item.publishedAt).getFullYear(),
+        type: 'video',
+        platform: 'youtube',
+        platformId: item.videoId,
+      },
+    }))
+
+  // Bulk insert in batches of 100
+  let imported = 0
+  const batchSize = 100
+  for (let i = 0; i < newPins.length; i += batchSize) {
+    const batch = newPins.slice(i, i + batchSize)
+    const { error: insertErr, count } = await db
+      .from('links')
+      .insert(batch)
+
+    if (insertErr) {
+      console.error(`[youtube-import] Batch insert error at offset ${i}:`, insertErr)
+    } else {
+      imported += count ?? batch.length
+    }
+  }
+
+  // Update account stats
+  await db.from('connected_accounts').update({
+    last_import_at: new Date().toISOString(),
+    last_import_count: imported,
+  }).eq('user_id', userId).eq('platform', 'youtube')
+
+  const skipped = existingUrls.size
+  console.log(`[youtube-import] Done: ${imported} imported, ${skipped} skipped (already saved)`)
+
+  return json({
+    imported,
+    skipped,
+    total: uniqueItems.length,
+    message: `Imported ${imported} videos${skipped > 0 ? ` (${skipped} already in your library)` : ''}`,
+  })
+}
+
+/** Infer category from playlist name */
+function inferCategory(playlistName: string | null): string {
+  if (!playlistName) return 'watch'
+  const lower = playlistName.toLowerCase()
+  if (/music|songs?|playlist|mix|beats|tracks/i.test(lower)) return 'listen'
+  if (/cook|recipe|food|eat/i.test(lower)) return 'eat'
+  if (/learn|tutorial|course|how.?to|lecture/i.test(lower)) return 'read'
+  if (/style|fashion|outfit|wear/i.test(lower)) return 'wear'
+  if (/travel|places|visit/i.test(lower)) return 'go'
+  return 'watch'
+}
+
+async function handleDisconnect(userId: string) {
+  const db = getServiceClient()
+  const { error } = await db
+    .from('connected_accounts')
+    .update({ status: 'revoked' })
+    .eq('user_id', userId)
+    .eq('platform', 'youtube')
+
+  if (error) {
+    console.error('[youtube-import] Disconnect error:', error)
+    return err('Failed to disconnect')
+  }
+
+  return json({ success: true, message: 'YouTube disconnected. Imported videos remain in your library.' })
+}
+
+async function handleStatus(userId: string) {
+  const db = getServiceClient()
+  const { data, error } = await db
+    .from('connected_accounts')
+    .select('platform_username, status, last_import_at, last_import_count, connected_at')
+    .eq('user_id', userId)
+    .eq('platform', 'youtube')
+    .single()
+
+  if (error || !data) {
+    return json({ connected: false })
+  }
+
+  return json({
+    connected: data.status === 'active',
+    channel: data.platform_username,
+    status: data.status,
+    last_import_at: data.last_import_at,
+    last_import_count: data.last_import_count,
+    connected_at: data.connected_at,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const userId = await getUserId(req)
+    if (!userId) {
+      return err('Not authenticated', 401)
+    }
+
+    const body = await req.json()
+    const action = body.action
+
+    switch (action) {
+      case 'connect':
+        if (!body.code || !body.redirect_uri) {
+          return err('Missing code or redirect_uri')
+        }
+        return await handleConnect(body, userId)
+
+      case 'import':
+        return await handleImport(body, userId)
+
+      case 'disconnect':
+        return await handleDisconnect(userId)
+
+      case 'status':
+        return await handleStatus(userId)
+
+      default:
+        return err(`Unknown action: ${action}`)
+    }
+  } catch (e) {
+    console.error('[youtube-import] Unhandled error:', e)
+    return err(e instanceof Error ? e.message : 'Internal error', 500)
+  }
+})

--- a/supabase/migrations/027_youtube_import.sql
+++ b/supabase/migrations/027_youtube_import.sql
@@ -1,0 +1,64 @@
+-- ============================================
+-- 027_youtube_import.sql
+-- Adds import_source tracking to links table
+-- and connected_accounts table for OAuth tokens
+-- ============================================
+
+-- 1. import_source on links
+-- Tracks which platform a pin was bulk-imported from
+-- NULL = user-saved pin (first-class citizen)
+-- 'youtube' = imported from YouTube liked videos / playlists
+ALTER TABLE links ADD COLUMN IF NOT EXISTS import_source TEXT DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_links_import_source
+  ON links(import_source) WHERE import_source IS NOT NULL;
+
+-- 2. connected_accounts table
+CREATE TABLE IF NOT EXISTS connected_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  platform TEXT NOT NULL,
+  access_token TEXT NOT NULL,
+  refresh_token TEXT,
+  token_expires_at TIMESTAMPTZ,
+  scopes TEXT[],
+  platform_user_id TEXT,
+  platform_username TEXT,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'revoked', 'expired', 'error')),
+  last_import_at TIMESTAMPTZ,
+  last_import_count INTEGER DEFAULT 0,
+  connected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, platform)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connected_accounts_user_platform
+  ON connected_accounts(user_id, platform);
+
+ALTER TABLE connected_accounts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own connected accounts"
+  ON connected_accounts FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users insert own connected accounts"
+  ON connected_accounts FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users update own connected accounts"
+  ON connected_accounts FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Service role full access connected_accounts"
+  ON connected_accounts FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE OR REPLACE FUNCTION update_connected_accounts_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = NOW(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER connected_accounts_updated_at
+  BEFORE UPDATE ON connected_accounts
+  FOR EACH ROW EXECUTE FUNCTION update_connected_accounts_updated_at();

--- a/taste-map/src/App.tsx
+++ b/taste-map/src/App.tsx
@@ -20,17 +20,19 @@ import { EdgeDetail } from './components/EdgeDetail';
 
 type AppState = 'loading' | 'unauthenticated' | 'empty' | 'clustering' | 'labeling' | 'ready';
 
-const CACHE_KEY_PREFIX = 'boards-taste-graph-v7-';
+const CACHE_KEY_PREFIX = 'boards-taste-graph-v8-';
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-function clusterFingerprint(clusters: Cluster[]): string {
+function clusterFingerprint(clusters: Cluster[], showYoutube: boolean): string {
   const tokens = clusters
     .map(c => c.topTokens.slice(0, 4).sort().join(','))
     .sort()
     .join('|');
+  const source = showYoutube ? '+yt' : '-yt';
+  const input = tokens + source;
   let hash = 0;
-  for (let i = 0; i < tokens.length; i++) {
-    hash = ((hash << 5) - hash + tokens.charCodeAt(i)) | 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
   }
   return Math.abs(hash).toString(36);
 }
@@ -72,6 +74,10 @@ export default function App() {
   const [highlightedMotif, setHighlightedMotif] = useState<string | null>(null);
   const [selectedEdge, setSelectedEdge] = useState<GraphEdge | null>(null);
   const [edgeScreenPos, setEdgeScreenPos] = useState<{ x: number; y: number } | null>(null);
+
+  // YouTube toggle
+  const [showYoutube, setShowYoutube] = useState<boolean>(true);
+  const [hasYoutubePins, setHasYoutubePins] = useState<boolean>(false);
 
   // Drill stack
   const [drillStack, setDrillStack] = useState<DrillFrame[]>([]);
@@ -118,10 +124,11 @@ export default function App() {
       }
 
       setPins(pinData);
+      setHasYoutubePins(pinData.some(p => p.import_source === 'youtube'));
       setState('clustering');
 
       // Cluster
-      const rawClusters = buildClusters(pinData);
+      const rawClusters = buildClusters(pinData, 'c', undefined, showYoutube);
       const graphEdges = buildEdges(rawClusters);
 
       if (cancelled) return;
@@ -131,7 +138,7 @@ export default function App() {
       setDrillStack([rootFrame]);
 
       // Try cache
-      const fp = clusterFingerprint(rawClusters);
+      const fp = clusterFingerprint(rawClusters, showYoutube);
       const cached = loadCache(fp);
 
       if (cached) {
@@ -200,7 +207,7 @@ export default function App() {
 
     init();
     return () => { cancelled = true; };
-  }, [authTrigger]);
+  }, [authTrigger, showYoutube]);
 
   const handleSelectCluster = useCallback((id: string | null) => {
     setSelectedCluster(id);
@@ -229,14 +236,15 @@ export default function App() {
       drillStack.length,
       clusterId,
       cluster.label,
-      clusterPins
+      clusterPins,
+      showYoutube
     );
 
     setDrillStack(prev => [...prev, newFrame]);
     setSelectedCluster(null);
     setSelectedEdge(null);
     setEdgeScreenPos(null);
-  }, [currentClusters, pins, drillStack]);
+  }, [currentClusters, pins, drillStack, showYoutube]);
 
   const handleDrillTo = useCallback((depth: number) => {
     if (depth >= drillStack.length) return;
@@ -257,6 +265,15 @@ export default function App() {
       <header className="tg-header">
         <h1 className="tg-header__title">Taste Map</h1>
         <div className="tg-header__actions">
+          {hasYoutubePins && (
+            <button
+              className={`tg-btn ${showYoutube ? 'tg-btn--active' : ''}`}
+              onClick={() => setShowYoutube(prev => !prev)}
+              title={showYoutube ? 'Hide YouTube imports' : 'Show YouTube imports'}
+            >
+              {showYoutube ? 'YT ON' : 'YT OFF'}
+            </button>
+          )}
           <a href="/boards/" className="tg-btn">Boards</a>
         </div>
       </header>

--- a/taste-map/src/components/ConceptDetail.tsx
+++ b/taste-map/src/components/ConceptDetail.tsx
@@ -54,6 +54,24 @@ export function ConceptDetail({
         {cluster.pinCount} ITEMS &middot; {pct}% OF SAVES
       </div>
 
+      {/* Source breakdown — only shown for clusters with YouTube data */}
+      {cluster.sourceBreakdown && cluster.sourceBreakdown.youtube > 0 && (
+        <>
+          <div className="tg-detail__section-header">{'\u2500\u2500'} SOURCES</div>
+          <div className="tg-detail__source-row">
+            {cluster.sourceBreakdown.manual > 0 && (
+              <span className="tg-detail__source-label">
+                SAVED: <span className="tg-detail__source-count">{cluster.sourceBreakdown.manual}</span>
+              </span>
+            )}
+            <span className="tg-detail__source-label">
+              YOUTUBE: <span className="tg-detail__source-count">{cluster.sourceBreakdown.youtube}</span>
+              <span className="tg-detail__source-badge">IMPORTED</span>
+            </span>
+          </div>
+        </>
+      )}
+
       {/* Tokens */}
       {cluster.topTokens.length > 0 && (
         <>

--- a/taste-map/src/components/Graph.tsx
+++ b/taste-map/src/components/Graph.tsx
@@ -222,6 +222,9 @@ function GraphScene({
         const isSelected = selectedCluster === node.id;
         const isDimmed = highlightedMotif != null && !isMotifMatch(node.cluster, highlightedMotif);
         const isHighlighted = highlightedMotif != null && isMotifMatch(node.cluster, highlightedMotif);
+        const breakdown = node.cluster.sourceBreakdown;
+        const isYoutubeOnly = breakdown?.isYoutubeOnly ?? false;
+        const hasMixedSources = breakdown?.hasMixedSources ?? false;
 
         return (
           <Node3D
@@ -230,6 +233,8 @@ function GraphScene({
             isSelected={isSelected}
             isDimmed={isDimmed}
             isHighlighted={isHighlighted}
+            isYoutubeOnly={isYoutubeOnly}
+            hasMixedSources={hasMixedSources}
             onClick={() => onSelectCluster(isSelected ? null : node.id)}
             onDoubleClick={() => {
               if (node.cluster.drillable) {

--- a/taste-map/src/components/Node3D.tsx
+++ b/taste-map/src/components/Node3D.tsx
@@ -7,6 +7,8 @@ interface Node3DProps {
   isSelected: boolean;
   isDimmed: boolean;
   isHighlighted: boolean;
+  isYoutubeOnly: boolean;
+  hasMixedSources: boolean;
   onClick: () => void;
   onDoubleClick: () => void;
 }
@@ -16,6 +18,8 @@ export function Node3D({
   isSelected,
   isDimmed,
   isHighlighted,
+  isYoutubeOnly,
+  hasMixedSources,
   onClick,
   onDoubleClick,
 }: Node3DProps) {
@@ -24,9 +28,12 @@ export function Node3D({
     isSelected && 'tg-3d-label--selected',
     isDimmed && 'tg-3d-label--dimmed',
     isHighlighted && 'tg-3d-label--highlighted',
+    isYoutubeOnly && 'tg-3d-label--youtube-only',
+    hasMixedSources && 'tg-3d-label--mixed-sources',
   ].filter(Boolean).join(' ');
 
   const drillIndicator = node.cluster.drillable ? ' \u21B3' : '';
+  const sourceIndicator = isYoutubeOnly ? ' [YT]' : hasMixedSources ? ' [+YT]' : '';
 
   return (
     <group position={[node.x, node.y, node.z]}>
@@ -45,7 +52,7 @@ export function Node3D({
             {node.cluster.label.toUpperCase()}
           </span>
           <span className="tg-3d-label__count">
-            {'\u2500\u2500 '}{node.cluster.pinCount} ITEMS{drillIndicator}
+            {'\u2500\u2500 '}{node.cluster.pinCount} ITEMS{drillIndicator}{sourceIndicator}
           </span>
         </div>
       </Html>

--- a/taste-map/src/lib/clustering.ts
+++ b/taste-map/src/lib/clustering.ts
@@ -3,7 +3,7 @@
 // Soft assignment: pins can appear in multiple clusters
 // ============================================
 
-import type { Pin, Cluster, GraphEdge } from './types';
+import type { Pin, Cluster, GraphEdge, SourceBreakdown } from './types';
 import { tokenize, buildPinDocument, computeIDF, tfidfVector, cosineSimilarity, cleanDomain } from './tfidf';
 
 const CATEGORY_DOMAIN_MAP: Record<string, string> = {
@@ -146,10 +146,15 @@ function collectTags(members: PinVector[], max: number): string[] {
     .map(([t]) => t);
 }
 
-export function buildClusters(pins: Pin[], idPrefix = 'c', kOverride?: number): Cluster[] {
-  const idf = computeIDF(pins);
+export function buildClusters(pins: Pin[], idPrefix = 'c', kOverride?: number, includeYoutube = true): Cluster[] {
+  const activePins = includeYoutube
+    ? pins
+    : pins.filter(p => p.import_source !== 'youtube');
 
-  const pinVectors: PinVector[] = pins.map(p => {
+  if (activePins.length === 0) return [];
+  const idf = computeIDF(activePins);
+
+  const pinVectors: PinVector[] = activePins.map(p => {
     const doc = buildPinDocument(p);
     const tokens = tokenize(doc);
     return { pin: p, tokens, vector: tfidfVector(tokens, idf) };
@@ -292,6 +297,18 @@ export function buildClusters(pins: Pin[], idPrefix = 'c', kOverride?: number): 
     // Deduplicate pinIds (a pin can appear via both hard and soft assignment)
     const uniquePinIds = [...new Set(members.map(m => m.pin.id))];
 
+    // Source breakdown for YouTube toggle visualization
+    const uniqueMembers = [...new Set(members.map(m => m.pin))];
+    const youtubeCount = uniqueMembers.filter(p => p.import_source === 'youtube').length;
+    const manualCount = uniqueMembers.length - youtubeCount;
+    const sourceBreakdown: SourceBreakdown = {
+      youtube: youtubeCount,
+      manual: manualCount,
+      total: uniqueMembers.length,
+      isYoutubeOnly: youtubeCount === uniqueMembers.length && youtubeCount > 0,
+      hasMixedSources: youtubeCount > 0 && manualCount > 0,
+    };
+
     clusters.push({
       id: `${idPrefix}${clusterIdx}`,
       pinIds: uniquePinIds,
@@ -308,6 +325,7 @@ export function buildClusters(pins: Pin[], idPrefix = 'c', kOverride?: number): 
       topDomains: domains,
       tags,
       categoryBreakdown: catBreakdown,
+      sourceBreakdown,
     });
     clusterIdx++;
   }
@@ -315,10 +333,10 @@ export function buildClusters(pins: Pin[], idPrefix = 'c', kOverride?: number): 
   return clusters;
 }
 
-export function buildSubClusters(pins: Pin[], parentId: string): Cluster[] {
+export function buildSubClusters(pins: Pin[], parentId: string, includeYoutube = true): Cluster[] {
   if (pins.length < 4) return [];
   const K = Math.min(12, Math.max(3, Math.floor(pins.length / 3)));
-  return buildClusters(pins, `${parentId}-s`, K);
+  return buildClusters(pins, `${parentId}-s`, K, includeYoutube);
 }
 
 export function buildEdges(clusters: Cluster[]): GraphEdge[] {

--- a/taste-map/src/lib/drill.ts
+++ b/taste-map/src/lib/drill.ts
@@ -24,9 +24,10 @@ export function createDrillFrame(
   depth: number,
   parentClusterId: string,
   parentLabel: string,
-  pins: Pin[]
+  pins: Pin[],
+  includeYoutube = true
 ): DrillFrame {
-  const subClusters = buildSubClusters(pins, parentClusterId);
+  const subClusters = buildSubClusters(pins, parentClusterId, includeYoutube);
   const subEdges = buildEdges(subClusters);
 
   return {

--- a/taste-map/src/lib/types.ts
+++ b/taste-map/src/lib/types.ts
@@ -56,6 +56,7 @@ export interface Pin {
   book?: BookMeta | null;
   notes?: string | null;
   is_merged?: boolean;
+  import_source?: string | null;
 }
 
 // --- Clustering ---
@@ -64,6 +65,14 @@ export interface ClusterDescription {
   whatItIs: string;
   whyYou: string;
   howItChanged: string;
+}
+
+export interface SourceBreakdown {
+  youtube: number;
+  manual: number;
+  total: number;
+  isYoutubeOnly: boolean;
+  hasMixedSources: boolean;
 }
 
 export interface Cluster {
@@ -83,6 +92,7 @@ export interface Cluster {
   topDomains?: string[];
   tags?: string[];
   categoryBreakdown?: string;
+  sourceBreakdown?: SourceBreakdown;
 }
 
 export interface GraphEdge {

--- a/taste-map/src/styles/graph.css
+++ b/taste-map/src/styles/graph.css
@@ -113,6 +113,12 @@ html, body, #root {
   line-height: 1;
 }
 
+.tg-btn--active {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+
 .tg-btn--drill {
   display: block;
   width: 100%;
@@ -232,6 +238,27 @@ html, body, #root {
 
 .tg-3d-label--highlighted {
   border: 2px solid var(--fg);
+}
+
+/* YouTube second-class nodes */
+.tg-3d-label--youtube-only {
+  opacity: 0.55;
+  border-style: dashed;
+}
+
+.tg-3d-label--youtube-only:hover,
+.tg-3d-label--youtube-only.tg-3d-label--selected {
+  opacity: 1;
+  border-style: solid;
+}
+
+.tg-3d-label--mixed-sources {
+  opacity: 0.85;
+}
+
+.tg-3d-label--mixed-sources:hover,
+.tg-3d-label--mixed-sources.tg-3d-label--selected {
+  opacity: 1;
 }
 
 .tg-3d-label__name {
@@ -564,6 +591,39 @@ html, body, #root {
   flex-wrap: wrap;
   gap: var(--space-1);
   margin-top: var(--space-1);
+}
+
+/* Source breakdown */
+
+.tg-detail__source-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.tg-detail__source-label {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.tg-detail__source-count {
+  color: var(--fg);
+}
+
+.tg-detail__source-badge {
+  font-size: 7px;
+  color: var(--muted);
+  border: 1px solid var(--subtle);
+  padding: 1px 4px;
+  letter-spacing: 0.08em;
+  margin-left: 2px;
 }
 
 /* Sample titles */


### PR DESCRIPTION
## Summary
- Adds YouTube OAuth integration to import liked videos and playlists as second-class pins (`import_source = 'youtube'`)
- YouTube-imported clusters appear in the taste map with dashed borders and lower opacity, visually distinct from manually-saved pins
- YT toggle button in header lets users show/hide YouTube data — graph re-clusters on toggle
- Source breakdown section in ConceptDetail panel shows SAVED vs YOUTUBE counts

## Changes
- **Migration 027**: `import_source` column on `links`, `connected_accounts` table with RLS
- **Edge function**: `youtube-import` — OAuth connect, import liked videos + playlists, disconnect, status
- **Boards UI**: Connect YouTube section in account modal with import buttons
- **Taste map**: Source-aware clustering, Node3D rendering, ConceptDetail sources panel
- **CSS**: Second-class visual treatment (dashed borders, reduced opacity) for YouTube-only and mixed clusters

## Test plan
- [ ] Run migration 027 against Supabase Boards project
- [ ] Deploy `youtube-import` edge function
- [ ] Set up Google Cloud OAuth credentials and add `YOUTUBE_CLIENT_ID` / `YOUTUBE_CLIENT_SECRET` to Supabase secrets
- [ ] Test Connect YouTube flow in Boards account modal
- [ ] Import liked videos and verify they appear with `import_source = 'youtube'`
- [ ] Open taste map — YouTube clusters should show dashed borders, lower opacity
- [ ] Toggle YT OFF — YouTube-only clusters disappear, mixed clusters shrink
- [ ] Drill into mixed cluster — sub-clusters maintain source breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)