### PR TITLE
feat: sense-making & pin creation agent architecture (Phases 1-2)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6532,8 +6532,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.10.0';
-  console.log('[boards] v' + VERSION + ' - youtube import integration');
+  const VERSION = '2.11.0';
+  console.log('[boards] v' + VERSION + ' - two-step enrichment (analyze-content + create-pin)');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -9749,7 +9749,7 @@ Return JSON:
   // ============================================
   // Image Resolution System (server-first)
   // ============================================
-  // Strategy selection is now server-side in enrich-link.
+  // Strategy selection is now server-side in create-pin.
   // Client only handles: CORS proxy (fetchMetadata) and platform APIs (resolvePlatformImage).
   // Everything else delegates to the server via queueServerEnrichment().
 
@@ -10021,7 +10021,7 @@ Return JSON:
   //         releaseDate, contentFormat, platformId, isExplicit, key, label
   // musicTags: optional og:music tags already scraped by fetchMetadata (avoids re-fetching)
 
-  // BPM/key lookup is now server-side in enrich-link step 7 (GetSongBPM CORS blocks browser calls)
+  // BPM/key lookup is now server-side in create-pin step 7 (GetSongBPM CORS blocks browser calls)
 
   async function extractMusicMetadata(url, title, description, musicTags) {
     const meta = {
@@ -10198,7 +10198,7 @@ Return JSON:
           }
         }
 
-        // 6b: BPM/key now resolved server-side in enrich-link step 7
+        // 6b: BPM/key now resolved server-side in create-pin step 7
         if (meta.bpm || meta.key) {
           console.log('%c[music-meta] BPM/key from server:', 'color: #1DB954', { bpm: meta.bpm, key: meta.key });
         }
@@ -10572,9 +10572,9 @@ Return JSON:
   };
 
   // ============================================
-  // Tier 3: AI Vision Validation (now server-side in enrich-link)
+  // Tier 3: AI Vision Validation (now server-side in create-pin)
   // ============================================
-  // Tier 3 quality evaluation is now integrated into the server-side enrich-link pipeline.
+  // Tier 3 quality evaluation is now integrated into the server-side create-pin pipeline.
   // Images are validated BEFORE being returned to the client, so no async post-display queue is needed.
   // The server returns pre-validated images with full scores (accuracy, aesthetic_fit, distinctiveness, safety).
 
@@ -10799,7 +10799,31 @@ Return JSON:
     return new Promise(resolve => setTimeout(resolve, ms));
   }
 
-  // Call enrichment API with retry logic
+  // Call analyze-content API (sense-making: classification + tags + entities)
+  async function callAnalyzeContentAPI(url, title, description) {
+    try {
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/analyze-content`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify({ url, title, description })
+      });
+
+      if (!response.ok) {
+        console.warn('%c[ANALYZE] analyze-content returned', 'color: #9b59b6', response.status);
+        return null;
+      }
+
+      return await response.json();
+    } catch (e) {
+      console.warn('%c[ANALYZE] analyze-content error:', 'color: #9b59b6', e.message);
+      return null;
+    }
+  }
+
+  // Call create-pin API with retry logic (image resolution + metadata enrichment)
   async function callEnrichmentAPI(item, currentImage, forceRefresh) {
     let lastError = null;
 
@@ -10815,7 +10839,7 @@ Return JSON:
         // supabase.functions.invoke() sent the user JWT which expires and
         // returns a generic "non-2xx status code" error that hid the real
         // HTTP status, causing 401s to be retried pointlessly.
-        const response = await fetch(`${SUPABASE_URL}/functions/v1/enrich-link`, {
+        const response = await fetch(`${SUPABASE_URL}/functions/v1/create-pin`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -10828,7 +10852,7 @@ Return JSON:
             linkId: item.linkId,
             currentImage: currentImage,
             skipIfHasImage: !forceRefresh && !!currentImage,
-            skipClassification: item.skipClassification || false,
+            content_type: item.content_type || null,
             forceRefresh: forceRefresh,
             category: item.category || null,
             enrichWatch: item.enrichWatch || false,
@@ -10841,14 +10865,14 @@ Return JSON:
           const status = response.status;
           // 400/401/403/404 are not retryable — stop immediately
           if (status >= 400 && status < 500) {
-            throw new Error(`enrich-link returned ${status}`);
+            throw new Error(`create-pin returned ${status}`);
           }
           // 5xx are retryable
           if (attempt < ENRICHMENT_MAX_RETRIES) {
-            lastError = new Error(`enrich-link returned ${status}`);
+            lastError = new Error(`create-pin returned ${status}`);
             continue;
           }
-          throw new Error(`enrich-link returned ${status}`);
+          throw new Error(`create-pin returned ${status}`);
         }
 
         const result = await response.json();
@@ -10908,22 +10932,55 @@ Return JSON:
       const currentImage = currentLink?.image || null;
       const forceRefresh = item.forceRefresh || false;
 
-      // Check domain cache first - skip classification if high confidence cached
-      let skipClassification = false;
-      let cachedType = null;
-      try {
-        const domain = new URL(item.url).hostname.replace('www.', '');
-        const cached = domainProfileCache[domain];
-        if (cached && cached.confidence >= 0.85) {
-          console.log('%c[ENRICH] Domain cache hit:', 'color: #27ae60', domain, cached.primaryType, cached.confidence);
-          skipClassification = true;
-          cachedType = cached;
-        }
-      } catch {}
+      // Step 1: Sense-making via analyze-content (classification + tags + entities)
+      let analysisResult = null;
+      if (!item.skipAnalysis) {
+        console.log('%c[ANALYZE] Calling analyze-content for:', 'color: #9b59b6', item.url);
+        analysisResult = await callAnalyzeContentAPI(item.url, item.title, item.description);
 
-      // Call API with retry logic (skip classification if cached)
+        if (analysisResult) {
+          console.log('%c[ANALYZE] Result:', 'color: #9b59b6; font-weight: bold', {
+            content_type: analysisResult.content_type,
+            content_structure: analysisResult.content_structure,
+            practical_tags: analysisResult.practical_tags?.length,
+            taste_tags: analysisResult.taste_tags?.length,
+            entities: analysisResult.entities?.length
+          });
+
+          // Apply analysis results to link immediately
+          const analysisData = load();
+          const analysisLink = analysisData.links.find(l => l.id === item.linkId);
+          if (analysisLink) {
+            if (analysisResult.content_type && analysisResult.content_type !== 'unknown') {
+              analysisLink.content_type = analysisResult.content_type;
+              analysisLink.type_confidence = analysisResult.type_confidence;
+            }
+            if (analysisResult.content_structure) {
+              analysisLink.content_structure = analysisResult.content_structure;
+            }
+            if (analysisResult.entities?.length) {
+              analysisLink.entities = analysisResult.entities;
+            }
+            if (analysisResult.practical_tags?.length) {
+              analysisLink.practical_tags = analysisResult.practical_tags;
+            }
+            if (analysisResult.taste_tags?.length) {
+              analysisLink.taste_tags = analysisResult.taste_tags;
+            }
+            // Recompute tags with new data
+            analysisLink.tags = computeLinkTags(analysisLink);
+            // Update title if platform API resolved a better one
+            if (analysisResult.title && (!analysisLink.title || analysisLink.title.length < 5)) {
+              analysisLink.title = analysisResult.title;
+            }
+            save(analysisData);
+          }
+        }
+      }
+
+      // Step 2: Pin creation via create-pin (image resolution + metadata enrichment)
       const { success, result, error } = await callEnrichmentAPI(
-        { ...item, skipClassification },
+        { ...item, content_type: analysisResult?.content_type || item.content_type || null },
         currentImage,
         forceRefresh
       );
@@ -10969,25 +11026,22 @@ Return JSON:
         delete link.enrichment_failed;
         delete link.enrichment_failed_at;
 
-        // Update content type - prefer server result, fallback to client cache
-        if (result.content_type && result.content_type !== 'unknown') {
+        // Content type: prefer analyze-content result (already applied), then create-pin fallback
+        if (result.content_type && result.content_type !== 'unknown' && !link.content_type) {
           link.content_type = result.content_type;
           link.type_confidence = result.type_confidence;
-          // Update client cache with server result
+        }
+        // Update client domain cache with best available type
+        if (link.content_type && link.content_type !== 'unknown') {
           try {
             const domain = new URL(item.url).hostname.replace('www.', '');
             domainProfileCache[domain] = {
-              primaryType: result.content_type,
-              confidence: result.type_confidence,
+              primaryType: link.content_type,
+              confidence: link.type_confidence || 0.8,
               updatedAt: Date.now()
             };
             saveDomainCache();
           } catch {}
-        } else if (cachedType && cachedType.primaryType) {
-          // Use cached type if server returned unknown
-          link.content_type = cachedType.primaryType;
-          link.type_confidence = cachedType.confidence;
-          console.log('%c[ENRICH] Using cached type:', 'color: #f39c12', cachedType.primaryType);
         }
 
         // Only update image if:
@@ -12135,6 +12189,14 @@ Return JSON:
     // Content type
     if (link.content_type) tags.add(link.content_type);
 
+    // Sense-making tags (from analyze-content)
+    if (link.practical_tags) {
+      for (const t of link.practical_tags) tags.add(t);
+    }
+    if (link.taste_tags) {
+      for (const t of link.taste_tags) tags.add(t);
+    }
+
     // SUB_TAGS sub-category (previously runtime-only, now persisted)
     const subTags = detectTags(link);
     if (subTags) {
@@ -12747,6 +12809,16 @@ Return JSON:
         image_source: link.image_source || null,
         // image_scores intentionally omitted — client-only field, DB column exists but
         // PostgREST schema cache may be stale. Scores live in localStorage and are recomputed.
+        // Sense-making fields (from analyze-content)
+        entities: link.entities || null,
+        practical_tags: link.practical_tags || [],
+        taste_tags: link.taste_tags || [],
+        content_structure: link.content_structure || null,
+        hero_score: link.hero_score || null,
+        // Provenance fields
+        instagram: link.instagram || null,
+        extraction: link.extraction || null,
+        source_url: link.source_url || null,
         // Structured metadata (JSONB columns)
         video: link.video || null,
         music: link.music || null,

--- a/boards/index.html
+++ b/boards/index.html
@@ -5741,6 +5741,9 @@ body {
   .ig-entity--unresolved { border-color: var(--subtle); opacity: 0.85; cursor: default; }
   .ig-entity--unresolved:hover { border-color: var(--muted); background: none; }
   .ig-entity--unresolved-resolved { border-color: var(--fg) !important; opacity: 1; }
+  .ig-tag { display: inline-block; padding: 1px 6px; font-size: var(--font-size-xs); font-family: var(--font-mono); border: 1px solid var(--subtle); color: var(--muted); }
+  .ig-tag--structure { color: var(--fg); border-color: var(--muted); }
+  .ig-tag--taste { font-style: italic; }
   #igEntities { max-height: 50vh; overflow-y: auto; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
@@ -6508,6 +6511,7 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
       <div style="padding: var(--space-4);">
         <p id="igSummary" style="margin-bottom: var(--space-3); font-family: var(--font-serif); font-size: var(--font-size-sm); line-height: var(--line-height-normal);"></p>
         <p id="igStats" style="margin-bottom: var(--space-3); font-family: var(--font-mono); font-size: var(--font-size-xs); color: var(--muted);"></p>
+        <div id="igTagsRow" style="display:none;flex-wrap:wrap;gap:4px;margin-bottom:var(--space-3);"></div>
         <div id="igKeepSourceRow" style="display:none;align-items:center;gap:var(--space-2);margin-bottom:var(--space-3);padding:var(--space-2) var(--space-3);border:1px solid var(--subtle);">
           <input type="checkbox" id="igKeepSource" checked style="width:16px;height:16px;accent-color:var(--fg);cursor:pointer;">
           <label for="igKeepSource" style="font-family:var(--font-mono);font-size:var(--font-size-xs);color:var(--muted);cursor:pointer;user-select:none;">Keep original Instagram post as a pin</label>
@@ -16590,6 +16594,10 @@ Return JSON:
               image: src.image || link.image,
               instagram: src.instagram || {},
               content_type: src.content_type || link.content_type,
+              entities: src.entities || null,
+              practical_tags: result.practical_tags || [],
+              taste_tags: result.taste_tags || [],
+              content_structure: result.content_structure || null,
               enrichment_failed: false
             });
             renderFilters();
@@ -18489,6 +18497,23 @@ Return JSON:
       + (unresolvedCount > 0 ? ` \u00b7 ${unresolvedCount} not found` : '')
       + ` \u00b7 ${stats.entities_review} need review \u00b7 ${stats.entities_discarded} skipped`;
 
+    // Show sense-making tags below stats
+    const tagsRow = $('igTagsRow');
+    if (tagsRow) {
+      const pTags = result.practical_tags || [];
+      const tTags = result.taste_tags || [];
+      const structure = result.content_structure || null;
+      if (pTags.length > 0 || tTags.length > 0 || structure) {
+        tagsRow.style.display = 'flex';
+        tagsRow.innerHTML =
+          (structure ? '<span class="ig-tag ig-tag--structure">' + escHtml(structure.replace(/_/g, ' ')) + '</span>' : '') +
+          pTags.map(t => '<span class="ig-tag ig-tag--practical">' + escHtml(t) + '</span>').join('') +
+          tTags.map(t => '<span class="ig-tag ig-tag--taste">' + escHtml(t) + '</span>').join('');
+      } else {
+        tagsRow.style.display = 'none';
+      }
+    }
+
     igEntities.innerHTML = '';
 
     if (!derived_pins || derived_pins.length === 0) {
@@ -18734,7 +18759,7 @@ Return JSON:
         added++;
         queueServerEnrichment(norm.id, norm.url, norm.title, norm.description, {
           category: norm.category,
-          skipClassification: true
+          content_type: norm.content_type || null
         });
         // Immediately extract music metadata for listen-category pins
         if ((norm.category === 'listen' || norm.content_type === 'music') && norm.url) {
@@ -19039,6 +19064,10 @@ Return JSON:
                 type_confidence: 1.0,
                 category: src.category || 'follow',
                 domain: 'instagram.com',
+                entities: src.entities || null,
+                practical_tags: result.practical_tags || [],
+                taste_tags: result.taste_tags || [],
+                content_structure: result.content_structure || null,
                 loading: false,
                 enrichment_failed: false,
               });

--- a/extension/chrome/lib/supabase.js
+++ b/extension/chrome/lib/supabase.js
@@ -43,7 +43,7 @@ async function supabaseDelete(path, accessToken) {
 // Uses anon key auth (matches boards/index.html:10477-10481)
 async function triggerEnrichment({ url, title, description, linkId }) {
   try {
-    await fetch(`${SUPABASE_URL}/functions/v1/enrich-link`, {
+    await fetch(`${SUPABASE_URL}/functions/v1/create-pin`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/js/image-enrichment.js
+++ b/js/image-enrichment.js
@@ -4,7 +4,7 @@
    images based on content metadata.
 
    Strategies (in priority order):
-     1. enrich  — call enrich-link edge function (needs URL + API key)
+     1. enrich  — call create-pin edge function (needs URL + API key)
      2. unsplash — Unsplash search by keywords (needs API key)
      3. picsum  — picsum.photos seeded by content context (no key)
 
@@ -97,7 +97,7 @@
   function enrichResolve(context, size, config) {
     if (!context.url) return picsumResolve(context, size);
 
-    var endpoint = config.supabaseUrl + '/functions/v1/enrich-link';
+    var endpoint = config.supabaseUrl + '/functions/v1/create-pin';
     return fetch(endpoint, {
       method: 'POST',
       headers: {

--- a/supabase/functions/analyze-content/index.ts
+++ b/supabase/functions/analyze-content/index.ts
@@ -1,0 +1,584 @@
+// Supabase Edge Function: analyze-content
+// Sense-Making Agent — classifies content, extracts entities, produces practical + taste tags.
+// This function handles "understanding" the content; create-pin handles visual representation.
+//
+// POST /functions/v1/analyze-content
+// Body: { url, title?, description? }
+// Returns: {
+//   content_type, type_confidence, type_source,
+//   content_structure,
+//   entities[],
+//   practical_tags[], taste_tags[],
+//   summary
+// }
+const VERSION = '1.0.0'
+console.log(`[analyze-content] v${VERSION} - Sense-Making Agent`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// Expanded content types (includes new types from sense-making plan)
+const CONTENT_TYPES = [
+  'product', 'article', 'book', 'video', 'music', 'repository', 'social',
+  'document', 'tool', 'place', 'recipe', 'event', 'newsletter', 'dataset', 'unknown'
+]
+
+// Content structure types
+const CONTENT_STRUCTURES = [
+  'original_expression', 'curated_collection', 'summary', 'review', 'reference'
+]
+
+// JSON-LD types for title resolution (moved from enrich-link)
+const JSON_LD_TITLE_TYPES = new Set([
+  'TVEpisode', 'VideoObject', 'Movie', 'TVSeries', 'Episode', 'Clip',
+  'Article', 'NewsArticle', 'BlogPosting', 'Review',
+  'Product', 'Book', 'Recipe',
+  'MusicRecording', 'MusicAlbum', 'PodcastEpisode',
+  'SoftwareApplication', 'Course', 'Event', 'CreativeWork'
+])
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    let { url, title, description } = await req.json()
+
+    if (!url) {
+      return new Response(
+        JSON.stringify({ error: 'URL is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('[analyze-content] Processing:', url)
+
+    const domain = new URL(url).hostname.replace('www.', '')
+    const path = new URL(url).pathname
+
+    // ========================================
+    // STEP 0: Platform API metadata — resolve titles for sites that block scraping
+    // ========================================
+    const isYouTube = domain.includes('youtube.com') || domain.includes('youtu.be')
+    let platformMeta: { title?: string, author?: string, description?: string } | null = null
+
+    if (isYouTube) {
+      const ytData = await lookupYouTube(url)
+      if (ytData) {
+        platformMeta = {
+          title: ytData.title,
+          author: ytData.channelTitle,
+          description: ytData.description?.slice(0, 500)
+        }
+      }
+    } else if (domain.includes('vimeo.com')) {
+      const vimeoData = await resolveOembedMetadata(url, domain)
+      if (vimeoData) {
+        platformMeta = { title: vimeoData.title, author: vimeoData.author || undefined }
+      }
+    }
+
+    // Override generic titles with platform-resolved ones
+    if (platformMeta?.title) {
+      const genericTitles = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+      if (!title || genericTitles.includes(title.toLowerCase().trim())) {
+        console.log('[analyze-content] Platform API resolved title:', platformMeta.title)
+        title = platformMeta.title
+      }
+    }
+    if (platformMeta?.description && (!description || description.length < 20)) {
+      description = platformMeta.description
+    }
+
+    // ========================================
+    // STEP 0.5: JSON-LD title resolution for non-platform URLs
+    // ========================================
+    if (title && !isYouTube && /[\|–—]/.test(title)) {
+      console.log('[analyze-content] Title has separators, trying JSON-LD resolution:', title)
+      const jsonLdTitle = await resolveJsonLdTitle(url)
+      if (jsonLdTitle && jsonLdTitle !== title) {
+        console.log('[analyze-content] JSON-LD resolved better title:', jsonLdTitle)
+        title = jsonLdTitle
+      }
+    }
+
+    // ========================================
+    // STEP 1: Content Type Classification (rules → domain cache → AI)
+    // ========================================
+    let contentType = 'unknown'
+    let typeConfidence = 0
+    let typeSource: 'rules' | 'cache' | 'ai' = 'rules'
+
+    // Rules-based: known platform → known type
+    if (isYouTube || domain.includes('vimeo.com') || domain.includes('dailymotion.com')) {
+      contentType = 'video'
+      typeConfidence = 1.0
+      console.log('[analyze-content] Video platform detected:', domain)
+    } else if (
+      domain.includes('spotify.com') || domain.includes('soundcloud.com') ||
+      domain.includes('bandcamp.com') || domain.includes('beatport.com') ||
+      domain.includes('music.apple.com') || domain.includes('tidal.com') ||
+      domain.includes('deezer.com') || domain.includes('audiomack.com') ||
+      domain.includes('music.youtube.com')
+    ) {
+      contentType = 'music'
+      typeConfidence = 1.0
+      console.log('[analyze-content] Music platform detected:', domain)
+    } else if (domain.includes('github.com') || domain.includes('gitlab.com')) {
+      contentType = 'repository'
+      typeConfidence = 0.95
+      console.log('[analyze-content] Code platform detected:', domain)
+    } else if (
+      domain.includes('instagram.com') || domain.includes('tiktok.com') ||
+      domain.includes('twitter.com') || domain.includes('x.com')
+    ) {
+      contentType = 'social'
+      typeConfidence = 0.9
+      console.log('[analyze-content] Social platform detected:', domain)
+    } else if (
+      domain.includes('maps.google.com') || domain.includes('yelp.com') ||
+      domain.includes('tripadvisor.com') || domain.includes('opentable.com')
+    ) {
+      contentType = 'place'
+      typeConfidence = 0.95
+      console.log('[analyze-content] Place platform detected:', domain)
+    } else if (domain.includes('eventbrite.com') || domain.includes('meetup.com')) {
+      contentType = 'event'
+      typeConfidence = 0.9
+      console.log('[analyze-content] Event platform detected:', domain)
+    } else if (
+      domain.includes('goodreads.com') || domain.includes('openlibrary.org') ||
+      (domain.includes('amazon.com') && path.includes('/dp/') && (title?.toLowerCase().includes('book') || path.includes('/books/')))
+    ) {
+      contentType = 'book'
+      typeConfidence = 0.9
+      console.log('[analyze-content] Book platform detected:', domain)
+    }
+
+    // Domain profile cache (if rules didn't match)
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    if (contentType === 'unknown') {
+      const { data: profile } = await supabase
+        .from('domain_profiles')
+        .select('*')
+        .eq('domain', domain)
+        .single()
+
+      if (profile && profile.confidence > 0.85) {
+        console.log('[analyze-content] Cache hit:', profile.primary_type, profile.confidence)
+        contentType = profile.primary_type
+        typeConfidence = profile.confidence
+        typeSource = 'cache'
+      }
+    }
+
+    // ========================================
+    // STEP 2: AI Sense-Making (classification + entities + tags + structure)
+    // Single Claude call for all sense-making outputs
+    // ========================================
+    let entities: any[] = []
+    let practicalTags: string[] = []
+    let tasteTags: string[] = []
+    let contentStructure: string | null = null
+    let summary: string | null = null
+
+    const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+    const hasInput = title || description
+
+    if (apiKey && hasInput) {
+      console.log('[analyze-content] Step 2: AI sense-making')
+
+      const needsClassification = contentType === 'unknown'
+      const classificationBlock = needsClassification ? `
+"content_type": one of [${CONTENT_TYPES.join(', ')}],
+"type_confidence": 0.0-1.0,` : ''
+
+      const prompt = `Analyze this content and produce structured metadata.
+
+URL: ${url}
+Title: ${title || 'N/A'}
+Description: ${description?.slice(0, 500) || 'N/A'}
+${contentType !== 'unknown' ? `Known content_type: ${contentType}` : ''}
+
+Respond with JSON only:
+{${classificationBlock}
+  "content_structure": one of ["original_expression", "curated_collection", "summary", "review", "reference"],
+  "entities": [{"type": "restaurant|product|brand|song|album|person|place|food|event|book|tool|concept|generic", "name": "canonical name", "confidence": 0.0-1.0}],
+  "practical_tags": ["3-8 objective factual tags, e.g. restaurant, italian, monitor, electronics"],
+  "taste_tags": ["3-8 subjective aesthetic tags, e.g. minimalist, vintage, upscale, cozy"],
+  "summary": "one-sentence summary of the content"
+}
+
+Guidelines:
+- practical_tags: objective, factual, searchable classification. What IS this about.
+- taste_tags: subjective aesthetic/cultural/vibe tags. What does this FEEL like.
+- entities: the main real-world things referenced (top 3-5). Not generic concepts.
+- content_structure: how the content is organized (original work, list, review, etc.)
+- Keep tags lowercase, use underscores for multi-word tags.`
+
+      try {
+        const response = await fetch('https://api.anthropic.com/v1/messages', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01'
+          },
+          body: JSON.stringify({
+            model: 'claude-3-5-haiku-20241022',
+            max_tokens: 800,
+            messages: [{ role: 'user', content: prompt }]
+          })
+        })
+
+        if (!response.ok) {
+          console.error('[analyze-content] Anthropic API error:', response.status)
+        } else {
+          const data = await response.json()
+          const text = data.content?.[0]?.text || ''
+          const match = text.match(/\{[\s\S]*\}/)
+
+          if (match) {
+            const result = JSON.parse(match[0])
+
+            // Classification (if AI was asked to classify)
+            if (needsClassification && result.content_type && CONTENT_TYPES.includes(result.content_type)) {
+              contentType = result.content_type
+              typeConfidence = result.type_confidence || 0.8
+              typeSource = 'ai'
+
+              // Update domain profile cache
+              await updateDomainProfile(supabase, domain, path, { type: contentType, confidence: typeConfidence })
+            }
+
+            // Content structure
+            if (result.content_structure && CONTENT_STRUCTURES.includes(result.content_structure)) {
+              contentStructure = result.content_structure
+            }
+
+            // Entities
+            if (Array.isArray(result.entities)) {
+              entities = result.entities
+                .filter((e: any) => e.name && e.type)
+                .slice(0, 5)
+                .map((e: any) => ({
+                  type: e.type,
+                  name: e.name,
+                  confidence: e.confidence || 0.8
+                }))
+            }
+
+            // Tags
+            if (Array.isArray(result.practical_tags)) {
+              practicalTags = result.practical_tags
+                .filter((t: any) => typeof t === 'string')
+                .slice(0, 8)
+                .map((t: string) => t.toLowerCase().replace(/\s+/g, '_'))
+            }
+            if (Array.isArray(result.taste_tags)) {
+              tasteTags = result.taste_tags
+                .filter((t: any) => typeof t === 'string')
+                .slice(0, 8)
+                .map((t: string) => t.toLowerCase().replace(/\s+/g, '_'))
+            }
+
+            // Summary
+            if (typeof result.summary === 'string') {
+              summary = result.summary.slice(0, 200)
+            }
+
+            console.log('[analyze-content] AI result:', {
+              content_type: contentType,
+              content_structure: contentStructure,
+              entities: entities.length,
+              practical_tags: practicalTags.length,
+              taste_tags: tasteTags.length
+            })
+          }
+        }
+      } catch (e) {
+        console.error('[analyze-content] AI sense-making error:', e)
+      }
+    } else if (!apiKey) {
+      console.log('[analyze-content] No ANTHROPIC_API_KEY, skipping AI sense-making')
+    } else {
+      console.log('[analyze-content] No title or description, skipping AI sense-making')
+    }
+
+    // ========================================
+    // Build response
+    // ========================================
+    const response: Record<string, any> = {
+      content_type: contentType,
+      type_confidence: typeConfidence,
+      type_source: typeSource,
+      content_structure: contentStructure,
+      entities,
+      practical_tags: practicalTags,
+      taste_tags: tasteTags,
+      summary
+    }
+
+    // Include platform-resolved title if meaningful
+    if (platformMeta?.title && title && title !== platformMeta.title) {
+      response.title = title
+    } else if (platformMeta?.title) {
+      response.title = platformMeta.title
+    }
+    if (platformMeta?.author) {
+      response.author = platformMeta.author
+    }
+
+    console.log('[analyze-content] Complete:', {
+      content_type: contentType,
+      type_source: typeSource,
+      content_structure: contentStructure,
+      entities: entities.length,
+      practical_tags: practicalTags.length,
+      taste_tags: tasteTags.length
+    })
+
+    return new Response(
+      JSON.stringify(response),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('[analyze-content] Error:', error)
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})
+
+// ========================================
+// oEmbed Metadata Resolution (Vimeo)
+// ========================================
+async function resolveOembedMetadata(
+  url: string,
+  domain: string
+): Promise<{ title: string, author: string | null, thumbnail: string | null } | null> {
+  if (domain.includes('vimeo.com')) {
+    try {
+      const resp = await fetch(
+        `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(url)}`
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        if (data.title) {
+          return {
+            title: data.title,
+            author: data.author_name || null,
+            thumbnail: data.thumbnail_url || null
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[analyze-content] Vimeo oEmbed error:', e)
+    }
+  }
+  return null
+}
+
+// ========================================
+// JSON-LD Title Resolution
+// ========================================
+async function resolveJsonLdTitle(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+      }
+    })
+    if (!response.ok) return null
+
+    const html = await response.text()
+    const jsonLdMatches = html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+
+    for (const match of jsonLdMatches) {
+      try {
+        const ld = JSON.parse(match[1])
+        const candidates = ld['@graph'] ? ld['@graph'] : [ld]
+        for (const item of candidates) {
+          if (item?.name && JSON_LD_TITLE_TYPES.has(item['@type'])) {
+            if (item.name.length < 5) continue
+            console.log('[analyze-content] JSON-LD resolved title:', item.name, 'from @type:', item['@type'])
+            return item.name
+          }
+        }
+      } catch (_e) { /* JSON parse error, continue */ }
+    }
+  } catch (e) {
+    console.log('[analyze-content] JSON-LD fetch failed:', (e as Error).message)
+  }
+  return null
+}
+
+// ========================================
+// YouTube Data API v3
+// ========================================
+interface YouTubeVideoData {
+  videoId: string
+  title: string
+  description: string
+  channelTitle: string
+  publishedAt: string
+  thumbnailUrl: string | null
+  duration: number | null
+  tags: string[]
+  categoryId: string | null
+  viewCount: number | null
+  likeCount: number | null
+}
+
+function extractYouTubeVideoId(url: string): string | null {
+  const match = url.match(/(?:v=|youtu\.be\/|\/shorts\/)([^&\?\/]+)/)
+  return match?.[1] || null
+}
+
+function parseISO8601Duration(iso: string | null): number | null {
+  if (!iso) return null
+  const match = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/)
+  if (!match) return null
+  return (parseInt(match[1] || '0') * 3600) +
+         (parseInt(match[2] || '0') * 60) +
+         parseInt(match[3] || '0')
+}
+
+async function lookupYouTube(url: string): Promise<YouTubeVideoData | null> {
+  const videoId = extractYouTubeVideoId(url)
+  if (!videoId) return null
+
+  const apiKey = Deno.env.get('YOUTUBE_API_KEY')
+  if (!apiKey) {
+    console.log('[analyze-content] No YOUTUBE_API_KEY, trying oEmbed fallback')
+    // oEmbed fallback for basic metadata
+    try {
+      const resp = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`)
+      if (resp.ok) {
+        const data = await resp.json()
+        return {
+          videoId,
+          title: data.title || '',
+          description: '',
+          channelTitle: data.author_name || '',
+          publishedAt: '',
+          thumbnailUrl: data.thumbnail_url || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
+          duration: null,
+          tags: [],
+          categoryId: null,
+          viewCount: null,
+          likeCount: null
+        }
+      }
+    } catch (_e) { /* oEmbed failed */ }
+    return null
+  }
+
+  try {
+    const apiUrl = `https://www.googleapis.com/youtube/v3/videos?id=${videoId}&key=${apiKey}&part=snippet,contentDetails,statistics`
+    const resp = await fetch(apiUrl)
+    if (!resp.ok) {
+      console.error('[analyze-content] YouTube API error:', resp.status)
+      return null
+    }
+
+    const { items } = await resp.json()
+    if (!items || items.length === 0) return null
+
+    const video = items[0]
+    const snippet = video.snippet || {}
+    const contentDetails = video.contentDetails || {}
+    const statistics = video.statistics || {}
+
+    const thumbs = snippet.thumbnails || {}
+    const thumbnailUrl = thumbs.maxres?.url
+      || thumbs.standard?.url
+      || thumbs.high?.url
+      || thumbs.medium?.url
+      || thumbs.default?.url
+      || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
+
+    return {
+      videoId,
+      title: snippet.title || '',
+      description: snippet.description || '',
+      channelTitle: snippet.channelTitle || '',
+      publishedAt: snippet.publishedAt || '',
+      thumbnailUrl,
+      duration: parseISO8601Duration(contentDetails.duration),
+      tags: snippet.tags || [],
+      categoryId: snippet.categoryId || null,
+      viewCount: statistics.viewCount ? parseInt(statistics.viewCount, 10) : null,
+      likeCount: statistics.likeCount ? parseInt(statistics.likeCount, 10) : null
+    }
+  } catch (e) {
+    console.error('[analyze-content] YouTube API lookup error:', e)
+    return null
+  }
+}
+
+// ========================================
+// Update Domain Profile Cache
+// ========================================
+async function updateDomainProfile(
+  supabase: any,
+  domain: string,
+  path: string,
+  result: { type: string, confidence: number }
+) {
+  try {
+    const { data: existing } = await supabase
+      .from('domain_profiles')
+      .select('*')
+      .eq('domain', domain)
+      .single()
+
+    if (existing) {
+      const typesSeen = existing.types_seen || {}
+      typesSeen[result.type] = (typesSeen[result.type] || 0) + 1
+
+      const types = Object.keys(typesSeen)
+      const total = Object.values(typesSeen).reduce((a: number, b: number) => a + b, 0) as number
+      const dominant = Object.entries(typesSeen).sort((a, b) => (b[1] as number) - (a[1] as number))[0]
+      const dominantRatio = (dominant[1] as number) / total
+
+      await supabase
+        .from('domain_profiles')
+        .update({
+          types_seen: typesSeen,
+          sample_count: total,
+          primary_type: dominant[0],
+          confidence: dominantRatio,
+          classification: types.length === 1 || dominantRatio > 0.9 ? 'single_type' : 'multi_type',
+          updated_at: new Date().toISOString()
+        })
+        .eq('domain', domain)
+    } else {
+      await supabase
+        .from('domain_profiles')
+        .insert({
+          domain,
+          primary_type: result.type,
+          types_seen: { [result.type]: 1 },
+          sample_count: 1,
+          confidence: result.confidence,
+          classification: 'unknown'
+        })
+    }
+  } catch (e) {
+    console.error('[analyze-content] Domain profile update error:', e)
+  }
+}

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -63,7 +63,7 @@ interface SourceOutcome {
   durationMs?: number
 }
 
-// --- Source Health Upsert (mirrors domain_profiles pattern from enrich-link) ---
+// --- Source Health Upsert (mirrors domain_profiles pattern from create-pin) ---
 
 function deriveStatus(successRate: number, consecutiveFailures: number, totalScrapes: number, countDegraded = false): string {
   if (totalScrapes === 0) return 'unknown'

--- a/supabase/functions/create-pin/index.ts
+++ b/supabase/functions/create-pin/index.ts
@@ -1,0 +1,2481 @@
+// Supabase Edge Function: create-pin
+// Pin Creation Agent — handles image resolution, hero scoring, and category-specific metadata enrichment.
+// Classification and sense-making are handled by analyze-content (separate function).
+//
+// POST /functions/v1/create-pin
+// Body: { url, title?, description?, linkId?, content_type?, category?,
+//         skipImage?, currentImage?, forceRefresh?,
+//         enrichWatch?, enrichBook?, enrichListen? }
+const VERSION = '2.0.0'
+console.log(`[create-pin] v${VERSION} - Pin Creation Agent (image + metadata)`)
+// Returns: { content_type, type_confidence, type_source, image_url, image_source, hero_score, video?, book?, music? }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+// Visual standards — product gate for URL pattern and technical checks
+import { checkGateUrlPatterns, checkGateTechnical } from '../generate-widget/config/visual-standards.ts'
+
+// CORS headers for browser requests
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// Musical key → Camelot wheel notation (used by DJs for harmonic mixing)
+// Maps standard key names to Camelot codes (e.g. "Cm" → "5A", "G" → "9B")
+const CAMELOT_MAP: Record<string, string> = {
+  'C': '8B',  'Cm': '5A',  'C#': '3B', 'C#m': '12A', 'Db': '3B',  'Dbm': '12A',
+  'D': '10B', 'Dm': '7A',  'D#': '5B', 'D#m': '2A',  'Eb': '5B',  'Ebm': '2A',
+  'E': '12B', 'Em': '9A',
+  'F': '7B',  'Fm': '4A',  'F#': '2B', 'F#m': '11A', 'Gb': '2B',  'Gbm': '11A',
+  'G': '9B',  'Gm': '6A',  'G#': '4B', 'G#m': '1A',  'Ab': '4B',  'Abm': '1A',
+  'A': '11B', 'Am': '8A',  'A#': '6B', 'A#m': '3A',  'Bb': '6B',  'Bbm': '3A',
+  'B': '1B',  'Bm': '10A',
+}
+function toCamelotKey(key: string): string {
+  if (!key) return key
+  // Normalize: trim, handle "C minor" → "Cm", "C Major" → "C"
+  let k = key.trim()
+  k = k.replace(/\s*(minor|min)\s*$/i, 'm').replace(/\s*(major|maj)\s*$/i, '')
+  return CAMELOT_MAP[k] || key  // fallback to original if not found
+}
+
+// Image resolution strategies per content type
+const IMAGE_STRATEGIES: Record<string, string[]> = {
+  product: ['scrape', 'search', 'favicon', 'template'],
+  article: ['scrape', 'search', 'favicon', 'template'],
+  book: ['platform', 'scrape', 'search', 'template'],
+  video: ['platform', 'scrape', 'template'],              // platform thumbnails are best
+  music: ['platform', 'scrape', 'search', 'template'],
+  repository: ['platform', 'template'],                    // GitHub OG is sufficient
+  social: ['platform', 'scrape', 'template'],              // platform images are best
+  document: ['search', 'template'],
+  tool: ['scrape', 'search', 'favicon', 'template'],
+  unknown: ['scrape', 'search', 'favicon', 'template']
+}
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    let { url, title, description, linkId, content_type, skipImage,
+            skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, enrichListen, category } = await req.json()
+
+    // Support skipIfHasImage: skip image resolution if client already has a valid image
+    const shouldSkipImage = skipImage || (skipIfHasImage && !!currentImage)
+
+    if (!url) {
+      return new Response(
+        JSON.stringify({ error: 'URL is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    console.log('[create-pin] Processing:', url)
+
+    const domain = new URL(url).hostname.replace('www.', '')
+    const path = new URL(url).pathname
+
+    // ========================================
+    // STEP 0: Platform API metadata for sites that block scraping
+    // YouTube blocks CORS proxies — use YouTube Data API v3 for full metadata.
+    // Vimeo uses oEmbed (simple, reliable).
+    // ========================================
+    const isYouTube = domain.includes('youtube.com') || domain.includes('youtu.be')
+    let youtubeData: YouTubeVideoData | null = null
+    const oembedTitle = await (async () => {
+      // YouTube: use Data API v3 (full metadata) with oEmbed fallback
+      if (isYouTube) {
+        youtubeData = await lookupYouTube(url)
+        if (youtubeData) {
+          return {
+            title: youtubeData.title,
+            author: youtubeData.channelTitle,
+            thumbnail: youtubeData.thumbnailUrl
+          }
+        }
+        // YouTube API/oEmbed both failed (deleted/private video) —
+        // Still construct a minimal result with the video ID so we have
+        // a thumbnail and correct content_type
+        const videoId = extractYouTubeVideoId(url)
+        if (videoId) {
+          console.log('[create-pin] YouTube API/oEmbed failed, using fallback for videoId:', videoId)
+          youtubeData = {
+            videoId,
+            title: '',
+            description: '',
+            channelTitle: '',
+            publishedAt: '',
+            thumbnailUrl: `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
+            duration: null,
+            tags: [],
+            categoryId: null,
+            viewCount: null,
+            likeCount: null
+          }
+          return {
+            title: '',  // empty — won't override existing title
+            author: null,
+            thumbnail: youtubeData.thumbnailUrl
+          }
+        }
+      }
+      // Vimeo: oEmbed
+      return await resolveOembedMetadata(url, domain)
+    })()
+
+    if (oembedTitle) {
+      // Only override if title is missing or generic
+      const genericTitles = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+      if (!title || genericTitles.includes(title.toLowerCase().trim())) {
+        if (oembedTitle.title) {
+          console.log('[create-pin] Platform API resolved title:', oembedTitle.title)
+          title = oembedTitle.title
+        }
+      }
+      if ((!description || description.length < 20) && youtubeData?.description) {
+        description = youtubeData.description.slice(0, 500)
+      } else if (!description && oembedTitle.author) {
+        description = `By ${oembedTitle.author}`
+      }
+    }
+
+    // ========================================
+    // STEP 0.5: JSON-LD title resolution for non-platform URLs
+    // When the client title looks like a raw <title> tag (has | or – separators),
+    // try to get a cleaner title from the page's JSON-LD structured data.
+    // This handles PBS, BBC, news sites, etc. without hardcoding network names.
+    // ========================================
+    if (title && !isYouTube && /[\|–—]/.test(title)) {
+      console.log('[create-pin] Title has separators, trying JSON-LD resolution:', title)
+      const jsonLdTitle = await resolveJsonLdTitle(url)
+      if (jsonLdTitle && jsonLdTitle !== title) {
+        console.log('[create-pin] JSON-LD resolved better title:', jsonLdTitle)
+        title = jsonLdTitle
+      }
+    }
+
+    // Content type: prefer caller-provided (from analyze-content), with platform rules as fallback
+    let contentType = content_type || 'unknown'
+    let typeConfidence = content_type ? 0.9 : 0
+    let typeSource: 'caller' | 'rules' = content_type ? 'caller' : 'rules'
+    let imageUrl: string | null = null
+    let imageSource: 'scraped' | 'platform' | 'generated' | 'template' | 'favicon' = 'template'
+    let imageScores: Record<string, any> | null = null
+
+    // Platform rules override — always correct for known platforms
+    if (isYouTube) {
+      contentType = 'video'
+      typeConfidence = 1.0
+      typeSource = 'rules'
+      console.log('[create-pin] YouTube URL detected, forcing content_type=video')
+    }
+
+    const isMusicPlatform = domain.includes('spotify.com') ||
+      domain.includes('soundcloud.com') || domain.includes('bandcamp.com') ||
+      domain.includes('beatport.com') || domain.includes('music.apple.com') ||
+      domain.includes('tidal.com') || domain.includes('deezer.com') ||
+      domain.includes('audiomack.com') || domain.includes('music.youtube.com')
+    if (isMusicPlatform) {
+      contentType = 'music'
+      typeConfidence = 1.0
+      typeSource = 'rules'
+      console.log('[create-pin] Music platform detected, forcing content_type=music:', domain)
+    }
+
+    // Initialize Supabase client
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    console.log('[create-pin] Using content_type:', contentType, '(source:', typeSource + ')')
+
+    // ========================================
+    // STEP 2: Image Resolution (with Tier 3 quality gate)
+    // ========================================
+    const imageLog: Array<Record<string, any>> = []
+    let bestCandidate: { url: string, source: string, scores: Record<string, any> } | null = null
+
+    if (!shouldSkipImage) {
+      console.log('[create-pin] Step 2: Image resolution for type:', contentType)
+
+      // YouTube shortcut: use thumbnail directly from API/oEmbed/fallback
+      // This avoids the full strategy loop which can fail for YouTube
+      if (isYouTube && youtubeData?.thumbnailUrl) {
+        console.log('[create-pin] Using YouTube thumbnail directly:', youtubeData.thumbnailUrl)
+        imageUrl = youtubeData.thumbnailUrl
+        imageSource = 'platform'
+        imageScores = {
+          visual_quality: 0.9, distinctiveness: 1.0,
+          evaluated_at: new Date().toISOString(),
+          evaluation_method: 'youtube_thumbnail_direct'
+        }
+        imageLog.push({
+          strategy: 'youtube_direct', result: 'accepted',
+          image_url: imageUrl, duration_ms: 0
+        })
+      }
+
+      // Only run strategy loop if we don't already have an image (e.g. from YouTube shortcut)
+      const strategies = IMAGE_STRATEGIES[contentType] || IMAGE_STRATEGIES.unknown
+
+      for (const strategy of strategies) {
+        if (imageUrl) break  // Already resolved (e.g. YouTube direct)
+        const attemptStart = Date.now()
+        console.log('[create-pin] Trying strategy:', strategy)
+
+        try {
+          const result = await executeImageStrategy(strategy, url, title, description)
+          if (!result || !result.url) {
+            imageLog.push({ strategy, result: 'no_image', duration_ms: Date.now() - attemptStart })
+            continue
+          }
+
+          // Tier 2 validation: check image loads, dimensions, format
+          console.log('[create-pin] Validating image via Tier 2:', result.url)
+          const validation = await validateImageTier2(result.url)
+
+          if (!validation.pass) {
+            console.log('[create-pin] Tier 2 rejected:', result.url, validation.reason)
+            imageLog.push({
+              strategy, result: 'tier2_rejected', reason: validation.reason,
+              image_url: result.url, duration_ms: Date.now() - attemptStart,
+              tier2: { pass: false, checks: validation.checks?.filter((c: any) => !c.pass) }
+            })
+            continue
+          }
+
+          const tier2Scores = {
+            visual_quality: validation.scores.visual_quality,
+            distinctiveness: validation.scores.distinctiveness,
+            dimensions: validation.dimensions || null,
+            file_size: validation.fileSize || null,
+            content_type_header: validation.contentType || null
+          }
+
+          // Tier 3: AI vision quality gate
+          const tier3 = await evaluateImageQuality(result.url, title, category || contentType, contentType)
+
+          if (tier3 && tier3.tier === 'rejected') {
+            console.log('[create-pin] Tier 3 rejected:', result.url, tier3.reason)
+            imageLog.push({
+              strategy, result: 'tier3_rejected', reason: tier3.reason,
+              image_url: result.url, duration_ms: Date.now() - attemptStart,
+              tier2: { pass: true, ...tier2Scores },
+              tier3: tier3.scores
+            })
+            continue
+          }
+
+          if (tier3 && tier3.tier === 'poor') {
+            console.log('[create-pin] Tier 3 poor quality, saving as candidate:', result.url)
+            if (!bestCandidate) {
+              bestCandidate = {
+                url: result.url,
+                source: result.source,
+                scores: {
+                  ...tier2Scores,
+                  ...tier3.scores,
+                  evaluated_at: new Date().toISOString(),
+                  evaluation_method: 'tier3_ai_vision'
+                }
+              }
+            }
+            imageLog.push({
+              strategy, result: 'tier3_poor', reason: 'Poor quality, kept as candidate',
+              image_url: result.url, duration_ms: Date.now() - attemptStart,
+              tier2: { pass: true, ...tier2Scores },
+              tier3: tier3.scores
+            })
+            continue
+          }
+
+          // Good/excellent or Tier 3 unavailable (budget/error) — accept it
+          imageUrl = result.url
+          imageSource = result.source
+          imageScores = {
+            ...tier2Scores,
+            ...(tier3?.scores || {}),
+            evaluated_at: new Date().toISOString(),
+            evaluation_method: tier3 ? 'tier3_ai_vision' : 'tier2_technical',
+            tier2_checks: validation.checks
+          }
+          imageLog.push({
+            strategy, result: 'accepted',
+            image_url: result.url, duration_ms: Date.now() - attemptStart,
+            tier2: { pass: true, ...tier2Scores },
+            tier3: tier3?.scores || null,
+            tier: tier3?.tier || 'tier2_only'
+          })
+          console.log('[create-pin] Image accepted via', strategy, ':', imageUrl,
+            tier3 ? `(tier: ${tier3.tier})` : '(tier2 only)',
+            validation.dimensions ? `${validation.dimensions.width}x${validation.dimensions.height}` : '')
+          break
+        } catch (e) {
+          console.error('[create-pin] Strategy failed:', strategy, e)
+          imageLog.push({
+            strategy, result: 'error', reason: (e as Error).message,
+            duration_ms: Date.now() - attemptStart
+          })
+        }
+      }
+
+      // If no excellent/good image found, use best candidate (poor > nothing)
+      if (!imageUrl && bestCandidate) {
+        console.log('[create-pin] Using best candidate (poor quality):', bestCandidate.url)
+        imageUrl = bestCandidate.url
+        imageSource = bestCandidate.source as any
+        imageScores = bestCandidate.scores
+        imageLog.push({
+          strategy: 'fallback_to_candidate', result: 'accepted_poor',
+          image_url: bestCandidate.url, reason: 'Best available from poor-quality candidates'
+        })
+      }
+    } else {
+      imageLog.push({ strategy: 'skipped', result: 'skip', reason: shouldSkipImage ? 'skipIfHasImage' : 'skipImage' })
+    }
+
+    // Truncate summary to ~60 words for card display (shared by watch + book enrichment)
+    const truncSummary = (text: string | null): string | null => {
+      if (!text) return null
+      const words = text.split(/\s+/)
+      if (words.length <= 60) return text
+      return words.slice(0, 60).join(' ') + '…'
+    }
+
+    // ========================================
+    // STEP 2.5: Watch Enrichment — YouTube API / TMDB / AI
+    // ========================================
+    let videoMeta: Record<string, any> | null = null
+    if (enrichWatch || category === 'watch' || contentType === 'video') {
+      // YouTube videos: use YouTube Data API directly (skip TMDB — it's for movies/TV)
+      if (youtubeData) {
+        console.log('[create-pin] Step 2.5: Watch enrichment from YouTube API')
+        const publishYear = youtubeData.publishedAt
+          ? parseInt(youtubeData.publishedAt.split('-')[0], 10)
+          : null
+
+        videoMeta = {
+          title: youtubeData.title,
+          summary: truncSummary(youtubeData.description),
+          type: 'video',
+          genre: youtubeData.tags?.[0] || null,
+          genres: youtubeData.tags?.slice(0, 3) || [],
+          year: publishYear,
+          creator: youtubeData.channelTitle || null,
+          rating: null,
+          runtime: youtubeData.duration,
+          voteAverage: null,
+          tmdbId: null,
+          imdbId: null,
+          tmdbUrl: null,
+          posterPath: null,
+          streamingServices: [{ name: 'YouTube', type: 'free', logoPath: null }],
+          // YouTube-specific fields
+          youtubeVideoId: youtubeData.videoId,
+          viewCount: youtubeData.viewCount,
+          likeCount: youtubeData.likeCount,
+          channelTitle: youtubeData.channelTitle,
+          publishedAt: youtubeData.publishedAt,
+          tags: youtubeData.tags?.slice(0, 10) || []
+        }
+        console.log('[create-pin] YouTube watch enrichment result:', videoMeta)
+      } else {
+        // Non-YouTube: TMDB first, AI fills gaps
+        console.log('[create-pin] Step 2.5: Watch enrichment (TMDB → AI)')
+
+        // 1. Try TMDB first (structured, real-time data)
+        const tmdbResult = await lookupTMDB(title || '', null, null)
+
+        // 2. Only call AI if TMDB left gaps
+        const needsAI = !tmdbResult
+          || !tmdbResult.overview
+          || !tmdbResult.streamingServices?.length
+
+        let aiResult: Record<string, any> | null = null
+        if (needsAI) {
+          console.log('[create-pin] TMDB incomplete, calling AI for gaps')
+          aiResult = await enrichWatchWithAI(url, title, description)
+        } else {
+          console.log('[create-pin] TMDB complete, skipping AI call')
+        }
+
+        // 3. Merge: TMDB is primary, AI fills gaps
+        videoMeta = {
+          title: tmdbResult?.title || null,
+          summary: truncSummary(tmdbResult?.overview || aiResult?.summary || null),
+          type: aiResult?.type || (tmdbResult ? inferTypeFromTMDB(tmdbResult.mediaType) : null),
+          genre: tmdbResult?.genres?.[0] || aiResult?.genre || null,
+          genres: tmdbResult?.genres || (aiResult?.genres?.length ? aiResult.genres : (aiResult?.genre ? [aiResult.genre] : [])),
+          year: tmdbResult?.year || aiResult?.year || null,
+          creator: tmdbResult?.creator || aiResult?.creator || null,
+          rating: aiResult?.rating || null,
+          runtime: tmdbResult?.runtime ? tmdbResult.runtime * 60 : null,
+          voteAverage: tmdbResult?.voteAverage || null,
+          tmdbId: tmdbResult?.tmdbId || null,
+          imdbId: tmdbResult?.imdbId || null,
+          tmdbUrl: tmdbResult?.tmdbUrl || null,
+          posterPath: tmdbResult?.posterPath || null,
+          streamingServices: tmdbResult?.streamingServices?.length
+            ? tmdbResult.streamingServices
+            : aiResult?.streamingServices || [],
+        }
+      }
+
+      console.log('[create-pin] Watch enrichment result:', videoMeta)
+    }
+
+    // ========================================
+    // STEP 2.6: Book Enrichment — Open Library first, AI fills gaps
+    // ========================================
+    let bookMeta: Record<string, any> | null = null
+    if (enrichBook || category === 'read') {
+      console.log('[create-pin] Step 2.6: Book enrichment (Open Library → AI)')
+
+      // 1. Try Open Library first (free, structured data)
+      // For blocked sites (B&N, etc.), extract search title from URL path
+      let bookSearchTitle = title || ''
+      if (url.includes('barnesandnoble.com/w/')) {
+        const bnMatch = url.match(/barnesandnoble\.com\/w\/([^\/]+)/)
+        if (bnMatch && (!bookSearchTitle || bookSearchTitle === domain)) {
+          bookSearchTitle = bnMatch[1].replace(/-/g, ' ')
+          console.log('[create-pin] B&N title from URL slug:', bookSearchTitle)
+        }
+      }
+      const olResult = await lookupOpenLibrary(bookSearchTitle)
+
+      // 2. Only call AI if Open Library left gaps
+      const needsAI = !olResult
+        || !olResult.summary
+        || !olResult.author
+        || !olResult.genre
+
+      let aiResult: Record<string, any> | null = null
+      if (needsAI) {
+        console.log('[create-pin] Open Library incomplete, calling AI for gaps')
+        aiResult = await enrichBookWithAI(url, title, description)
+      } else {
+        console.log('[create-pin] Open Library complete, skipping AI call')
+      }
+
+      // 3. Merge: Open Library is primary, AI fills gaps
+      bookMeta = {
+        title: olResult?.title || null,
+        author: olResult?.author || aiResult?.author || null,
+        isbn: olResult?.isbn || null,
+        year: olResult?.year || aiResult?.year || null,
+        pages: olResult?.pages || aiResult?.pages || null,
+        genre: olResult?.genre || aiResult?.genre || null,
+        summary: truncSummary(olResult?.summary || aiResult?.summary || null),
+        coverPath: olResult?.coverPath || null,
+        openLibraryKey: olResult?.openLibraryKey || null,
+        goodreadsUrl: null,
+        format: aiResult?.format || 'book'
+      }
+
+      console.log('[create-pin] Book enrichment result:', bookMeta)
+
+      // Prefer stable book cover (Open Library) over scraped og:image
+      if (bookMeta?.coverPath) {
+        const olCoverUrl = `https://covers.openlibrary.org/b/id/${bookMeta.coverPath}-L.jpg`
+        console.log('[create-pin] Book cover from Open Library, overriding scraped image:', olCoverUrl)
+        imageUrl = olCoverUrl
+        imageSource = 'openlibrary'
+        imageScores = { evaluation_method: 'known_good_source', tier: 'trusted' }
+      }
+    }
+
+    // ========================================
+    // STEP 2.7: Music Enrichment — oEmbed + URL parsing + MusicBrainz/Last.fm
+    // ========================================
+    let musicMeta: Record<string, any> | null = null
+    if (enrichListen || category === 'listen' || contentType === 'music') {
+      console.log('[create-pin] Step 2.7: Music enrichment for:', url)
+
+      const musicResult: Record<string, any> = {
+        artist: null,
+        trackTitle: null,
+        albumTitle: null,
+        genre: null,
+        duration: null,
+        contentFormat: null,
+        releaseDate: null,
+        label: null,
+        isExplicit: null,
+        embedUrl: null,
+        embedType: null,
+        embedHeight: null,
+        server_enriched_at: new Date().toISOString(),
+      }
+
+      // 1. Infer contentFormat from URL
+      if (/\/track[\/s]/.test(path)) musicResult.contentFormat = 'track'
+      else if (/\/album[\/s]/.test(path)) musicResult.contentFormat = 'album'
+      else if (/\/playlist[\/s]/.test(path)) musicResult.contentFormat = 'playlist'
+      else if (/\/episode[\/s]/.test(path) || /\/podcast/.test(path)) musicResult.contentFormat = 'podcast-episode'
+      else if (/\/artist[\/s]/.test(path)) musicResult.contentFormat = 'artist'
+      else if (/\/sets?[\/]/.test(path) && domain.includes('soundcloud.com')) musicResult.contentFormat = 'mix'
+
+      // 2. Spotify: scrape page meta tags + oEmbed
+      // Spotify's oEmbed doesn't return author_name, but the HTML page has rich meta tags:
+      //   music:musician_description → artist name
+      //   music:duration → seconds
+      //   music:release_date → YYYY-MM-DD
+      //   og:description → "Artist · Track · Type · Year"
+      //   <title> → "Track - song and lyrics by Artist | Spotify"
+      //   og:image → album art
+      if (domain.includes('spotify.com')) {
+        // 2a. Fetch page HTML for meta tags
+        try {
+          const pageResp = await fetch(url, {
+            headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ctrl.rodeo/1.0)' },
+            redirect: 'follow',
+          })
+          if (pageResp.ok) {
+            const html = await pageResp.text()
+
+            // music:musician_description → direct artist name (most reliable)
+            const artistMeta = html.match(/<meta\s+name="music:musician_description"\s+content="([^"]+)"/i)
+            if (artistMeta) {
+              musicResult.artist = artistMeta[1].trim()
+              console.log('[create-pin] Spotify meta artist:', musicResult.artist)
+            }
+
+            // music:duration → seconds
+            const durMeta = html.match(/<meta\s+name="music:duration"\s+content="(\d+)"/i)
+            if (durMeta) {
+              musicResult.duration = parseInt(durMeta[1], 10)
+            }
+
+            // music:release_date → YYYY-MM-DD
+            const releaseMeta = html.match(/<meta\s+name="music:release_date"\s+content="([^"]+)"/i)
+            if (releaseMeta) {
+              musicResult.releaseDate = releaseMeta[1].trim()
+            }
+
+            // og:title → track title
+            const ogTitle = html.match(/<meta\s+property="og:title"\s+content="([^"]+)"/i)
+            if (ogTitle) {
+              musicResult.trackTitle = ogTitle[1].trim()
+            }
+
+            // og:image → album art (we'll pass this through separately)
+            const ogImage = html.match(/<meta\s+property="og:image"\s+content="([^"]+)"/i)
+            if (ogImage) {
+              musicResult.imageUrl = ogImage[1].trim()
+            }
+
+            // <title> fallback: "Track - song and lyrics by Artist | Spotify"
+            if (!musicResult.artist) {
+              const titleTag = html.match(/<title[^>]*>([^<]+)<\/title>/i)
+              if (titleTag) {
+                const spTitle = titleTag[1].match(/^(.+?)\s*-\s*(?:song and lyrics by|Song by|Album by)\s+(.+?)\s*\|/i)
+                if (spTitle) {
+                  musicResult.trackTitle = musicResult.trackTitle || spTitle[1].trim()
+                  musicResult.artist = spTitle[2].trim()
+                }
+              }
+            }
+
+            // og:description fallback: "Artist · Track · Type · Year" or "Type · Artist · Year"
+            if (!musicResult.artist) {
+              const ogDesc = html.match(/<meta\s+property="og:description"\s+content="([^"]+)"/i)
+              if (ogDesc) {
+                const desc = ogDesc[1]
+                // Format: "Artist · Track · Song · 2026"
+                const parts = desc.split(/\s*[·]\s*/)
+                if (parts.length >= 3) {
+                  // Check if a part is a type keyword
+                  const typeIdx = parts.findIndex(p => /^(Song|Album|Playlist|EP|Single|Podcast)$/i.test(p.trim()))
+                  if (typeIdx === 0 && parts.length >= 2) {
+                    // "Song · Artist · Year"
+                    musicResult.artist = parts[1].trim()
+                  } else if (typeIdx >= 2) {
+                    // "Artist · Track · Song · Year"
+                    musicResult.artist = parts[0].trim()
+                  }
+                }
+              }
+            }
+
+            console.log('[create-pin] Spotify page scrape:', {
+              artist: musicResult.artist, track: musicResult.trackTitle,
+              duration: musicResult.duration, releaseDate: musicResult.releaseDate
+            })
+          }
+        } catch (e) { console.warn('[create-pin] Spotify page scrape failed:', (e as Error).message) }
+
+        // 2b. Spotify oEmbed for embed URL (lightweight, always works)
+        try {
+          const oembedResp = await fetch(`https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`)
+          if (oembedResp.ok) {
+            const oe = await oembedResp.json()
+            musicResult.trackTitle = musicResult.trackTitle || oe.title || null
+            if (!musicResult.artist && oe.author_name) {
+              musicResult.artist = oe.author_name
+            }
+            if (oe.html) {
+              const m = oe.html.match(/src=["']([^"']+)["']/)
+              if (m) { musicResult.embedUrl = m[1]; musicResult.embedType = 'iframe'; musicResult.embedHeight = oe.height || 152 }
+            }
+          }
+        } catch (e) { console.warn('[create-pin] Spotify oEmbed failed:', (e as Error).message) }
+      }
+
+      // 3. SoundCloud oEmbed
+      if (domain.includes('soundcloud.com')) {
+        try {
+          const oembedResp = await fetch(`https://soundcloud.com/oembed?format=json&url=${encodeURIComponent(url)}`)
+          if (oembedResp.ok) {
+            const oe = await oembedResp.json()
+            musicResult.trackTitle = musicResult.trackTitle || oe.title || null
+            musicResult.artist = musicResult.artist || oe.author_name || null
+            if (oe.html) {
+              const m = oe.html.match(/src=["']([^"']+)["']/)
+              if (m) { musicResult.embedUrl = m[1]; musicResult.embedType = 'iframe'; musicResult.embedHeight = oe.height || 166 }
+            }
+          }
+        } catch (e) { console.warn('[create-pin] SoundCloud oEmbed failed:', (e as Error).message) }
+      }
+
+      // 4. Title-based fallback for artist/track (from client-provided title)
+      if (!musicResult.artist && title) {
+        // "Track - song and lyrics by Artist | Spotify"
+        const spTitle = title.match(/^(.+?)\s*-\s*(?:song and lyrics by|Song by|Album by)\s+(.+?)\s*\|/i)
+        if (spTitle) {
+          musicResult.trackTitle = musicResult.trackTitle || spTitle[1].trim()
+          musicResult.artist = spTitle[2].trim()
+        }
+        // "Artist - Track" or "Track by Artist"
+        if (!musicResult.artist) {
+          const dashSplit = title.match(/^(.+?)\s*[-–—]\s+(.+?)(?:\s*\|.*)?$/)
+          if (dashSplit) {
+            musicResult.artist = musicResult.artist || dashSplit[1].trim()
+            musicResult.trackTitle = musicResult.trackTitle || dashSplit[2].trim()
+          }
+        }
+      }
+
+      // 5. Description-based fallback
+      if (!musicResult.artist && description) {
+        // "Listen to Track on Spotify. Song · Artist · Year"
+        const spDesc = description.match(/(?:Song|Album|Playlist|EP)\s*[·•]\s*(.+?)\s*[·•]\s*(\d{4})/i)
+        if (spDesc) {
+          musicResult.artist = spDesc[1].trim()
+          musicResult.releaseDate = musicResult.releaseDate || spDesc[2]
+        }
+        // "Artist · Track · Song · Year" (og:description format)
+        if (!musicResult.artist) {
+          const parts = description.split(/\s*[·•]\s*/)
+          if (parts.length >= 3) {
+            const typeIdx = parts.findIndex(p => /^(Song|Album|Playlist|EP|Single)$/i.test(p.trim()))
+            if (typeIdx >= 2) {
+              musicResult.artist = parts[0].trim()
+              musicResult.releaseDate = musicResult.releaseDate || (parts[parts.length - 1].match(/\d{4}/) || [])[0] || null
+            }
+          }
+        }
+      }
+
+      // 6. MusicBrainz + Last.fm for genre/label (if we have artist + track)
+      if (musicResult.artist && musicResult.trackTitle) {
+        try {
+          // Call our own enrich-music function internally
+          const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+          const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+          const enrichResp = await fetch(`${supabaseUrl}/functions/v1/enrich-music`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${supabaseServiceKey}`,
+            },
+            body: JSON.stringify({
+              artist: musicResult.artist,
+              track: musicResult.trackTitle,
+              album: musicResult.albumTitle,
+            }),
+          })
+          if (enrichResp.ok) {
+            const enrichData = await enrichResp.json()
+            if (enrichData.genre) musicResult.genre = enrichData.genre
+            if (enrichData.genreTags) musicResult.genreTags = enrichData.genreTags
+            if (enrichData.label) musicResult.label = enrichData.label
+            if (enrichData.album) musicResult.albumTitle = musicResult.albumTitle || enrichData.album
+            if (enrichData.releaseDate) musicResult.releaseDate = musicResult.releaseDate || enrichData.releaseDate
+            console.log('[create-pin] enrich-music result:', enrichData)
+          }
+        } catch (e) { console.warn('[create-pin] enrich-music call failed:', (e as Error).message) }
+      }
+
+      // 7. BPM + musical key via Claude Haiku (replaces GetSongBPM — blocked by Cloudflare)
+      if (musicResult.artist && musicResult.trackTitle) {
+        try {
+          const bpmApiKey = Deno.env.get('ANTHROPIC_API_KEY')
+          if (bpmApiKey) {
+            const bpmPrompt = `What is the BPM (tempo) and musical key of "${musicResult.trackTitle}" by "${musicResult.artist}"? Reply ONLY with JSON, no explanation: {"bpm": <number or null>, "key": "<key like Cm, G, F#m or null>"}`
+            const bpmResp = await fetch('https://api.anthropic.com/v1/messages', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'x-api-key': bpmApiKey,
+                'anthropic-version': '2023-06-01'
+              },
+              body: JSON.stringify({
+                model: 'claude-3-haiku-20240307',
+                max_tokens: 100,
+                messages: [{ role: 'user', content: bpmPrompt }]
+              })
+            })
+            if (bpmResp.ok) {
+              const bpmData = await bpmResp.json()
+              const text = bpmData.content?.[0]?.text || ''
+              const match = text.match(/\{[\s\S]*\}/)
+              if (match) {
+                const parsed = JSON.parse(match[0])
+                if (parsed.bpm) musicResult.bpm = parseInt(parsed.bpm, 10)
+                if (parsed.key) {
+                  musicResult.key = toCamelotKey(parsed.key)
+                  musicResult.musicalKey = parsed.key
+                }
+                console.log('[create-pin] Claude BPM/key:', { bpm: musicResult.bpm, key: musicResult.key, musicalKey: parsed.key })
+              }
+            } else {
+              console.warn('[create-pin] Claude BPM/key HTTP', bpmResp.status)
+            }
+          }
+        } catch (e) { console.warn('[create-pin] Claude BPM/key failed:', (e as Error).message) }
+      }
+
+      // Return if we got anything useful
+      const hasData = musicResult.artist || musicResult.trackTitle || musicResult.contentFormat
+      if (hasData) {
+        musicMeta = musicResult
+      }
+
+      // Use Spotify og:image as fallback if no image was resolved
+      if (musicMeta?.imageUrl && !imageUrl) {
+        imageUrl = musicMeta.imageUrl
+        imageSource = 'platform'
+        imageLog.push({ strategy: 'music_page_scrape', result: 'accepted', url: imageUrl })
+        console.log('[create-pin] Using Spotify og:image as fallback:', imageUrl)
+      }
+      // Remove imageUrl from musicMeta (it's handled by the image pipeline)
+      if (musicMeta?.imageUrl) delete musicMeta.imageUrl
+
+      console.log('[create-pin] Music enrichment result:', musicMeta)
+    }
+
+    // ========================================
+    // STEP 3: Update link in database (if linkId provided)
+    // ========================================
+    if (linkId) {
+      console.log('[create-pin] Step 3: Updating link', linkId)
+
+      const updatePayload: Record<string, any> = {
+        content_type: contentType,
+        type_confidence: typeConfidence,
+        image: imageUrl,
+        image_source: imageSource,
+        image_resolved_at: new Date().toISOString()
+      }
+      // Save platform-resolved title to DB (overrides generic "YouTube" etc.)
+      // Only save if we actually resolved a meaningful title
+      if (oembedTitle) {
+        const genericTitleValues = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+        const titleIsGeneric = !title || genericTitleValues.includes(title.toLowerCase().trim())
+          || title.toLowerCase().trim() === domain
+        if (!titleIsGeneric) {
+          updatePayload.title = title
+        }
+        if (youtubeData?.description) {
+          updatePayload.description = youtubeData.description.slice(0, 500)
+        }
+      }
+      if (imageScores) {
+        updatePayload.image_scores = imageScores
+      }
+      if (videoMeta) {
+        updatePayload.video = videoMeta
+      }
+      if (bookMeta) {
+        updatePayload.book = bookMeta
+      }
+      if (musicMeta) {
+        updatePayload.music = musicMeta
+      }
+      await supabase
+        .from('links')
+        .update(updatePayload)
+        .eq('id', linkId)
+    }
+
+    // Build image resolution log
+    const imageResolutionLog = {
+      resolved_at: new Date().toISOString(),
+      attempts: imageLog,
+      final_image: imageUrl,
+      final_source: imageUrl ? imageSource : null,
+      final_tier: imageScores?.tier || imageScores?.evaluation_method || null,
+      final_reason: imageUrl
+        ? `Accepted via ${imageSource}${imageScores?.tier ? ` (${imageScores.tier})` : ''}`
+        : (imageLog.length > 0
+          ? `All ${imageLog.length} strategies failed: ${imageLog.map(a => `${a.strategy}(${a.result})`).join(', ')}`
+          : 'Image resolution skipped')
+    }
+
+    // Return result
+    const response: Record<string, any> = {
+      content_type: contentType,
+      type_confidence: typeConfidence,
+      type_source: typeSource,
+      image_url: imageUrl,
+      image_source: imageSource,
+      image_scores: imageScores,
+      image_resolution_log: imageResolutionLog
+    }
+    // Include platform-resolved title so client can update its stored data
+    // Only include if we actually resolved a meaningful title (not empty or generic domain names)
+    if (oembedTitle) {
+      const genericTitleValues = ['youtube', 'youtu.be', 'vimeo', 'watch', '']
+      const titleIsGeneric = !title || genericTitleValues.includes(title.toLowerCase().trim())
+        || title.toLowerCase().trim() === domain
+      if (!titleIsGeneric) {
+        response.title = title
+      }
+      if (oembedTitle.author) response.author = oembedTitle.author
+      if (youtubeData?.description) response.description = youtubeData.description.slice(0, 500)
+    }
+    if (videoMeta) {
+      response.video = videoMeta
+    }
+    if (bookMeta) {
+      response.book = bookMeta
+    }
+    if (musicMeta) {
+      response.music = musicMeta
+    }
+
+    console.log('[create-pin] Complete:', response)
+
+    return new Response(
+      JSON.stringify(response),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('[create-pin] Error:', error)
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})
+
+// ========================================
+// oEmbed Metadata Resolution (Vimeo, etc.)
+// YouTube is handled by lookupYouTube() which uses Data API v3 + oEmbed fallback
+// ========================================
+async function resolveOembedMetadata(
+  url: string,
+  domain: string
+): Promise<{ title: string, author: string | null, thumbnail: string | null } | null> {
+  // Vimeo oEmbed
+  if (domain.includes('vimeo.com')) {
+    try {
+      const resp = await fetch(
+        `https://vimeo.com/api/oembed.json?url=${encodeURIComponent(url)}`
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        if (data.title) {
+          return {
+            title: data.title,
+            author: data.author_name || null,
+            thumbnail: data.thumbnail_url || null
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[oembed] Vimeo oEmbed error:', e)
+    }
+  }
+
+  return null
+}
+
+// ========================================
+// JSON-LD Title Resolution — extract clean titles from structured data
+// Pages often have messy <title> tags ("SHOW | Episode | Season | Network")
+// but clean names in JSON-LD structured data. This is a generalized approach
+// that works across content types (videos, articles, products, recipes, etc.)
+// ========================================
+const JSON_LD_TITLE_TYPES = new Set([
+  'TVEpisode', 'VideoObject', 'Movie', 'TVSeries', 'Episode', 'Clip',
+  'Article', 'NewsArticle', 'BlogPosting', 'Review',
+  'Product', 'Book', 'Recipe',
+  'MusicRecording', 'MusicAlbum', 'PodcastEpisode',
+  'SoftwareApplication', 'Course', 'Event', 'CreativeWork'
+])
+
+async function resolveJsonLdTitle(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+      }
+    })
+    if (!response.ok) return null
+
+    const html = await response.text()
+    const jsonLdMatches = html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+
+    for (const match of jsonLdMatches) {
+      try {
+        const ld = JSON.parse(match[1])
+        const candidates = ld['@graph'] ? ld['@graph'] : [ld]
+        for (const item of candidates) {
+          if (item?.name && JSON_LD_TITLE_TYPES.has(item['@type'])) {
+            // Skip very short names (likely just a site name)
+            if (item.name.length < 5) continue
+            console.log('[json-ld] Resolved title:', item.name, 'from @type:', item['@type'])
+            return item.name
+          }
+        }
+      } catch (_e) { /* JSON parse error, continue */ }
+    }
+  } catch (e) {
+    console.log('[json-ld] Fetch failed:', e.message)
+  }
+  return null
+}
+
+// ========================================
+// YouTube Data API v3 — full video metadata
+// ========================================
+interface YouTubeVideoData {
+  videoId: string
+  title: string
+  description: string
+  channelTitle: string
+  publishedAt: string
+  thumbnailUrl: string | null
+  duration: number | null      // seconds
+  tags: string[]
+  categoryId: string | null
+  viewCount: number | null
+  likeCount: number | null
+}
+
+/**
+ * Extract YouTube video ID from various URL formats.
+ */
+function extractYouTubeVideoId(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    // youtube.com/watch?v=ID
+    if (parsed.hostname.includes('youtube.com')) {
+      return parsed.searchParams.get('v')
+    }
+    // youtu.be/ID
+    if (parsed.hostname.includes('youtu.be')) {
+      return parsed.pathname.slice(1).split(/[?#]/)[0] || null
+    }
+  } catch {}
+  return null
+}
+
+/**
+ * Parse ISO 8601 duration (PT1H2M3S) to seconds.
+ */
+function parseISO8601Duration(iso: string): number | null {
+  if (!iso) return null
+  const match = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/)
+  if (!match) return null
+  const hours = parseInt(match[1] || '0', 10)
+  const minutes = parseInt(match[2] || '0', 10)
+  const seconds = parseInt(match[3] || '0', 10)
+  return hours * 3600 + minutes * 60 + seconds
+}
+
+/**
+ * Look up a YouTube video using the Data API v3.
+ * Returns rich metadata: title, description, channel, duration, tags, thumbnails, stats.
+ * Falls back to oEmbed if no API key.
+ */
+async function lookupYouTube(url: string): Promise<YouTubeVideoData | null> {
+  const videoId = extractYouTubeVideoId(url)
+  if (!videoId) {
+    console.log('[youtube] Could not extract video ID from:', url)
+    return null
+  }
+
+  const apiKey = Deno.env.get('YOUTUBE_API_KEY')
+  if (!apiKey) {
+    console.log('[youtube] No YOUTUBE_API_KEY, falling back to oEmbed')
+    // Fallback: use oEmbed for basic title/author
+    try {
+      const resp = await fetch(
+        `https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`
+      )
+      if (resp.ok) {
+        const data = await resp.json()
+        if (data.title) {
+          return {
+            videoId,
+            title: data.title,
+            description: '',
+            channelTitle: data.author_name || '',
+            publishedAt: '',
+            thumbnailUrl: data.thumbnail_url || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
+            duration: null,
+            tags: [],
+            categoryId: null,
+            viewCount: null,
+            likeCount: null
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[youtube] oEmbed fallback error:', e)
+    }
+    return null
+  }
+
+  try {
+    const apiUrl = `https://www.googleapis.com/youtube/v3/videos?` +
+      `id=${videoId}` +
+      `&part=snippet,contentDetails,statistics` +
+      `&key=${apiKey}`
+
+    console.log('[youtube] Fetching video data for:', videoId)
+    const resp = await fetch(apiUrl)
+
+    if (!resp.ok) {
+      console.error('[youtube] API error:', resp.status, await resp.text())
+      return null
+    }
+
+    const data = await resp.json()
+    const items = data.items || []
+
+    if (items.length === 0) {
+      console.log('[youtube] Video not found:', videoId)
+      return null
+    }
+
+    const video = items[0]
+    const snippet = video.snippet || {}
+    const contentDetails = video.contentDetails || {}
+    const statistics = video.statistics || {}
+
+    // Pick best thumbnail: maxres > standard > high > medium > default
+    const thumbs = snippet.thumbnails || {}
+    const thumbnailUrl = thumbs.maxres?.url
+      || thumbs.standard?.url
+      || thumbs.high?.url
+      || thumbs.medium?.url
+      || thumbs.default?.url
+      || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
+
+    const result: YouTubeVideoData = {
+      videoId,
+      title: snippet.title || '',
+      description: snippet.description || '',
+      channelTitle: snippet.channelTitle || '',
+      publishedAt: snippet.publishedAt || '',
+      thumbnailUrl,
+      duration: parseISO8601Duration(contentDetails.duration),
+      tags: snippet.tags || [],
+      categoryId: snippet.categoryId || null,
+      viewCount: statistics.viewCount ? parseInt(statistics.viewCount, 10) : null,
+      likeCount: statistics.likeCount ? parseInt(statistics.likeCount, 10) : null
+    }
+
+    console.log('[youtube] Video data:', result.title, `(${result.duration}s)`, 'by', result.channelTitle)
+    return result
+  } catch (e) {
+    console.error('[youtube] API lookup error:', e)
+    return null
+  }
+}
+
+// ========================================
+// Watch Enrichment using TMDB
+// ========================================
+
+interface TMDBResult {
+  tmdbId: number
+  mediaType: 'movie' | 'tv'
+  imdbId: string | null
+  title: string
+  overview: string | null
+  year: number | null
+  runtime: number | null   // minutes
+  genres: string[]
+  voteAverage: number | null
+  creator: string | null
+  posterPath: string | null
+  streamingServices: Array<{ name: string, type: string, logoPath: string | null }>
+  tmdbUrl: string
+}
+
+/**
+ * Look up a title on TMDB. Tries movie search first, then TV.
+ * Uses append_to_response to get details + watch providers + credits in one call.
+ */
+async function lookupTMDB(rawTitle: string, type: string | null, year: number | null): Promise<TMDBResult | null> {
+  const tmdbKey = Deno.env.get('TMDB_API_KEY')
+  if (!tmdbKey || !rawTitle) {
+    console.log('[tmdb] No TMDB_API_KEY or title, skipping')
+    return null
+  }
+
+  // Clean title: strip platform/network suffixes after separators
+  const cleanTitle = rawTitle
+    .replace(/\s*[\|\-–—]\s*(Netflix|YouTube|Hulu|Disney\+?|HBO|Max|Prime Video|Apple TV\+?|Vimeo|IMDb|Letterboxd|Rotten Tomatoes|Watch|Stream|Official|Wikipedia|Wiki|Fandom|PBS|BBC|CBC|ABC|NBC|CBS|CNN|FOX|ITV|NHK|Season\s+\d|Episode\s+\d).*$/i, '')
+    .replace(/\s*\(\d{4}\)\s*$/, '')  // strip trailing (2024)
+    .replace(/\s*-\s*(IMDb|Wikipedia)\s*$/i, '')
+    .replace(/\s*\(TV series\)\s*$/i, '')  // strip "(TV series)" from Wikipedia titles
+    .replace(/\s*\(film\)\s*$/i, '')  // strip "(film)" from Wikipedia titles
+    .replace(/\s*\(TV programme\)\s*$/i, '')
+    .trim()
+
+  if (!cleanTitle) return null
+  console.log('[tmdb] Searching for:', cleanTitle, type ? `(${type})` : '', year || '')
+
+  const baseUrl = 'https://api.themoviedb.org/3'
+  const headers = {
+    'Authorization': `Bearer ${Deno.env.get('TMDB_READ_TOKEN') || ''}`,
+    'Accept': 'application/json'
+  }
+  // Use API key auth (simpler, no bearer token needed)
+  const authParam = `api_key=${tmdbKey}`
+
+  try {
+    // Determine search order based on type hint
+    const searchOrder: Array<'movie' | 'tv'> =
+      type === 'tv-show' || type === 'anime' ? ['tv', 'movie'] : ['movie', 'tv']
+
+    let searchResult: { id: number, mediaType: 'movie' | 'tv' } | null = null
+
+    for (const mediaType of searchOrder) {
+      const yearParam = year
+        ? (mediaType === 'movie' ? `&year=${year}` : `&first_air_date_year=${year}`)
+        : ''
+      const searchUrl = `${baseUrl}/search/${mediaType}?${authParam}&query=${encodeURIComponent(cleanTitle)}${yearParam}`
+
+      console.log('[tmdb] Search:', mediaType, cleanTitle)
+      const searchResp = await fetch(searchUrl)
+
+      if (!searchResp.ok) {
+        console.error('[tmdb] Search error:', searchResp.status)
+        continue
+      }
+
+      const searchData = await searchResp.json()
+      const results = searchData.results || []
+
+      if (results.length > 0) {
+        // Pick best match: exact title match > first result (sorted by popularity)
+        const titleLower = cleanTitle.toLowerCase()
+        const exactMatch = results.find((r: any) => {
+          const rTitle = (mediaType === 'movie' ? r.title : r.name)?.toLowerCase()
+          return rTitle === titleLower
+        })
+        const best = exactMatch || results[0]
+        searchResult = { id: best.id, mediaType }
+        console.log('[tmdb] Found:', mediaType, best.id, mediaType === 'movie' ? best.title : best.name)
+        break
+      }
+    }
+
+    if (!searchResult) {
+      console.log('[tmdb] No results found for:', cleanTitle)
+      return null
+    }
+
+    // Get details + watch providers + credits in one call
+    const appendParts = ['watch/providers', 'credits']
+    if (searchResult.mediaType === 'tv') {
+      appendParts.push('external_ids')  // TV needs this for imdb_id
+    }
+    const detailsUrl = `${baseUrl}/${searchResult.mediaType}/${searchResult.id}?${authParam}&append_to_response=${appendParts.join(',')}`
+
+    console.log('[tmdb] Getting details for:', searchResult.mediaType, searchResult.id)
+    const detailsResp = await fetch(detailsUrl)
+
+    if (!detailsResp.ok) {
+      console.error('[tmdb] Details error:', detailsResp.status)
+      return null
+    }
+
+    const details = await detailsResp.json()
+
+    // Extract fields based on media type
+    const isMovie = searchResult.mediaType === 'movie'
+    const tmdbTitle = isMovie ? details.title : details.name
+    const releaseDate = isMovie ? details.release_date : details.first_air_date
+    const releaseYear = releaseDate ? parseInt(releaseDate.split('-')[0], 10) : null
+    const runtime = isMovie ? details.runtime : (details.episode_run_time?.[0] || null)
+    const genres = (details.genres || []).map((g: any) => g.name)
+
+    // Extract creator/director
+    let creator: string | null = null
+    if (isMovie) {
+      const director = details.credits?.crew?.find((c: any) => c.job === 'Director')
+      creator = director?.name || null
+    } else {
+      creator = details.created_by?.[0]?.name || null
+    }
+
+    // Extract IMDB ID
+    const imdbId = isMovie ? (details.imdb_id || null) : (details.external_ids?.imdb_id || null)
+
+    // Extract US streaming providers
+    const usProviders = details['watch/providers']?.results?.US || {}
+    const streamingServices: Array<{ name: string, type: string, logoPath: string | null }> = []
+
+    // Flatrate (subscription streaming) first
+    for (const provider of (usProviders.flatrate || [])) {
+      streamingServices.push({
+        name: provider.provider_name,
+        type: 'flatrate',
+        logoPath: provider.logo_path || null
+      })
+    }
+    // Then free/ads
+    for (const provider of (usProviders.free || [])) {
+      streamingServices.push({
+        name: provider.provider_name,
+        type: 'free',
+        logoPath: provider.logo_path || null
+      })
+    }
+    // Then rent/buy (limited to top 3)
+    const rentBuy = [...(usProviders.rent || []), ...(usProviders.buy || [])]
+    const seenRentBuy = new Set<string>()
+    for (const provider of rentBuy) {
+      if (!seenRentBuy.has(provider.provider_name) && seenRentBuy.size < 3) {
+        seenRentBuy.add(provider.provider_name)
+        streamingServices.push({
+          name: provider.provider_name,
+          type: 'rent',
+          logoPath: provider.logo_path || null
+        })
+      }
+    }
+
+    const tmdbUrl = `https://www.themoviedb.org/${searchResult.mediaType}/${searchResult.id}`
+
+    console.log('[tmdb] Enrichment complete:', tmdbTitle, `(${releaseYear})`,
+      streamingServices.length, 'providers', imdbId || 'no imdb')
+
+    return {
+      tmdbId: searchResult.id,
+      mediaType: searchResult.mediaType,
+      imdbId,
+      title: tmdbTitle,
+      overview: details.overview || null,
+      year: releaseYear,
+      runtime,
+      genres,
+      voteAverage: details.vote_average || null,
+      creator,
+      posterPath: details.poster_path || null,
+      streamingServices,
+      tmdbUrl
+    }
+  } catch (e) {
+    console.error('[tmdb] Lookup error:', e)
+    return null
+  }
+}
+
+/**
+ * Infer content type from TMDB media type
+ */
+function inferTypeFromTMDB(mediaType: 'movie' | 'tv'): string {
+  if (mediaType === 'movie') return 'movie'
+  if (mediaType === 'tv') return 'tv-show'
+  return 'video'
+}
+
+// ========================================
+// Watch Enrichment using AI (fallback)
+// ========================================
+async function enrichWatchWithAI(url: string, title: string, description: string): Promise<Record<string, any> | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+
+  if (!apiKey) {
+    console.log('[create-pin] No ANTHROPIC_API_KEY, skipping watch enrichment')
+    return null
+  }
+
+  const prompt = `Given this video/film link, provide structured metadata. Be concise and accurate.
+
+URL: ${url}
+Title: ${title || 'N/A'}
+Description: ${description?.slice(0, 500) || 'N/A'}
+
+Return JSON only:
+{
+  "summary": "1-2 sentence summary, max 50 words. Present tense, no spoilers.",
+  "type": "movie|tv-show|documentary|short|anime|video|trailer",
+  "genre": "primary genre (e.g. drama, comedy, thriller, sci-fi, horror, action, romance, animation)",
+  "genres": ["primary genre", "secondary genre if applicable"],
+  "year": year as number or null if unknown,
+  "creator": "director name for films, showrunner for TV, channel name for YouTube, or null",
+  "streamingServices": ["list of major streaming services where this is typically available, e.g. Netflix, Hulu, Disney+, Amazon Prime Video, HBO Max, Apple TV+"],
+  "rating": "content rating (G, PG, PG-13, R, NC-17, TV-Y, TV-G, TV-PG, TV-14, TV-MA) or null"
+}`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 400,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    })
+
+    if (!response.ok) {
+      console.error('[create-pin] Watch enrichment API error:', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const text = data.content?.[0]?.text || ''
+    const match = text.match(/\{[\s\S]*\}/)
+
+    if (match) {
+      const result = JSON.parse(match[0])
+      // Validate and clean the result
+      const validTypes = ['movie', 'tv-show', 'documentary', 'short', 'anime', 'video', 'trailer']
+      return {
+        summary: typeof result.summary === 'string' ? result.summary.slice(0, 500) : null,
+        type: validTypes.includes(result.type) ? result.type : null,
+        genre: typeof result.genre === 'string' ? result.genre : null,
+        genres: Array.isArray(result.genres) ? result.genres.filter((g: any) => typeof g === 'string').slice(0, 3) : (typeof result.genre === 'string' ? [result.genre] : []),
+        year: typeof result.year === 'number' && result.year > 1800 && result.year < 2100 ? result.year : null,
+        creator: typeof result.creator === 'string' ? result.creator : null,
+        streamingServices: Array.isArray(result.streamingServices) ? result.streamingServices.filter((s: any) => typeof s === 'string').slice(0, 10) : [],
+        rating: typeof result.rating === 'string' ? result.rating : null
+      }
+    }
+  } catch (e) {
+    console.error('[create-pin] Watch enrichment error:', e)
+  }
+
+  return null
+}
+
+// ========================================
+// Open Library Lookup for Books
+// ========================================
+async function lookupOpenLibrary(rawTitle: string): Promise<{
+  openLibraryKey: string, title: string, author: string | null, isbn: string | null,
+  year: number | null, pages: number | null, genre: string | null,
+  summary: string | null, coverPath: string | null
+} | null> {
+  if (!rawTitle) {
+    console.log('[openlibrary] No title, skipping')
+    return null
+  }
+
+  // Clean title: strip common suffixes
+  const cleanTitle = rawTitle
+    .replace(/\s*-\s*Wikipedia\s*$/i, '')  // "Hyperion (novel) - Wikipedia"
+    .replace(/\s*[\|\-–—]\s*Wikipedia\s*$/i, '')  // "Hyperion | Wikipedia"
+    .replace(/\s*\([^)]*(?:novel|book|story|memoir|essay|anthology|series|autobiography|biography|poem|play|novella|collection|treatise|manuscript)[^)]*\)\s*/gi, '')  // "(Simmons novel)"
+    .replace(/\s*[\|\-–—]\s*(Goodreads|Amazon|Barnes & Noble|Bookshop|Book|Read|Review|Buy|Kindle|Audible|Open Library).*$/i, '')
+    .replace(/\s*by\s+.+$/i, '')
+    .replace(/\s*\(\d{4}\)\s*$/, '')
+    .trim()
+
+  if (!cleanTitle) return null
+  console.log('[openlibrary] Searching for:', cleanTitle)
+
+  try {
+    const searchUrl = `https://openlibrary.org/search.json?q=${encodeURIComponent(cleanTitle)}&fields=key,title,author_name,first_publish_year,number_of_pages_median,isbn,cover_i,subject&limit=5`
+    const searchResp = await fetch(searchUrl)
+    if (!searchResp.ok) {
+      console.error('[openlibrary] Search error:', searchResp.status)
+      return null
+    }
+
+    const searchData = await searchResp.json()
+    const results = searchData.docs || []
+
+    if (results.length === 0) {
+      console.log('[openlibrary] No results for:', cleanTitle)
+      return null
+    }
+
+    // Take first result (Open Library ranks by relevance)
+    const book = results[0]
+    const workKey = book.key  // e.g., "/works/OL45883W"
+
+    // Fetch work details for description
+    let summary: string | null = null
+    if (workKey) {
+      try {
+        const workResp = await fetch(`https://openlibrary.org${workKey}.json`)
+        if (workResp.ok) {
+          const workData = await workResp.json()
+          summary = typeof workData.description === 'string'
+            ? workData.description
+            : workData.description?.value || null
+        }
+      } catch (e) {
+        console.error('[openlibrary] Work details error:', e)
+      }
+    }
+
+    // Extract primary subject as genre
+    const genre = book.subject?.[0] || null
+
+    const result = {
+      openLibraryKey: workKey,
+      title: book.title,
+      author: book.author_name?.[0] || null,
+      isbn: book.isbn?.[0] || null,
+      year: book.first_publish_year || null,
+      pages: book.number_of_pages_median || null,
+      genre,
+      summary,
+      coverPath: book.cover_i ? String(book.cover_i) : null
+    }
+
+    console.log('[openlibrary] Found:', result.title, 'by', result.author)
+    return result
+  } catch (e) {
+    console.error('[openlibrary] Lookup error:', e)
+    return null
+  }
+}
+
+// ========================================
+// Book Enrichment using AI (fallback)
+// ========================================
+async function enrichBookWithAI(url: string, title: string, description: string): Promise<Record<string, any> | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.log('[create-pin] No ANTHROPIC_API_KEY, skipping book enrichment')
+    return null
+  }
+
+  const prompt = `Given this book/reading link, provide structured metadata. Be concise and accurate.
+
+URL: ${url}
+Title: ${title || 'N/A'}
+Description: ${description?.slice(0, 500) || 'N/A'}
+
+Return JSON only:
+{
+  "author": "Primary author name or null",
+  "year": year as number or null,
+  "pages": page count as number or null,
+  "genre": "primary genre (e.g. Fiction, Non-Fiction, Science, Biography, History, Fantasy, Mystery, Self-Help)",
+  "summary": "1-2 sentence description, max 50 words.",
+  "format": "book|ebook|audiobook|article|paper"
+}`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 300,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    })
+
+    if (!response.ok) {
+      console.error('[create-pin] Book enrichment API error:', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const text = data.content?.[0]?.text || ''
+    const match = text.match(/\{[\s\S]*\}/)
+
+    if (match) {
+      const result = JSON.parse(match[0])
+      const validFormats = ['book', 'ebook', 'audiobook', 'article', 'paper']
+      return {
+        author: typeof result.author === 'string' ? result.author : null,
+        year: typeof result.year === 'number' && result.year > 1800 && result.year < 2100 ? result.year : null,
+        pages: typeof result.pages === 'number' && result.pages > 0 ? result.pages : null,
+        genre: typeof result.genre === 'string' ? result.genre : null,
+        summary: typeof result.summary === 'string' ? result.summary.slice(0, 500) : null,
+        format: validFormats.includes(result.format) ? result.format : 'book'
+      }
+    }
+  } catch (e) {
+    console.error('[create-pin] Book enrichment error:', e)
+  }
+
+  return null
+}
+
+// ========================================
+// Image Resolution Strategies
+// ========================================
+async function executeImageStrategy(
+  strategy: string,
+  url: string,
+  title: string,
+  description: string
+): Promise<{ url: string, source: 'scraped' | 'platform' | 'generated' | 'template' | 'favicon' } | null> {
+
+  switch (strategy) {
+    case 'platform':
+      return await resolvePlatformImage(url)
+
+    case 'search':
+      return await searchImageSerpApi(url, title, description)
+
+    case 'scrape':
+      return await scrapeImage(url)
+
+    case 'favicon':
+      return await resolveFavicon(url)
+
+    case 'template':
+    default:
+      return null
+  }
+}
+
+// Platform-specific image resolution (YouTube, GitHub, Vimeo)
+async function resolvePlatformImage(url: string): Promise<{ url: string, source: 'platform' } | null> {
+  const domain = new URL(url).hostname
+
+  // YouTube — verify thumbnail exists (deleted/private videos return 404)
+  if (domain.includes('youtube.com') || domain.includes('youtu.be')) {
+    const videoId = url.match(/(?:v=|youtu\.be\/)([^&\?]+)/)?.[1]
+    if (videoId) {
+      for (const quality of ['hqdefault', 'mqdefault']) {
+        const thumbUrl = `https://img.youtube.com/vi/${videoId}/${quality}.jpg`
+        try {
+          const check = await fetch(thumbUrl, { method: 'HEAD' })
+          if (check.ok) {
+            return { url: thumbUrl, source: 'platform' }
+          }
+        } catch (e) { /* try next quality */ }
+      }
+      console.log('[platform] YouTube thumbnail not found for videoId:', videoId)
+    }
+  }
+
+  // Vimeo
+  if (domain.includes('vimeo.com')) {
+    const videoId = url.match(/vimeo\.com\/(\d+)/)?.[1]
+    if (videoId) {
+      try {
+        const response = await fetch(`https://vimeo.com/api/v2/video/${videoId}.json`)
+        if (response.ok) {
+          const data = await response.json()
+          if (data[0]?.thumbnail_large) {
+            return { url: data[0].thumbnail_large, source: 'platform' }
+          }
+        }
+      } catch (e) {
+        console.error('[platform] Vimeo API error:', e)
+      }
+    }
+  }
+
+  // Spotify (oEmbed API — bypasses bot detection)
+  if (domain.includes('spotify.com')) {
+    try {
+      const oembedUrl = `https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`
+      console.log('[platform] Spotify oEmbed request:', oembedUrl)
+      const response = await fetch(oembedUrl)
+      console.log('[platform] Spotify oEmbed response:', response.status)
+      if (response.ok) {
+        const data = await response.json()
+        if (data.thumbnail_url) {
+          // oEmbed returns spotifycdn.com 300x300 thumbnails — upgrade to i.scdn.co 640x640
+          // Image hash prefix ab67616d00001e02 = 300px, ab67616d0000b273 = 640px
+          let thumbUrl = data.thumbnail_url
+          const hashMatch = thumbUrl.match(/\/image\/(ab67616d\w{8})(\w{24})/)
+          if (hashMatch) {
+            thumbUrl = `https://i.scdn.co/image/ab67616d0000b273${hashMatch[2]}`
+            console.log('[platform] Spotify thumbnail upgraded to 640px:', thumbUrl)
+          }
+          return { url: thumbUrl, source: 'platform' }
+        }
+        console.log('[platform] Spotify oEmbed response missing thumbnail_url:', JSON.stringify(data).slice(0, 200))
+      }
+    } catch (e) {
+      console.error('[platform] Spotify oEmbed error:', e)
+    }
+  }
+
+  // SoundCloud (oEmbed API)
+  if (domain.includes('soundcloud.com')) {
+    try {
+      const response = await fetch(`https://soundcloud.com/oembed?url=${encodeURIComponent(url)}&format=json`)
+      if (response.ok) {
+        const data = await response.json()
+        if (data.thumbnail_url) {
+          console.log('[platform] SoundCloud oEmbed thumbnail:', data.thumbnail_url)
+          return { url: data.thumbnail_url, source: 'platform' }
+        }
+      }
+    } catch (e) {
+      console.error('[platform] SoundCloud oEmbed error:', e)
+    }
+  }
+
+  // GitHub
+  if (domain.includes('github.com')) {
+    const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/)
+    if (match) {
+      return {
+        url: `https://opengraph.githubassets.com/1/${match[1]}/${match[2]}`,
+        source: 'platform'
+      }
+    }
+  }
+
+  return null
+}
+
+// Scrape OG image from URL (server-side, no CORS issues)
+async function scrapeImage(url: string): Promise<{ url: string, source: 'scraped' } | null> {
+  try {
+    // Use a more browser-like User-Agent to avoid bot blocks
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Cache-Control': 'no-cache'
+      }
+    })
+
+    if (!response.ok) {
+      console.log('[scrape] HTTP error:', response.status, 'for', url)
+      return null
+    }
+
+    const html = await response.text()
+
+    // Detect error pages that return 200 — check title for error patterns
+    const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
+    if (titleMatch) {
+      const pageTitle = titleMatch[1].toLowerCase().trim()
+      const errorPatterns = [
+        /page\s*not\s*found/, /^404/, /not\s*found/, /access\s*denied/,
+        /403\s*forbidden/, /something\s*went\s*wrong/, /unavailable/,
+        /page\s*doesn'?t?\s*exist/, /this\s*page\s*isn'?t?\s*available/
+      ]
+      if (errorPatterns.some(p => p.test(pageTitle))) {
+        console.log('[scrape] Error page detected (title:', titleMatch[1].trim(), '), skipping:', url)
+        return null
+      }
+    }
+
+    const base = new URL(url)
+
+    // Helper to resolve relative URLs
+    const resolveUrl = (imgUrl: string): string => {
+      if (!imgUrl) return ''
+      if (imgUrl.startsWith('//')) return `https:${imgUrl}`
+      if (imgUrl.startsWith('/')) return `${base.origin}${imgUrl}`
+      if (!imgUrl.startsWith('http')) return `${base.origin}/${imgUrl}`
+      return imgUrl
+    }
+
+    // 1. Try og:image first (handle both single and double quotes)
+    const ogMatch = html.match(/<meta[^>]*property=["']og:image["'][^>]*content=["']([^"']+)["']/i)
+      || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*property=["']og:image["']/i)
+
+    if (ogMatch?.[1]) {
+      const imageUrl = resolveUrl(ogMatch[1])
+      if (!isRejectedByGate(imageUrl)) {
+        console.log('[scrape] Found og:image:', imageUrl)
+        return { url: imageUrl, source: 'scraped' }
+      }
+      console.log('[scrape] Skipping og:image (rejected by gate):', imageUrl)
+    }
+
+    // 2. Try twitter:image (handle both single and double quotes)
+    const twitterMatch = html.match(/<meta[^>]*name=["']twitter:image["'][^>]*content=["']([^"']+)["']/i)
+      || html.match(/<meta[^>]*content=["']([^"']+)["'][^>]*name=["']twitter:image["']/i)
+
+    if (twitterMatch?.[1]) {
+      const imageUrl = resolveUrl(twitterMatch[1])
+      if (!isRejectedByGate(imageUrl)) {
+        console.log('[scrape] Found twitter:image:', imageUrl)
+        return { url: imageUrl, source: 'scraped' }
+      }
+    }
+
+    // 3. Try JSON-LD structured data (common in Shopify, e-commerce)
+    const jsonLdMatches = html.matchAll(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/gi)
+    for (const match of jsonLdMatches) {
+      try {
+        const jsonLd = JSON.parse(match[1])
+        // Handle Product schema
+        const product = jsonLd['@type'] === 'Product' ? jsonLd : jsonLd['@graph']?.find((item: any) => item['@type'] === 'Product')
+        if (product?.image) {
+          const productImage = Array.isArray(product.image) ? product.image[0] : product.image
+          const imageUrl = typeof productImage === 'string' ? productImage : productImage?.url
+          if (imageUrl && !isRejectedByGate(resolveUrl(imageUrl))) {
+            console.log('[scrape] Found JSON-LD product image:', imageUrl)
+            return { url: resolveUrl(imageUrl), source: 'scraped' }
+          }
+        }
+      } catch (e) {
+        // JSON parse error, continue
+      }
+    }
+
+    // 4. Try Shopify CDN pattern (common in Shopify stores)
+    const shopifyMatch = html.match(/https:\/\/cdn\.shopify\.com\/s\/files\/[^"'\s]+\.(?:jpg|jpeg|png|webp)/i)
+    if (shopifyMatch?.[0] && !isRejectedByGate(shopifyMatch[0])) {
+      console.log('[scrape] Found Shopify CDN image:', shopifyMatch[0])
+      return { url: shopifyMatch[0], source: 'scraped' }
+    }
+
+    // 5. Try first large image in srcset (common in Next.js sites)
+    const srcsetMatch = html.match(/srcset="([^"]+)"/i)
+    if (srcsetMatch?.[1]) {
+      const srcsetParts = srcsetMatch[1].split(',').map(s => s.trim())
+      // Get the largest image (usually last in srcset)
+      const largestSrc = srcsetParts[srcsetParts.length - 1]?.split(' ')[0]
+      if (largestSrc && !isRejectedByGate(resolveUrl(largestSrc))) {
+        console.log('[scrape] Found srcset image:', largestSrc)
+        return { url: resolveUrl(largestSrc), source: 'scraped' }
+      }
+    }
+
+    console.log('[scrape] No suitable image found for:', url)
+
+  } catch (e) {
+    console.error('[scrape] Error:', e)
+  }
+
+  return null
+}
+
+// Patterns that indicate a logo/icon rather than product image
+const LOGO_PATTERNS = [
+  /logo/i, /icon/i, /favicon/i, /brand/i, /avatar/i,
+  /placeholder/i, /default/i, /blank/i, /spacer/i,
+  /pixel/i, /1x1/i, /transparent/i, /sprite/i,
+  /tracking/i, /beacon/i, /badge/i, /button/i,
+  /banner-ad/i, /ad-banner/i, /widget-icon/i,
+  /static\/images\/project-logos\//i  // Wikipedia project logos (globe icon)
+]
+
+// Known CDN placeholder URL patterns
+const PLACEHOLDER_URL_PATTERNS = [
+  /no-image/i, /noimage/i, /no_image/i,
+  /missing/i, /not-found/i, /not_found/i,
+  /fallback/i,
+  /placeholder\.(jpg|png|gif|svg|webp)/i,
+  /default\.(jpg|png|gif|svg|webp)/i,
+  /blank\.(jpg|png|gif|svg|webp)/i,
+  /Wikipedia-logo/i,  // Wikipedia logo files
+  /Wiki-logo/i        // Variant wiki logos
+]
+
+function isLikelyLogo(url: string): boolean {
+  return LOGO_PATTERNS.some(p => p.test(url))
+}
+
+function isPlaceholderUrl(url: string): boolean {
+  return PLACEHOLDER_URL_PATTERNS.some(p => p.test(url))
+}
+
+/**
+ * Combined URL-level rejection: logo patterns + placeholder patterns + visual standards gate.
+ * Runs before any network requests.
+ */
+function isRejectedByGate(url: string): boolean {
+  if (isLikelyLogo(url)) return true
+  if (isPlaceholderUrl(url)) return true
+  const gateCheck = checkGateUrlPatterns(url)
+  if (!gateCheck.pass) {
+    console.log('[gate] URL rejected by visual standards:', gateCheck.reason)
+    return true
+  }
+  return false
+}
+
+// ========================================
+// Tier 2: Server-Side Image Validation
+// ========================================
+
+// Known-good image sources that bypass Tier 2 checks
+const KNOWN_GOOD_SOURCES = [
+  /img\.youtube\.com\/vi\//,
+  /i\.vimeocdn\.com\//,
+  /opengraph\.githubassets\.com\//,
+  /i\.scdn\.co\//,
+  /mosaic\.scdn\.co\//,
+  /image-cdn.*\.spotifycdn\.com\//,
+  /image\.tmdb\.org\//,
+  /m\.media-amazon\.com\//,
+  /images-na\.ssl-images-amazon\.com\//,
+  /covers\.openlibrary\.org\//
+]
+
+// Card context minimum dimensions
+const CARD_THRESHOLDS: Record<string, { minWidth: number, minHeight: number, maxAspect: number }> = {
+  grid:   { minWidth: 300, minHeight: 200, maxAspect: 3 },
+  hero:   { minWidth: 600, minHeight: 400, maxAspect: 2.5 },
+  thumb:  { minWidth: 100, minHeight: 100, maxAspect: 2 },
+  widget: { minWidth: 200, minHeight: 200, maxAspect: 2 }
+}
+
+// Valid image content types
+const VALID_IMAGE_TYPES = [
+  'image/jpeg', 'image/png', 'image/webp', 'image/avif', 'image/gif', 'image/svg+xml'
+]
+
+interface Tier2Result {
+  pass: boolean
+  reason?: string
+  scores: {
+    visual_quality: number
+    distinctiveness: number
+  }
+  checks: Array<{ check: string, pass: boolean, detail?: string }>
+  dimensions?: { width: number, height: number }
+  fileSize?: number
+  contentType?: string
+}
+
+/**
+ * Tier 2 server-side image validation.
+ * Uses HEAD request + optional partial download to check dimensions, format, and file size.
+ */
+async function validateImageTier2(imageUrl: string, cardContext: string = 'grid'): Promise<Tier2Result> {
+  const checks: Array<{ check: string, pass: boolean, detail?: string }> = []
+  let visualQuality = 1.0
+  let distinctiveness = 1.0
+  let dimensions: { width: number, height: number } | undefined
+  let fileSize: number | undefined
+  let contentType: string | undefined
+
+  // Known-good source bypass
+  if (KNOWN_GOOD_SOURCES.some(p => p.test(imageUrl))) {
+    checks.push({ check: 'known_good_source', pass: true, detail: 'trusted source' })
+    return {
+      pass: true,
+      scores: { visual_quality: 0.9, distinctiveness: 1.0 },
+      checks,
+      dimensions: undefined,
+      fileSize: undefined,
+      contentType: undefined
+    }
+  }
+
+  // Placeholder URL check
+  if (isPlaceholderUrl(imageUrl)) {
+    return {
+      pass: false,
+      reason: 'placeholder_url',
+      scores: { visual_quality: 0, distinctiveness: 0 },
+      checks: [{ check: 'placeholder_url', pass: false }]
+    }
+  }
+
+  // Visual standards gate — URL pattern check (ad networks, stock watermarks, data URIs)
+  const gateUrlCheck = checkGateUrlPatterns(imageUrl)
+  if (!gateUrlCheck.pass) {
+    checks.push({ check: 'visual_gate_url', pass: false, detail: gateUrlCheck.reason })
+    return {
+      pass: false,
+      reason: 'visual_gate_url_rejected',
+      scores: { visual_quality: 0, distinctiveness: 0 },
+      checks
+    }
+  }
+  checks.push({ check: 'visual_gate_url', pass: true })
+
+  try {
+    // HEAD request to get metadata without downloading full image
+    const headResponse = await fetch(imageUrl, {
+      method: 'HEAD',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; ctrl.rodeo image validator)',
+        'Accept': 'image/*'
+      }
+    })
+
+    // Check 1: Image loads (HTTP 200)
+    if (!headResponse.ok) {
+      checks.push({ check: 'http_status', pass: false, detail: `HTTP ${headResponse.status}` })
+      return {
+        pass: false,
+        reason: 'http_error',
+        scores: { visual_quality: 0, distinctiveness: 0 },
+        checks
+      }
+    }
+    checks.push({ check: 'http_status', pass: true })
+
+    // Check 2: Content-Type is an image
+    contentType = headResponse.headers.get('content-type')?.split(';')[0]?.trim() || ''
+    const isValidType = VALID_IMAGE_TYPES.some(t => contentType!.startsWith(t))
+    checks.push({ check: 'content_type', pass: isValidType, detail: contentType })
+    if (!isValidType) {
+      return {
+        pass: false,
+        reason: 'not_image',
+        scores: { visual_quality: 0, distinctiveness: 0 },
+        checks,
+        contentType
+      }
+    }
+
+    // Check 3: File size (from Content-Length header)
+    const contentLength = headResponse.headers.get('content-length')
+    if (contentLength) {
+      fileSize = parseInt(contentLength, 10)
+
+      // Too small — likely placeholder/pixel
+      if (fileSize < 5000) { // 5KB
+        visualQuality = Math.min(visualQuality, 0.1)
+        distinctiveness = Math.min(distinctiveness, 0.1)
+        checks.push({ check: 'file_size', pass: false, detail: `${fileSize} bytes (< 5KB minimum)` })
+      }
+      // Very small — suspicious but not definitive
+      else if (fileSize < 15000) { // 15KB
+        visualQuality = Math.min(visualQuality, 0.5)
+        checks.push({ check: 'file_size', pass: true, detail: `${fileSize} bytes (small but acceptable)` })
+      } else {
+        checks.push({ check: 'file_size', pass: true, detail: `${fileSize} bytes` })
+      }
+    } else {
+      checks.push({ check: 'file_size', pass: true, detail: 'no Content-Length header' })
+    }
+
+    // Check 4: Redirect detection — if final URL differs significantly, might be error page
+    const finalUrl = headResponse.url
+    if (finalUrl && finalUrl !== imageUrl) {
+      const finalLower = finalUrl.toLowerCase()
+      if (finalLower.includes('error') || finalLower.includes('404') || finalLower.includes('not-found')) {
+        checks.push({ check: 'redirect_check', pass: false, detail: `redirected to error page: ${finalUrl}` })
+        return {
+          pass: false,
+          reason: 'redirect_to_error',
+          scores: { visual_quality: 0, distinctiveness: 0 },
+          checks,
+          contentType,
+          fileSize
+        }
+      }
+      checks.push({ check: 'redirect_check', pass: true, detail: `redirected to ${finalUrl}` })
+    }
+
+    // Check 5: Try to extract dimensions by partial download (first 32KB for JPEG/PNG headers)
+    try {
+      const partialResponse = await fetch(imageUrl, {
+        headers: {
+          'Range': 'bytes=0-32768',
+          'User-Agent': 'Mozilla/5.0 (compatible; ctrl.rodeo image validator)',
+          'Accept': 'image/*'
+        }
+      })
+
+      if (partialResponse.ok || partialResponse.status === 206) {
+        const buffer = await partialResponse.arrayBuffer()
+        const bytes = new Uint8Array(buffer)
+        dimensions = extractDimensions(bytes, contentType!)
+
+        if (dimensions) {
+          // Visual standards gate — technical checks (min resolution, aspect ratio, file size)
+          const gateTechCheck = checkGateTechnical(dimensions, fileSize || null)
+          if (!gateTechCheck.pass) {
+            checks.push({ check: 'visual_gate_technical', pass: false, detail: gateTechCheck.reason })
+            return {
+              pass: false,
+              reason: 'visual_gate_technical_rejected',
+              scores: { visual_quality: 0, distinctiveness: 0 },
+              checks,
+              dimensions,
+              fileSize,
+              contentType
+            }
+          }
+          checks.push({ check: 'visual_gate_technical', pass: true, detail: `${dimensions.width}x${dimensions.height}` })
+
+          const thresholds = CARD_THRESHOLDS[cardContext] || CARD_THRESHOLDS.grid
+          const aspect = dimensions.width / dimensions.height
+
+          // Card-context-specific resolution check (stricter than gate for larger display contexts)
+          if (dimensions.width < 50 || dimensions.height < 50) {
+            visualQuality = 0
+            checks.push({ check: 'dimensions', pass: false, detail: `${dimensions.width}x${dimensions.height} (below absolute minimum 50px)` })
+          } else if (dimensions.width < thresholds.minWidth || dimensions.height < thresholds.minHeight) {
+            visualQuality = Math.min(visualQuality, 0.4)
+            checks.push({ check: 'dimensions', pass: false, detail: `${dimensions.width}x${dimensions.height} (below ${cardContext} minimum ${thresholds.minWidth}x${thresholds.minHeight})` })
+          } else {
+            checks.push({ check: 'dimensions', pass: true, detail: `${dimensions.width}x${dimensions.height}` })
+          }
+
+          // Aspect ratio check
+          if (aspect > thresholds.maxAspect || aspect < (1 / thresholds.maxAspect)) {
+            visualQuality = Math.min(visualQuality, 0.3)
+            checks.push({ check: 'aspect_ratio', pass: false, detail: `${aspect.toFixed(2)} (outside ${thresholds.maxAspect}:1 limit)` })
+          } else {
+            checks.push({ check: 'aspect_ratio', pass: true, detail: `${aspect.toFixed(2)}` })
+          }
+        } else {
+          checks.push({ check: 'dimensions', pass: true, detail: 'could not extract from headers' })
+        }
+      }
+    } catch (e) {
+      // Partial download failed — not critical, skip dimension checks
+      checks.push({ check: 'dimensions', pass: true, detail: 'partial download failed, skipping' })
+    }
+
+  } catch (e) {
+    checks.push({ check: 'network', pass: false, detail: (e as Error).message })
+    return {
+      pass: false,
+      reason: 'network_error',
+      scores: { visual_quality: 0, distinctiveness: 0 },
+      checks
+    }
+  }
+
+  const pass = visualQuality > 0 && distinctiveness > 0
+
+  return {
+    pass,
+    reason: !pass ? 'below_quality_threshold' : undefined,
+    scores: { visual_quality: visualQuality, distinctiveness },
+    checks,
+    dimensions,
+    fileSize,
+    contentType
+  }
+}
+
+/**
+ * Extract image dimensions from the first bytes of an image file.
+ * Supports JPEG (SOF markers) and PNG (IHDR chunk).
+ */
+function extractDimensions(bytes: Uint8Array, contentType: string): { width: number, height: number } | null {
+  // PNG: width/height at bytes 16-23 in IHDR
+  if (contentType.includes('png') && bytes.length >= 24) {
+    if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4E && bytes[3] === 0x47) {
+      const width = (bytes[16] << 24) | (bytes[17] << 16) | (bytes[18] << 8) | bytes[19]
+      const height = (bytes[20] << 24) | (bytes[21] << 16) | (bytes[22] << 8) | bytes[23]
+      if (width > 0 && height > 0 && width < 100000 && height < 100000) {
+        return { width, height }
+      }
+    }
+  }
+
+  // JPEG: scan for SOF0 (0xFFC0) or SOF2 (0xFFC2) marker
+  if (contentType.includes('jpeg') || contentType.includes('jpg')) {
+    for (let i = 0; i < bytes.length - 9; i++) {
+      if (bytes[i] === 0xFF && (bytes[i + 1] === 0xC0 || bytes[i + 1] === 0xC2)) {
+        const height = (bytes[i + 5] << 8) | bytes[i + 6]
+        const width = (bytes[i + 7] << 8) | bytes[i + 8]
+        if (width > 0 && height > 0 && width < 100000 && height < 100000) {
+          return { width, height }
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+// Search for image using Unsplash API
+// searchImage removed — Unsplash search strategy deprecated (no API key, generic results)
+
+// Get high-res favicon
+async function resolveFavicon(url: string): Promise<{ url: string, source: 'favicon' } | null> {
+  try {
+    const domain = new URL(url).hostname
+    // Use Google's favicon service for high-res icons
+    const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=128`
+
+    // Verify it exists
+    const response = await fetch(faviconUrl, { method: 'HEAD' })
+    if (response.ok) {
+      return { url: faviconUrl, source: 'favicon' }
+    }
+  } catch (e) {
+    console.error('[favicon] Error:', e)
+  }
+
+  return null
+}
+
+// Search for image using SerpApi Google Images
+async function searchImageSerpApi(
+  url: string,
+  title: string,
+  description: string
+): Promise<{ url: string, source: 'scraped' } | null> {
+  const serpApiKey = Deno.env.get('SERP_API_KEY')
+  if (!serpApiKey) {
+    console.log('[search] SERP_API_KEY not configured, skipping')
+    return null
+  }
+
+  try {
+    // Build search query: prefer title, fall back to domain
+    const query = title && title.length > 3
+      ? title
+      : new URL(url).hostname.replace('www.', '')
+
+    console.log('[search] SerpApi Google Images query:', query)
+
+    const params = new URLSearchParams({
+      api_key: serpApiKey,
+      engine: 'google_images',
+      q: query,
+      num: '5'
+    })
+
+    const response = await fetch(`https://serpapi.com/search?${params}`)
+    if (!response.ok) {
+      console.log('[search] SerpApi returned', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const results = data.images_results || []
+
+    if (results.length === 0) {
+      console.log('[search] No image results for:', query)
+      return null
+    }
+
+    // Find first result with a full-res original URL
+    for (const result of results) {
+      const imageUrl = result.original
+      if (imageUrl && imageUrl.startsWith('http')) {
+        console.log('[search] Found image via SerpApi:', imageUrl)
+        return { url: imageUrl, source: 'scraped' }
+      }
+    }
+
+    console.log('[search] No usable image URLs in results')
+    return null
+  } catch (e) {
+    console.error('[search] SerpApi error:', e)
+    return null
+  }
+}
+
+// ========================================
+// Tier 3: AI Vision Quality Gate
+// ========================================
+
+// Known-good sources skip AI evaluation entirely
+const KNOWN_GOOD_SOURCES_T3 = [
+  /img\.youtube\.com\/vi\//,
+  /i\.vimeocdn\.com\//,
+  /opengraph\.githubassets\.com\//,
+  /i\.scdn\.co\//,
+  /mosaic\.scdn\.co\//,
+  /image\.tmdb\.org\//,
+  /m\.media-amazon\.com\//,
+  /images-na\.ssl-images-amazon\.com\//,
+  /covers\.openlibrary\.org\//
+]
+
+const TIER3_WEIGHTS = {
+  accuracy: 0.35,
+  visual_quality: 0.25,
+  aesthetic_fit: 0.20,
+  distinctiveness: 0.15,
+  safety: 0.05
+}
+
+function computeTier3Composite(scores: Record<string, number>): number {
+  if (scores.safety === 0) return 0
+  return (
+    (scores.accuracy || 0) * TIER3_WEIGHTS.accuracy +
+    (scores.visual_quality || 0) * TIER3_WEIGHTS.visual_quality +
+    (scores.aesthetic_fit || 0) * TIER3_WEIGHTS.aesthetic_fit +
+    (scores.distinctiveness || 0) * TIER3_WEIGHTS.distinctiveness +
+    (scores.safety || 1) * TIER3_WEIGHTS.safety
+  )
+}
+
+function getTier3Label(composite: number): string {
+  if (composite >= 0.85) return 'excellent'
+  if (composite >= 0.65) return 'good'
+  if (composite >= 0.40) return 'marginal'
+  if (composite >= 0.15) return 'poor'
+  return 'rejected'
+}
+
+interface Tier3Result {
+  scores: Record<string, any>
+  tier: string
+  safety_tier: string
+  reason?: string
+}
+
+async function evaluateImageQuality(
+  imageUrl: string,
+  title: string,
+  category: string,
+  contentType: string
+): Promise<Tier3Result | null> {
+  // Known-good sources get automatic high scores
+  if (KNOWN_GOOD_SOURCES_T3.some(p => p.test(imageUrl))) {
+    console.log('[tier3] Known-good source, bypassing AI:', imageUrl)
+    const scores = {
+      accuracy: 0.9, visual_quality: 0.9, aesthetic_fit: 0.8,
+      distinctiveness: 1.0, safety: 1.0
+    }
+    const composite = computeTier3Composite(scores)
+    return {
+      scores: { ...scores, composite: Math.round(composite * 100) / 100, tier: getTier3Label(composite) },
+      tier: getTier3Label(composite),
+      safety_tier: 'safe'
+    }
+  }
+
+  // Budget check — share the daily budget with validate-image
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+  const today = new Date().toISOString().split('T')[0]
+  try {
+    const { data } = await supabase
+      .from('image_validation_cache')
+      .select('scores')
+      .gte('evaluated_at', `${today}T00:00:00Z`)
+    const todayCount = data?.length || 0
+    const estimatedCostCents = todayCount * 0.1
+    if (estimatedCostCents >= 50) { // $0.50/day budget
+      console.log('[tier3] Daily budget exhausted, passing through')
+      return null // null = pass through (don't block)
+    }
+  } catch (e) {
+    console.log('[tier3] Budget check failed, passing through')
+    return null
+  }
+
+  // Check cache first
+  const urlHash = await hashImageUrl(imageUrl)
+  try {
+    const { data: cached } = await supabase
+      .from('image_validation_cache')
+      .select('*')
+      .eq('image_url_hash', urlHash)
+      .single()
+    if (cached && cached.scores) {
+      console.log('[tier3] Cache hit:', imageUrl)
+      return {
+        scores: cached.scores,
+        tier: cached.scores.tier || 'unknown',
+        safety_tier: cached.scores.safety_tier || 'safe'
+      }
+    }
+  } catch {
+    // No cache entry, continue to AI evaluation
+  }
+
+  // AI Vision evaluation
+  const prompt = `Evaluate this image for a pin titled "${title || 'Unknown'}" (category: ${category || 'unknown'}, type: ${contentType || 'unknown'}).
+
+Score each dimension from 0.0 to 1.0:
+
+1. accuracy: Does this image depict "${title || 'the content'}"? 1.0 = clearly shows the specific item/content. 0.0 = completely unrelated.
+
+2. aesthetic_fit: Is the image visually clean, high-contrast, and minimal? 1.0 = editorial quality, no text overlays or watermarks. 0.0 = heavy watermarks, all-text image, extreme visual clutter.
+
+3. distinctiveness: Is this a real, content-specific image (not a logo, favicon, stock placeholder, or generic site asset)? 1.0 = unique content image. 0.0 = logo/placeholder.
+
+4. safety: Content safety classification. Use one of:
+   - "safe": General content, no concerns
+   - "mature": Contains nudity, graphic language, drug references, or mature themes (ALLOWED — do not block)
+   - "blocked": Pornographic content (explicit sexual acts), child exploitation, or extreme gore (BLOCKED)
+   IMPORTANT: Artistic nudity, fashion photography, swimwear, and lingerie are "mature" NOT "blocked". Only classify as "blocked" for exploitative, illegal, or explicitly pornographic content.
+
+Respond with ONLY this JSON, no other text:
+{"accuracy": 0.0, "aesthetic_fit": 0.0, "distinctiveness": 0.0, "safety": "safe"}`
+
+  // Try Claude first, then OpenAI
+  const anthropicKey = Deno.env.get('ANTHROPIC_API_KEY')
+  const openaiKey = Deno.env.get('OPENAI_API_KEY')
+
+  let aiResult: { scores: Record<string, number>, safety_tier: string, model: string, tokens_used: number } | null = null
+
+  if (anthropicKey) {
+    try {
+      const response = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': anthropicKey,
+          'anthropic-version': '2023-06-01'
+        },
+        body: JSON.stringify({
+          model: 'claude-sonnet-4-5-20250929',
+          max_tokens: 300,
+          messages: [{
+            role: 'user',
+            content: [
+              { type: 'image', source: { type: 'url', url: imageUrl } },
+              { type: 'text', text: prompt }
+            ]
+          }]
+        })
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        const text = data.content?.[0]?.text || ''
+        const tokensUsed = (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)
+        aiResult = parseTier3Response(text, 'claude-sonnet-4-5-20250929', tokensUsed)
+      } else {
+        console.error('[tier3] Claude API error:', response.status)
+      }
+    } catch (e) {
+      console.error('[tier3] Claude evaluation error:', e)
+    }
+  }
+
+  if (!aiResult && openaiKey) {
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${openaiKey}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          max_tokens: 300,
+          messages: [{
+            role: 'user',
+            content: [
+              { type: 'image_url', image_url: { url: imageUrl, detail: 'low' } },
+              { type: 'text', text: prompt }
+            ]
+          }]
+        })
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        const text = data.choices?.[0]?.message?.content || ''
+        const tokensUsed = (data.usage?.prompt_tokens || 0) + (data.usage?.completion_tokens || 0)
+        aiResult = parseTier3Response(text, 'gpt-4o-mini', tokensUsed)
+      } else {
+        console.error('[tier3] OpenAI API error:', response.status)
+      }
+    } catch (e) {
+      console.error('[tier3] OpenAI evaluation error:', e)
+    }
+  }
+
+  if (!aiResult) {
+    console.log('[tier3] No AI result available, passing through')
+    return null
+  }
+
+  // Compute composite and tier
+  const composite = computeTier3Composite(aiResult.scores)
+  const tier = getTier3Label(composite)
+  const fullScores = {
+    ...aiResult.scores,
+    composite: Math.round(composite * 100) / 100,
+    tier,
+    safety_tier: aiResult.safety_tier,
+    evaluated_at: new Date().toISOString(),
+    evaluation_method: 'tier3_ai_vision',
+    evaluation_model: aiResult.model
+  }
+
+  // Cache the result
+  try {
+    await supabase
+      .from('image_validation_cache')
+      .upsert({
+        image_url_hash: urlHash,
+        image_url: imageUrl,
+        scores: fullScores,
+        evaluated_at: new Date().toISOString(),
+        ttl_days: 30,
+        source_domain: new URL(imageUrl).hostname.replace('www.', ''),
+        content_type: contentType || null
+      })
+  } catch (e) {
+    console.error('[tier3] Cache write error:', e)
+  }
+
+  console.log('[tier3] Evaluated:', imageUrl, '→', tier, `(${composite.toFixed(2)})`)
+
+  return {
+    scores: fullScores,
+    tier,
+    safety_tier: aiResult.safety_tier,
+    reason: tier === 'rejected' || tier === 'poor'
+      ? `${tier}: accuracy=${aiResult.scores.accuracy}, aesthetic_fit=${aiResult.scores.aesthetic_fit}, distinctiveness=${aiResult.scores.distinctiveness}`
+      : undefined
+  }
+}
+
+function parseTier3Response(text: string, model: string, tokensUsed: number) {
+  try {
+    const match = text.match(/\{[\s\S]*\}/)
+    if (!match) return null
+
+    const parsed = JSON.parse(match[0])
+    const safetyTier = ['safe', 'mature', 'blocked'].includes(parsed.safety) ? parsed.safety : 'safe'
+    const safetyScore = safetyTier === 'blocked' ? 0 : 1
+    const clamp = (v: number) => Math.max(0, Math.min(1, Number(v) || 0))
+
+    return {
+      scores: {
+        accuracy: clamp(parsed.accuracy),
+        visual_quality: 0.9, // Tier 2 already validated
+        aesthetic_fit: clamp(parsed.aesthetic_fit),
+        distinctiveness: clamp(parsed.distinctiveness),
+        safety: safetyScore
+      },
+      safety_tier: safetyTier,
+      model,
+      tokens_used: tokensUsed
+    }
+  } catch {
+    return null
+  }
+}
+
+async function hashImageUrl(url: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(url.toLowerCase().trim())
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  return hashArray.map(b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/supabase/functions/generate-widget/config/visual-standards.ts
+++ b/supabase/functions/generate-widget/config/visual-standards.ts
@@ -5,7 +5,7 @@
 //   Layer 2: Category Aesthetic — mood/palette per board category (home, wear, listen, etc.)
 //
 // Usage:
-//   - enrich-link: Gate rejects bad images, type + category scores rank candidates
+//   - create-pin: Gate rejects bad images, type + category scores rank candidates
 //   - generate-widget: Category context shapes AI prompt tone and recommendations
 
 // =============================================================================

--- a/supabase/functions/instagram-import/index.ts
+++ b/supabase/functions/instagram-import/index.ts
@@ -16,6 +16,9 @@
 //
 // Returns: { source_pin, derived_pins[], transcript?, entities[], cost_estimate }
 
+const VERSION = '1.1.0'
+console.log(`[instagram-import] v${VERSION} - enhanced extraction + parallel resolution`)
+
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
 const corsHeaders = {
@@ -293,8 +296,16 @@ Return ONLY valid JSON, no markdown fences:
   "expected_count": 8,
   "entities": [...],
   "post_category": "eat|go|wear|watch|listen|use|follow|read",
-  "post_summary": "one sentence summary"
-}`
+  "post_summary": "one sentence summary",
+  "practical_tags": ["3-8 objective factual tags classifying the content, e.g. restaurant, fine_dining, italian, nyc"],
+  "taste_tags": ["3-8 subjective aesthetic/vibe tags, e.g. upscale, romantic, cozy, modern"],
+  "content_structure": "original_expression|curated_collection|summary|review|reference"
+}
+
+Tag guidelines:
+- practical_tags: objective, factual, searchable. What IS this content about. Use lowercase, underscores for multi-word.
+- taste_tags: subjective aesthetic/cultural/vibe. What does this FEEL like. Use lowercase, underscores for multi-word.
+- content_structure: how the content is organized — "summary" for top-N lists, "review" for opinions, "curated_collection" for aggregations, "original_expression" for creator's own work, "reference" for informational.`
 
 async function extractEntities(reel: ReelData, transcript: string | null): Promise<ExtractionResult> {
   const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
@@ -445,13 +456,28 @@ Pick the URL that is the OFFICIAL or CANONICAL source for this entity. Prefer:
 - brand: official brand website (not aggregators or review sites)
 - product: brand's own product page (not homepage) > specific retailer listing (not retailer homepage)
 - person/follow: if the entity is a specific piece of content by a person, prefer the direct URL for that content; if the entity is the person themselves, prefer Instagram profile > personal website > LinkedIn
+- book: Open Library > Goodreads > Amazon book page
+- event: Official event page > Eventbrite > venue website
 
-Specificity: when the entity refers to a specific piece of content, prefer the direct URL for that content over the creator's profile or channel page. Examples: specific YouTube video over channel, specific article over blog homepage, specific podcast episode over show page, specific product listing over brand homepage, specific recipe page over food blog. If the entity IS the creator/channel/brand itself (not a specific piece of their content), then the profile or homepage is correct.
+## Domain Authority Scoring
+Score each candidate URL's authority:
+- Authoritative (0.9+): google.com/maps, yelp.com, spotify.com, openlibrary.org, brand's own domain, official product pages
+- Good (0.7): well-known review sites, Wikipedia, major retailers with specific product pages
+- Weak (0.4): unknown blogs, aggregator sites, social media mentions, listicles
+- Bad (0.2): wrong entity type (e.g., a blog post when we need a place)
+
+## Primary Source Validation
+The URL must ACTUALLY BE the entity, not just mention it. For example:
+- A restaurant entity should resolve to the restaurant's Google Maps page or official website, NOT a blog post reviewing it
+- A product should resolve to where you can buy/view it, NOT an article about it
+- A song should resolve to where you can listen to it, NOT a review
+
+Specificity: when the entity refers to a specific piece of content, prefer the direct URL for that content over the creator's profile or channel page.
 
 If none of the URLs match the entity well, set selected_url to null.
 
 Return ONLY a valid JSON array, no markdown fences:
-[{"entity_index": 0, "selected_url": "https://...", "match_quality": 0.95}]`
+[{"entity_index": 0, "selected_url": "https://...", "match_quality": 0.95, "is_primary_source": true}]`
 
 async function selectBestUrls(
   entities: { index: number; name: string; type: string; category: string; location_hint: string | null; results: SearchResult[] }[]
@@ -506,6 +532,46 @@ async function selectBestUrls(
   }
 }
 
+// Match validation: score how well a resolved URL matches the entity
+function validateResolution(entity: Entity, resolvedUrl: string): number {
+  if (!resolvedUrl) return 0
+  try {
+    const urlDomain = new URL(resolvedUrl).hostname.replace('www.', '')
+
+    // Domain authority for entity type
+    let authorityScore = 0.5
+    const type = entity.type
+    if (type === 'place' || type === 'food') {
+      if (urlDomain.includes('google.com') || urlDomain.includes('maps.google')) authorityScore = 1.0
+      else if (urlDomain.includes('yelp.com') || urlDomain.includes('tripadvisor.com') || urlDomain.includes('opentable.com')) authorityScore = 0.85
+      else if (urlDomain.includes('instagram.com') || urlDomain.includes('facebook.com')) authorityScore = 0.4
+    } else if (type === 'song') {
+      if (urlDomain.includes('spotify.com') || urlDomain.includes('music.apple.com')) authorityScore = 1.0
+      else if (urlDomain.includes('soundcloud.com') || urlDomain.includes('youtube.com')) authorityScore = 0.8
+    } else if (type === 'product') {
+      // Brand's own domain is authoritative
+      const brandName = entity.name.toLowerCase().replace(/[^a-z0-9]/g, '')
+      if (urlDomain.includes(brandName)) authorityScore = 0.9
+      else if (urlDomain.includes('amazon.com') || urlDomain.includes('nordstrom.com')) authorityScore = 0.7
+    } else if (type === 'book') {
+      if (urlDomain.includes('openlibrary.org') || urlDomain.includes('goodreads.com')) authorityScore = 0.9
+      else if (urlDomain.includes('amazon.com')) authorityScore = 0.7
+    } else if (type === 'brand') {
+      const brandName = entity.name.toLowerCase().replace(/[^a-z0-9]/g, '')
+      if (urlDomain.includes(brandName)) authorityScore = 1.0
+    }
+
+    // Name match: check if entity name appears in URL path
+    const nameTokens = entity.name.toLowerCase().split(/\s+/).filter(t => t.length > 2)
+    const urlPath = new URL(resolvedUrl).pathname.toLowerCase()
+    const nameInUrl = nameTokens.filter(t => urlPath.includes(t)).length / Math.max(nameTokens.length, 1)
+
+    return 0.6 * authorityScore + 0.4 * nameInUrl
+  } catch {
+    return 0
+  }
+}
+
 async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<Entity[]> {
   // Phase 1: Classify entities
   const toResolve: Entity[] = []
@@ -521,14 +587,21 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
     }
   }
 
-  // Phase 2: Search DDG for each entity (serial, rate-limited)
+  // Phase 2: Search DDG for each entity (parallel, concurrency-limited to 3)
   const searchResults = new Map<number, SearchResult[]>()
-  for (let i = 0; i < toResolve.length; i++) {
-    const query = buildSearchQuery(toResolve[i])
-    const results = await searchDuckDuckGo(query)
-    searchResults.set(i, results)
-    console.log(`[instagram-import] DDG: ${toResolve[i].name} -> ${results.length} results`)
-    if (i < toResolve.length - 1) await new Promise(r => setTimeout(r, 500))
+  const CONCURRENCY = 3
+  for (let batch = 0; batch < toResolve.length; batch += CONCURRENCY) {
+    const chunk = toResolve.slice(batch, batch + CONCURRENCY)
+    const promises = chunk.map(async (entity, offset) => {
+      const i = batch + offset
+      const query = buildSearchQuery(entity)
+      const results = await searchDuckDuckGo(query)
+      searchResults.set(i, results)
+      console.log(`[instagram-import] DDG: ${entity.name} -> ${results.length} results`)
+    })
+    await Promise.allSettled(promises)
+    // Brief pause between batches to avoid rate limiting
+    if (batch + CONCURRENCY < toResolve.length) await new Promise(r => setTimeout(r, 300))
   }
 
   // Phase 3: Batch Claude call to pick best URL per entity
@@ -538,7 +611,7 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
 
   const selections = forSelection.length > 0 ? await selectBestUrls(forSelection) : new Map()
 
-  // Phase 4: Apply selections, fall back to first DDG result
+  // Phase 4: Apply selections with validation scoring
   for (let i = 0; i < toResolve.length; i++) {
     const entity = toResolve[i]
     const results = searchResults.get(i) || []
@@ -547,18 +620,26 @@ async function resolveAllEntities(entities: Entity[], reel: ReelData): Promise<E
     if (selection?.url) {
       entity.resolved_url = selection.url
       entity.resolved_via = 'duckduckgo+claude'
-      entity.match_quality = selection.quality
+      // Two-dimensional confidence: match_quality from Claude, validated by domain authority
+      const validationScore = validateResolution(entity, selection.url)
+      entity.match_quality = Math.round(((selection.quality * 0.5 + validationScore * 0.5)) * 100) / 100
     } else if (results.length > 0) {
       entity.resolved_url = results[0].url
       entity.resolved_via = 'duckduckgo-first'
-      entity.match_quality = 0
+      entity.match_quality = Math.round(validateResolution(entity, results[0].url) * 0.5 * 100) / 100
     } else {
       entity.resolved_url = null
       entity.resolved_via = null
       entity.match_quality = 0
     }
 
-    console.log(`[instagram-import] Resolved: ${entity.name} -> ${entity.resolved_url || 'NOT FOUND'} (${entity.resolved_via})`)
+    // Update status based on two-dimensional confidence: min(extraction, resolution)
+    const overallConfidence = Math.min(entity.confidence, entity.match_quality || 0)
+    if (entity.resolved_url) {
+      entity.status = overallConfidence >= 0.7 ? 'auto' : 'review'
+    }
+
+    console.log(`[instagram-import] Resolved: ${entity.name} -> ${entity.resolved_url || 'NOT FOUND'} (${entity.resolved_via}, quality: ${entity.match_quality})`)
   }
 
   // Phase 5: Enhanced music resolution (Spotify + AudD multi-track)
@@ -989,6 +1070,11 @@ function createPins(
     type_confidence: 1.0,
     source: 'social',
     source_id: 'instagram',
+    // Sense-making fields
+    entities: extraction.entities,
+    practical_tags: (extraction as any).practical_tags || [],
+    taste_tags: (extraction as any).taste_tags || [],
+    content_structure: (extraction as any).content_structure || 'summary',
     instagram: {
       shortcode: reel.shortcode,
       media_type: 'reel',
@@ -1081,13 +1167,29 @@ serve(async (req) => {
       // Step 2: Transcribe audio
       const transcript = await transcribeAudio(reel)
 
-      // Step 3: Extract entities
-      const extraction = await extractEntities(reel, transcript)
+      // Step 3: Extract entities (with verification retry)
+      let extraction = await extractEntities(reel, transcript)
       const expectedCount = (extraction as Record<string, unknown>).expected_count as number | undefined
-      if (expectedCount && extraction.entities.length < expectedCount) {
-        console.warn(`[instagram-import] Extraction gap: expected ${expectedCount}, found ${extraction.entities.length} entities`)
-      }
       console.log(`[instagram-import] Found ${extraction.entities.length} entities (expected: ${expectedCount ?? 'unknown'})`)
+
+      // Verification: retry once if significant count gap
+      if (expectedCount && expectedCount > 0 && extraction.entities.length < expectedCount * 0.7) {
+        console.warn(`[instagram-import] Extraction gap: expected ${expectedCount}, found ${extraction.entities.length}. Retrying...`)
+        try {
+          const retry = await extractEntities(reel, transcript)
+          // Merge new entities (dedup by name similarity)
+          const existingNames = new Set(extraction.entities.map(e => e.name.toLowerCase()))
+          for (const entity of retry.entities) {
+            if (!existingNames.has(entity.name.toLowerCase())) {
+              extraction.entities.push(entity)
+              existingNames.add(entity.name.toLowerCase())
+            }
+          }
+          console.log(`[instagram-import] After retry: ${extraction.entities.length} entities (was ${extraction.entities.length - retry.entities.filter(e => !existingNames.has(e.name.toLowerCase())).length})`)
+        } catch (retryErr) {
+          console.warn('[instagram-import] Retry failed:', (retryErr as Error).message)
+        }
+      }
 
       // Step 4: Resolve entities
       extraction.entities = await resolveAllEntities(extraction.entities, reel)
@@ -1111,6 +1213,9 @@ serve(async (req) => {
           unresolved_entities: unresolvedEntities,
           post_category: extraction.post_category,
           post_summary: extraction.post_summary,
+          practical_tags: (extraction as any).practical_tags || [],
+          taste_tags: (extraction as any).taste_tags || [],
+          content_structure: (extraction as any).content_structure || null,
           stats: {
             elapsed_seconds: parseFloat(elapsed),
             entities_found: extraction.entities.length,

--- a/supabase/migrations/028_sense_making_columns.sql
+++ b/supabase/migrations/028_sense_making_columns.sql
@@ -1,0 +1,35 @@
+-- Migration 028: Sense-Making & Pin Creation Agent schema
+--
+-- Adds columns needed by the three-function architecture:
+--   analyze-content (sense-making): entities, practical_tags, taste_tags, content_structure
+--   create-pin (pin creation): hero_score
+--   instagram-import (provenance): instagram, extraction, source_url
+--
+-- These enable:
+--   - 6-dimension pin classification (content_type, entity_type, category, structure, practical, taste)
+--   - Primary source validation (extraction.source_mismatch)
+--   - Taste graph modeling (taste_tags weighted 4x in TF-IDF)
+--   - Entity-based pin relationships (shared entities = clustering signal)
+
+-- Sense-Making columns
+ALTER TABLE links ADD COLUMN IF NOT EXISTS entities JSONB DEFAULT NULL;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS practical_tags TEXT[] DEFAULT '{}';
+ALTER TABLE links ADD COLUMN IF NOT EXISTS taste_tags TEXT[] DEFAULT '{}';
+ALTER TABLE links ADD COLUMN IF NOT EXISTS content_structure TEXT DEFAULT NULL;
+
+-- Pin Creation columns
+ALTER TABLE links ADD COLUMN IF NOT EXISTS hero_score REAL DEFAULT NULL;
+
+-- Provenance columns (instagram-import)
+ALTER TABLE links ADD COLUMN IF NOT EXISTS instagram JSONB DEFAULT NULL;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS extraction JSONB DEFAULT NULL;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS source_url TEXT DEFAULT NULL;
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_links_practical_tags ON links USING GIN (practical_tags);
+CREATE INDEX IF NOT EXISTS idx_links_taste_tags ON links USING GIN (taste_tags);
+CREATE INDEX IF NOT EXISTS idx_links_source_url ON links (source_url) WHERE source_url IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_links_content_structure ON links (content_structure) WHERE content_structure IS NOT NULL;
+
+-- Composite index for entity-based queries (find pins with entities)
+CREATE INDEX IF NOT EXISTS idx_links_entities ON links USING GIN (entities) WHERE entities IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Three-function architecture**: Split monolithic `enrich-link` into `analyze-content` (sense-making) + `create-pin` (image/metadata) + `instagram-import` (platform adapter)
- **New `analyze-content` edge function**: Content classification, entity extraction, practical + taste tagging, content structure analysis — reusable for all URLs
- **Enhanced Instagram extraction**: Parallel DDG search, domain authority scoring, two-dimensional confidence (extraction x resolution), extraction verification retry
- **New DB schema**: 8 columns + 5 indexes for entities, practical_tags, taste_tags, content_structure, hero_score, instagram, extraction, source_url
- **Two-step enrichment flow**: Client calls analyze-content first (classification + tags), then create-pin (image + metadata)
- **Review modal**: Shows sense-making tags (practical + taste + structure) on Instagram import review

## Key Changes

| File | Change |
|------|--------|
| `supabase/functions/analyze-content/index.ts` | NEW — sense-making agent |
| `supabase/functions/create-pin/index.ts` | RENAMED from enrich-link, classification removed |
| `supabase/functions/instagram-import/index.ts` | Enhanced extraction + validation |
| `supabase/migrations/028_sense_making_columns.sql` | NEW — schema migration |
| `boards/index.html` | Two-step flow, new field sync, review modal tags |
| `extension/chrome/lib/supabase.js` | Fetch URL update |
| `js/image-enrichment.js` | Fetch URL update |

## Test plan

- [ ] Run migration 028 against Supabase
- [ ] Deploy `create-pin`, `analyze-content`, `instagram-import` functions
- [ ] Verify manual URL enrichment: analyze-content fires -> create-pin fires -> all fields populated
- [ ] Verify Instagram import: entities extracted with practical_tags/taste_tags, review modal shows tags
- [ ] Verify Chrome extension still calls create-pin correctly
- [ ] Backward compat: existing pins render normally, `tags` field computed from practical + taste

> Phases 3-4 (hero scoring + taste map integration) planned for follow-up sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)