### PR TITLE
fix: add docs/ layout routing to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ Slash commands (`/plan /arch /capture /ux /branch /cleanup /pm`): `.claude/agent
 
 ---
 
+**Docs layout:** `docs/strategy/prds/` (PRDs) | `docs/infrastructure/technical-design/` (tech specs) | `docs/execution/project-plan/` (plans) | `docs/ux/` (UX docs) | `*/archive/` (archived)
+
 ## Reference
 - [Brand Positioning](./docs/strategy/brand-positioning.md) | [Personas](./docs/ux/personas.md)
 - [Project Plan](./docs/execution/project-plan/index.md) | [Backlog](./docs/execution/project-plan/backlog.md) | [Bugs](./docs/execution/BUGS.md)


### PR DESCRIPTION
## Summary
- Adds one-line docs directory map so agents know where to create/find PRDs, tech specs, plans, and UX docs
- This routing info was in the original CLAUDE.md but got cut during the 80% trim — it's not available in any single destination file

Still 79% smaller than original (5,697 vs 27,575 chars).

## Test plan
- [ ] Agent can find correct path for new PRD creation
- [ ] Agent can find correct path for tech spec creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)