### PR TITLE
fix(extension): error handling, token refresh, and popup timeout

### DIFF
--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -90,13 +90,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
   if (msg.action === 'save') {
     // Popup requesting a save
-    savePin(msg.data).then(sendResponse);
+    savePin(msg.data)
+      .then(sendResponse)
+      .catch(e => {
+        console.error('[rodeo] save crashed:', e.message);
+        sendResponse({ error: 'save_failed', detail: e.message });
+      });
     return true; // async response
   }
 
   if (msg.action === 'get_session') {
     // Popup checking auth state
-    getSession().then(sendResponse);
+    getSession()
+      .then(sendResponse)
+      .catch(() => sendResponse(null));
     return true;
   }
 
@@ -113,7 +120,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           domain: extractDomain(tab.url)
         });
       }
-    });
+    }).catch(() => sendResponse({ error: 'unsupported_page' }));
     return true;
   }
 
@@ -205,25 +212,46 @@ async function savePin({ url, title, selectedText, source }) {
   };
 
   // Insert with merge-duplicates (same Prefer header as boards/index.html:12441)
-  const res = await supabasePost('/rest/v1/links', payload, accessToken, {
-    'Prefer': 'resolution=merge-duplicates'
-  });
+  let res;
+  try {
+    res = await supabasePost('/rest/v1/links', payload, accessToken, {
+      'Prefer': 'resolution=merge-duplicates'
+    });
+  } catch (e) {
+    console.error('[rodeo] save network error:', e.message);
+    return { error: 'save_failed', detail: e.message };
+  }
 
   if (!res.ok) {
     const errBody = await res.text();
     console.error('[rodeo] save failed:', res.status, errBody);
 
-    // If a column is unrecognized (schema cache), retry without it
+    // 401/403 = token expired — clear cached session so next attempt re-auths
+    if (res.status === 401 || res.status === 403) {
+      await clearCachedSession();
+      try { await chrome.storage.local.remove(SESSION_CACHE_KEY); } catch {}
+      return { error: 'not_authenticated' };
+    }
+
+    // If a column is unrecognized (schema cache), retry without it (up to 5)
+    let schemaRetries = 0;
     if (errBody.includes('schema cache')) {
-      const colMatch = errBody.match(/Could not find the '(\w+)' column/);
-      if (colMatch) {
+      while (schemaRetries < 5) {
+        const colMatch = errBody.match(/Could not find the '(\w+)' column/);
+        if (!colMatch) break;
         delete payload[colMatch[1]];
-        const retry = await supabasePost('/rest/v1/links', payload, accessToken, {
-          'Prefer': 'resolution=merge-duplicates'
-        });
-        if (retry.ok) {
-          triggerEnrichment({ url: canonical, title: pinTitle, linkId: pinId });
-          return { success: true, pinId };
+        schemaRetries++;
+        try {
+          const retry = await supabasePost('/rest/v1/links', payload, accessToken, {
+            'Prefer': 'resolution=merge-duplicates'
+          });
+          if (retry.ok) {
+            triggerEnrichment({ url: canonical, title: pinTitle, linkId: pinId });
+            return { success: true, pinId };
+          }
+        } catch (e) {
+          console.error('[rodeo] retry network error:', e.message);
+          return { error: 'save_failed', detail: e.message };
         }
       }
     }

--- a/extension/chrome/lib/auth.js
+++ b/extension/chrome/lib/auth.js
@@ -62,35 +62,72 @@ async function readSessionFromTab() {
   }
 }
 
-// Get a valid session — checks cache first, then tries tab injection
+// Try to refresh an expired session using the refresh_token
+async function tryRefreshToken(session) {
+  if (!session || !session.refresh_token) return null;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=refresh_token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_ANON_KEY
+      },
+      body: JSON.stringify({ refresh_token: session.refresh_token })
+    });
+    if (!res.ok) return null;
+    const refreshed = await res.json();
+    if (refreshed.access_token && refreshed.user) {
+      const newSession = { ...session, ...refreshed };
+      await cacheSession(newSession);
+      await chrome.storage.local.set({ [SESSION_CACHE_KEY]: newSession });
+      console.log('[rodeo] token refreshed successfully');
+      return newSession;
+    }
+    return null;
+  } catch (e) {
+    console.warn('[rodeo] token refresh failed:', e.message);
+    return null;
+  }
+}
+
+// Get a valid session — checks cache first, then tries refresh, then tab injection
 async function getSession() {
-  // 1. Check cache
+  // 1. Check in-memory cache
   const cached = await getCachedSession();
-  if (cached) return cached;
+  if (cached && isTokenValid(cached.access_token)) return cached;
 
   // 2. Check chrome.storage.local (set by content script relay)
+  let localSession = null;
   try {
     const local = await chrome.storage.local.get(SESSION_CACHE_KEY);
     if (local[SESSION_CACHE_KEY]) {
-      const session = local[SESSION_CACHE_KEY];
-      // Validate token is not expired (JWT exp claim)
-      if (isTokenValid(session.access_token)) {
-        await cacheSession(session);
-        return session;
+      localSession = local[SESSION_CACHE_KEY];
+      if (isTokenValid(localSession.access_token)) {
+        await cacheSession(localSession);
+        return localSession;
       }
     }
   } catch {}
 
-  // 3. Try reading from an open ctrl.rodeo tab
+  // 3. Try refreshing the expired token
+  if (localSession && localSession.refresh_token) {
+    const refreshed = await tryRefreshToken(localSession);
+    if (refreshed) return refreshed;
+  }
+
+  // 4. Try reading from an open ctrl.rodeo tab
   const tabSession = await readSessionFromTab();
   if (tabSession) {
     await cacheSession(tabSession);
-    // Also persist to local storage for future use
     try {
       await chrome.storage.local.set({ [SESSION_CACHE_KEY]: tabSession });
     } catch {}
     return tabSession;
   }
+
+  // 5. No valid session — clear stale data
+  await clearCachedSession();
+  try { await chrome.storage.local.remove(SESSION_CACHE_KEY); } catch {}
 
   return null;
 }

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Rodeo — Save & Discover",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Save links, highlight text, and build your taste library",
   "icons": {
     "16": "icons/icon-16.png",

--- a/extension/chrome/popup.js
+++ b/extension/chrome/popup.js
@@ -112,9 +112,11 @@ async function handleSave() {
     return;
   }
 
-  showError(result.error === 'save_failed'
-    ? `Save failed (${result.status})`
-    : result.error || 'Unknown error');
+  if (result.error === 'save_failed') {
+    showError(result.detail || `Save failed (${result.status})`);
+  } else {
+    showError(result.error || 'Unknown error');
+  }
 }
 
 function showError(message) {
@@ -149,9 +151,15 @@ document.getElementById('btn-retry').addEventListener('click', () => {
 // ============================================
 // Messaging Helper
 // ============================================
-function sendMessage(msg) {
+function sendMessage(msg, timeoutMs = 15000) {
   return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      console.warn('[rodeo popup] message timed out:', msg.action);
+      resolve(null);
+    }, timeoutMs);
+
     chrome.runtime.sendMessage(msg, response => {
+      clearTimeout(timer);
       if (chrome.runtime.lastError) {
         console.warn('[rodeo popup]', chrome.runtime.lastError.message);
         resolve(null);


### PR DESCRIPTION
## Summary
- **Missing try/catch around save POST** — network errors crashed the handler, leaving the popup stuck on "Saving..." forever
- **No timeout on popup messaging** — if the service worker died, the popup waited indefinitely. Now times out at 15s with a clear error
- **Expired tokens caused cryptic errors** — added automatic token refresh via Supabase `refresh_token`. Also clears stale sessions on 401/403 so the next attempt shows sign-in instead of "Save failed"

Also added `.catch()` on all async message handlers and improved the schema-cache retry loop to match boards (up to 5 retries).

Bumps extension to v2.0.1.

## Test plan
- [ ] Load updated extension in Chrome (`chrome://extensions` → Load unpacked)
- [ ] Save a pin while logged in → should show "Saved"
- [ ] Wait for token to expire (or clear `rodeo_session` from chrome.storage.local) → should auto-refresh or show sign-in
- [ ] Disconnect from network, try to save → should show error message (not hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)