### PR TITLE
fix: username modal showing on every page load

### DIFF
--- a/auth/ctrl-auth.js
+++ b/auth/ctrl-auth.js
@@ -85,10 +85,10 @@
             _currentUsername = profile.username;
             updateBarUI();
             dispatch('ctrl:auth:signedin', { user: _currentUser, username: _currentUsername, session: stored });
-          } else if (_currentUser) {
-            // No username yet — show onboarding
-            showUsernameModal();
           }
+          // Don't show username modal here — the token may be expired causing
+          // fetchProfile to return null. Let onAuthStateChange handle it with
+          // a fresh token instead.
         });
       }
     },
@@ -317,8 +317,8 @@
         updateBarUI();
         hideLoginModal();
         dispatch('ctrl:auth:signedin', { user: _currentUser, username: _currentUsername, session });
-      } else {
-        // No username — show onboarding
+      } else if (!_currentUsername) {
+        // No username in DB and not already set — show onboarding
         updateBarUI();
         hideLoginModal();
         showUsernameModal();


### PR DESCRIPTION
## Summary
- Fix race condition where username modal appears on every page load for existing users
- The fast restore path used an expired access token to fetch the profile, got `null`, and showed the modal
- Removed modal trigger from fast restore (let `onAuthStateChange` handle it with a fresh token)
- Added guard: skip modal if `_currentUsername` was already resolved

## Test plan
- [ ] Reload boards page — username modal should NOT appear
- [ ] Sign out and back in — username modal should still work for new users without a username

🤖 Generated with [Claude Code](https://claude.com/claude-code)