### PR TITLE
fix(events): remove Hyperallergic (articles, not events)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1575,7 +1575,6 @@ body {
     { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
     { id: 'bonobo-sf', name: 'Bonobo Network', category: 'social', type: 'bonobo', url: 'https://www.bonobonetwork.com/events', region: 'bay-area', description: 'Social & community events' },
     // Bay Area — Art
-    { id: 'hyperallergic-sf', name: 'Hyperallergic', category: 'art', type: 'rss', url: 'https://hyperallergic.com/feed/', region: 'bay-area', description: 'Art criticism, gallery openings & exhibitions' },
     { id: 'sfmoma-events', name: 'SFMOMA', category: 'art', type: 'json', url: 'https://www.sfmoma.org/wp-json/wp/v2/event-series?per_page=20&_fields=title,link,date,excerpt', region: 'bay-area', description: 'Museum events & artist talks' },
     { id: 'sfmoma-exhibitions', name: 'SFMOMA Exhibitions', category: 'art', type: 'json', url: 'https://www.sfmoma.org/wp-json/wp/v2/exhibition?per_page=20&_fields=title,link,date,excerpt', region: 'bay-area', description: 'Current & upcoming exhibitions' },
     { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'html', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
@@ -4786,7 +4785,7 @@ body {
     music: ['19hz', 'ra-'],
     film: ['screenslate', 'roxie'],
     tech: ['garysguide'],
-    art: ['hyperallergic', 'sfmoma', 'famsf'],
+    art: ['sfmoma', 'famsf'],
     design: ['sfdesignweek'],
     literary: ['citylights', 'sfpl', 'commonwealthclub'],
     comedy: ['punchline', 'cobbs'],


### PR DESCRIPTION
## Summary
- Removed Hyperallergic from STOCK_SOURCES — its RSS feed returns art blog articles, not events with dates/times/venues
- Removed from art category suggestion list

🤖 Generated with [Claude Code](https://claude.com/claude-code)