### PR TITLE
feat(extension): browser history capture with privacy-first architecture

### DIFF
--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -1,7 +1,7 @@
 // Rodeo — Save & Discover
 // Service worker: context menus, message routing, pin save flow
 
-importScripts('lib/sanitize.js', 'lib/supabase.js', 'lib/auth.js');
+importScripts('lib/sanitize.js', 'lib/supabase.js', 'lib/auth.js', 'lib/privacy.js', 'lib/history.js');
 
 const BOARDS_URL = 'https://ctrl.rodeo/boards/';
 
@@ -63,6 +63,31 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
     showBadge(tab.id, '!', '#c00');
   } else {
     showBadge(tab.id, 'ERR', '#c00');
+  }
+});
+
+// ============================================
+// History Capture (Phase 2+3)
+// ============================================
+initHistoryCapture();
+
+chrome.webNavigation.onCompleted.addListener(async (details) => {
+  // Main frame only
+  if (details.frameId !== 0) return;
+  // Skip chrome:// and extension pages
+  if (!details.url || !details.url.startsWith('http')) return;
+
+  try {
+    const tab = await chrome.tabs.get(details.tabId);
+    if (tab.incognito) return;
+    recordNavigation({
+      url: details.url,
+      title: tab.title || '',
+      referrerUrl: null,
+      tabId: details.tabId
+    });
+  } catch {
+    // Tab may have closed
   }
 });
 
@@ -154,6 +179,46 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'open_boards') {
     chrome.tabs.create({ url: BOARDS_URL });
     return false;
+  }
+
+  // --- History / Privacy handlers ---
+
+  if (msg.action === 'get_privacy_settings') {
+    getPrivacySettings()
+      .then(sendResponse)
+      .catch(() => sendResponse(null));
+    return true;
+  }
+
+  if (msg.action === 'save_privacy_settings') {
+    savePrivacySettings(msg.settings)
+      .then(() => sendResponse({ ok: true }))
+      .catch(e => sendResponse({ error: e.message }));
+    return true;
+  }
+
+  if (msg.action === 'start_backfill') {
+    runBackfill()
+      .then(sendResponse)
+      .catch(e => sendResponse({ error: e.message }));
+    return true;
+  }
+
+  if (msg.action === 'delete_history') {
+    const handler = msg.window === 'all'
+      ? deleteAllHistory()
+      : deleteHistoryInWindow(msg.window);
+    handler
+      .then(sendResponse)
+      .catch(e => sendResponse({ error: e.message }));
+    return true;
+  }
+
+  if (msg.action === 'flush_history') {
+    flushBuffer()
+      .then(() => sendResponse({ ok: true }))
+      .catch(e => sendResponse({ error: e.message }));
+    return true;
   }
 });
 

--- a/extension/chrome/lib/history.js
+++ b/extension/chrome/lib/history.js
@@ -1,0 +1,280 @@
+// Rodeo Extension — Browser history capture (privacy-first)
+// Loaded via importScripts() in background.js
+// Depends on: privacy.js, sanitize.js, auth.js, supabase.js, background.js (getOrCreateDeviceId)
+//
+// Privacy invariant: Raw URLs NEVER leave the device.
+// Only url_hash (SHA-256), canonical_domain, truncated page_title,
+// and referrer_domain are transmitted to the server.
+
+const HISTORY_BUFFER_KEY = 'rodeo_history_buffer';
+const HISTORY_SESSION_KEY = 'rodeo_history_session';
+const FLUSH_INTERVAL_MS = 30_000;   // 30 seconds
+const FLUSH_BATCH_SIZE = 50;        // auto-flush threshold
+const SESSION_GAP_MS = 30 * 60_000; // 30 min inactivity → new session
+const INGEST_ENDPOINT = '/functions/v1/ingest-history';
+
+let _historyBuffer = [];
+let _flushTimer = null;
+let _sessionId = null;
+let _lastEventTime = 0;
+
+// ============================================
+// Initialization (called once from background.js)
+// ============================================
+async function initHistoryCapture() {
+  // Restore persisted buffer (MV3 service worker may have been suspended)
+  try {
+    const data = await chrome.storage.local.get([HISTORY_BUFFER_KEY, HISTORY_SESSION_KEY]);
+    _historyBuffer = data[HISTORY_BUFFER_KEY] || [];
+    _sessionId = data[HISTORY_SESSION_KEY] || crypto.randomUUID();
+    _lastEventTime = Date.now();
+  } catch {
+    _historyBuffer = [];
+    _sessionId = crypto.randomUUID();
+  }
+
+  // Load privacy settings into cache
+  await getPrivacySettings();
+
+  // Schedule periodic flush
+  _scheduleFlush();
+
+  // Flush any events left over from previous worker lifecycle
+  if (_historyBuffer.length > 0) {
+    flushBuffer();
+  }
+
+  console.log(`[rodeo] history capture initialized, buffer=${_historyBuffer.length}`);
+}
+
+// ============================================
+// Record a Navigation Event
+// ============================================
+async function recordNavigation({ url, title, referrerUrl, tabId }) {
+  // Check if history capture is enabled
+  const settings = await getPrivacySettings();
+  if (settings.historyEnabled === false) return;
+
+  // Skip non-http(s) URLs
+  if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) return;
+
+  // Skip incognito tabs
+  if (tabId) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (tab.incognito) return;
+    } catch {
+      // Tab may have closed — skip
+      return;
+    }
+  }
+
+  // Extract and check domain
+  const domain = extractDomain(url);
+  if (isDomainBlocked(domain)) return;
+
+  // Canonicalize URL and hash it
+  const canonical = canonicalizeForHash(url);
+  if (!canonical) return;
+  const urlHash = await hashUrl(canonical);
+
+  // Session management — new session after 30 min gap
+  const now = Date.now();
+  if (now - _lastEventTime > SESSION_GAP_MS) {
+    _sessionId = crypto.randomUUID();
+    chrome.storage.local.set({ [HISTORY_SESSION_KEY]: _sessionId }).catch(() => {});
+  }
+  _lastEventTime = now;
+
+  // Build event
+  const deviceId = await getOrCreateDeviceId();
+  const event = {
+    device_id: deviceId,
+    visited_at: new Date(now).toISOString(),
+    canonical_domain: domain.slice(0, 253),
+    url_hash: urlHash,
+    page_title: title ? title.slice(0, 100) : null,
+    referrer_domain: referrerUrl ? extractDomain(referrerUrl).slice(0, 253) : null,
+    session_id: _sessionId,
+    source: 'navigation'
+  };
+
+  _historyBuffer.push(event);
+  _persistBuffer();
+
+  // Auto-flush at threshold
+  if (_historyBuffer.length >= FLUSH_BATCH_SIZE) {
+    flushBuffer();
+  }
+}
+
+// ============================================
+// Flush Buffer to Server
+// ============================================
+async function flushBuffer() {
+  if (_historyBuffer.length === 0) return;
+
+  const session = await getSession();
+  if (!session || !session.access_token) {
+    // Not authenticated — keep buffer, try later
+    _scheduleFlush();
+    return;
+  }
+
+  // Take current batch and clear buffer
+  const batch = _historyBuffer.splice(0, 200);
+  _persistBuffer();
+
+  try {
+    const res = await fetch(`${SUPABASE_URL}${INGEST_ENDPOINT}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${session.access_token}`
+      },
+      body: JSON.stringify({ events: batch })
+    });
+
+    if (res.ok) {
+      const result = await res.json();
+      console.log(`[rodeo] history flush: inserted=${result.inserted} skipped=${result.skipped}`);
+    } else if (res.status === 401 || res.status === 403) {
+      // Token expired — re-queue events and clear session
+      _historyBuffer.unshift(...batch);
+      _persistBuffer();
+      await clearCachedSession();
+      console.warn('[rodeo] history flush auth failed, will retry');
+    } else {
+      // Server error — re-queue events
+      _historyBuffer.unshift(...batch);
+      _persistBuffer();
+      console.warn(`[rodeo] history flush failed: ${res.status}`);
+    }
+  } catch (e) {
+    // Network error — re-queue events
+    _historyBuffer.unshift(...batch);
+    _persistBuffer();
+    console.warn('[rodeo] history flush network error:', e.message);
+  }
+
+  _scheduleFlush();
+}
+
+// ============================================
+// Backfill from Chrome History API
+// ============================================
+async function runBackfill() {
+  const settings = await getPrivacySettings();
+  if (settings.historyEnabled === false) {
+    return { error: 'History capture is paused' };
+  }
+
+  const days = settings.backfillDays || 30;
+  const startTime = Date.now() - (days * 24 * 60 * 60 * 1000);
+
+  let items;
+  try {
+    items = await chrome.history.search({
+      text: '',
+      startTime,
+      maxResults: 10000
+    });
+  } catch (e) {
+    console.error('[rodeo] backfill history.search failed:', e.message);
+    return { error: 'Failed to read browser history' };
+  }
+
+  const deviceId = await getOrCreateDeviceId();
+  let queued = 0;
+
+  for (const item of items) {
+    if (!item.url || (!item.url.startsWith('http://') && !item.url.startsWith('https://'))) continue;
+
+    const domain = extractDomain(item.url);
+    if (isDomainBlocked(domain)) continue;
+
+    const canonical = canonicalizeForHash(item.url);
+    if (!canonical) continue;
+
+    const urlHash = await hashUrl(canonical);
+
+    _historyBuffer.push({
+      device_id: deviceId,
+      visited_at: new Date(item.lastVisitTime || Date.now()).toISOString(),
+      canonical_domain: domain.slice(0, 253),
+      url_hash: urlHash,
+      page_title: item.title ? item.title.slice(0, 100) : null,
+      referrer_domain: null,
+      session_id: 'backfill',
+      source: 'history'
+    });
+    queued++;
+  }
+
+  _persistBuffer();
+  console.log(`[rodeo] backfill queued ${queued} events from ${items.length} history items`);
+
+  // Immediately start flushing
+  flushBuffer();
+
+  return { queued, total: items.length };
+}
+
+// ============================================
+// Delete History
+// ============================================
+async function deleteHistoryInWindow(windowMs) {
+  const session = await getSession();
+  if (!session || !session.access_token) return { error: 'Not authenticated' };
+
+  const cutoff = new Date(Date.now() - windowMs).toISOString();
+  try {
+    const res = await supabaseDelete(
+      `/rest/v1/browsing_history?user_id=eq.${session.user.id}&visited_at=gte.${encodeURIComponent(cutoff)}`,
+      session.access_token
+    );
+    if (!res.ok) {
+      console.error('[rodeo] delete history failed:', res.status);
+      return { error: 'Delete failed' };
+    }
+    return { success: true };
+  } catch (e) {
+    console.error('[rodeo] delete history error:', e.message);
+    return { error: e.message };
+  }
+}
+
+async function deleteAllHistory() {
+  const session = await getSession();
+  if (!session || !session.access_token) return { error: 'Not authenticated' };
+
+  try {
+    const res = await supabaseDelete(
+      `/rest/v1/browsing_history?user_id=eq.${session.user.id}`,
+      session.access_token
+    );
+    if (!res.ok) {
+      console.error('[rodeo] delete all history failed:', res.status);
+      return { error: 'Delete failed' };
+    }
+    // Also clear local buffer
+    _historyBuffer = [];
+    _persistBuffer();
+    return { success: true };
+  } catch (e) {
+    console.error('[rodeo] delete all history error:', e.message);
+    return { error: e.message };
+  }
+}
+
+// ============================================
+// Internal Helpers
+// ============================================
+function _persistBuffer() {
+  chrome.storage.local.set({ [HISTORY_BUFFER_KEY]: _historyBuffer }).catch(() => {});
+}
+
+function _scheduleFlush() {
+  if (_flushTimer) clearTimeout(_flushTimer);
+  _flushTimer = setTimeout(() => flushBuffer(), FLUSH_INTERVAL_MS);
+}

--- a/extension/chrome/lib/privacy.js
+++ b/extension/chrome/lib/privacy.js
@@ -1,0 +1,182 @@
+// Rodeo Extension — Privacy settings and domain blocklist
+// Loaded via importScripts() in background.js
+// Source of truth: chrome.storage.sync
+// Mirrors to Supabase extension_settings table on change (best-effort)
+
+// ============================================
+// Default Domain Blocklist (hardcoded)
+// ============================================
+const DEFAULT_BLOCKLIST = new Set([
+  // Email
+  'mail.google.com',
+  'outlook.live.com',
+  'mail.yahoo.com',
+  // Banking
+  'chase.com',
+  'bankofamerica.com',
+  'wellsfargo.com',
+  // Health
+  'mychart.com',
+  'myhealth.kaiserpermanente.org',
+  // Government
+  'irs.gov',
+  'ssa.gov',
+  'usa.gov',
+  // Work SaaS
+  'okta.com',
+  'workday.com',
+  'adp.com'
+]);
+
+// ============================================
+// Sensitive Query Params (stripped before hashing)
+// ============================================
+const SENSITIVE_PARAMS = new Set([
+  'token', 'access_token', 'refresh_token', 'id_token', 'session',
+  'auth', 'key', 'apikey', 'api_key', 'secret', 'password', 'pwd',
+  'code', 'state', 'nonce', 'csrf', 'sig', 'signature', 'hmac',
+  'jwt', 'bearer', 'oauth_token', 'oauth_verifier',
+  'email', 'username', 'user', 'phone', 'ssn', 'dob',
+  'samlresponse', 'samlrequest'
+]);
+
+// ============================================
+// Settings Cache
+// ============================================
+const PRIVACY_SETTINGS_KEY = 'rodeo_privacy_settings';
+let _privacySettingsCache = null;
+
+const DEFAULT_PRIVACY_SETTINGS = {
+  historyEnabled: true,
+  userBlocklist: [],
+  backfillDays: 30
+};
+
+async function getPrivacySettings() {
+  if (_privacySettingsCache) return _privacySettingsCache;
+  try {
+    const data = await chrome.storage.sync.get(PRIVACY_SETTINGS_KEY);
+    _privacySettingsCache = data[PRIVACY_SETTINGS_KEY] || { ...DEFAULT_PRIVACY_SETTINGS };
+  } catch {
+    _privacySettingsCache = { ...DEFAULT_PRIVACY_SETTINGS };
+  }
+  return _privacySettingsCache;
+}
+
+async function savePrivacySettings(settings) {
+  _privacySettingsCache = { ...DEFAULT_PRIVACY_SETTINGS, ...settings };
+  try {
+    await chrome.storage.sync.set({ [PRIVACY_SETTINGS_KEY]: _privacySettingsCache });
+  } catch (e) {
+    console.warn('[rodeo] failed to save privacy settings:', e.message);
+  }
+  // Best-effort mirror to Supabase
+  syncSettingsToSupabase(_privacySettingsCache);
+}
+
+// Invalidate in-memory cache when storage changes
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes[PRIVACY_SETTINGS_KEY]) {
+    _privacySettingsCache = changes[PRIVACY_SETTINGS_KEY].newValue || { ...DEFAULT_PRIVACY_SETTINGS };
+  }
+});
+
+// ============================================
+// Domain Blocking
+// ============================================
+
+// Returns true if the domain should be excluded from history capture
+function isDomainBlocked(domain) {
+  if (!domain) return true;
+  const d = domain.toLowerCase().replace(/^www\./, '');
+
+  // Check hardcoded blocklist (exact + suffix match)
+  if (DEFAULT_BLOCKLIST.has(d)) return true;
+  for (const blocked of DEFAULT_BLOCKLIST) {
+    if (d.endsWith('.' + blocked)) return true;
+  }
+
+  // Check user blocklist
+  if (_privacySettingsCache && _privacySettingsCache.userBlocklist) {
+    for (const userDomain of _privacySettingsCache.userBlocklist) {
+      const ud = userDomain.toLowerCase().replace(/^www\./, '');
+      if (d === ud || d.endsWith('.' + ud)) return true;
+    }
+  }
+
+  return false;
+}
+
+// ============================================
+// URL Sanitization
+// ============================================
+
+// Canonicalize a URL for hashing:
+// - Only http/https
+// - Strip fragment
+// - Strip sensitive query params
+// - Hash numeric path segments >5 digits (e.g. /users/123456789 → /users/:id)
+// Returns null if URL should be excluded
+function canonicalizeForHash(rawUrl) {
+  let u;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+
+  // Strip fragment
+  u.hash = '';
+
+  // Strip sensitive query params
+  const toDelete = [];
+  for (const [key] of u.searchParams) {
+    if (SENSITIVE_PARAMS.has(key.toLowerCase())) toDelete.push(key);
+  }
+  toDelete.forEach(k => u.searchParams.delete(k));
+
+  // Hash numeric path segments longer than 5 digits
+  u.pathname = u.pathname
+    .split('/')
+    .map(seg => /^\d{6,}$/.test(seg) ? ':id' : seg)
+    .join('/');
+
+  // Lowercase hostname
+  u.hostname = u.hostname.toLowerCase();
+
+  return u.toString();
+}
+
+// SHA-256 hash of a URL (Web Crypto API — available in service workers)
+async function hashUrl(url) {
+  const data = new TextEncoder().encode(url);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+// ============================================
+// Supabase Settings Sync (best-effort)
+// ============================================
+async function syncSettingsToSupabase(settings) {
+  try {
+    const session = await getSession();
+    if (!session || !session.access_token || !session.user) return;
+
+    const payload = {
+      user_id: session.user.id,
+      history_enabled: settings.historyEnabled !== false,
+      domain_blocklist: settings.userBlocklist || [],
+      backfill_days: settings.backfillDays || 30
+    };
+
+    await supabasePost('/rest/v1/extension_settings', payload, session.access_token, {
+      'Prefer': 'resolution=merge-duplicates'
+    });
+  } catch (e) {
+    console.warn('[rodeo] settings sync failed:', e.message);
+  }
+}

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Rodeo — Save & Discover",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Save links, highlight text, and build your taste library",
   "icons": {
     "16": "icons/icon-16.png",
@@ -33,7 +33,7 @@
       "run_at": "document_idle"
     }
   ],
-  "permissions": ["activeTab", "storage", "contextMenus", "scripting"],
+  "permissions": ["activeTab", "storage", "contextMenus", "scripting", "history", "tabs", "webNavigation"],
   "host_permissions": ["https://ctrl.rodeo/*"],
   "externally_connectable": {
     "matches": ["https://ctrl.rodeo/*"]

--- a/extension/chrome/popup.css
+++ b/extension/chrome/popup.css
@@ -289,3 +289,178 @@ body {
   color: var(--color-error);
   margin-bottom: var(--space-4);
 }
+
+/* ============================================
+   Tab Bar
+   ============================================ */
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 var(--space-4);
+}
+
+.tab-bar[hidden] {
+  display: none !important;
+}
+
+.tab-btn {
+  flex: 1;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-subtle);
+  font-family: var(--font-primary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: color var(--duration-fast), border-color var(--duration-fast);
+}
+
+.tab-btn:hover {
+  color: var(--fg-muted);
+}
+
+.tab-btn.active {
+  color: var(--fg);
+  border-bottom-color: var(--fg);
+}
+
+/* ============================================
+   Settings State
+   ============================================ */
+.settings-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.settings-label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  color: var(--fg);
+}
+
+.settings-hint {
+  font-size: 9px;
+  color: var(--fg-subtle);
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settings-textarea {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg);
+  font-family: var(--font-primary);
+  font-size: var(--text-xs);
+  padding: var(--space-2);
+  resize: vertical;
+  min-height: 48px;
+}
+
+.settings-textarea:focus {
+  outline: none;
+  border-color: var(--fg);
+}
+
+.settings-textarea::placeholder {
+  color: var(--fg-subtle);
+}
+
+.settings-status {
+  font-size: 9px;
+  text-align: center;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+}
+
+.settings-status--ok {
+  color: var(--color-success);
+}
+
+.settings-status--err {
+  color: var(--color-error);
+}
+
+.settings-danger {
+  margin-top: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-delete-row {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.btn--danger {
+  background: transparent;
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
+  font-family: var(--font-primary);
+  font-size: 8px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+  transition: all var(--duration-fast);
+}
+
+.btn--danger:hover {
+  background: var(--color-error);
+  color: var(--bg);
+}
+
+.btn--sm {
+  flex: 1;
+}
+
+/* Toggle checkbox (simple) */
+#toggle-history {
+  appearance: none;
+  width: 32px;
+  height: 16px;
+  background: var(--gray-400);
+  border-radius: 8px;
+  position: relative;
+  cursor: pointer;
+  transition: background var(--duration-fast);
+}
+
+#toggle-history::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--fg);
+  border-radius: 50%;
+  transition: transform var(--duration-fast);
+}
+
+#toggle-history:checked {
+  background: var(--color-success);
+}
+
+#toggle-history:checked::after {
+  transform: translateX(16px);
+}

--- a/extension/chrome/popup.html
+++ b/extension/chrome/popup.html
@@ -35,6 +35,12 @@
     </div>
   </div>
 
+  <!-- Tab Bar (shown when authenticated) -->
+  <div id="tab-bar" class="tab-bar" hidden>
+    <button class="tab-btn active" data-tab="save">Save</button>
+    <button class="tab-btn" data-tab="settings">Settings</button>
+  </div>
+
   <!-- State: Ready to save -->
   <div id="state-save" class="state" hidden>
     <div class="save-header">
@@ -92,6 +98,36 @@
       <button id="btn-retry" class="btn btn--outline btn--block">
         Try Again
       </button>
+    </div>
+  </div>
+
+  <!-- State: Settings -->
+  <div id="state-settings" class="state" hidden>
+    <div class="settings-container">
+      <div class="settings-row">
+        <label class="settings-label" for="toggle-history">Capture browsing history</label>
+        <input type="checkbox" id="toggle-history" checked>
+      </div>
+
+      <div class="settings-section">
+        <label class="settings-label">Blocked domains</label>
+        <p class="settings-hint">One domain per line. These sites won't be tracked.</p>
+        <textarea id="blocklist-input" class="settings-textarea" rows="4" placeholder="example.com&#10;another-site.org"></textarea>
+      </div>
+
+      <button id="btn-save-settings" class="btn btn--filled btn--block">Save Settings</button>
+      <p id="settings-status" class="settings-status" hidden></p>
+
+      <div class="settings-section settings-danger">
+        <label class="settings-label">Import &amp; Delete</label>
+        <button id="btn-backfill" class="btn btn--outline btn--block">Import Last 30 Days</button>
+        <p id="backfill-status" class="settings-status" hidden></p>
+        <div class="settings-delete-row">
+          <button id="btn-delete-hour" class="btn btn--danger btn--sm">Delete Last Hour</button>
+          <button id="btn-delete-day" class="btn btn--danger btn--sm">Delete Last Day</button>
+          <button id="btn-delete-all" class="btn btn--danger btn--sm">Delete All</button>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/extension/chrome/popup.js
+++ b/extension/chrome/popup.js
@@ -12,7 +12,8 @@ const states = {
   saving: document.getElementById('state-saving'),
   saved: document.getElementById('state-saved'),
   duplicate: document.getElementById('state-duplicate'),
-  error: document.getElementById('state-error')
+  error: document.getElementById('state-error'),
+  settings: document.getElementById('state-settings')
 };
 
 // Current page data (set during init)
@@ -63,6 +64,9 @@ async function init() {
   if (selResult && selResult.text) {
     currentSelection = selResult.text;
   }
+
+  // Show tab bar (user is authenticated)
+  document.getElementById('tab-bar').hidden = false;
 
   // Populate save state
   document.getElementById('save-domain').textContent = tabInfo.domain;
@@ -169,6 +173,97 @@ function sendMessage(msg, timeoutMs = 15000) {
     });
   });
 }
+
+// ============================================
+// Tab Bar
+// ============================================
+let activeTab = 'save';
+
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const tab = btn.dataset.tab;
+    if (tab === activeTab) return;
+    activeTab = tab;
+
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+
+    if (tab === 'settings') {
+      loadSettings();
+      showState('settings');
+    } else {
+      showState('save');
+    }
+  });
+});
+
+// ============================================
+// Settings Tab
+// ============================================
+async function loadSettings() {
+  const settings = await sendMessage({ action: 'get_privacy_settings' });
+  if (!settings) return;
+
+  document.getElementById('toggle-history').checked = settings.historyEnabled !== false;
+  document.getElementById('blocklist-input').value =
+    (settings.userBlocklist || []).join('\n');
+}
+
+document.getElementById('btn-save-settings').addEventListener('click', async () => {
+  const historyEnabled = document.getElementById('toggle-history').checked;
+  const raw = document.getElementById('blocklist-input').value;
+  const userBlocklist = raw.split('\n')
+    .map(d => d.trim().toLowerCase())
+    .filter(d => d.length > 0);
+
+  const result = await sendMessage({
+    action: 'save_privacy_settings',
+    settings: { historyEnabled, userBlocklist }
+  });
+
+  const status = document.getElementById('settings-status');
+  if (result && result.ok) {
+    status.textContent = 'Settings saved';
+    status.className = 'settings-status settings-status--ok';
+  } else {
+    status.textContent = 'Failed to save';
+    status.className = 'settings-status settings-status--err';
+  }
+  status.hidden = false;
+  setTimeout(() => { status.hidden = true; }, 3000);
+});
+
+document.getElementById('btn-backfill').addEventListener('click', async () => {
+  const status = document.getElementById('backfill-status');
+  status.textContent = 'Importing...';
+  status.className = 'settings-status';
+  status.hidden = false;
+
+  const result = await sendMessage({ action: 'start_backfill' }, 60000);
+  if (result && result.queued !== undefined) {
+    status.textContent = `Imported ${result.queued} of ${result.total} pages`;
+    status.className = 'settings-status settings-status--ok';
+  } else {
+    status.textContent = result?.error || 'Import failed';
+    status.className = 'settings-status settings-status--err';
+  }
+  setTimeout(() => { status.hidden = true; }, 5000);
+});
+
+document.getElementById('btn-delete-hour').addEventListener('click', async () => {
+  if (!confirm('Delete browsing history from the last hour?')) return;
+  await sendMessage({ action: 'delete_history', window: 60 * 60 * 1000 });
+});
+
+document.getElementById('btn-delete-day').addEventListener('click', async () => {
+  if (!confirm('Delete browsing history from the last 24 hours?')) return;
+  await sendMessage({ action: 'delete_history', window: 24 * 60 * 60 * 1000 });
+});
+
+document.getElementById('btn-delete-all').addEventListener('click', async () => {
+  if (!confirm('Delete ALL browsing history? This cannot be undone.')) return;
+  await sendMessage({ action: 'delete_history', window: 'all' });
+});
 
 // ============================================
 // Start

--- a/supabase/functions/ingest-history/index.ts
+++ b/supabase/functions/ingest-history/index.ts
@@ -1,0 +1,150 @@
+// Supabase Edge Function: ingest-history
+// Receives batched browsing history events from the Chrome extension.
+// Raw URLs are NEVER received — client sends only url_hash, canonical_domain,
+// page_title, referrer_domain, session_id, visited_at, source, device_id.
+//
+// POST /functions/v1/ingest-history
+// Authorization: Bearer <user_access_token>
+// Body: { events: HistoryEvent[] }
+// Returns: { inserted: number, skipped: number }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const VERSION = '1.0.0'
+console.log(`[ingest-history] v${VERSION} - privacy-first browsing history ingestion`)
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface HistoryEvent {
+  device_id: string
+  visited_at: string
+  canonical_domain: string
+  url_hash: string
+  page_title?: string
+  referrer_domain?: string
+  session_id: string
+  source: 'history' | 'navigation'
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+function err(message: string, status = 400) {
+  return json({ error: message }, status)
+}
+
+async function getUserId(req: Request): Promise<string | null> {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) return null
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: authHeader } } }
+  )
+
+  const { data: { user } } = await supabase.auth.getUser()
+  return user?.id ?? null
+}
+
+function getServiceClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Authenticate
+    const userId = await getUserId(req)
+    if (!userId) return err('Unauthorized', 401)
+
+    // Parse body
+    const body = await req.json()
+    const events: HistoryEvent[] = body.events
+    if (!Array.isArray(events) || events.length === 0) {
+      return err('events must be a non-empty array')
+    }
+
+    if (events.length > 200) {
+      return err('Batch too large (max 200 events)')
+    }
+
+    // Validate each event
+    const rows = []
+    for (const e of events) {
+      if (!e.device_id || !e.visited_at || !e.canonical_domain ||
+          !e.url_hash || !/^[0-9a-f]{64}$/.test(e.url_hash) ||
+          !e.session_id ||
+          (e.source !== 'history' && e.source !== 'navigation')) {
+        continue  // skip invalid events silently
+      }
+
+      rows.push({
+        user_id: userId,
+        device_id: e.device_id,
+        visited_at: e.visited_at,
+        canonical_domain: e.canonical_domain.toLowerCase().slice(0, 253),
+        url_hash: e.url_hash,
+        page_title: e.page_title ? e.page_title.slice(0, 100) : null,
+        referrer_domain: e.referrer_domain ? e.referrer_domain.toLowerCase().slice(0, 253) : null,
+        session_id: e.session_id,
+        source: e.source,
+      })
+    }
+
+    if (rows.length === 0) {
+      return err('No valid events in batch')
+    }
+
+    // Insert with ON CONFLICT DO NOTHING (dedup on user_id, url_hash)
+    const db = getServiceClient()
+    const { count, error: insertError } = await db
+      .from('browsing_history')
+      .upsert(rows, {
+        onConflict: 'user_id,url_hash',
+        ignoreDuplicates: true,
+        count: 'exact'
+      })
+
+    if (insertError) {
+      console.error('[ingest-history] insert error:', insertError)
+      return err('Insert failed', 500)
+    }
+
+    const inserted = count ?? 0
+    const skipped = rows.length - inserted
+    console.log(`[ingest-history] batch=${rows.length} inserted=${inserted} skipped=${skipped} user=${userId}`)
+
+    return json({ inserted, skipped })
+
+  } catch (e) {
+    console.error('[ingest-history] unhandled error:', e)
+    return err('Internal server error', 500)
+  }
+})

--- a/supabase/migrations/028_extension_settings.sql
+++ b/supabase/migrations/028_extension_settings.sql
@@ -1,0 +1,55 @@
+-- ============================================
+-- 028_extension_settings.sql
+-- Per-user extension preferences for Phase 2 privacy controls.
+-- Source of truth: chrome.storage.sync; this table mirrors it server-side.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS extension_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  history_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  domain_blocklist TEXT[] NOT NULL DEFAULT '{}',
+  backfill_days INTEGER NOT NULL DEFAULT 30,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE extension_settings IS
+  'Per-user extension preferences. Source of truth is chrome.storage.sync; this mirrors it server-side.';
+COMMENT ON COLUMN extension_settings.history_enabled IS
+  'When false, extension stops capturing navigation events. Pause toggle.';
+COMMENT ON COLUMN extension_settings.domain_blocklist IS
+  'User-added domains to exclude from history capture. Merged with hardcoded DEFAULT_BLOCKLIST at runtime.';
+COMMENT ON COLUMN extension_settings.backfill_days IS
+  'How many days back to read from chrome.history on opt-in backfill. Default 30.';
+
+CREATE OR REPLACE FUNCTION update_extension_settings_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER extension_settings_updated_at
+  BEFORE UPDATE ON extension_settings
+  FOR EACH ROW EXECUTE FUNCTION update_extension_settings_updated_at();
+
+ALTER TABLE extension_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own settings"
+  ON extension_settings FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own settings"
+  ON extension_settings FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own settings"
+  ON extension_settings FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own settings"
+  ON extension_settings FOR DELETE
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/029_browsing_history.sql
+++ b/supabase/migrations/029_browsing_history.sql
@@ -1,0 +1,73 @@
+-- ============================================
+-- 029_browsing_history.sql
+-- Append-only table for hashed navigation events from the Chrome extension.
+-- Raw URLs are NEVER stored — only url_hash (SHA-256), canonical_domain,
+-- page_title (truncated 100 chars), referrer_domain, session_id.
+-- Deduplication: one record per user per URL (same URL on different days
+-- is still one row — we track first visit only).
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS browsing_history (
+  event_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  device_id TEXT NOT NULL,
+  visited_at TIMESTAMPTZ NOT NULL,
+  canonical_domain TEXT NOT NULL,
+  url_hash TEXT NOT NULL,
+  page_title TEXT,
+  referrer_domain TEXT,
+  session_id TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('history', 'navigation'))
+);
+
+COMMENT ON TABLE browsing_history IS
+  'Hashed navigation events. Raw URLs never stored. One record per user per URL.';
+COMMENT ON COLUMN browsing_history.url_hash IS
+  'SHA-256 hex of normalized URL. Used for deduplication. Raw URL never transmitted or stored.';
+COMMENT ON COLUMN browsing_history.page_title IS
+  'Page title truncated to 100 characters. May be empty for backfill events.';
+COMMENT ON COLUMN browsing_history.session_id IS
+  'Client-generated UUID, reset when gap since last event exceeds 30 minutes.';
+COMMENT ON COLUMN browsing_history.source IS
+  '''history'' = backfill from chrome.history API; ''navigation'' = live webNavigation event.';
+
+-- Deduplication: one row per user per URL
+CREATE UNIQUE INDEX idx_browsing_history_user_url
+  ON browsing_history (user_id, url_hash);
+
+-- Time-range queries (most common access pattern)
+CREATE INDEX idx_browsing_history_user_time
+  ON browsing_history (user_id, visited_at DESC);
+
+-- Domain aggregation queries for taste graph
+CREATE INDEX idx_browsing_history_user_domain
+  ON browsing_history (user_id, canonical_domain);
+
+-- Device-level queries for cross-device merging
+CREATE INDEX idx_browsing_history_device
+  ON browsing_history (device_id, visited_at DESC);
+
+ALTER TABLE browsing_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own history"
+  ON browsing_history FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own history"
+  ON browsing_history FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own history"
+  ON browsing_history FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- No UPDATE policy — browsing_history is append-only.
+
+-- Rolling retention: pg_cron deletes events older than 12 months daily.
+-- Run this manually in Supabase Dashboard → SQL Editor after applying migration:
+--
+-- SELECT cron.schedule(
+--   'purge-old-browsing-history',
+--   '0 3 * * *',
+--   $$DELETE FROM browsing_history WHERE visited_at < NOW() - INTERVAL '12 months'$$
+-- );


### PR DESCRIPTION
## Summary
- Privacy-first browser history capture (Phase 2+3 from extension-v1 PRD)
- Raw URLs **never leave the device** — only SHA-256 hashes, canonical domains, and truncated page titles are transmitted
- Default blocklist for sensitive domains (email, banking, health, gov, work SaaS)
- Settings tab in popup with history toggle, domain blocklist editor, backfill import, and delete controls
- MV3-safe event buffer persisted to `chrome.storage.local` with 30s flush interval
- New `ingest-history` Supabase edge function with JWT auth and batch dedup

## New files
- `extension/chrome/lib/privacy.js` — domain blocklist, URL sanitization, SHA-256 hashing
- `extension/chrome/lib/history.js` — event buffer, webNavigation capture, backfill, delete
- `supabase/functions/ingest-history/index.ts` — batch ingestion endpoint
- `supabase/migrations/028_extension_settings.sql` — per-user privacy preferences
- `supabase/migrations/029_browsing_history.sql` — append-only hashed event store

## Test plan
- [ ] Load extension in Chrome — service worker logs `initHistoryCapture` without errors
- [ ] Navigate to a normal URL — check service worker console for `[rodeo]` recording log
- [ ] Navigate to mail.google.com — confirm no event recorded (blocked)
- [ ] Open popup → Settings tab — toggle should be on, blocklist empty
- [ ] Toggle history off → navigate → confirm no events captured
- [ ] Click "Import Last 30 Days" → check browsing_history table in Supabase
- [ ] Click "Delete Last Hour" → verify rows removed
- [ ] Inspect network requests — confirm no raw URLs in payloads (only url_hash)
- [ ] Open incognito tab → navigate → confirm no events captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)