### PR TITLE
fix(instagram-import): fix bio resolution response parsing

### DIFF
--- a/supabase/functions/instagram-import/index.ts
+++ b/supabase/functions/instagram-import/index.ts
@@ -17,8 +17,8 @@
 //
 // Returns: { source_pin, derived_pins[], transcript?, entities[], cost_estimate }
 
-const VERSION = '1.3.0'
-console.log(`[instagram-import] v${VERSION} - @mention bio resolution, ScrapeCreators transcripts, caption URLs`)
+const VERSION = '1.3.1'
+console.log(`[instagram-import] v${VERSION} - fix bio resolution response parsing`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 
@@ -755,8 +755,9 @@ async function resolveViaBio(handle: string): Promise<string | null> {
     if (!resp.ok) return null
 
     const data = await resp.json()
-    const profile = data.data || data
-    const externalUrl = profile.external_url || profile.bio_link || profile.website || null
+    if (!data.success) return null
+    const profile = data.data?.user || data.data || data
+    const externalUrl = profile.external_url || profile.bio_links?.[0]?.url || profile.bio_link || profile.website || null
     if (externalUrl) {
       console.log(`[instagram-import] Bio resolution: @${handle} -> ${externalUrl}`)
     }


### PR DESCRIPTION
## Summary
- Fix ScrapeCreators profile API response navigation: data lives at `data.data.user`, not `data.data`
- Add `bio_links[0].url` fallback for profiles using link-in-bio arrays
- Add `data.success` check before parsing response
- Bump instagram-import 1.3.0 → 1.3.1

## Context
Bio resolution (Phase 0b) was returning null for all entities because it couldn't find `external_url` — the field was nested one level deeper than expected.

## Test plan
- [ ] Re-test Sublime reel (DUa3xdzlJLK) — Sublime should resolve via `instagram-bio` to `sublime.app`
- [ ] Verify other @mention entities also resolve via bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)