### PR TITLE
fix(mobile-safari): auth, clipboard, and FAB stability

### DIFF
--- a/auth/ctrl-auth.js
+++ b/auth/ctrl-auth.js
@@ -58,11 +58,18 @@
       const ref = config.supabaseUrl.match(/\/\/([^.]+)\./)?.[1] || '';
       _authStorageKey = `sb-${ref}-auth-token`;
 
+      // Detect mobile browsers where PKCE code-verifier can be lost during
+      // the OAuth redirect chain, causing silent auth failures on mobile Safari.
+      // Use implicit flow on mobile — tokens arrive in the URL hash which the
+      // iOS Auth Token Capture script in boards/index.html already handles.
+      const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent) ||
+        (navigator.maxTouchPoints > 1 && /Macintosh/.test(navigator.userAgent));
+
       // Create Supabase client
       _supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey, {
         auth: {
           detectSessionInUrl: true,
-          flowType: 'pkce',
+          flowType: isMobile ? 'implicit' : 'pkce',
           autoRefreshToken: true,
           persistSession: true
         }

--- a/boards/index.html
+++ b/boards/index.html
@@ -6536,8 +6536,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.11.1';
-  console.log('[boards] v' + VERSION + ' - rotating loader for Instagram import');
+  const VERSION = '2.11.2';
+  console.log('[boards] v' + VERSION + ' - fix mobile Safari auth, clipboard, FAB');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -15436,6 +15436,12 @@ Return JSON:
   // FAB Menu - Toggle open/close
   fabTrigger.onclick = () => {
     fabMenu.classList.toggle('fab-menu--open');
+    // On mobile, use the tap gesture to check clipboard (Safari requires a
+    // user activation for navigator.clipboard.readText — the visibility/focus
+    // polling never works there)
+    if (window.innerWidth <= 600) {
+      checkClipboardForUrls();
+    }
   };
 
   // Close FAB menu when clicking outside
@@ -15449,6 +15455,20 @@ Return JSON:
   fabShareLink.onclick = () => {
     fabMenu.classList.remove('fab-menu--open');
     openModal(addModal);
+    // Attempt clipboard read using the tap gesture (Safari requires user
+    // activation). Pre-fill the link input if there's a URL on the clipboard.
+    if (!linkInput.value) {
+      (async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+          const urls = extractUrls(text);
+          const newUrls = urls.filter(u => !findByUrl(u));
+          if (newUrls.length > 0 && !linkInput.value) {
+            linkInput.value = newUrls.join('\n');
+          }
+        } catch (e) { /* clipboard permission denied — that's fine */ }
+      })();
+    }
   };
 
   fabPhotoUpload.onclick = () => {


### PR DESCRIPTION
## Summary
- **Auth**: Use implicit OAuth flow on mobile instead of PKCE — the PKCE code verifier stored in localStorage can be lost during the OAuth redirect chain on mobile Safari, causing silent auth failures. The iOS Auth Token Capture script in `<head>` already handles implicit flow tokens in the URL hash.
- **Clipboard**: Trigger `navigator.clipboard.readText()` on user gestures (FAB tap, Share Link tap) instead of relying on `visibilitychange`/`focus` polling, which Safari blocks without a user activation.
- **FAB (+button)**: Was hidden because auth never completed — fixed as a downstream effect of the auth fix.
- Bumps boards v2.11.1 → v2.11.2

## Test plan
- [ ] On mobile Safari (iPhone): tap Login → Continue with Google → verify auth completes and FAB appears
- [ ] On mobile Safari: copy a URL in another app, switch to Boards, tap + → verify mobile paste bar appears
- [ ] On mobile Safari: tap + → Share Link → verify clipboard URL is pre-filled in textarea
- [ ] On desktop Chrome/Firefox: verify Google auth still works via PKCE flow
- [ ] On desktop: verify clipboard auto-detection on focus/visibility still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)