### PR TITLE
feat(mcp-connector): taste connector for Claude Connectors Directory

### DIFF
--- a/.claude/skills/taste-connector.md
+++ b/.claude/skills/taste-connector.md
@@ -1,0 +1,74 @@
+# Taste Connector Skill
+
+This skill enables Claude Code to interact with the user's curated library via the MCP Connector. The connector surfaces taste intelligence — curated links with AI-generated categories, tags, entities, and computed taste profiles.
+
+## When to Trigger
+
+Activate when the user mentions:
+- Their library, saved links, bookmarks, pins, or boards
+- Taste, preferences, aesthetic patterns
+- Recommendations grounded in "what I like" or "what I've saved"
+- Saving or capturing a URL to their library
+- Board names: home, wear, watch, listen, use, eat, go, follow, read
+- Questions like "what have I collected about X?" or "what are my taste patterns?"
+
+## Available MCP Tools
+
+### Read Tools
+
+**`search_pins`** — Search saved items by keyword, board, content type, or tags.
+- Args: `query`, `board`, `content_type`, `tag`, `limit`
+- Use for: finding specific saves, filtering by topic
+
+**`get_board`** — Get all items in a specific board/category.
+- Args: `board` (required), `limit`, `offset`
+- Built-in boards: home, wear, watch, listen, use, eat, go, follow, read
+
+**`get_boards_list`** — List all boards with item counts.
+- No args. Returns board slugs, counts, descriptions.
+
+**`get_taste_profile`** — Get cross-board taste aggregation.
+- Returns: top taste_tags (aesthetic), practical_tags (functional), entities (brands/people/places), content type distribution
+- This is the richest tool for understanding the user's taste
+
+**`get_recent_saves`** — Recent items.
+- Args: `limit`, `days`
+
+**`get_connector_context`** — Orientation context with board taxonomy and composition guidance.
+- Call first if unsure how to use other tools
+
+### Write Tools
+
+**`save_pin`** — Save a URL to the library with full enrichment.
+- Args: `url` (required), `notes`, `category`, `source`
+- The platform auto-resolves images, categorizes, extracts entities, generates tags
+- Idempotent: returns existing pin if URL already saved
+- Set `source: "claude_auto"` for auto-captures on choice signals
+
+## Composition Patterns
+
+### Recommendations
+1. `get_taste_profile` → understand cross-board taste patterns
+2. `search_pins` or `get_board` → see what they've already saved in the category
+3. Recommend based on actual taste signals, not generic suggestions
+
+### Research
+1. `search_pins(query=...)` → find what they've collected
+2. Build on their existing collection, don't re-search the web for things they already have
+
+### Self-Discovery
+1. `get_taste_profile` + `get_boards_list` → full picture
+2. Synthesize patterns, surface cross-board connections
+
+### Auto-Capture
+When the user expresses a clear choice signal ("I'll get that", "that's the one", "perfect, ordering that"), proactively:
+1. `save_pin(url, source="claude_auto", notes="<conversation context>")`
+2. This keeps the library growing passively
+
+## Privacy
+The user controls what's shared via privacy tiers (Taste Only / Library / Full Access) and per-board/field toggles. All filtering happens server-side — you'll only see data the user has chosen to share. Never ask for data that returns empty due to privacy settings.
+
+## Tag System
+- **taste_tags**: Subjective aesthetic/vibe (minimalist, brutalist, artisanal, lo_fi)
+- **practical_tags**: Objective functional (waterproof, noise_cancelling, hardcover)
+- **entities**: Named things (brands, people, places, products, concepts)

--- a/connect/index.html
+++ b/connect/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connect — ctrl.rodeo</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .container {
+      max-width: 420px;
+      width: 100%;
+      padding: 2rem;
+    }
+    .logo {
+      font-size: 0.85rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #888;
+      margin-bottom: 2rem;
+    }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+      color: #fff;
+    }
+    .subtitle {
+      color: #888;
+      font-size: 0.9rem;
+      margin-bottom: 2rem;
+      line-height: 1.5;
+    }
+    .client-name {
+      color: #fff;
+      font-weight: 500;
+    }
+
+    /* Auth section */
+    .auth-section {
+      margin-bottom: 2rem;
+    }
+    .auth-section.hidden { display: none; }
+    .auth-btn {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border: 1px solid #333;
+      border-radius: 8px;
+      background: #1a1a1a;
+      color: #fff;
+      font-size: 0.9rem;
+      cursor: pointer;
+      transition: border-color 0.2s;
+      margin-bottom: 0.75rem;
+    }
+    .auth-btn:hover { border-color: #555; }
+    .auth-divider {
+      text-align: center;
+      color: #555;
+      font-size: 0.8rem;
+      margin: 0.75rem 0;
+    }
+    .email-input {
+      width: 100%;
+      padding: 0.75rem 1rem;
+      border: 1px solid #333;
+      border-radius: 8px;
+      background: #1a1a1a;
+      color: #fff;
+      font-size: 0.9rem;
+      margin-bottom: 0.75rem;
+    }
+    .email-input:focus { outline: none; border-color: #555; }
+
+    /* Tier selector */
+    .tier-section { margin-bottom: 2rem; }
+    .tier-label {
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #888;
+      margin-bottom: 0.75rem;
+    }
+    .tier-option {
+      padding: 0.75rem 1rem;
+      border: 1px solid #333;
+      border-radius: 8px;
+      margin-bottom: 0.5rem;
+      cursor: pointer;
+      transition: border-color 0.2s, background 0.2s;
+    }
+    .tier-option:hover { border-color: #555; }
+    .tier-option.selected {
+      border-color: #fff;
+      background: #1a1a1a;
+    }
+    .tier-option .tier-name {
+      font-size: 0.9rem;
+      font-weight: 500;
+      color: #fff;
+      margin-bottom: 0.25rem;
+    }
+    .tier-option .tier-desc {
+      font-size: 0.8rem;
+      color: #888;
+      line-height: 1.4;
+    }
+
+    /* Allow button */
+    .allow-btn {
+      width: 100%;
+      padding: 0.85rem 1rem;
+      border: none;
+      border-radius: 8px;
+      background: #fff;
+      color: #000;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    }
+    .allow-btn:hover { opacity: 0.9; }
+    .allow-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Status */
+    .status {
+      text-align: center;
+      padding: 2rem;
+      color: #888;
+      font-size: 0.9rem;
+    }
+    .status.error { color: #e55; }
+    .status.success { color: #5e5; }
+
+    .loading { display: none; }
+    .loading.active { display: block; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo">ctrl.rodeo</div>
+
+    <!-- Step 1: Auth (shown if not logged in) -->
+    <div id="auth-section" class="auth-section">
+      <h1>Connect your library</h1>
+      <p class="subtitle">Sign in to share your curated collection with <span class="client-name" id="client-name">Claude</span>.</p>
+
+      <button class="auth-btn" id="google-btn" onclick="signInGoogle()">Continue with Google</button>
+      <div class="auth-divider">or</div>
+      <input class="email-input" id="email-input" type="email" placeholder="Email address" />
+      <button class="auth-btn" id="email-btn" onclick="signInEmail()">Send magic link</button>
+      <div id="auth-status" class="status"></div>
+    </div>
+
+    <!-- Step 2: Consent (shown after auth) -->
+    <div id="consent-section" class="auth-section hidden">
+      <h1>Share with <span class="client-name" id="client-name-2">Claude</span></h1>
+      <p class="subtitle">Choose how much of your library to share.</p>
+
+      <div class="tier-section">
+        <div class="tier-label">Privacy level</div>
+
+        <div class="tier-option" data-tier="taste_only" onclick="selectTier('taste_only')">
+          <div class="tier-name">Taste Only</div>
+          <div class="tier-desc">Categories, tags, and interests — no specific links or titles.</div>
+        </div>
+
+        <div class="tier-option selected" data-tier="library" onclick="selectTier('library')">
+          <div class="tier-name">Library</div>
+          <div class="tier-desc">Titles, categories, tags — no URLs or private notes.</div>
+        </div>
+
+        <div class="tier-option" data-tier="full_access" onclick="selectTier('full_access')">
+          <div class="tier-name">Full Access</div>
+          <div class="tier-desc">Everything including URLs, notes, and images.</div>
+        </div>
+      </div>
+
+      <button class="allow-btn" id="allow-btn" onclick="authorize()">Allow</button>
+      <div id="consent-status" class="status"></div>
+    </div>
+
+    <!-- Loading / result -->
+    <div id="result-section" class="auth-section hidden">
+      <div id="result-status" class="status"></div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+  <script>
+    const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co'
+    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzgxOTQzMTgsImV4cCI6MjA1Mzc3MDMxOH0.VSwk27_TuN4WfbJ8gq9tp4FLOwtBN7BZDH-9i1CWBRI'
+    const OAUTH_BASE = `${SUPABASE_URL}/functions/v1/mcp-oauth`
+
+    const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { flowType: 'pkce' }
+    })
+
+    // Parse OAuth params from URL
+    const params = new URLSearchParams(window.location.search)
+    const oauthParams = {
+      client_id: params.get('client_id'),
+      redirect_uri: params.get('redirect_uri'),
+      code_challenge: params.get('code_challenge'),
+      code_challenge_method: params.get('code_challenge_method') || 'S256',
+      scope: params.get('scope') || 'read',
+      state: params.get('state'),
+    }
+
+    let selectedTier = 'library'
+
+    // Set client name from params if available
+    document.getElementById('client-name').textContent = 'Claude'
+    document.getElementById('client-name-2').textContent = 'Claude'
+
+    // Check if already logged in
+    async function init() {
+      const { data: { session } } = await supabase.auth.getSession()
+      if (session) {
+        showConsent()
+      }
+    }
+
+    function showConsent() {
+      document.getElementById('auth-section').classList.add('hidden')
+      document.getElementById('consent-section').classList.remove('hidden')
+    }
+
+    function showResult(message, isError = false) {
+      document.getElementById('auth-section').classList.add('hidden')
+      document.getElementById('consent-section').classList.add('hidden')
+      document.getElementById('result-section').classList.remove('hidden')
+      const el = document.getElementById('result-status')
+      el.textContent = message
+      el.className = isError ? 'status error' : 'status success'
+    }
+
+    function selectTier(tier) {
+      selectedTier = tier
+      document.querySelectorAll('.tier-option').forEach(el => {
+        el.classList.toggle('selected', el.dataset.tier === tier)
+      })
+    }
+
+    async function signInGoogle() {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: window.location.href }
+      })
+      if (error) {
+        document.getElementById('auth-status').textContent = error.message
+        document.getElementById('auth-status').className = 'status error'
+      }
+    }
+
+    async function signInEmail() {
+      const email = document.getElementById('email-input').value
+      if (!email) return
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { emailRedirectTo: window.location.href }
+      })
+      if (error) {
+        document.getElementById('auth-status').textContent = error.message
+        document.getElementById('auth-status').className = 'status error'
+      } else {
+        document.getElementById('auth-status').textContent = 'Check your email for the magic link.'
+        document.getElementById('auth-status').className = 'status'
+      }
+    }
+
+    async function authorize() {
+      const btn = document.getElementById('allow-btn')
+      btn.disabled = true
+      btn.textContent = 'Connecting...'
+
+      try {
+        const { data: { session } } = await supabase.auth.getSession()
+        if (!session) {
+          document.getElementById('consent-status').textContent = 'Session expired. Please sign in again.'
+          document.getElementById('consent-status').className = 'status error'
+          btn.disabled = false
+          btn.textContent = 'Allow'
+          return
+        }
+
+        // Call our OAuth server to create an authorization code
+        const response = await fetch(`${OAUTH_BASE}/code`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${session.access_token}`,
+          },
+          body: JSON.stringify({
+            ...oauthParams,
+            privacy_tier: selectedTier,
+          }),
+        })
+
+        const result = await response.json()
+
+        if (!response.ok || !result.redirect_url) {
+          throw new Error(result.error_description || result.error || 'Authorization failed')
+        }
+
+        // Redirect back to Claude with the auth code
+        showResult('Connected! Redirecting...')
+        window.location.href = result.redirect_url
+
+      } catch (e) {
+        document.getElementById('consent-status').textContent = e.message
+        document.getElementById('consent-status').className = 'status error'
+        btn.disabled = false
+        btn.textContent = 'Allow'
+      }
+    }
+
+    // Listen for auth state changes (after Google redirect or magic link)
+    supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        showConsent()
+      }
+    })
+
+    init()
+  </script>
+</body>
+</html>

--- a/supabase/functions/mcp-oauth/index.ts
+++ b/supabase/functions/mcp-oauth/index.ts
@@ -1,0 +1,462 @@
+// Supabase Edge Function: mcp-oauth
+// OAuth 2.1 Authorization Server for the MCP Connector.
+// Handles: metadata discovery, dynamic client registration,
+// authorization, token exchange, and token refresh.
+//
+// Endpoints:
+//   GET  /.well-known/oauth-authorization-server → metadata
+//   POST /register                               → dynamic client registration
+//   GET  /authorize                              → redirect to consent page
+//   POST /token                                  → code exchange / refresh
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const VERSION = '0.1.0'
+console.log(`[mcp-oauth] v${VERSION} - MCP OAuth 2.1 authorization server`)
+
+const BASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth'
+const CONSENT_URL = 'https://ctrl.rodeo/connect/'
+
+const ALLOWED_REDIRECT_URIS = [
+  'http://localhost:6274/oauth/callback',
+  'http://localhost:6274/oauth/callback/debug',
+  'https://claude.ai/api/mcp/auth_callback',
+  'https://claude.com/api/mcp/auth_callback',
+]
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status = 200, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Cache-Control': 'no-store', ...extraHeaders },
+  })
+}
+
+function err(error: string, description: string, status = 400) {
+  return json({ error, error_description: description }, status)
+}
+
+function getServiceClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  )
+}
+
+function generateToken(bytes = 32): string {
+  const array = new Uint8Array(bytes)
+  crypto.getRandomValues(array)
+  return Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function sha256(plain: string): Promise<string> {
+  const encoded = new TextEncoder().encode(plain)
+  const hash = await crypto.subtle.digest('SHA-256', encoded)
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// ---------------------------------------------------------------------------
+// Metadata discovery (RFC 8414)
+// ---------------------------------------------------------------------------
+
+function handleMetadata(): Response {
+  return json({
+    issuer: BASE_URL,
+    authorization_endpoint: `${BASE_URL}/authorize`,
+    token_endpoint: `${BASE_URL}/token`,
+    registration_endpoint: `${BASE_URL}/register`,
+    response_types_supported: ['code'],
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+    scopes_supported: ['read', 'write'],
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic Client Registration (RFC 7591)
+// ---------------------------------------------------------------------------
+
+async function handleRegister(req: Request): Promise<Response> {
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return err('invalid_request', 'Invalid JSON body')
+  }
+
+  const clientName = (body.client_name as string) || 'Unknown Client'
+  const redirectUris = (body.redirect_uris as string[]) || []
+
+  // Validate redirect URIs
+  for (const uri of redirectUris) {
+    if (!uri.startsWith('http://localhost:') && !uri.startsWith('https://')) {
+      return err('invalid_redirect_uri', `Redirect URI must be localhost or HTTPS: ${uri}`)
+    }
+  }
+
+  const clientId = `mcp_${generateToken(16)}`
+
+  const db = getServiceClient()
+  const { error: insertErr } = await db.from('mcp_clients').insert({
+    client_id: clientId,
+    client_name: clientName,
+    redirect_uris: redirectUris,
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  })
+
+  if (insertErr) {
+    console.error('[mcp-oauth] DCR insert failed:', insertErr)
+    return err('server_error', 'Failed to register client', 500)
+  }
+
+  return json({
+    client_id: clientId,
+    client_name: clientName,
+    redirect_uris: redirectUris,
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  }, 201)
+}
+
+// ---------------------------------------------------------------------------
+// Authorization endpoint
+// ---------------------------------------------------------------------------
+
+function handleAuthorize(url: URL): Response {
+  const clientId = url.searchParams.get('client_id')
+  const redirectUri = url.searchParams.get('redirect_uri')
+  const responseType = url.searchParams.get('response_type')
+  const codeChallenge = url.searchParams.get('code_challenge')
+  const codeChallengeMethod = url.searchParams.get('code_challenge_method') || 'S256'
+  const state = url.searchParams.get('state')
+  const scope = url.searchParams.get('scope') || 'read'
+
+  if (!clientId) return err('invalid_request', 'Missing client_id')
+  if (responseType !== 'code') return err('unsupported_response_type', 'Only code is supported')
+  if (!redirectUri) return err('invalid_request', 'Missing redirect_uri')
+  if (!codeChallenge) return err('invalid_request', 'PKCE code_challenge is required')
+  if (codeChallengeMethod !== 'S256') return err('invalid_request', 'Only S256 code_challenge_method is supported')
+
+  // Redirect to consent page with all params
+  const consentParams = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallengeMethod,
+    scope,
+    ...(state ? { state } : {}),
+  })
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      ...corsHeaders,
+      Location: `${CONSENT_URL}?${consentParams.toString()}`,
+    },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Authorization code creation (called by consent page after user approves)
+// ---------------------------------------------------------------------------
+
+async function handleCreateCode(req: Request): Promise<Response> {
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return err('invalid_request', 'Invalid JSON body')
+  }
+
+  const userAccessToken = req.headers.get('authorization')
+  if (!userAccessToken) return err('unauthorized', 'Missing authorization header', 401)
+
+  // Validate user via Supabase JWT
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: userAccessToken } } },
+  )
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return err('unauthorized', 'Invalid user token', 401)
+
+  const clientId = body.client_id as string
+  const redirectUri = body.redirect_uri as string
+  const codeChallenge = body.code_challenge as string
+  const codeChallengeMethod = (body.code_challenge_method as string) || 'S256'
+  const scope = (body.scope as string) || 'read'
+  const state = body.state as string | undefined
+  const privacyTier = (body.privacy_tier as string) || 'library'
+
+  if (!clientId || !redirectUri || !codeChallenge) {
+    return err('invalid_request', 'Missing required fields')
+  }
+
+  // Generate authorization code
+  const code = generateToken(32)
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString() // 10 min
+
+  const db = getServiceClient()
+
+  // Store the code
+  const { error: insertErr } = await db.from('mcp_auth_codes').insert({
+    code,
+    user_id: user.id,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: codeChallengeMethod,
+    scopes: scope.split(' '),
+    privacy_tier: privacyTier,
+    expires_at: expiresAt,
+  })
+
+  if (insertErr) {
+    console.error('[mcp-oauth] Code insert failed:', insertErr)
+    return err('server_error', 'Failed to create authorization code', 500)
+  }
+
+  // Upsert connector settings with chosen privacy tier
+  await db.from('connector_settings').upsert({
+    user_id: user.id,
+    privacy_tier: privacyTier,
+  }, { onConflict: 'user_id' })
+
+  // Build redirect URL
+  const redirectParams = new URLSearchParams({ code })
+  if (state) redirectParams.set('state', state)
+
+  console.log(`[mcp-oauth] Auth code created for user ${user.id}, tier: ${privacyTier}`)
+  return json({
+    redirect_url: `${redirectUri}?${redirectParams.toString()}`,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Token endpoint
+// ---------------------------------------------------------------------------
+
+async function handleToken(req: Request): Promise<Response> {
+  let body: URLSearchParams
+  const contentType = req.headers.get('content-type') || ''
+
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    body = new URLSearchParams(await req.text())
+  } else if (contentType.includes('application/json')) {
+    const jsonBody = await req.json()
+    body = new URLSearchParams(jsonBody as Record<string, string>)
+  } else {
+    return err('invalid_request', 'Content-Type must be application/x-www-form-urlencoded or application/json')
+  }
+
+  const grantType = body.get('grant_type')
+
+  if (grantType === 'authorization_code') {
+    return handleCodeExchange(body)
+  } else if (grantType === 'refresh_token') {
+    return handleRefresh(body)
+  } else {
+    return err('unsupported_grant_type', `Unsupported grant_type: ${grantType}`)
+  }
+}
+
+async function handleCodeExchange(body: URLSearchParams): Promise<Response> {
+  const code = body.get('code')
+  const clientId = body.get('client_id')
+  const redirectUri = body.get('redirect_uri')
+  const codeVerifier = body.get('code_verifier')
+
+  if (!code || !clientId || !codeVerifier) {
+    return err('invalid_request', 'Missing code, client_id, or code_verifier')
+  }
+
+  const db = getServiceClient()
+
+  // Look up the authorization code
+  const { data: authCode, error: lookupErr } = await db
+    .from('mcp_auth_codes')
+    .select('*')
+    .eq('code', code)
+    .eq('used', false)
+    .single()
+
+  if (lookupErr || !authCode) {
+    return err('invalid_grant', 'Invalid or expired authorization code')
+  }
+
+  // Check expiry
+  if (new Date(authCode.expires_at) < new Date()) {
+    await db.from('mcp_auth_codes').update({ used: true }).eq('code', code)
+    return err('invalid_grant', 'Authorization code has expired')
+  }
+
+  // Verify client_id matches
+  if (authCode.client_id !== clientId) {
+    return err('invalid_grant', 'client_id mismatch')
+  }
+
+  // Verify redirect_uri matches
+  if (redirectUri && authCode.redirect_uri !== redirectUri) {
+    return err('invalid_grant', 'redirect_uri mismatch')
+  }
+
+  // Verify PKCE code_verifier → code_challenge
+  const computedChallenge = await sha256(codeVerifier)
+  if (computedChallenge !== authCode.code_challenge) {
+    return err('invalid_grant', 'PKCE code_verifier does not match code_challenge')
+  }
+
+  // Mark code as used
+  await db.from('mcp_auth_codes').update({ used: true }).eq('code', code)
+
+  // Generate tokens
+  const accessToken = generateToken(32)
+  const refreshToken = generateToken(32)
+  const accessExpiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString() // 1 hour
+  const refreshExpiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days
+
+  const { error: tokenErr } = await db.from('mcp_tokens').insert({
+    user_id: authCode.user_id,
+    client_id: clientId,
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    access_token_expires_at: accessExpiresAt,
+    refresh_token_expires_at: refreshExpiresAt,
+    scopes: authCode.scopes,
+  })
+
+  if (tokenErr) {
+    console.error('[mcp-oauth] Token insert failed:', tokenErr)
+    return err('server_error', 'Failed to create tokens', 500)
+  }
+
+  console.log(`[mcp-oauth] Tokens issued for user ${authCode.user_id}`)
+  return json({
+    access_token: accessToken,
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: refreshToken,
+    scope: authCode.scopes.join(' '),
+  })
+}
+
+async function handleRefresh(body: URLSearchParams): Promise<Response> {
+  const refreshToken = body.get('refresh_token')
+  const clientId = body.get('client_id')
+
+  if (!refreshToken) return err('invalid_request', 'Missing refresh_token')
+
+  const db = getServiceClient()
+
+  // Look up refresh token
+  const { data: existing, error: lookupErr } = await db
+    .from('mcp_tokens')
+    .select('*')
+    .eq('refresh_token', refreshToken)
+    .single()
+
+  if (lookupErr || !existing) {
+    return err('invalid_grant', 'Invalid refresh token')
+  }
+
+  // Check refresh token expiry
+  if (existing.refresh_token_expires_at && new Date(existing.refresh_token_expires_at) < new Date()) {
+    await db.from('mcp_tokens').delete().eq('id', existing.id)
+    return err('invalid_grant', 'Refresh token has expired')
+  }
+
+  // Verify client_id if provided
+  if (clientId && existing.client_id !== clientId) {
+    return err('invalid_grant', 'client_id mismatch')
+  }
+
+  // Rotate tokens
+  const newAccessToken = generateToken(32)
+  const newRefreshToken = generateToken(32)
+  const accessExpiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString()
+  const refreshExpiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+
+  const { error: updateErr } = await db
+    .from('mcp_tokens')
+    .update({
+      access_token: newAccessToken,
+      refresh_token: newRefreshToken,
+      access_token_expires_at: accessExpiresAt,
+      refresh_token_expires_at: refreshExpiresAt,
+    })
+    .eq('id', existing.id)
+
+  if (updateErr) {
+    console.error('[mcp-oauth] Token refresh failed:', updateErr)
+    return err('server_error', 'Failed to refresh tokens', 500)
+  }
+
+  console.log(`[mcp-oauth] Tokens refreshed for user ${existing.user_id}`)
+  return json({
+    access_token: newAccessToken,
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: newRefreshToken,
+    scope: existing.scopes.join(' '),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+
+  const url = new URL(req.url)
+  const path = url.pathname.replace('/functions/v1/mcp-oauth', '')
+
+  try {
+    // Metadata discovery
+    if (path === '/.well-known/oauth-authorization-server' || path === '/metadata') {
+      return handleMetadata()
+    }
+
+    // Dynamic Client Registration
+    if (path === '/register' && req.method === 'POST') {
+      return await handleRegister(req)
+    }
+
+    // Authorization
+    if (path === '/authorize' && req.method === 'GET') {
+      return handleAuthorize(url)
+    }
+
+    // Authorization code creation (from consent page)
+    if (path === '/code' && req.method === 'POST') {
+      return await handleCreateCode(req)
+    }
+
+    // Token exchange / refresh
+    if (path === '/token' && req.method === 'POST') {
+      return await handleToken(req)
+    }
+
+    return err('not_found', `Unknown endpoint: ${req.method} ${path}`, 404)
+  } catch (e) {
+    console.error('[mcp-oauth] Unhandled error:', e)
+    return err('server_error', 'Internal server error', 500)
+  }
+})

--- a/supabase/functions/mcp-server/config.ts
+++ b/supabase/functions/mcp-server/config.ts
@@ -1,0 +1,183 @@
+// MCP Connector — Product configuration
+// Change these values when the product name changes.
+// Both the MCP server and OAuth consent page reference this file.
+
+export const VERSION = '0.1.0'
+
+export const PRODUCT_CONFIG = {
+  name: 'ctrl.rodeo',
+  connector_name: 'ctrl.rodeo',
+  description: 'Your curated library — search, discover, and save across everything you collect.',
+  server_url: 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-server',
+  oauth_url: 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth',
+  consent_copy: {
+    taste_only: 'Share your taste patterns (categories, tags, interests) — no specific links or titles.',
+    library: 'Share your library (titles, categories, tags) — no URLs or private notes.',
+    full_access: 'Full access to your library including URLs, notes, and images.',
+  },
+} as const
+
+// Built-in board definitions (semantic meaning for Claude context)
+export const BUILTIN_BOARDS: Record<string, string> = {
+  home: 'Home, furniture, interior design, decor',
+  wear: 'Clothing, fashion, accessories, shoes',
+  watch: 'Film, TV, documentaries, video content',
+  listen: 'Music, podcasts, audio, playlists',
+  use: 'Tools, gadgets, software, products',
+  eat: 'Restaurants, recipes, food, drink',
+  go: 'Travel, places, neighborhoods, destinations',
+  follow: 'People, creators, accounts to follow',
+  read: 'Articles, books, essays, long-form writing',
+}
+
+// Privacy tier field mapping
+export const PRIVACY_TIERS = {
+  taste_only: {
+    allowed_fields: ['category', 'content_type', 'taste_tags', 'practical_tags', 'entities', 'domain'],
+    description: 'Taste patterns only — no titles, URLs, or notes',
+  },
+  library: {
+    allowed_fields: ['title', 'category', 'content_type', 'taste_tags', 'practical_tags', 'entities', 'domain', 'image', 'video', 'music', 'book'],
+    description: 'Library metadata — titles, categories, tags, media info',
+  },
+  full_access: {
+    allowed_fields: ['title', 'url', 'description', 'category', 'content_type', 'taste_tags', 'practical_tags', 'entities', 'domain', 'image', 'notes', 'video', 'music', 'book', 'selected_text', 'source_url'],
+    description: 'Full access — everything including URLs and notes',
+  },
+} as const
+
+export type PrivacyTier = keyof typeof PRIVACY_TIERS
+
+// MCP Tool definitions with annotations
+export const TOOL_DEFINITIONS = [
+  {
+    name: 'search_pins',
+    description: `Search saved items in the user's ${PRODUCT_CONFIG.name} library by keyword, board, content type, or tags. Returns matching pins with metadata filtered by the user's privacy settings.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Search query (matched against titles, descriptions, tags, entities)' },
+        board: { type: 'string', description: 'Filter by board/category slug (e.g., "wear", "listen", "read")' },
+        content_type: { type: 'string', description: 'Filter by content type (product, article, book, video, music, repository, social, tool, place, recipe)' },
+        tag: { type: 'string', description: 'Filter by a specific taste or practical tag' },
+        limit: { type: 'integer', description: 'Max results to return (default: 20, max: 50)', default: 20 },
+      },
+      required: [],
+    },
+    annotations: {
+      title: 'Search Pins',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: 'get_board',
+    description: `Get all items in a specific board/category from the user's ${PRODUCT_CONFIG.name} library. Boards represent interest areas like Wear, Listen, Read, etc.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        board: { type: 'string', description: 'Board/category slug (e.g., "wear", "listen", "read", "home", "use", "eat", "go", "follow", "watch", or a custom board slug)' },
+        limit: { type: 'integer', description: 'Max results (default: 50, max: 100)', default: 50 },
+        offset: { type: 'integer', description: 'Pagination offset', default: 0 },
+      },
+      required: ['board'],
+    },
+    annotations: {
+      title: 'Get Board',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: 'get_boards_list',
+    description: `List all boards in the user's ${PRODUCT_CONFIG.name} library with item counts and descriptions. Includes both built-in boards (home, wear, watch, listen, use, eat, go, follow, read) and user-created boards.`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    annotations: {
+      title: 'List Boards',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: 'get_taste_profile',
+    description: `Get the user's taste profile — AI-generated clusters with labels, descriptions, cross-board bridges, and motifs. Reveals the user's signature patterns and aesthetic identity across their entire library.`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    annotations: {
+      title: 'Get Taste Profile',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: 'get_recent_saves',
+    description: `Get the most recently saved items from the user's ${PRODUCT_CONFIG.name} library. Useful for understanding what the user is currently interested in.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: { type: 'integer', description: 'Number of recent saves (default: 20, max: 50)', default: 20 },
+        days: { type: 'integer', description: 'Only include saves from the last N days (optional)' },
+      },
+      required: [],
+    },
+    annotations: {
+      title: 'Recent Saves',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: 'save_pin',
+    description: `Save a URL to the user's ${PRODUCT_CONFIG.name} library. The platform automatically resolves images, categorizes into the right board, extracts entities, and generates taste/practical tags. The pin arrives fully enriched — same quality as a manual save. Idempotent: if the URL already exists, returns the existing pin. Use this proactively when the user expresses a clear choice signal (e.g., "I'll get that", "that's perfect", "add to cart").`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to save' },
+        notes: { type: 'string', description: 'Optional notes (e.g., conversation context: "Recommended during running shoe research")' },
+        category: { type: 'string', description: 'Optional board override (e.g., "wear"). If omitted, AI auto-categorizes.' },
+        source: { type: 'string', description: 'Capture source identifier (default: "claude_connector", use "claude_auto" for auto-captures on choice signals)', default: 'claude_connector' },
+      },
+      required: ['url'],
+    },
+    annotations: {
+      title: 'Save Pin',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: 'get_connector_context',
+    description: `Get orientation context for the ${PRODUCT_CONFIG.name} connector — board taxonomy with semantic meanings, available content types, how taste/practical tags work, and tool composition guidance. Call this first to understand how to use the other tools effectively.`,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    annotations: {
+      title: 'Connector Context',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+]

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -1,0 +1,712 @@
+// Supabase Edge Function: mcp-server
+// MCP Streamable HTTP server for the Taste Connector.
+// Implements the MCP 2025-03-26 spec: JSON-RPC over HTTP POST,
+// session management, tool dispatch, and privacy filtering.
+//
+// POST /functions/v1/mcp-server → JSON-RPC request
+// Authorization: Bearer <mcp_access_token>
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { VERSION, PRODUCT_CONFIG, TOOL_DEFINITIONS, BUILTIN_BOARDS, PRIVACY_TIERS, type PrivacyTier } from './config.ts'
+
+console.log(`[mcp-server] v${VERSION} - MCP Streamable HTTP server`)
+
+const MCP_PROTOCOL_VERSION = '2025-03-26'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, accept, mcp-session-id',
+  'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+  'Access-Control-Expose-Headers': 'mcp-session-id',
+}
+
+// In-memory session store (edge functions are short-lived, so sessions are ephemeral per instance)
+const sessions = new Map<string, { userId: string, privacyTier: PrivacyTier, createdAt: number }>()
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function json(data: unknown, status = 200, extraHeaders: Record<string, string> = {}) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json', ...extraHeaders },
+  })
+}
+
+function jsonRpcResponse(id: unknown, result: unknown) {
+  return { jsonrpc: '2.0', id, result }
+}
+
+function jsonRpcError(id: unknown, code: number, message: string, data?: unknown) {
+  return { jsonrpc: '2.0', id, error: { code, message, ...(data ? { data } : {}) } }
+}
+
+function getServiceClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  )
+}
+
+function generateSessionId(): string {
+  const array = new Uint8Array(16)
+  crypto.getRandomValues(array)
+  return Array.from(array, b => b.toString(16).padStart(2, '0')).join('')
+}
+
+// ---------------------------------------------------------------------------
+// Auth: resolve MCP token → user_id
+// ---------------------------------------------------------------------------
+
+async function resolveUser(req: Request): Promise<{ userId: string, privacyTier: PrivacyTier } | null> {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader?.startsWith('Bearer ')) return null
+
+  const token = authHeader.slice(7)
+  const db = getServiceClient()
+
+  const { data, error } = await db
+    .from('mcp_tokens')
+    .select('user_id, access_token_expires_at')
+    .eq('access_token', token)
+    .single()
+
+  if (error || !data) return null
+  if (new Date(data.access_token_expires_at) < new Date()) return null
+
+  // Get privacy settings
+  const { data: settings } = await db
+    .from('connector_settings')
+    .select('privacy_tier, board_visibility, field_visibility')
+    .eq('user_id', data.user_id)
+    .single()
+
+  return {
+    userId: data.user_id,
+    privacyTier: (settings?.privacy_tier || 'library') as PrivacyTier,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Privacy filtering
+// ---------------------------------------------------------------------------
+
+interface ConnectorSettings {
+  privacy_tier: PrivacyTier
+  board_visibility: Record<string, boolean>
+  field_visibility: Record<string, boolean>
+}
+
+async function getSettings(userId: string): Promise<ConnectorSettings> {
+  const db = getServiceClient()
+  const { data } = await db
+    .from('connector_settings')
+    .select('privacy_tier, board_visibility, field_visibility')
+    .eq('user_id', userId)
+    .single()
+
+  return {
+    privacy_tier: (data?.privacy_tier || 'library') as PrivacyTier,
+    board_visibility: data?.board_visibility || {},
+    field_visibility: data?.field_visibility || {},
+  }
+}
+
+function filterPin(pin: Record<string, unknown>, settings: ConnectorSettings): Record<string, unknown> {
+  const tier = PRIVACY_TIERS[settings.privacy_tier]
+  const allowedFields = new Set(tier.allowed_fields)
+  const fieldVis = settings.field_visibility
+
+  const filtered: Record<string, unknown> = { id: pin.id, created_at: pin.created_at }
+
+  for (const field of allowedFields) {
+    // Check field-level override (default: visible)
+    if (fieldVis[field] === false) continue
+    if (pin[field] !== undefined && pin[field] !== null) {
+      filtered[field] = pin[field]
+    }
+  }
+
+  return filtered
+}
+
+function isBoardVisible(category: string, settings: ConnectorSettings): boolean {
+  // Default: all boards visible. Only hide if explicitly set to false.
+  return settings.board_visibility[category] !== false
+}
+
+// ---------------------------------------------------------------------------
+// Usage logging
+// ---------------------------------------------------------------------------
+
+async function logUsage(
+  userId: string,
+  toolName: string,
+  inputParams: unknown,
+  resultCount: number,
+  privacyTier: string,
+  sessionId: string | null,
+  startTime: number,
+  error?: string,
+) {
+  const db = getServiceClient()
+  await db.from('connector_usage').insert({
+    user_id: userId,
+    tool_name: toolName,
+    input_params: inputParams,
+    result_count: resultCount,
+    privacy_tier: privacyTier,
+    session_id: sessionId,
+    duration_ms: Date.now() - startTime,
+    error,
+  }).then(() => {}, (e: Error) => console.error('[mcp-server] Usage log failed:', e))
+}
+
+// ---------------------------------------------------------------------------
+// Tool implementations
+// ---------------------------------------------------------------------------
+
+async function toolSearchPins(
+  userId: string, args: Record<string, unknown>, settings: ConnectorSettings
+): Promise<unknown> {
+  const db = getServiceClient()
+  const limit = Math.min((args.limit as number) || 20, 50)
+
+  let query = db.from('links').select('*').eq('user_id', userId).order('created_at', { ascending: false }).limit(limit)
+
+  if (args.board) query = query.eq('category', args.board)
+  if (args.content_type) query = query.eq('content_type', args.content_type)
+
+  const { data: pins, error } = await query
+
+  if (error) throw new Error(`Search failed: ${error.message}`)
+
+  let results = (pins || [])
+    .filter((p: Record<string, unknown>) => isBoardVisible(p.category as string, settings))
+
+  // Text search filter (client-side since we're using Supabase REST)
+  if (args.query) {
+    const q = (args.query as string).toLowerCase()
+    results = results.filter((p: Record<string, unknown>) => {
+      const searchable = [
+        p.title, p.description, p.domain,
+        ...(Array.isArray(p.tags) ? p.tags : []),
+        ...(Array.isArray(p.taste_tags) ? p.taste_tags : []),
+        ...(Array.isArray(p.practical_tags) ? p.practical_tags : []),
+      ].filter(Boolean).join(' ').toLowerCase()
+      return searchable.includes(q)
+    })
+  }
+
+  // Tag filter
+  if (args.tag) {
+    const tag = (args.tag as string).toLowerCase()
+    results = results.filter((p: Record<string, unknown>) => {
+      const allTags = [
+        ...(Array.isArray(p.tags) ? p.tags : []),
+        ...(Array.isArray(p.taste_tags) ? p.taste_tags : []),
+        ...(Array.isArray(p.practical_tags) ? p.practical_tags : []),
+      ]
+      return allTags.some((t: string) => t.toLowerCase().includes(tag))
+    })
+  }
+
+  return {
+    pins: results.map(p => filterPin(p, settings)),
+    total: results.length,
+    query: args.query || null,
+    board: args.board || null,
+  }
+}
+
+async function toolGetBoard(
+  userId: string, args: Record<string, unknown>, settings: ConnectorSettings
+): Promise<unknown> {
+  const board = args.board as string
+  if (!isBoardVisible(board, settings)) {
+    return { pins: [], total: 0, board, message: 'This board is not shared.' }
+  }
+
+  const db = getServiceClient()
+  const limit = Math.min((args.limit as number) || 50, 100)
+  const offset = (args.offset as number) || 0
+
+  const { data: pins, error, count } = await db
+    .from('links')
+    .select('*', { count: 'exact' })
+    .eq('user_id', userId)
+    .eq('category', board)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1)
+
+  if (error) throw new Error(`Get board failed: ${error.message}`)
+
+  return {
+    pins: (pins || []).map(p => filterPin(p, settings)),
+    total: count || 0,
+    board,
+    description: BUILTIN_BOARDS[board] || null,
+  }
+}
+
+async function toolGetBoardsList(
+  userId: string, settings: ConnectorSettings
+): Promise<unknown> {
+  const db = getServiceClient()
+
+  const { data: pins, error } = await db
+    .from('links')
+    .select('category')
+    .eq('user_id', userId)
+
+  if (error) throw new Error(`Get boards failed: ${error.message}`)
+
+  // Count pins per category
+  const counts: Record<string, number> = {}
+  for (const pin of (pins || [])) {
+    const cat = pin.category as string
+    if (!isBoardVisible(cat, settings)) continue
+    counts[cat] = (counts[cat] || 0) + 1
+  }
+
+  const boards = Object.entries(counts)
+    .map(([slug, count]) => ({
+      slug,
+      count,
+      description: BUILTIN_BOARDS[slug] || null,
+      is_builtin: slug in BUILTIN_BOARDS,
+    }))
+    .sort((a, b) => b.count - a.count)
+
+  return { boards, total_pins: Object.values(counts).reduce((a, b) => a + b, 0) }
+}
+
+async function toolGetTasteProfile(
+  userId: string, settings: ConnectorSettings
+): Promise<unknown> {
+  const db = getServiceClient()
+
+  // Get taste_tags and practical_tags aggregation
+  const { data: pins, error } = await db
+    .from('links')
+    .select('category, taste_tags, practical_tags, entities, content_type')
+    .eq('user_id', userId)
+
+  if (error) throw new Error(`Taste profile failed: ${error.message}`)
+
+  const visiblePins = (pins || []).filter((p: Record<string, unknown>) =>
+    isBoardVisible(p.category as string, settings)
+  )
+
+  // Aggregate taste_tags
+  const tasteCounts: Record<string, { count: number, boards: Set<string> }> = {}
+  const practicalCounts: Record<string, { count: number, boards: Set<string> }> = {}
+  const entityCounts: Record<string, { count: number, boards: Set<string>, type: string }> = {}
+  const contentTypeCounts: Record<string, number> = {}
+
+  for (const pin of visiblePins) {
+    const cat = pin.category as string
+    const ct = pin.content_type as string
+    if (ct) contentTypeCounts[ct] = (contentTypeCounts[ct] || 0) + 1
+
+    for (const tag of (pin.taste_tags as string[] || [])) {
+      if (!tasteCounts[tag]) tasteCounts[tag] = { count: 0, boards: new Set() }
+      tasteCounts[tag].count++
+      tasteCounts[tag].boards.add(cat)
+    }
+    for (const tag of (pin.practical_tags as string[] || [])) {
+      if (!practicalCounts[tag]) practicalCounts[tag] = { count: 0, boards: new Set() }
+      practicalCounts[tag].count++
+      practicalCounts[tag].boards.add(cat)
+    }
+    for (const entity of (pin.entities as Array<{ name: string, type: string }> || [])) {
+      const key = entity.name
+      if (!entityCounts[key]) entityCounts[key] = { count: 0, boards: new Set(), type: entity.type }
+      entityCounts[key].count++
+      entityCounts[key].boards.add(cat)
+    }
+  }
+
+  const toSorted = (counts: Record<string, { count: number, boards: Set<string>, type?: string }>) =>
+    Object.entries(counts)
+      .map(([name, { count, boards, type }]) => ({
+        name, count, boards: Array.from(boards),
+        ...(type ? { type } : {}),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 30)
+
+  return {
+    taste_tags: toSorted(tasteCounts),
+    practical_tags: toSorted(practicalCounts),
+    top_entities: toSorted(entityCounts),
+    content_types: contentTypeCounts,
+    total_pins: visiblePins.length,
+    boards_analyzed: new Set(visiblePins.map((p: Record<string, unknown>) => p.category)).size,
+  }
+}
+
+async function toolGetRecentSaves(
+  userId: string, args: Record<string, unknown>, settings: ConnectorSettings
+): Promise<unknown> {
+  const db = getServiceClient()
+  const limit = Math.min((args.limit as number) || 20, 50)
+
+  let query = db.from('links').select('*').eq('user_id', userId).order('created_at', { ascending: false }).limit(limit)
+
+  if (args.days) {
+    const since = new Date(Date.now() - (args.days as number) * 24 * 60 * 60 * 1000).toISOString()
+    query = query.gte('created_at', since)
+  }
+
+  const { data: pins, error } = await query
+
+  if (error) throw new Error(`Recent saves failed: ${error.message}`)
+
+  const results = (pins || [])
+    .filter((p: Record<string, unknown>) => isBoardVisible(p.category as string, settings))
+
+  return {
+    pins: results.map(p => filterPin(p, settings)),
+    total: results.length,
+  }
+}
+
+async function toolSavePin(
+  userId: string, args: Record<string, unknown>
+): Promise<unknown> {
+  const url = args.url as string
+  if (!url) throw new Error('url is required')
+
+  // Call the existing create-pin pipeline
+  const createPinUrl = `${Deno.env.get('SUPABASE_URL')}/functions/v1/create-pin`
+  const categorizeUrl = `${Deno.env.get('SUPABASE_URL')}/functions/v1/categorize`
+  const analyzeUrl = `${Deno.env.get('SUPABASE_URL')}/functions/v1/analyze-content`
+
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+  // Generate deterministic pin ID from URL (same as client)
+  const urlHash = await generatePinId(url)
+
+  // Check if pin already exists
+  const db = getServiceClient()
+  const { data: existing } = await db
+    .from('links')
+    .select('id, title, category, content_type, short_code')
+    .eq('id', urlHash)
+    .eq('user_id', userId)
+    .single()
+
+  if (existing) {
+    return {
+      action: 'existing',
+      pin: existing,
+      message: 'This URL is already in your library.',
+    }
+  }
+
+  // Create the pin record first
+  const pinData: Record<string, unknown> = {
+    id: urlHash,
+    user_id: userId,
+    url,
+    source: (args.source as string) || 'claude_connector',
+    notes: (args.notes as string) || null,
+  }
+
+  if (args.category) {
+    pinData.category = args.category
+  }
+
+  const { error: insertErr } = await db.from('links').insert(pinData)
+  if (insertErr) throw new Error(`Failed to save pin: ${insertErr.message}`)
+
+  // Trigger enrichment pipeline in parallel (fire-and-forget)
+  const enrichPromises = [
+    fetch(createPinUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${serviceKey}`,
+      },
+      body: JSON.stringify({ url, linkId: urlHash }),
+    }).catch(e => console.error('[mcp-server] create-pin call failed:', e)),
+
+    fetch(analyzeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${serviceKey}`,
+      },
+      body: JSON.stringify({ url, linkId: urlHash }),
+    }).catch(e => console.error('[mcp-server] analyze-content call failed:', e)),
+  ]
+
+  // Categorize if no explicit category
+  if (!args.category) {
+    enrichPromises.push(
+      fetch(categorizeUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${serviceKey}`,
+        },
+        body: JSON.stringify({ url, linkId: urlHash }),
+      }).catch(e => console.error('[mcp-server] categorize call failed:', e))
+    )
+  }
+
+  // Don't await enrichment — it runs async
+  Promise.allSettled(enrichPromises)
+
+  return {
+    action: 'created',
+    pin: { id: urlHash, url, category: args.category || 'pending', notes: args.notes || null },
+    message: 'Pin saved. It will be enriched with images, tags, and categorization shortly.',
+  }
+}
+
+async function generatePinId(url: string): Promise<string> {
+  // Deterministic UUID v5-like hash from URL (matches client-side logic)
+  const encoded = new TextEncoder().encode(url)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', encoded)
+  const hashArray = new Uint8Array(hashBuffer)
+  // Format as UUID
+  const hex = Array.from(hashArray.slice(0, 16), b => b.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
+}
+
+function toolGetConnectorContext(settings: ConnectorSettings): unknown {
+  return {
+    product: PRODUCT_CONFIG.name,
+    description: PRODUCT_CONFIG.description,
+    privacy_tier: settings.privacy_tier,
+    privacy_description: PRIVACY_TIERS[settings.privacy_tier].description,
+    boards: Object.entries(BUILTIN_BOARDS).map(([slug, description]) => ({
+      slug,
+      description,
+      shared: isBoardVisible(slug, settings),
+    })),
+    content_types: [
+      'product', 'article', 'book', 'video', 'music',
+      'repository', 'social', 'document', 'tool', 'place',
+      'recipe', 'event', 'newsletter', 'dataset',
+    ],
+    tag_system: {
+      taste_tags: 'Subjective aesthetic/cultural/vibe tags (e.g., minimalist, brutalist, artisanal). These represent the FEEL of what the user saves.',
+      practical_tags: 'Objective, factual, searchable tags (e.g., waterproof, noise_cancelling, hardcover). These represent what the item IS.',
+      entities: 'Named entities extracted from each pin: brands, people, places, products, concepts.',
+    },
+    composition_guidance: {
+      recommendations: 'Call get_taste_profile first for cross-board context, then search_pins or get_board for specifics.',
+      research: 'Use search_pins first. Add get_taste_profile if the user wants contextual filtering.',
+      self_discovery: 'get_taste_profile + get_boards_list together give the full picture.',
+      saving: 'save_pin alone — the platform handles categorization and tagging automatically.',
+      auto_capture: 'When the user expresses a clear choice signal ("I\'ll get that", "that\'s the one", "perfect"), proactively call save_pin with source "claude_auto" and conversation context as notes.',
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP JSON-RPC dispatch
+// ---------------------------------------------------------------------------
+
+async function handleJsonRpc(
+  request: Record<string, unknown>,
+  userId: string,
+  settings: ConnectorSettings,
+  sessionId: string | null,
+): Promise<unknown> {
+  const method = request.method as string
+  const id = request.id
+  const params = (request.params || {}) as Record<string, unknown>
+
+  switch (method) {
+    case 'initialize':
+      return jsonRpcResponse(id, {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {
+          tools: { listChanged: false },
+          resources: { subscribe: false, listChanged: false },
+        },
+        serverInfo: {
+          name: PRODUCT_CONFIG.connector_name,
+          version: VERSION,
+        },
+      })
+
+    case 'notifications/initialized':
+      // No response needed for notifications
+      return null
+
+    case 'tools/list':
+      return jsonRpcResponse(id, { tools: TOOL_DEFINITIONS })
+
+    case 'tools/call': {
+      const toolName = params.name as string
+      const toolArgs = (params.arguments || {}) as Record<string, unknown>
+      const startTime = Date.now()
+      let resultCount = 0
+      let error: string | undefined
+
+      try {
+        let result: unknown
+
+        switch (toolName) {
+          case 'search_pins':
+            result = await toolSearchPins(userId, toolArgs, settings)
+            resultCount = ((result as Record<string, unknown>).total as number) || 0
+            break
+          case 'get_board':
+            result = await toolGetBoard(userId, toolArgs, settings)
+            resultCount = ((result as Record<string, unknown>).total as number) || 0
+            break
+          case 'get_boards_list':
+            result = await toolGetBoardsList(userId, settings)
+            resultCount = ((result as Record<string, unknown>).boards as unknown[])?.length || 0
+            break
+          case 'get_taste_profile':
+            result = await toolGetTasteProfile(userId, settings)
+            resultCount = (result as Record<string, unknown>).total_pins as number || 0
+            break
+          case 'get_recent_saves':
+            result = await toolGetRecentSaves(userId, toolArgs, settings)
+            resultCount = ((result as Record<string, unknown>).total as number) || 0
+            break
+          case 'save_pin':
+            result = await toolSavePin(userId, toolArgs)
+            resultCount = 1
+            break
+          case 'get_connector_context':
+            result = toolGetConnectorContext(settings)
+            resultCount = 1
+            break
+          default:
+            return jsonRpcResponse(id, {
+              content: [{ type: 'text', text: JSON.stringify({ error: `Unknown tool: ${toolName}` }) }],
+              isError: true,
+            })
+        }
+
+        // Log usage
+        logUsage(userId, toolName, toolArgs, resultCount, settings.privacy_tier, sessionId, startTime)
+
+        return jsonRpcResponse(id, {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+        })
+      } catch (e) {
+        error = (e as Error).message
+        logUsage(userId, toolName, toolArgs, 0, settings.privacy_tier, sessionId, startTime, error)
+
+        return jsonRpcResponse(id, {
+          content: [{ type: 'text', text: JSON.stringify({ error }) }],
+          isError: true,
+        })
+      }
+    }
+
+    case 'resources/list':
+      return jsonRpcResponse(id, {
+        resources: [{
+          uri: `connector://${PRODUCT_CONFIG.name}/context`,
+          name: `${PRODUCT_CONFIG.name} Connector Context`,
+          description: 'Board taxonomy, content types, taste model, and tool composition guidance.',
+          mimeType: 'application/json',
+        }],
+      })
+
+    case 'resources/read': {
+      const uri = params.uri as string
+      if (uri === `connector://${PRODUCT_CONFIG.name}/context`) {
+        const context = toolGetConnectorContext(settings)
+        return jsonRpcResponse(id, {
+          contents: [{
+            uri,
+            mimeType: 'application/json',
+            text: JSON.stringify(context),
+          }],
+        })
+      }
+      return jsonRpcError(id, -32602, `Unknown resource: ${uri}`)
+    }
+
+    case 'ping':
+      return jsonRpcResponse(id, {})
+
+    default:
+      return jsonRpcError(id, -32601, `Method not found: ${method}`)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler
+// ---------------------------------------------------------------------------
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders })
+  }
+
+  // POST: JSON-RPC requests
+  if (req.method === 'POST') {
+    const accept = req.headers.get('accept') || ''
+    if (!accept.includes('application/json') && !accept.includes('text/event-stream') && accept !== '*/*') {
+      return json(
+        jsonRpcError(null, -32600, 'Accept header must include application/json or text/event-stream'),
+        400,
+      )
+    }
+
+    // Authenticate
+    const user = await resolveUser(req)
+    if (!user) {
+      return new Response(null, {
+        status: 401,
+        headers: { ...corsHeaders, 'WWW-Authenticate': 'Bearer' },
+      })
+    }
+
+    // Session management
+    let sessionId = req.headers.get('mcp-session-id')
+    if (!sessionId) {
+      sessionId = generateSessionId()
+      sessions.set(sessionId, { userId: user.userId, privacyTier: user.privacyTier, createdAt: Date.now() })
+    }
+
+    const settings = await getSettings(user.userId)
+
+    let body: unknown
+    try {
+      body = await req.json()
+    } catch {
+      return json(jsonRpcError(null, -32700, 'Parse error'), 400)
+    }
+
+    // Handle batch requests
+    if (Array.isArray(body)) {
+      const results = await Promise.all(
+        body.map(request => handleJsonRpc(request, user.userId, settings, sessionId))
+      )
+      return json(results.filter(r => r !== null), 200, { 'Mcp-Session-Id': sessionId })
+    }
+
+    const result = await handleJsonRpc(body as Record<string, unknown>, user.userId, settings, sessionId)
+    if (result === null) {
+      // Notification — no response body
+      return new Response(null, { status: 204, headers: { ...corsHeaders, 'Mcp-Session-Id': sessionId } })
+    }
+
+    return json(result, 200, { 'Mcp-Session-Id': sessionId })
+  }
+
+  // DELETE: close session
+  if (req.method === 'DELETE') {
+    const sessionId = req.headers.get('mcp-session-id')
+    if (sessionId) sessions.delete(sessionId)
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  return json(jsonRpcError(null, -32600, 'Only POST and DELETE are supported'), 405)
+})

--- a/supabase/migrations/030_mcp_connector.sql
+++ b/supabase/migrations/030_mcp_connector.sql
@@ -1,0 +1,167 @@
+-- ============================================
+-- 030_mcp_connector.sql
+-- Tables for the MCP Connector: OAuth tokens,
+-- user privacy settings, and usage analytics
+-- ============================================
+
+-- 1. mcp_tokens — issued OAuth tokens mapped to user_id
+-- MCP clients (Claude) authenticate with these tokens,
+-- which are separate from Supabase JWTs.
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  client_id TEXT NOT NULL,
+  access_token TEXT NOT NULL UNIQUE,
+  refresh_token TEXT UNIQUE,
+  access_token_expires_at TIMESTAMPTZ NOT NULL,
+  refresh_token_expires_at TIMESTAMPTZ,
+  scopes TEXT[] DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_access_token
+  ON mcp_tokens(access_token);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_refresh_token
+  ON mcp_tokens(refresh_token) WHERE refresh_token IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_user_id
+  ON mcp_tokens(user_id);
+
+ALTER TABLE mcp_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access mcp_tokens"
+  ON mcp_tokens FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 2. mcp_auth_codes — temporary authorization codes for OAuth flow
+CREATE TABLE IF NOT EXISTS mcp_auth_codes (
+  code TEXT PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  client_id TEXT NOT NULL,
+  redirect_uri TEXT NOT NULL,
+  code_challenge TEXT,
+  code_challenge_method TEXT DEFAULT 'S256',
+  scopes TEXT[] DEFAULT '{}',
+  privacy_tier TEXT NOT NULL DEFAULT 'library',
+  expires_at TIMESTAMPTZ NOT NULL,
+  used BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE mcp_auth_codes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access mcp_auth_codes"
+  ON mcp_auth_codes FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 3. mcp_clients — dynamic client registration (RFC 7591)
+CREATE TABLE IF NOT EXISTS mcp_clients (
+  client_id TEXT PRIMARY KEY,
+  client_secret TEXT,
+  client_name TEXT,
+  redirect_uris TEXT[] NOT NULL DEFAULT '{}',
+  grant_types TEXT[] DEFAULT '{authorization_code, refresh_token}',
+  response_types TEXT[] DEFAULT '{code}',
+  token_endpoint_auth_method TEXT DEFAULT 'none',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE mcp_clients ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access mcp_clients"
+  ON mcp_clients FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- Pre-register known Claude redirect URIs as a default client
+INSERT INTO mcp_clients (client_id, client_name, redirect_uris)
+VALUES (
+  'claude-default',
+  'Claude',
+  ARRAY[
+    'http://localhost:6274/oauth/callback',
+    'http://localhost:6274/oauth/callback/debug',
+    'https://claude.ai/api/mcp/auth_callback',
+    'https://claude.com/api/mcp/auth_callback'
+  ]
+) ON CONFLICT (client_id) DO NOTHING;
+
+-- 4. connector_settings — per-user privacy controls
+CREATE TABLE IF NOT EXISTS connector_settings (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  privacy_tier TEXT NOT NULL DEFAULT 'library'
+    CHECK (privacy_tier IN ('taste_only', 'library', 'full_access')),
+  board_visibility JSONB NOT NULL DEFAULT '{}',
+  field_visibility JSONB NOT NULL DEFAULT '{}',
+  auto_save_enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE connector_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users see own connector settings"
+  ON connector_settings FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users update own connector settings"
+  ON connector_settings FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users insert own connector settings"
+  ON connector_settings FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Service role full access connector_settings"
+  ON connector_settings FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- 5. connector_usage — analytics/instrumentation
+CREATE TABLE IF NOT EXISTS connector_usage (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  tool_name TEXT NOT NULL,
+  input_params JSONB,
+  result_count INTEGER,
+  privacy_tier TEXT,
+  session_id TEXT,
+  client_type TEXT,
+  duration_ms INTEGER,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_usage_user_id
+  ON connector_usage(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_connector_usage_tool_name
+  ON connector_usage(tool_name);
+
+CREATE INDEX IF NOT EXISTS idx_connector_usage_created_at
+  ON connector_usage(created_at);
+
+ALTER TABLE connector_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access connector_usage"
+  ON connector_usage FOR ALL
+  USING (auth.role() = 'service_role');
+
+-- Timestamp triggers
+CREATE OR REPLACE FUNCTION update_mcp_tokens_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = NOW(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER mcp_tokens_updated_at
+  BEFORE UPDATE ON mcp_tokens
+  FOR EACH ROW EXECUTE FUNCTION update_mcp_tokens_updated_at();
+
+CREATE OR REPLACE FUNCTION update_connector_settings_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN NEW.updated_at = NOW(); RETURN NEW; END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER connector_settings_updated_at
+  BEFORE UPDATE ON connector_settings
+  FOR EACH ROW EXECUTE FUNCTION update_connector_settings_updated_at();


### PR DESCRIPTION
## Summary

- MCP Streamable HTTP server with 7 tools for reading/writing to users' curated libraries
- OAuth 2.1 authorization server with PKCE, dynamic client registration, metadata discovery
- 1-click consent page with 3-tier privacy model (Taste Only / Library / Full Access)
- Database migration for connector settings, tokens, auth codes, and usage analytics
- Claude Code skill definition for tool composition guidance

This connector makes every user's curated library available as portable taste context in Claude. Built for submission to Anthropic's Claude Connectors Directory.

### Architecture
```
Claude (claude.ai / Desktop / Code)
  → MCP Streamable HTTP (Bearer token)
  → mcp-server (tool dispatch + privacy filtering + usage logging)
  → mcp-oauth (OAuth 2.1 + PKCE + DCR)
  → Supabase (links table, scoped by user_id)
```

### Tools
| Tool | Type | Purpose |
|------|------|---------|
| `search_pins` | Read | Search by keyword, board, content type, tags |
| `get_board` | Read | Get all items in a board |
| `get_boards_list` | Read | List boards with counts |
| `get_taste_profile` | Read | Cross-board taste aggregation |
| `get_recent_saves` | Read | Recent activity |
| `save_pin` | Write | Save URL with full enrichment pipeline |
| `get_connector_context` | Read | Orientation + composition guidance |

### Privacy
- 3 tiers at connect time (Library is default)
- Per-board and per-field toggles in settings
- All filtering server-side, never client-side

## Test plan
- [ ] Deploy mcp-oauth and mcp-server edge functions
- [ ] Run migration 030 against Boards project
- [ ] Test OAuth flow: metadata discovery → authorize → consent → code → token
- [ ] Test each tool via Claude Desktop custom connector
- [ ] Verify privacy filtering per tier
- [ ] Verify save_pin triggers enrichment pipeline
- [ ] Verify usage logging in connector_usage table

🤖 Generated with [Claude Code](https://claude.com/claude-code)