### PR TITLE
feat(recipe): recipe viewer with scaling and unit conversion

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -3143,6 +3143,276 @@ body {
 }
 
 /* ============================================
+   Recipe Card Styles
+   ============================================ */
+.grid-item--recipe .grid-item__overlay {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: var(--space-2) var(--space-3);
+}
+.grid-item__recipe-title {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.2;
+}
+.grid-item__recipe-meta {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 400;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+/* Full color food photography — no grayscale filter */
+.grid-item--recipe .grid-item__image {
+  filter: none;
+}
+.grid-item--recipe:hover .grid-item__image {
+  filter: none;
+}
+/* Expanded recipe cards */
+.grid-item--recipe.grid-item--expanded-medium .grid-item__overlay,
+.grid-item--recipe.grid-item--expanded-large .grid-item__overlay {
+  display: none;
+}
+
+/* ============================================
+   Recipe Drawer
+   Right-side panel for recipe viewer
+   ============================================ */
+.recipe-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.recipe-drawer:not([hidden]) {
+  pointer-events: all;
+  opacity: 1;
+}
+.recipe-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  transition: opacity 0.25s;
+}
+.recipe-drawer:not([hidden]) .recipe-drawer__backdrop {
+  opacity: 1;
+}
+.recipe-drawer__panel {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  height: 100%;
+  background: var(--bg);
+  border-left: 2px solid var(--fg);
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform 0.25s ease-out;
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.recipe-drawer:not([hidden]) .recipe-drawer__panel {
+  transform: translateX(0);
+}
+.recipe-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+.recipe-drawer__title {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.2;
+  flex: 1;
+  margin: 0;
+}
+.recipe-drawer__close {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--fg);
+  flex-shrink: 0;
+}
+.recipe-drawer__close:hover {
+  text-decoration: underline;
+}
+.recipe-drawer__meta-bar {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+  border-top: 1px solid var(--subtle);
+  border-bottom: 1px solid var(--subtle);
+  padding: var(--space-2) 0;
+}
+.recipe-drawer__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.recipe-drawer__meta-label {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+.recipe-drawer__meta-value {
+  font-size: 10px;
+  color: var(--fg);
+}
+.recipe-drawer__description {
+  font-size: 10px;
+  line-height: 1.5;
+  color: var(--muted);
+}
+.recipe-drawer__controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.recipe-drawer__scaler {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.recipe-drawer__scaler-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--fg);
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.recipe-drawer__scaler-btn:hover {
+  background: var(--fg);
+  color: var(--bg);
+}
+.recipe-drawer__scaler-value {
+  min-width: 24px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 12px;
+}
+.recipe-drawer__scaler-label {
+  color: var(--muted);
+}
+.recipe-drawer__unit-toggle {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: 1px solid var(--fg);
+  background: none;
+  color: var(--fg);
+  padding: var(--space-1) var(--space-3);
+  cursor: pointer;
+}
+.recipe-drawer__unit-toggle:hover,
+.recipe-drawer__unit-toggle--active {
+  background: var(--fg);
+  color: var(--bg);
+}
+.recipe-drawer__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.recipe-drawer__section-title {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--subtle);
+  padding-bottom: var(--space-1);
+  margin: 0;
+}
+.recipe-drawer__ingredients {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.recipe-drawer__ingredient {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.5;
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+.recipe-drawer__ingredient:last-child {
+  border-bottom: none;
+}
+.recipe-drawer__instructions {
+  padding-left: var(--space-5);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.recipe-drawer__step {
+  font-size: 10px;
+  line-height: 1.6;
+  padding-left: var(--space-2);
+}
+.recipe-drawer__source-link {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  text-decoration: none;
+  margin-top: auto;
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--subtle);
+}
+.recipe-drawer__source-link:hover {
+  color: var(--fg);
+  text-decoration: underline;
+}
+@media (max-width: 600px) {
+  .recipe-drawer__panel {
+    max-width: 100%;
+    border-left: none;
+    border-top: 2px solid var(--fg);
+  }
+}
+
+/* ============================================
    Watch Grid Override
    ============================================ */
 .grid--watch {
@@ -6488,6 +6758,37 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
     </div>
   </div>
 
+  <!-- Recipe Drawer — right-side panel for recipe viewer -->
+  <div class="recipe-drawer" id="recipeDrawer" role="dialog" aria-modal="true" aria-labelledby="recipeDrawerTitle" hidden>
+    <div class="recipe-drawer__backdrop" id="recipeDrawerBackdrop"></div>
+    <div class="recipe-drawer__panel">
+      <div class="recipe-drawer__header">
+        <h2 class="recipe-drawer__title" id="recipeDrawerTitle"></h2>
+        <button class="recipe-drawer__close" id="recipeDrawerClose" aria-label="Close">&times;</button>
+      </div>
+      <div class="recipe-drawer__meta-bar" id="recipeDrawerMeta"></div>
+      <div class="recipe-drawer__description" id="recipeDrawerDescription"></div>
+      <div class="recipe-drawer__controls">
+        <div class="recipe-drawer__scaler">
+          <button class="recipe-drawer__scaler-btn" id="recipeScaleMinus" aria-label="Decrease servings">&minus;</button>
+          <span class="recipe-drawer__scaler-value" id="recipeScaleValue">4</span>
+          <button class="recipe-drawer__scaler-btn" id="recipeScalePlus" aria-label="Increase servings">+</button>
+          <span class="recipe-drawer__scaler-label">servings</span>
+        </div>
+        <button class="recipe-drawer__unit-toggle" id="recipeUnitToggle">Imperial</button>
+      </div>
+      <section class="recipe-drawer__section">
+        <h3 class="recipe-drawer__section-title">Ingredients</h3>
+        <ul class="recipe-drawer__ingredients" id="recipeDrawerIngredients"></ul>
+      </section>
+      <section class="recipe-drawer__section">
+        <h3 class="recipe-drawer__section-title">Instructions</h3>
+        <ol class="recipe-drawer__instructions" id="recipeDrawerInstructions"></ol>
+      </section>
+      <a class="recipe-drawer__source-link" id="recipeDrawerSourceLink" target="_blank" rel="noopener">View original recipe</a>
+    </div>
+  </div>
+
   <!-- Confirm Modal -->
   <div class="modal modal--small" id="confirmModal" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
     <div class="modal__backdrop"></div>
@@ -6541,8 +6842,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.12.0';
-  console.log('[boards] v' + VERSION + ' - provisional entity resolution UX');
+  const VERSION = '2.13.0';
+  console.log('[boards] v' + VERSION + ' - recipe viewer with scaling and unit conversion');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -6584,7 +6885,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
     { name: 'repository', keywords: ['code', 'repo', 'commit', 'fork'], domains: ['github.com', 'gitlab.com', 'bitbucket.org'] },
     { name: 'social', keywords: ['tweet', 'post', 'profile'], domains: ['twitter.com', 'x.com', 'linkedin.com', 'instagram.com', 'threads.net'] },
     { name: 'document', keywords: ['document', 'pdf', 'doc'], patterns: ['.pdf', '.doc', '.xls', 'docs.google.com'] },
-    { name: 'tool', keywords: ['app', 'tool', 'dashboard', 'login'], patterns: ['app.', '/app/', '/dashboard'] }
+    { name: 'tool', keywords: ['app', 'tool', 'dashboard', 'login'], patterns: ['app.', '/app/', '/dashboard'] },
+    { name: 'recipe', keywords: ['recipe', 'ingredients', 'servings', 'prep time', 'cook time', 'preheat', 'tablespoon', 'teaspoon'], domains: [], patterns: ['/recipe/', '/recipes/'] }
   ];
 
   // Multi-topic domains: content varies per page, never cache at domain level
@@ -10866,7 +11168,8 @@ Return JSON:
             category: item.category || null,
             enrichWatch: item.enrichWatch || false,
             enrichBook: item.enrichBook || false,
-            enrichListen: item.enrichListen || false
+            enrichListen: item.enrichListen || false,
+            enrichRecipe: item.enrichRecipe || false
           })
         });
 
@@ -11216,6 +11519,29 @@ Return JSON:
           if (link.music.artist && link.music.trackTitle) {
             link.title = `${link.music.artist} – ${link.music.trackTitle}`;
           }
+        }
+
+        // Merge recipe metadata
+        if (result.recipe) {
+          const existing = link.recipe || {};
+          link.recipe = {
+            title: result.recipe.title || existing.title || null,
+            description: result.recipe.description || existing.description || null,
+            servings: result.recipe.servings || existing.servings || null,
+            servings_text: result.recipe.servings_text || existing.servings_text || null,
+            prep_time: result.recipe.prep_time || existing.prep_time || null,
+            cook_time: result.recipe.cook_time || existing.cook_time || null,
+            total_time: result.recipe.total_time || existing.total_time || null,
+            ingredients: result.recipe.ingredients?.length ? result.recipe.ingredients : (existing.ingredients || []),
+            instructions: result.recipe.instructions?.length ? result.recipe.instructions : (existing.instructions || []),
+            cuisine: result.recipe.cuisine || existing.cuisine || null,
+            difficulty: result.recipe.difficulty || existing.difficulty || null,
+            source_name: result.recipe.source_name || existing.source_name || null,
+            server_enriched_at: result.recipe.server_enriched_at || existing.server_enriched_at || null,
+          };
+          console.log('%c[ENRICH] Recipe metadata merged:', 'color: #e67e22', link.recipe);
+          delete link._tags;
+          link.tags = computeLinkTags(link);
         }
 
         // Update title/description from platform API if server resolved better data (e.g. YouTube)
@@ -12149,6 +12475,34 @@ Return JSON:
       enrichFlag: 'enrichListen',
       backfillCheck: (link) => link.music && !link.music.server_enriched_at,
     },
+    eat: {
+      category: 'eat',
+      metaField: 'recipe',
+      doneField: null,
+      doneLabel: null,
+      cssClass: 'recipe',
+      doneClass: null,
+      getPlatform: null,
+      overlay: {
+        titleField: 'title',
+        metaField: 'cuisine',
+        metaFallback: (meta) => meta.source_name || null,
+        titleClass: 'recipe-title',
+        metaClass: 'recipe-meta',
+      },
+      metaLine: [
+        { field: 'servings', format: (s) => s + ' servings' },
+        { field: 'prep_time', format: (t) => Math.round(t / 60) + 'm prep' },
+        { field: 'cook_time', format: (t) => Math.round(t / 60) + 'm cook' },
+        { field: 'total_time', format: formatDuration },
+      ],
+      badge: { typeField: 'cuisine', durationField: 'total_time' },
+      externalLink: null,
+      extras: () => '',
+      summaryField: 'description',
+      enrichFlag: 'enrichRecipe',
+      backfillCheck: (link) => !link.recipe || !link.recipe.server_enriched_at,
+    },
   };
 
   let currentFilters = {}; // Multi-dimension filter state: { format: 'movies', genre: 'action' }
@@ -12253,6 +12607,13 @@ Return JSON:
     if (link.book) {
       if (link.book.genre) tags.add(link.book.genre.toLowerCase());
       if (link.book.format) tags.add(link.book.format);
+    }
+
+    // Recipe: cuisine + difficulty
+    if (link.recipe) {
+      if (link.recipe.cuisine) tags.add(link.recipe.cuisine.toLowerCase());
+      if (link.recipe.difficulty) tags.add(link.recipe.difficulty);
+      tags.add('recipe');
     }
 
     return [...tags].filter(Boolean);
@@ -12554,8 +12915,8 @@ Return JSON:
       domains: ['github.com', 'gitlab.com', 'npmjs.com', 'producthunt.com']
     },
     eat: {
-      kw: ['restaurant', 'cafe', 'bar', 'food', 'dining', 'menu', 'recipe', 'cook', 'cuisine', 'meal', 'dish', 'chef', 'reservation', 'brunch', 'dinner', 'lunch'],
-      domains: ['yelp.com', 'tripadvisor.com', 'opentable.com', 'doordash.com', 'ubereats.com', 'resy.com']
+      kw: ['restaurant', 'cafe', 'bar', 'food', 'dining', 'menu', 'recipe', 'cook', 'cuisine', 'meal', 'dish', 'chef', 'reservation', 'brunch', 'dinner', 'lunch', 'ingredients', 'servings', 'bake', 'roast'],
+      domains: ['yelp.com', 'tripadvisor.com', 'opentable.com', 'doordash.com', 'ubereats.com', 'resy.com', 'allrecipes.com', 'seriouseats.com', 'food52.com', 'bonappetit.com', 'epicurious.com', 'foodnetwork.com', 'simplyrecipes.com', 'budgetbytes.com', 'minimalistbaker.com', 'tasty.co']
     },
     go: {
       kw: ['hotel', 'travel', 'map', 'city', 'venue', 'booking', 'destination', 'trip', 'flight', 'stay', 'vacation', 'visit', 'explore'],
@@ -15173,6 +15534,12 @@ Return JSON:
         }
       }
 
+      // Recipe viewer button (for eat pins with recipe data)
+      const hasRecipe = l.recipe && (l.recipe.ingredients?.length || l.recipe.instructions?.length);
+      if (hasRecipe) {
+        richActionsHtml += `<button class="grid-item__action" data-action="view-recipe">Recipe</button>`;
+      }
+
       // Truncate summary to ~60 words for display
       function truncateSummary(text, maxWords) {
         if (!text) return '';
@@ -16744,11 +17111,13 @@ Return JSON:
 
               const isWatchRerun = cat.category === 'watch' || contentType.type === 'video';
               const isBookRerun = cat.category === 'read' || contentType.type === 'book';
-              if (isWatchRerun || isBookRerun) {
+              const isRecipeRerun = cat.category === 'eat' || contentType.type === 'recipe';
+              if (isWatchRerun || isBookRerun || isRecipeRerun) {
                 queueServerEnrichment(id, link.url, meta.title, meta.description, {
                   category: cat.category,
                   enrichWatch: isWatchRerun,
-                  enrichBook: isBookRerun
+                  enrichBook: isBookRerun,
+                  enrichRecipe: isRecipeRerun
                 });
               }
               toast('Refreshed', { id: 'refresh-' + id });
@@ -16804,6 +17173,12 @@ Return JSON:
           if (item) item.classList.toggle('grid-item--' + richConfig.doneClass, nowDone);
           if (currentUser) syncLinkToSupabase(link);
           toast(nowDone ? `Marked as ${richConfig.doneLabel.toLowerCase()}` : 'Unmarked');
+        }
+        return;
+      } else if (actionType === 'view-recipe') {
+        const link = getAllLinks().find(l => l.id === id);
+        if (link && link.recipe) {
+          openRecipeDrawer(link);
         }
         return;
       } else if (actionType === 'visit-imdb' || actionType === 'visit-wiki' || actionType === 'visit-ext') {
@@ -17867,7 +18242,219 @@ Return JSON:
     if (m._trapHandler) { m.removeEventListener('keydown', m._trapHandler); m._trapHandler = null; }
     if (m._previousFocus) { m._previousFocus.focus(); m._previousFocus = null; }
   }
-  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal, createBoardModal].forEach(closeModal); }
+  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal, createBoardModal].forEach(closeModal); closeRecipeDrawer(); }
+
+  // ============================================
+  // Recipe Drawer
+  // ============================================
+  const recipeDrawer = $('recipeDrawer');
+  const recipeDrawerClose = $('recipeDrawerClose');
+  const recipeDrawerBackdrop = $('recipeDrawerBackdrop');
+  const recipeDrawerTitle = $('recipeDrawerTitle');
+  const recipeDrawerMeta = $('recipeDrawerMeta');
+  const recipeDrawerDescription = $('recipeDrawerDescription');
+  const recipeDrawerIngredients = $('recipeDrawerIngredients');
+  const recipeDrawerInstructions = $('recipeDrawerInstructions');
+  const recipeDrawerSourceLink = $('recipeDrawerSourceLink');
+  const recipeScaleMinus = $('recipeScaleMinus');
+  const recipeScalePlus = $('recipeScalePlus');
+  const recipeScaleValue = $('recipeScaleValue');
+  const recipeUnitToggle = $('recipeUnitToggle');
+
+  let recipeDrawerState = {
+    recipe: null,
+    linkUrl: null,
+    baseServings: 4,
+    currentServings: 4,
+    useMetric: !(navigator.language || '').startsWith('en-US'),
+  };
+
+  function openRecipeDrawer(link) {
+    const recipe = link.recipe;
+    if (!recipe) return;
+    recipeDrawerState.recipe = recipe;
+    recipeDrawerState.linkUrl = link.url;
+    recipeDrawerState.baseServings = recipe.servings || 4;
+    recipeDrawerState.currentServings = recipeDrawerState.baseServings;
+    recipeUnitToggle.textContent = recipeDrawerState.useMetric ? 'Metric' : 'Imperial';
+    recipeUnitToggle.classList.toggle('recipe-drawer__unit-toggle--active', recipeDrawerState.useMetric);
+    renderRecipeDrawer();
+    recipeDrawer.removeAttribute('hidden');
+    recipeDrawerSourceLink.href = link.url;
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeRecipeDrawer() {
+    if (recipeDrawer.hasAttribute('hidden')) return;
+    recipeDrawer.setAttribute('hidden', '');
+    document.body.style.overflow = '';
+  }
+
+  function renderRecipeDrawer() {
+    const { recipe, currentServings, baseServings, useMetric } = recipeDrawerState;
+    const scaleFactor = baseServings > 0 ? currentServings / baseServings : 1;
+
+    recipeDrawerTitle.textContent = recipe.title || 'Recipe';
+
+    // Meta bar
+    const metaItems = [];
+    if (currentServings) metaItems.push({ label: 'Servings', value: String(currentServings) });
+    if (recipe.prep_time) metaItems.push({ label: 'Prep', value: formatRecipeTime(recipe.prep_time) });
+    if (recipe.cook_time) metaItems.push({ label: 'Cook', value: formatRecipeTime(recipe.cook_time) });
+    if (recipe.total_time) metaItems.push({ label: 'Total', value: formatRecipeTime(recipe.total_time) });
+    if (recipe.cuisine) metaItems.push({ label: 'Cuisine', value: recipe.cuisine });
+    if (recipe.difficulty) metaItems.push({ label: 'Difficulty', value: cap(recipe.difficulty) });
+    recipeDrawerMeta.innerHTML = metaItems.map(function(item) {
+      return '<div class="recipe-drawer__meta-item"><span class="recipe-drawer__meta-label">' + esc(item.label) + '</span><span class="recipe-drawer__meta-value">' + esc(item.value) + '</span></div>';
+    }).join('');
+
+    // Description
+    recipeDrawerDescription.textContent = recipe.description || '';
+    recipeDrawerDescription.style.display = recipe.description ? '' : 'none';
+
+    // Scaler
+    recipeScaleValue.textContent = String(currentServings);
+
+    // Ingredients
+    var ingredients = recipe.ingredients || [];
+    recipeDrawerIngredients.innerHTML = ingredients.map(function(raw) {
+      return '<li class="recipe-drawer__ingredient">' + esc(scaleIngredient(raw, scaleFactor, useMetric)) + '</li>';
+    }).join('');
+
+    // Instructions
+    var instructions = recipe.instructions || [];
+    recipeDrawerInstructions.innerHTML = instructions.map(function(step) {
+      return '<li class="recipe-drawer__step">' + esc(step) + '</li>';
+    }).join('');
+  }
+
+  function formatRecipeTime(seconds) {
+    if (!seconds) return '';
+    var h = Math.floor(seconds / 3600);
+    var m = Math.floor((seconds % 3600) / 60);
+    if (h > 0 && m > 0) return h + 'h ' + m + 'm';
+    if (h > 0) return h + 'h';
+    return m + 'm';
+  }
+
+  // ============================================
+  // Ingredient Scaling and Unit Conversion
+  // ============================================
+  var UNIT_TO_METRIC = {
+    'cup': { factor: 236.588, unit: 'ml' },
+    'cups': { factor: 236.588, unit: 'ml' },
+    'tbsp': { factor: 14.787, unit: 'ml' },
+    'tablespoon': { factor: 14.787, unit: 'ml' },
+    'tablespoons': { factor: 14.787, unit: 'ml' },
+    'tsp': { factor: 4.929, unit: 'ml' },
+    'teaspoon': { factor: 4.929, unit: 'ml' },
+    'teaspoons': { factor: 4.929, unit: 'ml' },
+    'oz': { factor: 28.3495, unit: 'g' },
+    'ounce': { factor: 28.3495, unit: 'g' },
+    'ounces': { factor: 28.3495, unit: 'g' },
+    'lb': { factor: 453.592, unit: 'g' },
+    'lbs': { factor: 453.592, unit: 'g' },
+    'pound': { factor: 453.592, unit: 'g' },
+    'pounds': { factor: 453.592, unit: 'g' },
+    'fl oz': { factor: 29.5735, unit: 'ml' },
+    'quart': { factor: 946.353, unit: 'ml' },
+    'quarts': { factor: 946.353, unit: 'ml' },
+    'pint': { factor: 473.176, unit: 'ml' },
+    'pints': { factor: 473.176, unit: 'ml' },
+    'gallon': { factor: 3785.41, unit: 'ml' },
+    'gallons': { factor: 3785.41, unit: 'ml' },
+  };
+
+  function parseFraction(str) {
+    str = str.trim();
+    var mixed = str.match(/^(\d+)\s+(\d+)\/(\d+)$/);
+    if (mixed) return parseInt(mixed[1]) + parseInt(mixed[2]) / parseInt(mixed[3]);
+    var frac = str.match(/^(\d+)\/(\d+)$/);
+    if (frac) return parseInt(frac[1]) / parseInt(frac[2]);
+    var num = parseFloat(str);
+    return isNaN(num) ? null : num;
+  }
+
+  function formatFraction(num) {
+    if (num === Math.floor(num)) return String(Math.round(num));
+    var fracs = [[1,4],[1,3],[1,2],[2,3],[3,4]];
+    for (var i = 0; i < fracs.length; i++) {
+      if (Math.abs(num - fracs[i][0]/fracs[i][1]) < 0.05) return fracs[i][0] + '/' + fracs[i][1];
+    }
+    var whole = Math.floor(num);
+    var remainder = num - whole;
+    for (var j = 0; j < fracs.length; j++) {
+      if (Math.abs(remainder - fracs[j][0]/fracs[j][1]) < 0.05) {
+        return whole > 0 ? whole + ' ' + fracs[j][0] + '/' + fracs[j][1] : fracs[j][0] + '/' + fracs[j][1];
+      }
+    }
+    return num.toFixed(1).replace(/\.0$/, '');
+  }
+
+  function scaleIngredient(raw, scaleFactor, useMetric) {
+    if (scaleFactor === 1 && !useMetric) return raw;
+    // Match: optional number (int, decimal, fraction, mixed) + optional unit + rest
+    var match = raw.match(/^([\d\s\/\.]+)\s+([a-zA-Z]+\.?)\s+(.+)$/);
+    if (!match) {
+      // Try just number + rest (no unit), e.g. "2 eggs"
+      var match2 = raw.match(/^([\d\s\/\.]+)\s+(.+)$/);
+      if (match2) {
+        var amt2 = parseFraction(match2[1].trim());
+        if (amt2 !== null) {
+          var scaled2 = amt2 * scaleFactor;
+          return formatFraction(scaled2) + ' ' + match2[2];
+        }
+      }
+      return raw;
+    }
+    var numStr = match[1], unit = match[2], ingredient = match[3];
+    var amount = parseFraction(numStr.trim());
+    if (amount === null) return raw;
+
+    var scaledAmount = amount * scaleFactor;
+    var displayUnit = unit;
+
+    if (useMetric) {
+      var conv = UNIT_TO_METRIC[unit.toLowerCase()];
+      if (conv) {
+        var metricAmount = scaledAmount * conv.factor;
+        displayUnit = conv.unit;
+        if (metricAmount > 100) metricAmount = Math.round(metricAmount);
+        else if (metricAmount > 10) metricAmount = Math.round(metricAmount * 10) / 10;
+        else metricAmount = Math.round(metricAmount * 100) / 100;
+        if (displayUnit === 'ml' && metricAmount >= 1000) { metricAmount = metricAmount / 1000; displayUnit = 'L'; }
+        if (displayUnit === 'g' && metricAmount >= 1000) { metricAmount = metricAmount / 1000; displayUnit = 'kg'; }
+        return metricAmount + ' ' + displayUnit + ' ' + ingredient;
+      }
+    }
+
+    return formatFraction(scaledAmount) + ' ' + unit + ' ' + ingredient;
+  }
+
+  // Scaler button handlers
+  recipeScaleMinus.onclick = function() {
+    if (recipeDrawerState.currentServings <= 1) return;
+    recipeDrawerState.currentServings--;
+    renderRecipeDrawer();
+  };
+  recipeScalePlus.onclick = function() {
+    if (recipeDrawerState.currentServings >= 99) return;
+    recipeDrawerState.currentServings++;
+    renderRecipeDrawer();
+  };
+  recipeUnitToggle.onclick = function() {
+    recipeDrawerState.useMetric = !recipeDrawerState.useMetric;
+    recipeUnitToggle.textContent = recipeDrawerState.useMetric ? 'Metric' : 'Imperial';
+    recipeUnitToggle.classList.toggle('recipe-drawer__unit-toggle--active', recipeDrawerState.useMetric);
+    renderRecipeDrawer();
+  };
+  recipeDrawerClose.onclick = closeRecipeDrawer;
+  recipeDrawerBackdrop.onclick = closeRecipeDrawer;
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape' && !recipeDrawer.hasAttribute('hidden')) {
+      closeRecipeDrawer();
+    }
+  });
 
   // Custom confirm dialog (native confirm() is blocked in some contexts)
   const confirmModal = $('confirmModal');
@@ -19405,13 +19992,15 @@ Return JSON:
           const isWatchItem2 = cat.category === 'watch' || contentType.type === 'video';
           const isBookItem2 = cat.category === 'read' || contentType.type === 'book';
           const isListenItem2 = cat.category === 'listen' || contentType.type === 'music';
-          const needsEnrichment2 = contentType.confidence < 0.7 || !meta.image || isWatchItem2 || isBookItem2 || isListenItem2;
+          const isRecipeItem2 = cat.category === 'eat' || contentType.type === 'recipe';
+          const needsEnrichment2 = contentType.confidence < 0.7 || !meta.image || isWatchItem2 || isBookItem2 || isListenItem2 || isRecipeItem2;
           if (needsEnrichment2) {
             queueServerEnrichment(id, url, meta.title, meta.description, {
               category: cat.category,
               enrichWatch: isWatchItem2,
               enrichBook: isBookItem2,
-              enrichListen: isListenItem2
+              enrichListen: isListenItem2,
+              enrichRecipe: isRecipeItem2
             });
           }
 

--- a/supabase/functions/create-pin/index.ts
+++ b/supabase/functions/create-pin/index.ts
@@ -5,10 +5,10 @@
 // POST /functions/v1/create-pin
 // Body: { url, title?, description?, linkId?, content_type?, category?,
 //         skipImage?, currentImage?, forceRefresh?,
-//         enrichWatch?, enrichBook?, enrichListen? }
-const VERSION = '2.0.0'
-console.log(`[create-pin] v${VERSION} - Pin Creation Agent (image + metadata)`)
-// Returns: { content_type, type_confidence, type_source, image_url, image_source, hero_score, video?, book?, music? }
+//         enrichWatch?, enrichBook?, enrichListen?, enrichRecipe? }
+const VERSION = '2.1.0'
+console.log(`[create-pin] v${VERSION} - Pin Creation Agent (image + metadata + recipe)`)
+// Returns: { content_type, type_confidence, type_source, image_url, image_source, hero_score, video?, book?, music?, recipe? }
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -52,6 +52,7 @@ const IMAGE_STRATEGIES: Record<string, string[]> = {
   social: ['platform', 'scrape', 'template'],              // platform images are best
   document: ['search', 'template'],
   tool: ['scrape', 'search', 'favicon', 'template'],
+  recipe: ['scrape', 'search', 'favicon', 'template'],
   unknown: ['scrape', 'search', 'favicon', 'template']
 }
 
@@ -63,7 +64,7 @@ serve(async (req) => {
 
   try {
     let { url, title, description, linkId, content_type, skipImage,
-            skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, enrichListen, category } = await req.json()
+            skipIfHasImage, currentImage, forceRefresh, enrichWatch, enrichBook, enrichListen, enrichRecipe, category } = await req.json()
 
     // Support skipIfHasImage: skip image resolution if client already has a valid image
     const shouldSkipImage = skipImage || (skipIfHasImage && !!currentImage)
@@ -185,6 +186,40 @@ serve(async (req) => {
       typeConfidence = 1.0
       typeSource = 'rules'
       console.log('[create-pin] Music platform detected, forcing content_type=music:', domain)
+    }
+
+    // Recipe content signal detection (content-first, not domain-only)
+    // Known recipe domains boost confidence but don't gate detection.
+    // JSON-LD @type: "Recipe" is the primary signal (checked in Step 2.8).
+    const RECIPE_DOMAIN_BOOST = [
+      'allrecipes.com', 'seriouseats.com', 'food52.com', 'bonappetit.com',
+      'epicurious.com', 'thekitchn.com', 'smittenkitchen.com', 'cookingclassy.com',
+      'tasty.co', 'delish.com', 'foodnetwork.com', 'myrecipes.com',
+      'simplyrecipes.com', 'budgetbytes.com', 'recipetineats.com',
+      'damndelicious.net', 'halfbakedharvest.com', 'minimalistbaker.com',
+      'skinnytaste.com', 'therecipecritic.com', 'averiecooks.com',
+      'cookieandkate.com', 'loveandlemons.com', 'pinchofyum.com',
+      'kingarthurbaking.com', 'sallysbakingaddiction.com', 'justonecookbook.com',
+    ]
+    const hasRecipeDomainBoost = RECIPE_DOMAIN_BOOST.some(d => domain.includes(d))
+    const hasRecipeUrlPattern = /\/recipes?\//.test(path)
+    const recipeKeywords = /\b(recipe|ingredients|prep time|cook time|servings|preheat|tablespoon|teaspoon)\b/i
+    const hasRecipeContentSignal = recipeKeywords.test(title || '') || recipeKeywords.test(description || '')
+
+    // Set content_type to recipe if strong signals present (domain+content or domain+URL pattern)
+    if (contentType !== 'video' && contentType !== 'music') {
+      if (hasRecipeDomainBoost && (hasRecipeContentSignal || hasRecipeUrlPattern)) {
+        contentType = 'recipe'
+        typeConfidence = 0.95
+        typeSource = 'rules'
+        console.log('[create-pin] Recipe detected via domain + content signals:', domain)
+      } else if (hasRecipeContentSignal && hasRecipeUrlPattern) {
+        contentType = 'recipe'
+        typeConfidence = 0.85
+        typeSource = 'rules'
+        console.log('[create-pin] Recipe detected via URL pattern + content signals:', domain)
+      }
+      // Note: JSON-LD detection happens in Step 2.8 and can upgrade content_type to 'recipe'
     }
 
     // Initialize Supabase client
@@ -770,6 +805,75 @@ serve(async (req) => {
     }
 
     // ========================================
+    // STEP 2.8: Recipe Enrichment — JSON-LD first, AI fills gaps
+    // Triggered for eat category items, content_type=recipe, or enrichRecipe flag.
+    // JSON-LD @type: "Recipe" is the primary extraction path (works on ANY domain).
+    // AI fallback handles the long tail of sites without structured data.
+    // ========================================
+    let recipeMeta: Record<string, any> | null = null
+    if (enrichRecipe || category === 'eat' || contentType === 'recipe') {
+      console.log('[create-pin] Step 2.8: Recipe enrichment for:', url)
+
+      // 1. Try JSON-LD structured data first (most recipe sites implement schema.org/Recipe for SEO)
+      const jsonLdResult = await extractRecipeJsonLd(url)
+
+      // If JSON-LD found a recipe, upgrade content_type regardless of domain
+      if (jsonLdResult && contentType !== 'recipe') {
+        contentType = 'recipe'
+        typeConfidence = 1.0
+        typeSource = 'jsonld'
+        console.log('[create-pin] JSON-LD confirmed recipe, upgrading content_type')
+      }
+
+      // 2. Only call AI if JSON-LD left gaps or returned nothing
+      const needsAI = !jsonLdResult
+        || !jsonLdResult.ingredients?.length
+        || !jsonLdResult.instructions?.length
+      let aiResult: Record<string, any> | null = null
+      if (needsAI) {
+        console.log('[create-pin] Recipe JSON-LD incomplete or missing, calling AI for gaps')
+        aiResult = await enrichRecipeWithAI(url, title, description)
+      } else {
+        console.log('[create-pin] Recipe JSON-LD complete, skipping AI call')
+      }
+
+      // 3. Merge: JSON-LD is primary, AI fills gaps
+      if (jsonLdResult || aiResult) {
+        recipeMeta = {
+          title: jsonLdResult?.title || null,
+          description: aiResult?.description || (jsonLdResult?.description ? jsonLdResult.description.slice(0, 300) : null),
+          servings: jsonLdResult?.servings || aiResult?.servings || null,
+          servings_text: jsonLdResult?.servings_text || null,
+          prep_time: jsonLdResult?.prep_time || null,
+          cook_time: jsonLdResult?.cook_time || null,
+          total_time: jsonLdResult?.total_time || null,
+          ingredients: jsonLdResult?.ingredients?.length ? jsonLdResult.ingredients : (aiResult?.ingredients || []),
+          instructions: jsonLdResult?.instructions?.length ? jsonLdResult.instructions : (aiResult?.instructions || []),
+          cuisine: jsonLdResult?.cuisine || aiResult?.cuisine || null,
+          difficulty: aiResult?.difficulty || null,
+          source_name: jsonLdResult?.source_name || domain,
+          server_enriched_at: new Date().toISOString(),
+        }
+
+        // Use recipe's own image if no image resolved yet
+        if (jsonLdResult?.image_url && !imageUrl) {
+          imageUrl = jsonLdResult.image_url
+          imageSource = 'platform'
+          imageLog.push({ strategy: 'recipe_jsonld', result: 'accepted', url: imageUrl })
+          console.log('[create-pin] Using recipe JSON-LD image:', imageUrl)
+        }
+      }
+
+      console.log('[create-pin] Recipe enrichment result:', recipeMeta ? {
+        title: recipeMeta.title,
+        ingredients: recipeMeta.ingredients?.length,
+        instructions: recipeMeta.instructions?.length,
+        servings: recipeMeta.servings,
+        cuisine: recipeMeta.cuisine,
+      } : null)
+    }
+
+    // ========================================
     // STEP 3: Update link in database (if linkId provided)
     // ========================================
     if (linkId) {
@@ -806,6 +910,9 @@ serve(async (req) => {
       }
       if (musicMeta) {
         updatePayload.music = musicMeta
+      }
+      if (recipeMeta) {
+        updatePayload.recipe = recipeMeta
       }
       await supabase
         .from('links')
@@ -857,6 +964,9 @@ serve(async (req) => {
     }
     if (musicMeta) {
       response.music = musicMeta
+    }
+    if (recipeMeta) {
+      response.recipe = recipeMeta
     }
 
     console.log('[create-pin] Complete:', response)
@@ -1532,6 +1642,206 @@ Return JSON only:
     console.error('[create-pin] Book enrichment error:', e)
   }
 
+  return null
+}
+
+// ========================================
+// Recipe JSON-LD Extraction
+// Fetches the recipe page and parses schema.org Recipe structured data.
+// Works on ANY domain — not tied to an allowlist.
+// ========================================
+async function extractRecipeJsonLd(url: string): Promise<Record<string, any> | null> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+      },
+      redirect: 'follow',
+    })
+    if (!response.ok) {
+      console.log('[recipe-jsonld] Fetch failed:', response.status)
+      return null
+    }
+
+    const html = await response.text()
+    const jsonLdMatches = html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+
+    for (const match of jsonLdMatches) {
+      try {
+        const ld = JSON.parse(match[1])
+        // JSON-LD can be a single object, an array, or have @graph
+        const candidates: any[] = []
+        if (Array.isArray(ld)) candidates.push(...ld)
+        else if (ld['@graph']) candidates.push(...ld['@graph'])
+        else candidates.push(ld)
+
+        for (const item of candidates) {
+          const itemType = item?.['@type']
+          // Handle @type as string or array
+          const isRecipe = itemType === 'Recipe'
+            || (Array.isArray(itemType) && itemType.includes('Recipe'))
+          if (!isRecipe) continue
+
+          // Extract ingredients (recipeIngredient is an array of strings)
+          const ingredients: string[] = Array.isArray(item.recipeIngredient)
+            ? item.recipeIngredient.filter((s: any) => typeof s === 'string').map((s: string) => s.trim())
+            : []
+
+          // Normalize instructions: HowToStep objects → string array
+          const rawInstructions = item.recipeInstructions || []
+          const instructions: string[] = []
+          if (Array.isArray(rawInstructions)) {
+            for (const step of rawInstructions) {
+              if (typeof step === 'string') {
+                instructions.push(step.trim())
+              } else if (step?.['@type'] === 'HowToStep' && step.text) {
+                instructions.push(step.text.trim())
+              } else if (step?.['@type'] === 'HowToSection' && Array.isArray(step.itemListElement)) {
+                for (const sub of step.itemListElement) {
+                  if (sub?.text) instructions.push(sub.text.trim())
+                }
+              }
+            }
+          }
+
+          // Parse ISO 8601 duration → seconds (reuse existing function)
+          const prepTime = parseISO8601Duration(item.prepTime)
+          const cookTime = parseISO8601Duration(item.cookTime)
+          const totalTime = parseISO8601Duration(item.totalTime)
+
+          // Normalize servings: recipeYield can be string "4 servings" or number or array
+          let servings: number | null = null
+          let servings_text: string | null = null
+          const rawYield = Array.isArray(item.recipeYield) ? item.recipeYield[0] : item.recipeYield
+          if (rawYield != null) {
+            servings_text = String(rawYield)
+            const numMatch = String(rawYield).match(/\d+/)
+            if (numMatch) servings = parseInt(numMatch[0], 10)
+          }
+
+          // Recipe image
+          let image_url: string | null = null
+          if (typeof item.image === 'string') image_url = item.image
+          else if (Array.isArray(item.image)) {
+            const first = item.image[0]
+            image_url = typeof first === 'string' ? first : first?.url || null
+          }
+          else if (item.image?.url) image_url = item.image.url
+
+          // Cuisine
+          const cuisine = typeof item.recipeCuisine === 'string'
+            ? item.recipeCuisine
+            : (Array.isArray(item.recipeCuisine) ? item.recipeCuisine[0] : null)
+
+          console.log('[recipe-jsonld] Extracted:', {
+            title: item.name,
+            ingredients: ingredients.length,
+            instructions: instructions.length,
+            servings,
+            prepTime,
+            cookTime,
+            totalTime,
+            cuisine,
+          })
+
+          return {
+            title: item.name || null,
+            description: item.description || null,
+            servings,
+            servings_text,
+            prep_time: prepTime,
+            cook_time: cookTime,
+            total_time: totalTime,
+            ingredients,
+            instructions,
+            cuisine,
+            image_url,
+            source_name: new URL(url).hostname.replace('www.', ''),
+          }
+        }
+      } catch (_e) { /* JSON parse error, skip this block */ }
+    }
+  } catch (e) {
+    console.log('[recipe-jsonld] Fetch failed:', (e as Error).message)
+  }
+  return null
+}
+
+// ========================================
+// Recipe Enrichment using AI (fallback for sites without JSON-LD)
+// ========================================
+async function enrichRecipeWithAI(url: string, title: string, description: string): Promise<Record<string, any> | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.log('[create-pin] No ANTHROPIC_API_KEY, skipping recipe AI enrichment')
+    return null
+  }
+
+  const prompt = `Given this recipe link, provide structured metadata. Be concise and accurate. If this is NOT a recipe (e.g. it's a restaurant listing, food article, or general cooking page), return {"not_recipe": true}.
+
+URL: ${url}
+Title: ${title || 'N/A'}
+Description: ${description?.slice(0, 500) || 'N/A'}
+
+Return JSON only:
+{
+  "description": "1-2 sentence description of the dish, max 40 words.",
+  "servings": servings as number or null,
+  "cuisine": "cuisine type (e.g. Italian, Mexican, Japanese, American) or null",
+  "difficulty": "easy|medium|hard or null",
+  "ingredients": ["ingredient 1 with quantity", "ingredient 2 with quantity"],
+  "instructions": ["step 1", "step 2"]
+}`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-3-haiku-20240307',
+        max_tokens: 800,
+        messages: [{ role: 'user', content: prompt }]
+      })
+    })
+
+    if (!response.ok) {
+      console.error('[create-pin] Recipe AI enrichment error:', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const text = data.content?.[0]?.text || ''
+    const match = text.match(/\{[\s\S]*\}/)
+
+    if (match) {
+      const result = JSON.parse(match[0])
+      // AI determined this is not actually a recipe
+      if (result.not_recipe) {
+        console.log('[create-pin] AI determined URL is not a recipe')
+        return null
+      }
+      return {
+        description: typeof result.description === 'string' ? result.description.slice(0, 300) : null,
+        servings: typeof result.servings === 'number' ? result.servings : null,
+        cuisine: typeof result.cuisine === 'string' ? result.cuisine : null,
+        difficulty: ['easy', 'medium', 'hard'].includes(result.difficulty) ? result.difficulty : null,
+        ingredients: Array.isArray(result.ingredients)
+          ? result.ingredients.filter((s: any) => typeof s === 'string').slice(0, 50)
+          : [],
+        instructions: Array.isArray(result.instructions)
+          ? result.instructions.filter((s: any) => typeof s === 'string').slice(0, 30)
+          : [],
+      }
+    }
+  } catch (e) {
+    console.error('[create-pin] Recipe AI enrichment error:', e)
+  }
   return null
 }
 

--- a/supabase/migrations/030_recipe_columns.sql
+++ b/supabase/migrations/030_recipe_columns.sql
@@ -1,0 +1,9 @@
+-- Recipe Metadata System
+-- Adds structured recipe metadata storage for eat category items
+
+ALTER TABLE links ADD COLUMN IF NOT EXISTS recipe JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN links.recipe IS 'Structured recipe metadata: title, description, servings, servings_text, prep_time, cook_time, total_time, ingredients[], instructions[], cuisine, difficulty, source_name, server_enriched_at';
+
+-- Index for querying pinned recipes
+CREATE INDEX IF NOT EXISTS idx_links_recipe ON links USING GIN (recipe) WHERE recipe IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds full recipe support to the `eat` category with structured extraction (JSON-LD primary, AI fallback), a Recipe Drawer with serving scaling and imperial/metric unit conversion
- Content-first detection works on **any domain** — domain lists boost confidence but don't gate recipe detection
- Includes `recipe` JSONB column migration, `create-pin` enrichment pipeline (v2.1.0), and Boards UI (v2.12.0) with ingredient parser, fraction formatting, and locale-aware defaults

## Test plan
- [ ] Save a recipe URL (e.g., seriouseats.com) → verify JSON-LD extraction populates `recipe` JSONB
- [ ] Click "Recipe" button on enriched eat pin → drawer slides in with title, meta, ingredients, steps
- [ ] Change servings 4→8 → quantities double; 4→2 → quantities halve; fractions display correctly
- [ ] Toggle Imperial/Metric → cups become ml, oz become g; toggle back restores values
- [ ] Save recipe from non-allowlisted domain with JSON-LD → still detected and enriched
- [ ] Non-recipe eat pins (restaurants, food articles) → no "Recipe" button shown
- [ ] Mobile: drawer takes full width, scrollable, controls accessible
- [ ] Existing eat pins backfill on next page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)