### PR TITLE
fix(create-pin): validate and normalize URLs to prevent 500 errors

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6842,7 +6842,7 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.13.1';
+  const VERSION = '2.13.2';
   console.log('[boards] v' + VERSION + ' - recipe viewer with scaling and unit conversion');
 
   // ============================================
@@ -11136,6 +11136,15 @@ Return JSON:
 
   // Call create-pin API with retry logic (image resolution + metadata enrichment)
   async function callEnrichmentAPI(item, currentImage, forceRefresh) {
+    // Normalize URL: fix protocol-relative and HTML entities before sending
+    let enrichUrl = item.url;
+    if (enrichUrl && enrichUrl.startsWith('//')) enrichUrl = 'https:' + enrichUrl;
+    if (enrichUrl) enrichUrl = enrichUrl.replace(/&amp;/g, '&');
+    try { new URL(enrichUrl); } catch (_e) {
+      console.warn('%c[ENRICH] Skipping invalid URL:', 'color: #e74c3c', enrichUrl);
+      return { success: false, error: new Error('Invalid URL: ' + enrichUrl) };
+    }
+
     let lastError = null;
 
     for (let attempt = 0; attempt <= ENRICHMENT_MAX_RETRIES; attempt++) {
@@ -11157,7 +11166,7 @@ Return JSON:
             'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
           },
           body: JSON.stringify({
-            url: item.url,
+            url: enrichUrl,
             title: item.title,
             description: item.description,
             linkId: item.linkId,

--- a/supabase/functions/create-pin/index.ts
+++ b/supabase/functions/create-pin/index.ts
@@ -6,7 +6,7 @@
 // Body: { url, title?, description?, linkId?, content_type?, category?,
 //         skipImage?, currentImage?, forceRefresh?,
 //         enrichWatch?, enrichBook?, enrichListen?, enrichRecipe? }
-const VERSION = '2.1.0'
+const VERSION = '2.1.1'
 console.log(`[create-pin] v${VERSION} - Pin Creation Agent (image + metadata + recipe)`)
 // Returns: { content_type, type_confidence, type_source, image_url, image_source, hero_score, video?, book?, music?, recipe? }
 
@@ -76,10 +76,26 @@ serve(async (req) => {
       )
     }
 
+    // Normalize protocol-relative URLs and decode HTML entities
+    if (url.startsWith('//')) url = 'https:' + url
+    url = url.replace(/&amp;/g, '&')
+
+    // Validate URL is parseable
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(url)
+    } catch (_e) {
+      console.warn('[create-pin] Invalid URL:', url)
+      return new Response(
+        JSON.stringify({ error: 'Invalid URL format', url }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
     console.log('[create-pin] Processing:', url)
 
-    const domain = new URL(url).hostname.replace('www.', '')
-    const path = new URL(url).pathname
+    const domain = parsedUrl.hostname.replace('www.', '')
+    const path = parsedUrl.pathname
 
     // ========================================
     // STEP 0: Platform API metadata for sites that block scraping


### PR DESCRIPTION
## Summary
- Protocol-relative URLs (`//domain.com/...`) and URLs with HTML entities (`&amp;`) caused `new URL()` to throw in create-pin, resulting in 500 errors that got retried 3 times
- Server now normalizes `//` prefix → `https://` and decodes `&amp;` → `&` before parsing, and returns 400 (non-retryable) for truly invalid URLs
- Client now validates and normalizes URLs before sending, skipping enrichment entirely for unparseable URLs

## Test plan
- [ ] Save a pin with a protocol-relative URL — should normalize and process instead of 500
- [ ] Save a pin with `&amp;` in URL — should decode and process correctly
- [ ] Existing recipe/watch/music enrichment unaffected
- [ ] Console shows no more 500 retry storms for malformed URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)