### PR TITLE
fix(ios): update AASA appID for rodeo bundle

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -3,7 +3,7 @@
     "apps": [],
     "details": [
       {
-        "appID": "RJ8FB5M6HX.com.ctrlrodeo.boards",
+        "appID": "RJ8FB5M6HX.com.ctrlrodeo.rodeo",
         "paths": [
           "/boards/*"
         ]


### PR DESCRIPTION
## Summary
- Updated `.well-known/apple-app-site-association` to use `RJ8FB5M6HX.com.ctrlrodeo.rodeo` instead of the old `RJ8FB5M6HX.com.ctrlrodeo.boards`
- The iOS app was extracted to `rodeo-ios` with bundle ID `com.ctrlrodeo.rodeo` but the AASA still referenced the old bundle ID
- Universal Links from `ctrl.rodeo/boards/*` in Safari would not deep-link into the native app

## Test plan
- [x] Verified new bundle ID matches `project.yml` in rodeo-ios (`com.ctrlrodeo.rodeo`)
- [x] Verified team ID matches entitlements (`RJ8FB5M6HX`)
- [ ] After deploy, test Universal Link: open `https://ctrl.rodeo/boards/` in Safari on device with app installed — should offer to open in Rodeo app

🤖 Generated with [Claude Code](https://claude.com/claude-code)