### PR TITLE
feat(boards): AI connector privacy settings + submission docs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -70,7 +70,24 @@
       "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon add:*)",
       "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon commit -m \"$\\(cat <<''EOF''\nfix: enrich-music improvements + client-side BPM lookup\n\nEdge function fixes:\n- Remove GetSongBPM from server-side \\(blocked by Cloudflare bot protection\\)\n- Fix MusicBrainz: filter results by artist name match, prefer original\n  album releases over compilations\n- Fix Last.fm: fall back to artist.getTopTags when track tags are empty,\n  also try track.getTopTags as intermediate step\n\nClient-side BPM \\(boards/index.html\\):\n- Add queryGetSongBPM\\(\\) at module scope — calls GetSongBPM API directly\n  from browser, bypassing Cloudflare bot protection\n- Step 6 split: 6a server enrichment \\(genre/label\\), 6b client BPM/key\n- Backfill v4: re-enriches links missing BPM/key/genre/label\n- Backfill Step 2 \\(server\\) + Step 3 \\(client BPM\\) with rate limiting\n\nCo-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>\nEOF\n\\)\")",
       "Bash(git -C /Users/ian/.claude-worktrees/fikei.github.io/interesting-cannon push -u origin claude/fix-enrich-music-0dc05)",
-      "Bash(git stash:*)"
+      "Bash(git stash:*)",
+      "Bash(grep -n \"CREATE TABLE.*links\\\\b\\\\|CREATE TABLE IF NOT EXISTS links\" /Users/ian/Documents/GitHub/fikei.github.io/supabase/migrations/*.sql)",
+      "WebFetch(domain:support.claude.com)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:claude.ai)",
+      "Bash(# Check the supabase config.toml cat /Users/ian/Documents/GitHub/fikei.github.io/supabase/config.toml)",
+      "WebFetch(domain:www.explorium.ai)",
+      "WebFetch(domain:pluginsforcowork.com)",
+      "WebFetch(domain:medium.com)",
+      "WebFetch(domain:sunpeak.ai)",
+      "WebFetch(domain:dev.to)",
+      "WebFetch(domain:help.raindrop.io)",
+      "WebFetch(domain:almcorp.com)",
+      "WebFetch(domain:mcpize.com)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:www.docusign.com)",
+      "WebFetch(domain:docs.readwise.io)",
+      "WebFetch(domain:www.moesif.com)"
     ]
   }
 }

--- a/boards/index.html
+++ b/boards/index.html
@@ -465,6 +465,124 @@
   margin-top: 2px;
 }
 
+/* Connector settings */
+.settings-section {
+  padding-top: var(--space-3);
+}
+
+.settings-section__title {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--subtle);
+  margin-bottom: var(--space-1);
+}
+
+.settings-tier {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.settings-tier__option {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--subtle);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.settings-tier__option:hover {
+  border-color: var(--fg);
+}
+
+.settings-tier__option:has(input:checked) {
+  border-color: var(--fg);
+  background: var(--subtle);
+}
+
+.settings-tier__option input {
+  margin-top: 2px;
+  accent-color: var(--fg);
+}
+
+.settings-tier__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.settings-tier__text strong {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.settings-tier__text small {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+}
+
+.settings-boards {
+  padding: var(--space-2) 0;
+}
+
+.settings-boards__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-1) 0;
+}
+
+.settings-boards__name {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  text-transform: capitalize;
+}
+
+.settings-boards__count {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--muted);
+  margin-left: var(--space-1);
+}
+
+.connector-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.connector-status__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.connector-status__dot--active {
+  background: #0a0;
+}
+
+.toggle--on {
+  background: var(--fg);
+}
+
+.toggle--on .theme-toggle__knob {
+  background: var(--bg);
+  transform: translateX(14px);
+}
+
 /* Username input */
 .username-input-row {
   display: flex;
@@ -6384,7 +6502,7 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   </div>
 
   <!-- Settings Modal -->
-  <div class="modal modal--small" id="settingsModal">
+  <div class="modal" id="settingsModal">
     <div class="modal__backdrop" data-close></div>
     <div class="modal__content">
       <div class="modal__header">
@@ -6400,6 +6518,71 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
           <button class="theme-toggle" id="themeToggle">
             <div class="theme-toggle__knob"></div>
           </button>
+        </div>
+
+        <!-- AI Connector Settings -->
+        <div class="settings-section" id="connectorSettingsSection" style="display:none;">
+          <div class="settings-section__title">AI Connector</div>
+
+          <div class="settings-row">
+            <div class="settings-row__label">
+              <span class="settings-row__title">Connection</span>
+              <span class="settings-row__description" id="connectorStatusText">Not connected</span>
+            </div>
+            <div class="connector-status">
+              <span class="connector-status__dot" id="connectorStatusDot"></span>
+            </div>
+          </div>
+
+          <div class="settings-row" style="flex-direction:column;align-items:stretch;">
+            <div class="settings-row__label" style="margin-bottom:var(--space-2);">
+              <span class="settings-row__title">Privacy Level</span>
+              <span class="settings-row__description">What Claude can see from your library</span>
+            </div>
+            <div class="settings-tier" id="privacyTierPicker">
+              <label class="settings-tier__option">
+                <input type="radio" name="privacyTier" value="taste_only">
+                <span class="settings-tier__text">
+                  <strong>Taste Only</strong>
+                  <small>Categories, tags, interests — no titles or links</small>
+                </span>
+              </label>
+              <label class="settings-tier__option">
+                <input type="radio" name="privacyTier" value="library" checked>
+                <span class="settings-tier__text">
+                  <strong>Library</strong>
+                  <small>Titles, categories, tags, media info — no URLs or notes</small>
+                </span>
+              </label>
+              <label class="settings-tier__option">
+                <input type="radio" name="privacyTier" value="full_access">
+                <span class="settings-tier__text">
+                  <strong>Full Access</strong>
+                  <small>Everything including URLs, notes, and images</small>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <div class="settings-row">
+            <div class="settings-row__label">
+              <span class="settings-row__title">Auto-Save</span>
+              <span class="settings-row__description">Claude saves pins when you express a choice</span>
+            </div>
+            <button class="theme-toggle" id="autoSaveToggle">
+              <div class="theme-toggle__knob"></div>
+            </button>
+          </div>
+
+          <div class="settings-row" style="flex-direction:column;align-items:stretch;">
+            <div class="settings-row__label" style="margin-bottom:var(--space-2);">
+              <span class="settings-row__title">Board Visibility</span>
+              <span class="settings-row__description">Toggle which boards Claude can access</span>
+            </div>
+            <div class="settings-boards" id="boardVisibilityList">
+              <!-- Populated by JS -->
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -6806,8 +6989,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.15.0';
-  console.log('[boards] v' + VERSION + ' - reduce line weight, full color images');
+  const VERSION = '2.16.0';
+  console.log('[boards] v' + VERSION + ' - AI connector privacy settings');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -20231,6 +20414,166 @@ Return JSON:
   };
 
   // ============================================
+  // Connector Settings (AI privacy controls)
+  // ============================================
+  const connectorSection = $('connectorSettingsSection');
+  const connectorStatusDot = $('connectorStatusDot');
+  const connectorStatusText = $('connectorStatusText');
+  const privacyTierPicker = $('privacyTierPicker');
+  const autoSaveToggle = $('autoSaveToggle');
+  const boardVisibilityList = $('boardVisibilityList');
+  let connectorSettings = null;
+
+  async function loadConnectorSettings() {
+    if (!currentUser) {
+      connectorSection.style.display = 'none';
+      return;
+    }
+    connectorSection.style.display = '';
+    const token = getAccessToken();
+    try {
+      // Check if user has an active MCP token
+      const { data: tokens } = await supabase
+        .from('mcp_tokens')
+        .select('id, access_token_expires_at')
+        .eq('user_id', currentUser.id)
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      const hasActiveToken = tokens && tokens.length > 0 &&
+        new Date(tokens[0].access_token_expires_at) > new Date();
+
+      if (hasActiveToken) {
+        connectorStatusDot.classList.add('connector-status__dot--active');
+        connectorStatusText.textContent = 'Connected to Claude';
+      } else if (tokens && tokens.length > 0) {
+        connectorStatusDot.classList.remove('connector-status__dot--active');
+        connectorStatusText.textContent = 'Token expired — reconnect in Claude';
+      } else {
+        connectorStatusDot.classList.remove('connector-status__dot--active');
+        connectorStatusText.textContent = 'Not connected';
+      }
+
+      // Load or create settings
+      const { data: settings } = await supabase
+        .from('connector_settings')
+        .select('*')
+        .eq('user_id', currentUser.id)
+        .single();
+
+      if (settings) {
+        connectorSettings = settings;
+      } else {
+        // Create default settings
+        const { data: newSettings } = await supabase
+          .from('connector_settings')
+          .insert({ user_id: currentUser.id })
+          .select()
+          .single();
+        connectorSettings = newSettings || {
+          privacy_tier: 'library',
+          board_visibility: {},
+          auto_save_enabled: true,
+        };
+      }
+
+      // Apply to UI
+      const tierRadio = privacyTierPicker.querySelector(`input[value="${connectorSettings.privacy_tier}"]`);
+      if (tierRadio) tierRadio.checked = true;
+
+      if (connectorSettings.auto_save_enabled) {
+        autoSaveToggle.classList.add('toggle--on');
+      } else {
+        autoSaveToggle.classList.remove('toggle--on');
+      }
+
+      renderBoardVisibility();
+    } catch (err) {
+      console.log('[connector] Failed to load settings:', err);
+    }
+  }
+
+  function renderBoardVisibility() {
+    const cats = getCategories();
+    const links = getAllLinks();
+    // Count pins per board
+    const counts = {};
+    links.forEach(l => {
+      const c = (l.category || 'uncategorized').toLowerCase();
+      counts[c] = (counts[c] || 0) + 1;
+    });
+    // Combine built-in + any categories with pins
+    const allBoards = new Set([
+      'home', 'wear', 'watch', 'listen', 'use', 'eat', 'go', 'follow', 'read',
+      ...Object.keys(cats),
+      ...Object.keys(counts),
+    ]);
+
+    const boardVis = connectorSettings?.board_visibility || {};
+    boardVisibilityList.innerHTML = '';
+
+    Array.from(allBoards).sort().forEach(board => {
+      const count = counts[board] || 0;
+      // Default: visible (true) unless explicitly set to false
+      const isVisible = boardVis[board] !== false;
+      const item = document.createElement('div');
+      item.className = 'settings-boards__item';
+      item.innerHTML = `
+        <span>
+          <span class="settings-boards__name">${board}</span>
+          <span class="settings-boards__count">${count}</span>
+        </span>
+        <input type="checkbox" ${isVisible ? 'checked' : ''} data-board="${board}" style="accent-color:var(--fg);">
+      `;
+      boardVisibilityList.appendChild(item);
+    });
+
+    // Wire up checkbox changes
+    boardVisibilityList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+      cb.addEventListener('change', () => {
+        const board = cb.dataset.board;
+        if (!connectorSettings.board_visibility) connectorSettings.board_visibility = {};
+        connectorSettings.board_visibility[board] = cb.checked;
+        saveConnectorSettings();
+      });
+    });
+  }
+
+  async function saveConnectorSettings() {
+    if (!currentUser || !connectorSettings) return;
+    try {
+      await supabase
+        .from('connector_settings')
+        .update({
+          privacy_tier: connectorSettings.privacy_tier,
+          board_visibility: connectorSettings.board_visibility || {},
+          auto_save_enabled: connectorSettings.auto_save_enabled,
+        })
+        .eq('user_id', currentUser.id);
+    } catch (err) {
+      console.log('[connector] Failed to save settings:', err);
+    }
+  }
+
+  // Privacy tier change
+  privacyTierPicker.querySelectorAll('input[name="privacyTier"]').forEach(radio => {
+    radio.addEventListener('change', () => {
+      if (connectorSettings) {
+        connectorSettings.privacy_tier = radio.value;
+        saveConnectorSettings();
+      }
+    });
+  });
+
+  // Auto-save toggle
+  autoSaveToggle.addEventListener('click', () => {
+    if (!connectorSettings) return;
+    connectorSettings.auto_save_enabled = !connectorSettings.auto_save_enabled;
+    autoSaveToggle.classList.toggle('toggle--on', connectorSettings.auto_save_enabled);
+    saveConnectorSettings();
+  });
+
+  // ============================================
   // Auth Functions
   // ============================================
   function getDisplayName() {
@@ -20927,6 +21270,7 @@ Return JSON:
 
   document.addEventListener('ctrl:auth:settingsclick', () => {
     openModal(settingsModal);
+    loadConnectorSettings();
   });
 
   function getDeviceInfo() {

--- a/connect/docs.html
+++ b/connect/docs.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ctrl.rodeo Connector — Documentation</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+    }
+    .logo {
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #666;
+      margin-bottom: 2rem;
+    }
+    .logo a { color: #666; text-decoration: none; }
+    .logo a:hover { color: #e0e0e0; }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-bottom: 0.5rem;
+    }
+    .subtitle {
+      color: #888;
+      font-size: 0.85rem;
+      margin-bottom: 3rem;
+    }
+    h2 {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #888;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #222;
+    }
+    h3 {
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-top: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    p, li {
+      font-size: 0.85rem;
+      color: #ccc;
+      margin-bottom: 0.75rem;
+    }
+    ul { padding-left: 1.25rem; }
+    li { margin-bottom: 0.5rem; }
+    code {
+      background: #1a1a1a;
+      padding: 0.15em 0.4em;
+      font-size: 0.8rem;
+      border: 1px solid #333;
+    }
+    pre {
+      background: #111;
+      border: 1px solid #333;
+      padding: 1rem;
+      overflow-x: auto;
+      margin: 1rem 0;
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
+    pre code {
+      background: none;
+      border: none;
+      padding: 0;
+    }
+    .tool-card {
+      border: 1px solid #222;
+      padding: 1rem;
+      margin: 0.75rem 0;
+    }
+    .tool-card__name {
+      font-size: 0.85rem;
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+    .tool-card__desc {
+      font-size: 0.8rem;
+      color: #999;
+    }
+    .tool-card__badge {
+      display: inline-block;
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 0.1em 0.4em;
+      border: 1px solid #444;
+      color: #888;
+      margin-left: 0.5rem;
+    }
+    .tool-card__badge--write {
+      border-color: #664;
+      color: #aa8;
+    }
+    .example {
+      background: #111;
+      border-left: 2px solid #444;
+      padding: 1rem;
+      margin: 1rem 0;
+    }
+    .example__prompt {
+      font-size: 0.8rem;
+      color: #aaa;
+      margin-bottom: 0.5rem;
+    }
+    .example__result {
+      font-size: 0.8rem;
+      color: #888;
+    }
+    a { color: #e0e0e0; }
+    a:hover { color: #fff; }
+    .footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid #222;
+      font-size: 0.75rem;
+      color: #555;
+    }
+    .footer a { color: #666; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo"><a href="https://ctrl.rodeo">ctrl.rodeo</a></div>
+
+    <h1>Connector Documentation</h1>
+    <p class="subtitle">Connect your curated library to Claude. Search your saves, get taste-aware recommendations, and capture new finds — all from within Claude.</p>
+
+    <h2>Description</h2>
+    <p>ctrl.rodeo is a personal curation platform for collecting and organizing everything that matters — products, articles, music, restaurants, travel, fashion, and more. The connector gives Claude access to your curated library so it can provide recommendations informed by your actual taste.</p>
+
+    <h2>Features</h2>
+    <ul>
+      <li>Search your library by keyword, board, content type, or tags</li>
+      <li>Browse boards (Wear, Listen, Read, Home, Use, Eat, Go, Follow, Watch)</li>
+      <li>Get your taste profile — AI-generated patterns across your saves</li>
+      <li>Save new pins back to your library with full enrichment</li>
+      <li>Auto-capture: Claude saves items when you express a clear choice signal</li>
+      <li>Privacy controls: choose exactly what Claude can see</li>
+    </ul>
+
+    <h2>Installation</h2>
+    <p>Add the connector in Claude settings or click the install link:</p>
+    <pre><code>Server URL: https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-server</code></pre>
+    <p>Claude handles the OAuth flow automatically. You'll be redirected to ctrl.rodeo to sign in and choose your privacy level. No API keys or configuration needed.</p>
+
+    <h2>Configuration</h2>
+    <p>After connecting, manage your settings in the Boards app:</p>
+    <ul>
+      <li><strong>Privacy Level</strong> — Choose what Claude can see: Taste Only (tags/categories), Library (titles + tags), or Full Access (everything including URLs)</li>
+      <li><strong>Board Visibility</strong> — Toggle which boards Claude can access</li>
+      <li><strong>Auto-Save</strong> — Let Claude save pins when you say things like "I'll get that" or "add to cart"</li>
+    </ul>
+    <p>Open the settings at <a href="https://ctrl.rodeo/boards/">ctrl.rodeo/boards</a> (gear icon).</p>
+
+    <h2>Tools</h2>
+
+    <div class="tool-card">
+      <div class="tool-card__name">search_pins <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">Search saved items by keyword, board, content type, or tags. Returns matching pins filtered by privacy settings.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">get_board <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">Get all items in a board (e.g., Wear, Listen, Read). Supports pagination.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">get_boards_list <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">List all boards with item counts and descriptions.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">get_taste_profile <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">Get the user's taste profile — cross-board patterns, top tags, brand affinities, and aesthetic identity.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">get_recent_saves <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">Get recent saves. Useful for understanding current interests.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">save_pin <span class="tool-card__badge--write tool-card__badge">write</span></div>
+      <div class="tool-card__desc">Save a URL to the library. Automatically enriched with images, categories, entities, and tags. Idempotent — saving the same URL twice returns the existing pin.</div>
+    </div>
+
+    <div class="tool-card">
+      <div class="tool-card__name">get_connector_context <span class="tool-card__badge">read</span></div>
+      <div class="tool-card__desc">Orientation tool — returns board taxonomy, content types, tag system, and composition guidance.</div>
+    </div>
+
+    <h2>Usage Examples</h2>
+
+    <div class="example">
+      <div class="example__prompt">"I need new running shoes. What brands do I already like?"</div>
+      <div class="example__result">Claude calls get_taste_profile to understand your brand affinities, then search_pins with board="wear" and tag="running" to find specific saves. It recommends brands based on your actual collection.</div>
+    </div>
+
+    <div class="example">
+      <div class="example__prompt">"Find me a restaurant like that Italian place I saved."</div>
+      <div class="example__result">Claude calls search_pins in the "eat" board to find your Italian saves, identifies what you liked (taste tags, entities), then uses those patterns to suggest similar restaurants.</div>
+    </div>
+
+    <div class="example">
+      <div class="example__prompt">"Help me plan a weekend trip to Portland."</div>
+      <div class="example__result">Claude searches your "go", "eat", and "use" boards for Portland saves, checks your taste profile for travel patterns, and builds an itinerary informed by places and things you already love.</div>
+    </div>
+
+    <div class="example">
+      <div class="example__prompt">"That Aesop hand cream looks perfect — save it."</div>
+      <div class="example__result">Claude calls save_pin with the product URL. The pin is auto-categorized into the right board, enriched with images and tags, and appears in your library within seconds.</div>
+    </div>
+
+    <div class="example">
+      <div class="example__prompt">"What's my design style based on my saves?"</div>
+      <div class="example__result">Claude calls get_taste_profile and get_board for "home", analyzes cross-board patterns between your home, wear, and follow boards, and describes your aesthetic identity with specific examples from your library.</div>
+    </div>
+
+    <h2>Privacy Policy</h2>
+    <p>See our full <a href="/connect/privacy.html">Privacy Policy</a> for how connector data is handled.</p>
+
+    <h2>Support</h2>
+    <p>Email: <a href="mailto:hello@ctrl.rodeo">hello@ctrl.rodeo</a></p>
+    <p>Issues: <a href="https://github.com/fikei/fikei.github.io/issues">GitHub Issues</a></p>
+
+    <div class="footer">
+      <a href="https://ctrl.rodeo">ctrl.rodeo</a> &middot;
+      <a href="/connect/privacy.html">Privacy</a> &middot;
+      <a href="mailto:hello@ctrl.rodeo">Contact</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/connect/privacy.html
+++ b/connect/privacy.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — ctrl.rodeo Connector</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      background: #0a0a0a;
+      color: #e0e0e0;
+      min-height: 100vh;
+      line-height: 1.6;
+    }
+    .container {
+      max-width: 680px;
+      margin: 0 auto;
+      padding: 3rem 1.5rem;
+    }
+    .logo {
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #666;
+      margin-bottom: 2rem;
+    }
+    .logo a { color: #666; text-decoration: none; }
+    .logo a:hover { color: #e0e0e0; }
+    h1 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-bottom: 0.5rem;
+    }
+    .updated {
+      color: #666;
+      font-size: 0.75rem;
+      margin-bottom: 3rem;
+    }
+    h2 {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #888;
+      margin-top: 2.5rem;
+      margin-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid #222;
+    }
+    p, li {
+      font-size: 0.85rem;
+      color: #ccc;
+      margin-bottom: 0.75rem;
+    }
+    ul { padding-left: 1.25rem; }
+    li { margin-bottom: 0.5rem; }
+    strong { color: #e0e0e0; }
+    a { color: #e0e0e0; }
+    a:hover { color: #fff; }
+    .footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid #222;
+      font-size: 0.75rem;
+      color: #555;
+    }
+    .footer a { color: #666; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="logo"><a href="https://ctrl.rodeo">ctrl.rodeo</a></div>
+
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: March 11, 2026</p>
+
+    <p>This privacy policy describes how the ctrl.rodeo AI Connector ("Connector") handles your data when you connect your ctrl.rodeo account to Claude or other AI platforms.</p>
+
+    <h2>What Data is Shared</h2>
+    <p>You control exactly what the Connector shares through three privacy levels:</p>
+    <ul>
+      <li><strong>Taste Only</strong> — Categories, taste tags, practical tags, entities, and content types. No titles, URLs, or personal notes are shared.</li>
+      <li><strong>Library</strong> (default) — Titles, categories, tags, entities, images, and media metadata. URLs and personal notes are not shared.</li>
+      <li><strong>Full Access</strong> — All library data including URLs, descriptions, notes, and images.</li>
+    </ul>
+    <p>You can also control visibility per board and toggle auto-save behavior in your Boards settings.</p>
+
+    <h2>How Data Flows</h2>
+    <p>When you use the Connector:</p>
+    <ul>
+      <li>Claude sends tool requests to the ctrl.rodeo MCP server</li>
+      <li>The server authenticates your OAuth token, checks your privacy settings, and returns only the fields your privacy level allows</li>
+      <li>Data flows directly between your browser/Claude client and our server — we do not share your data with other third parties</li>
+      <li>When you save a pin through Claude, the URL is processed through our standard enrichment pipeline (image resolution, AI categorization, tag generation)</li>
+    </ul>
+
+    <h2>Data We Collect</h2>
+    <p>The Connector logs the following for each tool call:</p>
+    <ul>
+      <li>Tool name and input parameters</li>
+      <li>Result count, privacy tier, and response time</li>
+      <li>Session identifier and client type</li>
+      <li>Errors (if any)</li>
+    </ul>
+    <p>This usage data helps us improve the Connector and is not shared with third parties. It is associated with your user account and subject to the same data retention policies as your library data.</p>
+
+    <h2>Authentication</h2>
+    <p>The Connector uses OAuth 2.1 with PKCE. When you connect:</p>
+    <ul>
+      <li>You sign in with your existing ctrl.rodeo account (Google OAuth or magic link)</li>
+      <li>You choose your privacy level</li>
+      <li>An access token is issued that can be revoked at any time</li>
+    </ul>
+    <p>We do not store your Google credentials. OAuth tokens expire after 1 hour and are refreshed automatically. Refresh tokens expire after 30 days.</p>
+
+    <h2>Data Storage</h2>
+    <ul>
+      <li>Your library data is stored in Supabase (hosted on AWS, US region)</li>
+      <li>OAuth tokens are stored in our database with row-level security</li>
+      <li>Connector settings (privacy tier, board visibility) are stored per-user</li>
+      <li>We do not store copies of your data for AI training purposes</li>
+    </ul>
+
+    <h2>Your Rights</h2>
+    <ul>
+      <li><strong>Revoke access</strong> — Disconnect the Connector at any time from Claude settings or by clearing your tokens</li>
+      <li><strong>Change privacy level</strong> — Adjust what is shared in Boards settings (gear icon), effective immediately</li>
+      <li><strong>Delete data</strong> — Deleting your ctrl.rodeo account removes all associated data including OAuth tokens and connector settings</li>
+      <li><strong>Export</strong> — Your library data is yours; export is available through the Boards app</li>
+    </ul>
+
+    <h2>Third-Party AI Platforms</h2>
+    <p>When you use the Connector with Claude, your library data is sent to Anthropic's servers as part of your conversation. Anthropic's handling of this data is governed by <a href="https://www.anthropic.com/privacy">Anthropic's Privacy Policy</a>. We recommend reviewing their policies regarding data retention and model training.</p>
+
+    <h2>Changes to This Policy</h2>
+    <p>We may update this policy as the Connector evolves. Significant changes will be communicated through the Boards app. The "last updated" date at the top reflects the most recent revision.</p>
+
+    <h2>Contact</h2>
+    <p>For privacy questions or data requests: <a href="mailto:hello@ctrl.rodeo">hello@ctrl.rodeo</a></p>
+
+    <div class="footer">
+      <a href="https://ctrl.rodeo">ctrl.rodeo</a> &middot;
+      <a href="/connect/docs.html">Documentation</a> &middot;
+      <a href="mailto:hello@ctrl.rodeo">Contact</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- **Privacy Settings UI** in Boards Settings modal — privacy tier picker (Taste Only / Library / Full Access), per-board visibility toggles, auto-save toggle, and connection status indicator
- **Connector documentation** at `/connect/docs.html` — tool reference, 5 usage examples, installation guide, configuration instructions
- **Privacy policy** at `/connect/privacy.html` — data flow, storage, user rights, third-party handling
- Boards bumped to v2.16.0

## Test plan
- [ ] Open Settings in Boards → verify AI Connector section appears for logged-in users
- [ ] Change privacy tier → verify saved to connector_settings table
- [ ] Toggle board visibility → verify persists
- [ ] Toggle auto-save → verify persists
- [ ] Visit /connect/docs.html → verify renders correctly
- [ ] Visit /connect/privacy.html → verify renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)