### PR TITLE
feat: wire taste engine activation triggers

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -7063,8 +7063,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.17.0';
-  console.log('[boards] v' + VERSION + ' - AI connector privacy settings');
+  const VERSION = '2.18.0';
+  console.log('[boards] v' + VERSION + ' - taste engine activation triggers');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -9731,6 +9731,25 @@ Return JSON:
       bridges: [],
       motifs: [],
     };
+  }
+
+  // Debounced affinity recomputation after pin saves
+  // Waits 30s after last pin add before firing, so bulk imports batch naturally
+  let _tasteAffinityTimer = null;
+  let _tastePendingPinCount = 0;
+
+  function scheduleTasteAffinityUpdate() {
+    _tastePendingPinCount++;
+    if (_tasteAffinityTimer) clearTimeout(_tasteAffinityTimer);
+    _tasteAffinityTimer = setTimeout(function() {
+      var count = _tastePendingPinCount;
+      _tastePendingPinCount = 0;
+      _tasteAffinityTimer = null;
+      console.log('[taste-engine] ' + count + ' new pin(s) — recomputing affinities');
+      triggerTasteComputation('compute-affinities').catch(function(e) {
+        console.warn('[taste-engine] Affinity recomputation error:', e);
+      });
+    }, 30000); // 30s debounce
   }
 
   // =============================================================================
@@ -14233,6 +14252,11 @@ Return JSON:
 
     // Onboarding: track first pin and show hints
     checkOnboardingMilestones(data.links.length);
+
+    // Taste Engine: schedule affinity recomputation (debounced for bulk imports)
+    if (CtrlAuth.getUser && CtrlAuth.getUser()) {
+      scheduleTasteAffinityUpdate();
+    }
 
     return { success: true };
   }
@@ -21538,8 +21562,23 @@ Return JSON:
       loadAllShares();
       initYouTubeSection();
 
-      // Preload taste profile (non-blocking, used by widgets and search)
-      loadTasteProfile().catch(function(e) { console.warn('[taste-engine] Preload error:', e); });
+      // Preload taste profile — if empty and user has enough pins, bootstrap the engine
+      loadTasteProfile().then(function(profile) {
+        var hasDomains = profile && profile.domains && profile.domains.length > 0;
+        if (!hasDomains) {
+          var pinCount = getAllLinks().length;
+          if (pinCount >= 10) {
+            console.log('[taste-engine] Empty profile with ' + pinCount + ' pins — bootstrapping full pipeline');
+            triggerTasteComputation('full-pipeline').then(function(result) {
+              if (result && result.profile) {
+                console.log('[taste-engine] Bootstrap complete — ' + (result.profile.domains || []).length + ' domains discovered');
+              }
+            }).catch(function(e) { console.warn('[taste-engine] Bootstrap error:', e); });
+          } else {
+            console.log('[taste-engine] Only ' + pinCount + ' pins (need 10+), skipping bootstrap');
+          }
+        }
+      }).catch(function(e) { console.warn('[taste-engine] Preload error:', e); });
 
       // Fetch from Supabase and update if different
       const t2 = performance.now();

--- a/supabase/functions/generate-widget/index.ts
+++ b/supabase/functions/generate-widget/index.ts
@@ -12,6 +12,7 @@
 // - Instrumentation (track success/failure for validation)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.3'
 
 // Phase 2: Config-driven widget system
 import {
@@ -1090,6 +1091,74 @@ interface TasteContext {
   motifs?: string[]
 }
 
+// --- Server-side taste profile loader (fallback when client doesn't send tasteContext) ---
+async function loadTasteFromDB(authHeader: string | null): Promise<TasteContext | null> {
+  if (!authHeader) return null
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || ''
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || ''
+    if (!supabaseUrl || !supabaseKey) return null
+
+    // Create client with user's JWT to respect RLS
+    const token = authHeader.replace('Bearer ', '')
+    const supabase = createClient(supabaseUrl, supabaseKey, {
+      global: { headers: { Authorization: `Bearer ${token}` } },
+      auth: { persistSession: false, autoRefreshToken: false },
+    })
+
+    // Get user ID from token
+    const { data: { user } } = await supabase.auth.getUser(token)
+    if (!user?.id) return null
+
+    // Read taste_domains (top 6 by confidence)
+    const { data: domains } = await supabase
+      .from('taste_domains')
+      .select('label, summary, spanning_categories, confidence, pin_ids')
+      .eq('user_id', user.id)
+      .order('confidence', { ascending: false })
+      .limit(6)
+
+    if (!domains || domains.length === 0) return null
+
+    // Read taste_axes (confidence > 0.3)
+    const { data: axes } = await supabase
+      .from('taste_axes')
+      .select('axis, position, low_label, high_label, confidence')
+      .eq('user_id', user.id)
+      .gt('confidence', 0.3)
+
+    // Read global sensibility summary
+    const { data: summaries } = await supabase
+      .from('taste_summaries')
+      .select('summary')
+      .eq('user_id', user.id)
+      .eq('scope', 'global')
+      .limit(1)
+
+    console.log(`[generate-widget] Loaded taste from DB: ${domains.length} domains, ${(axes || []).length} axes`)
+
+    return {
+      domains: domains.map(d => ({
+        label: d.label,
+        summary: d.summary || '',
+        spanning_categories: d.spanning_categories || [],
+        confidence: d.confidence,
+      })),
+      axes: (axes || []).map(a => ({
+        axis: a.axis,
+        position: a.position,
+        low_label: a.low_label,
+        high_label: a.high_label,
+      })),
+      sensibility: summaries?.[0]?.summary || null,
+    }
+  } catch (err) {
+    console.warn('[generate-widget] Taste DB read error:', err)
+    return null
+  }
+}
+
 serve(async (req) => {
   // Handle CORS preflight
   if (req.method === 'OPTIONS') {
@@ -1184,7 +1253,7 @@ serve(async (req) => {
     // ========================================================================
     // Standard widget generation (existing flow)
     // ========================================================================
-    const { widgetId, prompt, items, category, userPrefs, skipEligibility, tasteContext } = requestBody as ExtendedWidgetRequest
+    const { widgetId, prompt, items, category, userPrefs, skipEligibility, tasteContext: clientTasteContext } = requestBody as ExtendedWidgetRequest
 
     if (!widgetId || !prompt || !items || items.length === 0) {
       return new Response(
@@ -1321,7 +1390,9 @@ Example: "confidence": 0.85`
     // ==========================================================================
     // TASTE ENGINE: USER PREFERENCE CONTEXT
     // Inject taste profile so AI recommendations align with user's aesthetic
+    // Client sends tasteContext if available; otherwise load from DB server-side
     // ==========================================================================
+    const tasteContext = clientTasteContext || await loadTasteFromDB(req.headers.get('Authorization'))
     let tasteConstraint = ''
     if (tasteContext) {
       const parts: string[] = []

--- a/supabase/migrations/031_taste_engine_tables.sql
+++ b/supabase/migrations/031_taste_engine_tables.sql
@@ -118,7 +118,7 @@ CREATE INDEX IF NOT EXISTS idx_snapshots_user ON taste_snapshots(user_id);
 CREATE TABLE IF NOT EXISTS pin_intent (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  link_id UUID NOT NULL REFERENCES links(id) ON DELETE CASCADE,
+  link_id TEXT NOT NULL REFERENCES links(id) ON DELETE CASCADE,
   intent TEXT NOT NULL DEFAULT 'appreciate' CHECK (intent IN ('acquire', 'reference', 'appreciate')),
   action_state TEXT NOT NULL DEFAULT 'unprocessed' CHECK (action_state IN ('unprocessed', 'active', 'done', 'archived')),
   horizon TEXT DEFAULT 'someday' CHECK (horizon IN ('now', 'soon', 'someday', 'ongoing')),


### PR DESCRIPTION
## Summary
- **Bootstrap on login**: when taste profile is empty and user has ≥10 pins, auto-triggers `full-pipeline` to populate taste_domains, taste_axes, and taste_summaries
- **Incremental after pin save**: debounced (30s) `compute-affinities` call keeps the taste model current as pins are added — batches naturally during bulk imports
- **Server-side DB read in generate-widget**: falls back to reading taste_domains/axes/summaries from DB when client doesn't send tasteContext, so widget personalization works even before client cache is populated
- **Migration fix**: `pin_intent.link_id` type changed from `UUID` to `TEXT` to match `links.id` column type
- **Boards v2.18.0**

## What this unblocks
Phase 1 of the taste engine had the edge function and schema but nothing ever triggered computation — tables stayed empty. This PR closes the loop: the engine now runs automatically and its output feeds into widget personalization.

## Test plan
- [ ] Login with ≥10 pins → console shows `[taste-engine] Empty profile... bootstrapping full pipeline`
- [ ] After bootstrap: `[taste-engine] Bootstrap complete — N domains discovered`
- [ ] Add a pin → after 30s, console shows `[taste-engine] 1 new pin(s) — recomputing affinities`
- [ ] Widget generation includes `USER TASTE PROFILE` section in prompt (check edge function logs)
- [ ] Migration 031 applies cleanly (pin_intent.link_id is TEXT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)