### PR TITLE
fix(mcp): host OAuth metadata on ctrl.rodeo for discovery

### DIFF
--- a/.well-known/oauth-authorization-server
+++ b/.well-known/oauth-authorization-server
@@ -1,0 +1,11 @@
+{
+  "issuer": "https://ctrl.rodeo",
+  "authorization_endpoint": "https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth/authorize",
+  "token_endpoint": "https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth/token",
+  "registration_endpoint": "https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth/register",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "code_challenge_methods_supported": ["S256"],
+  "token_endpoint_auth_methods_supported": ["none"],
+  "scopes_supported": ["read", "write"]
+}

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-minimal
+include: [".well-known"]

--- a/supabase/functions/mcp-server/index.ts
+++ b/supabase/functions/mcp-server/index.ts
@@ -14,7 +14,7 @@ console.log(`[mcp-server] v${VERSION} - MCP Streamable HTTP server`)
 
 const MCP_PROTOCOL_VERSION = '2025-03-26'
 const MCP_SERVER_BASE = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-server'
-const OAUTH_SERVER_BASE = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth'
+const OAUTH_SERVER_BASE = 'https://ctrl.rodeo'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- Claude Code's MCP SDK follows RFC 8414 to discover OAuth metadata at `{origin}/.well-known/oauth-authorization-server`
- Supabase Edge Functions can't serve content at `/.well-known/` paths — so metadata discovery always fails
- Fix: host OAuth metadata as a static file on ctrl.rodeo (GitHub Pages), update MCP server to point `authorization_servers` to `https://ctrl.rodeo`

## Test plan
- [ ] Verify `https://ctrl.rodeo/.well-known/oauth-authorization-server` returns JSON after GH Pages deploy
- [ ] Deploy `mcp-server` edge function
- [ ] `claude mcp add` + `/mcp` → Authenticate should open browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)