### PR TITLE
fix(boards): restore grid element id — null addEventListener

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6141,7 +6141,7 @@ a:hover { color: var(--accent-cyan); }
   <script src="../js/image-validation.js"></script>
 </head>
 <body>
-<a href="#main-content" class="skip-link">Skip to content</a>
+<a href="#grid" class="skip-link">Skip to content</a>
   <!-- Progress Bar -->
   <div class="progress-bar" id="progressBar">
     <div class="progress-bar__fill" id="progressFill"></div>
@@ -6209,7 +6209,7 @@ a:hover { color: var(--accent-cyan); }
     <div class="widget-section__content" id="widgetContent"></div>
   </section>
 
-  <main class="grid" id="main-content" role="main"></main>
+  <main class="grid" id="grid" role="main"></main>
 
   <!-- AI Widget Section - Footer Zone -->
   <section class="widget-section widget-zone widget-zone--footer" id="widgetFooter" data-zone="footer">


### PR DESCRIPTION
## Summary
- Restores `id="grid"` on `<main>` element (was changed to `id="main-content"` by skip-link commit)
- Fixes `TypeError: Cannot read properties of null (reading 'addEventListener')` at line 17223
- Updates skip-link `href` to `#grid`

## Test plan
- [ ] No console errors on page load
- [ ] Grid keyboard navigation works (arrow keys between cards)
- [ ] Skip-link still functions (Tab on page load → Enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)