### PR TITLE
feat(extension): tab lifecycle — save & close, idle nudge, triage, PWA share

### DIFF
--- a/boards/pwa-share.html
+++ b/boards/pwa-share.html
@@ -3,8 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Saving to Boards...</title>
+  <title>Save to Rodeo</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap" rel="stylesheet">
   <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
       background: #111;
       color: #fff;
@@ -13,47 +17,269 @@
       align-items: center;
       justify-content: center;
       min-height: 100vh;
-      margin: 0;
+      padding: 24px;
     }
-    .saving {
+    .card {
+      width: 100%;
+      max-width: 360px;
       text-align: center;
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
     }
+    .logo {
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.3em;
+      color: #999;
+      margin-bottom: 24px;
+    }
+    .state { display: none; }
+    .state.active { display: block; }
+    .spinner {
+      width: 16px;
+      height: 16px;
+      border: 1px solid #333;
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      margin: 0 auto 16px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .message {
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: #999;
+    }
+    .url-preview {
+      font-size: 10px;
+      color: #666;
+      margin-top: 8px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 300px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .check {
+      font-size: 18px;
+      color: #0f0;
+      margin-bottom: 8px;
+    }
+    .check--dup { color: #f90; }
+    .check--err { color: #c00; }
+    .btn {
+      display: inline-block;
+      font-family: "Space Grotesk", sans-serif;
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      padding: 8px 16px;
+      border: 1px solid #fff;
+      background: transparent;
+      color: #fff;
+      text-decoration: none;
+      cursor: pointer;
+      margin-top: 16px;
+    }
+    .btn:hover { background: #fff; color: #000; }
   </style>
 </head>
 <body>
-  <div class="saving">Saving to Boards...</div>
+  <div class="card">
+    <div class="logo">RODEO</div>
+
+    <!-- Saving -->
+    <div id="state-saving" class="state active">
+      <div class="spinner"></div>
+      <p class="message">Saving...</p>
+      <p class="url-preview" id="url-preview"></p>
+    </div>
+
+    <!-- Saved -->
+    <div id="state-saved" class="state">
+      <div class="check">&#10003;</div>
+      <p class="message">Saved</p>
+      <p class="url-preview" id="saved-url"></p>
+      <a id="btn-open" class="btn" href="/boards/">Open in Boards</a>
+    </div>
+
+    <!-- Duplicate -->
+    <div id="state-duplicate" class="state">
+      <div class="check check--dup">&#9679;</div>
+      <p class="message">Already saved</p>
+      <a id="btn-open-dup" class="btn" href="/boards/">Open in Boards</a>
+    </div>
+
+    <!-- Auth Error -->
+    <div id="state-auth" class="state">
+      <div class="check check--err">!</div>
+      <p class="message">Sign in first</p>
+      <a class="btn" href="/boards/">Open Boards</a>
+    </div>
+
+    <!-- Error -->
+    <div id="state-error" class="state">
+      <div class="check check--err">!</div>
+      <p class="message" id="error-msg">Something went wrong</p>
+      <a class="btn" href="/boards/">Open Boards</a>
+    </div>
+
+    <!-- No URL -->
+    <div id="state-no-url" class="state">
+      <p class="message">No link found</p>
+      <a class="btn" href="/boards/">Open Boards</a>
+    </div>
+  </div>
+
   <script>
-    // Extract shared data from query params
-    const params = new URLSearchParams(window.location.search);
-    const sharedUrl = params.get('url') || '';
-    const sharedText = params.get('text') || '';
-    const sharedTitle = params.get('title') || '';
+    const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+    const AUTH_STORAGE_KEY = 'sb-yfhudwakpgzswiylhfbh-auth-token';
 
-    // Try to find a URL in the shared data
-    // Priority: url param > URLs in text > text itself
-    let targetUrl = sharedUrl;
+    function show(id) {
+      document.querySelectorAll('.state').forEach(el => el.classList.remove('active'));
+      document.getElementById(id).classList.add('active');
+    }
 
-    if (!targetUrl && sharedText) {
-      // Extract URL from shared text (common on Android where URL is in text field)
-      const urlMatch = sharedText.match(/https?:\/\/[^\s]+/);
-      if (urlMatch) {
-        targetUrl = urlMatch[0];
-      } else {
-        targetUrl = sharedText;
+    function extractDomain(url) {
+      try { return new URL(url).hostname.replace(/^www\./, ''); } catch { return ''; }
+    }
+
+    function normalizeUrl(raw) {
+      try {
+        const u = new URL(raw);
+        if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+        u.hash = '';
+        return u.toString();
+      } catch { return null; }
+    }
+
+    (async function main() {
+      // Extract shared data from query params
+      const params = new URLSearchParams(window.location.search);
+      const sharedUrl = params.get('url') || '';
+      const sharedText = params.get('text') || '';
+      const sharedTitle = params.get('title') || '';
+
+      // Find a URL — priority: url param > URLs in text > text itself
+      let targetUrl = sharedUrl;
+      if (!targetUrl && sharedText) {
+        const urlMatch = sharedText.match(/https?:\/\/[^\s]+/);
+        targetUrl = urlMatch ? urlMatch[0] : sharedText;
       }
-    }
 
-    if (targetUrl) {
-      // Redirect to main Boards app with the URL to add
-      window.location.replace('/boards/?add=' + encodeURIComponent(targetUrl));
-    } else {
-      // No URL found — redirect to Boards anyway
-      document.querySelector('.saving').textContent = 'No link found. Opening Boards...';
-      setTimeout(() => window.location.replace('/boards/'), 1500);
-    }
+      const canonical = targetUrl ? normalizeUrl(targetUrl) : null;
+      if (!canonical) {
+        show('state-no-url');
+        return;
+      }
+
+      // Show URL preview
+      document.getElementById('url-preview').textContent = canonical;
+
+      // Get auth from localStorage (Supabase JS stores session here)
+      let session;
+      try {
+        const raw = localStorage.getItem(AUTH_STORAGE_KEY);
+        session = raw ? JSON.parse(raw) : null;
+      } catch { session = null; }
+
+      if (!session || !session.access_token || !session.user) {
+        show('state-auth');
+        return;
+      }
+
+      const accessToken = session.access_token;
+      const userId = session.user.id;
+
+      // Check for duplicate
+      try {
+        const checkRes = await fetch(
+          `${SUPABASE_URL}/rest/v1/links?url=eq.${encodeURIComponent(canonical)}&user_id=eq.${userId}&select=id`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              'apikey': SUPABASE_ANON_KEY,
+              'Authorization': `Bearer ${accessToken}`
+            }
+          }
+        );
+        if (checkRes.ok) {
+          const existing = await checkRes.json();
+          if (existing.length > 0) {
+            const pinId = existing[0].id;
+            document.getElementById('btn-open-dup').href = `/boards/?pin=${pinId}`;
+            show('state-duplicate');
+            setTimeout(() => history.back(), 2000);
+            return;
+          }
+        }
+      } catch {}
+
+      // Build payload
+      const pinId = crypto.randomUUID();
+      const domain = extractDomain(canonical);
+      const pinTitle = sharedTitle || canonical;
+
+      const payload = {
+        id: pinId,
+        user_id: userId,
+        url: canonical,
+        title: pinTitle,
+        description: '',
+        domain: domain,
+        category: 'uncategorized',
+        confidence: 0,
+        source: 'pwa_share',
+        selected_text: null,
+        created_at: new Date().toISOString()
+      };
+
+      // Save
+      try {
+        const res = await fetch(`${SUPABASE_URL}/rest/v1/links`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'apikey': SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${accessToken}`,
+            'Prefer': 'resolution=merge-duplicates'
+          },
+          body: JSON.stringify(payload)
+        });
+
+        if (!res.ok) {
+          if (res.status === 401 || res.status === 403) {
+            show('state-auth');
+            return;
+          }
+          throw new Error(`HTTP ${res.status}`);
+        }
+      } catch (e) {
+        document.getElementById('error-msg').textContent = e.message || 'Save failed';
+        show('state-error');
+        return;
+      }
+
+      // Fire-and-forget enrichment
+      fetch(`${SUPABASE_URL}/functions/v1/create-pin`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify({ url: canonical, title: pinTitle, linkId: pinId })
+      }).catch(() => {});
+
+      // Show success
+      document.getElementById('saved-url').textContent = domain;
+      document.getElementById('btn-open').href = `/boards/?pin=${pinId}`;
+      show('state-saved');
+
+      // Auto-navigate back after 2s
+      setTimeout(() => history.back(), 2000);
+    })();
   </script>
 </body>
 </html>

--- a/extension/chrome/background.js
+++ b/extension/chrome/background.js
@@ -142,7 +142,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         sendResponse({
           url: tab.url,
           title: tab.title || '',
-          domain: extractDomain(tab.url)
+          domain: extractDomain(tab.url),
+          tabId: tab.id
         });
       }
     }).catch(() => sendResponse({ error: 'unsupported_page' }));
@@ -218,6 +219,139 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     flushBuffer()
       .then(() => sendResponse({ ok: true }))
       .catch(e => sendResponse({ error: e.message }));
+    return true;
+  }
+
+  // --- Tab lifecycle handlers ---
+
+  if (msg.action === 'close_tab') {
+    if (msg.tabId) {
+      chrome.tabs.remove(msg.tabId).catch(() => {});
+    }
+    sendResponse({ ok: true });
+    return false;
+  }
+
+  if (msg.action === 'check_domain_blocked') {
+    getPrivacySettings().then(() => {
+      sendResponse({ blocked: isDomainBlocked(msg.domain) });
+    }).catch(() => sendResponse({ blocked: false }));
+    return true;
+  }
+
+  if (msg.action === 'get_nudge_settings') {
+    getPrivacySettings().then(settings => {
+      sendResponse({ nudgeEnabled: settings.nudgeEnabled !== false });
+    }).catch(() => sendResponse({ nudgeEnabled: true }));
+    return true;
+  }
+
+  if (msg.action === 'get_visit_data_for_url') {
+    (async () => {
+      try {
+        const canonical = canonicalizeForHash(msg.url);
+        if (!canonical) { sendResponse(null); return; }
+        const urlHash = await hashUrl(canonical);
+        const data = await chrome.storage.local.get(VISIT_COUNT_KEY);
+        const counts = data[VISIT_COUNT_KEY] || {};
+        sendResponse(counts[urlHash] || null);
+      } catch { sendResponse(null); }
+    })();
+    return true;
+  }
+
+  if (msg.action === 'get_all_visit_counts') {
+    chrome.storage.local.get(VISIT_URL_KEY).then(data => {
+      sendResponse(data[VISIT_URL_KEY] || {});
+    }).catch(() => sendResponse({}));
+    return true;
+  }
+
+  if (msg.action === 'get_all_tabs') {
+    (async () => {
+      try {
+        const allTabs = await chrome.tabs.query({ incognito: false });
+
+        // Get tab groups
+        let groups = {};
+        try {
+          const tabGroups = await chrome.tabGroups.query({});
+          for (const g of tabGroups) {
+            groups[g.id] = { title: g.title || '', color: g.color || 'grey', id: g.id };
+          }
+        } catch {
+          // tabGroups API not available — continue without groups
+        }
+
+        // Filter: keep only http/https tabs that aren't blocked
+        await getPrivacySettings();
+        const saveable = allTabs.filter(t => {
+          if (!t.url) return false;
+          if (!t.url.startsWith('http://') && !t.url.startsWith('https://')) return false;
+          const domain = extractDomain(t.url);
+          if (isDomainBlocked(domain)) return false;
+          if (t.url.startsWith('https://ctrl.rodeo/')) return false;
+          return true;
+        });
+
+        const TAB_GROUP_ID_NONE = -1;
+        const result = saveable.map(t => ({
+          id: t.id,
+          url: t.url,
+          title: t.title || t.url,
+          domain: extractDomain(t.url),
+          favIconUrl: t.favIconUrl || null,
+          groupId: (t.groupId !== undefined && t.groupId !== TAB_GROUP_ID_NONE) ? t.groupId : null,
+          groupInfo: (t.groupId !== undefined && t.groupId !== TAB_GROUP_ID_NONE && groups[t.groupId]) ? groups[t.groupId] : null,
+          windowId: t.windowId
+        }));
+
+        sendResponse({ tabs: result, groups });
+      } catch (e) {
+        sendResponse({ error: e.message, tabs: [], groups: {} });
+      }
+    })();
+    return true;
+  }
+
+  if (msg.action === 'bulk_save') {
+    (async () => {
+      const { tabData } = msg;
+      let saved = 0, duplicates = 0, failed = 0;
+      const closeable = [];
+
+      for (const t of tabData) {
+        try {
+          const result = await savePin({
+            url: t.url,
+            title: t.title,
+            selectedText: null,
+            source: 'triage'
+          });
+          if (result.success) {
+            saved++;
+            closeable.push(t.id);
+          } else if (result.error === 'duplicate') {
+            duplicates++;
+            closeable.push(t.id);
+          } else {
+            failed++;
+          }
+        } catch {
+          failed++;
+        }
+      }
+
+      if (closeable.length > 0) {
+        try {
+          await chrome.tabs.remove(closeable);
+        } catch (e) {
+          console.warn('[rodeo] triage: failed to close some tabs:', e.message);
+        }
+      }
+
+      sendResponse({ saved, duplicates, failed });
+    })();
     return true;
   }
 });

--- a/extension/chrome/content-nudge.js
+++ b/extension/chrome/content-nudge.js
@@ -1,0 +1,329 @@
+// Rodeo Extension — Idle Reading Nudge
+// Content script: detects idle + scroll depth, injects save banner via Shadow DOM
+// Injected at document_idle on all URLs (excludes chrome://, extension://, ctrl.rodeo)
+
+(function() {
+  'use strict';
+
+  // ============================================
+  // Config
+  // ============================================
+  const IDLE_TIMEOUT_MS = 3 * 60 * 1000;   // 3 minutes idle
+  const SCROLL_THRESHOLD = 0.5;             // 50% scroll depth
+  const DISMISS_KEY_PREFIX = 'rodeo_nudge_dismissed_';
+
+  // ============================================
+  // Guards — bail early if not applicable
+  // ============================================
+  const pageUrl = window.location.href;
+  if (!pageUrl.startsWith('http')) return;
+
+  const domain = window.location.hostname.replace(/^www\./, '');
+  let nudgeInjected = false;
+  let idleTimer = null;
+  let maxScrollDepth = 0;
+
+  // Check if domain is blocked or nudge is disabled
+  Promise.all([
+    msg({ action: 'check_domain_blocked', domain }),
+    msg({ action: 'get_nudge_settings' })
+  ]).then(([blockResult, nudgeResult]) => {
+    if (blockResult && blockResult.blocked) return;
+    if (nudgeResult && nudgeResult.nudgeEnabled === false) return;
+
+    // Check if page is long enough (at least 2x viewport)
+    if (document.documentElement.scrollHeight < window.innerHeight * 2) return;
+
+    // Check dismiss cache
+    const dismissKey = DISMISS_KEY_PREFIX + btoa(pageUrl).slice(0, 40);
+    chrome.storage.session.get(dismissKey).then(data => {
+      if (data[dismissKey]) return; // already dismissed this session
+      startTracking();
+    }).catch(() => startTracking());
+  }).catch(() => {});
+
+  // ============================================
+  // Scroll + Idle Tracking
+  // ============================================
+  function startTracking() {
+    // Track scroll depth
+    window.addEventListener('scroll', onActivity, { passive: true });
+    window.addEventListener('mousedown', onActivity, { passive: true });
+    window.addEventListener('keydown', onActivity, { passive: true });
+
+    // Initial scroll check
+    updateScrollDepth();
+    resetIdleTimer();
+  }
+
+  function updateScrollDepth() {
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+    const scrollHeight = document.documentElement.scrollHeight - window.innerHeight;
+    if (scrollHeight > 0) {
+      const depth = scrollTop / scrollHeight;
+      if (depth > maxScrollDepth) maxScrollDepth = depth;
+    }
+  }
+
+  function onActivity() {
+    updateScrollDepth();
+    resetIdleTimer();
+  }
+
+  function resetIdleTimer() {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(onIdle, IDLE_TIMEOUT_MS);
+  }
+
+  function onIdle() {
+    if (nudgeInjected) return;
+    if (maxScrollDepth < SCROLL_THRESHOLD) {
+      // Not scrolled far enough — keep waiting
+      resetIdleTimer();
+      return;
+    }
+    injectBanner();
+  }
+
+  // ============================================
+  // Context-Aware Copy
+  // ============================================
+  function detectPageType() {
+    // Article detection: <article> tag or high word count
+    const hasArticle = !!document.querySelector('article');
+    const bodyText = document.body ? document.body.innerText : '';
+    const wordCount = bodyText.split(/\s+/).length;
+
+    if (hasArticle || wordCount > 500) {
+      return { headline: 'Finish reading later?', type: 'article' };
+    }
+
+    // Product detection: price patterns + cart signals
+    const hasPrice = /\$\d+|\d+\.\d{2}/.test(bodyText);
+    const hasCart = !!(
+      document.querySelector('[class*="cart"], [class*="add-to-bag"], [data-action*="cart"]') ||
+      /add to (cart|bag|basket)/i.test(bodyText.slice(0, 5000))
+    );
+
+    if (hasPrice && hasCart) {
+      return { headline: 'Saving this for later?', type: 'product' };
+    }
+
+    return { headline: 'Come back to this?', type: 'default' };
+  }
+
+  // ============================================
+  // Banner Injection (Shadow DOM)
+  // ============================================
+  async function injectBanner() {
+    if (nudgeInjected) return;
+    nudgeInjected = true;
+
+    const pageType = detectPageType();
+
+    // Get visit count for subtitle
+    let visitText = '';
+    try {
+      const visitData = await msg({ action: 'get_visit_data_for_url', url: pageUrl });
+      if (visitData && visitData.count > 1) {
+        visitText = `You've visited this page ${visitData.count} times.`;
+      }
+    } catch {}
+
+    // Create host element
+    const host = document.createElement('rodeo-nudge');
+    host.style.cssText = 'all:initial;position:fixed;top:0;left:0;right:0;z-index:2147483647;';
+    document.documentElement.appendChild(host);
+
+    const shadow = host.attachShadow({ mode: 'closed' });
+
+    shadow.innerHTML = `
+      <style>
+        @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600&display=swap');
+
+        :host {
+          all: initial;
+          display: block;
+        }
+
+        .bar {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          padding: 10px 16px;
+          background: #111;
+          border-bottom: 1px solid #333;
+          font-family: "Space Grotesk", sans-serif;
+          font-size: 12px;
+          color: #fff;
+          transform: translateY(-100%);
+          transition: transform 0.3s ease;
+          box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+        }
+
+        .bar.visible {
+          transform: translateY(0);
+        }
+
+        .copy {
+          flex: 1;
+          min-width: 0;
+        }
+
+        .headline {
+          font-weight: 500;
+          font-size: 12px;
+          line-height: 1.3;
+        }
+
+        .subtitle {
+          font-size: 10px;
+          color: #999;
+          margin-top: 2px;
+        }
+
+        .actions {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          flex-shrink: 0;
+        }
+
+        .btn-save {
+          background: #fff;
+          color: #000;
+          border: 1px solid #fff;
+          padding: 5px 12px;
+          font-family: "Space Grotesk", sans-serif;
+          font-size: 10px;
+          font-weight: 500;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          cursor: pointer;
+          white-space: nowrap;
+          transition: all 0.1s;
+        }
+
+        .btn-save:hover {
+          background: transparent;
+          color: #fff;
+        }
+
+        .btn-dismiss {
+          background: none;
+          border: none;
+          color: #666;
+          font-family: "Space Grotesk", sans-serif;
+          font-size: 10px;
+          letter-spacing: 0.05em;
+          cursor: pointer;
+          padding: 5px 8px;
+          white-space: nowrap;
+        }
+
+        .btn-dismiss:hover {
+          color: #fff;
+        }
+
+        .btn-close {
+          background: none;
+          border: none;
+          color: #666;
+          font-size: 14px;
+          cursor: pointer;
+          padding: 4px;
+          line-height: 1;
+        }
+
+        .btn-close:hover {
+          color: #fff;
+        }
+      </style>
+
+      <div class="bar" id="bar">
+        <div class="copy">
+          <div class="headline">${escHtml(pageType.headline)}</div>
+          ${visitText ? `<div class="subtitle">${escHtml(visitText)}</div>` : ''}
+        </div>
+        <div class="actions">
+          <button class="btn-save" id="btn-save">Save & Close</button>
+          <button class="btn-dismiss" id="btn-not-now">Not now</button>
+          <button class="btn-close" id="btn-close" aria-label="Dismiss">&times;</button>
+        </div>
+      </div>
+    `;
+
+    // Slide in after a frame
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        shadow.getElementById('bar').classList.add('visible');
+      });
+    });
+
+    // Save & Close
+    shadow.getElementById('btn-save').addEventListener('click', async () => {
+      const btn = shadow.getElementById('btn-save');
+      btn.textContent = 'Saving...';
+      btn.style.pointerEvents = 'none';
+
+      await msg({
+        action: 'save',
+        data: {
+          url: pageUrl,
+          title: document.title,
+          selectedText: null,
+          source: 'nudge'
+        }
+      });
+
+      btn.textContent = 'Saved';
+      setTimeout(() => {
+        msg({ action: 'close_tab', tabId: undefined });
+        // Also try to get current tab and close it
+        chrome.runtime.sendMessage({ action: 'get_tab_info' }, (info) => {
+          if (info && info.tabId) {
+            chrome.runtime.sendMessage({ action: 'close_tab', tabId: info.tabId });
+          }
+        });
+      }, 500);
+    });
+
+    // Dismiss handlers
+    const dismiss = () => {
+      const bar = shadow.getElementById('bar');
+      bar.classList.remove('visible');
+      setTimeout(() => host.remove(), 300);
+      // Mark dismissed for this session
+      const dismissKey = DISMISS_KEY_PREFIX + btoa(pageUrl).slice(0, 40);
+      chrome.storage.session.set({ [dismissKey]: Date.now() }).catch(() => {});
+    };
+
+    shadow.getElementById('btn-not-now').addEventListener('click', dismiss);
+    shadow.getElementById('btn-close').addEventListener('click', dismiss);
+  }
+
+  // ============================================
+  // Helpers
+  // ============================================
+  function msg(data) {
+    return new Promise(resolve => {
+      try {
+        chrome.runtime.sendMessage(data, response => {
+          if (chrome.runtime.lastError) {
+            resolve(null);
+          } else {
+            resolve(response);
+          }
+        });
+      } catch {
+        resolve(null);
+      }
+    });
+  }
+
+  function escHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+})();

--- a/extension/chrome/lib/history.js
+++ b/extension/chrome/lib/history.js
@@ -13,6 +13,12 @@ const FLUSH_BATCH_SIZE = 50;        // auto-flush threshold
 const SESSION_GAP_MS = 30 * 60_000; // 30 min inactivity → new session
 const INGEST_ENDPOINT = '/functions/v1/ingest-history';
 
+// Visit counting (per-page, local-only)
+const VISIT_COUNT_KEY = 'rodeo_visit_counts';  // keyed by url_hash
+const VISIT_URL_KEY = 'rodeo_visit_urls';      // keyed by canonical URL (for popup)
+const VISIT_COUNT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const VISIT_COUNT_MAX_ENTRIES = 2000;
+
 let _historyBuffer = [];
 let _flushTimer = null;
 let _sessionId = null;
@@ -101,6 +107,9 @@ async function recordNavigation({ url, title, referrerUrl, tabId }) {
 
   _historyBuffer.push(event);
   _persistBuffer();
+
+  // Update local visit counter (per-page, dual-keyed)
+  updateLocalVisitCount({ urlHash, canonicalUrl: canonical, title: title ? title.slice(0, 100) : '', domain });
 
   // Auto-flush at threshold
   if (_historyBuffer.length >= FLUSH_BATCH_SIZE) {
@@ -264,6 +273,67 @@ async function deleteAllHistory() {
   } catch (e) {
     console.error('[rodeo] delete all history error:', e.message);
     return { error: e.message };
+  }
+}
+
+// ============================================
+// Local Visit Counting (per-page, dual-keyed)
+// ============================================
+async function updateLocalVisitCount({ urlHash, canonicalUrl, title, domain }) {
+  const now = Date.now();
+  try {
+    // Hash-keyed map (for content script lookups via background)
+    const data = await chrome.storage.local.get(VISIT_COUNT_KEY);
+    const counts = data[VISIT_COUNT_KEY] || {};
+    const existing = counts[urlHash];
+
+    counts[urlHash] = {
+      count: (existing?.count || 0) + 1,
+      lastVisit: now,
+      title: title || (existing?.title || ''),
+      domain: domain || (existing?.domain || '')
+    };
+
+    // Prune if over limit
+    const keys = Object.keys(counts);
+    if (keys.length > VISIT_COUNT_MAX_ENTRIES) {
+      const cutoff = now - VISIT_COUNT_MAX_AGE_MS;
+      for (const k of keys) {
+        if (counts[k].lastVisit < cutoff) delete counts[k];
+      }
+      const remaining = Object.keys(counts);
+      if (remaining.length > VISIT_COUNT_MAX_ENTRIES) {
+        remaining
+          .sort((a, b) => counts[a].lastVisit - counts[b].lastVisit)
+          .slice(0, remaining.length - VISIT_COUNT_MAX_ENTRIES)
+          .forEach(k => delete counts[k]);
+      }
+    }
+
+    await chrome.storage.local.set({ [VISIT_COUNT_KEY]: counts });
+  } catch (e) {
+    console.warn('[rodeo] visit count update failed:', e.message);
+  }
+
+  // URL-keyed map (for popup lookups without crypto.subtle)
+  if (canonicalUrl) {
+    try {
+      const urlData = await chrome.storage.local.get(VISIT_URL_KEY);
+      const urlCounts = urlData[VISIT_URL_KEY] || {};
+      urlCounts[canonicalUrl] = {
+        count: (urlCounts[canonicalUrl]?.count || 0) + 1,
+        lastVisit: now,
+        urlHash
+      };
+      const urlKeys = Object.keys(urlCounts);
+      if (urlKeys.length > VISIT_COUNT_MAX_ENTRIES) {
+        urlKeys
+          .sort((a, b) => urlCounts[a].lastVisit - urlCounts[b].lastVisit)
+          .slice(0, urlKeys.length - VISIT_COUNT_MAX_ENTRIES)
+          .forEach(k => delete urlCounts[k]);
+      }
+      await chrome.storage.local.set({ [VISIT_URL_KEY]: urlCounts });
+    } catch {}
   }
 }
 

--- a/extension/chrome/lib/privacy.js
+++ b/extension/chrome/lib/privacy.js
@@ -49,7 +49,8 @@ let _privacySettingsCache = null;
 const DEFAULT_PRIVACY_SETTINGS = {
   historyEnabled: true,
   userBlocklist: [],
-  backfillDays: 30
+  backfillDays: 30,
+  nudgeEnabled: true
 };
 
 async function getPrivacySettings() {

--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Rodeo — Save & Discover",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Save links, highlight text, and build your taste library",
   "icons": {
     "16": "icons/icon-16.png",
@@ -31,9 +31,19 @@
       "matches": ["<all_urls>"],
       "js": ["content-selection.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-nudge.js"],
+      "run_at": "document_idle",
+      "exclude_matches": [
+        "chrome://*/*",
+        "chrome-extension://*/*",
+        "https://ctrl.rodeo/*"
+      ]
     }
   ],
-  "permissions": ["activeTab", "storage", "contextMenus", "scripting", "history", "tabs", "webNavigation"],
+  "permissions": ["activeTab", "storage", "contextMenus", "scripting", "history", "tabs", "webNavigation", "tabGroups"],
   "host_permissions": ["https://ctrl.rodeo/*"],
   "externally_connectable": {
     "matches": ["https://ctrl.rodeo/*"]

--- a/extension/chrome/popup.css
+++ b/extension/chrome/popup.css
@@ -433,7 +433,205 @@ body {
   flex: 1;
 }
 
-/* Toggle checkbox (simple) */
+/* ============================================
+   Save Actions (dual buttons)
+   ============================================ */
+.save-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* ============================================
+   Tab Count Badge
+   ============================================ */
+.tab-count {
+  font-size: 8px;
+  background: var(--fg);
+  color: var(--bg);
+  border-radius: 2px;
+  padding: 1px 4px;
+  margin-left: var(--space-1);
+  vertical-align: middle;
+}
+
+/* ============================================
+   Triage State
+   ============================================ */
+body.triage-open {
+  max-height: 560px;
+}
+
+.state--triage {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.state--triage.state[hidden] {
+  display: none !important;
+}
+
+.triage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.triage-header__title {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.triage-toggle-all {
+  background: none;
+  border: none;
+  color: var(--fg-subtle);
+  font-family: var(--font-primary);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  padding: 0;
+}
+
+.triage-toggle-all:hover {
+  color: var(--fg);
+}
+
+.triage-list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 120px;
+  max-height: 340px;
+}
+
+.triage-group {
+  padding: var(--space-2) var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  cursor: pointer;
+  user-select: none;
+}
+
+.triage-group__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.triage-group__name {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  flex: 1;
+}
+
+.triage-group__count {
+  font-size: 9px;
+  color: var(--fg-subtle);
+}
+
+.triage-group__checkbox {
+  flex-shrink: 0;
+}
+
+.triage-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--gray-300);
+  cursor: pointer;
+}
+
+.triage-row:hover {
+  background: var(--bg-surface);
+}
+
+.triage-row__checkbox {
+  flex-shrink: 0;
+}
+
+.triage-row__favicon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 2px;
+  background: var(--gray-400);
+}
+
+.triage-row__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.triage-row__title {
+  font-size: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--fg);
+}
+
+.triage-row__domain {
+  font-size: 9px;
+  color: var(--fg-muted);
+}
+
+.triage-row__badge {
+  font-size: 8px;
+  color: var(--fg-subtle);
+  background: var(--gray-300);
+  border-radius: 2px;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.triage-footer {
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.triage-status {
+  font-size: 9px;
+  text-align: center;
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+}
+
+/* Tab group colors (Chrome tabGroups API) */
+.triage-group--grey .triage-group__dot { background: #5f6368; }
+.triage-group--blue .triage-group__dot { background: #1a73e8; }
+.triage-group--red .triage-group__dot { background: #ea4335; }
+.triage-group--yellow .triage-group__dot { background: #fbbc04; }
+.triage-group--green .triage-group__dot { background: #34a853; }
+.triage-group--pink .triage-group__dot { background: #f538a0; }
+.triage-group--purple .triage-group__dot { background: #a142f4; }
+.triage-group--cyan .triage-group__dot { background: #24c1e0; }
+.triage-group--orange .triage-group__dot { background: #ff7537; }
+
+/* ============================================
+   Toggle Checkbox (shared)
+   ============================================ */
+.rodeo-toggle,
 #toggle-history {
   appearance: none;
   width: 32px;
@@ -445,6 +643,7 @@ body {
   transition: background var(--duration-fast);
 }
 
+.rodeo-toggle::after,
 #toggle-history::after {
   content: '';
   position: absolute;
@@ -457,10 +656,12 @@ body {
   transition: transform var(--duration-fast);
 }
 
+.rodeo-toggle:checked,
 #toggle-history:checked {
   background: var(--color-success);
 }
 
+.rodeo-toggle:checked::after,
 #toggle-history:checked::after {
   transform: translateX(16px);
 }

--- a/extension/chrome/popup.html
+++ b/extension/chrome/popup.html
@@ -38,6 +38,7 @@
   <!-- Tab Bar (shown when authenticated) -->
   <div id="tab-bar" class="tab-bar" hidden>
     <button class="tab-btn active" data-tab="save">Save</button>
+    <button class="tab-btn" data-tab="triage">Triage <span id="triage-tab-count" class="tab-count" hidden></span></button>
     <button class="tab-btn" data-tab="settings">Settings</button>
   </div>
 
@@ -56,9 +57,10 @@
       </div>
     </div>
 
-    <button id="btn-save" class="btn btn--filled btn--block">
-      Save to Rodeo
-    </button>
+    <div class="save-actions">
+      <button id="btn-save-close" class="btn btn--filled btn--block">Save &amp; Close Tab</button>
+      <button id="btn-save" class="btn btn--outline btn--block">Save</button>
+    </div>
   </div>
 
   <!-- State: Saving -->
@@ -74,6 +76,7 @@
     <div class="saved-container">
       <div class="saved-check">&#10003;</div>
       <p class="saved-message">Saved</p>
+      <button id="btn-close-after-save" class="btn btn--filled btn--block">Close Tab</button>
       <button id="btn-view" class="btn btn--outline btn--block">
         View in Library
       </button>
@@ -101,12 +104,32 @@
     </div>
   </div>
 
+  <!-- State: Tab Triage -->
+  <div id="state-triage" class="state state--triage" hidden>
+    <div class="triage-header">
+      <div class="triage-header__title">Open Tabs</div>
+      <div class="triage-header__actions">
+        <button id="triage-select-all" class="triage-toggle-all">Deselect all</button>
+      </div>
+    </div>
+    <div id="triage-list" class="triage-list"></div>
+    <div class="triage-footer">
+      <div id="triage-status" class="triage-status" hidden></div>
+      <button id="btn-triage-save" class="btn btn--filled btn--block" disabled>Save All &amp; Close</button>
+    </div>
+  </div>
+
   <!-- State: Settings -->
   <div id="state-settings" class="state" hidden>
     <div class="settings-container">
       <div class="settings-row">
         <label class="settings-label" for="toggle-history">Capture browsing history</label>
-        <input type="checkbox" id="toggle-history" checked>
+        <input type="checkbox" id="toggle-history" class="rodeo-toggle" checked>
+      </div>
+
+      <div class="settings-row">
+        <label class="settings-label" for="toggle-nudge">Show idle reading nudge</label>
+        <input type="checkbox" id="toggle-nudge" class="rodeo-toggle" checked>
       </div>
 
       <div class="settings-section">

--- a/extension/chrome/popup.js
+++ b/extension/chrome/popup.js
@@ -1,5 +1,6 @@
 // Rodeo Extension — Popup controller
 // Manages UI state: loading → auth → save → saving → saved
+// Tab bar: Save | Triage | Settings
 
 const BOARDS_URL = 'https://ctrl.rodeo/boards/';
 
@@ -13,6 +14,7 @@ const states = {
   saved: document.getElementById('state-saved'),
   duplicate: document.getElementById('state-duplicate'),
   error: document.getElementById('state-error'),
+  triage: document.getElementById('state-triage'),
   settings: document.getElementById('state-settings')
 };
 
@@ -21,6 +23,11 @@ let currentTab = null;
 let currentSelection = null;
 let lastPinId = null;
 
+// Triage state
+let triageTabs = [];
+let triageVisitCounts = {};
+let triageSelected = new Set();
+
 // ============================================
 // State Management
 // ============================================
@@ -28,6 +35,15 @@ function showState(name) {
   Object.entries(states).forEach(([key, el]) => {
     el.hidden = key !== name;
   });
+  // Body class for triage max-height
+  document.body.classList.toggle('triage-open', name === 'triage');
+}
+
+// Escape HTML for safe insertion
+function esc(str) {
+  const d = document.createElement('div');
+  d.textContent = str;
+  return d.innerHTML;
 }
 
 // ============================================
@@ -84,7 +100,7 @@ async function init() {
 // ============================================
 // Save Flow
 // ============================================
-async function handleSave() {
+async function handleSave(shouldClose) {
   showState('saving');
 
   const result = await sendMessage({
@@ -105,6 +121,12 @@ async function handleSave() {
   if (result.success) {
     lastPinId = result.pinId;
     showState('saved');
+    if (shouldClose) {
+      setTimeout(() => {
+        sendMessage({ action: 'close_tab', tabId: currentTab.tabId });
+        window.close();
+      }, 1500);
+    }
     return;
   }
 
@@ -139,7 +161,15 @@ document.getElementById('btn-signin').addEventListener('click', () => {
   window.close();
 });
 
-document.getElementById('btn-save').addEventListener('click', handleSave);
+document.getElementById('btn-save-close').addEventListener('click', () => handleSave(true));
+document.getElementById('btn-save').addEventListener('click', () => handleSave(false));
+
+document.getElementById('btn-close-after-save').addEventListener('click', () => {
+  if (currentTab && currentTab.tabId) {
+    sendMessage({ action: 'close_tab', tabId: currentTab.tabId });
+  }
+  window.close();
+});
 
 document.getElementById('btn-view').addEventListener('click', () => {
   const url = lastPinId ? `${BOARDS_URL}?pin=${lastPinId}` : BOARDS_URL;
@@ -154,7 +184,7 @@ document.getElementById('btn-view-dup').addEventListener('click', () => {
 });
 
 document.getElementById('btn-retry').addEventListener('click', () => {
-  handleSave();
+  handleSave(false);
 });
 
 // ============================================
@@ -196,10 +226,268 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
     if (tab === 'settings') {
       loadSettings();
       showState('settings');
+    } else if (tab === 'triage') {
+      loadTriage();
+      showState('triage');
     } else {
       showState('save');
     }
   });
+});
+
+// ============================================
+// Triage Tab
+// ============================================
+async function loadTriage() {
+  const triageList = document.getElementById('triage-list');
+  triageList.innerHTML = '<div style="text-align:center;padding:24px 0;"><div class="loading-spinner" style="margin:0 auto;"></div></div>';
+
+  // Fetch tabs and visit counts in parallel
+  const [tabResult, visitCounts] = await Promise.all([
+    sendMessage({ action: 'get_all_tabs' }),
+    sendMessage({ action: 'get_all_visit_counts' })
+  ]);
+
+  if (!tabResult || !tabResult.tabs) {
+    triageList.innerHTML = '<div style="text-align:center;padding:24px 0;color:#666;">Could not load tabs</div>';
+    return;
+  }
+
+  triageTabs = tabResult.tabs;
+  triageVisitCounts = visitCounts || {};
+
+  // All selected by default
+  triageSelected = new Set(triageTabs.map(t => t.id));
+
+  // Update tab count badge
+  const badge = document.getElementById('triage-tab-count');
+  if (triageTabs.length > 0) {
+    badge.textContent = triageTabs.length;
+    badge.hidden = false;
+  } else {
+    badge.hidden = true;
+  }
+
+  renderTriageList();
+  updateTriageButton();
+}
+
+function renderTriageList() {
+  const list = document.getElementById('triage-list');
+
+  if (triageTabs.length === 0) {
+    list.innerHTML = '<div style="text-align:center;padding:24px 0;color:#666;">No saveable tabs open</div>';
+    return;
+  }
+
+  // Group tabs: grouped first, then ungrouped
+  const grouped = {};
+  const ungrouped = [];
+
+  for (const tab of triageTabs) {
+    if (tab.groupId && tab.groupInfo) {
+      if (!grouped[tab.groupId]) {
+        grouped[tab.groupId] = { info: tab.groupInfo, tabs: [] };
+      }
+      grouped[tab.groupId].tabs.push(tab);
+    } else {
+      ungrouped.push(tab);
+    }
+  }
+
+  let html = '';
+
+  // Render grouped tabs
+  for (const [groupId, group] of Object.entries(grouped)) {
+    const allChecked = group.tabs.every(t => triageSelected.has(t.id));
+    const color = group.info.color || 'grey';
+    const name = group.info.title || 'Group';
+    html += `<div class="triage-group triage-group--${esc(color)}" data-group-id="${esc(String(groupId))}">
+      <div class="triage-group__dot"></div>
+      <div class="triage-group__name">${esc(name)}</div>
+      <div class="triage-group__count">${group.tabs.length}</div>
+      <input type="checkbox" class="triage-group__checkbox" ${allChecked ? 'checked' : ''} data-group-id="${esc(String(groupId))}">
+    </div>`;
+    for (const tab of group.tabs) {
+      html += buildTabRow(tab);
+    }
+  }
+
+  // Render ungrouped tabs
+  for (const tab of ungrouped) {
+    html += buildTabRow(tab);
+  }
+
+  list.innerHTML = html;
+
+  // Bind row click → toggle checkbox
+  list.querySelectorAll('.triage-row').forEach(row => {
+    row.addEventListener('click', (e) => {
+      if (e.target.type === 'checkbox') return;
+      const cb = row.querySelector('.triage-row__checkbox');
+      cb.checked = !cb.checked;
+      cb.dispatchEvent(new Event('change'));
+    });
+  });
+
+  // Bind individual checkboxes
+  list.querySelectorAll('.triage-row__checkbox').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const tabId = parseInt(cb.dataset.tabId, 10);
+      if (cb.checked) {
+        triageSelected.add(tabId);
+      } else {
+        triageSelected.delete(tabId);
+      }
+      updateGroupCheckboxes();
+      updateTriageButton();
+      updateSelectAllText();
+    });
+  });
+
+  // Bind group checkboxes
+  list.querySelectorAll('.triage-group__checkbox').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const groupId = cb.dataset.groupId;
+      const group = grouped[groupId];
+      if (!group) return;
+      for (const tab of group.tabs) {
+        if (cb.checked) {
+          triageSelected.add(tab.id);
+        } else {
+          triageSelected.delete(tab.id);
+        }
+      }
+      // Update individual checkboxes in this group
+      list.querySelectorAll(`.triage-row__checkbox`).forEach(tcb => {
+        const tid = parseInt(tcb.dataset.tabId, 10);
+        const inGroup = group.tabs.some(t => t.id === tid);
+        if (inGroup) tcb.checked = cb.checked;
+      });
+      updateTriageButton();
+      updateSelectAllText();
+    });
+  });
+
+  // Bind group row click → toggle group checkbox
+  list.querySelectorAll('.triage-group').forEach(row => {
+    row.addEventListener('click', (e) => {
+      if (e.target.type === 'checkbox') return;
+      const cb = row.querySelector('.triage-group__checkbox');
+      cb.checked = !cb.checked;
+      cb.dispatchEvent(new Event('change'));
+    });
+  });
+}
+
+function buildTabRow(tab) {
+  const checked = triageSelected.has(tab.id) ? 'checked' : '';
+  const favicon = tab.favIconUrl
+    ? `<img class="triage-row__favicon" src="${esc(tab.favIconUrl)}" onerror="this.style.display='none'">`
+    : '<div class="triage-row__favicon"></div>';
+
+  // Visit count badge
+  let badge = '';
+  const visitData = triageVisitCounts[tab.url];
+  if (visitData && visitData.count > 1) {
+    badge = `<span class="triage-row__badge">${visitData.count}x</span>`;
+  }
+
+  return `<div class="triage-row" data-tab-id="${tab.id}">
+    <input type="checkbox" class="triage-row__checkbox" data-tab-id="${tab.id}" ${checked}>
+    ${favicon}
+    <div class="triage-row__info">
+      <div class="triage-row__title">${esc(tab.title)}</div>
+      <div class="triage-row__domain">${esc(tab.domain)}</div>
+    </div>
+    ${badge}
+  </div>`;
+}
+
+function updateGroupCheckboxes() {
+  document.querySelectorAll('.triage-group__checkbox').forEach(cb => {
+    const groupId = cb.dataset.groupId;
+    const rows = document.querySelectorAll(`.triage-row__checkbox`);
+    // Find tabs in this group
+    const groupTabs = triageTabs.filter(t => t.groupId && String(t.groupId) === groupId);
+    if (groupTabs.length === 0) return;
+    const allChecked = groupTabs.every(t => triageSelected.has(t.id));
+    cb.checked = allChecked;
+  });
+}
+
+function updateTriageButton() {
+  const btn = document.getElementById('btn-triage-save');
+  const count = triageSelected.size;
+  const total = triageTabs.length;
+
+  if (count === 0) {
+    btn.disabled = true;
+    btn.textContent = 'Save All & Close';
+  } else if (count === total) {
+    btn.disabled = false;
+    btn.textContent = 'Save All & Close';
+  } else {
+    btn.disabled = false;
+    btn.textContent = `Save ${count} & Close`;
+  }
+}
+
+function updateSelectAllText() {
+  const btn = document.getElementById('triage-select-all');
+  const allSelected = triageSelected.size === triageTabs.length;
+  btn.textContent = allSelected ? 'Deselect all' : 'Select all';
+}
+
+// Select all / deselect all
+document.getElementById('triage-select-all').addEventListener('click', () => {
+  const allSelected = triageSelected.size === triageTabs.length;
+  if (allSelected) {
+    triageSelected.clear();
+  } else {
+    triageSelected = new Set(triageTabs.map(t => t.id));
+  }
+  // Update all checkboxes
+  document.querySelectorAll('.triage-row__checkbox').forEach(cb => {
+    cb.checked = triageSelected.has(parseInt(cb.dataset.tabId, 10));
+  });
+  updateGroupCheckboxes();
+  updateTriageButton();
+  updateSelectAllText();
+});
+
+// Bulk save handler
+document.getElementById('btn-triage-save').addEventListener('click', async () => {
+  const btn = document.getElementById('btn-triage-save');
+  const status = document.getElementById('triage-status');
+  btn.disabled = true;
+  btn.textContent = 'Saving...';
+  status.hidden = true;
+
+  const tabData = triageTabs
+    .filter(t => triageSelected.has(t.id))
+    .map(t => ({ id: t.id, url: t.url, title: t.title }));
+
+  const result = await sendMessage({ action: 'bulk_save', tabData }, 60000);
+
+  if (!result) {
+    status.textContent = 'Save failed — no response';
+    status.hidden = false;
+    btn.disabled = false;
+    btn.textContent = 'Try Again';
+    return;
+  }
+
+  // Show results
+  const parts = [];
+  if (result.saved > 0) parts.push(`Saved ${result.saved}`);
+  if (result.duplicates > 0) parts.push(`${result.duplicates} already saved`);
+  if (result.failed > 0) parts.push(`${result.failed} failed`);
+  status.textContent = parts.join(' · ') || 'Done';
+  status.hidden = false;
+
+  // Reload triage after a moment
+  setTimeout(() => loadTriage(), 2000);
 });
 
 // ============================================
@@ -210,12 +498,14 @@ async function loadSettings() {
   if (!settings) return;
 
   document.getElementById('toggle-history').checked = settings.historyEnabled !== false;
+  document.getElementById('toggle-nudge').checked = settings.nudgeEnabled !== false;
   document.getElementById('blocklist-input').value =
     (settings.userBlocklist || []).join('\n');
 }
 
 document.getElementById('btn-save-settings').addEventListener('click', async () => {
   const historyEnabled = document.getElementById('toggle-history').checked;
+  const nudgeEnabled = document.getElementById('toggle-nudge').checked;
   const raw = document.getElementById('blocklist-input').value;
   const userBlocklist = raw.split('\n')
     .map(d => d.trim().toLowerCase())
@@ -223,7 +513,7 @@ document.getElementById('btn-save-settings').addEventListener('click', async () 
 
   const result = await sendMessage({
     action: 'save_privacy_settings',
-    settings: { historyEnabled, userBlocklist }
+    settings: { historyEnabled, nudgeEnabled, userBlocklist }
   });
 
   const status = document.getElementById('settings-status');


### PR DESCRIPTION
## Summary

Close the loop on open tabs: **See → Decide → Save → Close → Move on.**

- **Post-Save Tab Close**: dual "Save & Close Tab" (primary) / "Save" (secondary) buttons. Shows checkmark for 1.5s then closes tab.
- **Idle Nudge Banner**: content script detects 50% scroll depth + 3min idle, injects Shadow DOM banner with context-aware copy ("Finish reading later?" for articles, "Saving this for later?" for products). Shows per-page visit count. Save & Close or dismiss.
- **Tab Triage / Bulk Save**: new popup tab lists all open tabs. Chrome tab group awareness with colored dots. Per-page visit count badges. Select all / deselect / save N & close.
- **Repeat Visit Detection**: per-page visit counting (dual-keyed by url_hash + canonical URL), stored in chrome.storage.local, pruned at 2000 entries / 30 days.
- **Tab Group Awareness**: chrome.tabGroups API with 9 Chrome color classes (grey, blue, red, yellow, green, pink, purple, cyan, orange).
- **PWA Share Sheet**: self-contained save page replacing the redirect flow. Auth from localStorage, direct Supabase REST save, success/error/duplicate states, auto-navigate back after 2s.

Extension version: 2.1.0 → **2.2.0**

### Files changed (9)

| File | Change |
|------|--------|
| `extension/chrome/manifest.json` | Version bump, `tabGroups` permission, `content-nudge.js` entry |
| `extension/chrome/background.js` | `tabId` in tab info, 7 new message handlers |
| `extension/chrome/lib/history.js` | `updateLocalVisitCount()` with dual storage |
| `extension/chrome/lib/privacy.js` | `nudgeEnabled` in default settings |
| `extension/chrome/popup.html` | Dual save buttons, triage state, nudge toggle |
| `extension/chrome/popup.css` | Save actions, triage styles, tab group colors, toggle |
| `extension/chrome/popup.js` | Complete rewrite with triage + save&close flows |
| `extension/chrome/content-nudge.js` | **New** — idle detection + Shadow DOM nudge banner |
| `boards/pwa-share.html` | Rewrite as self-contained save page |

## Test plan

- [ ] Open popup on any tab → "Save & Close Tab" saves and closes tab after 1.5s. "Save" saves and stays.
- [ ] Open popup → click Triage tab → all open tabs listed, all checked, grouped by Chrome tab groups
- [ ] Uncheck some tabs → button shows "Save N & Close". Click → tabs save and close.
- [ ] Visit a page 3+ times → triage shows "3x" badge, nudge shows "You've visited this page 3 times."
- [ ] Long article → scroll 50% → wait 3 min idle → nudge banner slides in from top
- [ ] Nudge "Save & Close" saves and closes. "Not now" dismisses for session.
- [ ] Settings → "Show idle reading nudge" toggle disables nudge
- [ ] Share URL via Android/PWA share sheet → pwa-share.html saves directly → auto-navigates back

🤖 Generated with [Claude Code](https://claude.com/claude-code)