### PR TITLE
fix(boards): revert amber accent to white

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -164,9 +164,9 @@
 }
 
 .auth-bar__btn:hover {
-  background: var(--accent-amber);
+  background: var(--fg);
   color: var(--bg);
-  border-color: var(--accent-amber);
+  border-color: var(--fg);
 }
 
 /* User menu dropdown */
@@ -785,15 +785,15 @@ a:hover { color: var(--accent-cyan); }
 }
 
 .bottom-nav__share-btn:hover {
-  background: var(--accent-amber);
+  background: var(--fg);
   color: var(--bg);
-  border-color: var(--accent-amber);
+  border-color: var(--fg);
 }
 
 .bottom-nav__share-btn--active {
-  background: var(--accent-amber);
+  background: var(--fg);
   color: var(--bg);
-  border-color: var(--accent-amber);
+  border-color: var(--fg);
 }
 
 /* Floating Button Base */
@@ -968,9 +968,9 @@ a:hover { color: var(--accent-cyan); }
 }
 
 .filter-token--active {
-  background: var(--accent-amber);
+  background: var(--fg);
   color: var(--bg);
-  border-color: var(--accent-amber);
+  border-color: var(--fg);
 }
 
 /* Sub-tag filter bar — single horizontal row, sticky below category tabs */
@@ -1736,7 +1736,7 @@ a:hover { color: var(--accent-cyan); }
 }
 
 .grid-item--selected {
-  outline: 1px solid var(--accent-amber);
+  outline: 1px solid var(--fg);
   outline-offset: 0;
 }
 
@@ -2316,7 +2316,7 @@ a:hover { color: var(--accent-cyan); }
   letter-spacing: 0.1em;
   padding: 2px 6px;
   background: var(--bg);
-  color: var(--accent-amber);
+  color: var(--fg);
   border-right: 0.25px solid var(--fg);
   border-bottom: 0.25px solid var(--fg);
   opacity: 0;
@@ -2612,9 +2612,9 @@ a:hover { color: var(--accent-cyan); }
 }
 
 .grid-item__action:hover {
-  background: var(--accent-amber);
+  background: var(--fg);
   color: var(--bg);
-  border-color: var(--accent-amber);
+  border-color: var(--fg);
 }
 
 .grid-item__action--danger {


### PR DESCRIPTION
## Summary
- Replaces all `--accent-amber` usage with `--fg`/`--bg` (white-on-black)
- Active filters, hover states, category badges, selected outlines all white again
- Keeps: monospace font, warm palette, subtle borders, cyan links/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)