### PR TITLE
fix(connector): QA fixes — OAuth redirect validation + API hardening

### DIFF
--- a/supabase/functions/connector-api/index.ts
+++ b/supabase/functions/connector-api/index.ts
@@ -33,7 +33,7 @@ import {
   logUsage,
 } from '../_shared/connector-core.ts'
 
-const VERSION = '0.1.0'
+const VERSION = '0.1.1'
 console.log(`[connector-api] v${VERSION} - REST API for multi-platform connectors`)
 
 const RATE_LIMIT_MAX = 60  // requests per minute per token
@@ -65,7 +65,8 @@ function parseQuery(url: URL): Record<string, unknown> {
   for (const [key, value] of url.searchParams) {
     // Parse integers for known numeric params
     if (['limit', 'offset', 'days'].includes(key)) {
-      args[key] = parseInt(value, 10)
+      const parsed = parseInt(value, 10)
+      if (!isNaN(parsed)) args[key] = parsed
     } else if (value === 'true') {
       args[key] = true
     } else if (value === 'false') {
@@ -245,7 +246,7 @@ async function matchRoute(
   // DELETE /v1/boards/:slug
   if (method === 'DELETE' && boardMatch) {
     const query = parseQuery(url)
-    return { toolName: 'delete_board', args: { board: boardMatch[1], confirm: true, ...query } }
+    return { toolName: 'delete_board', args: { board: boardMatch[1], ...query, confirm: true } }
   }
 
   // GET /v1/taste-profile

--- a/supabase/functions/mcp-oauth/index.ts
+++ b/supabase/functions/mcp-oauth/index.ts
@@ -12,7 +12,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-const VERSION = '0.2.0'
+const VERSION = '0.2.1'
 console.log(`[mcp-oauth] v${VERSION} - OAuth 2.1 authorization server (multi-platform)`)
 
 const BASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/mcp-oauth'
@@ -147,7 +147,7 @@ async function handleRegister(req: Request): Promise<Response> {
 // Authorization endpoint
 // ---------------------------------------------------------------------------
 
-function handleAuthorize(url: URL): Response {
+async function handleAuthorize(url: URL): Promise<Response> {
   const clientId = url.searchParams.get('client_id')
   const redirectUri = url.searchParams.get('redirect_uri')
   const responseType = url.searchParams.get('response_type')
@@ -161,6 +161,22 @@ function handleAuthorize(url: URL): Response {
   if (!redirectUri) return err('invalid_request', 'Missing redirect_uri')
   if (!codeChallenge) return err('invalid_request', 'PKCE code_challenge is required')
   if (codeChallengeMethod !== 'S256') return err('invalid_request', 'Only S256 code_challenge_method is supported')
+
+  // Validate redirect_uri: must be in the allowlist OR registered for this client
+  const isAllowed = ALLOWED_REDIRECT_URIS.includes(redirectUri)
+  if (!isAllowed) {
+    const db = getServiceClient()
+    const { data: client } = await db
+      .from('connector_clients')
+      .select('redirect_uris')
+      .eq('client_id', clientId)
+      .single()
+    if (!client) return err('invalid_client', 'Unknown client_id')
+    const registeredUris = (client.redirect_uris as string[]) || []
+    if (!registeredUris.includes(redirectUri)) {
+      return err('invalid_redirect_uri', 'redirect_uri is not registered for this client')
+    }
+  }
 
   // Redirect to consent page with all params
   const consentParams = new URLSearchParams({
@@ -320,9 +336,12 @@ async function handleCodeExchange(body: URLSearchParams): Promise<Response> {
     return err('invalid_grant', 'client_id mismatch')
   }
 
-  // Verify redirect_uri matches
-  if (redirectUri && authCode.redirect_uri !== redirectUri) {
-    return err('invalid_grant', 'redirect_uri mismatch')
+  // Verify redirect_uri matches (required per OAuth 2.1 if present in auth request)
+  if (authCode.redirect_uri) {
+    if (!redirectUri) return err('invalid_request', 'redirect_uri is required')
+    if (authCode.redirect_uri !== redirectUri) {
+      return err('invalid_grant', 'redirect_uri mismatch')
+    }
   }
 
   // Verify PKCE code_verifier → code_challenge
@@ -455,7 +474,7 @@ serve(async (req: Request) => {
 
     // Authorization
     if (path === '/authorize' && req.method === 'GET') {
-      return handleAuthorize(url)
+      return await handleAuthorize(url)
     }
 
     // Authorization code creation (from consent page)


### PR DESCRIPTION
## Summary
- Automated QA found 4 auto-fixable bugs and 8 items for human review after PR #373 deploy
- 4 bugs auto-fixed, 8 flagged for review
- Platforms tested: Backend only (all changes are Supabase edge functions)

## Auto-Fixed Bugs
- **[mcp-oauth:150] OAuth open redirector** — `ALLOWED_REDIRECT_URIS` was defined but never enforced. Now validates redirect_uri against the allowlist or the client's registered URIs in `connector_clients`
- **[mcp-oauth:340] redirect_uri optional in token exchange** — Per OAuth 2.1, redirect_uri must be required in the token request when it was present during authorization. Fixed
- **[connector-api:248] delete_board confirm bypass** — `?confirm=false` query param could override the hardcoded `confirm: true` due to JS spread order. Fixed by placing `confirm: true` after the spread
- **[connector-api:67] parseQuery NaN passthrough** — Non-numeric `?days=abc` passed `NaN` downstream, causing `toolGetRecentSaves` to silently ignore the filter. Now drops invalid numeric params

## Flagged for Review (not fixed)

| Severity | Issue | Location |
|----------|-------|----------|
| Medium | `search_pins` applies query filter in JS after DB `LIMIT` — may return fewer results than expected for large libraries | connector-core.ts:228-250 |
| Medium | `logUsage` writes `platform` column; original schema had `client_type` which is now permanently null | connector-core.ts:127 vs migration 030 |
| Medium | `toolBatchUpdatePins` doesn't guard against missing `value` param | connector-core.ts:976 |
| Medium | `handleAuthorize` doesn't validate `client_id` exists in DB (only checks redirect_uri now) | mcp-oauth:159 |
| Low | `toolGetBoardsList` and `toolGetTasteProfile` fetch entire library with no row limit | connector-core.ts:307,337 |
| Low | Double DB read: `resolveUser` fetches settings, then caller immediately calls `getSettings` again | connector-core.ts:59-68 |
| Low | `rateLimitMap` grows unboundedly — no cleanup of expired entries | connector-api:40 |
| Low | Session Map stores user data that is never read back | mcp-server:199-203 |

## Test Evidence
- No frontend or iOS changes — all changes are Supabase edge functions
- Static analysis of all 4 function files (connector-core, mcp-server, connector-api, mcp-oauth)
- No web pages affected — boards app uses Supabase Auth directly, not the connector OAuth

## Pages/Screens Tested
- N/A — backend-only changes, no UI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)