### PR TITLE
fix(extension): remove invalid chrome:// scheme from exclude_matches

### DIFF
--- a/extension/chrome/manifest.json
+++ b/extension/chrome/manifest.json
@@ -37,8 +37,6 @@
       "js": ["content-nudge.js"],
       "run_at": "document_idle",
       "exclude_matches": [
-        "chrome://*/*",
-        "chrome-extension://*/*",
         "https://ctrl.rodeo/*"
       ]
     }


### PR DESCRIPTION
## Summary

- Fix extension load failure caused by `chrome://*/*` and `chrome-extension://*/*` in `exclude_matches` — these aren't valid match pattern schemes
- MV3 content scripts with `<all_urls>` already don't inject into `chrome://` pages, so only the `https://ctrl.rodeo/*` exclusion is needed

## Test plan

- [ ] Load unpacked extension in `chrome://extensions` — no error
- [ ] Visit any page — nudge content script injects normally
- [ ] Visit `ctrl.rodeo` — nudge does NOT inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)