### PR TITLE
fix(boards): show triple-dot menu on card hover (v2.21.1)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -2638,6 +2638,10 @@ a:hover { color: var(--accent-cyan); }
   transition: opacity 0.15s, background 0.15s;
 }
 
+.grid-item:hover .grid-item__menu-btn {
+  opacity: 1;
+}
+
 .grid-item__menu-btn:hover {
   background: rgba(0, 0, 0, 0.8);
 }
@@ -7158,7 +7162,7 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.21.0';
+  const VERSION = '2.21.1';
   console.log('[boards] v' + VERSION + ' - masonry grid + full-page detail overlay');
 
   // ============================================


### PR DESCRIPTION
## Summary
- Add `.grid-item:hover .grid-item__menu-btn { opacity: 1 }` rule lost when expanded-card CSS was removed in v2.21.0
- Triple-dot menu now fades in on card hover as expected

## Test plan
- [ ] Hover over a card — triple-dot (•••) menu appears top-right
- [ ] Menu disappears when hover leaves card

🤖 Generated with [Claude Code](https://claude.com/claude-code)