### PR TITLE
feat(import): Instagram takeout → taste profile

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -6402,6 +6402,7 @@ a:hover { color: var(--accent-cyan); }
   <input type="file" id="videoInput" class="hidden-input" accept="video/*" multiple>
   <input type="file" id="spotifyImportInput" class="hidden-input" accept=".json,application/json">
   <input type="file" id="youtubeImportInput" class="hidden-input" accept=".json,application/json">
+  <input type="file" id="instagramImportInput" class="hidden-input" accept=".json,application/json">
 
   <!-- Add Modal -->
   <div class="modal" id="addModal" role="dialog" aria-modal="true" aria-labelledby="addModalTitle">
@@ -6653,6 +6654,14 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
             <button class="auth-bar__btn" id="youtube-takeout-btn" style="width: 100%;">Import YouTube History</button>
             <div class="yt-import-section__note" id="youtube-takeout-status">
               Upload watch-history.json from Google Takeout.
+            </div>
+          </div>
+
+          <!-- Instagram Takeout -->
+          <div style="margin-bottom: var(--space-3);">
+            <button class="auth-bar__btn" id="instagram-import-btn" style="width: 100%;">Import Instagram Saves</button>
+            <div class="yt-import-section__note" id="instagram-import-status">
+              Upload saved_posts.json or liked_posts.json from Instagram's data export.
             </div>
           </div>
 
@@ -7161,8 +7170,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.24.1';
-  console.log('[boards] v' + VERSION + ' - UI polish: filters, menu, merged badge');
+  const VERSION = '2.25.0';
+  console.log('[boards] v' + VERSION + ' - Instagram takeout import');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -11911,6 +11920,61 @@ Return JSON:
     }
   }
 
+  // Instagram: normalize saved/liked posts from both format variants
+  // New format (2024+): { saved_saved_media: [...] } or { likes_media_likes: [...] }
+  // Old format: array of { title, string_list_data: [...] }
+  function normalizeInstagramEvents(raw) {
+    let items = [];
+    if (Array.isArray(raw)) {
+      items = raw;
+    } else if (raw && typeof raw === 'object') {
+      const knownKeys = [
+        'saved_saved_media',
+        'likes_media_likes',
+        'saved_collections',
+      ];
+      for (const key of knownKeys) {
+        if (Array.isArray(raw[key])) {
+          items = items.concat(raw[key]);
+        }
+      }
+    }
+    return items.filter(item => {
+      const title = item?.title?.trim();
+      return title && title.length > 0;
+    });
+  }
+
+  async function handleInstagramImport(file) {
+    setImportStatus('instagram-import-status', 'Reading file...');
+    let raw;
+    try {
+      raw = await readJsonFile(file);
+    } catch (e) {
+      setImportStatus('instagram-import-status', 'Invalid file format. Expected JSON.');
+      toast('Invalid Instagram file', { level: 'error' });
+      return;
+    }
+
+    const events = normalizeInstagramEvents(raw);
+    if (events.length === 0) {
+      setImportStatus('instagram-import-status', 'No saved posts found. Try saved_posts.json or liked_posts.json from your Instagram data export.');
+      return;
+    }
+
+    setImportStatus('instagram-import-status', events.length.toLocaleString() + ' saves found, importing...');
+    try {
+      const signals = await importSecondarySignals('instagram_takeout', events);
+      setImportStatus('instagram-import-status', 'Imported ' + signals + ' creator signals from ' + events.length.toLocaleString() + ' saves.');
+      toast('Instagram history imported', { level: 'success' });
+      if (window._sourcePrompt) window._sourcePrompt.markImported();
+    } catch (e) {
+      setImportStatus('instagram-import-status', 'Import failed — try again.');
+      toast('Instagram import failed', { level: 'error' });
+      console.error('[instagram-import]', e);
+    }
+  }
+
   async function handleYouTubeTakeoutImport(file) {
     setImportStatus('youtube-takeout-status', 'Reading file...');
     let raw;
@@ -11956,6 +12020,14 @@ Return JSON:
   document.getElementById('youtubeImportInput')?.addEventListener('change', (e) => {
     const file = e.target.files?.[0];
     if (file) handleYouTubeTakeoutImport(file);
+    e.target.value = '';
+  });
+  document.getElementById('instagram-import-btn')?.addEventListener('click', () => {
+    document.getElementById('instagramImportInput').click();
+  });
+  document.getElementById('instagramImportInput')?.addEventListener('change', (e) => {
+    const file = e.target.files?.[0];
+    if (file) handleInstagramImport(file);
     e.target.value = '';
   });
 

--- a/supabase/functions/import-source/index.ts
+++ b/supabase/functions/import-source/index.ts
@@ -1,20 +1,20 @@
 // Supabase Edge Function: import-source
-// Ingests secondary taste signals from file exports (Spotify, YouTube Takeout).
+// Ingests secondary taste signals from file exports (Spotify, YouTube Takeout, Instagram Takeout).
 // Client-side parses files → batches events → POSTs to this function.
-// Signals are grouped by artist/channel, classified via Haiku, and stored in
+// Signals are grouped by artist/channel/account, classified via Haiku, and stored in
 // secondary_signals table. These feed the taste engine but are never shown as pins.
 //
 // POST /functions/v1/import-source
 // Authorization: Bearer <user_access_token>
 // Actions:
-//   { action: 'create-job', source: 'spotify'|'youtube_takeout' }
+//   { action: 'create-job', source: 'spotify'|'youtube_takeout'|'instagram_takeout' }
 //   { action: 'ingest-batch', jobId: string, source: string, batch: Event[] }
 //   { action: 'complete-job', jobId: string }
 //   { action: 'job-status', jobId: string }
 //   { action: 'delete-source', source: string }
 
-const VERSION = '1.0.0'
-console.log(`[import-source] v${VERSION} - secondary signal ingestion`)
+const VERSION = '1.1.0'
+console.log(`[import-source] v${VERSION} - added instagram_takeout source`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -36,6 +36,7 @@ const SIGNAL_WEIGHTS: Record<string, number> = {
   spotify: 0.3,
   youtube_takeout: 0.35,
   youtube_api: 0.6,         // playlists & likes — managed by youtube-import function
+  instagram_takeout: 0.25,  // saves = intent, not repeated consumption
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,16 @@ interface YouTubeTakeoutEvent {
   subtitles?: Array<{ name: string; url?: string }>
   time?: string
   snippet?: { title: string; channelTitle: string; publishedAt?: string }
+}
+
+interface InstagramTakeoutEvent {
+  title?: string                          // creator username
+  string_list_data?: Array<{
+    href?: string
+    value?: string
+    timestamp?: number
+  }>
+  string_map_data?: Record<string, { timestamp?: number; value?: string }>
 }
 
 interface Bucket {
@@ -184,24 +195,76 @@ function groupYouTubeByChannel(events: YouTubeTakeoutEvent[]): Bucket[] {
 }
 
 // ---------------------------------------------------------------------------
+// Instagram Takeout: group raw events by creator account
+// ---------------------------------------------------------------------------
+
+function groupInstagramByAccount(events: InstagramTakeoutEvent[]): Bucket[] {
+  const map = new Map<string, Bucket>()
+
+  for (const e of events) {
+    const accountName = e.title?.trim()
+    if (!accountName) continue
+
+    // Extract timestamp: prefer string_list_data[0].timestamp, fall back to string_map_data
+    let tsEpoch: number | undefined
+    if (e.string_list_data?.[0]?.timestamp) {
+      tsEpoch = e.string_list_data[0].timestamp
+    } else if (e.string_map_data) {
+      const savedOn = e.string_map_data['Saved on'] || e.string_map_data['Liked on']
+      tsEpoch = savedOn?.timestamp
+    }
+    const ts = tsEpoch
+      ? new Date(tsEpoch * 1000).toISOString()
+      : new Date().toISOString()
+
+    // Extract caption/value as context
+    const caption = e.string_list_data?.[0]?.value?.trim() || ''
+
+    const key = accountName.toLowerCase()
+    const existing = map.get(key)
+    if (existing) {
+      existing.count++
+      if (existing.context.length < 5 && caption && !existing.context.includes(caption)) {
+        existing.context.push(caption)
+      }
+      if (ts > existing.mostRecent) existing.mostRecent = ts
+    } else {
+      map.set(key, {
+        name: accountName,
+        count: 1,
+        context: caption ? [caption] : [],
+        mostRecent: ts,
+      })
+    }
+  }
+
+  // Min count = 1: any save is intentional (unlike passive plays)
+  return [...map.values()].sort((a, b) => b.count - a.count)
+}
+
+// ---------------------------------------------------------------------------
 // Haiku classification: batch subjects for taste/practical tag extraction
 // ---------------------------------------------------------------------------
 
 async function classifyBatch(
   subjects: Array<{ name: string; context: string[] }>,
-  mediaType: 'music' | 'video'
+  mediaType: 'music' | 'video' | 'social'
 ): Promise<Classification[]> {
   const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
   if (!apiKey) {
     console.warn('[import-source] No ANTHROPIC_API_KEY — skipping classification')
     return subjects.map(s => ({
       name: s.name, taste_tags: [], practical_tags: [],
-      entities: [{ type: mediaType === 'music' ? 'person' : 'brand', name: s.name, confidence: 0.85 }],
+      entities: [{ type: mediaType === 'video' ? 'brand' : 'person', name: s.name, confidence: 0.85 }],
     }))
   }
 
-  const subjectType = mediaType === 'music' ? 'artists' : 'YouTube channels'
-  const contextLabel = mediaType === 'music' ? 'tracks' : 'videos'
+  const subjectType = mediaType === 'music' ? 'artists'
+    : mediaType === 'social' ? 'Instagram accounts'
+    : 'YouTube channels'
+  const contextLabel = mediaType === 'music' ? 'tracks'
+    : mediaType === 'social' ? 'saved captions'
+    : 'videos'
 
   const prompt = `Classify these ${subjectType} for a personal taste profile.
 For each, produce taste_tags (aesthetic/cultural/emotional vibe) and practical_tags (genre/format/topic).
@@ -214,7 +277,7 @@ Return a JSON array with one entry per subject (same order):
 Rules:
 - taste_tags: vibe/aesthetic/mood, lowercase, underscores for spaces (e.g. lo_fi, melancholic, experimental, cinematic)
 - practical_tags: factual genre/format/topic, lowercase (e.g. techno, ambient, cooking, documentary, indie_rock)
-- entities: the ${mediaType === 'music' ? 'artist' : 'channel'} as person or brand, confidence >= 0.8
+- entities: the ${mediaType === 'music' ? 'artist' : mediaType === 'social' ? 'account' : 'channel'} as person or brand, confidence >= 0.8
 - 3-6 taste_tags and 3-5 practical_tags per subject
 JSON array only, no other text.`
 
@@ -255,13 +318,13 @@ JSON array only, no other text.`
 
 function fallbackClassifications(
   subjects: Array<{ name: string; context: string[] }>,
-  mediaType: 'music' | 'video'
+  mediaType: 'music' | 'video' | 'social'
 ): Classification[] {
   return subjects.map(s => ({
     name: s.name,
     taste_tags: [],
     practical_tags: [],
-    entities: [{ type: mediaType === 'music' ? 'person' : 'brand', name: s.name, confidence: 0.85 }],
+    entities: [{ type: mediaType === 'video' ? 'brand' : 'person', name: s.name, confidence: 0.85 }],
   }))
 }
 
@@ -277,8 +340,12 @@ async function insertSignals(
   classified: Array<Bucket & { classification: Classification }>
 ): Promise<number> {
   const sourceWeight = SIGNAL_WEIGHTS[source] ?? 0.3
-  const category = source === 'spotify' ? 'listen' : 'watch'
-  const contentType = source === 'spotify' ? 'music' : 'video'
+  const category = source === 'spotify' ? 'listen'
+    : source === 'instagram_takeout' ? 'follow'
+    : 'watch'
+  const contentType = source === 'spotify' ? 'music'
+    : source === 'instagram_takeout' ? 'social'
+    : 'video'
 
   const rows = classified.map(b => ({
     user_id: userId,
@@ -375,14 +442,18 @@ async function handleIngestBatch(
     await db.from('import_jobs').update({ status: 'processing' }).eq('id', jobId)
   }
 
-  // Group events by artist/channel
+  // Group events by artist/channel/account
   let buckets: Bucket[]
-  const mediaType = source === 'spotify' ? 'music' : 'video'
+  const mediaType: 'music' | 'video' | 'social' = source === 'spotify' ? 'music'
+    : source === 'instagram_takeout' ? 'social'
+    : 'video'
 
   if (source === 'spotify') {
     buckets = groupSpotifyByArtist(batch as SpotifyEvent[])
   } else if (source === 'youtube_takeout') {
     buckets = groupYouTubeByChannel(batch as YouTubeTakeoutEvent[])
+  } else if (source === 'instagram_takeout') {
+    buckets = groupInstagramByAccount(batch as InstagramTakeoutEvent[])
   } else {
     return err(`Unknown source: ${source}`)
   }
@@ -401,7 +472,7 @@ async function handleIngestBatch(
     const subjectBatch = toClassify.slice(i, i + HAIKU_BATCH_SIZE)
     const classifications = await classifyBatch(
       subjectBatch.map(b => ({ name: b.name, context: b.context })),
-      mediaType as 'music' | 'video'
+      mediaType
     )
     haikuCallsMade++
 
@@ -421,7 +492,7 @@ async function handleIngestBatch(
         name: b.name,
         taste_tags: [],
         practical_tags: [],
-        entities: [{ type: mediaType === 'music' ? 'person' : 'brand', name: b.name, confidence: 0.85 }],
+        entities: [{ type: mediaType === 'video' ? 'brand' : 'person', name: b.name, confidence: 0.85 }],
       },
     })
   }

--- a/supabase/migrations/037_instagram_takeout_source.sql
+++ b/supabase/migrations/037_instagram_takeout_source.sql
@@ -1,0 +1,17 @@
+-- ============================================================
+-- 037_instagram_takeout_source.sql
+-- Adds 'instagram_takeout' as a source type for secondary_signals
+-- Instagram saved/liked posts are intent signals but not repeated
+-- consumption — lower weight than Spotify (saves vs. listens).
+-- Weight hierarchy: pin=1.0 > youtube_api=0.6 > youtube_takeout=0.35 > spotify=0.3 > instagram_takeout=0.25
+-- ============================================================
+
+-- Expand source CHECK on secondary_signals
+ALTER TABLE secondary_signals DROP CONSTRAINT IF EXISTS secondary_signals_source_check;
+ALTER TABLE secondary_signals ADD CONSTRAINT secondary_signals_source_check
+  CHECK (source IN ('spotify', 'youtube_takeout', 'youtube_api', 'instagram_takeout'));
+
+-- Expand source CHECK on import_jobs
+ALTER TABLE import_jobs DROP CONSTRAINT IF EXISTS import_jobs_source_check;
+ALTER TABLE import_jobs ADD CONSTRAINT import_jobs_source_check
+  CHECK (source IN ('spotify', 'youtube_takeout', 'youtube_api', 'instagram_takeout'));


### PR DESCRIPTION
## Summary
- Adds Instagram takeout (saved_posts.json / liked_posts.json) as a secondary signal source for the taste profile
- Extends the existing import-source pipeline — no new edge functions or tables, just new source type
- Handles both old and new (2024+) Instagram export JSON formats
- Weight 0.25 (below spotify 0.3), grouped by creator account, classified as social/follow signals

## Changes
- **Migration 037**: expand CHECK constraints on `secondary_signals` and `import_jobs` for `instagram_takeout`
- **import-source v1.1.0**: `InstagramTakeoutEvent` type, `groupInstagramByAccount()`, `social` mediaType in Haiku classification, `follow`/`social` category/contentType
- **boards v2.25.0**: "Import Instagram Saves" button in Taste History section, `normalizeInstagramEvents()`, `handleInstagramImport()`

## Test plan
- [ ] Run migration 037 on Boards project
- [ ] Deploy import-source function
- [ ] Upload saved_posts.json from Instagram data export → verify signals created
- [ ] Upload liked_posts.json → verify signals created
- [ ] Verify taste engine recomputes after import completes
- [ ] Verify button appears in Account panel → Taste History section

🤖 Generated with [Claude Code](https://claude.com/claude-code)