### PR TITLE
feat(events): server-side event scraper (Phase 1)

### DIFF
--- a/.github/workflows/scrape-events.yml
+++ b/.github/workflows/scrape-events.yml
@@ -1,0 +1,58 @@
+name: Scrape Events Cache
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      source_id:
+        description: 'Specific source ID to scrape (blank = all)'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scrape event sources
+        run: |
+          if [ -n "${{ inputs.source_id }}" ]; then
+            ACTION="refresh"
+            BODY="{\"action\": \"refresh\", \"sourceId\": \"${{ inputs.source_id }}\"}"
+          else
+            ACTION="refresh-all"
+            BODY="{\"action\": \"refresh-all\"}"
+          fi
+
+          echo "Action: $ACTION"
+
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            "${{ secrets.SUPABASE_BOARDS_URL }}/functions/v1/scrape-events" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_BOARDS_SERVICE_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -n -1)
+
+          echo "Status: $HTTP_CODE"
+          echo "Response: $BODY"
+
+          if [ "$HTTP_CODE" -ge 400 ]; then
+            echo "::error::Scrape failed with HTTP $HTTP_CODE"
+            exit 1
+          fi
+
+          # Summary stats
+          SUCCEEDED=$(echo "$BODY" | jq -r '.sourcesSucceeded // 0')
+          FAILED=$(echo "$BODY" | jq -r '.sourcesFailed // 0')
+          EVENTS=$(echo "$BODY" | jq -r '.eventsTotal // 0')
+          echo "Sources: $SUCCEEDED succeeded, $FAILED failed | Events: $EVENTS total"
+
+          # Log errors
+          ERRORS=$(echo "$BODY" | jq -r '.errorLog[]? | "\(.sourceId): \(.error)"')
+          if [ -n "$ERRORS" ]; then
+            echo "::warning::Some sources had errors:"
+            echo "$ERRORS"
+          fi

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -1,0 +1,458 @@
+// Supabase Edge Function: scrape-events
+// Server-side scraper for all non-Discord event sources.
+// Runs on cron (every 2h) or manual trigger. Scrapes STOCK_SOURCES,
+// pushes events to cache-events for dedup/upsert/enrichment,
+// and tracks run metadata in scrape_runs table.
+//
+// Actions:
+//   POST { action: "refresh-all" }                → scrape all sources
+//   POST { action: "refresh", sourceId: "..." }   → scrape single source
+//   POST { action: "status" }                     → return last run info
+
+const VERSION = '1.0.0'
+console.log(`[scrape-events] v${VERSION} - server-side event scraper`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+import { STOCK_SOURCES, type EventSource } from './sources.ts'
+import type { ScrapedEvent } from './parsers/utils.ts'
+
+// Parser imports
+import { scrapeHtml } from './parsers/html.ts'
+import { scrapeRA } from './parsers/ra.ts'
+import { scrapeScreenSlate } from './parsers/screenslate.ts'
+import { scrapeGarysGuide } from './parsers/garysguide.ts'
+import { scrapeBonobo } from './parsers/bonobo.ts'
+import { scrapeSFMOMA } from './parsers/sfmoma.ts'
+import { scrapeIcal } from './parsers/ical.ts'
+import { scrapeJson } from './parsers/json.ts'
+import { scrapeRss } from './parsers/rss.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+// --- Concurrency limiter ---
+
+function createSemaphore(limit: number) {
+  let running = 0
+  const queue: Array<() => void> = []
+
+  return async function <T>(fn: () => Promise<T>): Promise<T> {
+    if (running >= limit) {
+      await new Promise<void>(resolve => queue.push(resolve))
+    }
+    running++
+    try {
+      return await fn()
+    } finally {
+      running--
+      if (queue.length > 0) queue.shift()!()
+    }
+  }
+}
+
+// --- Parser dispatch ---
+
+async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
+  switch (source.type) {
+    case 'html': return scrapeHtml(source)
+    case 'ra': return scrapeRA(source)
+    case 'screenslate': return scrapeScreenSlate(source)
+    case 'garysguide': return scrapeGarysGuide(source)
+    case 'bonobo': return scrapeBonobo(source)
+    case 'sfmoma': return scrapeSFMOMA(source)
+    case 'ical': return scrapeIcal(source)
+    case 'json': return scrapeJson(source)
+    case 'rss': return scrapeRss(source)
+    default:
+      console.log(`[scrape-events] Unknown source type: ${source.type} for ${source.id}`)
+      return []
+  }
+}
+
+// --- Source outcome interface (matches cache-events SourceOutcome) ---
+
+interface SourceOutcome {
+  sourceId: string
+  sourceName: string
+  sourceUrl: string
+  sourceType: string
+  eventCount: number
+  ok: boolean
+  errorReason?: string
+  durationMs?: number
+}
+
+// --- Push events to cache-events ---
+
+async function pushToCache(
+  events: ScrapedEvent[],
+  sourceOutcomes: SourceOutcome[],
+  supabaseUrl: string,
+  serviceKey: string,
+): Promise<{ cached: number; updated: number; enrichQueued: number }> {
+  // Format events to match ScrapedEvent interface expected by cache-events
+  const formatted = events.map(ev => ({
+    source: ev.source,
+    date: ev.date,
+    time: ev.time || undefined,
+    name: ev.name,
+    venue: ev.venue,
+    address: ev.address || undefined,
+    city: ev.city || undefined,
+    genre: ev.genre || undefined,
+    price: ev.price || undefined,
+    ages: ev.ages || undefined,
+    promoter: ev.promoter || undefined,
+    url: ev.url,
+    contentType: ev.contentType || undefined,
+  }))
+
+  // Send in batches of 400 (cache-events limit is 500)
+  let totalCached = 0, totalUpdated = 0, totalEnrichQueued = 0
+
+  for (let i = 0; i < formatted.length; i += 400) {
+    const batch = formatted.slice(i, i + 400)
+    const isLastBatch = i + 400 >= formatted.length
+
+    try {
+      const resp = await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${serviceKey}`,
+        },
+        body: JSON.stringify({
+          events: batch,
+          // Only send sourceOutcomes with the last batch
+          sourceOutcomes: isLastBatch ? sourceOutcomes : undefined,
+        }),
+      })
+
+      if (resp.ok) {
+        const result = await resp.json()
+        totalCached += result.cached || 0
+        totalUpdated += result.updated || 0
+        totalEnrichQueued += result.enrichQueued || 0
+      } else {
+        const errText = await resp.text()
+        console.error(`[scrape-events] cache-events batch failed: ${resp.status} ${errText}`)
+      }
+    } catch (e) {
+      console.error(`[scrape-events] cache-events call failed: ${(e as Error).message}`)
+    }
+  }
+
+  // If no events but we have outcomes, still send outcomes
+  if (formatted.length === 0 && sourceOutcomes.length > 0) {
+    try {
+      await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${serviceKey}`,
+        },
+        body: JSON.stringify({ events: [], sourceOutcomes }),
+      })
+    } catch (e) {
+      console.error(`[scrape-events] health-only push failed: ${(e as Error).message}`)
+    }
+  }
+
+  return { cached: totalCached, updated: totalUpdated, enrichQueued: totalEnrichQueued }
+}
+
+// --- Scrape run tracking ---
+
+async function createRun(supabase: ReturnType<typeof createClient>, triggeredBy: string): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('scrape_runs')
+    .insert({ triggered_by: triggeredBy })
+    .select('id')
+    .single()
+
+  if (error) {
+    console.error(`[scrape-events] Failed to create run: ${error.message}`)
+    return null
+  }
+  return data.id
+}
+
+async function completeRun(
+  supabase: ReturnType<typeof createClient>,
+  runId: string,
+  stats: {
+    sourcesAttempted: number
+    sourcesSucceeded: number
+    sourcesFailed: number
+    eventsTotal: number
+    eventsNew: number
+    eventsUpdated: number
+    errorLog: Array<{ sourceId: string; error: string }>
+  },
+): Promise<void> {
+  const { error } = await supabase
+    .from('scrape_runs')
+    .update({
+      completed_at: new Date().toISOString(),
+      sources_attempted: stats.sourcesAttempted,
+      sources_succeeded: stats.sourcesSucceeded,
+      sources_failed: stats.sourcesFailed,
+      events_total: stats.eventsTotal,
+      events_new: stats.eventsNew,
+      events_updated: stats.eventsUpdated,
+      error_log: stats.errorLog,
+    })
+    .eq('id', runId)
+
+  if (error) {
+    console.error(`[scrape-events] Failed to complete run: ${error.message}`)
+  }
+}
+
+// --- Main scrape orchestration ---
+
+async function scrapeAll(triggeredBy: string): Promise<Record<string, unknown>> {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, serviceKey)
+
+  const runId = await createRun(supabase, triggeredBy)
+  const semaphore = createSemaphore(5)
+
+  const allEvents: ScrapedEvent[] = []
+  const sourceOutcomes: SourceOutcome[] = []
+  const errorLog: Array<{ sourceId: string; error: string }> = []
+  let sourcesSucceeded = 0
+  let sourcesFailed = 0
+
+  console.log(`[scrape-events] Starting refresh-all: ${STOCK_SOURCES.length} sources, concurrency=5`)
+
+  const results = await Promise.allSettled(
+    STOCK_SOURCES.map(source =>
+      semaphore(async () => {
+        const start = Date.now()
+        try {
+          // Add delay for fragile sources to avoid burst patterns
+          if (['sfmoma', 'ra'].includes(source.type)) {
+            await new Promise(r => setTimeout(r, 2000))
+          }
+
+          const events = await scrapeSource(source)
+          const durationMs = Date.now() - start
+
+          console.log(`[scrape-events] ${source.id}: ${events.length} events (${durationMs}ms)`)
+
+          sourceOutcomes.push({
+            sourceId: source.id,
+            sourceName: source.name,
+            sourceUrl: source.url,
+            sourceType: source.type,
+            eventCount: events.length,
+            ok: true,
+            errorReason: events.length === 0 ? 'zero_results' : undefined,
+            durationMs,
+          })
+
+          if (events.length > 0) {
+            allEvents.push(...events)
+            sourcesSucceeded++
+          } else {
+            // Zero results is ok but noteworthy
+            sourcesSucceeded++
+          }
+
+          return { source, events, ok: true }
+        } catch (err) {
+          const durationMs = Date.now() - start
+          const msg = (err as Error).message || 'Unknown error'
+          console.error(`[scrape-events] ${source.id} FAILED (${durationMs}ms): ${msg}`)
+
+          sourceOutcomes.push({
+            sourceId: source.id,
+            sourceName: source.name,
+            sourceUrl: source.url,
+            sourceType: source.type,
+            eventCount: 0,
+            ok: false,
+            errorReason: classifyError(msg),
+            durationMs,
+          })
+
+          errorLog.push({ sourceId: source.id, error: msg })
+          sourcesFailed++
+
+          return { source, events: [], ok: false, error: msg }
+        }
+      })
+    )
+  )
+
+  console.log(`[scrape-events] Scraping complete: ${sourcesSucceeded} succeeded, ${sourcesFailed} failed, ${allEvents.length} total events`)
+
+  // Push all events to cache-events
+  const cacheResult = await pushToCache(allEvents, sourceOutcomes, supabaseUrl, serviceKey)
+  console.log(`[scrape-events] Cache: ${cacheResult.cached} new, ${cacheResult.updated} updated, ${cacheResult.enrichQueued} enrich queued`)
+
+  // Complete run tracking
+  if (runId) {
+    await completeRun(supabase, runId, {
+      sourcesAttempted: STOCK_SOURCES.length,
+      sourcesSucceeded,
+      sourcesFailed,
+      eventsTotal: allEvents.length,
+      eventsNew: cacheResult.cached,
+      eventsUpdated: cacheResult.updated,
+      errorLog,
+    })
+  }
+
+  return {
+    sourcesAttempted: STOCK_SOURCES.length,
+    sourcesSucceeded,
+    sourcesFailed,
+    eventsTotal: allEvents.length,
+    eventsNew: cacheResult.cached,
+    eventsUpdated: cacheResult.updated,
+    enrichQueued: cacheResult.enrichQueued,
+    errorLog: errorLog.length > 0 ? errorLog : undefined,
+    runId,
+  }
+}
+
+async function scrapeSingle(sourceId: string): Promise<Record<string, unknown>> {
+  const source = STOCK_SOURCES.find(s => s.id === sourceId)
+  if (!source) {
+    return { error: `Source not found: ${sourceId}` }
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+  const start = Date.now()
+  try {
+    const events = await scrapeSource(source)
+    const durationMs = Date.now() - start
+
+    console.log(`[scrape-events] ${source.id}: ${events.length} events (${durationMs}ms)`)
+
+    const outcome: SourceOutcome = {
+      sourceId: source.id,
+      sourceName: source.name,
+      sourceUrl: source.url,
+      sourceType: source.type,
+      eventCount: events.length,
+      ok: true,
+      errorReason: events.length === 0 ? 'zero_results' : undefined,
+      durationMs,
+    }
+
+    const cacheResult = await pushToCache(events, [outcome], supabaseUrl, serviceKey)
+
+    return {
+      sourceId: source.id,
+      eventsScraped: events.length,
+      eventsNew: cacheResult.cached,
+      eventsUpdated: cacheResult.updated,
+      enrichQueued: cacheResult.enrichQueued,
+      durationMs,
+    }
+  } catch (err) {
+    const durationMs = Date.now() - start
+    const msg = (err as Error).message || 'Unknown error'
+
+    const outcome: SourceOutcome = {
+      sourceId: source.id,
+      sourceName: source.name,
+      sourceUrl: source.url,
+      sourceType: source.type,
+      eventCount: 0,
+      ok: false,
+      errorReason: classifyError(msg),
+      durationMs,
+    }
+
+    await pushToCache([], [outcome], supabaseUrl, serviceKey)
+
+    return { sourceId: source.id, error: msg, durationMs }
+  }
+}
+
+async function getStatus(): Promise<Record<string, unknown>> {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, serviceKey)
+
+  const { data } = await supabase
+    .from('scrape_runs')
+    .select('*')
+    .order('started_at', { ascending: false })
+    .limit(5)
+
+  return { runs: data || [], totalSources: STOCK_SOURCES.length }
+}
+
+function classifyError(msg: string): string {
+  const m = msg.toLowerCase()
+  if (m.includes('timeout') || m.includes('aborted')) return 'timeout'
+  if (m.includes('403') || m.includes('forbidden') || m.includes('blocked')) return 'blocked'
+  if (m.includes('404') || m.includes('not found')) return 'missing'
+  if (m.includes('500') || m.includes('502') || m.includes('503')) return 'server'
+  if (m.includes('parse') || m.includes('unexpected token')) return 'parse'
+  return 'unknown'
+}
+
+// --- Handler ---
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'POST required' }), {
+      status: 405,
+      headers: jsonHeaders,
+    })
+  }
+
+  try {
+    const body = await req.json() as { action?: string; sourceId?: string }
+    const action = body.action || 'refresh-all'
+
+    if (action === 'status') {
+      const result = await getStatus()
+      return new Response(JSON.stringify(result), { headers: jsonHeaders })
+    }
+
+    if (action === 'refresh' && body.sourceId) {
+      const result = await scrapeSingle(body.sourceId)
+      return new Response(JSON.stringify(result), {
+        status: result.error ? 500 : 200,
+        headers: jsonHeaders,
+      })
+    }
+
+    if (action === 'refresh-all') {
+      const result = await scrapeAll('manual')
+      return new Response(JSON.stringify(result), { headers: jsonHeaders })
+    }
+
+    return new Response(JSON.stringify({ error: `Unknown action: ${action}` }), {
+      status: 400,
+      headers: jsonHeaders,
+    })
+  } catch (err) {
+    console.error('[scrape-events] Handler error:', err)
+    return new Response(JSON.stringify({ error: (err as Error).message }), {
+      status: 500,
+      headers: jsonHeaders,
+    })
+  }
+})

--- a/supabase/functions/scrape-events/parsers/bonobo.ts
+++ b/supabase/functions/scrape-events/parsers/bonobo.ts
@@ -1,0 +1,112 @@
+// Bonobo Network scraper (Squarespace)
+// Ported from events/index.html fetchBonobo()
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeBonobo(source: EventSource): Promise<ScrapedEvent[]> {
+  const baseUrl = 'https://www.bonobonetwork.com'
+
+  // Strategy 1: Squarespace JSON endpoint
+  try {
+    const jsonUrl = source.url + (source.url.includes('?') ? '&' : '?') + 'format=json'
+    const text = await fetchUrl(jsonUrl)
+    const data = JSON.parse(text)
+    const items = data.items || data.upcoming || []
+    if (items.length > 0) {
+      return items.map((item: any) => {
+        const name = item.title || ''
+        if (!name) return null
+        const startMs = item.startDate
+        let date = '', time = ''
+        if (startMs) {
+          const d = new Date(startMs)
+          date = d.toISOString().split('T')[0]
+          const hours = d.getHours().toString().padStart(2, '0')
+          const mins = d.getMinutes().toString().padStart(2, '0')
+          if (hours !== '00' || mins !== '00') time = hours + ':' + mins
+        }
+        const venue = item.location?.addressTitle || item.location?.addressLine1 || ''
+        const city = item.location?.addressLine2 || ''
+        const url = item.fullUrl ? baseUrl + item.fullUrl : (item.sourceUrl || '')
+        return {
+          date, time, name, venue, city, genre: '', url,
+          source: source.id, contentType: 'social',
+        } as ScrapedEvent
+      }).filter(Boolean) as ScrapedEvent[]
+    }
+  } catch (e) {
+    console.log(`[scrape-events] Bonobo JSON failed: ${(e as Error).message}`)
+  }
+
+  // Strategy 2: Fetch HTML and parse
+  const text = await fetchUrl(source.url)
+  const doc = parseHtml(text)
+  if (!doc) return []
+
+  const events: ScrapedEvent[] = []
+
+  // Strategy 2a: JSON-LD
+  const ldScripts = doc.querySelectorAll('script[type="application/ld+json"]')
+  ldScripts.forEach((script: any) => {
+    try {
+      const data = JSON.parse(script.textContent || '')
+      const items = Array.isArray(data) ? data : (data['@graph'] || [data])
+      items.forEach((item: any) => {
+        if (!item['@type'] || !['Event', 'SocialEvent'].includes(item['@type'])) return
+        const name = item.name || ''
+        const startDate = item.startDate || ''
+        if (!name || !startDate) return
+        const d = new Date(startDate)
+        const date = d.toISOString().split('T')[0]
+        const hours = d.getHours().toString().padStart(2, '0')
+        const mins = d.getMinutes().toString().padStart(2, '0')
+        const time = (hours !== '00' || mins !== '00') ? hours + ':' + mins : ''
+        events.push({
+          date, time, name,
+          venue: item.location?.name || '',
+          city: item.location?.address?.addressLocality || '',
+          genre: '', url: item.url || '',
+          source: source.id, contentType: 'social',
+        })
+      })
+    } catch (_e) { /* ignore */ }
+  })
+
+  if (events.length > 0) return events
+
+  // Strategy 2b: Squarespace HTML structure
+  const eventEls = doc.querySelectorAll('.eventlist-event, [class*="eventlist"], [class*="summary-item"], article[class*="event"], [data-type="events"] article')
+  eventEls.forEach((el: any) => {
+    const titleEl = el.querySelector('.eventlist-title a, [class*="title"] a, h1 a, h2 a, h3 a')
+    const dateEl = el.querySelector('time, .event-date, [class*="date"], [datetime]')
+
+    const name = titleEl?.textContent?.trim() || el.querySelector('h1, h2, h3')?.textContent?.trim() || ''
+    if (!name) return
+
+    let date = '', time = ''
+    const dateAttr = dateEl?.getAttribute('datetime') || dateEl?.textContent?.trim() || ''
+    if (dateAttr) {
+      try {
+        const d = new Date(dateAttr)
+        if (!isNaN(d.getTime())) {
+          date = d.toISOString().split('T')[0]
+          const hours = d.getHours().toString().padStart(2, '0')
+          const mins = d.getMinutes().toString().padStart(2, '0')
+          if (hours !== '00' || mins !== '00') time = hours + ':' + mins
+        }
+      } catch (_e) { /* ignore */ }
+    }
+    if (!date) {
+      const parsed = parseFuzzyDate(dateAttr)
+      if (parsed) date = parsed
+    }
+
+    const href = titleEl?.getAttribute('href') || ''
+    const url = href.startsWith('http') ? href : (href ? baseUrl + href : '')
+
+    events.push({ date: date || '', time, name, venue: '', city: '', genre: '', url, source: source.id, contentType: 'social' })
+  })
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/garysguide.ts
+++ b/supabase/functions/scrape-events/parsers/garysguide.ts
@@ -1,0 +1,97 @@
+// Gary's Guide scraper — HTML table parsing
+// Ported from events/index.html fetchGarysGuide()
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeGarysGuide(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+  const doc = parseHtml(text)
+  if (!doc) return []
+
+  const events: ScrapedEvent[] = []
+  const baseUrl = 'https://www.garysguide.com'
+  const seen = new Set<string>()
+
+  // Strategy 1: Parse table rows containing .ftitle event links
+  let currentDayDate = ''
+  const allRows = doc.querySelectorAll('tr')
+
+  allRows.forEach((tr: any) => {
+    const tds = tr.querySelectorAll('td')
+    if (!tds || tds.length === 0) return
+
+    // Check for day header row
+    const firstTdText = (tds[0]?.textContent || '').trim()
+    const dayMatch = firstTdText.match(/(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),?\s+([\w]+\.?\s+\d{1,2})/i)
+    if (dayMatch) {
+      const parsed = parseFuzzyDate(dayMatch[2])
+      if (parsed) currentDayDate = parsed
+      return
+    }
+
+    // Look for event link
+    const titleFont = tr.querySelector('.ftitle')
+    const linkEl = titleFont ? titleFont.querySelector('a') : tr.querySelector('a[href*="/events/"]')
+    if (!linkEl) return
+    const href = linkEl.getAttribute('href') || ''
+    if (!href.includes('/events/') || href.includes('?')) return
+    const fullUrl = href.startsWith('http') ? href : baseUrl + href
+    if (seen.has(fullUrl)) return
+    seen.add(fullUrl)
+
+    const name = (linkEl.textContent || '').trim()
+    if (!name || name.length < 3) return
+
+    // Extract venue and city from .fdescription
+    let venue = '', city = ''
+    const descFont = tr.querySelector('.fdescription')
+    if (descFont) {
+      const venueEl = descFont.querySelector('b')
+      if (venueEl) venue = (venueEl.textContent || '').trim()
+      const descText = (descFont.textContent || '').trim()
+      const parts = descText.replace(venue, '').replace(/^[\s,]+/, '').split(',').map((s: string) => s.trim()).filter(Boolean)
+      if (parts.length > 0) city = parts[parts.length - 1]
+    }
+
+    // Extract date and time from sibling td cells
+    let date = currentDayDate || ''
+    let time = ''
+    for (const td of tds) {
+      const tdText = (td.textContent || '').trim()
+      const dateTimeMatch = tdText.match(/([\w]+\.?\s+\d{1,2})\s*(\d{1,2}:\d{2}\s*(am|pm)?)/i)
+      if (dateTimeMatch) {
+        const parsed = parseFuzzyDate(dateTimeMatch[1])
+        if (parsed) date = parsed
+        time = dateTimeMatch[2].trim()
+        break
+      }
+      const dateOnly = tdText.match(/^([\w]+\.?\s+\d{1,2})$/)
+      if (dateOnly) {
+        const parsed = parseFuzzyDate(dateOnly[1])
+        if (parsed) date = parsed
+      }
+      const timeOnly = tdText.match(/^(\d{1,2}:\d{2}\s*(am|pm)?)$/i)
+      if (timeOnly) time = timeOnly[1].trim()
+    }
+
+    events.push({ date, time, name, venue, city, genre: 'Tech', url: fullUrl, source: source.id, contentType: 'tech' })
+  })
+
+  if (events.length > 0) return events
+
+  // Strategy 2: Fallback — find all .ftitle links
+  const ftitleLinks = doc.querySelectorAll('.ftitle a')
+  ftitleLinks.forEach((link: any) => {
+    const href = link.getAttribute('href') || ''
+    if (!href.includes('/events/') || href.includes('?')) return
+    const fullUrl = href.startsWith('http') ? href : baseUrl + href
+    if (seen.has(fullUrl)) return
+    seen.add(fullUrl)
+    const name = (link.textContent || '').trim()
+    if (!name || name.length < 3) return
+    events.push({ date: '', time: '', name, venue: '', city: '', genre: 'Tech', url: fullUrl, source: source.id, contentType: 'tech' })
+  })
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/html.ts
+++ b/supabase/functions/scrape-events/parsers/html.ts
@@ -1,0 +1,201 @@
+// HTML Table Scraper — handles 19hz and generic table formats
+// Ported from events/index.html parseHtmlTable()
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate, parseEventName, parseLocationString, resolveUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeHtml(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+  return parseHtmlTable(text, source.id, source.url)
+}
+
+function parseHtmlTable(html: string, sourceId: string, baseUrl: string): ScrapedEvent[] {
+  const doc = parseHtml(html)
+  if (!doc) return []
+
+  const tables = Array.from(doc.querySelectorAll('table'))
+  if (tables.length === 0) return []
+
+  // Prefer the largest table
+  const table = tables.reduce((a, b) =>
+    (b.querySelectorAll('tr').length > a.querySelectorAll('tr').length ? b : a), tables[0])
+
+  // Detect headers
+  const headers: string[] = []
+  table.querySelectorAll('thead th, tr:first-child th').forEach((th: any) => {
+    headers.push((th.textContent || '').trim().toLowerCase().replace(/\s+/g, ' '))
+  })
+
+  // Count columns from first data row
+  let rows = Array.from(table.querySelectorAll('tbody tr'))
+  if (rows.length === 0) rows = Array.from(table.querySelectorAll('tr')).filter((r: any) => !r.querySelector('th'))
+  if (rows.length === 0) return []
+
+  const colCount = (rows[0] as any).querySelectorAll('td').length
+
+  // Build column map
+  const colMap: Record<string, any> = {}
+  let format = 'unknown'
+
+  if (headers.length > 0) {
+    headers.forEach((h, i) => {
+      if ((/^date/.test(h) || h === 'date/time' || h === 'when') && colMap.date === undefined) colMap.date = i
+      else if ((/event|title|artist/.test(h) || (h === 'name')) && colMap.name === undefined) { colMap.name = i; if (h.includes('venue') || h.includes('@')) colMap._nameHasVenue = true }
+      else if (/genre|tag|style|music|type/.test(h) && colMap.genre === undefined) colMap.genre = i
+      else if (/venue|location|place/.test(h) && colMap.location === undefined) colMap.location = i
+      else if (h === 'time' && colMap.time === undefined) colMap.time = i
+      else if (/price|cost|\$/.test(h) && colMap.price === undefined) colMap.price = i
+      else if (/age/.test(h) && !(/price/.test(h)) && colMap.ages === undefined) colMap.ages = i
+      else if (/promoter|organizer|host|present/.test(h) && colMap.promoter === undefined) colMap.promoter = i
+      else if (/link|url/.test(h) && colMap.links === undefined) colMap.links = i
+    })
+    const dateHeader = headers[colMap.date] || ''
+    if (dateHeader.includes('time') && colMap.time === undefined) colMap._dateHasTime = true
+    const priceHeader = headers[colMap.price] || ''
+    if (priceHeader.includes('age') && colMap.ages === undefined) colMap._priceHasAge = true
+    const nameHeader = headers[colMap.name] || ''
+    if (nameHeader.includes('venue') || nameHeader.includes('@')) colMap._nameHasVenue = true
+    format = 'header-detected'
+  }
+
+  // Positional fallback
+  if (colMap.date === undefined && colMap.name === undefined) {
+    if (colCount >= 10) {
+      Object.assign(colMap, { date: 0, name: 1, genre: 2, location: 3, time: 4, price: 5, ages: 6, promoter: 7 })
+      format = '11-col-raw'
+    } else if (colCount >= 7) {
+      Object.assign(colMap, { date: 0, name: 1, genre: 2, location: 3, time: 4, price: 5, ages: 6, promoter: 7 })
+      format = '8-col'
+    } else if (colCount === 6) {
+      Object.assign(colMap, { date: 0, name: 1, genre: 2, price: 3, promoter: 4, links: 5 })
+      colMap._dateHasTime = true
+      colMap._nameHasVenue = true
+      colMap._priceHasAge = true
+      format = '6-col-combined'
+    } else if (colCount >= 4) {
+      Object.assign(colMap, { date: 0, name: 1, location: 2, time: 3 })
+      format = '4-col-minimal'
+    }
+  }
+
+  // Parse rows
+  const events: ScrapedEvent[] = []
+  rows.forEach((row: any) => {
+    const cells = row.querySelectorAll('td')
+    if (cells.length < 2) return
+
+    const getCell = (key: string) => colMap[key] !== undefined && cells[colMap[key]] ? cells[colMap[key]] : null
+    const getText = (key: string) => { const c = getCell(key); return c ? (c.textContent || '').replace(/\s+/g, ' ').trim() : '' }
+    const getCellLinks = (key: string) => {
+      const c = getCell(key)
+      if (!c) return []
+      return Array.from(c.querySelectorAll('a')).map((a: any) => ({
+        href: a.getAttribute('href') || '',
+        text: (a.textContent || '').trim(),
+      })).filter((l: any) => l.href && l.href !== '#' && !l.href.startsWith('javascript:'))
+    }
+
+    // DATE
+    const rawDate = getText('date')
+    let date = '', time = ''
+    if (colMap._dateHasTime) {
+      const timeMatch = rawDate.match(/\(([^)]+)\)/)
+      if (timeMatch) {
+        time = timeMatch[1].trim()
+        date = parseFuzzyDate(rawDate.substring(0, rawDate.indexOf('(')).trim())
+      } else {
+        date = parseFuzzyDate(rawDate)
+      }
+    } else {
+      date = parseFuzzyDate(rawDate)
+      time = getText('time')
+    }
+
+    // NAME
+    const rawName = getText('name')
+    if (!rawName) return
+
+    let eventTitle = rawName
+    let venueFromName = '', cityFromName = ''
+
+    if (colMap._nameHasVenue || rawName.includes(' @ ')) {
+      const parsed = parseEventName(rawName)
+      eventTitle = parsed.title
+      venueFromName = parsed.venue
+      cityFromName = parsed.city
+    }
+
+    // LOCATION
+    const rawLocation = getText('location')
+    let locVenue = '', locAddress = '', locCity = ''
+    if (rawLocation) {
+      const locCityMatch = rawLocation.match(/\(([^)]+)\)\s*$/)
+      if (locCityMatch) {
+        locCity = locCityMatch[1].trim()
+        const before = rawLocation.substring(0, rawLocation.lastIndexOf('(')).trim()
+        const locParts = before.split(',').map((s: string) => s.trim())
+        locVenue = locParts[0] || ''
+        locAddress = locParts.slice(1).join(', ')
+      } else {
+        const locParsed = parseLocationString(rawLocation)
+        locVenue = locParsed.venue
+        locAddress = locParsed.address
+        locCity = locParsed.city
+      }
+    }
+
+    const venue = locVenue || venueFromName
+    const city = locCity || cityFromName
+    const address = locAddress
+
+    // GENRE
+    let genre = getText('genre')
+    if (genre.startsWith(rawName)) genre = genre.substring(rawName.length).replace(/^\t+/, '').trim()
+    genre = genre.replace(/\t+/g, ', ').replace(/,\s*,/g, ',').replace(/^,\s*/, '').replace(/,\s*$/, '').trim()
+
+    // PRICE + AGES
+    let price = getText('price')
+    let ages = getText('ages')
+    if (colMap._priceHasAge || (!ages && price && /\|/.test(price))) {
+      const parts = price.split(/\s*\|\s*/)
+      if (parts.length >= 2) {
+        const lastPart = parts[parts.length - 1].trim()
+        if (/^\d+\+$|^all\s*ages?$/i.test(lastPart) || /age/i.test(lastPart)) {
+          ages = lastPart
+          price = parts.slice(0, -1).join(', ')
+        }
+      }
+    }
+    price = price.trim()
+    if (/^free$/i.test(price)) price = 'Free'
+    ages = ages.trim()
+    if (/^all\s*ages?$/i.test(ages)) ages = 'All Ages'
+
+    // PROMOTER
+    let promoter = getText('promoter')
+    promoter = promoter.replace(/\t+/g, ' ').trim()
+
+    // URLs
+    const nameLinks = getCellLinks('name')
+    const linksCellLinks = getCellLinks('links')
+    const allRowLinks = Array.from(row.querySelectorAll('a'))
+      .map((a: any) => ({ href: a.getAttribute('href') || '', text: (a.textContent || '').trim() }))
+      .filter((l: any) => l.href && l.href !== '#' && !l.href.startsWith('javascript:'))
+
+    let bestUrl = ''
+    if (nameLinks.length > 0) bestUrl = (nameLinks[0] as any).href
+    else if (linksCellLinks.length > 0) bestUrl = (linksCellLinks[0] as any).href
+    else if (allRowLinks.length > 0) bestUrl = (allRowLinks[0] as any).href
+
+    events.push({
+      date, time, name: eventTitle,
+      venue, address, city,
+      genre, price, ages,
+      promoter,
+      url: resolveUrl(bestUrl, baseUrl),
+      source: sourceId,
+    })
+  })
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/ical.ts
+++ b/supabase/functions/scrape-events/parsers/ical.ts
@@ -1,0 +1,47 @@
+// iCal parser — text-based, no DOM needed
+// Ported from events/index.html fetchIcal() + parseIcal()
+
+import { type ScrapedEvent, fetchUrl, parseLocationString } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeIcal(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+  return parseIcal(text, source.id)
+}
+
+function parseIcal(text: string, sourceId: string): ScrapedEvent[] {
+  const events: ScrapedEvent[] = []
+  const blocks = text.split('BEGIN:VEVENT')
+
+  for (let i = 1; i < blocks.length; i++) {
+    const block = blocks[i].split('END:VEVENT')[0]
+    const get = (key: string) => {
+      const re = new RegExp(key + '[^:]*:(.+)', 'i')
+      const m = block.match(re)
+      return m ? m[1].trim().replace(/\\n/g, ' ').replace(/\\,/g, ',') : ''
+    }
+
+    const dtstart = get('DTSTART')
+    const loc = parseLocationString(get('LOCATION'))
+
+    events.push({
+      date: dtstart ? parseIcalDate(dtstart) : '',
+      time: '',
+      name: get('SUMMARY'),
+      venue: loc.venue,
+      address: loc.address,
+      city: loc.city,
+      genre: '', price: '', ages: '',
+      url: get('URL') || '',
+      source: sourceId,
+    })
+  }
+
+  return events
+}
+
+function parseIcalDate(str: string): string {
+  const clean = str.replace(/[^0-9T]/g, '')
+  if (clean.length >= 8) return `${clean.substring(0, 4)}-${clean.substring(4, 6)}-${clean.substring(6, 8)}`
+  return str
+}

--- a/supabase/functions/scrape-events/parsers/json.ts
+++ b/supabase/functions/scrape-events/parsers/json.ts
@@ -1,0 +1,40 @@
+// JSON feed parser
+// Ported from events/index.html fetchJson()
+
+import { type ScrapedEvent, fetchUrl, parseLocationString } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeJson(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+  const data = JSON.parse(text)
+
+  const items = Array.isArray(data)
+    ? data
+    : (data.events || data.items || data.results || [])
+
+  if (!Array.isArray(items) || items.length === 0) return []
+
+  // Helper: unwrap WordPress {rendered: "..."} objects
+  const unwrapWP = (v: any) => (v && typeof v === 'object' && v.rendered != null) ? v.rendered : v
+
+  return items.map((item: any) => {
+    const title = unwrapWP(item.name) || unwrapWP(item.title) || unwrapWP(item.summary) || ''
+    const excerpt = unwrapWP(item.excerpt) || unwrapWP(item.description) || ''
+    const loc = parseLocationString(item.location || item.venue || item.address || '')
+
+    return {
+      date: (item.date || item.start_date || item.startDate || item.start || '').substring(0, 10),
+      time: item.time || '',
+      name: typeof title === 'string' ? title.replace(/<[^>]*>/g, '').trim() : String(title),
+      description: typeof excerpt === 'string' ? excerpt.replace(/<[^>]*>/g, '').trim() : '',
+      venue: item.venue?.name || item.venue_name || loc.venue,
+      address: item.venue?.address || item.address || loc.address,
+      city: item.venue?.city || item.city || loc.city,
+      genre: item.genre || item.category || '',
+      price: item.price || item.cost || '',
+      ages: item.ages || item.age_restriction || '',
+      url: item.url || item.link || '',
+      source: source.id,
+    } as ScrapedEvent
+  })
+}

--- a/supabase/functions/scrape-events/parsers/ra.ts
+++ b/supabase/functions/scrape-events/parsers/ra.ts
@@ -1,0 +1,84 @@
+// Resident Advisor GraphQL scraper
+// Ported from events/index.html fetchRA()
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const RA_AREAS: Record<string, number> = {
+  sanfrancisco: 218, losangeles: 8, newyork: 9, seattle: 208,
+}
+
+export async function scrapeRA(source: EventSource): Promise<ScrapedEvent[]> {
+  const today = new Date().toISOString().split('T')[0]
+  const endDate = new Date(Date.now() + 14 * 86400000).toISOString().split('T')[0]
+
+  // Extract area slug from URL
+  const urlParts = source.url.replace(/\/$/, '').split('/')
+  const areaSlug = urlParts[urlParts.length - 1]
+  const areaId = RA_AREAS[areaSlug] || 218
+
+  const query = `query GET_DEFAULT_EVENTS_LISTING($filters: FilterInputDtoInput, $filterOptions: FilterOptionsInputDtoInput, $page: Int, $pageSize: Int) {
+    eventListings(filters: $filters, filterOptions: $filterOptions, page: $page, pageSize: $pageSize) {
+      data {
+        id listingDate
+        event {
+          id title date startTime endTime contentUrl
+          venue { id name area { id name } }
+          artists { id name }
+        }
+      }
+      totalResults
+    }
+  }`
+
+  const variables = {
+    filters: { areas: { eq: areaId }, listingDate: { gte: today, lte: endDate } },
+    filterOptions: { eventType: true, genre: true },
+    page: 1, pageSize: 100,
+  }
+
+  // GraphQL API call — direct fetch with RA headers
+  const text = await fetchUrl('https://ra.co/graphql', {
+    method: 'POST',
+    body: JSON.stringify({ query, variables }),
+    headers: {
+      'Content-Type': 'application/json',
+      'Referer': `https://ra.co/events/us/${areaSlug}`,
+      'Origin': 'https://ra.co',
+    },
+  })
+
+  const gqlData = JSON.parse(text)
+  if (gqlData.errors) {
+    console.log(`[scrape-events] RA GraphQL errors: ${JSON.stringify(gqlData.errors.map((e: any) => e.message))}`)
+  }
+
+  const listings = gqlData?.data?.eventListings?.data || []
+  if (listings.length === 0) return []
+
+  return listings.map((listing: any) => {
+    const ev = listing.event
+    if (!ev) return null
+
+    let date = '', time = ''
+    if (ev.startTime) {
+      const d = new Date(ev.startTime)
+      date = d.toISOString().split('T')[0]
+      const h = d.getHours(), m = d.getMinutes()
+      if (h !== 0 || m !== 0) time = h.toString().padStart(2, '0') + ':' + m.toString().padStart(2, '0')
+    } else if (ev.date) {
+      date = ev.date.split('T')[0]
+    }
+
+    return {
+      date, time,
+      name: ev.title || '',
+      venue: ev.venue?.name || '',
+      city: ev.venue?.area?.name || '',
+      genre: 'Electronic',
+      url: ev.contentUrl ? 'https://ra.co' + ev.contentUrl : '',
+      source: source.id,
+      contentType: 'music',
+    } as ScrapedEvent
+  }).filter(Boolean) as ScrapedEvent[]
+}

--- a/supabase/functions/scrape-events/parsers/rss.ts
+++ b/supabase/functions/scrape-events/parsers/rss.ts
@@ -1,0 +1,85 @@
+// RSS/Atom feed parser
+// Ported from events/index.html fetchRss()
+// Note: deno-dom doesn't fully support text/xml, so we parse as text/html
+// and use regex fallbacks for RSS-specific elements.
+
+import { type ScrapedEvent, fetchUrl, parseHtml, extractLocationFromHtml } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeRss(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+
+  // Try DOM parsing first (works for well-formed RSS that deno-dom can handle)
+  const doc = parseHtml(text)
+  const events: ScrapedEvent[] = []
+
+  if (doc) {
+    let items = doc.querySelectorAll('item')
+    if (!items || items.length === 0) items = doc.querySelectorAll('entry')
+
+    if (items && items.length > 0) {
+      items.forEach((item: any) => {
+        const getText = (tag: string) => {
+          const el = item.querySelector(tag)
+          return el ? (el.textContent || '').trim() : ''
+        }
+
+        const pubDate = getText('pubDate') || getText('published') || getText('updated') || ''
+        const description = getText('description') || getText('content') || getText('summary') || ''
+        const loc = extractLocationFromHtml(description)
+
+        let date = ''
+        if (pubDate) {
+          try { date = new Date(pubDate).toISOString().split('T')[0] }
+          catch (_e) { date = pubDate.substring(0, 10) }
+        }
+
+        const linkEl = item.querySelector('link')
+        const link = getText('link') || linkEl?.getAttribute('href') || ''
+
+        events.push({
+          date, time: '',
+          name: getText('title'),
+          venue: loc.venue, address: loc.address, city: loc.city,
+          genre: '', price: '', ages: '',
+          url: link,
+          source: source.id,
+        })
+      })
+
+      return events
+    }
+  }
+
+  // Regex fallback for RSS items if DOM parsing didn't find any
+  const itemRegex = /<item>([\s\S]*?)<\/item>/gi
+  let match
+  while ((match = itemRegex.exec(text)) !== null) {
+    const itemXml = match[1]
+    const getTag = (tag: string) => {
+      const m = itemXml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i'))
+      return m ? m[1].replace(/<!\[CDATA\[|\]\]>/g, '').trim() : ''
+    }
+
+    const pubDate = getTag('pubDate') || getTag('published')
+    let date = ''
+    if (pubDate) {
+      try { date = new Date(pubDate).toISOString().split('T')[0] }
+      catch (_e) { date = pubDate.substring(0, 10) }
+    }
+
+    const description = getTag('description') || getTag('content:encoded')
+    const loc = extractLocationFromHtml(description)
+
+    events.push({
+      date, time: '',
+      name: getTag('title'),
+      venue: loc.venue, address: loc.address, city: loc.city,
+      genre: '', price: '', ages: '',
+      url: getTag('link'),
+      source: source.id,
+    })
+  }
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/screenslate.ts
+++ b/supabase/functions/scrape-events/parsers/screenslate.ts
@@ -1,0 +1,179 @@
+// Screen Slate scraper — JSON API based
+// Ported from events/index.html fetchScreenSlate()
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const CITY_IDS: Record<string, string> = {
+  'bay-area': '10970',
+  'new-york': '10969',
+}
+
+export async function scrapeScreenSlate(source: EventSource): Promise<ScrapedEvent[]> {
+  const baseUrl = 'https://www.screenslate.com'
+  const cityId = CITY_IDS[source.region] || ''
+  const dayRange = 7
+
+  // Phase 1: Fetch showtimes per day
+  const allShowtimes: Array<{ nid: string; time: string; note: string; timestamp: string; dateStr: string }> = []
+
+  for (let dayOffset = 0; dayOffset < dayRange; dayOffset++) {
+    const d = new Date(Date.now() + dayOffset * 86400000)
+    const dateStr = d.toISOString().split('T')[0]
+    const dateParam = dateStr.replace(/-/g, '')
+    let apiUrl = `${baseUrl}/api/screenings/date?_format=json&date=${dateParam}`
+    if (cityId) apiUrl += `&field_city_target_id=${cityId}`
+
+    try {
+      const text = await fetchUrl(apiUrl)
+      const data = JSON.parse(text)
+      if (!Array.isArray(data)) continue
+
+      const items = data
+        .filter((item: any) => item.nid)
+        .map((item: any) => ({
+          nid: String(item.nid),
+          time: item.field_time || '',
+          note: item.field_note || '',
+          timestamp: item.field_timestamp || '',
+          dateStr,
+        }))
+      allShowtimes.push(...items)
+    } catch (e) {
+      console.error(`[scrape-events] ScreenSlate fetch failed for ${dateStr}: ${(e as Error).message}`)
+      if (dayOffset === 0) throw e
+      break
+    }
+  }
+
+  if (allShowtimes.length === 0) return []
+
+  // Phase 2: Batch-enrich via JSON:API
+  const uniqueNids = [...new Set(allShowtimes.map(s => s.nid))]
+  const enrichmentMap = await enrichNids(uniqueNids, baseUrl)
+
+  // Phase 3: Group showtimes by nid+date
+  const groups = new Map<string, typeof allShowtimes>()
+  allShowtimes.forEach(s => {
+    const key = `${s.nid}|${s.dateStr}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key)!.push(s)
+  })
+
+  const events: ScrapedEvent[] = []
+  groups.forEach((showtimes) => {
+    const first = showtimes[0]
+    const enriched = enrichmentMap.get(first.nid) || {} as any
+
+    const times = showtimes.map(s => {
+      const note = s.note ? ` (${s.note})` : ''
+      return s.time + note
+    })
+
+    let name = enriched.title || `Screening #${first.nid}`
+    const venue = enriched.venue || ''
+    if (venue && name.toLowerCase().endsWith(' at ' + venue.toLowerCase())) {
+      name = name.substring(0, name.length - (' at ' + venue).length)
+    }
+
+    const series = enriched.series || ''
+    const price = enriched.price || ''
+    const url = enriched.url || ''
+    const pathAlias = enriched.path || ''
+    const eventUrl = url.startsWith('http') ? url : (pathAlias ? baseUrl + pathAlias : '')
+
+    events.push({
+      date: first.dateStr,
+      time: times.join(', '),
+      name, venue,
+      address: enriched.address || '',
+      city: '',
+      genre: series || 'film',
+      price, ages: '',
+      url: eventUrl,
+      source: source.id,
+      contentType: 'film',
+    })
+  })
+
+  return events
+}
+
+interface EnrichedScreening {
+  title: string
+  venue: string
+  address: string
+  series: string
+  price: string
+  url: string
+  path: string
+}
+
+async function enrichNids(nids: string[], baseUrl: string): Promise<Map<string, EnrichedScreening>> {
+  const result = new Map<string, EnrichedScreening>()
+  const BATCH_SIZE = 40
+
+  for (let i = 0; i < nids.length; i += BATCH_SIZE) {
+    const batch = nids.slice(i, i + BATCH_SIZE)
+    const filterParams = batch.map((nid, idx) =>
+      `filter[drupal_internal__nid][value][${idx}]=${nid}`
+    ).join('&')
+    const apiUrl = `${baseUrl}/jsonapi/node/screening?${filterParams}`
+      + `&filter[drupal_internal__nid][operator]=IN`
+      + `&include=field_venue,field_series`
+      + `&fields[node--screening]=title,drupal_internal__nid,field_url,path,field_venue,field_series`
+      + `&fields[node--venue]=title,field_address,field_ticket_info`
+      + `&fields[node--series]=title`
+
+    try {
+      const text = await fetchUrl(apiUrl)
+      const json = JSON.parse(text)
+
+      const included = new Map<string, any>()
+      if (Array.isArray(json.included)) {
+        json.included.forEach((ent: any) => {
+          included.set(`${ent.type}:${ent.id}`, ent)
+        })
+      }
+
+      if (Array.isArray(json.data)) {
+        json.data.forEach((node: any) => {
+          const nid = String(node.attributes?.drupal_internal__nid || '')
+          if (!nid) return
+
+          let venue = '', address = '', price = ''
+          const venueRef = node.relationships?.field_venue?.data
+          if (venueRef) {
+            const venueEnt = included.get(`${venueRef.type}:${venueRef.id}`)
+            if (venueEnt) {
+              venue = venueEnt.attributes?.title || ''
+              address = venueEnt.attributes?.field_address || ''
+              price = venueEnt.attributes?.field_ticket_info || ''
+            }
+          }
+
+          let series = ''
+          const seriesRef = node.relationships?.field_series?.data
+          if (seriesRef) {
+            const seriesEnt = included.get(`${seriesRef.type}:${seriesRef.id}`)
+            if (seriesEnt) series = seriesEnt.attributes?.title || ''
+          }
+
+          const fieldUrl = node.attributes?.field_url
+          const url = typeof fieldUrl === 'string' ? fieldUrl
+            : (fieldUrl?.uri || fieldUrl?.url || '')
+
+          result.set(nid, {
+            title: node.attributes?.title || '',
+            venue, address, series, price, url,
+            path: node.attributes?.path?.alias || '',
+          })
+        })
+      }
+    } catch (e) {
+      console.error(`[scrape-events] ScreenSlate enrichment batch failed: ${(e as Error).message}`)
+    }
+  }
+
+  return result
+}

--- a/supabase/functions/scrape-events/parsers/sfmoma.ts
+++ b/supabase/functions/scrape-events/parsers/sfmoma.ts
@@ -1,0 +1,163 @@
+// SFMOMA scraper — HTML parsing
+// Ported from events/index.html fetchSFMOMA()
+
+import { type ScrapedEvent, fetchUrl, parseHtml } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeSFMOMA(source: EventSource): Promise<ScrapedEvent[]> {
+  const text = await fetchUrl(source.url)
+  const doc = parseHtml(text)
+  if (!doc) return []
+
+  const today = new Date().toISOString().split('T')[0]
+  const isExhibitions = source.url.includes('/exhibitions')
+
+  if (isExhibitions) {
+    return parseExhibitions(doc, source, today)
+  } else {
+    return parseEvents(doc, source, today)
+  }
+}
+
+function parseExhibitions(doc: any, source: EventSource, today: string): ScrapedEvent[] {
+  const items = doc.querySelectorAll('.exhibitionsgrid-wrapper-grid-item[href*="/exhibition/"]')
+  const events: ScrapedEvent[] = []
+
+  items.forEach((item: any) => {
+    const title = item.querySelector('.exhibitionsgrid-wrapper-grid-item-text-title')?.textContent?.trim() || ''
+    const dateText = item.querySelector('.exhibitionsgrid-wrapper-grid-item-text-date')?.textContent?.trim() || ''
+    const desc = item.querySelector('.exhibitionsgrid-wrapper-grid-item-text-desc')?.textContent?.trim() || ''
+    const location = item.querySelector('.exhibitionsgrid-wrapper-grid-item-location')?.textContent?.trim() || ''
+    const url = item.getAttribute('href') || ''
+    const fullUrl = url.startsWith('http') ? url : 'https://www.sfmoma.org' + url
+
+    const parsed = parseSFMOMADate(dateText)
+    if (!parsed.date) return
+
+    // Skip past exhibitions
+    if (parsed.endDate && parsed.endDate < today) return
+
+    events.push({
+      date: parsed.date,
+      endDate: parsed.endDate || '',
+      time: '',
+      name: title,
+      description: desc,
+      venue: location ? 'SFMOMA ' + location : 'SFMOMA',
+      city: 'San Francisco',
+      url: fullUrl,
+      source: source.id,
+      contentType: 'exhibition',
+    })
+  })
+
+  return events
+}
+
+function parseEvents(doc: any, source: EventSource, today: string): ScrapedEvent[] {
+  const items = doc.querySelectorAll('.archive--grid-wrapper-grid-item-link')
+  const events: ScrapedEvent[] = []
+
+  items.forEach((item: any) => {
+    const title = item.querySelector('.archive--grid-wrapper-grid-item-text-title')?.textContent?.trim() || ''
+    const subtitle = item.querySelector('.archive--grid-wrapper-grid-item-text-subtitle')?.textContent?.trim() || ''
+    const supertitle = item.querySelector('.archive--grid-wrapper-grid-item-text-supertitle')?.textContent?.trim() || ''
+    const url = item.getAttribute('href') || ''
+    const fullUrl = url.startsWith('http') ? url : 'https://www.sfmoma.org' + url
+
+    const parsed = parseSFMOMADate(subtitle)
+    if (!parsed.date) return
+
+    const eventEnd = parsed.endDate || parsed.date
+    if (eventEnd < today) return
+
+    let contentType = 'art'
+    const st = supertitle.toLowerCase()
+    if (st.includes('film') || st.includes('screening')) contentType = 'film'
+
+    events.push({
+      date: parsed.date,
+      endDate: parsed.endDate || '',
+      time: parsed.time || '',
+      name: title,
+      venue: 'SFMOMA',
+      city: 'San Francisco',
+      url: fullUrl,
+      source: source.id,
+      contentType,
+      genre: supertitle || '',
+    })
+  })
+
+  return events
+}
+
+function parseSFMOMADate(dateText: string): { date: string; endDate: string; time: string; isAllDay: boolean } {
+  const text = (dateText || '').replace(/\u2013|\u2014|&ndash;|&mdash;/g, '\u2013').trim()
+
+  // "Ongoing"
+  if (/^ongoing$/i.test(text)) {
+    const today = new Date().toISOString().split('T')[0]
+    return { date: today, endDate: '', time: '', isAllDay: true }
+  }
+
+  // "Closing Apr 19, 2026"
+  const closingMatch = text.match(/^closing\s+(.+)$/i)
+  if (closingMatch) {
+    const end = parseSimpleDate(closingMatch[1])
+    const today = new Date().toISOString().split('T')[0]
+    return { date: today, endDate: end || '', time: '', isAllDay: true }
+  }
+
+  // "Opened Jan 17, 2026"
+  const openedMatch = text.match(/opened\s+(.+)$/i)
+  if (openedMatch) {
+    const start = parseSimpleDate(openedMatch[1])
+    return { date: start || '', endDate: '', time: '', isAllDay: true }
+  }
+
+  const rangeText = text.replace(/\s*\(.*?\)\s*/g, '').trim()
+  const rangeParts = rangeText.split('\u2013')
+
+  // Events page: "Thursday, Mar 12, 2026 | 6 p.m."
+  const timeSplit = text.split('|')
+  const datePart = timeSplit[0].replace(/\s*\(.*?\)\s*/g, '').trim()
+  const timePart = timeSplit.length > 1 ? timeSplit[1].trim() : ''
+
+  // Multi-day event: "Thursday, Mar 12–Friday, Mar 13, 2026 | 10 a.m."
+  const multiDayMatch = datePart.match(/^(?:\w+,\s+)?(\w+\s+\d+)\s*\u2013\s*(?:\w+,\s+)?(\w+\s+\d+),?\s+(\d{4})$/)
+  if (multiDayMatch) {
+    const start = parseSimpleDate(multiDayMatch[1] + ', ' + multiDayMatch[3])
+    const end = parseSimpleDate(multiDayMatch[2] + ', ' + multiDayMatch[3])
+    return { date: start || '', endDate: end || '', time: timePart, isAllDay: !timePart }
+  }
+
+  // Single day: "Thursday, Mar 12, 2026"
+  const singleDayMatch = datePart.match(/^(?:\w+,\s+)?(\w+\s+\d+,?\s+\d{4})$/)
+  if (singleDayMatch) {
+    const d = parseSimpleDate(singleDayMatch[1])
+    return { date: d || '', endDate: '', time: timePart, isAllDay: false }
+  }
+
+  // Exhibition range: "November 15, 2025–May 3, 2026"
+  if (rangeParts.length === 2) {
+    const start = parseSimpleDate(rangeParts[0].trim())
+    let end = parseSimpleDate(rangeParts[1].trim())
+    if (!end && start) {
+      const year = start.substring(0, 4)
+      end = parseSimpleDate(rangeParts[1].trim() + ', ' + year)
+    }
+    return { date: start || '', endDate: end || '', time: '', isAllDay: true }
+  }
+
+  const simple = parseSimpleDate(text)
+  return { date: simple || '', endDate: '', time: '', isAllDay: false }
+}
+
+function parseSimpleDate(str: string): string {
+  if (!str) return ''
+  const cleaned = str.replace(/,/g, '').trim()
+  const d = new Date(cleaned)
+  if (isNaN(d.getTime())) return ''
+  return d.toISOString().split('T')[0]
+}

--- a/supabase/functions/scrape-events/parsers/utils.ts
+++ b/supabase/functions/scrape-events/parsers/utils.ts
@@ -1,0 +1,152 @@
+// Shared utilities for parsers — ported from events/index.html
+
+import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts'
+
+export { DOMParser }
+
+export interface ScrapedEvent {
+  source: string
+  date: string
+  time?: string
+  name: string
+  venue: string
+  address?: string
+  city?: string
+  genre?: string
+  price?: string
+  ages?: string
+  promoter?: string
+  url: string
+  contentType?: string
+  endDate?: string
+  description?: string
+  imageUrl?: string
+}
+
+const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+/** Direct fetch with browser-like headers. No CORS proxy needed server-side. */
+export async function fetchUrl(url: string, options?: {
+  method?: string
+  body?: string
+  headers?: Record<string, string>
+  timeoutMs?: number
+}): Promise<string> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options?.timeoutMs || 15000)
+
+  try {
+    const resp = await fetch(url, {
+      method: options?.method || 'GET',
+      headers: {
+        'User-Agent': USER_AGENT,
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        ...(options?.headers || {}),
+      },
+      body: options?.body,
+      signal: controller.signal,
+    })
+
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status} ${resp.statusText}`)
+    }
+
+    return await resp.text()
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+/** Parse HTML string into a DOM document */
+export function parseHtml(html: string) {
+  return new DOMParser().parseFromString(html, 'text/html')
+}
+
+/** Parse XML string into a DOM document */
+export function parseXml(xml: string) {
+  return new DOMParser().parseFromString(xml, 'text/html') // deno-dom doesn't support text/xml; use text/html
+}
+
+/** Parse fuzzy date strings like "Feb 8", "Sat Feb 08", "February 8, 2025" into YYYY-MM-DD */
+export function parseFuzzyDate(str: string): string {
+  if (!str) return ''
+  str = str.replace(/\s+/g, ' ').trim()
+
+  // ISO format
+  const isoMatch = str.match(/(\d{4})-(\d{2})-(\d{2})/)
+  if (isoMatch) return isoMatch[0]
+
+  // Month-day patterns
+  const monthMatch = str.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\w*[\s.:]+(\d{1,2})(?:\s*,?\s*(\d{4}))?/i)
+  if (monthMatch) {
+    const months: Record<string, string> = { jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06', jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12' }
+    const month = months[monthMatch[1].substring(0, 3).toLowerCase()]
+    const day = monthMatch[2].padStart(2, '0')
+    const year = monthMatch[3] || new Date().getFullYear().toString()
+    return `${year}-${month}-${day}`
+  }
+
+  // Try native Date as last resort
+  try {
+    const d = new Date(str)
+    if (!isNaN(d.getTime()) && d.getFullYear() > 2000) return d.toISOString().split('T')[0]
+  } catch (_e) { /* ignore */ }
+
+  return str
+}
+
+/** Parse "Venue, Address, City" or "Venue (City)" location strings */
+export function parseLocationString(str: string): { venue: string; address: string; city: string } {
+  if (!str) return { venue: '', address: '', city: '' }
+  const parts = str.split(',').map(s => s.trim())
+  if (parts.length >= 3) return { venue: parts[0], address: parts[1], city: parts[2].replace(/\s+\d{5}(-\d{4})?$/, '').trim() }
+  if (parts.length === 2) {
+    if (/^\d/.test(parts[0])) return { venue: '', address: parts[0], city: parts[1] }
+    return { venue: parts[0], address: '', city: parts[1] }
+  }
+  return { venue: str, address: '', city: '' }
+}
+
+/** Parse "Event Title: Artists @ Venue Name (City)" */
+export function parseEventName(raw: string): { title: string; venue: string; city: string } {
+  let title = raw
+  let venue = ''
+  let city = ''
+
+  // Extract city from trailing "(City Name)"
+  const cityMatch = raw.match(/\(([^)]+)\)\s*$/)
+  if (cityMatch) {
+    const candidate = cityMatch[1].trim()
+    if (!/^\d+\+$|^doors|^starts|^\$|^free|^all\s*ages/i.test(candidate)) {
+      city = candidate
+      raw = raw.substring(0, raw.lastIndexOf('(' + candidate)).trim()
+    }
+  }
+
+  // Split on " @ " to separate event from venue
+  const atIdx = raw.lastIndexOf(' @ ')
+  if (atIdx !== -1) {
+    title = raw.substring(0, atIdx).trim()
+    venue = raw.substring(atIdx + 3).trim()
+  } else {
+    title = raw
+  }
+
+  title = title.replace(/:\s*$/, '').trim()
+  return { title, venue, city }
+}
+
+/** Resolve relative URLs against a base */
+export function resolveUrl(href: string, baseUrl: string): string {
+  if (!href) return ''
+  if (href.startsWith('http://') || href.startsWith('https://')) return href
+  try { return new URL(href, baseUrl).href } catch (_e) { return href }
+}
+
+/** Extract location hints from HTML content (for RSS) */
+export function extractLocationFromHtml(html: string): { venue: string; address: string; city: string } {
+  const text = html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ')
+  const m = text.match(/(?:location|where|venue|place|address)\s*:\s*([^.]+)/i)
+  return m ? parseLocationString(m[1].trim()) : { venue: '', address: '', city: '' }
+}

--- a/supabase/functions/scrape-events/sources.ts
+++ b/supabase/functions/scrape-events/sources.ts
@@ -1,0 +1,45 @@
+// Source registry — canonical list of stock event sources.
+// Ported from events/index.html STOCK_SOURCES.
+
+export interface EventSource {
+  id: string
+  name: string
+  category: string
+  type: string
+  url: string
+  region: string
+  description: string
+}
+
+export const STOCK_SOURCES: EventSource[] = [
+  // Bay Area
+  { id: '19hz-bayarea', name: '19hz', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_BayArea.php', region: 'bay-area', description: 'Electronic music & nightlife' },
+  { id: 'ra-bayarea', name: 'Resident Advisor SF', category: 'music', type: 'ra', url: 'https://ra.co/events/us/sanfrancisco', region: 'bay-area', description: 'Electronic music events' },
+  { id: 'sf-punchline', name: 'Punchline SF', category: 'comedy', type: 'html', url: 'https://www.punchlinecomedyclub.com/events', region: 'bay-area', description: 'Stand-up comedy' },
+  { id: 'cobbs-sf', name: "Cobb's Comedy Club", category: 'comedy', type: 'html', url: 'https://www.cobbscomedy.com/events', region: 'bay-area', description: 'Comedy & variety' },
+  { id: 'screenslate-sf', name: 'Screen Slate', category: 'film', type: 'screenslate', url: 'https://www.screenslate.com/listings', region: 'bay-area', description: 'Repertory & arthouse cinema' },
+  // Los Angeles
+  { id: '19hz-losangeles', name: '19hz Los Angeles', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_LosAngeles.php', region: 'los-angeles', description: 'Electronic music & nightlife' },
+  // New York
+  { id: '19hz-newyork', name: '19hz New York', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_NewYork.php', region: 'new-york', description: 'Electronic music & nightlife' },
+  { id: 'screenslate-nyc', name: 'Screen Slate', category: 'film', type: 'screenslate', url: 'https://www.screenslate.com/listings', region: 'new-york', description: 'Repertory & arthouse cinema' },
+  // Seattle
+  { id: '19hz-seattle', name: '19hz Seattle', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_Seattle.php', region: 'seattle', description: 'Electronic music & nightlife' },
+  // Bay Area — Tech & Networking
+  { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
+  { id: 'bonobo-sf', name: 'Bonobo Network', category: 'social', type: 'bonobo', url: 'https://www.bonobonetwork.com/events', region: 'bay-area', description: 'Social & community events' },
+  // Bay Area — Art
+  { id: 'sfmoma-events', name: 'SFMOMA', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/events/', region: 'bay-area', description: 'Museum events & artist talks' },
+  { id: 'sfmoma-exhibitions', name: 'SFMOMA Exhibitions', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/exhibitions/', region: 'bay-area', description: 'Current & upcoming exhibitions' },
+  { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'html', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
+  // Bay Area — Design
+  { id: 'sfdesignweek', name: 'SF Design Week', category: 'design', type: 'html', url: 'https://www.sfdesignweek.org/events', region: 'bay-area', description: 'Design talks, workshops & exhibitions' },
+  // Bay Area — Literary
+  { id: 'citylights-sf', name: 'City Lights Books', category: 'literary', type: 'html', url: 'https://citylights.com/events/', region: 'bay-area', description: 'Author readings & poetry events' },
+  { id: 'sfpl-events', name: 'SF Public Library', category: 'literary', type: 'html', url: 'https://sfpl.org/events', region: 'bay-area', description: 'Library programs & author talks' },
+  { id: 'commonwealthclub-sf', name: 'Commonwealth Club', category: 'literary', type: 'html', url: 'https://www.commonwealthclub.org/events', region: 'bay-area', description: 'Speaker events & public affairs' },
+  // Bay Area — Sound Art
+  { id: 'audium-sf', name: 'Audium', category: 'music', type: 'html', url: 'https://www.audium.org/calendar/', region: 'bay-area', description: 'Sound-sculptured space performances' },
+  // New York — Tech & Networking
+  { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
+]

--- a/supabase/migrations/039_scrape_runs.sql
+++ b/supabase/migrations/039_scrape_runs.sql
@@ -1,0 +1,43 @@
+-- Migration 039: Scrape runs tracking table
+-- Tracks each server-side scrape invocation for observability and freshness display.
+
+CREATE TABLE IF NOT EXISTS scrape_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  sources_attempted INTEGER DEFAULT 0,
+  sources_succeeded INTEGER DEFAULT 0,
+  sources_failed INTEGER DEFAULT 0,
+  events_total INTEGER DEFAULT 0,
+  events_new INTEGER DEFAULT 0,
+  events_updated INTEGER DEFAULT 0,
+  error_log JSONB DEFAULT '[]'::jsonb,
+  triggered_by TEXT DEFAULT 'cron'
+);
+
+CREATE INDEX idx_scrape_runs_started ON scrape_runs(started_at DESC);
+
+-- RLS: public read, service role write
+ALTER TABLE scrape_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read access" ON scrape_runs
+  FOR SELECT USING (true);
+
+CREATE POLICY "Service role full access" ON scrape_runs
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Auto-cleanup: keep last 90 days
+CREATE OR REPLACE FUNCTION cleanup_old_scrape_runs()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM scrape_runs
+  WHERE started_at < NOW() - INTERVAL '90 days';
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **New edge function:** `scrape-events` — centralized server-side scraper for all 20 stock event sources (9 parser types: html, ra, screenslate, garysguide, bonobo, sfmoma, ical, json, rss)
- **New migration:** `039_scrape_runs.sql` — tracks each scrape invocation for observability (sources attempted/succeeded/failed, event counts, error log)
- **New workflow:** `scrape-events.yml` — GitHub Actions cron every 2 hours + manual `workflow_dispatch` with optional `source_id` input

## Architecture
Currently, event scraping runs in every user's browser via `fetchAllSourcesNetwork()` → CORS proxy → `cache-events`. This PR adds a server-side scraper that runs the same parsers centrally on a schedule.

**Key decisions:**
- Direct `fetch()` — no CORS proxy needed server-side
- Concurrency cap of 5 (`Promise.allSettled` + semaphore) — 20 sources in ~4 waves, well within edge function timeout
- Reuses existing `cache-events` function — same `{ events, sourceOutcomes }` payload, zero changes to cache-events or enrich-event
- DOMParser via `deno-dom` (same pattern as `enrich-event`)
- Fragile sources (SFMOMA, RA) get 2s delay before fetch to avoid burst patterns

**Phase 1 (this PR):** Shadow mode — server scraper runs alongside client scraping. SHA-256 dedup makes overlap harmless.

**Phase 2 (separate PR):** Remove client-side scraping from `events/index.html` after validating server parity.

## Test plan
- [ ] Deploy `scrape-events` function: `supabase functions deploy scrape-events`
- [ ] Run migration `039_scrape_runs.sql` via Supabase SQL editor
- [ ] Trigger manually via `workflow_dispatch` — verify events appear in `events` table
- [ ] Check `scrape_runs` table for completion stats
- [ ] Check `source_health` for updated statuses per source
- [ ] Verify no regression in client-side scraping (shadow mode, both paths active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)