### PR TITLE
feat(boards): intent-driven pin actions (v2.27.0)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -3309,6 +3309,214 @@ a:hover { color: var(--accent-cyan); }
   filter: none;
 }
 /* ============================================
+   Intent Action Buttons (on pin cards)
+   ============================================ */
+.grid-item__action--intent {
+  background: var(--accent);
+  color: var(--bg);
+  border: none;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  letter-spacing: 0.02em;
+  transition: opacity 0.15s;
+}
+.grid-item__action--intent:hover { opacity: 0.85; }
+.grid-item__action--intent-secondary {
+  background: rgba(255,255,255,0.15);
+  color: var(--fg);
+  border: 1px solid rgba(255,255,255,0.2);
+  font-size: 0.65rem;
+  padding: 3px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  transition: opacity 0.15s;
+}
+.grid-item__action--intent-secondary:hover { opacity: 0.85; }
+.grid-item__intent-price {
+  font-size: 0.65rem;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+/* ============================================
+   Commerce Modal
+   ============================================ */
+.commerce-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.commerce-modal[hidden] { display: none; }
+.commerce-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+}
+.commerce-modal__panel {
+  position: relative;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: var(--space-6);
+  max-width: 420px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+.commerce-modal__image {
+  width: 100%;
+  max-height: 200px;
+  object-fit: contain;
+  border-radius: 8px;
+  margin-bottom: var(--space-4);
+  background: var(--bg);
+}
+.commerce-modal__name {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+.commerce-modal__price {
+  font-family: var(--font-mono);
+  font-size: 1.2rem;
+  color: var(--accent);
+  font-weight: 700;
+  margin-bottom: var(--space-4);
+}
+.commerce-modal__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.commerce-modal__btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+}
+.commerce-modal__btn:hover { opacity: 0.85; }
+.commerce-modal__btn--primary {
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
+.commerce-modal__btn--secondary {
+  background: rgba(255,255,255,0.1);
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.commerce-modal__close {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+/* ============================================
+   AI Tool Plan Modal (Terminal Viewer)
+   ============================================ */
+.terminal-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.terminal-modal[hidden] { display: none; }
+.terminal-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+}
+.terminal-modal__panel {
+  position: relative;
+  background: #0d1117;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  max-width: 680px;
+  width: 95%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+}
+.terminal-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+.terminal-modal__title {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+.terminal-modal__controls {
+  display: flex;
+  gap: var(--space-2);
+}
+.terminal-modal__btn {
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.2);
+  background: rgba(255,255,255,0.05);
+  color: var(--fg-muted);
+  transition: opacity 0.15s;
+}
+.terminal-modal__btn:hover { opacity: 0.85; color: var(--fg); }
+.terminal-modal__output {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  color: #c9d1d9;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+  min-height: 200px;
+}
+.terminal-modal__cursor {
+  display: inline-block;
+  width: 8px;
+  height: 1em;
+  background: var(--accent);
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
+}
+@keyframes blink { 50% { opacity: 0; } }
+.terminal-modal__status {
+  padding: var(--space-2) var(--space-4);
+  border-top: 1px solid rgba(255,255,255,0.1);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+}
+
+/* ============================================
    Recipe Drawer
    Right-side panel for recipe viewer
    ============================================ */
@@ -7117,6 +7325,38 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
     </div>
   </div>
 
+  <!-- Commerce Modal -->
+  <div class="commerce-modal" id="commerceModal" role="dialog" aria-modal="true" hidden>
+    <div class="commerce-modal__backdrop" id="commerceModalBackdrop"></div>
+    <div class="commerce-modal__panel">
+      <button class="commerce-modal__close" id="commerceModalClose" aria-label="Close">&times;</button>
+      <img class="commerce-modal__image" id="commerceModalImage" alt="" />
+      <div class="commerce-modal__name" id="commerceModalName"></div>
+      <div class="commerce-modal__price" id="commerceModalPrice"></div>
+      <div class="commerce-modal__actions">
+        <button class="commerce-modal__btn commerce-modal__btn--primary" id="commerceModalBuy">Go to Product</button>
+        <button class="commerce-modal__btn commerce-modal__btn--secondary" id="commerceModalSave">Save for Later</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- AI Tool Plan Modal (Terminal Viewer) -->
+  <div class="terminal-modal" id="terminalModal" role="dialog" aria-modal="true" hidden>
+    <div class="terminal-modal__backdrop" id="terminalModalBackdrop"></div>
+    <div class="terminal-modal__panel">
+      <div class="terminal-modal__header">
+        <span class="terminal-modal__title" id="terminalModalTitle"></span>
+        <div class="terminal-modal__controls">
+          <button class="terminal-modal__btn" id="terminalModalCopy">Copy</button>
+          <button class="terminal-modal__btn" id="terminalModalAbort">Stop</button>
+          <button class="terminal-modal__btn" id="terminalModalClose">&times;</button>
+        </div>
+      </div>
+      <pre class="terminal-modal__output" id="terminalModalOutput"></pre>
+      <div class="terminal-modal__status" id="terminalModalStatus"></div>
+    </div>
+  </div>
+
   <!-- Confirm Modal -->
   <div class="modal modal--small" id="confirmModal" role="dialog" aria-modal="true" aria-labelledby="confirmTitle">
     <div class="modal__backdrop"></div>
@@ -7170,8 +7410,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.26.0';
-  console.log('[boards] v' + VERSION + ' - image proxy + onerror fallback');
+  const VERSION = '2.27.0';
+  console.log('[boards] v' + VERSION + ' - intent-driven pin actions');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -12089,6 +12329,194 @@ Return JSON:
     }
   }
 
+  // ============================================
+  // Intent Classification API (Pass 1)
+  // ============================================
+  async function callIntentClassifyAPI(link, analysisResult) {
+    try {
+      const payload = {
+        action: 'classify',
+        url: link.url,
+        title: link.title || '',
+        description: link.description || '',
+        domain: link.domain || '',
+        content_type: analysisResult?.content_type || link.content_type || 'unknown',
+        practical_tags: analysisResult?.practical_tags || link.practical_tags || [],
+        taste_tags: analysisResult?.taste_tags || link.taste_tags || [],
+        entities: analysisResult?.entities || link.entities || [],
+        og_type: link.og_type || null,
+        og_price_amount: link.og_price_amount || null,
+        og_price_currency: link.og_price_currency || null,
+        structured_data_types: link.structured_data_types || [],
+        source: link.source || 'explicit',
+        userId: currentUser?.id,
+        linkId: link.id
+      };
+
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/classify-intent`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        console.warn('%c[INTENT] classify-intent returned', 'color: #e67e22', response.status);
+        return null;
+      }
+
+      const result = await response.json();
+      if (result.intent_type === 'none') {
+        console.log('%c[INTENT] No intent detected (confidence: ' + result.confidence + ')', 'color: #e67e22');
+        return null;
+      }
+
+      console.log('%c[INTENT] Classified:', 'color: #e67e22; font-weight: bold', result.intent_type, '@', result.confidence);
+      return result;
+    } catch (e) {
+      console.warn('%c[INTENT] classify-intent error:', 'color: #e67e22', e.message);
+      return null;
+    }
+  }
+
+  // Intent Hypothesis API (Pass 2 — fire-and-forget)
+  function fireIntentHypothesis(link, allLinks) {
+    if (!currentUser) return;
+    const recentPins = allLinks
+      .sort((a, b) => new Date(b.addedAt) - new Date(a.addedAt))
+      .slice(0, 50)
+      .map(l => ({
+        id: l.id,
+        title: l.title || '',
+        domain: l.domain || '',
+        content_type: l.content_type || 'unknown',
+        intent_type: l.intent_type || null,
+        action_state: l.intent_action_state || null
+      }));
+
+    if (recentPins.length < 10) return;
+
+    // Fire and forget — no await
+    fetch(`${SUPABASE_URL}/functions/v1/classify-intent`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+      },
+      body: JSON.stringify({
+        action: 'hypothesize',
+        userId: currentUser.id,
+        linkId: link.id,
+        current_pin: {
+          url: link.url,
+          title: link.title || '',
+          domain: link.domain || '',
+          content_type: link.content_type || 'unknown',
+          practical_tags: link.practical_tags || [],
+          intent_type: link.intent_type || null
+        },
+        recent_pins: recentPins
+      })
+    }).then(r => {
+      if (r.ok) console.log('%c[INTENT] Hypothesis fired', 'color: #e67e22');
+      else console.warn('%c[INTENT] Hypothesis failed:', 'color: #e67e22', r.status);
+    }).catch(e => console.warn('%c[INTENT] Hypothesis error:', 'color: #e67e22', e.message));
+  }
+
+  // Stream integration plan from generate-intent-plan
+  let _intentPlanAbortController = null;
+  async function streamIntentPlan(link) {
+    const meta = link.intent_metadata || {};
+    const output = $('terminalModalOutput');
+    const status = $('terminalModalStatus');
+    const abortBtn = $('terminalModalAbort');
+    const title = $('terminalModalTitle');
+
+    if (!output || !status || !title) return;
+
+    title.textContent = (meta.tool_name || link.title || 'Tool') + ' — Integration Plan';
+    output.textContent = '';
+    status.textContent = 'Generating...';
+    $('terminalModal').hidden = false;
+    abortBtn.style.display = '';
+
+    _intentPlanAbortController = new AbortController();
+
+    try {
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/generate-intent-plan`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify({
+          tool_name: meta.tool_name || link.title || '',
+          tagline: meta.tagline || link.description || '',
+          url: link.url,
+          domain: link.domain || '',
+          docs_url: meta.docs_url || null,
+          github_url: meta.github_url || null,
+          practical_tags: link.practical_tags || [],
+          entities: link.entities || [],
+          recent_pins: getAllLinks().slice(0, 10).map(l => ({
+            title: l.title, domain: l.domain, content_type: l.content_type
+          }))
+        }),
+        signal: _intentPlanAbortController.signal
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        status.textContent = 'Failed — ' + (errData.error || response.status);
+        abortBtn.style.display = 'none';
+        return;
+      }
+
+      // Parse SSE stream from Anthropic (forwarded by edge function)
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const data = line.slice(6);
+          if (data === '[DONE]') continue;
+
+          try {
+            const event = JSON.parse(data);
+            // Anthropic streaming: content_block_delta with text delta
+            if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+              output.textContent += event.delta.text;
+              output.scrollTop = output.scrollHeight;
+            }
+          } catch (_) {
+            // Ignore parse errors on partial chunks
+          }
+        }
+      }
+
+      status.textContent = 'Done';
+      abortBtn.style.display = 'none';
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        status.textContent = 'Stopped';
+      } else {
+        status.textContent = 'Error — ' + err.message;
+      }
+      abortBtn.style.display = 'none';
+    }
+  }
+
   // Call create-pin API with retry logic (image resolution + metadata enrichment)
   async function callEnrichmentAPI(item, currentImage, forceRefresh) {
     // Normalize URL: fix protocol-relative and HTML entities before sending
@@ -12261,6 +12689,33 @@ Return JSON:
             }
             save(analysisData);
           }
+        }
+      }
+
+      // Step 1.5: Intent classification via classify-intent
+      if (!item.skipAnalysis) {
+        console.log('%c[INTENT] Calling classify-intent for:', 'color: #e67e22', item.url);
+        const currentDataForIntent = load();
+        const currentLinkForIntent = currentDataForIntent.links.find(l => l.id === item.linkId);
+        if (currentLinkForIntent) {
+          const intentResult = await callIntentClassifyAPI(currentLinkForIntent, analysisResult);
+          if (intentResult && intentResult.intent_type !== 'none') {
+            const intentData = load();
+            const intentLink = intentData.links.find(l => l.id === item.linkId);
+            if (intentLink) {
+              intentLink.intent_type = intentResult.intent_type;
+              intentLink.intent_confidence = intentResult.confidence;
+              intentLink.intent_metadata = intentResult.extracted_metadata;
+              intentLink.intent_classified_at = new Date().toISOString();
+              save(intentData);
+              syncLinkToSupabase(intentLink);
+              renderGrid();
+              console.log('%c[INTENT] Applied:', 'color: #e67e22; font-weight: bold', intentResult.intent_type);
+            }
+          }
+
+          // Step 1.5b: Fire hypothesis (Pass 2) — fire-and-forget
+          fireIntentHypothesis(currentLinkForIntent, currentDataForIntent.links);
         }
       }
 
@@ -14164,7 +14619,12 @@ Return JSON:
         // User-generated content
         notes: link.notes || null,
         // Unified tags (computed from scattered genre/sub-category/content-type fields)
-        tags: link.tags || computeLinkTags(link)
+        tags: link.tags || computeLinkTags(link),
+        // Intent classification
+        intent_type: link.intent_type || null,
+        intent_confidence: link.intent_confidence || null,
+        intent_metadata: link.intent_metadata || null,
+        intent_classified_at: link.intent_classified_at || null
       };
       const res = await fetch(`${SUPABASE_URL}/rest/v1/links`, {
         method: 'POST',
@@ -14383,7 +14843,12 @@ Return JSON:
         // User-generated content
         notes: l.notes || null,
         // Unified tags
-        tags: l.tags || []
+        tags: l.tags || [],
+        // Intent classification
+        intent_type: l.intent_type || null,
+        intent_confidence: l.intent_confidence || null,
+        intent_metadata: l.intent_metadata || null,
+        intent_classified_at: l.intent_classified_at || null
       }));
 
       const categories = { uncategorized: { pinned: true } };
@@ -16035,6 +16500,105 @@ Return JSON:
     } catch {}
   }
 
+  // ============================================
+  // Intent Registry — drives intent action cards on pins
+  // Add a new entry here to support a new intent type
+  // ============================================
+  const INTENT_CONFIDENCE_THRESHOLD = 0.75;
+
+  const INTENT_REGISTRY = {
+    commerce: {
+      id: 'commerce',
+      label: 'Product',
+      renderActions(link, meta) {
+        const price = meta?.price ? `<span class="grid-item__intent-price">${esc(meta.currency || '$')}${esc(String(meta.price))}</span> ` : '';
+        return `${price}<button class="grid-item__action grid-item__action--intent" data-action="intent:commerce:buy" data-id="${link.id}">View Product</button>` +
+          `<button class="grid-item__action grid-item__action--intent-secondary" data-action="intent:commerce:save" data-id="${link.id}">Save</button>`;
+      },
+      handleAction(action, link) {
+        if (action === 'buy') {
+          openCommerceModal(link);
+        } else if (action === 'save') {
+          saveToCart(link, 'saved');
+          toast('Saved for later');
+        }
+      }
+    },
+    ai_tool: {
+      id: 'ai_tool',
+      label: 'AI Tool',
+      renderActions(link, meta) {
+        let html = `<button class="grid-item__action grid-item__action--intent" data-action="intent:ai_tool:plan" data-id="${link.id}">Integration Plan</button>`;
+        if (meta?.docs_url) {
+          html += `<button class="grid-item__action grid-item__action--intent-secondary" data-action="intent:ai_tool:docs" data-id="${link.id}">Docs</button>`;
+        }
+        return html;
+      },
+      handleAction(action, link) {
+        if (action === 'plan') {
+          streamIntentPlan(link);
+        } else if (action === 'docs') {
+          const docsUrl = link.intent_metadata?.docs_url;
+          if (docsUrl) window.open(docsUrl, '_blank', 'noopener');
+        }
+      }
+    },
+    // V2 stubs
+    recipe: { id: 'recipe', label: 'Recipe', renderActions() { return ''; }, handleAction() {} },
+    design_inspiration: { id: 'design_inspiration', label: 'Design', renderActions() { return ''; }, handleAction() {} },
+    article: { id: 'article', label: 'Article', renderActions() { return ''; }, handleAction() {} },
+    person: { id: 'person', label: 'Person', renderActions() { return ''; }, handleAction() {} },
+    event: { id: 'event', label: 'Event', renderActions() { return ''; }, handleAction() {} },
+  };
+
+  // Commerce modal helpers
+  let _commerceModalLink = null;
+
+  function openCommerceModal(link) {
+    _commerceModalLink = link;
+    const meta = link.intent_metadata || {};
+    const modal = $('commerceModal');
+    const img = $('commerceModalImage');
+    const name = $('commerceModalName');
+    const price = $('commerceModalPrice');
+
+    name.textContent = meta.product_name || link.title || '';
+    price.textContent = meta.price ? `${meta.currency || '$'}${meta.price}` : 'See site for price';
+    img.src = link.image || '';
+    img.style.display = link.image ? '' : 'none';
+    modal.hidden = false;
+  }
+
+  function closeCommerceModal() {
+    $('commerceModal').hidden = true;
+    _commerceModalLink = null;
+  }
+
+  // Cart state (localStorage)
+  function getCart() {
+    try { return JSON.parse(localStorage.getItem('ctrl_rodeo_cart') || '[]'); } catch { return []; }
+  }
+
+  function saveToCart(link, status) {
+    const cart = getCart();
+    const meta = link.intent_metadata || {};
+    const existing = cart.findIndex(c => c.linkId === link.id);
+    const item = {
+      linkId: link.id,
+      url: link.url,
+      product_name: meta.product_name || link.title,
+      price: meta.price || null,
+      currency: meta.currency || null,
+      image: link.image || null,
+      retailer: meta.retailer || link.domain,
+      status: status || 'saved',
+      savedAt: new Date().toISOString()
+    };
+    if (existing >= 0) cart[existing] = item;
+    else cart.push(item);
+    localStorage.setItem('ctrl_rodeo_cart', JSON.stringify(cart));
+  }
+
   // Get first prompt dimension tag for card overlay display
   function getPromptSubTag(link) {
     const dims = loadPromptDimensions(link.category);
@@ -16504,6 +17068,13 @@ Return JSON:
       const hasRecipe = l.recipe && (l.recipe.ingredients?.length || l.recipe.instructions?.length);
       if (hasRecipe) {
         richActionsHtml += `<button class="grid-item__action" data-action="view-recipe">Recipe</button>`;
+      }
+
+      // Intent action cards (commerce, ai_tool, etc.)
+      if (l.intent_type && l.intent_confidence >= INTENT_CONFIDENCE_THRESHOLD && INTENT_REGISTRY[l.intent_type] && !l.loading) {
+        const intentReg = INTENT_REGISTRY[l.intent_type];
+        const intentHtml = intentReg.renderActions(l, l.intent_metadata);
+        if (intentHtml) richActionsHtml += intentHtml;
       }
 
       // Truncate summary to ~60 words for display
@@ -18451,6 +19022,15 @@ Return JSON:
           openRecipeDrawer(link);
         }
         return;
+      } else if (actionType && actionType.startsWith('intent:')) {
+        // Intent action dispatch: intent:{type}:{action}
+        const [, intentType, intentAction] = actionType.split(':');
+        const link = getAllLinks().find(l => l.id === id);
+        const reg = INTENT_REGISTRY[intentType];
+        if (link && reg) {
+          reg.handleAction(intentAction, link);
+        }
+        return;
       } else if (actionType === 'visit-imdb' || actionType === 'visit-wiki' || actionType === 'visit-ext') {
         // Let the <a> tag handle navigation, just stop propagation
         return;
@@ -19463,7 +20043,7 @@ Return JSON:
     if (m._trapHandler) { m.removeEventListener('keydown', m._trapHandler); m._trapHandler = null; }
     if (m._previousFocus) { m._previousFocus.focus(); m._previousFocus = null; }
   }
-  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal, createBoardModal].forEach(closeModal); closeRecipeDrawer(); }
+  function closeAll() { [addModal, scanModal, toolsModal, overlay, categoryModal, contentTypeModal, organizeModal, mergeModal, confirmModal, adminModal, widgetPrdModal, igReviewModal, createBoardModal].forEach(closeModal); closeRecipeDrawer(); closeCommerceModal(); $('terminalModal').hidden = true; }
 
   // ============================================
   // Recipe Drawer
@@ -19734,6 +20314,41 @@ Return JSON:
   document.addEventListener('keydown', function(e) {
     if (e.key === 'Escape' && !recipeDrawer.hasAttribute('hidden')) {
       closeRecipeDrawer();
+    }
+  });
+
+  // Commerce Modal event wiring
+  $('commerceModalClose').onclick = closeCommerceModal;
+  $('commerceModalBackdrop').onclick = closeCommerceModal;
+  $('commerceModalBuy').onclick = function() {
+    if (_commerceModalLink) {
+      window.open(_commerceModalLink.url, '_blank', 'noopener');
+      saveToCart(_commerceModalLink, 'visited');
+    }
+    closeCommerceModal();
+  };
+  $('commerceModalSave').onclick = function() {
+    if (_commerceModalLink) {
+      saveToCart(_commerceModalLink, 'saved');
+      toast('Saved for later');
+    }
+    closeCommerceModal();
+  };
+
+  // Terminal Modal event wiring
+  $('terminalModalClose').onclick = function() { $('terminalModal').hidden = true; };
+  $('terminalModalBackdrop').onclick = function() { $('terminalModal').hidden = true; };
+  $('terminalModalAbort').onclick = function() {
+    if (_intentPlanAbortController) _intentPlanAbortController.abort();
+  };
+  $('terminalModalCopy').onclick = function() {
+    const text = $('terminalModalOutput').textContent;
+    navigator.clipboard.writeText(text).then(() => toast('Copied')).catch(() => {});
+  };
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') {
+      if (!$('commerceModal').hidden) closeCommerceModal();
+      if (!$('terminalModal').hidden) $('terminalModal').hidden = true;
     }
   });
 

--- a/supabase/functions/classify-intent/index.ts
+++ b/supabase/functions/classify-intent/index.ts
@@ -1,0 +1,621 @@
+// Supabase Edge Function: classify-intent
+// Intent classification for pins — two-pass system:
+//   Pass 1 (classify): Fast signal-based → LLM fallback classification
+//   Pass 2 (hypothesize): Async pattern-level hypothesis generation
+//
+// POST /functions/v1/classify-intent
+// Body: { action: 'classify' | 'hypothesize', ...params }
+
+const VERSION = '1.0.0'
+console.log(`[classify-intent] v${VERSION} — intent classification pipeline`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+// --- Configuration ---
+
+const INTENT_CONFIDENCE_THRESHOLD = 0.75
+const LLM_TIMEOUT_MS = 5000
+const CLASSIFY_MODEL = 'claude-sonnet-4-20250514'
+const HYPOTHESIZE_MODEL = 'claude-sonnet-4-20250514'
+
+// Known commerce domains (partial match on domain)
+const COMMERCE_DOMAINS = new Set([
+  'amazon.com', 'amazon.co.uk', 'amazon.de', 'amazon.ca',
+  'etsy.com', 'ebay.com', 'walmart.com', 'target.com',
+  'bestbuy.com', 'nordstrom.com', 'nike.com', 'adidas.com',
+  'zara.com', 'hm.com', 'uniqlo.com', 'asos.com',
+  'net-a-porter.com', 'mrporter.com', 'ssense.com', 'farfetch.com',
+  'shopbop.com', 'revolve.com', 'aesop.com', 'glossier.com',
+  'sephora.com', 'ulta.com', 'wayfair.com', 'ikea.com',
+  'anthropologie.com', 'freepeople.com', 'urbanoutfitters.com',
+  'endclothing.com', 'matchesfashion.com', 'mytheresa.com',
+])
+
+// AI/dev tool signals in practical_tags
+const AI_TOOL_TAGS = new Set([
+  'ai', 'machine-learning', 'llm', 'api', 'developer-tool',
+  'devtool', 'saas', 'automation', 'no-code', 'low-code',
+  'coding', 'ide', 'framework', 'sdk', 'cli',
+])
+
+// --- Types ---
+
+interface ClassifyRequest {
+  action: 'classify'
+  url: string
+  title: string
+  description: string
+  domain: string
+  content_type: string
+  practical_tags: string[]
+  taste_tags: string[]
+  entities: Array<{ name: string; type: string }>
+  og_type?: string
+  og_price_amount?: string
+  og_price_currency?: string
+  structured_data_types?: string[]
+  source?: string
+  userId: string
+  linkId: string
+}
+
+interface HypothesizeRequest {
+  action: 'hypothesize'
+  userId: string
+  linkId: string
+  current_pin: {
+    url: string
+    title: string
+    domain: string
+    content_type: string
+    practical_tags: string[]
+    intent_type?: string
+  }
+  recent_pins: Array<{
+    id: string
+    title: string
+    domain: string
+    content_type: string
+    intent_type?: string
+    action_state?: string
+  }>
+}
+
+interface IntentResult {
+  intent_type: string
+  confidence: number
+  extracted_metadata: Record<string, unknown>
+  reasoning: string
+}
+
+// --- Tier 1: Rules-based classification ---
+
+function classifyByRules(req: ClassifyRequest): IntentResult | null {
+  // Commerce signals
+  const isProductOG = req.og_type === 'product'
+  const hasPrice = !!(req.og_price_amount && parseFloat(req.og_price_amount) > 0)
+  const hasProductSchema = req.structured_data_types?.includes('Product') || false
+  const isCommerceDomain = COMMERCE_DOMAINS.has(req.domain) ||
+    // Shopify stores: check for myshopify.com or common Shopify patterns
+    req.domain.endsWith('.myshopify.com')
+
+  if (isProductOG || hasProductSchema) {
+    const metadata: Record<string, unknown> = {
+      product_name: req.title,
+      retailer: req.domain,
+    }
+    if (hasPrice) {
+      metadata.price = req.og_price_amount
+      metadata.currency = req.og_price_currency || 'USD'
+    }
+    return {
+      intent_type: 'commerce',
+      confidence: 0.95,
+      extracted_metadata: metadata,
+      reasoning: `OG type=${req.og_type}, schema types=${req.structured_data_types?.join(',')}, price=${hasPrice}`,
+    }
+  }
+
+  if (isCommerceDomain && hasPrice) {
+    return {
+      intent_type: 'commerce',
+      confidence: 0.90,
+      extracted_metadata: {
+        product_name: req.title,
+        price: req.og_price_amount,
+        currency: req.og_price_currency || 'USD',
+        retailer: req.domain,
+      },
+      reasoning: `Known commerce domain ${req.domain} with price signal`,
+    }
+  }
+
+  if (isCommerceDomain) {
+    return {
+      intent_type: 'commerce',
+      confidence: 0.80,
+      extracted_metadata: {
+        product_name: req.title,
+        retailer: req.domain,
+      },
+      reasoning: `Known commerce domain ${req.domain} (no price found)`,
+    }
+  }
+
+  // AI Tool signals
+  const isToolType = req.content_type === 'tool' || req.content_type === 'repository'
+  const hasAITags = req.practical_tags?.some(t => AI_TOOL_TAGS.has(t.toLowerCase())) || false
+  const hasDocsSubdomain = req.url.includes('/docs') || req.url.includes('docs.')
+  const hasAIEntity = req.entities?.some(e =>
+    e.type === 'tool' || e.name.toLowerCase().includes('ai')
+  ) || false
+
+  if (isToolType && hasAITags) {
+    // Extract docs URL heuristic
+    const urlObj = new URL(req.url)
+    const docsUrl = hasDocsSubdomain ? req.url :
+      `https://docs.${urlObj.hostname}` // best guess
+
+    return {
+      intent_type: 'ai_tool',
+      confidence: 0.85,
+      extracted_metadata: {
+        tool_name: req.entities?.find(e => e.type === 'tool')?.name || req.title,
+        tagline: req.description?.slice(0, 120) || '',
+        docs_url: hasDocsSubdomain ? req.url : null,
+        github_url: req.url.includes('github.com') ? req.url : null,
+        category: req.practical_tags?.find(t => AI_TOOL_TAGS.has(t.toLowerCase())) || 'ai',
+      },
+      reasoning: `Content type=${req.content_type}, AI tags=${req.practical_tags?.filter(t => AI_TOOL_TAGS.has(t.toLowerCase())).join(',')}`,
+    }
+  }
+
+  if (isToolType && hasAIEntity) {
+    return {
+      intent_type: 'ai_tool',
+      confidence: 0.78,
+      extracted_metadata: {
+        tool_name: req.entities?.find(e => e.type === 'tool')?.name || req.title,
+        tagline: req.description?.slice(0, 120) || '',
+        docs_url: null,
+        github_url: req.url.includes('github.com') ? req.url : null,
+        category: 'tool',
+      },
+      reasoning: `Content type=${req.content_type} with AI entity detected`,
+    }
+  }
+
+  // V2 stubs — return with confidence so they're logged but below threshold
+  if (req.content_type === 'recipe') {
+    return {
+      intent_type: 'recipe',
+      confidence: 0.60, // Below threshold — V2
+      extracted_metadata: { recipe_name: req.title },
+      reasoning: 'Recipe content type detected (V2 stub)',
+    }
+  }
+
+  if (req.content_type === 'event') {
+    return {
+      intent_type: 'event',
+      confidence: 0.60, // Below threshold — V2
+      extracted_metadata: { event_name: req.title },
+      reasoning: 'Event content type detected (V2 stub)',
+    }
+  }
+
+  return null
+}
+
+// --- Tier 2: LLM classification ---
+
+async function classifyByLLM(req: ClassifyRequest): Promise<IntentResult | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.error('[classify-intent] ANTHROPIC_API_KEY not configured')
+    return null
+  }
+
+  const prompt = `Analyze this pinned URL and determine the user's likely intent.
+
+URL: ${req.url}
+Title: ${req.title}
+Description: ${req.description?.slice(0, 500) || 'none'}
+Domain: ${req.domain}
+Content type: ${req.content_type}
+Tags: ${req.practical_tags?.join(', ') || 'none'}
+Entities: ${req.entities?.map(e => `${e.name} (${e.type})`).join(', ') || 'none'}
+OG type: ${req.og_type || 'none'}
+Price: ${req.og_price_amount ? `${req.og_price_amount} ${req.og_price_currency || ''}` : 'none'}
+Structured data types: ${req.structured_data_types?.join(', ') || 'none'}
+Source: ${req.source || 'direct'}
+
+Classify the intent. Be confident or return "none" — a wrong classification is worse than no classification.`
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS)
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: CLASSIFY_MODEL,
+        max_tokens: 256,
+        tools: [
+          {
+            name: 'classify_intent',
+            description: 'Classify the intent behind a pinned URL',
+            input_schema: {
+              type: 'object',
+              properties: {
+                intent_type: {
+                  type: 'string',
+                  enum: ['commerce', 'ai_tool', 'recipe', 'design_inspiration', 'article', 'person', 'event', 'none'],
+                  description: 'The detected intent type, or "none" if uncertain',
+                },
+                confidence: {
+                  type: 'number',
+                  description: 'Confidence score 0.0-1.0. Must be above 0.75 to surface actions.',
+                },
+                extracted_metadata: {
+                  type: 'object',
+                  description: 'Intent-specific metadata extracted from the URL context',
+                  properties: {
+                    product_name: { type: 'string' },
+                    price: { type: 'string' },
+                    currency: { type: 'string' },
+                    retailer: { type: 'string' },
+                    tool_name: { type: 'string' },
+                    tagline: { type: 'string' },
+                    pricing_model: { type: 'string' },
+                    docs_url: { type: 'string' },
+                    github_url: { type: 'string' },
+                    category: { type: 'string' },
+                  },
+                },
+                reasoning: {
+                  type: 'string',
+                  description: 'Brief explanation of why this intent was chosen',
+                },
+              },
+              required: ['intent_type', 'confidence', 'extracted_metadata', 'reasoning'],
+            },
+          },
+        ],
+        tool_choice: { type: 'tool', name: 'classify_intent' },
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const errText = await response.text()
+      console.error('[classify-intent] Claude API error:', response.status, errText)
+      return null
+    }
+
+    const aiResponse = await response.json()
+    const toolUse = aiResponse.content?.find(
+      (block: { type: string }) => block.type === 'tool_use'
+    )
+
+    if (!toolUse?.input) {
+      console.error('[classify-intent] No tool_use in response')
+      return null
+    }
+
+    return toolUse.input as IntentResult
+  } catch (err) {
+    clearTimeout(timeout)
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      console.warn('[classify-intent] LLM classification timed out')
+    } else {
+      console.error('[classify-intent] LLM error:', err)
+    }
+    return null
+  }
+}
+
+// --- Pass 1: Classify ---
+
+async function handleClassify(req: ClassifyRequest): Promise<Response> {
+  const startTime = Date.now()
+
+  // Tier 1: Rules
+  const rulesResult = classifyByRules(req)
+
+  let result: IntentResult
+  if (rulesResult && rulesResult.confidence >= INTENT_CONFIDENCE_THRESHOLD) {
+    result = rulesResult
+    console.log(`[classify-intent] Tier 1 hit: ${result.intent_type} @ ${result.confidence} (${Date.now() - startTime}ms)`)
+  } else {
+    // Tier 2: LLM (only if rules didn't confidently match)
+    console.log(`[classify-intent] Tier 1 ${rulesResult ? `low confidence (${rulesResult.confidence})` : 'no match'}, falling back to LLM`)
+    const llmResult = await classifyByLLM(req)
+
+    if (llmResult && llmResult.confidence >= INTENT_CONFIDENCE_THRESHOLD) {
+      result = llmResult
+      console.log(`[classify-intent] Tier 2 hit: ${result.intent_type} @ ${result.confidence} (${Date.now() - startTime}ms)`)
+    } else {
+      // Below threshold — return none
+      result = {
+        intent_type: 'none',
+        confidence: llmResult?.confidence || rulesResult?.confidence || 0,
+        extracted_metadata: {},
+        reasoning: llmResult?.reasoning || rulesResult?.reasoning || 'No confident match',
+      }
+      console.log(`[classify-intent] Below threshold: ${llmResult?.intent_type || rulesResult?.intent_type || 'none'} @ ${result.confidence} (${Date.now() - startTime}ms)`)
+    }
+  }
+
+  // Write to DB if we have a positive classification
+  if (result.intent_type !== 'none' && req.userId && req.linkId) {
+    try {
+      const supabase = createClient(
+        Deno.env.get('SUPABASE_URL')!,
+        Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+      )
+
+      await supabase
+        .from('links')
+        .update({
+          intent_type: result.intent_type,
+          intent_confidence: result.confidence,
+          intent_metadata: result.extracted_metadata,
+          intent_classified_at: new Date().toISOString(),
+        })
+        .eq('id', req.linkId)
+        .eq('user_id', req.userId)
+
+      console.log(`[classify-intent] Saved ${result.intent_type} to link ${req.linkId}`)
+    } catch (err) {
+      console.error('[classify-intent] DB write error:', err)
+      // Non-fatal — return result anyway
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      ...result,
+      meta: { elapsed: Date.now() - startTime, version: VERSION, tier: rulesResult && rulesResult.confidence >= INTENT_CONFIDENCE_THRESHOLD ? 1 : 2 },
+    }),
+    { headers: jsonHeaders }
+  )
+}
+
+// --- Pass 2: Hypothesize ---
+
+async function handleHypothesize(req: HypothesizeRequest): Promise<Response> {
+  const startTime = Date.now()
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured' }),
+      { status: 500, headers: jsonHeaders }
+    )
+  }
+
+  if (req.recent_pins.length < 10) {
+    return new Response(
+      JSON.stringify({ skipped: true, reason: 'Insufficient pin history (need 10+)' }),
+      { headers: jsonHeaders }
+    )
+  }
+
+  const pinList = req.recent_pins
+    .slice(0, 50)
+    .map((p, i) => `${i + 1}. ${p.title} (${p.domain}) — type: ${p.content_type}, intent: ${p.intent_type || 'none'}, action: ${p.action_state || 'none'}`)
+    .join('\n')
+
+  const actionsSummary = req.recent_pins
+    .filter(p => p.action_state && p.action_state !== 'unprocessed')
+    .map(p => `- ${p.title}: ${p.action_state}`)
+    .join('\n') || 'No actions taken yet'
+
+  const prompt = `You are analyzing a user's browsing and saving patterns to surface non-obvious connections and opportunities.
+
+Current pin: ${req.current_pin.url} — ${req.current_pin.title}
+Content type: ${req.current_pin.content_type}
+Tags: ${req.current_pin.practical_tags?.join(', ') || 'none'}
+
+Recent activity (last ${req.recent_pins.length} pins, newest first):
+${pinList}
+
+Actions already taken:
+${actionsSummary}
+
+Generate 1-3 hypotheses about what the user might be trying to accomplish, discover, or build — going beyond what's explicit. These are pattern-level observations, not predictions for this single pin.`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: HYPOTHESIZE_MODEL,
+        max_tokens: 512,
+        tools: [
+          {
+            name: 'hypothesize_intent',
+            description: 'Generate hypotheses about user intent patterns',
+            input_schema: {
+              type: 'object',
+              properties: {
+                hypotheses: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      label: { type: 'string', description: 'Short hypothesis label' },
+                      confidence: { type: 'number', description: '0.0-1.0' },
+                      supporting_pin_ids: { type: 'array', items: { type: 'string' } },
+                      suggested_action: { type: 'string', description: 'What action might help' },
+                      reasoning: { type: 'string', description: 'Why this hypothesis' },
+                    },
+                    required: ['label', 'confidence', 'suggested_action', 'reasoning'],
+                  },
+                },
+              },
+              required: ['hypotheses'],
+            },
+          },
+        ],
+        tool_choice: { type: 'tool', name: 'hypothesize_intent' },
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!response.ok) {
+      const errText = await response.text()
+      console.error('[classify-intent:hypothesize] Claude API error:', response.status, errText)
+      await logHypothesisGap(req.userId, req.linkId, req.recent_pins.length, 'api_error', req.current_pin.practical_tags)
+      return new Response(
+        JSON.stringify({ error: 'Hypothesis generation failed' }),
+        { status: 200, headers: jsonHeaders } // 200 so client doesn't retry
+      )
+    }
+
+    const aiResponse = await response.json()
+    const toolUse = aiResponse.content?.find(
+      (block: { type: string }) => block.type === 'tool_use'
+    )
+
+    if (!toolUse?.input?.hypotheses) {
+      await logHypothesisGap(req.userId, req.linkId, req.recent_pins.length, 'no_output', req.current_pin.practical_tags)
+      return new Response(
+        JSON.stringify({ hypotheses: [], reason: 'No hypotheses generated' }),
+        { headers: jsonHeaders }
+      )
+    }
+
+    const hypotheses = toolUse.input.hypotheses
+    const topConfidence = Math.max(...hypotheses.map((h: { confidence: number }) => h.confidence), 0)
+
+    // Log gap if all hypotheses are low confidence
+    if (topConfidence < 0.5) {
+      await logHypothesisGap(req.userId, req.linkId, req.recent_pins.length, 'low_confidence', req.current_pin.practical_tags)
+    }
+
+    // Save to intent_hypotheses
+    try {
+      const supabase = createClient(
+        Deno.env.get('SUPABASE_URL')!,
+        Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+      )
+
+      await supabase
+        .from('intent_hypotheses')
+        .insert({
+          user_id: req.userId,
+          trigger_pin_id: req.linkId,
+          hypotheses: hypotheses,
+          confidence: topConfidence,
+          model_version: HYPOTHESIZE_MODEL,
+          expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days
+        })
+
+      console.log(`[classify-intent:hypothesize] Saved ${hypotheses.length} hypotheses for user ${req.userId.slice(0, 8)}`)
+    } catch (err) {
+      console.error('[classify-intent:hypothesize] DB write error:', err)
+    }
+
+    return new Response(
+      JSON.stringify({
+        hypotheses,
+        meta: { elapsed: Date.now() - startTime, version: VERSION, model: HYPOTHESIZE_MODEL },
+      }),
+      { headers: jsonHeaders }
+    )
+  } catch (err) {
+    console.error('[classify-intent:hypothesize] Error:', err)
+    await logHypothesisGap(req.userId, req.linkId, req.recent_pins.length, 'api_error', req.current_pin.practical_tags)
+    return new Response(
+      JSON.stringify({ error: 'Hypothesis generation failed' }),
+      { status: 200, headers: jsonHeaders }
+    )
+  }
+}
+
+async function logHypothesisGap(
+  userId: string,
+  triggerPinId: string,
+  pinCount: number,
+  reason: string,
+  topTags: string[]
+): Promise<void> {
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    await supabase
+      .from('intent_hypothesis_gaps')
+      .insert({
+        user_id: userId,
+        trigger_pin_id: triggerPinId,
+        pin_count_at_call: pinCount,
+        reason,
+        top_tags: topTags?.slice(0, 10) || [],
+      })
+  } catch (err) {
+    console.error('[classify-intent] Gap log failed:', err)
+  }
+}
+
+// --- Main handler ---
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const body = await req.json()
+    const { action } = body
+
+    if (action === 'health') {
+      return new Response(
+        JSON.stringify({ status: 'ok', version: VERSION }),
+        { headers: jsonHeaders }
+      )
+    }
+
+    if (action === 'classify') {
+      return await handleClassify(body as ClassifyRequest)
+    }
+
+    if (action === 'hypothesize') {
+      return await handleHypothesize(body as HypothesizeRequest)
+    }
+
+    return new Response(
+      JSON.stringify({ error: `Unknown action: ${action}` }),
+      { status: 400, headers: jsonHeaders }
+    )
+  } catch (err) {
+    console.error('[classify-intent] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal error', detail: String(err) }),
+      { status: 500, headers: jsonHeaders }
+    )
+  }
+})

--- a/supabase/functions/generate-intent-plan/index.ts
+++ b/supabase/functions/generate-intent-plan/index.ts
@@ -1,0 +1,136 @@
+// Supabase Edge Function: generate-intent-plan
+// Streams a Claude-generated integration plan for AI tools.
+// This is the only streaming function in the codebase.
+//
+// POST /functions/v1/generate-intent-plan
+// Body: { tool_name, tagline, url, domain, docs_url, practical_tags, entities, recent_pins }
+
+const VERSION = '1.0.0'
+console.log(`[generate-intent-plan] v${VERSION} — streaming integration plan generator`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+interface PlanRequest {
+  tool_name: string
+  tagline?: string
+  url: string
+  domain: string
+  docs_url?: string
+  github_url?: string
+  practical_tags?: string[]
+  entities?: Array<{ name: string; type: string }>
+  recent_pins?: Array<{ title: string; domain: string; content_type: string }>
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+
+  try {
+    const body: PlanRequest = await req.json()
+
+    if (!body.tool_name || !body.url) {
+      return new Response(
+        JSON.stringify({ error: 'tool_name and url are required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Build context from recent pins for personalization
+    const recentContext = body.recent_pins?.length
+      ? `\n\nRecent tools/projects in the user's collection:\n${body.recent_pins
+          .slice(0, 10)
+          .map(p => `- ${p.title} (${p.domain})`)
+          .join('\n')}`
+      : ''
+
+    const prompt = `You are a senior software architect. Generate a concrete integration plan for the following AI tool.
+
+**Tool:** ${body.tool_name}
+**URL:** ${body.url}
+**Description:** ${body.tagline || 'No description available'}
+**Domain:** ${body.domain}
+${body.docs_url ? `**Docs:** ${body.docs_url}` : ''}
+${body.github_url ? `**GitHub:** ${body.github_url}` : ''}
+${body.practical_tags?.length ? `**Tags:** ${body.practical_tags.join(', ')}` : ''}
+${body.entities?.length ? `**Related:** ${body.entities.map(e => e.name).join(', ')}` : ''}
+${recentContext}
+
+Generate a structured integration plan with these sections:
+
+## Overview
+One paragraph: what this tool does and why it's worth integrating.
+
+## Setup Steps
+Numbered steps to get started (install, auth, config).
+
+## API Approach
+How to integrate: key endpoints/methods, auth pattern, data format.
+
+## Architecture Fit
+How this fits into a web application: where it runs (client/server/edge), data flow, and dependencies.
+
+## Estimated Effort
+Time estimate and complexity rating (low/medium/high).
+
+## Risks & Gotchas
+Known limitations, pricing concerns, or compatibility issues.
+
+Be specific and actionable. Use code snippets where helpful (shell commands, config examples). Keep it under 800 words.`
+
+    // Stream from Anthropic
+    const anthropicResponse = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 2048,
+        stream: true,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!anthropicResponse.ok) {
+      const errText = await anthropicResponse.text()
+      console.error('[generate-intent-plan] Claude API error:', anthropicResponse.status, errText)
+      return new Response(
+        JSON.stringify({ error: 'Plan generation failed', detail: errText }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Forward SSE stream to client
+    return new Response(anthropicResponse.body, {
+      headers: {
+        ...corsHeaders,
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        'X-Accel-Buffering': 'no',
+      },
+    })
+  } catch (err) {
+    console.error('[generate-intent-plan] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal error', detail: String(err) }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})

--- a/supabase/migrations/039_intent_classification.sql
+++ b/supabase/migrations/039_intent_classification.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- 039_intent_classification.sql
+-- Intent classification columns on links table
+-- Stores the result of classify-intent (Pass 1) directly on
+-- the pin for fast rendering without extra joins.
+-- All additive — no existing columns modified.
+-- ============================================================
+
+ALTER TABLE links ADD COLUMN IF NOT EXISTS intent_type TEXT;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS intent_confidence REAL;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS intent_metadata JSONB;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS intent_classified_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_links_intent_type ON links(user_id, intent_type)
+  WHERE intent_type IS NOT NULL;

--- a/supabase/migrations/040_pin_intent_actions.sql
+++ b/supabase/migrations/040_pin_intent_actions.sql
@@ -1,0 +1,12 @@
+-- ============================================================
+-- 040_pin_intent_actions.sql
+-- Action tracking columns on pin_intent table
+-- Captures when users act on or dismiss intent suggestions.
+-- Feeds into the feedback loop for classifier improvement.
+-- All additive — no existing columns modified.
+-- ============================================================
+
+ALTER TABLE pin_intent ADD COLUMN IF NOT EXISTS acted_at TIMESTAMPTZ;
+ALTER TABLE pin_intent ADD COLUMN IF NOT EXISTS action_type TEXT;
+ALTER TABLE pin_intent ADD COLUMN IF NOT EXISTS dismissed_at TIMESTAMPTZ;
+ALTER TABLE pin_intent ADD COLUMN IF NOT EXISTS dismiss_reason TEXT;

--- a/supabase/migrations/041_intent_hypotheses.sql
+++ b/supabase/migrations/041_intent_hypotheses.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- 041_intent_hypotheses.sql
+-- Hypothesis engine (Pass 2) output storage.
+-- Stores pattern-level hypotheses about user intent across
+-- multiple pins. V1: logged only, not surfaced in UI.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS intent_hypotheses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  trigger_pin_id TEXT REFERENCES links(id) ON DELETE SET NULL,
+  hypotheses JSONB NOT NULL DEFAULT '[]',
+  confidence REAL,
+  model_version TEXT,
+  generated_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ,
+  acted_at TIMESTAMPTZ,
+  action_type TEXT,
+  dismissed_at TIMESTAMPTZ,
+  dismiss_reason TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_intent_hypotheses_user
+  ON intent_hypotheses(user_id, generated_at DESC);
+
+ALTER TABLE intent_hypotheses ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY intent_hypotheses_user
+  ON intent_hypotheses FOR ALL USING (auth.uid() = user_id);

--- a/supabase/migrations/042_intent_hypothesis_gaps.sql
+++ b/supabase/migrations/042_intent_hypothesis_gaps.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- 042_intent_hypothesis_gaps.sql
+-- Gap logging for the hypothesis engine.
+-- Records when Pass 2 fails or returns low confidence,
+-- building training signal for future model improvement.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS intent_hypothesis_gaps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  trigger_pin_id TEXT,
+  pin_count_at_call INTEGER,
+  reason TEXT,
+  top_tags TEXT[],
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_intent_gaps_user
+  ON intent_hypothesis_gaps(user_id, created_at DESC);
+
+ALTER TABLE intent_hypothesis_gaps ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY intent_hypothesis_gaps_user
+  ON intent_hypothesis_gaps FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- **Intent classification pipeline**: New `classify-intent` edge function with 3-tier classification (rules → LLM via tool_use). Detects commerce and AI tool intents with 0.75 confidence threshold — confident or silent.
- **Commerce V1**: Product pages detected via OG type, JSON-LD, known retailer domains. Pin cards show price + "View Product" button. Modal pre-populated with product name, price, image. Cart state in localStorage.
- **AI Tool V1**: Dev tools detected via content_type + AI tags. Pin cards show "Integration Plan" button. First streaming response in the codebase — Claude generates structured plan in terminal-style viewer via SSE passthrough.
- **Hypothesis engine stub (Pass 2)**: Fire-and-forget pattern analysis across last 50 pins. Results logged to `intent_hypotheses` table for V2 personalization — not surfaced in UI yet.
- **Extensible architecture**: `INTENT_REGISTRY` config object mirrors `RICH_CONTENT` pattern. Adding a new intent = 3 changes (registry entry + classification rule + optional migration). V2 stubs for recipe, design inspiration, article, person, event.

## New files
| File | Purpose |
|------|---------|
| `supabase/functions/classify-intent/index.ts` | Pass 1 + Pass 2 intent classification |
| `supabase/functions/generate-intent-plan/index.ts` | Streaming AI tool integration plan |
| `supabase/migrations/039-042` | Intent columns on links, action tracking, hypotheses + gap tables |

## Test plan
- [ ] Pin a Nike/Amazon product URL → commerce action card appears with price within 2-3s
- [ ] Pin a Cursor AI or v0.dev URL → AI Tool action card appears, click "Integration Plan" → streaming terminal output
- [ ] Pin a generic article URL → NO action card (below threshold or `none`)
- [ ] Check `intent_type` column populated in Supabase `links` table
- [ ] Verify pin creation speed not degraded (Step 1.5 adds <3s, non-blocking)
- [ ] Deploy `classify-intent` and `generate-intent-plan` edge functions
- [ ] Run migrations 039-042

🤖 Generated with [Claude Code](https://claude.com/claude-code)