### PR TITLE
feat(events): server-side event scraper with auth

### DIFF
--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,7 +9,7 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.0.0'
+const VERSION = '1.1.0'
 console.log(`[scrape-events] v${VERSION} - server-side event scraper`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -408,6 +408,29 @@ function classifyError(msg: string): string {
   return 'unknown'
 }
 
+// --- Auth: service-role only ---
+
+function requireServiceRole(req: Request): Response | null {
+  const authHeader = req.headers.get('authorization')
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: jsonHeaders,
+    })
+  }
+
+  const token = authHeader.replace('Bearer ', '')
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+  if (!serviceKey || token !== serviceKey) {
+    return new Response(JSON.stringify({ error: 'Forbidden — service role key required' }), {
+      status: 403,
+      headers: jsonHeaders,
+    })
+  }
+
+  return null // auth passed
+}
+
 // --- Handler ---
 
 serve(async (req: Request) => {
@@ -421,6 +444,10 @@ serve(async (req: Request) => {
       headers: jsonHeaders,
     })
   }
+
+  // Require service role key for all actions
+  const authError = requireServiceRole(req)
+  if (authError) return authError
 
   try {
     const body = await req.json() as { action?: string; sourceId?: string }


### PR DESCRIPTION
## Summary
- **New `scrape-events` edge function** — centralized server-side scraper for all 20 stock event sources, replacing per-user client-side scraping
- **2-hour cron via GitHub Actions** — `scrape-events.yml` triggers `refresh-all` every 2h, with optional `workflow_dispatch` for single-source refresh
- **Service-role auth** — all endpoints require `Authorization: Bearer <service_role_key>`, returning 401/403 for missing/invalid tokens
- **Shadow mode** — runs alongside existing client-side scraping; SHA-256 dedup prevents duplicates
- **Observability** — `scrape_runs` table tracks per-run stats, `source_health` updated per-source

### Parsers ported (9 types, 20 sources)
html (19hz), ra (Resident Advisor GraphQL), screenslate (JSON API), garysguide (HTML), bonobo (Squarespace JSON), sfmoma (exhibitions + events), ical, json (WordPress), rss

### New files
- `supabase/functions/scrape-events/` — index.ts, sources.ts, parsers/*
- `supabase/migrations/039_scrape_runs.sql`
- `.github/workflows/scrape-events.yml`

## Test plan
- [x] Deployed and ran `refresh-all` — 18/20 sources succeeded, ~700+ events scraped
- [x] Verified SHA-256 dedup: re-scraping returns `eventsNew: 0`
- [x] Confirmed 401/403 responses for unauthenticated requests
- [x] GHA workflow uses correct service role key header

🤖 Generated with [Claude Code](https://claude.com/claude-code)