### PR TITLE
Skip username modal on calendar page

### DIFF
--- a/auth/ctrl-auth.js
+++ b/auth/ctrl-auth.js
@@ -48,6 +48,7 @@
      * @param {string} [config.redirectTo] - URL to return to after auth (default: current page)
      * @param {string[]} [config.adminEmails] - admin email addresses
      * @param {string} [config.mountTo] - CSS selector for mount point (default: 'body')
+     * @param {boolean} [config.skipUsername] - skip username onboarding modal (default: false)
      */
     init(config) {
       if (_initialized) return;
@@ -324,11 +325,16 @@
         updateBarUI();
         hideLoginModal();
         dispatch('ctrl:auth:signedin', { user: _currentUser, username: _currentUsername, session });
-      } else if (!_currentUsername) {
+      } else if (!_currentUsername && !_config.skipUsername) {
         // No username in DB and not already set — show onboarding
         updateBarUI();
         hideLoginModal();
         showUsernameModal();
+      } else if (!_currentUsername && _config.skipUsername) {
+        // Username not required — sign in without it
+        updateBarUI();
+        hideLoginModal();
+        dispatch('ctrl:auth:signedin', { user: _currentUser, username: null, session });
       }
 
       _wasSignedIn = true;

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -544,6 +544,7 @@ body {
       redirectTo: window.location.origin + '/calendar/',
       adminEmails: [ADMIN_EMAIL],
       mountTo: '#ctrl-auth-root',
+      skipUsername: true,
     });
 
     document.getElementById('authLoginBtn').addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- Adds `skipUsername` config option to `CtrlAuth.init()` — when `true`, skips the username onboarding modal and fires `signedin` event immediately
- Calendar page sets `skipUsername: true` since it doesn't need usernames

## Test plan
- [ ] Visit ctrl.rodeo/calendar/, sign in — should NOT show username modal
- [ ] Other apps (boards) still show username modal as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)