### PR TITLE
fix(events): add famsf/sfpl/commonwealth parsers, remove dead sources

### DIFF
--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,7 +9,7 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.1.0'
+const VERSION = '1.2.0'
 console.log(`[scrape-events] v${VERSION} - server-side event scraper`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -28,6 +28,9 @@ import { scrapeSFMOMA } from './parsers/sfmoma.ts'
 import { scrapeIcal } from './parsers/ical.ts'
 import { scrapeJson } from './parsers/json.ts'
 import { scrapeRss } from './parsers/rss.ts'
+import { scrapeFamsf } from './parsers/famsf.ts'
+import { scrapeSfpl } from './parsers/sfpl.ts'
+import { scrapeCommonwealth } from './parsers/commonwealth.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -70,6 +73,9 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'ical': return scrapeIcal(source)
     case 'json': return scrapeJson(source)
     case 'rss': return scrapeRss(source)
+    case 'famsf': return scrapeFamsf(source)
+    case 'sfpl': return scrapeSfpl(source)
+    case 'commonwealth': return scrapeCommonwealth(source)
     default:
       console.log(`[scrape-events] Unknown source type: ${source.type} for ${source.id}`)
       return []

--- a/supabase/functions/scrape-events/parsers/commonwealth.ts
+++ b/supabase/functions/scrape-events/parsers/commonwealth.ts
@@ -1,0 +1,67 @@
+// Commonwealth Club events parser
+// Server-rendered Drupal with node--type-event teaser cards
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate, resolveUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeCommonwealth(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url)
+  const doc = parseHtml(html)
+  if (!doc) return []
+
+  const events: ScrapedEvent[] = []
+  const nodes = doc.querySelectorAll('.node--type-event.node--view-mode-teaser')
+
+  nodes.forEach((node: any) => {
+    try {
+      // Title + URL
+      const titleLink = node.querySelector('.field--name-node-title h3 a')
+      if (!titleLink) return
+      const name = (titleLink.textContent || '').replace(/\s+/g, ' ').trim()
+      if (!name) return
+      const url = resolveUrl(titleLink.getAttribute('href') || '', source.url)
+
+      // Date + Time — "Thu, Mar 19 / 7:00 PM PDT"
+      const dateEl = node.querySelector('.field--name-field-event-date')
+      let date = ''
+      let time = ''
+      if (dateEl) {
+        const raw = (dateEl.textContent || '').replace(/\s+/g, ' ').trim()
+        const parsed = parseCommonwealthDate(raw)
+        date = parsed.date
+        time = parsed.time
+      }
+
+      // Venue/Region — "San Francisco", "San Rafael", etc.
+      const regionEl = node.querySelector('.field--name-field-region .field__item')
+      const venue = regionEl
+        ? 'Commonwealth Club — ' + (regionEl.textContent || '').replace(/\s+/g, ' ').trim()
+        : 'Commonwealth Club'
+
+      events.push({
+        source: source.id,
+        date,
+        time,
+        name,
+        venue,
+        city: 'San Francisco',
+        url,
+        contentType: 'literary',
+      })
+    } catch (_e) { /* skip broken node */ }
+  })
+
+  return events
+}
+
+/** Parse "Thu, Mar 19 / 7:00 PM PDT" or "Tue, Apr 1 / 12:00 PM PDT" */
+function parseCommonwealthDate(raw: string): { date: string; time: string } {
+  // Split on "/" separator
+  const slashIdx = raw.indexOf('/')
+  if (slashIdx !== -1) {
+    const datePart = raw.substring(0, slashIdx).trim()
+    const timePart = raw.substring(slashIdx + 1).replace(/[A-Z]{2,4}$/, '').trim() // strip timezone
+    return { date: parseFuzzyDate(datePart), time: timePart }
+  }
+  return { date: parseFuzzyDate(raw), time: '' }
+}

--- a/supabase/functions/scrape-events/parsers/famsf.ts
+++ b/supabase/functions/scrape-events/parsers/famsf.ts
@@ -1,0 +1,83 @@
+// FAMSF (de Young / Legion of Honor) calendar parser
+// Server-rendered Twill CMS with structured event cards
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate, resolveUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeFamsf(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url)
+  const doc = parseHtml(html)
+  if (!doc) return []
+
+  const events: ScrapedEvent[] = []
+  const cards = doc.querySelectorAll('div[data-behavior="BlockLink"]')
+
+  cards.forEach((card: any) => {
+    try {
+      // Title + URL
+      const titleLink = card.querySelector('h3 a[data-BlockLink-target], h3 a')
+      if (!titleLink) return
+      const name = (titleLink.textContent || '').replace(/\s+/g, ' ').trim()
+      if (!name) return
+      const url = resolveUrl(titleLink.getAttribute('href') || '', source.url)
+
+      // Date — <time datetime="YYYY-MM-DD"> or text fallback
+      const timeEl = card.querySelector('time[datetime]')
+      let date = ''
+      let time = ''
+
+      if (timeEl) {
+        date = timeEl.getAttribute('datetime') || ''
+        if (!date) date = parseFuzzyDate((timeEl.textContent || '').trim())
+
+        // Time is text after the backslash separator in the parent <p>
+        const parentP = timeEl.parentElement
+        if (parentP) {
+          const fullText = (parentP.textContent || '').trim()
+          const slashIdx = fullText.indexOf('\\')
+          if (slashIdx !== -1) {
+            time = fullText.substring(slashIdx + 1).trim()
+          }
+        }
+      } else {
+        // Recurring events — date is free text like "Tues–Sun \ Noon + 2 pm"
+        const dateP = card.querySelector('p.order-3, p.f-body-1')
+        if (dateP) {
+          const text = (dateP.textContent || '').replace(/\s+/g, ' ').trim()
+          const slashIdx = text.indexOf('\\')
+          if (slashIdx !== -1) {
+            date = parseFuzzyDate(text.substring(0, slashIdx).trim())
+            time = text.substring(slashIdx + 1).trim()
+          } else {
+            date = parseFuzzyDate(text)
+          }
+        }
+      }
+
+      // Venue — badge class indicates which museum
+      let venue = ''
+      const dyBadge = card.querySelector('span.border-dy, span.text-dy')
+      const lohBadge = card.querySelector('span.border-loh, span.text-loh')
+      if (dyBadge) venue = 'de Young'
+      else if (lohBadge) venue = 'Legion of Honor'
+      else {
+        // Fallback: read badge text
+        const badge = card.querySelector('div.order-1 span')
+        if (badge) venue = (badge.textContent || '').replace(/\s+/g, ' ').trim()
+      }
+
+      events.push({
+        source: source.id,
+        date,
+        time,
+        name,
+        venue: venue || 'FAMSF',
+        city: 'San Francisco',
+        url,
+        contentType: 'art',
+      })
+    } catch (_e) { /* skip broken card */ }
+  })
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/sfpl.ts
+++ b/supabase/functions/scrape-events/parsers/sfpl.ts
@@ -1,0 +1,73 @@
+// SF Public Library events parser
+// Server-rendered Drupal with article.event--teaser cards
+
+import { type ScrapedEvent, fetchUrl, parseHtml, parseFuzzyDate, resolveUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+export async function scrapeSfpl(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url, { timeoutMs: 20000 })
+  const doc = parseHtml(html)
+  if (!doc) return []
+
+  const events: ScrapedEvent[] = []
+  const articles = doc.querySelectorAll('article.event--teaser')
+
+  articles.forEach((article: any) => {
+    try {
+      // Title
+      const titleLink = article.querySelector('h2.event__title a, h3.event__title a')
+      if (!titleLink) return
+      const name = (titleLink.textContent || '').replace(/\s+/g, ' ').trim()
+      if (!name) return
+
+      // URL — prefer article[about] for canonical path
+      const aboutPath = article.getAttribute('about') || ''
+      const hrefPath = titleLink.getAttribute('href') || ''
+      const url = resolveUrl(aboutPath || hrefPath, source.url)
+
+      // Date + Time — "Thursday, 3/19/2026, 9:00 - 6:00"
+      const dateEl = article.querySelector('span.date-display-range, .event__date .field__item')
+      let date = ''
+      let time = ''
+      if (dateEl) {
+        const raw = (dateEl.textContent || '').replace(/\s+/g, ' ').trim()
+        const parsed = parseSfplDate(raw)
+        date = parsed.date
+        time = parsed.time
+      }
+
+      // Venue
+      const venueEl = article.querySelector('a.location--short-label, .event__location .field--name-name')
+      const venue = venueEl ? (venueEl.textContent || '').replace(/\s+/g, ' ').trim() : 'SF Public Library'
+
+      events.push({
+        source: source.id,
+        date,
+        time,
+        name,
+        venue,
+        city: 'San Francisco',
+        url,
+        contentType: 'literary',
+      })
+    } catch (_e) { /* skip broken article */ }
+  })
+
+  return events
+}
+
+/** Parse SFPL date format: "Thursday, 3/19/2026, 9:00 - 6:00" or "Wednesday, 3/19/2026" */
+function parseSfplDate(raw: string): { date: string; time: string } {
+  // Try "Weekday, M/D/YYYY, TIME"
+  const match = raw.match(/\w+,\s*(\d{1,2})\/(\d{1,2})\/(\d{4})(?:,\s*(.+))?/)
+  if (match) {
+    const month = match[1].padStart(2, '0')
+    const day = match[2].padStart(2, '0')
+    const year = match[3]
+    const time = (match[4] || '').trim()
+    return { date: `${year}-${month}-${day}`, time }
+  }
+
+  // Fallback
+  return { date: parseFuzzyDate(raw), time: '' }
+}

--- a/supabase/functions/scrape-events/sources.ts
+++ b/supabase/functions/scrape-events/sources.ts
@@ -12,16 +12,14 @@ export interface EventSource {
 }
 
 export const STOCK_SOURCES: EventSource[] = [
-  // Bay Area
+  // Bay Area — Music
   { id: '19hz-bayarea', name: '19hz', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_BayArea.php', region: 'bay-area', description: 'Electronic music & nightlife' },
   { id: 'ra-bayarea', name: 'Resident Advisor SF', category: 'music', type: 'ra', url: 'https://ra.co/events/us/sanfrancisco', region: 'bay-area', description: 'Electronic music events' },
-  { id: 'sf-punchline', name: 'Punchline SF', category: 'comedy', type: 'html', url: 'https://www.punchlinecomedyclub.com/events', region: 'bay-area', description: 'Stand-up comedy' },
-  { id: 'cobbs-sf', name: "Cobb's Comedy Club", category: 'comedy', type: 'html', url: 'https://www.cobbscomedy.com/events', region: 'bay-area', description: 'Comedy & variety' },
+  // Bay Area — Film
   { id: 'screenslate-sf', name: 'Screen Slate', category: 'film', type: 'screenslate', url: 'https://www.screenslate.com/listings', region: 'bay-area', description: 'Repertory & arthouse cinema' },
   // Los Angeles
   { id: '19hz-losangeles', name: '19hz Los Angeles', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_LosAngeles.php', region: 'los-angeles', description: 'Electronic music & nightlife' },
   // New York
-  { id: '19hz-newyork', name: '19hz New York', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_NewYork.php', region: 'new-york', description: 'Electronic music & nightlife' },
   { id: 'screenslate-nyc', name: 'Screen Slate', category: 'film', type: 'screenslate', url: 'https://www.screenslate.com/listings', region: 'new-york', description: 'Repertory & arthouse cinema' },
   // Seattle
   { id: '19hz-seattle', name: '19hz Seattle', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_Seattle.php', region: 'seattle', description: 'Electronic music & nightlife' },
@@ -31,15 +29,18 @@ export const STOCK_SOURCES: EventSource[] = [
   // Bay Area — Art
   { id: 'sfmoma-events', name: 'SFMOMA', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/events/', region: 'bay-area', description: 'Museum events & artist talks' },
   { id: 'sfmoma-exhibitions', name: 'SFMOMA Exhibitions', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/exhibitions/', region: 'bay-area', description: 'Current & upcoming exhibitions' },
-  { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'html', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
-  // Bay Area — Design
-  { id: 'sfdesignweek', name: 'SF Design Week', category: 'design', type: 'html', url: 'https://www.sfdesignweek.org/events', region: 'bay-area', description: 'Design talks, workshops & exhibitions' },
+  { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'famsf', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
   // Bay Area — Literary
-  { id: 'citylights-sf', name: 'City Lights Books', category: 'literary', type: 'html', url: 'https://citylights.com/events/', region: 'bay-area', description: 'Author readings & poetry events' },
-  { id: 'sfpl-events', name: 'SF Public Library', category: 'literary', type: 'html', url: 'https://sfpl.org/events', region: 'bay-area', description: 'Library programs & author talks' },
-  { id: 'commonwealthclub-sf', name: 'Commonwealth Club', category: 'literary', type: 'html', url: 'https://www.commonwealthclub.org/events', region: 'bay-area', description: 'Speaker events & public affairs' },
-  // Bay Area — Sound Art
-  { id: 'audium-sf', name: 'Audium', category: 'music', type: 'html', url: 'https://www.audium.org/calendar/', region: 'bay-area', description: 'Sound-sculptured space performances' },
+  { id: 'sfpl-events', name: 'SF Public Library', category: 'literary', type: 'sfpl', url: 'https://sfpl.org/events', region: 'bay-area', description: 'Library programs & author talks' },
+  { id: 'commonwealthclub-sf', name: 'Commonwealth Club', category: 'literary', type: 'commonwealth', url: 'https://www.commonwealthclub.org/events', region: 'bay-area', description: 'Speaker events & public affairs' },
   // New York — Tech & Networking
   { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
 ]
+
+// Removed sources (unfixable server-side):
+// - 19hz-newyork: 404 — page does not exist
+// - sf-punchline: Next.js SPA, event data in RSC JSON hydration — needs headless browser
+// - cobbs-sf: Next.js SPA, same as punchline — needs headless browser
+// - citylights-sf: Sucuri WAF JS challenge blocks server-side fetch
+// - audium-sf: WordPress ai1ec calendar plugin, JS-rendered — needs headless browser
+// - sfdesignweek: No events until April 2026, Tribe Events plugin when live


### PR DESCRIPTION
## Summary
- **3 new parsers** for previously-broken sources that have server-rendered event data:
  - `famsf.ts` — de Young / Legion of Honor calendar (Twill CMS, `BlockLink` cards with `<time>` elements)
  - `sfpl.ts` — SF Public Library events (Drupal `article.event--teaser`, 2,300+ events)
  - `commonwealth.ts` — Commonwealth Club events (Drupal `node--type-event` teasers)
- **Removed 6 dead/unfixable sources** from `STOCK_SOURCES`:
  - `19hz-newyork` — 404, page doesn't exist
  - `sfdesignweek` — empty calendar until April 2026
  - `sf-punchline` / `cobbs-sf` — Next.js SPAs, event data in RSC JSON hydration
  - `citylights-sf` — Sucuri WAF JS challenge blocks all server-side fetches
  - `audium-sf` — WordPress ai1ec calendar, JS-rendered
- **Source count**: 20 → 14 (removed 6 broken, net -6)
- **Bump**: v1.1.0 → v1.2.0

## Test plan
- [ ] Deploy and run `refresh-all` — verify famsf, sfpl, commonwealth return >0 events
- [ ] Confirm removed sources no longer appear in scrape results
- [ ] Check `source_health` table updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)