### PR TITLE
Use implicit auth flow on calendar page

### DIFF
--- a/auth/ctrl-auth.js
+++ b/auth/ctrl-auth.js
@@ -49,6 +49,7 @@
      * @param {string[]} [config.adminEmails] - admin email addresses
      * @param {string} [config.mountTo] - CSS selector for mount point (default: 'body')
      * @param {boolean} [config.skipUsername] - skip username onboarding modal (default: false)
+     * @param {string} [config.flowType] - auth flow type: 'pkce' (default on desktop) or 'implicit'
      */
     init(config) {
       if (_initialized) return;
@@ -70,7 +71,7 @@
       _supabase = window.supabase.createClient(config.supabaseUrl, config.supabaseAnonKey, {
         auth: {
           detectSessionInUrl: true,
-          flowType: isMobile ? 'implicit' : 'pkce',
+          flowType: config.flowType || (isMobile ? 'implicit' : 'pkce'),
           autoRefreshToken: true,
           persistSession: true
         }

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -545,6 +545,7 @@ body {
       adminEmails: [ADMIN_EMAIL],
       mountTo: '#ctrl-auth-root',
       skipUsername: true,
+      flowType: 'implicit',
     });
 
     document.getElementById('authLoginBtn').addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- PKCE code verifier lost on desktop → 401 on token exchange
- Adds `flowType` config option to `CtrlAuth.init()` 
- Calendar page uses `flowType: 'implicit'` to bypass PKCE

## Test plan
- [ ] Visit ctrl.rodeo/calendar/, sign in — no 401, lands on booking page
- [ ] Boards still uses PKCE on desktop as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)