### PR TITLE
Pin Supabase SDK to v2.97.0 on calendar

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
   <!-- Supabase SDK -->
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <!-- Auth Module -->
   <script src="/auth/ctrl-auth.js"></script>
   <!-- Add to Calendar Button -->


### PR DESCRIPTION
## Summary
- Calendar was using unpinned `@supabase/supabase-js@2` which resolved to a newer version with broken implicit flow
- Pin to `@2.97.0` — same version boards uses successfully

## Test plan
- [ ] Visit ctrl.rodeo/calendar/, sign in — should work without 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)