### PR TITLE
fix(boards): intent actions to overlay + CORS fix (v2.28.2)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -7563,8 +7563,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.28.3';
-  console.log('[boards] v' + VERSION + ' - sync all missing fields to Supabase');
+  const VERSION = '2.28.4';
+  console.log('[boards] v' + VERSION + ' - intent actions to overlay + CORS fix');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -17615,13 +17615,6 @@ Return JSON:
         }
       }
 
-      // Intent action cards (commerce, ai_tool, etc.)
-      if (l.intent_type && l.intent_confidence >= INTENT_CONFIDENCE_THRESHOLD && INTENT_REGISTRY[l.intent_type] && !l.loading) {
-        const intentReg = INTENT_REGISTRY[l.intent_type];
-        const intentHtml = intentReg.renderActions(l, l.intent_metadata);
-        if (intentHtml) richActionsHtml += intentHtml;
-      }
-
       // Truncate summary to ~60 words for display
       function truncateSummary(text, maxWords) {
         if (!text) return '';
@@ -18064,6 +18057,12 @@ Return JSON:
     if (richConfig?.doneField) {
       actionsHtml += `<button class="pin-overlay__action pin-overlay__action--done${isDone ? ' pin-overlay__action--done-active' : ''}" data-action="toggle-done" data-link-id="${link.id}">${isDone ? '&#10003; ' + richConfig.doneLabel : richConfig.doneLabel + '?'}</button>`;
     }
+    // Intent actions (commerce, ai_tool, etc.) — overlay only
+    if (link.intent_type && link.intent_confidence >= INTENT_CONFIDENCE_THRESHOLD && INTENT_REGISTRY[link.intent_type] && !link.loading) {
+      const intentReg = INTENT_REGISTRY[link.intent_type];
+      const intentHtml = intentReg.renderActions(link, link.intent_metadata);
+      if (intentHtml) actionsHtml += intentHtml;
+    }
     const hasRecipe = link.recipe && (link.recipe.ingredients?.length || link.recipe.instructions?.length);
 
     // Inline recipe section
@@ -18223,6 +18222,14 @@ Return JSON:
         if (menuBtn) menuBtn.click();
       }
       if (action === 'delete') closePinOverlay();
+      return;
+    }
+
+    if (action.startsWith('intent:')) {
+      const [, intentType, intentAction] = action.split(':');
+      const link = getAllLinks().find(l => l.id === linkId);
+      const reg = INTENT_REGISTRY[intentType];
+      if (link && reg) reg.handleAction(intentAction, link);
       return;
     }
   });

--- a/supabase/functions/generate-intent-plan/index.ts
+++ b/supabase/functions/generate-intent-plan/index.ts
@@ -5,7 +5,7 @@
 // POST /functions/v1/generate-intent-plan
 // Body: { tool_name, tagline, url, domain, docs_url, practical_tags, entities, recent_pins }
 
-const VERSION = '1.0.0'
+const VERSION = '1.0.1'
 console.log(`[generate-intent-plan] v${VERSION} — streaming integration plan generator`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -13,6 +13,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
 interface PlanRequest {


### PR DESCRIPTION
## Summary
- **Moved intent action buttons** (Integration Plan, Docs) from grid cards to pin overlay — they were incorrectly rendering on cards and firing via `grid.onclick`
- **Fixed CORS preflight failure** on `generate-intent-plan` edge function by adding `Access-Control-Allow-Methods: POST, OPTIONS` header
- Added intent click delegation to overlay panel event handler

## Test plan
- [ ] Open a pin with `intent_type: ai_tool` → "Integration Plan" button appears in overlay actions, NOT on grid card
- [ ] Click "Integration Plan" → no CORS error, streaming plan renders in terminal modal
- [ ] Grid cards for ai_tool pins no longer show intent action buttons
- [ ] Deploy `generate-intent-plan` edge function after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)