### PR TITLE
fix(calendar): hide past time slots (v2.8.2)

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -788,7 +788,7 @@ body {
 (function () {
   'use strict';
 
-  const VERSION = '2.8.1';
+  const VERSION = '2.8.2';
   console.log('[calendar] v' + VERSION + ' - public booking page');
 
   // ============================================
@@ -1779,10 +1779,10 @@ body {
           col.appendChild(empty);
         } else {
           slots.forEach(function (slot) {
+            if (slot.isPast) return; // Hide past time slots
             var btn = document.createElement('button');
             var cls = 'cal-slot';
-            if (slot.isPast) cls += ' cal-slot--past';
-            else if (slot.isBusy) cls += ' cal-slot--busy';
+            if (slot.isBusy) cls += ' cal-slot--busy';
             else {
               // Story 5: optimal slot highlighting
               if (state.visitorGcalConnected && !slot.visitorBusy) {


### PR DESCRIPTION
## Summary
- Hide past time slots entirely instead of showing them greyed out
- Today's column only shows future bookable times

## Test plan
- [ ] Load `/calendar/` — today's column starts at the next available future slot
- [ ] Tomorrow's column still shows all slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)