### PR TITLE
Style reel embed cards to fit grid layout (v2.31.1)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -2228,20 +2228,49 @@ a:hover { color: var(--accent-cyan); }
   opacity: 1;
 }
 
+.grid-item--embed {
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+}
+.grid-item__embed-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 .grid-item__embed {
   display: block;
   width: 100%;
-  aspect-ratio: 9 / 16;
+  height: 260%;
   border: 0;
-  overflow: hidden;
-  border-radius: 4px 4px 0 0;
   pointer-events: none;
-}
-.grid-item--embed .grid-item__overlay {
-  display: none;
+  transform: scale(1.02);
+  transform-origin: top center;
 }
 .grid-item--embed .grid-item__initial {
   display: none;
+}
+.grid-item__reel-badge {
+  position: absolute;
+  top: var(--space-2);
+  left: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(4px);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg);
+  z-index: 2;
+}
+.grid-item__reel-badge::before {
+  content: '▶';
+  font-size: 8px;
 }
 
 .grid-item__overlay {
@@ -7788,8 +7817,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.31.0';
-  console.log('[boards] v' + VERSION + ' - Instagram reel embed fallback');
+  const VERSION = '2.31.1';
+  console.log('[boards] v' + VERSION + ' - reel embed card styling');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -18048,7 +18077,7 @@ Return JSON:
         // For Instagram reels: if image fails, swap in embed iframe
         const reelSC = isInstagramContent(l.url) ? getInstagramShortcode(l.url) : null;
         const imgOnerror = reelSC
-          ? `this.style.display='none';var f=document.createElement('iframe');f.className='grid-item__embed';f.src='https://www.instagram.com/reel/${reelSC}/embed/';f.loading='lazy';f.allowTransparency=true;this.parentNode.classList.add('grid-item--embed');this.parentNode.insertBefore(f,this)`
+          ? `this.style.display='none';var w=document.createElement('div');w.className='grid-item__embed-wrap';var b=document.createElement('span');b.className='grid-item__reel-badge';b.textContent='Reel';w.appendChild(b);var f=document.createElement('iframe');f.className='grid-item__embed';f.src='https://www.instagram.com/reel/${reelSC}/embed/';f.loading='lazy';w.appendChild(f);this.parentNode.classList.add('grid-item--embed');this.parentNode.insertBefore(w,this)`
           : "this.style.opacity='0'";
 
         html += `<article class="grid-item${categoryClass}${doneClass}${mergedClass}${newClass}${loadingClass}" data-id="${l.id}" draggable="true" tabindex="0">
@@ -18071,7 +18100,7 @@ Return JSON:
         const reelShortcode = isInstagramContent(l.url) ? getInstagramShortcode(l.url) : null;
         const embedClass = reelShortcode ? ' grid-item--embed' : '';
         const embedHtml = reelShortcode
-          ? `<iframe class="grid-item__embed" src="https://www.instagram.com/reel/${reelShortcode}/embed/" loading="lazy" allowtransparency="true"></iframe>`
+          ? `<div class="grid-item__embed-wrap"><span class="grid-item__reel-badge">Reel</span><iframe class="grid-item__embed" src="https://www.instagram.com/reel/${reelShortcode}/embed/" loading="lazy" allowtransparency="true"></iframe></div>`
           : '';
 
         html += `<article class="grid-item grid-item--placeholder${embedClass}${categoryClass}${doneClass}${mergedClass}${newClass}${loadingClass}" data-id="${l.id}" draggable="true" tabindex="0">


### PR DESCRIPTION
## Summary
- Crop embed iframe to 4:5 aspect ratio so reel cards match grid proportions
- Add `grid-item__embed-wrap` container for clean overflow clipping
- `▶ REEL` badge (frosted glass, top-left) identifies reel content at a glance
- Title/domain overlay shows on hover like all other cards
- Updated onerror image fallback to use same wrapper structure

## Test plan
- [ ] Reel cards without thumbnails render at proper grid size with REEL badge
- [ ] Reel cards with broken images gracefully swap to embed
- [ ] Normal cards unaffected
- [ ] Embeds render on production domain (localhost blocked by Instagram)

🤖 Generated with [Claude Code](https://claude.com/claude-code)