### PR TITLE
fix(boards): server-side soft-delete to prevent pin resurrection (v2.33.0)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -7848,8 +7848,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.33.0';
-  console.log('[boards] v' + VERSION + ' - reel embed card styling');
+  const VERSION = '2.33.1';
+  console.log('[boards] v' + VERSION + ' - server-side soft-delete to fix pin resurrection bug');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -15246,9 +15246,15 @@ Return JSON:
     if (!token) return;
     for (const id of pending) {
       try {
+        // Soft-delete: set deleted_at instead of hard DELETE
         const res = await fetch(`${SUPABASE_URL}/rest/v1/links?id=eq.${id}&user_id=eq.${currentUser.id}`, {
-          method: 'DELETE',
-          headers: { 'apikey': SUPABASE_ANON_KEY, 'Authorization': `Bearer ${token}` }
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'apikey': SUPABASE_ANON_KEY,
+            'Authorization': `Bearer ${token}`
+          },
+          body: JSON.stringify({ deleted_at: new Date().toISOString() })
         });
         if (res.ok || res.status === 404) {
           removePendingDelete(id);
@@ -15599,15 +15605,19 @@ Return JSON:
     }
     for (let attempt = 1; attempt <= retries; attempt++) {
       try {
+        // Soft-delete: set deleted_at instead of hard DELETE.
+        // This makes deletions durable across devices (no device-local tombstone needed).
         const res = await fetch(`${SUPABASE_URL}/rest/v1/links?id=eq.${id}&user_id=eq.${currentUser.id}`, {
-          method: 'DELETE',
+          method: 'PATCH',
           headers: {
+            'Content-Type': 'application/json',
             'apikey': SUPABASE_ANON_KEY,
             'Authorization': `Bearer ${accessToken}`
-          }
+          },
+          body: JSON.stringify({ deleted_at: new Date().toISOString() })
         });
         if (res.ok) {
-          console.log('[sync] Deleted:', id);
+          console.log('[sync] Soft-deleted:', id);
           removePendingDelete(id);
           return;
         }
@@ -15675,7 +15685,7 @@ Return JSON:
 
       // Fetch all data in parallel using raw fetch
       const [linksRes, orderRes, expandedRes, boardMetaRes] = await Promise.all([
-        fetch(`${SUPABASE_URL}/rest/v1/links?user_id=eq.${currentUser.id}&select=*`, { headers }),
+        fetch(`${SUPABASE_URL}/rest/v1/links?user_id=eq.${currentUser.id}&deleted_at=is.null&select=*`, { headers }),
         fetch(`${SUPABASE_URL}/rest/v1/link_order?user_id=eq.${currentUser.id}&select=order_ids&limit=1`, { headers }),
         fetch(`${SUPABASE_URL}/rest/v1/expanded_cards?user_id=eq.${currentUser.id}&select=cards&limit=1`, { headers }),
         fetch(`${SUPABASE_URL}/rest/v1/board_metadata?user_id=eq.${currentUser.id}&select=metadata&limit=1`, { headers })

--- a/supabase/migrations/046_soft_delete_links.sql
+++ b/supabase/migrations/046_soft_delete_links.sql
@@ -1,0 +1,13 @@
+-- Add soft-delete support to links table.
+-- Instead of hard-deleting rows, set deleted_at = now().
+-- fetchFromSupabase filters deleted_at=is.null so deleted pins never return.
+-- This fixes the bug where deleted pins resurrect on other devices because
+-- tombstones were only stored in localStorage (device-local).
+
+ALTER TABLE links ADD COLUMN IF NOT EXISTS deleted_at timestamptz DEFAULT NULL;
+
+-- Index for efficient filtering of non-deleted links
+CREATE INDEX IF NOT EXISTS idx_links_deleted_at ON links (deleted_at) WHERE deleted_at IS NULL;
+
+-- Soft-delete the 4 known zombie pins immediately
+UPDATE links SET deleted_at = now() WHERE id IN ('0vmuiqn4', 'nxfql1nz', 'zu922eiy', 'e00rxh0c');


### PR DESCRIPTION
## Summary
- **Bug:** Deleted pins (0vmuiqn4, nxfql1nz, zu922eiy, e00rxh0c) kept returning because tombstones were device-local (localStorage only). Other devices or expired tombstones would re-sync them from Supabase.
- **Fix:** Added `deleted_at` column to `links` table. Deletes now soft-delete (PATCH) instead of hard DELETE. `fetchFromSupabase` filters `deleted_at=is.null` so soft-deleted pins never return from any device.
- Migration also immediately soft-deletes the 4 known zombie pins.

## Changes
- `supabase/migrations/046_soft_delete_links.sql` — adds `deleted_at` column + partial index + fixes zombie pins
- `boards/index.html` — `deleteLinkFromSupabase` and `processPendingDeletes` use PATCH instead of DELETE; fetch query filters `deleted_at=is.null`; version bump to v2.33.0

## Test plan
- [ ] Run migration on Boards Supabase project
- [ ] Delete a pin → verify it soft-deletes (row stays with `deleted_at` set)
- [ ] Refresh / poll → verify deleted pin does not reappear
- [ ] Cross-device: delete on device A, verify device B never resurrects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)