### PR TITLE
feat(classify-intent): expand AI tool detection for docs/libraries (v1.1.0)

### DIFF
--- a/supabase/functions/classify-intent/index.ts
+++ b/supabase/functions/classify-intent/index.ts
@@ -6,7 +6,7 @@
 // POST /functions/v1/classify-intent
 // Body: { action: 'classify' | 'hypothesize', ...params }
 
-const VERSION = '1.0.0'
+const VERSION = '1.1.0'
 console.log(`[classify-intent] v${VERSION} — intent classification pipeline`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -43,6 +43,9 @@ const AI_TOOL_TAGS = new Set([
   'ai', 'machine-learning', 'llm', 'api', 'developer-tool',
   'devtool', 'saas', 'automation', 'no-code', 'low-code',
   'coding', 'ide', 'framework', 'sdk', 'cli',
+  'prompt-library', 'skills', 'library', 'plugin', 'extension',
+  'agent', 'chatbot', 'model', 'fine-tuning', 'embeddings',
+  'mcp', 'tool-use', 'prompt-engineering',
 ])
 
 // --- Types ---
@@ -189,6 +192,23 @@ function classifyByRules(req: ClassifyRequest): IntentResult | null {
         category: 'tool',
       },
       reasoning: `Content type=${req.content_type} with AI entity detected`,
+    }
+  }
+
+  // Non-tool content types with strong AI signals (e.g. docs, libraries, skill pages)
+  const aiTagMatches = req.practical_tags?.filter(t => AI_TOOL_TAGS.has(t.toLowerCase())) || []
+  if (!isToolType && (aiTagMatches.length >= 2 || (hasAITags && hasAIEntity))) {
+    return {
+      intent_type: 'ai_tool',
+      confidence: 0.80,
+      extracted_metadata: {
+        tool_name: req.entities?.find(e => e.type === 'tool')?.name || req.title,
+        tagline: req.description?.slice(0, 120) || '',
+        docs_url: hasDocsSubdomain ? req.url : null,
+        github_url: req.url.includes('github.com') ? req.url : null,
+        category: aiTagMatches[0] || 'ai',
+      },
+      reasoning: `Strong AI signals despite content_type=${req.content_type}: tags=[${aiTagMatches.join(',')}], entity=${hasAIEntity}`,
     }
   }
 


### PR DESCRIPTION
## Summary
A Claude skill library pin wasn't classified as ai_tool because:
1. AI_TOOL_TAGS was too narrow — missing library, skills, plugin, agent, mcp, etc.
2. Hard content_type gate — Tier 1 required content_type=tool|repository

### Changes
- Add 12 new tags to AI_TOOL_TAGS
- Add third Tier 1 rule path (confidence 0.80) for non-tool content types with strong AI signals

## Test plan
- [ ] Pin a Claude skill library page → classified as ai_tool
- [ ] Non-AI articles still don't get misclassified

Generated with Claude Code