### PR TITLE
feat(boards): AI suggested next actions for pins (v2.32.0)

### DIFF
--- a/boards/index.html
+++ b/boards/index.html
@@ -2984,6 +2984,46 @@ a:hover { color: var(--accent-cyan); }
   color: var(--accent-green);
 }
 
+/* Suggested next actions */
+.pin-overlay__suggestions {
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  margin-top: var(--space-4);
+}
+
+.pin-overlay__suggestions-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-2);
+}
+
+.pin-overlay__suggestions-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.pin-overlay__suggestion-chip {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
+  border: 1px dashed var(--border-subtle);
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: border-color var(--duration-normal), color var(--duration-normal);
+  white-space: nowrap;
+}
+
+.pin-overlay__suggestion-chip:hover {
+  border-color: var(--fg);
+  color: var(--fg);
+  border-style: solid;
+}
+
 .pin-overlay__rich-meta {
   display: flex;
   flex-direction: column;
@@ -7788,8 +7828,8 @@ Paste one or many links. Notes are ignored." rows="6"></textarea>
   // ============================================
   // Version
   // ============================================
-  const VERSION = '2.31.1';
-  console.log('[boards] v' + VERSION + ' - save integration plan to pin metadata');
+  const VERSION = '2.32.0';
+  console.log('[boards] v' + VERSION + ' - AI suggested next actions for pins');
 
   // ============================================
   // Supabase Setup (shared auth module manages the client)
@@ -12885,6 +12925,125 @@ Return JSON:
     }
   }
 
+  // ============================================
+  // Suggest Actions API
+  // ============================================
+  async function callSuggestActionsAPI(link) {
+    if (!currentUser) return null;
+    try {
+      const payload = {
+        url: link.url,
+        title: link.title || '',
+        description: link.description || '',
+        domain: link.domain || '',
+        category: link.category || '',
+        content_type: link.content_type || null,
+        intent_type: link.intent_type || null,
+        intent_metadata: link.intent_metadata || null,
+        practical_tags: link.practical_tags || [],
+        taste_tags: link.taste_tags || [],
+        entities: link.entities || [],
+        content_structure: link.content_structure || null,
+        video: link.video || null,
+        music: link.music || null,
+        book: link.book || null,
+        recipe: link.recipe || null,
+        userId: currentUser.id,
+        linkId: link.id
+      };
+
+      const response = await fetch(`${SUPABASE_URL}/functions/v1/suggest-actions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${SUPABASE_ANON_KEY}`
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        console.warn('%c[SUGGEST] suggest-actions returned', 'color: #8e44ad', response.status);
+        return null;
+      }
+
+      return await response.json();
+    } catch (e) {
+      console.warn('%c[SUGGEST] suggest-actions error:', 'color: #8e44ad', e.message);
+      return null;
+    }
+  }
+
+  // Suggested Actions — fire-and-forget (runs after intent classification)
+  function fireSuggestActions(link) {
+    if (!currentUser) return;
+
+    callSuggestActionsAPI(link).then(result => {
+      if (!result?.actions?.length) return;
+
+      const data = load();
+      const localLink = data.links.find(l => l.id === link.id);
+      if (localLink) {
+        localLink.suggested_actions = result.actions;
+        save(data);
+        syncLinkToSupabase(localLink);
+        // Re-render overlay if this pin is currently open
+        if (_overlayCurrentId === link.id) {
+          pinOverlayPanel.innerHTML = renderOverlayPanel(localLink);
+        }
+        console.log('%c[SUGGEST] Applied ' + result.actions.length + ' actions to', 'color: #8e44ad; font-weight: bold', link.title?.substring(0, 40));
+      }
+    }).catch(e => console.warn('%c[SUGGEST] Fire error:', 'color: #8e44ad', e.message));
+  }
+
+  // One-time backfill: suggest actions for pins that have content_type but no suggested_actions
+  const SUGGEST_ACTIONS_BACKFILL_KEY = 'ctrl_suggest_actions_backfill_v1';
+  async function backfillSuggestedActions() {
+    if (!currentUser) return;
+    if (localStorage.getItem(SUGGEST_ACTIONS_BACKFILL_KEY)) return;
+
+    const allLinks = getAllLinks();
+    const candidates = allLinks.filter(l =>
+      l.content_type && l.content_type !== 'unknown' && !l.suggested_actions
+    );
+
+    if (candidates.length === 0) {
+      localStorage.setItem(SUGGEST_ACTIONS_BACKFILL_KEY, Date.now().toString());
+      return;
+    }
+
+    console.log('%c[SUGGEST] Backfilling actions for ' + candidates.length + ' pins...', 'color: #8e44ad; font-weight: bold');
+
+    let filled = 0;
+    const BATCH_DELAY = 800;
+
+    for (let i = 0; i < Math.min(candidates.length, 50); i++) {
+      const link = candidates[i];
+      try {
+        const result = await callSuggestActionsAPI(link);
+        if (result?.actions?.length) {
+          const data = load();
+          const localLink = data.links.find(l => l.id === link.id);
+          if (localLink) {
+            localLink.suggested_actions = result.actions;
+            save(data);
+          }
+          filled++;
+          console.log('%c[SUGGEST] Backfill ' + (i + 1) + '/' + candidates.length + ':', 'color: #8e44ad', link.title?.substring(0, 40));
+        }
+      } catch (e) {
+        console.warn('%c[SUGGEST] Backfill error:', 'color: #8e44ad', link.url, e.message);
+      }
+
+      if (i < Math.min(candidates.length, 50) - 1) {
+        await new Promise(r => setTimeout(r, BATCH_DELAY));
+      }
+    }
+
+    localStorage.setItem(SUGGEST_ACTIONS_BACKFILL_KEY, Date.now().toString());
+    console.log('%c[SUGGEST] Backfill complete: ' + filled + ' filled', 'color: #8e44ad; font-weight: bold');
+    if (filled > 0) renderGrid();
+  }
+
   // Stream integration plan from generate-intent-plan
   let _intentPlanAbortController = null;
 
@@ -13233,6 +13392,9 @@ Return JSON:
 
           // Step 1.5b: Fire hypothesis (Pass 2) — fire-and-forget
           fireIntentHypothesis(currentLinkForIntent, currentDataForIntent.links);
+
+          // Step 1.5c: Fire suggested actions — fire-and-forget
+          fireSuggestActions(currentLinkForIntent);
         }
       }
 
@@ -15429,7 +15591,9 @@ Return JSON:
         enrichment_failed_at: link.enrichment_failed_at || null,
         source: link.source || null,
         // Widget reference
-        widgetId: link.widgetId || null
+        widgetId: link.widgetId || null,
+        // AI suggested next actions
+        suggested_actions: link.suggested_actions || null
       };
       const res = await fetch(`${SUPABASE_URL}/rest/v1/links`, {
         method: 'POST',
@@ -18377,6 +18541,24 @@ Return JSON:
     });
   }
 
+  function renderSuggestedActionsHtml(link) {
+    const actions = link.suggested_actions;
+    if (!actions?.length) return '';
+
+    const chips = actions.map((a, idx) =>
+      `<button class="pin-overlay__suggestion-chip"
+        data-action="suggestion:${idx}"
+        data-link-id="${link.id}"
+        title="${esc(a.reason)}"
+      >${esc(a.icon)} ${esc(a.label)}</button>`
+    ).join('');
+
+    return `<div class="pin-overlay__suggestions">
+      <div class="pin-overlay__suggestions-label">Next steps</div>
+      <div class="pin-overlay__suggestions-chips">${chips}</div>
+    </div>`;
+  }
+
   function renderOverlayPanel(link) {
     const dateStr = new Date(link.addedAt).toLocaleDateString();
     const contentTypeDisplay = link.content_type && link.content_type !== 'unknown' ? cap(link.content_type) : '';
@@ -18526,6 +18708,7 @@ Return JSON:
           <div class="pin-overlay__details-body">
             ${desc && desc !== recipe.description ? `<p class="pin-overlay__description">${esc(desc)}</p>` : ''}
             <textarea class="pin-overlay__notes" placeholder="Add a note..." data-link-id="${link.id}">${esc(link.notes || '')}</textarea>
+            ${renderSuggestedActionsHtml(link)}
             <div class="pin-overlay__meta">
               <span class="pin-overlay__meta-item">${cap(link.category)}</span>
               ${contentTypeDisplay ? `<span class="pin-overlay__meta-item">${contentTypeDisplay}</span>` : ''}
@@ -18547,6 +18730,7 @@ Return JSON:
       ${desc ? `<p class="pin-overlay__description">${esc(desc)}</p>` : ''}
       ${richMetaHtml}
       <textarea class="pin-overlay__notes" placeholder="Add a note..." data-link-id="${link.id}">${esc(link.notes || '')}</textarea>
+      ${renderSuggestedActionsHtml(link)}
       <div class="pin-overlay__meta">
         <span class="pin-overlay__meta-item">${cap(link.category)}</span>
         ${contentTypeDisplay ? `<span class="pin-overlay__meta-item">${contentTypeDisplay}</span>` : ''}
@@ -18647,6 +18831,26 @@ Return JSON:
       const link = getAllLinks().find(l => l.id === linkId);
       const reg = INTENT_REGISTRY[intentType];
       if (link && reg) reg.handleAction(intentAction, link);
+      return;
+    }
+
+    if (action.startsWith('suggestion:')) {
+      const idx = parseInt(action.split(':')[1], 10);
+      const link = getAllLinks().find(l => l.id === linkId);
+      const suggestion = link?.suggested_actions?.[idx];
+      if (!suggestion) return;
+
+      if (suggestion.action_data?.url) {
+        window.open(suggestion.action_data.url, '_blank', 'noopener');
+        return;
+      }
+
+      if (suggestion.action_data?.query) {
+        window.open(`https://www.google.com/search?q=${encodeURIComponent(suggestion.action_data.query)}`, '_blank', 'noopener');
+        return;
+      }
+
+      window.open(link.url, '_blank', 'noopener');
       return;
     }
   });
@@ -24206,6 +24410,9 @@ Return JSON:
 
     // One-time backfill: classify intent for pre-v2.27.0 pins
     backfillIntentClassification();
+
+    // One-time backfill: suggest actions for enriched pins
+    backfillSuggestedActions();
 
     // Retry image resolution for items with null images
     retryFailedImages();

--- a/supabase/functions/suggest-actions/index.ts
+++ b/supabase/functions/suggest-actions/index.ts
@@ -1,0 +1,282 @@
+// Supabase Edge Function: suggest-actions
+// Generates 3-5 contextual next-best-actions for a pin based on AI analysis data.
+// Called after intent classification completes in the enrichment pipeline.
+//
+// POST /functions/v1/suggest-actions
+// Body: { url, title, description, domain, category, content_type, intent_type,
+//         intent_metadata, practical_tags, taste_tags, entities, content_structure,
+//         video, music, book, recipe, userId, linkId }
+
+const VERSION = '1.0.0'
+console.log(`[suggest-actions] v${VERSION} — next-best-action generation`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+const MODEL = 'claude-haiku-4-5-20251001'
+const LLM_TIMEOUT_MS = 8000
+
+interface SuggestRequest {
+  url: string
+  title: string
+  description?: string
+  domain: string
+  category: string
+  content_type?: string
+  intent_type?: string
+  intent_metadata?: Record<string, unknown>
+  practical_tags?: string[]
+  taste_tags?: string[]
+  entities?: Array<{ name: string; type: string; confidence?: number }>
+  content_structure?: string
+  video?: Record<string, unknown>
+  music?: Record<string, unknown>
+  book?: Record<string, unknown>
+  recipe?: Record<string, unknown>
+  userId: string
+  linkId: string
+}
+
+interface SuggestedAction {
+  label: string
+  icon: string
+  reason: string
+  action_type: string
+  action_data?: Record<string, unknown>
+}
+
+// --- Main handler ---
+
+async function handleSuggest(req: SuggestRequest): Promise<Response> {
+  const startTime = Date.now()
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: 'ANTHROPIC_API_KEY not configured' }),
+      { status: 500, headers: jsonHeaders }
+    )
+  }
+
+  // Build context from all available pin analysis
+  const contextParts: string[] = []
+  contextParts.push(`URL: ${req.url}`)
+  contextParts.push(`Title: ${req.title}`)
+  if (req.description) contextParts.push(`Description: ${req.description.slice(0, 300)}`)
+  contextParts.push(`Domain: ${req.domain}`)
+  contextParts.push(`Category: ${req.category}`)
+  if (req.content_type) contextParts.push(`Content type: ${req.content_type}`)
+  if (req.intent_type) contextParts.push(`Intent: ${req.intent_type}`)
+  if (req.intent_metadata) {
+    const meta = req.intent_metadata
+    if (meta.price) contextParts.push(`Price: ${meta.currency || '$'}${meta.price}`)
+    if (meta.product_name) contextParts.push(`Product: ${meta.product_name}`)
+    if (meta.tool_name) contextParts.push(`Tool: ${meta.tool_name}`)
+    if (meta.docs_url) contextParts.push(`Docs: ${meta.docs_url}`)
+    if (meta.pricing_model) contextParts.push(`Pricing: ${meta.pricing_model}`)
+  }
+  if (req.practical_tags?.length) contextParts.push(`Tags: ${req.practical_tags.join(', ')}`)
+  if (req.taste_tags?.length) contextParts.push(`Aesthetic: ${req.taste_tags.join(', ')}`)
+  if (req.entities?.length) contextParts.push(`Entities: ${req.entities.map(e => `${e.name} (${e.type})`).join(', ')}`)
+  if (req.content_structure) contextParts.push(`Structure: ${req.content_structure}`)
+  if (req.video) {
+    const v = req.video
+    contextParts.push(`Video: ${v.type || 'video'} by ${v.creator || 'unknown'}${v.runtime ? `, ${v.runtime}` : ''}${v.genres ? `, genres: ${(v.genres as string[]).join(', ')}` : ''}`)
+  }
+  if (req.music) {
+    const m = req.music
+    contextParts.push(`Music: ${m.trackTitle || ''} by ${m.artist || 'unknown'}${m.genre ? `, ${m.genre}` : ''}${m.bpm ? `, ${m.bpm} BPM` : ''}`)
+  }
+  if (req.book) {
+    const b = req.book
+    contextParts.push(`Book: by ${b.author || 'unknown'}${b.genre ? `, ${b.genre}` : ''}${b.format ? `, ${b.format}` : ''}`)
+  }
+  if (req.recipe) {
+    const r = req.recipe
+    contextParts.push(`Recipe: ${r.cuisine || ''} cuisine${r.difficulty ? `, ${r.difficulty}` : ''}${r.total_time ? `, ${r.total_time}` : ''}`)
+  }
+
+  const prompt = `You are analyzing a pinned URL that a user saved to their personal curation platform. Based on the analysis data below, suggest 3-5 concrete next actions the user could take with this pin.
+
+${contextParts.join('\n')}
+
+Think about what a person who saved this would realistically want to do next. Actions should be specific to THIS pin's content, not generic. Consider:
+- Purchase/acquire actions (buy, pre-order, add to cart, find best price, check stock)
+- Integration/technical actions (integrate this tool, install, fork repo, try the API, set up locally)
+- Creative actions (generate 3D print file, remix, create playlist, design mood board)
+- Research actions (find alternatives, compare prices, read reviews, check compatibility)
+- Social actions (share with someone, recommend, save to wishlist, gift idea)
+- Content actions (watch later, add to reading list, bookmark recipe, save playlist)
+- Physical actions (visit location, book tickets, make reservation, find nearby)
+
+Be bold and specific. "Buy this" is better than "Consider purchasing". "Fork and customize" is better than "Explore the code".`
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), LLM_TIMEOUT_MS)
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 512,
+        tools: [
+          {
+            name: 'suggest_actions',
+            description: 'Suggest 3-5 next-best-actions for this pinned item',
+            input_schema: {
+              type: 'object',
+              properties: {
+                actions: {
+                  type: 'array',
+                  minItems: 3,
+                  maxItems: 5,
+                  items: {
+                    type: 'object',
+                    properties: {
+                      label: {
+                        type: 'string',
+                        description: 'Short action label, 2-5 words. Imperative verb. e.g. "Buy on Amazon", "Fork & customize", "Generate 3D file"',
+                      },
+                      icon: {
+                        type: 'string',
+                        description: 'Single emoji icon for the action',
+                      },
+                      reason: {
+                        type: 'string',
+                        description: 'One sentence explaining why this action is relevant for this specific pin',
+                      },
+                      action_type: {
+                        type: 'string',
+                        enum: ['purchase', 'integrate', 'create', 'research', 'social', 'content', 'physical', 'external_link'],
+                        description: 'Category of action',
+                      },
+                      action_data: {
+                        type: 'object',
+                        description: 'Optional structured data: { url: string } for external links, { query: string } for searches',
+                        properties: {
+                          url: { type: 'string' },
+                          query: { type: 'string' },
+                        },
+                      },
+                    },
+                    required: ['label', 'icon', 'reason', 'action_type'],
+                  },
+                },
+              },
+              required: ['actions'],
+            },
+          },
+        ],
+        tool_choice: { type: 'tool', name: 'suggest_actions' },
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const errText = await response.text()
+      console.error('[suggest-actions] Claude API error:', response.status, errText)
+      return new Response(
+        JSON.stringify({ error: 'Action suggestion failed', detail: errText }),
+        { status: 200, headers: jsonHeaders }
+      )
+    }
+
+    const aiResponse = await response.json()
+    const toolUse = aiResponse.content?.find(
+      (block: { type: string }) => block.type === 'tool_use'
+    )
+
+    if (!toolUse?.input?.actions?.length) {
+      console.warn('[suggest-actions] No actions in response')
+      return new Response(
+        JSON.stringify({ actions: [], reason: 'No actions generated' }),
+        { headers: jsonHeaders }
+      )
+    }
+
+    const actions: SuggestedAction[] = toolUse.input.actions
+
+    // Save to DB
+    if (req.userId && req.linkId) {
+      try {
+        const supabase = createClient(
+          Deno.env.get('SUPABASE_URL')!,
+          Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+        )
+
+        await supabase
+          .from('links')
+          .update({
+            suggested_actions: actions,
+          })
+          .eq('id', req.linkId)
+          .eq('user_id', req.userId)
+
+        console.log(`[suggest-actions] Saved ${actions.length} actions for link ${req.linkId}`)
+      } catch (err) {
+        console.error('[suggest-actions] DB write error:', err)
+      }
+    }
+
+    console.log(`[suggest-actions] Generated ${actions.length} actions in ${Date.now() - startTime}ms`)
+
+    return new Response(
+      JSON.stringify({
+        actions,
+        meta: { elapsed: Date.now() - startTime, version: VERSION, model: MODEL },
+      }),
+      { headers: jsonHeaders }
+    )
+  } catch (err) {
+    clearTimeout(timeout)
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      console.warn('[suggest-actions] LLM timed out')
+    } else {
+      console.error('[suggest-actions] Error:', err)
+    }
+    return new Response(
+      JSON.stringify({ error: 'Action suggestion failed', detail: String(err) }),
+      { status: 200, headers: jsonHeaders }
+    )
+  }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const body = await req.json()
+
+    if (body.action === 'health') {
+      return new Response(
+        JSON.stringify({ status: 'ok', version: VERSION }),
+        { headers: jsonHeaders }
+      )
+    }
+
+    return await handleSuggest(body as SuggestRequest)
+  } catch (err) {
+    console.error('[suggest-actions] Error:', err)
+    return new Response(
+      JSON.stringify({ error: 'Internal error', detail: String(err) }),
+      { status: 500, headers: jsonHeaders }
+    )
+  }
+})

--- a/supabase/migrations/046_suggested_actions.sql
+++ b/supabase/migrations/046_suggested_actions.sql
@@ -1,0 +1,11 @@
+-- ============================================================
+-- 046_suggested_actions.sql
+-- Suggested next actions for pins
+-- Stores AI-generated next-best-actions from suggest-actions
+-- edge function. Additive only — no existing columns modified.
+-- ============================================================
+
+ALTER TABLE links ADD COLUMN IF NOT EXISTS suggested_actions JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_links_suggested_actions ON links(user_id)
+  WHERE suggested_actions IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds 3-5 AI-generated "Next Steps" per pin using Claude Haiku analysis of existing metadata (content_type, intent, tags, entities)
- New `suggest-actions` edge function generates contextual actions like "Buy now", "Fork & customize", "Generate 3D file"
- Suggestions shown as dashed chips in pin overlay with hover tooltips for reasoning
- Fire-and-forget in enrichment pipeline + backfill for existing pins

## Changes
- **New:** `supabase/functions/suggest-actions/index.ts` — Claude Haiku tool_use edge function
- **New:** `supabase/migrations/046_suggested_actions.sql` — JSONB column + index
- **Modified:** `boards/index.html` — CSS, API client, pipeline hook, sync payload, overlay UI, click handler, backfill, version bump (v2.31.1 → v2.32.0)

## Test plan
- [ ] Deploy edge function: `supabase functions deploy suggest-actions --project-ref yfhudwakpgzswiylhfbh`
- [ ] Apply migration: `supabase db push --project-ref yfhudwakpgzswiylhfbh`
- [ ] Open pin overlay → verify "Next steps" section with 3-5 action chips
- [ ] Hover chip → tooltip shows AI reasoning
- [ ] Click chip → opens relevant URL
- [ ] Console: `[SUGGEST]` logs show generation and backfill
- [ ] New pins through enrichment pipeline get suggestions automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)