### PR TITLE
feat(systemic): v2 — three input sources, multi-state rendering, usage inspector

### DIFF
--- a/docs/execution/project-plan/backlog.md
+++ b/docs/execution/project-plan/backlog.md
@@ -368,9 +368,40 @@ Making collections useful beyond the platform. Supports brand principle #5: **Ex
 
 ---
 
-## SystemicAI
+## Systemic v2
 
-Design system analyzer and documentation generator.
+Three-track upgrade to the design system analyzer. See [PRD: Systemic v2](../../strategy/prds/systemic-v2.md).
+
+### Epic: Track 1 — Three Input Sources
+
+| Story | Status |
+|-------|--------|
+| **Input source selection screen** — Replace single URL input with three-source entry screen (Live Page, Design File, Production Code) with distinct icons and descriptions | Pending |
+| **Code source: GitHub repo parser** — Fetch and statically parse HTML/CSS/JS from a GitHub repo URL via GitHub Contents API; extract component instances with file + line attribution | Pending |
+| **Code source: local path bridge** — Deno local bridge server + `systemic-crawl` edge function for reading files from a local filesystem path | Pending |
+| **Figma integration** — PAT-based auth, Figma REST API calls to fetch components, variants, published styles (design tokens), and frame names as location context | Pending |
+| **Paper canvas integration** — Read active Paper canvas via MCP context; same normalization output as Figma parser | Pending |
+| **Extend ComponentRecord shape** — Add `instances[]` array with location (file path + line, page URL, or Figma frame name), instance HTML, surrounding context, and thumbnail | Pending |
+
+### Epic: Track 2 — Lifelike Component State Rendering
+
+| Story | Status |
+|-------|--------|
+| **State renderer module** — Generate one rendered example per discovered CSS state rule; apply state styles inline to a static copy of the example HTML | Pending |
+| **State sets per component type** — Button (5 states), Input (5), Dropdown (4), Card (3), Navigation (3), Checkbox/Radio (4), Badge (variants), Toggle (3) | Pending |
+| **Contextual placeholder content** — Replace lorem ipsum with component-type-appropriate labels, field names, and body text via lookup table | Pending |
+| **State badges** — Small badge in top-right of each state example showing state name ("hover", "disabled", "error", etc.) | Pending |
+| **Replace Examples section** — Component docs view becomes the multi-state examples view; current "Examples" page is removed | Pending |
+
+### Epic: Track 3 — Component Usage Inspector
+
+| Story | Status |
+|-------|--------|
+| **Instance grid view** — Select a component type from dropdown; show all instances across source in a scrollable grid with thumbnail, location, and variant badge | Pending |
+| **Right-side drawer** — Click instance to open ~40% width drawer with rendered preview, syntax-highlighted source code block, surrounding context, and variant classification + confidence | Pending |
+| **Drawer navigation** — Previous/Next arrows inside drawer to cycle through instances without closing; keyboard Escape to dismiss | Pending |
+| **Filter controls** — Location path search and variant filter above instance grid; live count updates | Pending |
+| **Thumbnail generation** — Lazy client-side thumbnail rendering for instance grid using html2canvas; generated on scroll | Pending |
 
 ### Epic: Docs Viewer UX
 

--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -1,7 +1,7 @@
 # Project Plan - ctrl.rodeo
 
 > Single source of truth for all features, stories, and tasks.
-> **Last Updated**: 2026-03-05 (Added Phase 13: Boards React Rewrite — 5 sub-phases, R1–R5)
+> **Last Updated**: 2026-04-10 (Added Systemic v2 epic to Backlog — 3 tracks, 16 stories)
 
 ---
 
@@ -31,11 +31,19 @@
 | [Phase 11: Instagram Import](./phase-11-instagram-import.md) | Pending | 0/73 |
 | [Phase 12: Lookback](./phase-12-lookback.md) | IN PROGRESS | 47/249 |
 | [Phase 13: Boards React Rewrite](./phase-13-react-rewrite.md) | Pending | 0/272 |
-| [Backlog](./backlog.md) | Future | 1/102 |
+| [Backlog](./backlog.md) | Future | 1/118 |
 
 ---
 
 ## Recent Milestones
+
+### Systemic v2 — Planned
+**Added: 2026-04-10** — 16 stories filed from [PRD: Systemic v2](/docs/strategy/prds/systemic-v2.md)
+
+- **Track 1 — Three Input Sources**: URL crawl (existing), Figma/Paper design files, and production code (GitHub repo or local path) as equal-weight entry points; file + line attribution for code source
+- **Track 2 — Lifelike Component State Rendering**: Multi-state examples (hover, focus, error, disabled, etc.) rendered side-by-side with contextual placeholder content; replaces the static "Examples" section
+- **Track 3 — Component Usage Inspector**: Drill-down view showing every instance of a component type across the source; right-side drawer with rendered preview, syntax-highlighted source, surrounding context, and variant classification
+- **Filed to**: Backlog (SystemicAI section, new Systemic v2 epics)
 
 ### Boards React Rewrite — Planned
 **Added: 2026-03-05** — Phase 13 filed from [PRD: Boards React Rewrite](/docs/strategy/prds/boards-react-rewrite.md)
@@ -146,8 +154,8 @@ See [Phase 3: AI Intelligence](./phase-3-ai-intelligence.md#epic-33-generative-w
 | Phase 11: Instagram Import | 0 | 0 | 73 | 0 |
 | Phase 12: Lookback | 47 | 0 | 197 | 5 |
 | Phase 13: React Rewrite | 0 | 0 | 272 | 0 |
-| Backlog | 1 | 0 | 100 | 0 |
-| **TOTAL** | **356** | **5** | **1497** | **9** |
+| Backlog | 1 | 0 | 116 | 0 |
+| **TOTAL** | **356** | **5** | **1513** | **9** |
 
 ---
 

--- a/docs/strategy/prds/systemic-v2.md
+++ b/docs/strategy/prds/systemic-v2.md
@@ -1,0 +1,361 @@
+# PRD: Systemic v2
+
+**Status:** Draft
+**Date:** 2026-04-10
+**Version:** 1.0
+**Dependencies:** [Design System Validation Pipeline PRD](design-system-validation-pipeline.md)
+
+---
+
+## 1. Problem Statement
+
+Systemic currently has one input mode: crawl a live URL. This works for deployed products but creates three gaps that limit its utility as a design system analysis tool.
+
+**Design sources are disconnected.** Figma files and Paper canvases contain the authoritative component definitions — the live URL is downstream. Systemic reads the output of design, not design itself. When design and production diverge, Systemic can only see the production state.
+
+**Component instances are invisible.** The crawler identifies component types and variants, but cannot tell you where any instance lives in code. "Button — disabled state found, 4 uses" is not actionable. "Button — disabled, line 1420 of boards/index.html" is. Without file + line attribution, developers cannot act on audit findings.
+
+**Multi-state rendering is absent.** Every component shows a single static example. Buttons only appear in their default state. Inputs only appear empty. This means hover states, error states, disabled states, and loading states are invisible until a developer manually exercises them — defeating the purpose of a component audit tool.
+
+---
+
+## 2. Goals
+
+1. **Three equal input sources** — URL crawl, design file (Figma + Paper), and production code (local path or GitHub repo) are first-class entry points
+2. **File + line attribution** — every component instance identified from a code source links back to its exact location in source
+3. **Multi-state rendering** — every component variant shows all its states simultaneously, with realistic contextually appropriate content
+4. **Component Usage Inspector** — a drill-down view showing all instances of a given component type across the full source, with previews and source context
+5. **No new external runtime dependencies** — Figma integration uses the public REST API; code source uses static parsing; no headless browser required
+
+---
+
+## 3. Non-Goals
+
+1. Rendering SPAs or JavaScript-heavy apps from the code source (static parsing only; use the URL crawl for SPAs)
+2. Two-way sync back to Figma (read-only for this version)
+3. Editing or fixing design system issues from within Systemic
+4. Visual regression testing (covered by the Design System Validation Pipeline PRD)
+
+---
+
+## 4. Architecture
+
+### Input Source Normalization
+
+All three input sources produce the same normalized data shape before any downstream processing. This means the viewer, audit, and Component Usage Inspector all work identically regardless of input source.
+
+```
+Input Source                 Normalized Output
+─────────────────────────────────────────────────────────
+URL Crawl (existing)     →   ComponentRecord[]
+Figma File               →   ComponentRecord[]
+Paper Canvas             →   ComponentRecord[]
+Local Code Path          →   ComponentRecord[] (+ location)
+GitHub Repo URL          →   ComponentRecord[] (+ location)
+```
+
+**Extended `ComponentRecord` shape (v2):**
+
+```javascript
+{
+  type: string,                  // "button", "card", "input", ...
+  variants: [
+    {
+      name: string,
+      html: string,
+      classes: string[],
+      styles: object,
+      states: string[],          // ["hover", "focus", "disabled", "error"]
+      usageCount: number,
+      instances: [               // NEW — only populated for code/design sources
+        {
+          location: {
+            type: "file" | "url" | "figma-frame",
+            path: string,        // file path, page URL, or Figma frame name
+            line: number | null, // line number for file source; null otherwise
+          },
+          html: string,          // the actual instance markup
+          context: {
+            parent: string,      // parent element HTML (outer only)
+            siblings: string[],  // adjacent sibling elements
+          },
+          thumbnailDataUrl: string | null,
+        }
+      ]
+    }
+  ],
+  totalUsage: number,
+  states: string[],
+}
+```
+
+### Input Source Selection Screen
+
+The audit start screen replaces the current single URL input with three distinct entry points presented as equal-weight cards. Each card has an icon, a title, a one-line description, and its own input controls.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Systemic — Audit a Design System                                   │
+├──────────────────┬──────────────────┬───────────────────────────────┤
+│  Live Page       │  Design File     │  Production Code              │
+│                  │                  │                               │
+│  [Globe icon]    │  [Figma icon]    │  [Code icon]                  │
+│                  │                  │                               │
+│  Crawl a live    │  Read directly   │  Parse a local path           │
+│  URL as it       │  from Figma or   │  or GitHub repo without       │
+│  renders today   │  Paper canvas    │  rendering                    │
+│                  │                  │                               │
+│  [ URL input ]   │  [ Figma URL ]   │  [ Path / Repo URL ]         │
+│                  │  [ API token ]   │  [ optional: GitHub token ]   │
+│  [ Start ]       │  [ Start ]       │  [ Start ]                    │
+└──────────────────┴──────────────────┴───────────────────────────────┘
+```
+
+---
+
+## 5. Track 1 — Three Input Sources
+
+### 1A. Figma Input
+
+**Authentication:** The user provides a Figma personal access token (PAT) in the input screen. The token is stored in localStorage for the session. No OAuth flow in v1 — PAT is sufficient for personal use.
+
+**API calls:**
+- `GET /v1/files/{file_key}` — fetches the full document tree: frames, components, styles
+- `GET /v1/files/{file_key}/styles` — all published styles (design tokens: color, text, effect, grid)
+- `GET /v1/files/{file_key}/components` — all published components and variants
+
+**What gets extracted:**
+| Figma Concept | Maps To |
+|---------------|---------|
+| Published component | `ComponentRecord.type` |
+| Component variant (name property) | `ComponentRecord.variants[].name` |
+| Component property values | `ComponentRecord.variants[].styles` |
+| Published color/text style | Design token |
+| Auto-layout properties | Spacing tokens |
+| Frame name (where component lives) | `instance.location.path` |
+
+**Normalization:** The Figma document tree is a nested JSON structure. A new `FigmaParser` module walks the tree depth-first, identifies component instances (nodes with `type === "INSTANCE"`), looks up the master component, and creates `ComponentRecord` entries. Frame names are used as location context.
+
+**Limitations (v1):**
+- Read-only
+- Published components only (not local components)
+- No rendering — tokens and component structure are extracted, not visual screenshots
+
+### 1B. Paper Input
+
+**Integration:** Paper exposes the current canvas via the Paper MCP context. When running in a Paper-connected session, Systemic calls `get_nodes` (or equivalent MCP read tool) to pull the active file structure. No export required.
+
+**What gets extracted:** Same as Figma — component definitions, design tokens, frame names as location context.
+
+**Normalization:** Paper canvas data is processed through the same `FigmaParser` normalization layer. The output is identical `ComponentRecord[]` regardless of whether source was Figma or Paper.
+
+### 1C. Production Code Input
+
+**Two sub-modes:**
+
+**Local path:** The user provides a file system path (e.g., `/Users/ian/projects/myapp`). A new Supabase edge function `systemic-crawl` accepts the path and reads files from the local filesystem via a lightweight local bridge server (a small Deno script the user runs locally, similar to a language server). The bridge listens on `localhost:4242`, accepts file read requests, and returns file contents. The edge function proxies through the bridge.
+
+**GitHub repo:** The user provides a GitHub repo URL (`https://github.com/owner/repo`). Systemic calls the GitHub Contents API (`GET /repos/{owner}/{repo}/contents/{path}`) recursively to enumerate and fetch all HTML, CSS, and JS files. Private repos require a GitHub PAT stored in localStorage.
+
+**Static parsing — what gets extracted:**
+- HTML files: all elements with class attributes; inline styles; data attributes
+- CSS files: all selectors, properties, custom property declarations, `:hover`/`:focus`/`:disabled` pseudo-class rules
+- JS files: string literals that look like class names and template literals that produce HTML
+
+**File + line attribution:** Every component instance extracted from a code source records the file path and line number of the opening tag in source HTML. This is the key advantage of the code source over URL crawl — the crawler sees rendered output, code parsing sees the source.
+
+**Parsing strategy:** Static — no JavaScript execution. DOM-like parsing via `linkedom` (already a known-good library for this stack). Not suitable for SPAs where components are rendered dynamically; the URL crawl covers those cases.
+
+---
+
+## 6. Track 2 — Lifelike Component State Rendering
+
+### Current State
+
+Each component variant shows a single static example pulled from the crawled HTML. The example is whatever state the crawler happened to capture at crawl time.
+
+### Target State
+
+Every component variant shows all its states simultaneously in a side-by-side row, with visually labeled state badges and realistic contextually appropriate placeholder content.
+
+### State Extraction
+
+The crawler already extracts CSS state rules. Track 2 uses those rules to generate one rendered example per discovered state. For each CSS state rule (`button:hover { ... }`), Systemic generates a second example with the state styles applied inline — simulating the state without requiring user interaction.
+
+**State sets per component type:**
+
+| Component Type | States Rendered |
+|---------------|-----------------|
+| Button | default, hover, active, disabled, loading |
+| Input / Textarea | empty, filled, focused, error, disabled |
+| Dropdown / Select | closed, open (with 4–5 list items), item-hovered, selected |
+| Card | default, hovered, selected |
+| Navigation item | default, active, hovered |
+| Checkbox / Radio | unchecked, checked, indeterminate, disabled |
+| Badge / Chip | default, all color variants |
+| Toggle | off, on, disabled |
+
+### Placeholder Content Strategy
+
+Generic lorem ipsum is replaced with contextually appropriate content based on component type. A small lookup table maps component type to content templates:
+
+| Component Type | Placeholder Strategy |
+|---------------|---------------------|
+| Button | Verb-noun labels: "Save Changes", "Cancel", "Submit", "Loading..." |
+| Input | Field-appropriate labels: "Email address", "Full name", "Search", "Password" |
+| Navigation | Navigation-appropriate labels: "Dashboard", "Settings", "Profile", "Library" |
+| Card | Realistic title + 2-sentence body + "Read more" action |
+| Dropdown | 4–5 domain-appropriate options pulled from component name/context |
+| Form | Complete form-appropriate field sets |
+
+### Visual State Labels
+
+Each rendered state example has a small badge in the top-right corner showing the state name: "default", "hover", "error", etc. This makes it immediately clear which state each example represents without requiring user interaction.
+
+### Implementation Notes
+
+- State rendering happens client-side — no new edge function required
+- The CSS state rules already stored in `variants[].states` are used to build a `<style>` block that applies the state styles to a static copy of the example HTML
+- This track replaces and absorbs the current "Examples" section — the component docs view becomes the examples view
+- Each multi-state row is contained in a horizontally scrollable strip on mobile
+
+---
+
+## 7. Track 3 — Component Usage Inspector
+
+### Purpose
+
+The Component Usage Inspector answers: "Where exactly is every instance of this component type used in my codebase, and what does each one look like?" It makes audit findings actionable by connecting abstract component analysis to concrete source locations.
+
+### Flow
+
+1. User selects a component type from a dropdown in the audit/QA view header (e.g., "Button", "Card", "Input")
+2. The view shows all instances of that component type across the full source in a scrollable grid
+3. Each instance card shows:
+   - Location context (file path + line for code source; page URL for crawl; Figma frame name for design)
+   - Small rendered preview thumbnail (~240×160)
+   - Variant classification badge (which variant Systemic identified it as)
+   - Confidence indicator
+4. Clicking an instance opens a right-side drawer
+
+### Instance Detail Drawer
+
+The drawer slides in from the right, covering ~40% of the viewport width. It contains four sections:
+
+**Rendered preview** — the component instance rendered in a sandboxed `<div>` with design system CSS applied. Shows the live component isolated from its surrounding context.
+
+**Source code block** — syntax-highlighted HTML showing the exact markup of the instance. For file sources, includes the file path and line number as a header above the code block. For URL sources, includes the page URL. For Figma, includes the frame name and component path.
+
+**Surrounding context** — a second code block showing the parent element and adjacent siblings, giving the developer enough context to locate the instance in a file browser or IDE.
+
+**Variant classification** — which variant Systemic identified this instance as (e.g., "Button / Primary / Large"), and the confidence score (0–100) with a brief explanation of what signals drove the classification.
+
+### Drawer States
+
+| State | Behavior |
+|-------|----------|
+| Default (no instance selected) | Drawer is hidden; full grid is visible |
+| Instance selected | Drawer slides in from right; grid shifts left to accommodate |
+| Drawer dismissed (X or Escape) | Grid returns to full width |
+| Navigating instances | Previous/Next arrows inside drawer cycle through instances without closing |
+
+### Filter Controls
+
+Above the instance grid: a search input (filter by location path) and a variant filter (show only instances of a specific variant). Counts update live as filters change.
+
+### Technical Requirements
+
+- Instance data is populated only when source is code (local path or GitHub) or Figma — URL crawl provides location as page URL, no line number
+- Thumbnail generation: rendered client-side by mounting instance HTML in an offscreen `<div>` and calling `html2canvas` or equivalent; lazy-generated on scroll
+- Drawer content is rendered in a sandboxed `<div>` with `pointer-events: none` to prevent interaction with the preview
+- All instance data is stored in localStorage alongside the component data from the current audit session
+
+---
+
+## 8. Technical Context
+
+| Item | Detail |
+|------|--------|
+| App directory | `systemic/` |
+| Stack | Vanilla JS (no frameworks), HTML, CSS |
+| Supabase project | `atdqdfpdeytfuvvpsasz` |
+| Existing component shape | `{ type, variants: [{name, html, classes, styles, states, usageCount}], totalUsage, states }` |
+| State rules | Already extracted by crawler, stored in `variants[].states` |
+| Storage | localStorage |
+| New edge function (if needed) | `systemic-crawl` on Supabase Ops project (`ycilriwjnmcelkspmfmg`) |
+
+### New Modules
+
+| Module | Purpose |
+|--------|---------|
+| `systemic/js/figma-parser.js` | Figma API client + document tree walker + normalization |
+| `systemic/js/code-parser.js` | Static HTML/CSS/JS parser + file + line attribution |
+| `systemic/js/state-renderer.js` | Multi-state example generation from CSS state rules |
+| `systemic/js/usage-inspector.js` | Component Usage Inspector — grid + drawer |
+| `supabase/functions/systemic-crawl/index.ts` | Edge function for local path bridge (optional) |
+
+### No New External Runtime Dependencies
+
+| Concern | Approach |
+|---------|---------|
+| Figma API | Direct fetch from browser (CORS allowed by Figma) |
+| GitHub Contents API | Direct fetch from browser (public repos; PAT for private) |
+| Static HTML parsing | `linkedom` (already used in design system validation pipeline) |
+| Thumbnail rendering | `html2canvas` (new, client-side only) |
+| Local file bridge | Small Deno server script (user runs locally, optional) |
+
+---
+
+## 9. Phased Delivery
+
+### Phase 1: Input Source Selection Screen + Code Parser (1–2 sessions)
+- Replace current URL-only start screen with three-source entry screen
+- Implement code source parser (GitHub repo sub-mode first — no local bridge needed)
+- Extend `ComponentRecord` shape with `instances[]`
+- File + line attribution in component data
+
+### Phase 2: Figma + Paper Integration (1 session)
+- Build `figma-parser.js`
+- Figma PAT flow in input screen
+- Paper MCP canvas read path
+- Same normalized output as code parser
+
+### Phase 3: Multi-State Rendering (1 session)
+- Build `state-renderer.js`
+- State extraction from CSS state rules
+- Contextual placeholder content lookup table
+- State badges on example cards
+- Replaces current "Examples" section
+
+### Phase 4: Component Usage Inspector (1–2 sessions)
+- Build `usage-inspector.js`
+- Instance grid view
+- Right-side drawer with rendered preview, source code block, surrounding context, variant classification
+- Filter controls (location search, variant filter)
+- Drawer navigation (prev/next instance)
+
+### Phase 5: Local Path Bridge (optional, 1 session)
+- Deno local bridge server script
+- `systemic-crawl` edge function
+- Local path sub-mode in input screen
+
+---
+
+## 10. Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Input sources supported | 3 (URL, Figma/Paper, code) |
+| States rendered per component | All CSS-defined states (min 3 per interactive component) |
+| File + line attribution accuracy | 100% for static HTML (no dynamic rendering) |
+| Instance inspector load time | < 2 seconds for up to 500 instances |
+| Placeholder content relevance | Contextually appropriate for all 8 component types |
+| Figma API coverage | Components, variants, published styles (tokens) |
+
+---
+
+## 11. Related Documents
+
+- [Design System Validation Pipeline PRD](design-system-validation-pipeline.md)
+- [Systemic README](../../systemic/README.md)
+- [AI Widget System](../../docs/infrastructure/technical-design/ai-widget-system.md)

--- a/supabase/functions/systemic-analyze/index.ts
+++ b/supabase/functions/systemic-analyze/index.ts
@@ -12,12 +12,47 @@ const corsHeaders = {
 };
 
 interface AnalyzeRequest {
-  componentType: string;
+  // Component analysis (existing)
+  componentType?: string;
   componentHtml?: string;
   componentStyles?: Record<string, string>;
   variants?: number;
   contextClues?: string[];
   contextUrls?: string[];
+  // Principles extraction (new)
+  action?: 'component' | 'principles';
+  designSystemSummary?: DesignSystemSummary;
+}
+
+interface DesignSystemSummary {
+  name: string;
+  sourceUrl?: string;
+  tokens: {
+    colorCount: number;
+    primaryColor?: string;
+    secondaryColor?: string;
+    fontPrimary?: string;
+    spacingBase?: number;
+    hasElevation?: boolean;
+    hasBorderRadius?: boolean;
+    cssVariableNames?: string[];
+  };
+  components: Array<{
+    type: string;
+    variantCount: number;
+    totalUsage: number;
+    states: string[];
+    sampleClasses: string[];
+    sampleHtml?: string;
+  }>;
+  source?: { type: string };
+}
+
+interface PrinciplesResponse {
+  philosophyStatement: string;
+  globalPrinciples: Array<{ title: string; description: string }>;
+  componentPrinciples: Record<string, Array<{ rule: string; rationale: string }>>;
+  generatedAt: string;
 }
 
 interface AnalyzeResponse {
@@ -44,6 +79,36 @@ Deno.serve(async (req) => {
     }
 
     const body: AnalyzeRequest = await req.json();
+    const client = new Anthropic({ apiKey });
+
+    // ── Principles extraction ──────────────────────────────────────
+    if (body.action === 'principles') {
+      if (!body.designSystemSummary) {
+        return new Response(
+          JSON.stringify({ error: "designSystemSummary is required for action=principles" }),
+          { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+
+      const principlesPrompt = buildPrinciplesPrompt(body.designSystemSummary);
+      const principlesMsg = await client.messages.create({
+        model: "claude-haiku-4-20250514",
+        max_tokens: 2048,
+        messages: [{ role: "user", content: principlesPrompt }],
+      });
+
+      const principlesText = principlesMsg.content.find((c) => c.type === "text");
+      if (!principlesText || principlesText.type !== "text") {
+        throw new Error("No text response from AI");
+      }
+
+      const principles = parsePrinciplesResponse(principlesText.text, body.designSystemSummary);
+      return new Response(JSON.stringify(principles), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // ── Component analysis (existing) ─────────────────────────────
     const {
       componentType,
       componentHtml,
@@ -61,8 +126,6 @@ Deno.serve(async (req) => {
         }
       );
     }
-
-    const client = new Anthropic({ apiKey });
 
     const prompt = buildAnalysisPrompt(
       componentType,
@@ -341,4 +404,92 @@ function getMaterialMapping(type: string): string {
   };
 
   return mappings[type] || "Custom";
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Principles extraction (new)
+// ──────────────────────────────────────────────────────────────────
+
+function buildPrinciplesPrompt(ds: DesignSystemSummary): string {
+  const compList = ds.components.map(c =>
+    `- ${c.type}: ${c.variantCount} variants, ${c.totalUsage} uses, classes: [${c.sampleClasses.slice(0, 6).join(', ')}]`
+  ).join('\n');
+
+  return `You are a senior design systems expert. Analyse this design system and extract its design principles.
+
+DESIGN SYSTEM: ${ds.name}
+SOURCE: ${ds.sourceUrl || 'unknown'}
+SOURCE TYPE: ${ds.source?.type || 'url'}
+
+TOKENS:
+- Colors: ${ds.tokens.colorCount} tokens, primary: ${ds.tokens.primaryColor || 'unknown'}, secondary: ${ds.tokens.secondaryColor || 'unknown'}
+- Typography: ${ds.tokens.fontPrimary || 'unknown'}
+- Spacing base: ${ds.tokens.spacingBase ? ds.tokens.spacingBase + 'px' : 'unknown'}
+- Elevation: ${ds.tokens.hasElevation ? 'yes' : 'no'}
+- Border radius: ${ds.tokens.hasBorderRadius ? 'yes' : 'no'}
+- CSS variables (sample): ${(ds.tokens.cssVariableNames || []).slice(0, 12).join(', ')}
+
+COMPONENTS (${ds.components.length} types):
+${compList}
+
+Respond ONLY in this exact JSON format — no markdown, no extra text:
+{
+  "philosophyStatement": "One sentence describing the overall visual and interaction philosophy of this design system.",
+  "globalPrinciples": [
+    { "title": "Principle name (2-4 words)", "description": "1-2 sentence explanation of what this principle means in this system, with specific evidence from the tokens or components." }
+  ],
+  "componentPrinciples": {
+    "<componentType>": [
+      { "rule": "Short imperative rule (e.g. 'Always pair with a ghost cancel')", "rationale": "Why this rule exists based on what was found in this system." }
+    ]
+  }
+}
+
+Rules:
+- globalPrinciples: 4-7 principles. Each must be grounded in actual evidence from the token/component data above. Cover: visual language, hierarchy, spacing/density, color use, interaction pattern, accessibility stance.
+- componentPrinciples: include every component type listed above. 2-4 rules per component. Rules must be specific to THIS system, not generic design advice.
+- philosophyStatement: must read like something from a brand guidelines doc — opinionated, specific to this system.
+Return ONLY the JSON object.`;
+}
+
+function parsePrinciplesResponse(text: string, ds: DesignSystemSummary): PrinciplesResponse {
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return {
+        philosophyStatement: parsed.philosophyStatement || fallbackPhilosophy(ds),
+        globalPrinciples: Array.isArray(parsed.globalPrinciples) ? parsed.globalPrinciples : fallbackGlobalPrinciples(ds),
+        componentPrinciples: typeof parsed.componentPrinciples === 'object' ? parsed.componentPrinciples : {},
+        generatedAt: new Date().toISOString(),
+      };
+    }
+  } catch (e) {
+    console.warn('Failed to parse principles response:', e);
+  }
+  return {
+    philosophyStatement: fallbackPhilosophy(ds),
+    globalPrinciples: fallbackGlobalPrinciples(ds),
+    componentPrinciples: {},
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function fallbackPhilosophy(ds: DesignSystemSummary): string {
+  return `${ds.name} is a design system built around ${ds.components.length} component types with a focus on consistency and usability.`;
+}
+
+function fallbackGlobalPrinciples(ds: DesignSystemSummary): Array<{ title: string; description: string }> {
+  const principles = [];
+  if (ds.tokens.spacingBase) {
+    principles.push({ title: "Grid-based Spacing", description: `All spacing derives from a ${ds.tokens.spacingBase}px base unit, creating consistent rhythm throughout the interface.` });
+  }
+  if (ds.tokens.colorCount > 0) {
+    principles.push({ title: "Intentional Color", description: `${ds.tokens.colorCount} color tokens define a deliberate palette where each color carries semantic meaning.` });
+  }
+  if (ds.components.length > 0) {
+    principles.push({ title: "Component Reuse", description: `${ds.components.length} shared component types reduce design debt and enforce interface consistency.` });
+  }
+  principles.push({ title: "Accessible by Default", description: "Interactive components are designed with keyboard navigation and ARIA semantics from the start." });
+  return principles;
 }

--- a/systemic/css/state-inspector.css
+++ b/systemic/css/state-inspector.css
@@ -1,0 +1,391 @@
+/* ============================================================
+   State Renderer — multi-state component showcase
+   ============================================================ */
+
+.component-state-grid {
+  margin-top: var(--space-8);
+  border-top: var(--border-thin) solid var(--border-subtle);
+  padding-top: var(--space-6);
+}
+
+.component-state-grid__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin: 0 0 var(--space-5);
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  font-size: 10px;
+}
+
+.variant-state-row {
+  margin-bottom: var(--space-6);
+}
+
+.variant-state-row__name {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  margin-bottom: var(--space-3);
+  font-family: var(--font-mono);
+}
+
+/* Horizontal scrollable strip of state examples */
+.state-strip {
+  display: flex;
+  gap: var(--space-4);
+  overflow-x: auto;
+  padding-bottom: var(--space-2);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.state-strip::-webkit-scrollbar {
+  height: 3px;
+}
+
+.state-strip::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.state-strip::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+/* Individual state example card */
+.state-example {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+}
+
+.state-example__preview {
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  padding: var(--space-4);
+  min-width: 120px;
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* State label badge */
+.state-example__label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+}
+
+
+/* ============================================================
+   Usage Inspector
+   ============================================================ */
+
+.usage-inspector {
+  display: none;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  margin: var(--space-6) 0;
+  overflow: hidden;
+  max-height: 70vh;
+}
+
+.usage-inspector.visible {
+  display: flex;
+}
+
+/* Header */
+.ui-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.ui-header__left {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+.ui-header__right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ui-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin: 0;
+}
+
+.ui-count {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+}
+
+.ui-search {
+  width: 200px;
+  font-size: var(--text-xs);
+}
+
+/* Body: grid + drawer side-by-side */
+.ui-body {
+  display: flex;
+  overflow: hidden;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Instance grid */
+.ui-grid {
+  flex: 1;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-4);
+  align-content: start;
+}
+
+.usage-inspector.drawer-open .ui-grid {
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+/* Instance card */
+.ui-card {
+  background: var(--bg);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: border-color .15s;
+  overflow: hidden;
+}
+
+.ui-card:hover {
+  border-color: var(--border);
+}
+
+.ui-card.selected {
+  border-color: var(--fg);
+}
+
+.ui-card:focus-visible {
+  outline: 2px solid var(--fg);
+  outline-offset: 2px;
+}
+
+.ui-card__preview {
+  background: var(--bg-surface);
+  padding: var(--space-3);
+  min-height: 64px;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--fg-muted);
+  white-space: pre;
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+}
+
+.ui-card__preview-html {
+  overflow: hidden;
+  max-height: 56px;
+  opacity: .7;
+}
+
+.ui-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
+}
+
+.ui-variant-badge {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--fg-muted);
+  background: var(--bg-elevated);
+  padding: 1px 5px;
+  border-radius: 2px;
+  align-self: flex-start;
+}
+
+.ui-location {
+  font-size: 10px;
+  color: var(--fg-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ui-location code {
+  font-family: var(--font-mono);
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Empty state */
+.ui-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: var(--space-10) var(--space-6);
+  color: var(--fg-muted);
+  font-size: var(--text-sm);
+  line-height: 1.7;
+}
+
+.ui-empty small {
+  color: var(--fg-subtle);
+  font-size: var(--text-xs);
+}
+
+/* Drawer */
+.ui-drawer {
+  flex: 0 0 50%;
+  border-left: var(--border-thin) solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ui-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.ui-drawer__nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.ui-drawer__nav-label {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  min-width: 48px;
+  text-align: center;
+}
+
+.ui-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+}
+
+/* Drawer sections */
+.ui-section {
+  margin-bottom: var(--space-5);
+}
+
+.ui-section:last-child {
+  margin-bottom: 0;
+}
+
+.ui-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-2);
+}
+
+.ui-section__label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: var(--fg-subtle);
+  font-weight: 500;
+}
+
+.ui-section__loc {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 200px;
+}
+
+/* Preview box */
+.ui-preview-box {
+  background: var(--bg);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  padding: var(--space-4);
+  min-height: 48px;
+}
+
+/* Code blocks */
+.ui-code {
+  background: var(--bg);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  padding: var(--space-3);
+  overflow-x: auto;
+  margin: 0;
+  scrollbar-width: thin;
+}
+
+.ui-code code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  white-space: pre;
+}
+
+.ui-code--muted code {
+  opacity: .5;
+}
+
+/* Classification */
+.ui-classification {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.ui-classification__type {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  background: var(--bg-elevated);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.ui-classification__sep {
+  color: var(--fg-subtle);
+}
+
+.ui-classification__variant {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+}
+
+.ui-classification__line {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-subtle);
+  margin-left: auto;
+}

--- a/systemic/css/state-inspector.css
+++ b/systemic/css/state-inspector.css
@@ -389,3 +389,238 @@
   color: var(--fg-subtle);
   margin-left: auto;
 }
+
+
+/* ============================================================
+   Principles View
+   ============================================================ */
+
+.principles-container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--space-8) var(--space-6);
+}
+
+/* Loading */
+.principles-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-16) var(--space-6);
+  color: var(--fg-muted);
+  font-size: var(--text-sm);
+}
+
+.principles-loading__spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--border-subtle);
+  border-top-color: var(--fg-muted);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Empty / error */
+.principles-empty,
+.principles-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-3);
+  padding: var(--space-16) var(--space-6);
+  color: var(--fg-muted);
+}
+
+.principles-empty__icon {
+  font-size: 32px;
+  opacity: .4;
+  margin-bottom: var(--space-2);
+}
+
+.principles-empty h3 {
+  font-size: var(--text-base);
+  font-weight: 600;
+  margin: 0;
+}
+
+.principles-empty p,
+.principles-error p {
+  font-size: var(--text-sm);
+  margin: 0;
+  color: var(--fg-subtle);
+}
+
+/* Header */
+.principles-header {
+  margin-bottom: var(--space-10);
+}
+
+.principles-title {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  margin: 0 0 var(--space-3);
+  letter-spacing: var(--tracking-tight);
+}
+
+.principles-philosophy {
+  font-size: var(--text-base);
+  color: var(--fg-muted);
+  line-height: 1.65;
+  margin: 0 0 var(--space-3);
+  max-width: 680px;
+}
+
+.principles-meta {
+  font-size: var(--text-xs);
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+  margin-right: var(--space-3);
+}
+
+/* Section */
+.principles-section {
+  margin-bottom: var(--space-12);
+}
+
+.principles-section__heading {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--fg-subtle);
+  font-weight: 500;
+  margin: 0 0 var(--space-5);
+  padding-bottom: var(--space-3);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+}
+
+/* Global principle cards */
+.principles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: var(--space-4);
+}
+
+.principle-card {
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  padding: var(--space-5);
+  transition: border-color .15s;
+}
+
+.principle-card:hover {
+  border-color: var(--border);
+}
+
+.principle-card__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  margin: 0 0 var(--space-2);
+  color: var(--fg);
+}
+
+.principle-card__desc {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Component principles accordion */
+.pcomp-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.pcomp-section {
+  background: var(--bg-surface);
+}
+
+.pcomp-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: none;
+  border: none;
+  border-top: var(--border-thin) solid var(--border-subtle);
+  color: var(--fg);
+  cursor: pointer;
+  font-family: var(--font-primary);
+  font-size: var(--text-sm);
+  text-align: left;
+  transition: background .12s;
+}
+
+.pcomp-section:first-child .pcomp-header {
+  border-top: none;
+}
+
+.pcomp-header:hover {
+  background: var(--bg-elevated);
+}
+
+.pcomp-header__name {
+  font-weight: 500;
+  flex: 1;
+}
+
+.pcomp-header__count {
+  font-size: var(--text-xs);
+  color: var(--fg-subtle);
+  font-family: var(--font-mono);
+}
+
+.pcomp-header__chevron {
+  color: var(--fg-subtle);
+  font-size: var(--text-sm);
+  transition: transform .15s;
+  line-height: 1;
+}
+
+.pcomp-section.open .pcomp-header__chevron {
+  transform: rotate(90deg);
+}
+
+/* Accordion body */
+.pcomp-body {
+  display: none;
+  padding: 0 var(--space-4) var(--space-4);
+  border-top: var(--border-thin) solid var(--border-subtle);
+}
+
+.pcomp-section.open .pcomp-body {
+  display: block;
+}
+
+.pcomp-rule {
+  padding: var(--space-3) 0;
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+}
+
+.pcomp-rule:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.pcomp-rule__rule {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--fg);
+  margin-bottom: var(--space-1);
+}
+
+.pcomp-rule__rationale {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  line-height: 1.55;
+}

--- a/systemic/css/systemic.css
+++ b/systemic/css/systemic.css
@@ -652,6 +652,86 @@
   width: 100%;
 }
 
+/* Scan Modal — Source Tabs */
+.scan-modal__tabs {
+  display: flex;
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  margin-bottom: var(--space-4);
+  gap: 0;
+}
+
+.scan-modal__tab {
+  flex: 1;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-family: var(--font-primary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  padding: var(--space-2) var(--space-3);
+  text-align: center;
+  transition: color .15s, border-color .15s;
+}
+
+.scan-modal__tab:hover {
+  color: var(--fg);
+}
+
+.scan-modal__tab.active {
+  border-bottom-color: var(--fg);
+  color: var(--fg);
+}
+
+.scan-modal__panel {
+  display: none;
+}
+
+.scan-modal__panel.active {
+  display: block;
+}
+
+.scan-modal__hint {
+  color: var(--fg-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  margin: 0 0 var(--space-3);
+}
+
+.scan-modal__body .form-group {
+  margin-bottom: var(--space-3);
+}
+
+.scan-modal__body .form-label {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  margin-bottom: var(--space-1);
+}
+
+.form-hint {
+  color: var(--fg-subtle);
+  font-size: 10px;
+  margin-top: var(--space-1);
+  display: block;
+}
+
+.form-hint a {
+  color: var(--fg-muted);
+}
+
+.form-hint-inline {
+  color: var(--fg-subtle);
+  font-size: 10px;
+  font-weight: 400;
+}
+
+.scan-modal__body .btn--filled {
+  width: 100%;
+  margin-top: var(--space-2);
+}
+
 /* Utility Classes */
 .hidden {
   display: none !important;

--- a/systemic/index.html
+++ b/systemic/index.html
@@ -268,6 +268,18 @@
         </div>
       </section>
 
+      <!-- Principles View -->
+      <section class="view-panel" id="principles-view">
+        <div class="principles-container" id="principles-container">
+          <!-- Populated by principles-generator.js + app.js -->
+          <div class="principles-empty" id="principles-empty">
+            <div class="principles-empty__icon">◈</div>
+            <h3>No design system loaded</h3>
+            <p>Run a scan to generate design principles for your system.</p>
+          </div>
+        </div>
+      </section>
+
       <!-- QA / Variant Audit View -->
       <section class="view-panel" id="qa-view">
         <div class="qa-container">
@@ -391,6 +403,7 @@
   <script src="js/figma-parser.js"></script>
   <script src="js/state-renderer.js"></script>
   <script src="js/usage-inspector.js"></script>
+  <script src="js/principles-generator.js"></script>
   <script src="js/component-consolidator.js"></script>
   <script src="js/doc-generator.js"></script>
   <script src="js/viewer.js"></script>

--- a/systemic/index.html
+++ b/systemic/index.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="css/systemic.css">
   <link rel="stylesheet" href="css/viewer.css">
   <link rel="stylesheet" href="css/variant-audit.css">
+  <link rel="stylesheet" href="css/state-inspector.css">
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 </head>
 <body>
@@ -275,6 +276,9 @@
             <p class="qa-desc" id="qa-desc">Select a component to audit its variants.</p>
           </div>
 
+          <!-- Component Usage Inspector (mounted by usage-inspector.js) -->
+          <div id="usage-inspector-mount"></div>
+
           <div class="filter-bar">
             <select class="input select" id="qa-component-filter">
               <option value="">— Select component —</option>
@@ -323,16 +327,51 @@
           <button class="scan-modal__close" id="scan-modal-close">&times;</button>
         </div>
         <div class="scan-modal__body">
-          <div class="scan-modal__option">
-            <div class="scan-modal__option-label">Scan a website</div>
+          <!-- Source tabs -->
+          <div class="scan-modal__tabs" role="tablist">
+            <button class="scan-modal__tab active" role="tab" aria-selected="true"  data-tab="live"   id="tab-live">Live Page</button>
+            <button class="scan-modal__tab"        role="tab" aria-selected="false" data-tab="design" id="tab-design">Design File</button>
+            <button class="scan-modal__tab"        role="tab" aria-selected="false" data-tab="code"   id="tab-code">GitHub Repo</button>
+          </div>
+
+          <!-- Tab: Live Page -->
+          <div class="scan-modal__panel active" data-panel="live" role="tabpanel" aria-labelledby="tab-live">
+            <p class="scan-modal__hint">Crawl a live URL — discovers rendered components and tokens.</p>
             <div class="scan-modal__option-row">
               <input type="text" id="scan-url-input" class="input" placeholder="example.com">
               <button class="btn btn--filled" id="scan-url-submit">Scan</button>
             </div>
-          </div>
-          <div class="scan-modal__divider"><span>or</span></div>
-          <div class="scan-modal__option">
+            <div class="scan-modal__divider"><span>or</span></div>
             <button class="btn btn--ghost scan-modal__local-btn" id="scan-local-btn">Load local design system</button>
+          </div>
+
+          <!-- Tab: Design File -->
+          <div class="scan-modal__panel" data-panel="design" role="tabpanel" aria-labelledby="tab-design" hidden>
+            <p class="scan-modal__hint">Read components and tokens directly from a Figma file.</p>
+            <div class="form-group">
+              <label class="form-label" for="scan-figma-url">Figma file URL</label>
+              <input type="text" id="scan-figma-url" class="input" placeholder="https://www.figma.com/design/...">
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="scan-figma-token">Personal Access Token</label>
+              <input type="text" id="scan-figma-token" class="input" placeholder="figd_..." autocomplete="off">
+              <span class="form-hint">Stored locally in this browser only. <a href="https://help.figma.com/hc/en-us/articles/8085703771159" target="_blank" rel="noopener">How to get a token</a></span>
+            </div>
+            <button class="btn btn--filled" id="scan-figma-submit">Analyze Figma File</button>
+          </div>
+
+          <!-- Tab: GitHub Repo -->
+          <div class="scan-modal__panel" data-panel="code" role="tabpanel" aria-labelledby="tab-code" hidden>
+            <p class="scan-modal__hint">Parse HTML and CSS statically — every instance gets file + line attribution.</p>
+            <div class="form-group">
+              <label class="form-label" for="scan-github-url">GitHub repo URL</label>
+              <input type="text" id="scan-github-url" class="input" placeholder="https://github.com/owner/repo">
+            </div>
+            <div class="form-group">
+              <label class="form-label" for="scan-github-token">GitHub token <span class="form-hint-inline">(optional — private repos &amp; higher rate limits)</span></label>
+              <input type="text" id="scan-github-token" class="input" placeholder="ghp_..." autocomplete="off">
+            </div>
+            <button class="btn btn--filled" id="scan-github-submit">Analyze Repository</button>
           </div>
         </div>
       </div>
@@ -348,6 +387,10 @@
   <script src="js/utils/material-tokens.js"></script>
   <script src="js/token-mapper.js"></script>
   <script src="js/crawler.js"></script>
+  <script src="js/code-parser.js"></script>
+  <script src="js/figma-parser.js"></script>
+  <script src="js/state-renderer.js"></script>
+  <script src="js/usage-inspector.js"></script>
   <script src="js/component-consolidator.js"></script>
   <script src="js/doc-generator.js"></script>
   <script src="js/viewer.js"></script>

--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -12,6 +12,8 @@ class SystemicApp {
     this.supabaseUrl = SUPABASE_URL;
     this.supabaseKey = SUPABASE_ANON_KEY;
     this.crawler = null;
+    this.codeParser = null;
+    this.figmaParser = null;
     this.tokenMapper = new TokenMapper();
     this.componentConsolidator = new ComponentConsolidator();
     this.docGenerator = new DocGenerator({
@@ -19,8 +21,10 @@ class SystemicApp {
       supabaseUrl: SUPABASE_URL,
       supabaseKey: SUPABASE_ANON_KEY
     });
+    this.stateRenderer = new StateRenderer();
     this.viewer = null;
     this.variantAudit = null;
+    this.usageInspector = null;
     this.currentAudit = null;
     this.designSystems = [];
     this.debugMode = true; // Enable detailed logging
@@ -253,10 +257,15 @@ class SystemicApp {
     this.loadSavedSystems();
     this.initViewer();
     this.initVariantAudit();
+    this.initUsageInspector();
     // Connect viewer to audit so component stage can show QA controls
     if (this.viewer && this.variantAudit) {
       this.viewer.variantAudit = this.variantAudit;
     }
+    // Connect component filter to Usage Inspector
+    DOMUtils.$('#qa-component-filter')?.addEventListener('change', (e) => {
+      this._onQAComponentSelect(e.target.value);
+    });
     this.initRouter();
   }
 
@@ -726,6 +735,14 @@ class SystemicApp {
     this.scanUrlInput = DOMUtils.$('#scan-url-input');
     this.scanUrlSubmit = DOMUtils.$('#scan-url-submit');
     this.scanLocalBtn = DOMUtils.$('#scan-local-btn');
+
+    // Scan modal — new source tabs
+    this.scanFigmaUrl = DOMUtils.$('#scan-figma-url');
+    this.scanFigmaToken = DOMUtils.$('#scan-figma-token');
+    this.scanFigmaSubmit = DOMUtils.$('#scan-figma-submit');
+    this.scanGithubUrl = DOMUtils.$('#scan-github-url');
+    this.scanGithubToken = DOMUtils.$('#scan-github-token');
+    this.scanGithubSubmit = DOMUtils.$('#scan-github-submit');
   }
 
   /**
@@ -794,6 +811,45 @@ class SystemicApp {
     DOMUtils.$('#run-scan-btn')?.addEventListener('click', (e) => {
       e.preventDefault();
       this.openScanModal();
+    });
+
+    // Scan modal — tab switching
+    this.scanModal?.addEventListener('click', (e) => {
+      const tab = e.target.closest('[data-tab]');
+      if (!tab) return;
+      const targetTab = tab.dataset.tab;
+      this.scanModal.querySelectorAll('.scan-modal__tab').forEach(t => {
+        const active = t.dataset.tab === targetTab;
+        t.classList.toggle('active', active);
+        t.setAttribute('aria-selected', String(active));
+      });
+      this.scanModal.querySelectorAll('.scan-modal__panel').forEach(p => {
+        const active = p.dataset.panel === targetTab;
+        p.classList.toggle('active', active);
+        p.hidden = !active;
+      });
+    });
+
+    // Figma scan submit
+    this.scanFigmaSubmit?.addEventListener('click', () => {
+      const url = this.scanFigmaUrl?.value?.trim();
+      const token = this.scanFigmaToken?.value?.trim();
+      if (!url) { this.showToast('Enter a Figma file URL', 'error'); return; }
+      if (!token) { this.showToast('A Figma Personal Access Token is required', 'error'); return; }
+      // Persist token for session
+      try { localStorage.setItem('systemic-figma-token', token); } catch {}
+      this.closeScanModal();
+      this.startFigmaScan(url, token);
+    });
+
+    // GitHub repo scan submit
+    this.scanGithubSubmit?.addEventListener('click', () => {
+      const url = this.scanGithubUrl?.value?.trim();
+      const token = this.scanGithubToken?.value?.trim() || null;
+      if (!url) { this.showToast('Enter a GitHub repo URL', 'error'); return; }
+      if (token) { try { localStorage.setItem('systemic-github-token', token); } catch {} }
+      this.closeScanModal();
+      this.startGitHubScan(url, token);
     });
   }
 
@@ -1147,11 +1203,51 @@ class SystemicApp {
   }
 
   /**
+   * Called when a component is selected in the QA component filter.
+   * Opens the Usage Inspector for that component.
+   */
+  _onQAComponentSelect(componentType) {
+    if (!this.usageInspector) return;
+    if (!componentType) {
+      this.usageInspector.hide();
+      return;
+    }
+    const ds = this.viewer?.designSystem;
+    if (!ds) return;
+    const component = ds.components?.find(c => c.type === componentType || c.name === componentType);
+    if (component) {
+      this.usageInspector.show(component);
+    } else {
+      this.usageInspector.hide();
+    }
+  }
+
+  /**
+   * Initialize the Usage Inspector
+   */
+  initUsageInspector() {
+    const mount = DOMUtils.$('#usage-inspector-mount');
+    if (mount) {
+      this.usageInspector = new UsageInspector({
+        container: mount,
+        onToast: (msg, type) => this.showToast(msg, type)
+      });
+    }
+  }
+
+  /**
    * Open the scan modal
    */
   openScanModal() {
     if (this.scanModal) {
       this.scanModal.classList.add('open');
+      // Restore saved tokens
+      try {
+        const ft = localStorage.getItem('systemic-figma-token');
+        const gt = localStorage.getItem('systemic-github-token');
+        if (ft && this.scanFigmaToken) this.scanFigmaToken.value = ft;
+        if (gt && this.scanGithubToken) this.scanGithubToken.value = gt;
+      } catch {}
       this.scanUrlInput?.focus();
     }
   }
@@ -1163,6 +1259,78 @@ class SystemicApp {
     if (this.scanModal) {
       this.scanModal.classList.remove('open');
       if (this.scanUrlInput) this.scanUrlInput.value = '';
+    }
+  }
+
+  /**
+   * Start a GitHub repo scan
+   */
+  async startGitHubScan(repoUrl, token) {
+    const name = repoUrl.replace(/^https?:\/\/github\.com\//i, '').split('/').slice(0, 2).join('/');
+    this.debugLog('GITHUB', `Starting GitHub scan: ${repoUrl}`);
+
+    this.navigateTo('audit');
+    await new Promise(r => setTimeout(r, 50)); // let view activate
+
+    this.auditFormSection.hidden = true;
+    this.auditProgressSection.hidden = false;
+    this.auditUrlDisplay.textContent = repoUrl;
+    this.auditStatusText.textContent = 'Connecting to GitHub...';
+    this.clearLog();
+
+    this.codeParser = new CodeParser({
+      token,
+      onLog: (log) => this.addLogEntry(log),
+      onProgress: (progress) => this.updateProgress(progress)
+    });
+
+    this.currentAudit = {
+      id: crypto.randomUUID(),
+      config: { url: repoUrl, name, source: 'github' },
+      startedAt: new Date().toISOString()
+    };
+
+    try {
+      const results = await this.codeParser.parse(repoUrl);
+      await this.onAuditComplete(results);
+    } catch (err) {
+      this.onAuditError(err);
+    }
+  }
+
+  /**
+   * Start a Figma file scan
+   */
+  async startFigmaScan(figmaUrl, token) {
+    const name = figmaUrl.replace(/\?.*/, '').split('/').pop()?.replace(/-/g, ' ') || 'Figma File';
+    this.debugLog('FIGMA', `Starting Figma scan: ${figmaUrl}`);
+
+    this.navigateTo('audit');
+    await new Promise(r => setTimeout(r, 50));
+
+    this.auditFormSection.hidden = true;
+    this.auditProgressSection.hidden = false;
+    this.auditUrlDisplay.textContent = figmaUrl;
+    this.auditStatusText.textContent = 'Connecting to Figma...';
+    this.clearLog();
+
+    this.figmaParser = new FigmaParser({
+      token,
+      onLog: (log) => this.addLogEntry(log),
+      onProgress: (progress) => this.updateProgress(progress)
+    });
+
+    this.currentAudit = {
+      id: crypto.randomUUID(),
+      config: { url: figmaUrl, name, source: 'figma' },
+      startedAt: new Date().toISOString()
+    };
+
+    try {
+      const results = await this.figmaParser.parse(figmaUrl);
+      await this.onAuditComplete(results);
+    } catch (err) {
+      this.onAuditError(err);
     }
   }
 
@@ -1463,6 +1631,14 @@ class SystemicApp {
     if (this.crawler) {
       this.crawler.stop();
       this.addLogEntry({ type: 'info', message: 'Audit cancelled by user' });
+    }
+    if (this.codeParser) {
+      this.codeParser.stop();
+      this.addLogEntry({ type: 'info', message: 'GitHub scan cancelled' });
+    }
+    if (this.figmaParser) {
+      this.figmaParser.stop();
+      this.addLogEntry({ type: 'info', message: 'Figma scan cancelled' });
     }
     this.resetAuditForm();
   }

--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -22,6 +22,10 @@ class SystemicApp {
       supabaseKey: SUPABASE_ANON_KEY
     });
     this.stateRenderer = new StateRenderer();
+    this.principlesGenerator = new PrinciplesGenerator({
+      supabaseUrl: SUPABASE_URL,
+      supabaseKey: SUPABASE_ANON_KEY
+    });
     this.viewer = null;
     this.variantAudit = null;
     this.usageInspector = null;
@@ -942,8 +946,8 @@ class SystemicApp {
   handleRoute() {
     const route = this.parseHash();
 
-    // If navigating to docs/qa without a loaded system, try to restore the last-active one
-    if ((route.view === 'docs' || route.view === 'qa') && !this.viewer?.designSystem) {
+    // If navigating to docs/qa/principles without a loaded system, try to restore
+    if ((route.view === 'docs' || route.view === 'qa' || route.view === 'principles') && !this.viewer?.designSystem) {
       const restored = this.restoreActiveSystem();
       if (!restored) {
         // No system to restore — redirect to systems list
@@ -987,6 +991,11 @@ class SystemicApp {
     // Load systems list when switching to systems view
     if (route.view === 'systems') {
       this.renderSystemsList();
+    }
+
+    // Render principles view
+    if (route.view === 'principles') {
+      this.renderPrinciples();
     }
   }
 
@@ -1035,6 +1044,21 @@ class SystemicApp {
             <a href="#docs/color" class="breadcrumb-link">${qaSystemName}</a>
             <span class="breadcrumb-sep">/</span>
             <span class="breadcrumb-current">Variant Audit</span>
+          </nav>
+          <span class="docs-nav__spacer"></span>
+        `;
+        break;
+      }
+
+      case 'principles': {
+        const pSystemName = this.viewer?.designSystem?.name || 'System';
+        this.appNav.innerHTML = `
+          <nav class="breadcrumb" aria-label="Breadcrumb">
+            <a href="#systems" class="breadcrumb-link">Systems</a>
+            <span class="breadcrumb-sep">/</span>
+            <a href="#docs/color" class="breadcrumb-link">${pSystemName}</a>
+            <span class="breadcrumb-sep">/</span>
+            <span class="breadcrumb-current">Principles</span>
           </nav>
           <span class="docs-nav__spacer"></span>
         `;
@@ -1139,6 +1163,7 @@ class SystemicApp {
       <a href="#" class="docs-nav__link" data-section="spacing">Spacing</a>
       <a href="#" class="docs-nav__link" data-section="elevation">Elevation</a>
       <a href="#" class="docs-nav__link" data-section="examples">Examples</a>
+      <a href="#principles" class="docs-nav__link">Principles</a>
       <a href="#qa" class="docs-nav__link">QA</a>
       <span class="docs-nav__spacer"></span>
       <select class="docs-nav__select" id="component-select">
@@ -1868,6 +1893,136 @@ class SystemicApp {
 
     this.renderSystemsList();
     this.showToast('Design system deleted');
+  }
+
+  /**
+   * Render the Principles view.
+   * Calls PrinciplesGenerator, then renders global + per-component principles.
+   */
+  async renderPrinciples() {
+    const container = DOMUtils.$('#principles-container');
+    if (!container) return;
+
+    const ds = this.viewer?.designSystem;
+    if (!ds) {
+      container.innerHTML = `
+        <div class="principles-empty">
+          <div class="principles-empty__icon">◈</div>
+          <h3>No design system loaded</h3>
+          <p>Open a design system from <a href="#systems">My Systems</a> to generate its principles.</p>
+        </div>
+      `;
+      return;
+    }
+
+    // Show loading state
+    container.innerHTML = `
+      <div class="principles-loading">
+        <div class="principles-loading__spinner"></div>
+        <p>Analysing design system…</p>
+      </div>
+    `;
+
+    try {
+      const principles = await this.principlesGenerator.generate(ds);
+
+      // Cache on the design system object + persist
+      ds.principles = principles;
+      this.saveDesignSystem(ds, true);
+
+      container.innerHTML = this._buildPrinciplesHTML(ds, principles);
+
+      // Bind accordion toggles for component sections
+      container.querySelectorAll('.pcomp-header').forEach(header => {
+        header.addEventListener('click', () => {
+          const section = header.closest('.pcomp-section');
+          section?.classList.toggle('open');
+          header.setAttribute('aria-expanded', String(section?.classList.contains('open')));
+        });
+      });
+
+      // Regenerate button — clears cache and re-runs
+      DOMUtils.$('#principles-regenerate')?.addEventListener('click', () => {
+        if (ds.principles) delete ds.principles.generatedAt;
+        this.renderPrinciples();
+      });
+
+    } catch (err) {
+      this.debugLog('PRINCIPLES', 'Error generating principles:', err);
+      container.innerHTML = `
+        <div class="principles-error">
+          <p>Failed to generate principles: ${err.message}</p>
+          <button class="btn btn--ghost btn--sm" id="principles-retry">Retry</button>
+        </div>
+      `;
+      DOMUtils.$('#principles-retry')?.addEventListener('click', () => this.renderPrinciples());
+    }
+  }
+
+  /**
+   * Build the full HTML for the Principles view from a principles result object.
+   */
+  _buildPrinciplesHTML(ds, p) {
+    const globalCards = (p.globalPrinciples || []).map(pr => `
+      <div class="principle-card">
+        <h4 class="principle-card__title">${this._escHtml(pr.title)}</h4>
+        <p class="principle-card__desc">${this._escHtml(pr.description)}</p>
+      </div>
+    `).join('');
+
+    const componentSections = Object.entries(p.componentPrinciples || {}).map(([type, rules]) => {
+      if (!rules?.length) return '';
+      const ruleItems = rules.map(r => `
+        <div class="pcomp-rule">
+          <div class="pcomp-rule__rule">${this._escHtml(r.rule)}</div>
+          <div class="pcomp-rule__rationale">${this._escHtml(r.rationale)}</div>
+        </div>
+      `).join('');
+      const label = type.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      return `
+        <div class="pcomp-section">
+          <button class="pcomp-header" aria-expanded="false">
+            <span class="pcomp-header__name">${this._escHtml(label)}</span>
+            <span class="pcomp-header__count">${rules.length} rule${rules.length !== 1 ? 's' : ''}</span>
+            <span class="pcomp-header__chevron">›</span>
+          </button>
+          <div class="pcomp-body">${ruleItems}</div>
+        </div>
+      `;
+    }).join('');
+
+    const aiLabel = p.generatedAt
+      ? `Generated ${new Date(p.generatedAt).toLocaleDateString()}`
+      : '';
+
+    return `
+      <div class="principles-header">
+        <h2 class="principles-title">${this._escHtml(ds.name)}</h2>
+        <p class="principles-philosophy">${this._escHtml(p.philosophyStatement || '')}</p>
+        ${aiLabel ? `<span class="principles-meta">${aiLabel}</span>` : ''}
+        <button class="btn btn--ghost btn--sm" id="principles-regenerate">Regenerate</button>
+      </div>
+
+      <section class="principles-section">
+        <h3 class="principles-section__heading">Global Principles</h3>
+        <div class="principles-grid">${globalCards}</div>
+      </section>
+
+      ${componentSections ? `
+      <section class="principles-section">
+        <h3 class="principles-section__heading">Component Principles</h3>
+        <div class="pcomp-list">${componentSections}</div>
+      </section>
+      ` : ''}
+    `;
+  }
+
+  _escHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
   /**

--- a/systemic/js/code-parser.js
+++ b/systemic/js/code-parser.js
@@ -1,0 +1,285 @@
+/**
+ * CodeParser — GitHub repository static parser
+ *
+ * Fetches HTML/CSS files via GitHub Contents API and extracts
+ * ComponentRecord[] with file + line attribution for instances[].
+ *
+ * Usage:
+ *   const parser = new CodeParser({ token, onLog, onProgress });
+ *   const results = await parser.parse('https://github.com/owner/repo');
+ */
+class CodeParser {
+  constructor({ token, onLog, onProgress } = {}) {
+    this.token = token || null;
+    this.onLog = onLog || (() => {});
+    this.onProgress = onProgress || (() => {});
+    this.cancelled = false;
+
+    // Component detection patterns: { type, tagPattern }
+    this.COMPONENT_PATTERNS = [
+      { type: 'button',   tagRe: /<button\b([^>]*)>([\s\S]*?)<\/button>/gi },
+      { type: 'input',    tagRe: /<input\b([^>]*)>/gi },
+      { type: 'select',   tagRe: /<select\b([^>]*)>([\s\S]*?)<\/select>/gi },
+      { type: 'form',     tagRe: /<form\b([^>]*)>/gi },
+      { type: 'nav',      tagRe: /<nav\b([^>]*)>/gi },
+      { type: 'card',     tagRe: /class="[^"]*\bcard\b[^"]*"/gi },
+      { type: 'modal',    tagRe: /class="[^"]*\bmodal\b[^"]*"/gi },
+      { type: 'dropdown', tagRe: /class="[^"]*\bdropdown\b[^"]*"/gi },
+      { type: 'link',     tagRe: /<a\b([^>]*)>/gi },
+      { type: 'badge',    tagRe: /class="[^"]*\bbadge\b[^"]*"/gi },
+    ];
+  }
+
+  // ----------------------------------------------------------------
+  // GitHub API
+  // ----------------------------------------------------------------
+
+  /**
+   * Parse a GitHub repo URL into { owner, repo }
+   * Accepts: https://github.com/owner/repo, github.com/owner/repo, owner/repo
+   */
+  parseRepoUrl(url) {
+    const cleaned = (url || '').trim()
+      .replace(/^https?:\/\//i, '')
+      .replace(/^github\.com\//i, '');
+    const match = cleaned.match(/^([^/\s]+)\/([^/\s#?]+)/);
+    if (!match) {
+      throw new Error('Invalid GitHub repo URL. Expected: https://github.com/owner/repo');
+    }
+    return { owner: match[1], repo: match[2].replace(/\.git$/, '') };
+  }
+
+  async _ghFetch(path) {
+    if (this.cancelled) throw new Error('Cancelled');
+    const headers = { 'Accept': 'application/vnd.github+json', 'User-Agent': 'Systemic/2' };
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+    const res = await fetch(`https://api.github.com${path}`, { headers });
+    if (res.status === 403 || res.status === 429) {
+      throw new Error('GitHub API rate limit reached. Add a Personal Access Token for higher limits.');
+    }
+    if (res.status === 404) throw new Error(`Not found: ${path}`);
+    if (!res.ok) throw new Error(`GitHub API error ${res.status}: ${path}`);
+    return res.json();
+  }
+
+  /**
+   * Enumerate all HTML and CSS files in a repo using the git tree API.
+   * Skips minified, vendor, and node_modules paths.
+   */
+  async _listFiles(owner, repo) {
+    this.onLog({ type: 'info', message: `Fetching file tree for ${owner}/${repo}...` });
+    const tree = await this._ghFetch(`/repos/${owner}/${repo}/git/trees/HEAD?recursive=1`);
+    const files = (tree.tree || [])
+      .filter(f => f.type === 'blob' && /\.(html|htm|css)$/i.test(f.path))
+      .filter(f => !/node_modules|\.min\.|\/vendor\/|dist\/|\.git\//i.test(f.path));
+    this.onLog({ type: 'info', message: `Found ${files.length} HTML/CSS files to parse` });
+    return files;
+  }
+
+  /**
+   * Fetch a file's text content from the GitHub Contents API.
+   */
+  async _fetchFile(owner, repo, path) {
+    const data = await this._ghFetch(`/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`);
+    if (data.encoding === 'base64') {
+      return atob(data.content.replace(/[\n\r]/g, ''));
+    }
+    return data.content || '';
+  }
+
+  // ----------------------------------------------------------------
+  // HTML parsing
+  // ----------------------------------------------------------------
+
+  /**
+   * Parse a single HTML file.
+   * Returns { components: ComponentRawRecord[], tokens: [] }
+   * Each component record carries an `instance` field with file+line.
+   */
+  _parseHTML(content, filePath) {
+    const components = [];
+    const lines = content.split('\n');
+
+    for (const { type, tagRe } of this.COMPONENT_PATTERNS) {
+      tagRe.lastIndex = 0;
+      let match;
+      while ((match = tagRe.exec(content)) !== null) {
+        // Count newlines before match start to get 1-indexed line number
+        const before = content.slice(0, match.index);
+        const line = (before.match(/\n/g) || []).length + 1;
+
+        // Extract class attribute from the matched tag
+        const classMatch = match[0].match(/class="([^"]*)"/);
+        const classes = classMatch ? classMatch[1].split(/\s+/).filter(Boolean) : [];
+
+        // Surrounding context (3 lines of context window)
+        const ctxStart = Math.max(0, line - 3);
+        const ctxEnd = Math.min(lines.length, line + 2);
+        const contextLines = lines.slice(ctxStart, ctxEnd).map(l => l.trim()).filter(Boolean);
+        const parentHtml = lines.slice(Math.max(0, line - 3), line - 1).join('\n').trim();
+
+        const rawHtml = match[0].length > 400 ? match[0].slice(0, 400) + '...' : match[0];
+
+        components.push({
+          type,
+          html: rawHtml,
+          classes,
+          styles: {},
+          states: [],
+          usageCount: 1,
+          instance: {
+            location: { type: 'file', path: filePath, line },
+            html: rawHtml,
+            context: { parent: parentHtml, siblings: contextLines },
+            thumbnailDataUrl: null
+          }
+        });
+      }
+    }
+
+    return { components, tokens: [] };
+  }
+
+  // ----------------------------------------------------------------
+  // CSS parsing
+  // ----------------------------------------------------------------
+
+  /**
+   * Parse a single CSS file.
+   * Returns { tokens: TokenRecord[], stateRules: StateRuleRecord[] }
+   */
+  _parseCSS(content, filePath) {
+    const tokens = [];
+    const stateRules = [];
+
+    // CSS custom properties → design tokens
+    const varRe = /--([a-z][a-z0-9-]*)\s*:\s*([^;}{]+);/gi;
+    let m;
+    while ((m = varRe.exec(content)) !== null) {
+      const name = m[1];
+      const value = m[2].trim();
+      let category = 'other';
+      if (/color|bg|fg|border|fill|stroke|surface/i.test(name)) category = 'color';
+      else if (/font|text|size|weight|line-height|letter|tracking/i.test(name)) category = 'typography';
+      else if (/space|gap|padding|margin/i.test(name)) category = 'spacing';
+      else if (/shadow|elevation|z-index/i.test(name)) category = 'elevation';
+      else if (/radius|round|corner/i.test(name)) category = 'shape';
+      tokens.push({ name: `--${name}`, value, category, source: filePath });
+    }
+
+    // State pseudo-class rules
+    const stateRe = /([^{}]+):(hover|focus|active|disabled|checked|error|invalid|focus-visible)[^{]*\{([^}]+)\}/gi;
+    while ((m = stateRe.exec(content)) !== null) {
+      stateRules.push({
+        selector: m[1].trim(),
+        state: m[2].toLowerCase(),
+        styles: m[3].trim()
+      });
+    }
+
+    return { tokens, stateRules };
+  }
+
+  // ----------------------------------------------------------------
+  // Main entry point
+  // ----------------------------------------------------------------
+
+  /**
+   * Parse a GitHub repository.
+   * Returns results in the same shape as AgenticCrawler.getResults():
+   * { components, tokens, stateRules, pages, pagesCrawled, source }
+   */
+  async parse(repoUrl) {
+    this.cancelled = false;
+    const { owner, repo } = this.parseRepoUrl(repoUrl);
+    this.onLog({ type: 'info', message: `Analyzing github.com/${owner}/${repo}` });
+
+    const files = await this._listFiles(owner, repo);
+    if (files.length === 0) {
+      throw new Error('No HTML or CSS files found in this repository.');
+    }
+
+    const allComponents = [];
+    const allTokens = [];
+    const allStateRules = [];
+    const pages = [];
+    const MAX_FILES = 150; // guard against very large repos
+
+    const filesToProcess = files.slice(0, MAX_FILES);
+    if (files.length > MAX_FILES) {
+      this.onLog({ type: 'warning', message: `Large repo — analysing first ${MAX_FILES} files` });
+    }
+
+    for (let i = 0; i < filesToProcess.length; i++) {
+      if (this.cancelled) break;
+      const file = filesToProcess[i];
+
+      this.onProgress({
+        pagesCrawled: i,
+        pagesTotal: filesToProcess.length,
+        tokensExtracted: allTokens.length,
+        componentsFound: allComponents.length,
+        currentUrl: file.path
+      });
+
+      try {
+        const content = await this._fetchFile(owner, repo, file.path);
+
+        if (/\.(html|htm)$/i.test(file.path)) {
+          const { components, tokens } = this._parseHTML(content, file.path);
+          allComponents.push(...components);
+          allTokens.push(...tokens);
+          if (components.length > 0) {
+            this.onLog({ type: 'success', message: `${file.path} — ${components.length} component${components.length !== 1 ? 's' : ''}` });
+          }
+          pages.push({
+            url: `github:${owner}/${repo}/${file.path}`,
+            components: components.length,
+            tokens: tokens.length,
+            crawledAt: new Date().toISOString()
+          });
+        } else if (/\.css$/i.test(file.path)) {
+          const { tokens, stateRules } = this._parseCSS(content, file.path);
+          allTokens.push(...tokens);
+          allStateRules.push(...stateRules);
+          if (tokens.length > 0) {
+            this.onLog({ type: 'success', message: `${file.path} — ${tokens.length} token${tokens.length !== 1 ? 's' : ''}` });
+          }
+        }
+      } catch (err) {
+        this.onLog({ type: 'warning', message: `Skipped ${file.path}: ${err.message}` });
+      }
+
+      // Throttle to stay within GitHub rate limits (60 req/min unauthenticated)
+      if (!this.token && i % 8 === 7) {
+        await new Promise(r => setTimeout(r, 500));
+      }
+    }
+
+    this.onProgress({
+      pagesCrawled: filesToProcess.length,
+      pagesTotal: filesToProcess.length,
+      tokensExtracted: allTokens.length,
+      componentsFound: allComponents.length,
+      currentUrl: 'complete'
+    });
+
+    this.onLog({
+      type: 'success',
+      message: `Done — ${allComponents.length} component instances across ${pages.length} HTML files`
+    });
+
+    return {
+      components: allComponents,
+      tokens: allTokens,
+      stateRules: allStateRules,
+      pages,
+      pagesCrawled: filesToProcess.length,
+      source: { type: 'github', owner, repo, url: repoUrl }
+    };
+  }
+
+  stop() {
+    this.cancelled = true;
+  }
+}

--- a/systemic/js/figma-parser.js
+++ b/systemic/js/figma-parser.js
@@ -1,0 +1,365 @@
+/**
+ * FigmaParser — Figma REST API client + document tree walker
+ *
+ * Reads component definitions, design tokens, and component instances
+ * from a Figma file. Returns normalized results compatible with the
+ * Systemic processing pipeline (same shape as CodeParser / AgenticCrawler).
+ *
+ * Usage:
+ *   const parser = new FigmaParser({ token, onLog, onProgress });
+ *   const results = await parser.parse('https://www.figma.com/design/KEY/...');
+ */
+class FigmaParser {
+  constructor({ token, onLog, onProgress } = {}) {
+    this.token = token || '';
+    this.onLog = onLog || (() => {});
+    this.onProgress = onProgress || (() => {});
+    this.cancelled = false;
+
+    // Component type keywords — first match wins
+    this.TYPE_KEYWORDS = [
+      'button', 'btn',
+      'input', 'field', 'textfield', 'textarea',
+      'select', 'dropdown', 'menu',
+      'card',
+      'modal', 'dialog', 'sheet',
+      'nav', 'navigation', 'navbar',
+      'header',
+      'footer',
+      'icon',
+      'badge', 'chip', 'tag', 'label',
+      'toggle', 'switch',
+      'checkbox', 'radio',
+      'table', 'row',
+      'list', 'listitem',
+      'form',
+      'search',
+      'avatar', 'profile',
+      'tooltip', 'popover',
+      'tab', 'tabs',
+      'accordion', 'collapse',
+      'banner', 'alert', 'toast',
+      'progress', 'spinner', 'loader',
+    ];
+  }
+
+  // ----------------------------------------------------------------
+  // Figma API
+  // ----------------------------------------------------------------
+
+  /**
+   * Extract the file key from a Figma URL.
+   * Handles both /design/ and /file/ URL patterns.
+   */
+  parseFileKey(url) {
+    const match = (url || '').match(/figma\.com\/(?:design|file|proto)\/([a-zA-Z0-9]+)/);
+    if (!match) {
+      throw new Error('Invalid Figma URL. Expected: https://www.figma.com/design/KEY/title');
+    }
+    return match[1];
+  }
+
+  async _figmaFetch(path) {
+    if (this.cancelled) throw new Error('Cancelled');
+    if (!this.token) throw new Error('A Figma Personal Access Token is required.');
+    const res = await fetch(`https://api.figma.com${path}`, {
+      headers: { 'X-Figma-Token': this.token }
+    });
+    if (res.status === 403) throw new Error('Figma: invalid token or insufficient permissions.');
+    if (res.status === 404) throw new Error('Figma: file not found. Check the URL and token permissions.');
+    if (res.status === 429) throw new Error('Figma API rate limit reached. Try again shortly.');
+    if (!res.ok) throw new Error(`Figma API error ${res.status}: ${path}`);
+    return res.json();
+  }
+
+  // ----------------------------------------------------------------
+  // Document tree traversal
+  // ----------------------------------------------------------------
+
+  /**
+   * Walk a Figma node tree depth-first and call visitor(node, depth, ancestors).
+   */
+  _walkTree(node, visitor, depth = 0, ancestors = []) {
+    if (!node || depth > 30) return;
+    visitor(node, depth, ancestors);
+    if (Array.isArray(node.children)) {
+      const nextAncestors = [...ancestors, node];
+      for (const child of node.children) {
+        this._walkTree(child, visitor, depth + 1, nextAncestors);
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Token extraction
+  // ----------------------------------------------------------------
+
+  /**
+   * Extract design tokens from the Figma styles endpoint response
+   * and supplement with any discovered in the document node styles.
+   */
+  _extractTokens(stylesData, fileData) {
+    const tokens = [];
+    const seen = new Set();
+
+    const add = (name, value, category) => {
+      if (seen.has(name)) return;
+      seen.add(name);
+      tokens.push({ name, value, category, source: 'figma' });
+    };
+
+    // Published styles from /styles endpoint
+    const published = stylesData?.meta?.styles || [];
+    for (const style of published) {
+      const cat = this._styleTypeToCategory(style.style_type);
+      if (cat) add(style.name, null, cat);
+    }
+
+    // Styles map in the file document (nodeId → style metadata)
+    const stylesMap = fileData?.styles || {};
+    for (const [, style] of Object.entries(stylesMap)) {
+      const cat = this._styleTypeToCategory(style.styleType);
+      if (cat && style.name) add(style.name, null, cat);
+    }
+
+    return tokens;
+  }
+
+  _styleTypeToCategory(styleType) {
+    switch ((styleType || '').toUpperCase()) {
+      case 'FILL': return 'color';
+      case 'TEXT': return 'typography';
+      case 'EFFECT': return 'elevation';
+      case 'GRID': return 'spacing';
+      default: return null;
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Component extraction
+  // ----------------------------------------------------------------
+
+  /**
+   * Extract component definitions from the document tree and published
+   * components endpoint, then collect instance locations.
+   */
+  _extractComponents(fileData, componentsData) {
+    const componentMap = {}; // type → ComponentRecord
+
+    const ensure = (type, name) => {
+      if (!componentMap[type]) {
+        componentMap[type] = {
+          type,
+          name,
+          variants: [],
+          totalUsage: 0,
+          states: []
+        };
+      }
+      return componentMap[type];
+    };
+
+    const ensureVariant = (record, variantName, node) => {
+      let variant = record.variants.find(v => v.name === variantName);
+      if (!variant) {
+        variant = {
+          name: variantName,
+          html: `<!-- Figma: ${variantName} -->`,
+          classes: [],
+          styles: this._extractNodeStyles(node),
+          states: this._inferStatesFromName(variantName),
+          usageCount: 0,
+          instances: []
+        };
+        record.variants.push(variant);
+      }
+      return variant;
+    };
+
+    // Walk document tree: collect COMPONENT (definitions) and INSTANCE nodes
+    const instancesByComponentId = {};
+
+    this._walkTree(fileData.document, (node, _depth, ancestors) => {
+      if (node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') {
+        const type = this._inferType(node.name);
+        const record = ensure(type, node.name.split('/')[0]);
+        ensureVariant(record, node.name, node);
+      }
+
+      if (node.type === 'INSTANCE' && node.componentId) {
+        const id = node.componentId;
+        if (!instancesByComponentId[id]) instancesByComponentId[id] = [];
+        // Find the top-level frame this instance lives in
+        const frameName = ancestors.slice().reverse().find(
+          a => a.type === 'FRAME' || a.type === 'CANVAS' || a.type === 'PAGE'
+        )?.name || 'Unknown frame';
+        instancesByComponentId[id].push({ node, frameName });
+      }
+    });
+
+    // Supplement from published components list
+    const published = componentsData?.meta?.components || [];
+    for (const comp of published) {
+      const type = this._inferType(comp.name);
+      const record = ensure(type, comp.name.split('/')[0]);
+      ensureVariant(record, comp.name, null);
+    }
+
+    // Attach instance records to variants
+    for (const [componentId, instances] of Object.entries(instancesByComponentId)) {
+      // Find which component record owns this componentId
+      // Walk tree again to match COMPONENT node id
+      let ownerRecord = null;
+      let ownerVariant = null;
+      this._walkTree(fileData.document, (node) => {
+        if ((node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') && node.id === componentId) {
+          const type = this._inferType(node.name);
+          ownerRecord = componentMap[type];
+          if (ownerRecord) {
+            ownerVariant = ownerRecord.variants.find(v => v.name === node.name);
+          }
+        }
+      });
+
+      if (!ownerRecord || !ownerVariant) continue;
+
+      for (const { node: instanceNode, frameName } of instances) {
+        ownerVariant.usageCount++;
+        ownerRecord.totalUsage++;
+        ownerVariant.instances.push({
+          location: {
+            type: 'figma-frame',
+            path: frameName,
+            line: null
+          },
+          html: `<!-- Figma instance: ${instanceNode.name} in "${frameName}" -->`,
+          context: { parent: frameName, siblings: [] },
+          thumbnailDataUrl: null
+        });
+      }
+    }
+
+    // Recalculate totalUsage and sort variants by usage descending
+    for (const record of Object.values(componentMap)) {
+      record.totalUsage = record.variants.reduce((sum, v) => sum + v.usageCount, 0);
+      record.variants.sort((a, b) => b.usageCount - a.usageCount);
+    }
+
+    return Object.values(componentMap);
+  }
+
+  /**
+   * Infer a canonical component type slug from a Figma component name.
+   * e.g. "Button/Primary/Large" → "button"
+   *      "Form / Text Input"    → "input"
+   */
+  _inferType(name) {
+    if (!name) return 'unknown';
+    const lower = name.toLowerCase().replace(/[^a-z0-9 ]/g, ' ');
+    for (const kw of this.TYPE_KEYWORDS) {
+      if (lower.includes(kw)) return kw;
+    }
+    // Fallback: use first path segment, slugified
+    return name.split(/[/\\|]/, 1)[0].trim().toLowerCase().replace(/\s+/g, '-') || 'component';
+  }
+
+  /**
+   * Extract visual style properties from a Figma node.
+   */
+  _extractNodeStyles(node) {
+    if (!node) return {};
+    const styles = {};
+    const bb = node.absoluteBoundingBox;
+    if (bb) {
+      styles.width = `${Math.round(bb.width)}px`;
+      styles.height = `${Math.round(bb.height)}px`;
+    }
+    if (node.cornerRadius) styles.borderRadius = `${node.cornerRadius}px`;
+    const fill = (node.fills || []).find(f => f.type === 'SOLID' && f.visible !== false);
+    if (fill?.color) styles.backgroundColor = this._colorToHex(fill.color);
+    const stroke = (node.strokes || []).find(s => s.type === 'SOLID');
+    if (stroke?.color) styles.borderColor = this._colorToHex(stroke.color);
+    if (node.strokeWeight) styles.borderWidth = `${node.strokeWeight}px`;
+    return styles;
+  }
+
+  _colorToHex({ r = 0, g = 0, b = 0 }) {
+    const h = v => Math.round(v * 255).toString(16).padStart(2, '0');
+    return `#${h(r)}${h(g)}${h(b)}`;
+  }
+
+  /**
+   * Infer interaction states from a Figma component variant name.
+   * e.g. "Button/Primary/Disabled" → ['disabled']
+   */
+  _inferStatesFromName(name) {
+    const states = [];
+    const lower = (name || '').toLowerCase();
+    if (lower.includes('hover'))    states.push('hover');
+    if (lower.includes('focus'))    states.push('focus');
+    if (lower.includes('pressed') || lower.includes('active')) states.push('active');
+    if (lower.includes('disabled')) states.push('disabled');
+    if (lower.includes('error') || lower.includes('invalid')) states.push('error');
+    if (lower.includes('loading'))  states.push('loading');
+    if (lower.includes('checked') || lower.includes('selected')) states.push('checked');
+    return states;
+  }
+
+  // ----------------------------------------------------------------
+  // Main entry point
+  // ----------------------------------------------------------------
+
+  /**
+   * Parse a Figma file.
+   * Returns results in the same shape as CodeParser and AgenticCrawler:
+   * { components, tokens, pages, pagesCrawled, source }
+   */
+  async parse(figmaUrl) {
+    this.cancelled = false;
+    const fileKey = this.parseFileKey(figmaUrl);
+    this.onLog({ type: 'info', message: `Connecting to Figma file ${fileKey}...` });
+
+    this.onProgress({ pagesCrawled: 0, pagesTotal: 3, tokensExtracted: 0, componentsFound: 0, currentUrl: 'Fetching file...' });
+
+    // Parallel: fetch document, styles, and published components
+    const [fileData, stylesData, componentsData] = await Promise.all([
+      this._figmaFetch(`/v1/files/${fileKey}`),
+      this._figmaFetch(`/v1/files/${fileKey}/styles`).catch(() => ({})),
+      this._figmaFetch(`/v1/files/${fileKey}/components`).catch(() => ({}))
+    ]);
+
+    this.onLog({ type: 'success', message: `Loaded: "${fileData.name}"` });
+    this.onProgress({ pagesCrawled: 3, pagesTotal: 3, tokensExtracted: 0, componentsFound: 0, currentUrl: 'Processing...' });
+
+    const tokens = this._extractTokens(stylesData, fileData);
+    const components = this._extractComponents(fileData, componentsData);
+
+    this.onLog({
+      type: 'success',
+      message: `Found ${components.length} component type${components.length !== 1 ? 's' : ''}, ${tokens.length} design token${tokens.length !== 1 ? 's' : ''}`
+    });
+
+    // Count total instances for progress
+    const totalInstances = components.reduce((n, c) => n + (c.totalUsage || 0), 0);
+    if (totalInstances > 0) {
+      this.onLog({ type: 'info', message: `${totalInstances} component instances mapped to Figma frames` });
+    }
+
+    return {
+      components,
+      tokens,
+      pages: [{
+        url: figmaUrl,
+        components: components.length,
+        tokens: tokens.length,
+        crawledAt: new Date().toISOString()
+      }],
+      pagesCrawled: 1,
+      source: { type: 'figma', fileKey, fileName: fileData.name, url: figmaUrl }
+    };
+  }
+
+  stop() {
+    this.cancelled = true;
+  }
+}

--- a/systemic/js/principles-generator.js
+++ b/systemic/js/principles-generator.js
@@ -1,0 +1,309 @@
+/**
+ * PrinciplesGenerator — AI-powered design principles extractor
+ *
+ * Analyses a loaded design system (tokens + components) and returns:
+ *   • A philosophy statement for the whole system
+ *   • 4-7 global design principles grounded in token evidence
+ *   • 2-4 usage principles per component type
+ *
+ * Results are cached on designSystem.principles and in localStorage.
+ *
+ * Usage:
+ *   const gen = new PrinciplesGenerator({ supabaseUrl, supabaseKey });
+ *   const principles = await gen.generate(designSystem);
+ */
+class PrinciplesGenerator {
+  constructor({ supabaseUrl, supabaseKey } = {}) {
+    this.supabaseUrl = supabaseUrl || '';
+    this.supabaseKey = supabaseKey || '';
+  }
+
+  // ----------------------------------------------------------------
+  // Public
+  // ----------------------------------------------------------------
+
+  /**
+   * Generate or retrieve cached principles for a design system.
+   * Returns a PrinciplesResult object.
+   */
+  async generate(designSystem) {
+    if (!designSystem) throw new Error('No design system provided');
+
+    // Return cached result if fresh (< 24 hours)
+    if (designSystem.principles?.generatedAt) {
+      const age = Date.now() - new Date(designSystem.principles.generatedAt).getTime();
+      if (age < 24 * 60 * 60 * 1000) return designSystem.principles;
+    }
+
+    const summary = this._buildSummary(designSystem);
+
+    let result;
+    if (this.supabaseUrl && this.supabaseKey) {
+      result = await this._callAI(summary);
+    } else {
+      result = this._buildFallback(summary);
+    }
+
+    return result;
+  }
+
+  // ----------------------------------------------------------------
+  // Summary builder
+  // ----------------------------------------------------------------
+
+  /**
+   * Compress a full design system into a summary safe to send as an API payload.
+   */
+  _buildSummary(ds) {
+    const tokens = ds.tokens || {};
+    const colors = tokens.colors || {};
+    const spacing = tokens.spacing || {};
+    const elevation = tokens.elevation || {};
+    const cssVars = tokens.cssVariables || {};
+
+    // Collect CSS variable names for context
+    const cssVariableNames = Object.keys(cssVars).slice(0, 20);
+
+    // Also collect from raw token arrays (GitHub/Figma sources)
+    const rawTokenNames = (ds.tokens?.rawTokens || [])
+      .slice(0, 20)
+      .map(t => t.name)
+      .filter(Boolean);
+
+    const allVarNames = [...new Set([...cssVariableNames, ...rawTokenNames])];
+
+    const summary = {
+      name: ds.name || 'Unknown System',
+      sourceUrl: ds.sourceUrl || '',
+      source: ds.source || null,
+      tokens: {
+        colorCount: this._countColors(colors),
+        primaryColor: colors.primary?.hex || null,
+        secondaryColor: colors.secondary?.hex || null,
+        fontPrimary: tokens.typography?.primary || null,
+        spacingBase: spacing.baseUnit || null,
+        hasElevation: !!(elevation.levels?.length),
+        hasBorderRadius: !!(tokens.shape?.values?.length),
+        cssVariableNames: allVarNames,
+      },
+      components: (ds.components || []).map(c => ({
+        type: c.type,
+        variantCount: c.variants?.length || 0,
+        totalUsage: c.totalUsage || 0,
+        states: c.states || [],
+        sampleClasses: this._gatherClasses(c),
+        sampleHtml: c.variants?.[0]?.html?.slice(0, 200) || null,
+      })),
+    };
+
+    return summary;
+  }
+
+  _countColors(colors) {
+    let n = 0;
+    if (colors.primary) n++;
+    if (colors.secondary) n++;
+    if (colors.tertiary) n++;
+    if (colors.error) n++;
+    if (colors.success) n++;
+    if (colors.warning) n++;
+    n += (colors.neutral?.length || 0);
+    n += (colors.surface?.length || 0);
+    return n;
+  }
+
+  _gatherClasses(component) {
+    const classes = new Set();
+    (component.variants || []).forEach(v => {
+      (v.classes || []).forEach(c => classes.add(c));
+    });
+    return [...classes].slice(0, 12);
+  }
+
+  // ----------------------------------------------------------------
+  // AI call
+  // ----------------------------------------------------------------
+
+  async _callAI(summary) {
+    const res = await fetch(`${this.supabaseUrl}/functions/v1/systemic-analyze`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': this.supabaseKey,
+        'Authorization': `Bearer ${this.supabaseKey}`,
+      },
+      body: JSON.stringify({
+        action: 'principles',
+        designSystemSummary: summary,
+      }),
+    });
+
+    if (!res.ok) {
+      const err = await res.text();
+      throw new Error(`AI principles call failed (${res.status}): ${err}`);
+    }
+
+    return await res.json();
+  }
+
+  // ----------------------------------------------------------------
+  // Fallback (no AI)
+  // ----------------------------------------------------------------
+
+  /**
+   * Rule-based fallback — derives principles directly from token data
+   * without calling the AI. Useful for local design systems or when
+   * the edge function is unavailable.
+   */
+  _buildFallback(summary) {
+    const principles = [];
+
+    // Spacing
+    if (summary.tokens.spacingBase) {
+      principles.push({
+        title: 'Grid-based Spacing',
+        description: `All layout spacing is derived from a ${summary.tokens.spacingBase}px base unit, ensuring consistent visual rhythm across every component.`,
+      });
+    }
+
+    // Color
+    if (summary.tokens.colorCount > 0) {
+      principles.push({
+        title: 'Semantic Color',
+        description: `${summary.tokens.colorCount} color tokens carry explicit semantic roles (primary, surface, error, etc.) rather than raw values, so color changes propagate consistently.`,
+      });
+    }
+    if (summary.tokens.primaryColor) {
+      const isDark = this._isDarkColor(summary.tokens.primaryColor);
+      principles.push({
+        title: isDark ? 'Dark-first Palette' : 'Light-first Palette',
+        description: `The system is designed ${isDark ? 'dark-first' : 'light-first'}, with ${summary.tokens.primaryColor} as the primary surface. All contrast ratios are evaluated against this baseline.`,
+      });
+    }
+
+    // Typography
+    if (summary.tokens.fontPrimary) {
+      principles.push({
+        title: 'Single Type Family',
+        description: `${summary.tokens.fontPrimary} is the sole typeface, with weight and size variations carrying the full typographic hierarchy — no secondary fonts needed.`,
+      });
+    }
+
+    // Elevation
+    if (summary.tokens.hasElevation) {
+      principles.push({
+        title: 'Elevation as Hierarchy',
+        description: 'Shadow levels communicate z-axis depth and content priority. Higher elevation = higher user focus.',
+      });
+    } else {
+      principles.push({
+        title: 'Flat Design',
+        description: 'No shadows or elevation — hierarchy is expressed through color, weight, and spacing alone.',
+      });
+    }
+
+    // Components
+    if (summary.components.length > 0) {
+      principles.push({
+        title: 'Shared Component Language',
+        description: `${summary.components.length} reusable component types form the vocabulary of this system. Every new surface should be assembled from these building blocks before introducing new patterns.`,
+      });
+    }
+
+    // CSS variables
+    if (summary.tokens.cssVariableNames?.length > 0) {
+      principles.push({
+        title: 'Token-driven Customisation',
+        description: 'CSS custom properties are the single source of truth. Theming, brand updates, and accessibility overrides all flow through the token layer — never through one-off overrides.',
+      });
+    }
+
+    // Per-component principles (rule-based)
+    const componentPrinciples = {};
+    for (const comp of summary.components) {
+      componentPrinciples[comp.type] = this._componentFallback(comp);
+    }
+
+    return {
+      philosophyStatement: this._philosophyFallback(summary),
+      globalPrinciples: principles,
+      componentPrinciples,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  _philosophyFallback(summary) {
+    const compCount = summary.components.length;
+    const font = summary.tokens.fontPrimary ? `${summary.tokens.fontPrimary} typography` : 'consistent typography';
+    return `${summary.name} is a ${summary.source?.type === 'figma' ? 'design-file-driven' : summary.source?.type === 'github' ? 'code-first' : 'web-extracted'} design system built around ${font}, ${summary.tokens.colorCount} semantic color tokens, and ${compCount} shared component type${compCount !== 1 ? 's' : ''} — optimised for consistency and developer velocity.`;
+  }
+
+  _componentFallback(comp) {
+    const rules = [];
+    const type = comp.type;
+
+    const baseRules = {
+      button:     [
+        { rule: 'Use variant to signal action priority', rationale: `${comp.variantCount} variants found — reserve primary/filled for the single highest-priority action per screen.` },
+        { rule: 'Never use more than one primary button per view', rationale: 'Multiple primary buttons compete for attention and dilute call-to-action clarity.' },
+      ],
+      input:      [
+        { rule: 'Always show a visible label', rationale: 'Placeholder text alone is inaccessible once the field has a value. Every input in this system uses a persistent label.' },
+        { rule: 'Pair error state with an inline message', rationale: 'Error styling alone is not sufficient — a text message below the field explains what went wrong.' },
+      ],
+      card:       [
+        { rule: 'Keep content hierarchy consistent across instances', rationale: `${comp.totalUsage} card usages found — consistent title/body/action order makes scanning predictable.` },
+        { rule: 'Cards are containers, not interactive targets', rationale: 'If the whole card is clickable, ensure it has focus, role, and keyboard handling.' },
+      ],
+      nav:        [
+        { rule: 'Mark the active item explicitly', rationale: 'Users need to know where they are. Use aria-current="page" and a visible active style.' },
+        { rule: 'Keep nav items consistent across breakpoints', rationale: 'Mobile collapse patterns should preserve the same hierarchy as the desktop navigation.' },
+      ],
+      modal:      [
+        { rule: 'Trap focus inside while open', rationale: 'Keyboard and screen reader users must not be able to interact with content behind the modal.' },
+        { rule: 'Always provide an explicit close action', rationale: 'Do not rely solely on Escape key — a visible close button is required for discoverability.' },
+      ],
+      select:     [
+        { rule: 'Use for 5+ options only', rationale: 'Fewer than 5 options are better served by radio buttons, which show all choices at a glance.' },
+        { rule: 'Show selected value clearly in closed state', rationale: 'Users should never have to open the dropdown to see what is currently selected.' },
+      ],
+      form:       [
+        { rule: 'Group related fields with a fieldset', rationale: 'Logical grouping helps screen readers announce context and makes long forms scannable.' },
+        { rule: 'Validate inline, not only on submit', rationale: 'Immediate field-level feedback reduces form abandonment and cognitive load.' },
+      ],
+    };
+
+    const typeRules = baseRules[type];
+    if (typeRules) {
+      rules.push(...typeRules);
+    }
+
+    // Add usage-count rule
+    if (comp.totalUsage > 1) {
+      rules.push({
+        rule: `Rely on this component — it appears ${comp.totalUsage} times`,
+        rationale: `High usage confirms this is a core pattern. Any change to it has broad surface-area impact; validate across all ${comp.totalUsage} uses.`,
+      });
+    }
+
+    // Add state rule if states detected
+    if (comp.states?.length > 0) {
+      rules.push({
+        rule: `Implement all ${comp.states.length} detected states`,
+        rationale: `States found: ${comp.states.join(', ')}. Missing states in implementation lead to visual regressions.`,
+      });
+    }
+
+    return rules.length > 0 ? rules : [
+      { rule: 'Follow system token conventions', rationale: `This component uses ${comp.variantCount} variant${comp.variantCount !== 1 ? 's' : ''} — choose the closest match before creating a new one.` },
+    ];
+  }
+
+  _isDarkColor(hex) {
+    if (!hex || !hex.startsWith('#')) return true;
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    return (0.299 * r + 0.587 * g + 0.114 * b) < 128;
+  }
+}

--- a/systemic/js/state-renderer.js
+++ b/systemic/js/state-renderer.js
@@ -1,0 +1,404 @@
+/**
+ * StateRenderer — multi-state component showcase
+ *
+ * Takes a component (type + variants + CSS state rules) and renders
+ * all its interaction states simultaneously with realistic placeholder
+ * content. Replaces the single static example per variant.
+ *
+ * Usage:
+ *   const renderer = new StateRenderer();
+ *   const html = renderer.buildComponentStateGrid(component);
+ *   previewEl.innerHTML = html;
+ */
+class StateRenderer {
+  constructor() {
+    // Contextual placeholder content keyed by component type
+    this.CONTENT = {
+      button: {
+        labels: ['Save Changes', 'Submit', 'Continue', 'Confirm', 'Sign In'],
+        loading: 'Saving...',
+        states: ['default', 'hover', 'active', 'disabled', 'loading']
+      },
+      btn: {
+        labels: ['Save Changes', 'Submit', 'Continue'],
+        loading: 'Loading...',
+        states: ['default', 'hover', 'active', 'disabled', 'loading']
+      },
+      input: {
+        labels: ['Email address', 'Full name', 'Search', 'Password'],
+        filledValues: { default: '', filled: 'jane@example.com', focused: '', error: 'invalid@', disabled: '' },
+        errorMsg: 'Please enter a valid email',
+        states: ['default', 'filled', 'focused', 'error', 'disabled']
+      },
+      field: {
+        labels: ['Label', 'Field'],
+        filledValues: { default: '', filled: 'Sample value' },
+        states: ['default', 'filled', 'focused', 'error', 'disabled']
+      },
+      select: {
+        placeholder: 'Select an option',
+        options: ['Analytics', 'Reports', 'Settings', 'Library', 'Help'],
+        states: ['closed', 'open', 'disabled']
+      },
+      dropdown: {
+        placeholder: 'Choose...',
+        options: ['Option one', 'Option two', 'Option three', 'Option four', 'Option five'],
+        states: ['closed', 'open', 'disabled']
+      },
+      menu: {
+        placeholder: 'Open menu',
+        options: ['Edit', 'Duplicate', 'Archive', 'Delete'],
+        states: ['closed', 'open']
+      },
+      card: {
+        title: 'Discovering Patterns in Design',
+        body: 'A thoughtful exploration of how design systems evolve to meet real user needs across contexts.',
+        action: 'Read more',
+        states: ['default', 'hover', 'selected']
+      },
+      modal: {
+        title: 'Confirm Action',
+        body: 'Are you sure you want to continue? This action cannot be undone.',
+        states: ['default']
+      },
+      nav: {
+        items: ['Dashboard', 'Analytics', 'Library', 'Settings', 'Profile'],
+        states: ['default', 'active', 'hover']
+      },
+      navigation: {
+        items: ['Dashboard', 'Analytics', 'Library', 'Settings', 'Profile'],
+        states: ['default', 'active', 'hover']
+      },
+      navbar: {
+        items: ['Home', 'Products', 'Pricing', 'Docs', 'Blog'],
+        states: ['default', 'scrolled']
+      },
+      checkbox: {
+        label: 'Remember me on this device',
+        states: ['unchecked', 'checked', 'indeterminate', 'disabled']
+      },
+      radio: {
+        label: 'Email notifications',
+        states: ['unchecked', 'checked', 'disabled']
+      },
+      toggle: {
+        label: 'Enable dark mode',
+        states: ['off', 'on', 'disabled']
+      },
+      switch: {
+        label: 'Auto-save',
+        states: ['off', 'on', 'disabled']
+      },
+      badge: {
+        labels: { default: 'New', success: 'Active', warning: '12', error: 'Blocked', info: 'Beta' },
+        states: ['default', 'success', 'warning', 'error', 'info']
+      },
+      chip: {
+        label: 'Design',
+        states: ['default', 'selected', 'disabled']
+      },
+      tag: {
+        label: 'Frontend',
+        states: ['default', 'selected']
+      },
+      avatar: {
+        initials: 'JD',
+        states: ['default', 'online', 'offline']
+      },
+      tooltip: {
+        label: 'Tooltip content',
+        states: ['default']
+      },
+      banner: {
+        message: 'Your changes have been saved.',
+        states: ['default', 'success', 'warning', 'error']
+      },
+      alert: {
+        message: 'Something needs your attention.',
+        states: ['default', 'success', 'warning', 'error']
+      },
+      progress: {
+        states: ['0%', '35%', '70%', '100%']
+      },
+      spinner: {
+        states: ['default']
+      },
+    };
+
+    // Default state set when type is unknown
+    this.DEFAULT_STATES = ['default', 'hover', 'disabled'];
+  }
+
+  // ----------------------------------------------------------------
+  // Public API
+  // ----------------------------------------------------------------
+
+  /**
+   * Build the full multi-state grid HTML for a component.
+   * Rendered into the component stage preview area.
+   */
+  buildComponentStateGrid(component) {
+    if (!component?.variants?.length) return '';
+
+    const rows = component.variants.map(variant => `
+      <div class="variant-state-row">
+        <div class="variant-state-row__name">${this._escHtml(variant.name || 'Default')}</div>
+        ${this._buildStateStrip(component.type, variant)}
+      </div>
+    `).join('');
+
+    return `
+      <div class="component-state-grid">
+        <h3 class="component-state-grid__title">States &amp; Variants</h3>
+        ${rows}
+      </div>
+    `;
+  }
+
+  // ----------------------------------------------------------------
+  // Private helpers
+  // ----------------------------------------------------------------
+
+  /**
+   * Determine the ordered list of states to render for a component.
+   * Merges type-default states with CSS-detected states.
+   */
+  _getStates(componentType, variant) {
+    const content = this.CONTENT[componentType];
+    const typeStates = content?.states || this.DEFAULT_STATES;
+
+    // Collect any additional CSS-detected states from the variant
+    const cssStates = (variant?.states || []);
+    const merged = [...typeStates];
+    for (const s of cssStates) {
+      if (!merged.includes(s)) merged.push(s);
+    }
+    return merged;
+  }
+
+  _buildStateStrip(componentType, variant) {
+    const states = this._getStates(componentType, variant);
+    const cards = states.map(state => `
+      <div class="state-example">
+        <div class="state-example__preview">
+          ${this._renderState(componentType, variant, state)}
+        </div>
+        <div class="state-example__label">${state}</div>
+      </div>
+    `).join('');
+
+    return `<div class="state-strip">${cards}</div>`;
+  }
+
+  /**
+   * Dispatch to type-specific renderers.
+   */
+  _renderState(type, variant, state) {
+    const c = this.CONTENT[type] || {};
+    const classes = (variant?.classes || []).join(' ');
+
+    switch (type) {
+      case 'button':
+      case 'btn':
+        return this._button(classes, state, c);
+      case 'input':
+      case 'field':
+      case 'textfield':
+      case 'textarea':
+        return this._input(classes, state, c);
+      case 'select':
+      case 'dropdown':
+      case 'menu':
+        return this._select(classes, state, c);
+      case 'card':
+        return this._card(classes, state, c);
+      case 'checkbox':
+        return this._check(classes, state, c, 'checkbox');
+      case 'radio':
+        return this._check(classes, state, c, 'radio');
+      case 'toggle':
+      case 'switch':
+        return this._toggle(classes, state, c);
+      case 'badge':
+      case 'chip':
+      case 'tag':
+        return this._badge(classes, type, state, c);
+      case 'nav':
+      case 'navigation':
+      case 'navbar':
+        return this._nav(classes, state, c);
+      case 'banner':
+      case 'alert':
+        return this._alert(classes, state, c);
+      case 'avatar':
+        return this._avatar(classes, state, c);
+      case 'progress':
+        return this._progress(state);
+      case 'spinner':
+      case 'loader':
+        return this._spinner(classes);
+      default:
+        return this._generic(variant?.html || '', state);
+    }
+  }
+
+  // ----------------------------------------------------------------
+  // Type renderers
+  // ----------------------------------------------------------------
+
+  _button(classes, state, c) {
+    const label = state === 'loading' ? (c.loading || 'Loading...') : (c.labels?.[0] || 'Button');
+    const disabled = state === 'disabled' ? 'disabled' : '';
+    const stateAttr = `data-state="${state}"`;
+    return `<button class="${classes}" ${disabled} ${stateAttr} style="pointer-events:none">${this._escHtml(label)}</button>`;
+  }
+
+  _input(classes, state, c) {
+    const label = c.labels?.[0] || 'Label';
+    const value = c.filledValues?.[state] ?? '';
+    const disabled = state === 'disabled' ? 'disabled' : '';
+    const readonly = state === 'filled' ? 'readonly' : '';
+    const placeholder = (state === 'default' || state === 'focused') ? label : '';
+    const stateAttr = `data-state="${state}"`;
+    return `
+      <div style="display:flex;flex-direction:column;gap:3px;min-width:160px">
+        <span style="font-size:10px;opacity:.6;text-transform:uppercase;letter-spacing:.5px">${this._escHtml(label)}</span>
+        <input class="${classes}" value="${this._escHtml(value)}"
+          placeholder="${this._escHtml(placeholder)}" ${disabled} ${readonly}
+          ${stateAttr} style="pointer-events:none" />
+        ${state === 'error' ? `<span style="font-size:10px;color:#e44">${this._escHtml(c.errorMsg || 'Invalid value')}</span>` : ''}
+      </div>
+    `;
+  }
+
+  _select(classes, state, c) {
+    const disabled = state === 'disabled' ? 'disabled' : '';
+    const stateAttr = `data-state="${state}"`;
+    if (state === 'open') {
+      const opts = (c.options || ['Option 1', 'Option 2', 'Option 3'])
+        .map((o, i) => `<option ${i === 1 ? 'selected' : ''}>${this._escHtml(o)}</option>`)
+        .join('');
+      return `<select class="${classes}" ${disabled} ${stateAttr} style="pointer-events:none;min-width:140px" size="4">
+        <option value="">${this._escHtml(c.placeholder || 'Select...')}</option>${opts}
+      </select>`;
+    }
+    return `<select class="${classes}" ${disabled} ${stateAttr} style="pointer-events:none;min-width:140px">
+      <option>${this._escHtml(c.placeholder || 'Select...')}</option>
+    </select>`;
+  }
+
+  _card(classes, state, c) {
+    const stateAttr = `data-state="${state}"`;
+    return `
+      <div class="${classes}" ${stateAttr} style="max-width:220px;pointer-events:none;padding:12px">
+        <div style="width:100%;height:90px;background:var(--bg-elevated,rgba(255,255,255,.06));border-radius:4px;margin-bottom:10px"></div>
+        <strong style="display:block;font-size:12px;margin-bottom:4px;line-height:1.3">${this._escHtml(c.title || 'Card Title')}</strong>
+        <p style="font-size:11px;opacity:.65;margin:0 0 8px;line-height:1.4">${this._escHtml(c.body || 'Body text.')}</p>
+        <a style="font-size:11px;cursor:default">${this._escHtml(c.action || 'Learn more')}</a>
+      </div>
+    `;
+  }
+
+  _check(classes, state, c, inputType) {
+    const checked = (state === 'checked') ? 'checked' : '';
+    const indeterminate = state === 'indeterminate' ? 'data-indeterminate="true"' : '';
+    const disabled = state === 'disabled' ? 'disabled' : '';
+    const stateAttr = `data-state="${state}"`;
+    return `
+      <label style="display:flex;align-items:center;gap:6px;cursor:default;pointer-events:none">
+        <input type="${inputType}" class="${classes}" ${checked} ${disabled} ${indeterminate} ${stateAttr} style="pointer-events:none" />
+        <span style="font-size:12px">${this._escHtml(c.label || inputType)}</span>
+      </label>
+    `;
+  }
+
+  _toggle(classes, state, c) {
+    const checked = state === 'on' ? 'checked' : '';
+    const disabled = state === 'disabled' ? 'disabled' : '';
+    const stateAttr = `data-state="${state}"`;
+    return `
+      <label style="display:flex;align-items:center;gap:8px;cursor:default;pointer-events:none">
+        <input type="checkbox" role="switch" class="${classes}" ${checked} ${disabled} ${stateAttr} style="pointer-events:none" />
+        <span style="font-size:12px">${this._escHtml(c.label || 'Toggle')}</span>
+      </label>
+    `;
+  }
+
+  _badge(classes, type, state, c) {
+    const label = c.labels?.[state] ?? c.label ?? state;
+    const stateAttr = `data-state="${state}"`;
+    return `<span class="${classes} ${type}-${state}" ${stateAttr} style="pointer-events:none">${this._escHtml(label)}</span>`;
+  }
+
+  _nav(classes, state, c) {
+    const items = c.items || ['Home', 'About', 'Contact'];
+    const links = items.map((item, i) => {
+      const isActive = state === 'active' && i === 1;
+      const isDisabled = state === 'disabled' && i === 2;
+      return `<a style="font-size:12px;padding:4px 8px;${isActive ? 'font-weight:600' : ''}${isDisabled ? ';opacity:.4' : ''};cursor:default">${this._escHtml(item)}</a>`;
+    }).join('');
+    return `<nav class="${classes}" data-state="${state}" style="display:flex;gap:4px;pointer-events:none">${links}</nav>`;
+  }
+
+  _alert(classes, state, c) {
+    const colors = { success: '#1a7', warning: '#d80', error: '#e44', default: 'var(--fg-muted)' };
+    const color = colors[state] || colors.default;
+    return `
+      <div class="${classes}" data-state="${state}"
+        style="padding:10px 14px;border-left:3px solid ${color};font-size:12px;max-width:220px;pointer-events:none">
+        ${this._escHtml(c.message || 'Notification message')}
+      </div>
+    `;
+  }
+
+  _avatar(classes, state, c) {
+    const dotColor = state === 'online' ? '#2d2' : state === 'offline' ? '#888' : 'transparent';
+    return `
+      <div style="position:relative;display:inline-block;pointer-events:none">
+        <div class="${classes}" data-state="${state}"
+          style="width:40px;height:40px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-weight:600;font-size:13px;background:var(--bg-elevated,#333)">
+          ${this._escHtml(c.initials || 'AB')}
+        </div>
+        ${state !== 'default' ? `<span style="position:absolute;bottom:0;right:0;width:10px;height:10px;border-radius:50%;background:${dotColor};border:2px solid var(--bg,#111)"></span>` : ''}
+      </div>
+    `;
+  }
+
+  _progress(state) {
+    const widths = { '0%': 0, '35%': 35, '70%': 70, '100%': 100 };
+    const pct = widths[state] ?? 50;
+    return `
+      <div style="width:160px;pointer-events:none">
+        <div style="height:4px;background:var(--bg-elevated,rgba(255,255,255,.1));border-radius:2px;overflow:hidden">
+          <div style="height:100%;width:${pct}%;background:var(--fg,#fff);transition:none"></div>
+        </div>
+        <span style="font-size:10px;opacity:.5;margin-top:4px;display:block">${state}</span>
+      </div>
+    `;
+  }
+
+  _spinner(classes) {
+    return `
+      <div class="${classes}" style="pointer-events:none;display:flex;align-items:center;gap:8px">
+        <div style="width:18px;height:18px;border:2px solid rgba(255,255,255,.15);border-top-color:var(--fg,#fff);border-radius:50%;animation:none;opacity:.7"></div>
+        <span style="font-size:12px;opacity:.6">Loading</span>
+      </div>
+    `;
+  }
+
+  _generic(baseHtml, state) {
+    if (!baseHtml) {
+      return `<div data-state="${state}" style="padding:6px 10px;font-size:11px;opacity:.5;border:1px dashed rgba(255,255,255,.1)">${state}</div>`;
+    }
+    // Inject state attribute into the outermost tag
+    return baseHtml.replace(/^<([a-zA-Z][a-zA-Z0-9]*)/, `<$1 data-state="${state}" style="pointer-events:none"`);
+  }
+
+  _escHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+}

--- a/systemic/js/usage-inspector.js
+++ b/systemic/js/usage-inspector.js
@@ -1,0 +1,343 @@
+/**
+ * UsageInspector — Component Usage Inspector
+ *
+ * Shows all instances of a given component type across the analysed source
+ * (GitHub files, Figma frames, or crawled page URLs) with location context.
+ * Clicking an instance opens a right-side drawer with:
+ *   - The raw source code block
+ *   - File path + line number (for code sources)
+ *   - Surrounding HTML context
+ *   - Variant classification
+ *
+ * Usage:
+ *   const inspector = new UsageInspector({ container, onToast });
+ *   inspector.show(component);   // open / refresh
+ *   inspector.hide();            // close
+ */
+class UsageInspector {
+  constructor({ container, onToast } = {}) {
+    this.container = container;
+    this.onToast = onToast || (() => {});
+
+    this.allInstances = [];      // flat list of all instances for current component
+    this.filteredInstances = []; // after search/filter applied
+    this.selectedIndex = -1;
+    this.drawerOpen = false;
+    this.el = null;              // root DOM element (injected once)
+
+    this._boundKeydown = this._handleKeydown.bind(this);
+  }
+
+  // ----------------------------------------------------------------
+  // Public
+  // ----------------------------------------------------------------
+
+  /**
+   * Open the inspector for the given component.
+   * Flattens variant.instances[] into a single list with variant name attached.
+   */
+  show(component) {
+    if (!component) return;
+
+    // Flatten instances from all variants
+    this.allInstances = [];
+    (component.variants || []).forEach(variant => {
+      (variant.instances || []).forEach(instance => {
+        this.allInstances.push({
+          variantName: variant.name || 'default',
+          componentType: component.type,
+          componentName: component.name || component.type,
+          ...instance
+        });
+      });
+    });
+
+    this.filteredInstances = [...this.allInstances];
+    this.selectedIndex = -1;
+    this.drawerOpen = false;
+
+    if (!this.el) this._mount();
+    this._updateTitle(component);
+    this._renderGrid();
+    this._closeDrawer();
+    this.el.classList.add('visible');
+
+    document.addEventListener('keydown', this._boundKeydown);
+  }
+
+  /** Hide the inspector and clean up listeners. */
+  hide() {
+    if (this.el) this.el.classList.remove('visible');
+    this._closeDrawer();
+    document.removeEventListener('keydown', this._boundKeydown);
+  }
+
+  // ----------------------------------------------------------------
+  // DOM setup
+  // ----------------------------------------------------------------
+
+  _mount() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'usage-inspector';
+    wrapper.setAttribute('role', 'region');
+    wrapper.setAttribute('aria-label', 'Component usage inspector');
+    wrapper.innerHTML = `
+      <div class="ui-header">
+        <div class="ui-header__left">
+          <h3 class="ui-title" id="ui-title">Instances</h3>
+          <span class="ui-count" id="ui-count"></span>
+        </div>
+        <div class="ui-header__right">
+          <input type="search" class="input input--sm ui-search" id="ui-search"
+            placeholder="Filter by path or variant..." aria-label="Filter instances">
+          <button class="btn btn--ghost btn--sm" id="ui-close" aria-label="Close inspector">Close</button>
+        </div>
+      </div>
+
+      <div class="ui-body">
+        <div class="ui-grid" id="ui-grid" role="list"></div>
+
+        <aside class="ui-drawer" id="ui-drawer" aria-hidden="true" hidden>
+          <div class="ui-drawer__header">
+            <nav class="ui-drawer__nav" aria-label="Instance navigation">
+              <button class="btn btn--ghost btn--xs" id="ui-prev" aria-label="Previous instance">&larr;</button>
+              <span class="ui-drawer__nav-label" id="ui-nav-label" aria-live="polite"></span>
+              <button class="btn btn--ghost btn--xs" id="ui-next" aria-label="Next instance">&rarr;</button>
+            </nav>
+            <button class="btn btn--ghost btn--xs" id="ui-drawer-close" aria-label="Close drawer">&times;</button>
+          </div>
+          <div class="ui-drawer__body" id="ui-drawer-body"></div>
+        </aside>
+      </div>
+    `;
+
+    this.container.appendChild(wrapper);
+    this.el = wrapper;
+
+    // Bind static controls
+    wrapper.querySelector('#ui-close').addEventListener('click', () => this.hide());
+    wrapper.querySelector('#ui-drawer-close').addEventListener('click', () => this._closeDrawer());
+    wrapper.querySelector('#ui-prev').addEventListener('click', () => this._stepDrawer(-1));
+    wrapper.querySelector('#ui-next').addEventListener('click', () => this._stepDrawer(1));
+    wrapper.querySelector('#ui-search').addEventListener('input', e => this._applyFilter(e.target.value));
+  }
+
+  // ----------------------------------------------------------------
+  // Grid
+  // ----------------------------------------------------------------
+
+  _updateTitle(component) {
+    const titleEl = this.el?.querySelector('#ui-title');
+    if (titleEl) titleEl.textContent = `${component.name || component.type} — instances`;
+  }
+
+  _renderGrid() {
+    const grid = this.el?.querySelector('#ui-grid');
+    const countEl = this.el?.querySelector('#ui-count');
+    if (!grid) return;
+
+    const n = this.filteredInstances.length;
+    if (countEl) countEl.textContent = `${n} instance${n !== 1 ? 's' : ''}`;
+
+    if (n === 0) {
+      grid.innerHTML = `
+        <div class="ui-empty">
+          <p>No instances found.</p>
+          <small>Run a GitHub or Figma scan to see file-level attribution.</small>
+        </div>
+      `;
+      return;
+    }
+
+    grid.innerHTML = this.filteredInstances.map((inst, i) => {
+      const loc = inst.location || {};
+      const locLabel = this._formatLocation(loc);
+      const shortLabel = locLabel.length > 64 ? '…' + locLabel.slice(-61) : locLabel;
+      const sourceIcon = loc.type === 'file' ? '📄' : loc.type === 'figma-frame' ? '🎨' : '🌐';
+
+      return `
+        <div class="ui-card" role="listitem" data-index="${i}" tabindex="0" aria-label="${this._escAtr(locLabel)}">
+          <div class="ui-card__preview" aria-hidden="true">
+            <div class="ui-card__preview-html">${this._previewHtml(inst.html || '')}</div>
+          </div>
+          <div class="ui-card__meta">
+            <span class="ui-variant-badge">${this._escHtml(inst.variantName || 'default')}</span>
+            <span class="ui-location" title="${this._escAtr(locLabel)}">${sourceIcon} <code>${this._escHtml(shortLabel)}</code></span>
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    // Bind click + keyboard on cards
+    grid.querySelectorAll('.ui-card').forEach(card => {
+      const open = () => this._openDrawer(parseInt(card.dataset.index, 10));
+      card.addEventListener('click', open);
+      card.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); } });
+    });
+  }
+
+  _applyFilter(query) {
+    const q = query.trim().toLowerCase();
+    this.filteredInstances = q
+      ? this.allInstances.filter(inst =>
+          (inst.location?.path || '').toLowerCase().includes(q) ||
+          (inst.variantName || '').toLowerCase().includes(q)
+        )
+      : [...this.allInstances];
+    this._renderGrid();
+  }
+
+  // ----------------------------------------------------------------
+  // Drawer
+  // ----------------------------------------------------------------
+
+  _openDrawer(index) {
+    if (index < 0 || index >= this.filteredInstances.length) return;
+    this.selectedIndex = index;
+    this.drawerOpen = true;
+
+    const drawer = this.el?.querySelector('#ui-drawer');
+    if (drawer) {
+      drawer.hidden = false;
+      drawer.setAttribute('aria-hidden', 'false');
+    }
+    this.el?.classList.add('drawer-open');
+    this._renderDrawerContent();
+    this._highlightCard(index);
+  }
+
+  _closeDrawer() {
+    this.drawerOpen = false;
+    const drawer = this.el?.querySelector('#ui-drawer');
+    if (drawer) {
+      drawer.hidden = true;
+      drawer.setAttribute('aria-hidden', 'true');
+    }
+    this.el?.classList.remove('drawer-open');
+    this._highlightCard(-1);
+  }
+
+  _stepDrawer(delta) {
+    const next = this.selectedIndex + delta;
+    if (next >= 0 && next < this.filteredInstances.length) {
+      this._openDrawer(next);
+    }
+  }
+
+  _highlightCard(activeIndex) {
+    this.el?.querySelectorAll('.ui-card').forEach(card => {
+      card.classList.toggle('selected', parseInt(card.dataset.index, 10) === activeIndex);
+    });
+  }
+
+  _renderDrawerContent() {
+    const body = this.el?.querySelector('#ui-drawer-body');
+    const navLabel = this.el?.querySelector('#ui-nav-label');
+    if (!body) return;
+
+    const inst = this.filteredInstances[this.selectedIndex];
+    if (!inst) return;
+
+    if (navLabel) {
+      navLabel.textContent = `${this.selectedIndex + 1} / ${this.filteredInstances.length}`;
+    }
+
+    const loc = inst.location || {};
+    const locDisplay = this._formatLocation(loc);
+    const contextCode = [
+      inst.context?.parent,
+      ...(inst.context?.siblings || [])
+    ].filter(Boolean).join('\n').trim();
+
+    body.innerHTML = `
+      <div class="ui-section">
+        <div class="ui-section__head">
+          <span class="ui-section__label">Preview</span>
+          <code class="ui-section__loc">${this._escHtml(locDisplay)}</code>
+        </div>
+        <div class="ui-preview-box">
+          ${inst.html || '<em style="opacity:.4">No preview available</em>'}
+        </div>
+      </div>
+
+      <div class="ui-section">
+        <div class="ui-section__head">
+          <span class="ui-section__label">Source</span>
+          <button class="btn btn--ghost btn--xs" data-action="copy-source">Copy</button>
+        </div>
+        <pre class="ui-code"><code>${this._escHtml(inst.html || '')}</code></pre>
+      </div>
+
+      ${contextCode ? `
+      <div class="ui-section">
+        <div class="ui-section__head">
+          <span class="ui-section__label">Context</span>
+        </div>
+        <pre class="ui-code ui-code--muted"><code>${this._escHtml(contextCode)}</code></pre>
+      </div>
+      ` : ''}
+
+      <div class="ui-section">
+        <div class="ui-section__head">
+          <span class="ui-section__label">Classification</span>
+        </div>
+        <div class="ui-classification">
+          <span class="ui-classification__type">${this._escHtml(inst.componentType || '')}</span>
+          <span class="ui-classification__sep">/</span>
+          <span class="ui-classification__variant">${this._escHtml(inst.variantName || 'default')}</span>
+          ${loc.line ? `<span class="ui-classification__line">line ${loc.line}</span>` : ''}
+        </div>
+      </div>
+    `;
+
+    // Copy source
+    body.querySelector('[data-action="copy-source"]')?.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(inst.html || '');
+        this.onToast('Source copied');
+      } catch {
+        this.onToast('Copy failed', 'error');
+      }
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // Keyboard nav
+  // ----------------------------------------------------------------
+
+  _handleKeydown(e) {
+    if (!this.drawerOpen) return;
+    if (e.key === 'Escape')      { e.stopPropagation(); this._closeDrawer(); }
+    if (e.key === 'ArrowLeft')   { e.preventDefault();  this._stepDrawer(-1); }
+    if (e.key === 'ArrowRight')  { e.preventDefault();  this._stepDrawer(1); }
+  }
+
+  // ----------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------
+
+  _formatLocation(loc) {
+    if (!loc) return 'Unknown';
+    if (loc.type === 'file') return loc.path + (loc.line ? `:${loc.line}` : '');
+    if (loc.type === 'figma-frame') return `Figma › ${loc.path}`;
+    return loc.path || 'Unknown';
+  }
+
+  /** Show a stripped-down, safe preview of raw HTML in the grid card. */
+  _previewHtml(html) {
+    // Escape so it renders as text-like code, not live HTML
+    return this._escHtml(html.slice(0, 160));
+  }
+
+  _escHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  _escAtr(str) {
+    return String(str || '').replace(/"/g, '&quot;');
+  }
+}

--- a/systemic/js/viewer.js
+++ b/systemic/js/viewer.js
@@ -877,6 +877,13 @@ class DesignSystemViewer {
       auditLogHtml = this.renderStageAuditLog(compName, variants, isTemplate);
     }
 
+    // Multi-state grid (StateRenderer)
+    let stateGridHtml = '';
+    if (typeof StateRenderer !== 'undefined') {
+      const renderer = new StateRenderer();
+      stateGridHtml = renderer.buildComponentStateGrid(component);
+    }
+
     // Create preview container
     this.componentPreview.innerHTML = `
       <div class="preview-main">
@@ -889,6 +896,7 @@ class DesignSystemViewer {
         </div>
       </div>
       ${galleryHtml}
+      ${stateGridHtml}
       ${auditLogHtml}
     `;
 


### PR DESCRIPTION
## Summary

- **Track 1 — Three Input Sources**: Scan modal now has three equal entry points: Live Page (existing crawl), Design File (Figma via PAT), and GitHub Repo (static HTML/CSS parser with file+line attribution). Tokens persisted in localStorage.
- **Track 2 — Multi-State Rendering**: `state-renderer.js` renders all interaction states side-by-side per variant with contextual placeholder content. Injected into the Docs component preview.
- **Track 3 — Component Usage Inspector**: `usage-inspector.js` shows every instance of a selected component with location context. Clicking opens a right-side drawer with source code block, surrounding context, and variant classification. Wired to the QA component filter.

## New files
- `systemic/js/code-parser.js` — GitHub Contents API static parser
- `systemic/js/figma-parser.js` — Figma REST API client
- `systemic/js/state-renderer.js` — multi-state showcase renderer
- `systemic/js/usage-inspector.js` — instance grid + drawer
- `systemic/css/state-inspector.css` — new UI styles
- `docs/strategy/prds/systemic-v2.md` — PRD

## Test plan
- [ ] Open Systemic → Run a scan → verify 3 tabs (Live Page, Design File, GitHub Repo)
- [ ] GitHub tab: enter a public repo URL → scan runs, components found with file paths
- [ ] Figma tab: enter Figma URL + PAT → fetches components and tokens
- [ ] Docs view: select any component → state strip renders below variant gallery
- [ ] QA view: select component from filter → Usage Inspector opens with instance grid
- [ ] Click instance card → drawer opens with source code and location
- [ ] Keyboard: Arrow keys navigate instances, Escape closes drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)