### PR TITLE
fix(systemic): Haiku model, Paper source, component principles sidebar

### DIFF
--- a/supabase/functions/systemic-analyze/index.ts
+++ b/supabase/functions/systemic-analyze/index.ts
@@ -92,7 +92,7 @@ Deno.serve(async (req) => {
 
       const principlesPrompt = buildPrinciplesPrompt(body.designSystemSummary);
       const principlesMsg = await client.messages.create({
-        model: "claude-haiku-4-20250514",
+        model: "claude-haiku-4-5-20251001",
         max_tokens: 2048,
         messages: [{ role: "user", content: principlesPrompt }],
       });

--- a/systemic/css/state-inspector.css
+++ b/systemic/css/state-inspector.css
@@ -624,3 +624,97 @@
   color: var(--fg-muted);
   line-height: 1.55;
 }
+
+
+/* ============================================================
+   Paper Import Status (scan modal Paper tab)
+   ============================================================ */
+
+.paper-import-status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-2);
+  padding: var(--space-6) var(--space-4);
+  background: var(--bg-surface);
+  border: var(--border-thin) solid var(--border-subtle);
+  border-radius: 4px;
+  margin-bottom: var(--space-4);
+}
+
+.paper-import-status__icon {
+  font-size: 24px;
+  opacity: .35;
+  line-height: 1;
+}
+
+.paper-import-status__icon--ready {
+  opacity: 1;
+  color: var(--color-success, #22c55e);
+}
+
+.paper-import-status__text {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--fg);
+}
+
+.paper-import-status__sub {
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  line-height: 1.5;
+}
+
+.paper-import-status__sub code {
+  font-family: var(--font-mono);
+  font-size: inherit;
+  background: var(--bg-elevated);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+
+/* ============================================================
+   Component Principles (context sidebar in docs view)
+   ============================================================ */
+
+.comp-principles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.comp-principles-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.comp-principles-item__rule {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--fg);
+  line-height: 1.4;
+}
+
+.comp-principles-item__rationale {
+  font-size: 11px;
+  color: var(--fg-subtle);
+  line-height: 1.5;
+}
+
+.comp-principles-more {
+  display: inline-block;
+  margin-top: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+.comp-principles-more:hover {
+  color: var(--fg);
+}

--- a/systemic/index.html
+++ b/systemic/index.html
@@ -229,6 +229,12 @@
                 <div id="states-list" class="states-list"></div>
               </div>
 
+              <div class="context-section" id="comp-principles-section" hidden>
+                <h4>Usage Principles</h4>
+                <ul id="comp-principles-list" class="comp-principles-list"></ul>
+                <a href="#principles" class="comp-principles-more" id="comp-principles-link">View all principles →</a>
+              </div>
+
             </div>
 
             <!-- Code Context -->
@@ -344,6 +350,7 @@
             <button class="scan-modal__tab active" role="tab" aria-selected="true"  data-tab="live"   id="tab-live">Live Page</button>
             <button class="scan-modal__tab"        role="tab" aria-selected="false" data-tab="design" id="tab-design">Design File</button>
             <button class="scan-modal__tab"        role="tab" aria-selected="false" data-tab="code"   id="tab-code">GitHub Repo</button>
+            <button class="scan-modal__tab"        role="tab" aria-selected="false" data-tab="paper"  id="tab-paper">Paper</button>
           </div>
 
           <!-- Tab: Live Page -->
@@ -385,6 +392,18 @@
             </div>
             <button class="btn btn--filled" id="scan-github-submit">Analyze Repository</button>
           </div>
+
+          <!-- Tab: Paper -->
+          <div class="scan-modal__panel" data-panel="paper" role="tabpanel" aria-labelledby="tab-paper" hidden>
+            <p class="scan-modal__hint">Import directly from your Paper canvas — extracted by the Claude Code agent.</p>
+            <div class="paper-import-status" id="paper-import-status">
+              <div class="paper-import-status__icon">◈</div>
+              <div class="paper-import-status__text">No Paper data ready</div>
+              <div class="paper-import-status__sub">Ask Claude Code to scan your Paper file: <code>"Scan my Paper file for Systemic"</code></div>
+            </div>
+            <button class="btn btn--filled" id="scan-paper-submit" disabled>Load from Paper</button>
+            <button class="btn btn--ghost" id="scan-paper-check" style="margin-left:var(--space-2)">Check for data</button>
+          </div>
         </div>
       </div>
     </div>
@@ -401,6 +420,7 @@
   <script src="js/crawler.js"></script>
   <script src="js/code-parser.js"></script>
   <script src="js/figma-parser.js"></script>
+  <script src="js/paper-parser.js"></script>
   <script src="js/state-renderer.js"></script>
   <script src="js/usage-inspector.js"></script>
   <script src="js/principles-generator.js"></script>

--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -747,6 +747,11 @@ class SystemicApp {
     this.scanGithubUrl = DOMUtils.$('#scan-github-url');
     this.scanGithubToken = DOMUtils.$('#scan-github-token');
     this.scanGithubSubmit = DOMUtils.$('#scan-github-submit');
+
+    // Scan modal — Paper
+    this.scanPaperSubmit   = DOMUtils.$('#scan-paper-submit');
+    this.scanPaperCheck    = DOMUtils.$('#scan-paper-check');
+    this.paperImportStatus = DOMUtils.$('#paper-import-status');
   }
 
   /**
@@ -854,6 +859,15 @@ class SystemicApp {
       if (token) { try { localStorage.setItem('systemic-github-token', token); } catch {} }
       this.closeScanModal();
       this.startGitHubScan(url, token);
+    });
+
+    // Paper scan — check for agent-written data
+    this.scanPaperCheck?.addEventListener('click', () => this._checkPaperImport());
+    this.scanPaperSubmit?.addEventListener('click', () => {
+      const raw = this._readPaperImport();
+      if (!raw) { this.showToast('No Paper data found — ask Claude to scan your file first', 'error'); return; }
+      this.closeScanModal();
+      this.startPaperScan(raw);
     });
   }
 
@@ -1273,6 +1287,8 @@ class SystemicApp {
         if (ft && this.scanFigmaToken) this.scanFigmaToken.value = ft;
         if (gt && this.scanGithubToken) this.scanGithubToken.value = gt;
       } catch {}
+      // Auto-check for Paper data
+      this._checkPaperImport();
       this.scanUrlInput?.focus();
     }
   }
@@ -1356,6 +1372,87 @@ class SystemicApp {
       await this.onAuditComplete(results);
     } catch (err) {
       this.onAuditError(err);
+    }
+  }
+
+  /**
+   * Start a Paper canvas scan.
+   * @param {object} extract — PaperExtract from localStorage
+   */
+  async startPaperScan(extract) {
+    const name = extract.name || 'Paper File';
+    this.debugLog('PAPER', `Starting Paper scan: ${name}`);
+
+    this.navigateTo('audit');
+    await new Promise(r => setTimeout(r, 50));
+
+    this.auditFormSection.hidden = true;
+    this.auditProgressSection.hidden = false;
+    this.auditUrlDisplay.textContent = name;
+    this.auditStatusText.textContent = 'Parsing Paper canvas…';
+    this.clearLog();
+
+    this.paperParser = new PaperParser({
+      onLog: (log) => this.addLogEntry(log),
+      onProgress: (progress) => this.updateProgress(progress),
+    });
+
+    this.currentAudit = {
+      id: crypto.randomUUID(),
+      config: { url: null, name, source: 'paper' },
+      startedAt: new Date().toISOString(),
+    };
+
+    try {
+      const results = this.paperParser.parse(extract);
+      // Clear the import slot so stale data isn't reloaded
+      try { localStorage.removeItem('systemic-paper-import'); } catch {}
+      await this.onAuditComplete(results);
+    } catch (err) {
+      this.onAuditError(err);
+    }
+  }
+
+  /**
+   * Read Paper import data written by the agent.
+   * Returns the parsed object or null.
+   */
+  _readPaperImport() {
+    try {
+      const raw = localStorage.getItem('systemic-paper-import');
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Check localStorage for agent-written Paper data and update the tab UI.
+   */
+  _checkPaperImport() {
+    const data = this._readPaperImport();
+    const statusEl = this.paperImportStatus;
+    const submitBtn = this.scanPaperSubmit;
+    if (!statusEl || !submitBtn) return;
+
+    if (data) {
+      const compCount = (data.components || []).length;
+      const ts = data.extractedAt ? new Date(data.extractedAt).toLocaleTimeString() : 'recently';
+      statusEl.innerHTML = `
+        <div class="paper-import-status__icon paper-import-status__icon--ready">✓</div>
+        <div class="paper-import-status__text">Paper data ready — ${data.name || 'Untitled'}</div>
+        <div class="paper-import-status__sub">${compCount} component type${compCount !== 1 ? 's' : ''} found · extracted ${ts}</div>
+      `;
+      submitBtn.disabled = false;
+      submitBtn.textContent = `Load "${data.name || 'Paper File'}"`;
+    } else {
+      statusEl.innerHTML = `
+        <div class="paper-import-status__icon">◈</div>
+        <div class="paper-import-status__text">No Paper data ready</div>
+        <div class="paper-import-status__sub">Ask Claude Code: <code>"Scan my Paper file for Systemic"</code></div>
+      `;
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Load from Paper';
     }
   }
 
@@ -1664,6 +1761,10 @@ class SystemicApp {
     if (this.figmaParser) {
       this.figmaParser.stop();
       this.addLogEntry({ type: 'info', message: 'Figma scan cancelled' });
+    }
+    if (this.paperParser) {
+      this.paperParser.stop();
+      this.addLogEntry({ type: 'info', message: 'Paper scan cancelled' });
     }
     this.resetAuditForm();
   }

--- a/systemic/js/paper-parser.js
+++ b/systemic/js/paper-parser.js
@@ -1,0 +1,399 @@
+/**
+ * PaperParser — converts Paper MCP extracted data into Systemic's standard format.
+ *
+ * Paper is a design tool accessible only through the Claude Code agent via MCP.
+ * This parser accepts a `PaperExtract` object (written by the agent to localStorage
+ * under the key `systemic-paper-import`) and produces the same shape as
+ * CodeParser / FigmaParser / AgenticCrawler.
+ *
+ * PaperExtract shape (written by agent):
+ * {
+ *   name:      string,          // file/artboard name
+ *   tree:      object,          // get_tree_summary() output
+ *   jsx:       string,          // get_jsx() output (optional)
+ *   styles:    object[],        // get_computed_styles() per-node results
+ *   meta:      object,          // get_basic_info() output
+ *   extractedAt: string,        // ISO timestamp
+ * }
+ */
+class PaperParser {
+  constructor({ onLog, onProgress } = {}) {
+    this.onLog    = onLog     || (() => {});
+    this.onProgress = onProgress || (() => {});
+    this._stopped = false;
+  }
+
+  stop() { this._stopped = true; }
+
+  // ─────────────────────────────────────────────────────────────
+  // Public entry point
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Parse a PaperExtract object into the standard design system format.
+   * @param {object} extract — from localStorage 'systemic-paper-import'
+   * @returns {{ components, tokens, pages, pagesCrawled, source }}
+   */
+  parse(extract) {
+    if (!extract || typeof extract !== 'object') {
+      throw new Error('Invalid Paper extract — expected an object');
+    }
+
+    this._log(`Parsing Paper file: ${extract.name || 'Untitled'}`);
+    this._progress(5);
+
+    const tree    = extract.tree  || {};
+    const jsx     = extract.jsx   || '';
+    const styles  = extract.styles || [];
+
+    // Build a flat index of nodes for quick lookup
+    const nodeIndex = {};
+    this._indexNodes(tree, nodeIndex);
+    this._progress(15);
+
+    // Extract tokens (colors, typography, spacing)
+    const tokens = this._extractTokens(nodeIndex, styles, extract.meta || {});
+    this._progress(35);
+
+    // Extract components (COMPONENT / COMPONENT_SET / reusable FRAMEs)
+    const rawComponents = this._extractComponents(nodeIndex, tokens);
+    this._progress(65);
+
+    // Parse JSX for additional class/token clues
+    if (jsx) {
+      this._enrichFromJsx(rawComponents, jsx);
+    }
+    this._progress(85);
+
+    // Build pages list
+    const pages = this._extractPages(tree);
+
+    this._progress(100);
+    this._log(`Done — ${rawComponents.length} components, ${tokens.colors ? Object.keys(tokens.colors).length : 0} color tokens`);
+
+    return {
+      components:   rawComponents,
+      tokens,
+      pages,
+      pagesCrawled: pages.length,
+      source: {
+        type:    'paper',
+        name:    extract.name || 'Paper File',
+        url:     null,
+        extractedAt: extract.extractedAt || new Date().toISOString(),
+      },
+    };
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Tree indexing
+  // ─────────────────────────────────────────────────────────────
+
+  _indexNodes(node, index, depth = 0) {
+    if (!node || depth > 40) return;
+    if (node.id) index[node.id] = node;
+    (node.children || []).forEach(child => this._indexNodes(child, index, depth + 1));
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Token extraction
+  // ─────────────────────────────────────────────────────────────
+
+  _extractTokens(nodeIndex, stylesArray, meta) {
+    const colors     = {};
+    const typography = {};
+    const cssVars    = {};
+
+    // Walk all nodes looking for fill colors and text styles
+    Object.values(nodeIndex).forEach(node => {
+      // Color fills
+      if (node.fills) {
+        (node.fills || []).forEach(fill => {
+          if (fill.type === 'SOLID' && fill.color) {
+            const hex = this._rgbaToHex(fill.color);
+            const role = this._guessColorRole(node.name || '', hex);
+            if (role && !colors[role]) {
+              colors[role] = { hex, opacity: fill.opacity ?? 1 };
+              cssVars[`--color-${role}`] = hex;
+            }
+          }
+        });
+      }
+
+      // Text styles
+      if (node.type === 'TEXT' && node.style) {
+        const s = node.style;
+        const key = `${s.fontFamily || 'unknown'}-${s.fontSize || 0}`;
+        if (!typography[key]) {
+          typography[key] = {
+            fontFamily: s.fontFamily,
+            fontSize:   s.fontSize,
+            fontWeight: s.fontWeight,
+            lineHeight: s.lineHeightPx,
+          };
+        }
+      }
+    });
+
+    // Derive primary font from most-used text style
+    const fontEntries = Object.values(typography);
+    const fontPrimary = fontEntries.length > 0
+      ? fontEntries.sort((a, b) => (b.fontSize || 0) - (a.fontSize || 0))[0]?.fontFamily
+      : null;
+
+    return {
+      colors,
+      typography: { primary: fontPrimary, scale: fontEntries },
+      spacing:    { baseUnit: this._guessSpacingBase(nodeIndex) },
+      elevation:  { levels: [] },
+      shape:      { values: this._gatherBorderRadius(nodeIndex) },
+      cssVariables: cssVars,
+    };
+  }
+
+  _rgbaToHex({ r = 0, g = 0, b = 0 } = {}) {
+    const toHex = v => Math.round(v * 255).toString(16).padStart(2, '0');
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  }
+
+  _guessColorRole(name, hex) {
+    const n = (name || '').toLowerCase();
+    if (n.includes('primary'))   return 'primary';
+    if (n.includes('secondary')) return 'secondary';
+    if (n.includes('tertiary'))  return 'tertiary';
+    if (n.includes('error') || n.includes('danger')) return 'error';
+    if (n.includes('success') || n.includes('green')) return 'success';
+    if (n.includes('warning') || n.includes('warn'))  return 'warning';
+    if (n.includes('background') || n.includes('bg')) return 'background';
+    if (n.includes('surface'))   return 'surface';
+    // Unnamed — guess from value
+    if (!hex) return null;
+    return null; // Skip unnamed fills to avoid noise
+  }
+
+  _guessSpacingBase(nodeIndex) {
+    // Collect all padding/gap values from auto-layout frames
+    const values = [];
+    Object.values(nodeIndex).forEach(node => {
+      if (node.layoutMode && node.itemSpacing) values.push(node.itemSpacing);
+      if (node.paddingLeft)  values.push(node.paddingLeft);
+      if (node.paddingRight) values.push(node.paddingRight);
+      if (node.paddingTop)   values.push(node.paddingTop);
+    });
+    if (values.length === 0) return 8;
+    // Find GCD-like base unit
+    const sorted = [...new Set(values)].filter(v => v > 0).sort((a, b) => a - b);
+    return sorted[0] || 8;
+  }
+
+  _gatherBorderRadius(nodeIndex) {
+    const radii = new Set();
+    Object.values(nodeIndex).forEach(node => {
+      if (node.cornerRadius) radii.add(node.cornerRadius);
+      if (node.rectangleCornerRadii) {
+        node.rectangleCornerRadii.forEach(r => radii.add(r));
+      }
+    });
+    return [...radii].filter(r => r > 0).sort((a, b) => a - b);
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Component extraction
+  // ─────────────────────────────────────────────────────────────
+
+  _extractComponents(nodeIndex, tokens) {
+    const componentDefs  = {};  // id → node
+    const instancesByDef = {};  // componentId → [instanceNode, ...]
+
+    Object.values(nodeIndex).forEach(node => {
+      if (node.type === 'COMPONENT' || node.type === 'COMPONENT_SET') {
+        componentDefs[node.id] = node;
+      }
+      if (node.type === 'INSTANCE' && node.componentId) {
+        (instancesByDef[node.componentId] = instancesByDef[node.componentId] || []).push(node);
+      }
+    });
+
+    // Also include prominent FRAMEs that look component-like (named with component keywords)
+    Object.values(nodeIndex).forEach(node => {
+      if (node.type === 'FRAME' && this._inferType(node.name || '') !== 'unknown' && !componentDefs[node.id]) {
+        componentDefs[node.id] = node;
+      }
+    });
+
+    const components = [];
+    const typeGroups = {};
+
+    Object.values(componentDefs).forEach(def => {
+      const type = this._inferType(def.name || '');
+      if (!typeGroups[type]) typeGroups[type] = [];
+      typeGroups[type].push(def);
+    });
+
+    Object.entries(typeGroups).forEach(([type, defs]) => {
+      const variants = defs.map(def => {
+        const instances = (instancesByDef[def.id] || []);
+        return {
+          name:       def.name || type,
+          html:       this._nodeToHtmlSummary(def),
+          classes:    this._gatherClasses(def),
+          usageCount: instances.length,
+          instances:  instances.map(inst => ({
+            location: {
+              type: 'design',
+              path: this._getNodePath(inst, nodeIndex),
+              line: null,
+            },
+            html:    this._nodeToHtmlSummary(inst),
+            context: {},
+          })),
+        };
+      });
+
+      const totalUsage = variants.reduce((n, v) => n + (v.usageCount || 0), 0);
+
+      components.push({
+        type,
+        name:         this._formatName(type),
+        variants,
+        totalUsage,
+        states:       this._inferStates(defs),
+        classes:      [...new Set(variants.flatMap(v => v.classes))],
+        source:       'paper',
+      });
+    });
+
+    return components;
+  }
+
+  _inferType(name) {
+    const n = name.toLowerCase().replace(/[-_/\s]+/g, ' ');
+    const map = [
+      [/\b(btn|button)\b/,                 'button'],
+      [/\b(input|text.?field|text.?box|field)\b/, 'input'],
+      [/\b(card|tile|panel)\b/,            'card'],
+      [/\b(nav|navigation|navbar|menu|header)\b/, 'nav'],
+      [/\b(modal|dialog|overlay|drawer|sheet)\b/, 'modal'],
+      [/\b(select|dropdown|picker)\b/,     'select'],
+      [/\b(checkbox|check)\b/,             'checkbox'],
+      [/\b(radio|radio.?button)\b/,        'radio'],
+      [/\b(toggle|switch)\b/,              'toggle'],
+      [/\b(badge|tag|chip|label)\b/,       'badge'],
+      [/\b(avatar|profile.?pic)\b/,        'avatar'],
+      [/\b(alert|toast|notification|snackbar)\b/, 'alert'],
+      [/\b(tab|tabs)\b/,                   'tabs'],
+      [/\b(tooltip|popover)\b/,            'tooltip'],
+      [/\b(table|data.?grid|grid)\b/,      'table'],
+      [/\b(form)\b/,                       'form'],
+      [/\b(icon)\b/,                       'icon'],
+      [/\b(image|img|photo)\b/,            'image'],
+      [/\b(link|anchor)\b/,               'link'],
+      [/\b(progress|spinner|loading|loader)\b/, 'progress'],
+    ];
+    for (const [re, type] of map) {
+      if (re.test(n)) return type;
+    }
+    return 'component';
+  }
+
+  _formatName(type) {
+    return type.charAt(0).toUpperCase() + type.slice(1);
+  }
+
+  _gatherClasses(node) {
+    // Paper doesn't use CSS classes, but we can derive them from node name tokens
+    const name  = (node.name || '').toLowerCase().replace(/\s+/g, '-');
+    const type  = this._inferType(node.name || '');
+    const classes = [type];
+    if (name && name !== type) classes.push(name.slice(0, 40));
+    return [...new Set(classes)];
+  }
+
+  _nodeToHtmlSummary(node) {
+    const type  = node.type || 'div';
+    const name  = node.name ? ` data-name="${node.name}"` : '';
+    const w     = node.absoluteBoundingBox?.width  ? ` data-w="${Math.round(node.absoluteBoundingBox.width)}"` : '';
+    const h     = node.absoluteBoundingBox?.height ? ` data-h="${Math.round(node.absoluteBoundingBox.height)}"` : '';
+    return `<div class="${this._inferType(node.name || '')}"${name}${w}${h}>[${type}]</div>`;
+  }
+
+  _getNodePath(node, nodeIndex) {
+    // Walk up via parentId to build a breadcrumb path
+    const parts = [node.name || node.id];
+    let current = node;
+    let depth   = 0;
+    while (current.parentId && depth < 6) {
+      const parent = nodeIndex[current.parentId];
+      if (!parent) break;
+      parts.unshift(parent.name || parent.id);
+      current = parent;
+      depth++;
+    }
+    return parts.join(' / ');
+  }
+
+  _inferStates(defs) {
+    const states = new Set(['default']);
+    defs.forEach(def => {
+      const n = (def.name || '').toLowerCase();
+      if (n.includes('hover'))    states.add('hover');
+      if (n.includes('focus'))    states.add('focus');
+      if (n.includes('active'))   states.add('active');
+      if (n.includes('disabled')) states.add('disabled');
+      if (n.includes('error'))    states.add('error');
+      if (n.includes('loading'))  states.add('loading');
+      if (n.includes('selected')) states.add('selected');
+      if (n.includes('checked'))  states.add('checked');
+      if (n.includes('empty'))    states.add('empty');
+    });
+    return [...states];
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // JSX enrichment
+  // ─────────────────────────────────────────────────────────────
+
+  _enrichFromJsx(components, jsx) {
+    // Extract class names from JSX (className="..." or class="...")
+    const classRe = /class(?:Name)?=["']([^"']+)["']/g;
+    const foundClasses = new Set();
+    let m;
+    while ((m = classRe.exec(jsx)) !== null) {
+      m[1].split(/\s+/).forEach(c => c && foundClasses.add(c));
+    }
+    if (foundClasses.size === 0) return;
+
+    // Match discovered classes to components by keyword overlap
+    components.forEach(comp => {
+      const matching = [...foundClasses].filter(cls => {
+        const cl = cls.toLowerCase();
+        return cl.includes(comp.type) || comp.type.includes(cl.split('-')[0]);
+      });
+      if (matching.length > 0) {
+        const existing = new Set(comp.classes || []);
+        matching.forEach(c => existing.add(c));
+        comp.classes = [...existing];
+      }
+    });
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Pages
+  // ─────────────────────────────────────────────────────────────
+
+  _extractPages(tree) {
+    // Top-level children of the document are pages
+    if (tree.type === 'DOCUMENT') {
+      return (tree.children || []).map(p => ({ url: p.name || 'Page', title: p.name || 'Page' }));
+    }
+    // If tree IS a page, return it
+    return [{ url: tree.name || 'Main', title: tree.name || 'Main' }];
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────
+
+  _log(msg)      { this.onLog(`[Paper] ${msg}`); }
+  _progress(pct) { this.onProgress(pct); }
+}

--- a/systemic/js/viewer.js
+++ b/systemic/js/viewer.js
@@ -48,6 +48,8 @@ class DesignSystemViewer {
     this.accessibilityNotes = DOMUtils.$('#accessibility-notes', this.container);
     this.statesSection = DOMUtils.$('#states-section', this.container);
     this.statesList = DOMUtils.$('#states-list', this.container);
+    this.compPrinciplesSection = DOMUtils.$('#comp-principles-section', this.container);
+    this.compPrinciplesList = DOMUtils.$('#comp-principles-list', this.container);
 
     // Code view elements
     this.tokenList = DOMUtils.$('#token-list', this.container);
@@ -1208,9 +1210,43 @@ class DesignSystemViewer {
     // States section
     this.renderStatesSection(component);
 
+    // Component-level principles (from already-generated system principles)
+    this.renderComponentPrinciples(component);
+
     // Update code context
     this.updateTokenListForComponent(component);
     this.updateCodeBlocksForComponent(component);
+  }
+
+  /**
+   * Inject component-specific usage principles into the context sidebar.
+   * Reads from this.designSystem.principles.componentPrinciples[type].
+   */
+  renderComponentPrinciples(component) {
+    if (!this.compPrinciplesSection || !this.compPrinciplesList) return;
+
+    const rules = this.designSystem?.principles?.componentPrinciples?.[component.type];
+
+    if (rules && rules.length > 0) {
+      this.compPrinciplesList.innerHTML = rules.map(r => `
+        <li class="comp-principles-item">
+          <span class="comp-principles-item__rule">${this._escHtml(r.rule)}</span>
+          ${r.rationale ? `<span class="comp-principles-item__rationale">${this._escHtml(r.rationale)}</span>` : ''}
+        </li>
+      `).join('');
+      this.compPrinciplesSection.hidden = false;
+    } else {
+      this.compPrinciplesSection.hidden = true;
+    }
+  }
+
+  /** HTML-escape helper */
+  _escHtml(str) {
+    return String(str ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Fix principles 500**: claude-haiku-4-20250514 → claude-haiku-4-5-20251001 (model didn't exist)
- **Paper source**: new PaperParser class + Paper tab in scan modal; agent writes canvas data to localStorage, browser imports on demand
- **Component principles in sidebar**: renderComponentPrinciples() reads ds.principles.componentPrinciples[type] and shows usage rules inline on every component doc page

## Test plan
- [ ] Open #principles on a loaded system → AI call should succeed (no 500)
- [ ] Open scan modal → Paper tab appears; "Check for data" updates status
- [ ] Open a component doc page after generating principles → sidebar shows Usage Principles section
- [ ] View all principles link navigates to #principles

Generated with Claude Code