### PR TITLE
feat(systemic): merge QA variant audit into docs viewer

### DIFF
--- a/docs/ux/systemic-qa-merge-design.md
+++ b/docs/ux/systemic-qa-merge-design.md
@@ -1,0 +1,269 @@
+# Systemic: QA + Docs Merge — Design Spec
+
+> **Status:** Design  
+> **Date:** 2026-04-10  
+> **Scope:** Merge the standalone QA Variant Audit view into the Docs Viewer as a mode toggle
+
+---
+
+## Problem
+
+Two separate "pick a component" UIs exist in Systemic. The **Docs viewer** has `#component-select` (hierarchical optgroups). The **QA view** has `#qa-component-filter` (flat list). Both source from the same `designSystem.components[]` array. Switching views loses component context and forces re-selection.
+
+## Solution
+
+Replace the standalone QA view with a **Docs | QA mode toggle** in the docs nav bar. One component dropdown drives both modes.
+
+---
+
+## Layout Architecture
+
+### Nav Bar (persistent across modes)
+
+Uses existing `.docs-nav` container (flex, `gap: var(--space-4)`, `align-items: center`).
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ .docs-nav                                                               │
+│                                                                         │
+│  .breadcrumb          .docs-nav__link(s)     .docs-nav__spacer          │
+│  Systems / Acme DS  │ Color Typo Space ...                              │
+│                                                                         │
+│  RIGHT SIDE (after spacer):                                             │
+│  ┌─────────────────┐ ┌────────────────┐ ┌──────────┐ ┌──────────────┐  │
+│  │ #component-select│ │ #variant-select│ │ .state-  │ │ .view-toggle │  │
+│  │ .docs-nav__select│ │ .docs-nav__sel │ │ toggles  │ │ --mode       │  │
+│  │ Component...     │ │ Variant...     │ │ ○ ◉ ◎ ◌  │ │ Docs │ QA   │  │
+│  └─────────────────┘ └────────────────┘ └──────────┘ └──────────────┘  │
+│                                                                         │
+│  (Design|Code toggle REMOVED from nav — moves into context sidebar)     │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Mode toggle** reuses `.view-toggle` + `.toggle-btn` pattern:
+```html
+<div class="view-toggle view-toggle--mode">
+  <button class="toggle-btn active" data-mode="docs">Docs</button>
+  <button class="toggle-btn" data-mode="qa">QA</button>
+</div>
+```
+
+**Conditional visibility by mode:**
+
+| Element | Docs mode | QA mode |
+|---------|-----------|---------|
+| `#component-select` | visible | visible |
+| `#variant-select` | visible (when variants exist) | hidden |
+| `.state-toggles` | visible | hidden |
+| `.view-toggle` (Design/Code) | visible | hidden |
+| `.qa-nav-controls` (variant filter + gridlines) | hidden | visible |
+| `.view-toggle--mode` (Docs/QA) | visible | visible |
+
+**QA nav controls** — new inline group that replaces state toggles + Design/Code toggle when QA mode is active:
+```html
+<div class="qa-nav-controls" hidden>
+  <select class="docs-nav__select" id="qa-variant-filter-nav">
+    <option value="">All variants</option>
+  </select>
+  <button class="btn btn--sm" id="qa-gridlines-nav">Grid lines</button>
+  <span class="filter-bar__stats" id="qa-stats-nav"></span>
+</div>
+```
+
+---
+
+### Docs Mode — Content Area
+
+Uses existing `.viewer-container` grid (`1fr var(--systemic-context-width)`).
+
+```
+┌──────────────────────────────────────┬──────────────────────────┐
+│ .component-stage                     │ .context-sidebar (360px) │
+│                                      │                          │
+│  .showcase (20px grid bg)            │  [Design│Code] toggle    │
+│  ┌──────────────────────────────┐    │  ─────────────────────   │
+│  │                              │    │  Specifications          │
+│  │   Component preview          │    │  Description             │
+│  │   (rendered variant)         │    │  When to Use             │
+│  │                              │    │  When Not to Use         │
+│  └──────────────────────────────┘    │  Accessibility           │
+│                                      │  Detected States         │
+│                                      │                          │
+│                                      │  ─── OR (Code tab) ───  │
+│                                      │  Tokens                  │
+│                                      │  CSS                     │
+│                                      │  HTML                    │
+│                                      │  React                   │
+└──────────────────────────────────────┴──────────────────────────┘
+```
+
+**Change:** Design/Code toggle moves from nav bar into the sidebar header. This frees nav space and keeps the toggle co-located with the content it controls.
+
+---
+
+### QA Mode — Content Area
+
+Replaces `.component-stage` + `.context-sidebar` with a single full-width QA container.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ .qa-inline (full width of .viewer-container, grid-column: 1 / -1)   │
+│                                                                     │
+│  ┌─ #usage-inspector-inline ──────────────────────────────────────┐ │
+│  │ 3 instances across 2 sources                                   │ │
+│  │ ├─ crawl: homepage (2x)                                        │ │
+│  │ └─ figma: card-grid (1x)                                       │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+│                                                                     │
+│  .qa-variant-grid (flex column, gap: var(--space-6))                │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │ .qa-variant-item--sm (200px)                                 │   │
+│  │ .qa-variant-label                                            │   │
+│  │ ┌─────────┐                                                  │   │
+│  │ │ 🟢 sm    │ .qa-variant-actions (opacity: 0 → 1 on hover)  │   │
+│  │ │         │ [Prefer] [Comment] [Block]                       │   │
+│  │ └─────────┘                                                  │   │
+│  │ .qa-variant-preview                                          │   │
+│  │ ┌──────────────────┐                                         │   │
+│  │ │                  │                                         │   │
+│  │ │  rendered widget │                                         │   │
+│  │ │                  │                                         │   │
+│  │ └──────────────────┘                                         │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │ .qa-variant-item--med (420px)                                │   │
+│  │ 🟡 med  [1 comment]                    [Prefer] [Comment]   │   │
+│  │ ┌────────────────────────────────────┐                       │   │
+│  │ │                                    │                       │   │
+│  │ │  rendered widget                   │                       │   │
+│  │ │                                    │                       │   │
+│  │ └────────────────────────────────────┘                       │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  .qa-blocked-toggle                                                 │
+│  ▶ Blocked (1) ──────────────────────────────────────               │
+│                                                                     │
+│  .qa-grid-test-section                                              │
+│  Grid Size Permutations                                             │
+│  [5 col] [4 col] [3 col] [Grid lines]                              │
+│  ┌────┬────┬────┬────┬────┐                                        │
+│  │    │    │    │    │    │                                         │
+│  └────┴────┴────┴────┴────┘                                        │
+│                                                                     │
+│  .qa-audit-output                                                   │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │ component │ size │ status │ note        [Export] [Clear]     │   │
+│  │ card      │ sm   │ 🟢     │                                  │   │
+│  │ card      │ med  │ 🟡     │ needs review                     │   │
+│  │ card      │ lg   │ 🔴     │ deprecated                       │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## CSS Token Usage
+
+All new styles compose existing design system tokens. No new tokens introduced.
+
+### New Classes
+
+| Class | Purpose | Tokens Used |
+|-------|---------|-------------|
+| `.view-toggle--mode` | Distinguishes Docs/QA toggle from Design/Code toggle | Inherits all `.view-toggle` styles |
+| `.qa-inline` | Full-width QA container inside `.viewer-container` | `grid-column: 1 / -1` |
+| `.qa-nav-controls` | Inline group for QA-specific nav controls | `display: flex; gap: var(--space-3)` |
+
+### Modified Classes
+
+| Class | Change | Reason |
+|-------|--------|--------|
+| `.viewer-container` | No change — `.qa-inline` uses `grid-column: 1 / -1` to span both columns | Avoids modifying the grid definition |
+| `.qa-container` | Removed (standalone QA view eliminated) | Content moves into `.qa-inline` |
+
+---
+
+## Interaction States
+
+### Component Selection Flow
+```
+User selects from #component-select
+  ↓
+app.selectComponentGlobal(type)
+  ├─ Persists to localStorage: selected-component:{systemId}
+  ├─ If docs mode: viewer.selectComponent(comp)
+  ├─ If qa mode: variantAudit.showVariants()
+  └─ Always: usageInspector.show(comp)
+```
+
+### Mode Toggle Flow
+```
+User clicks [QA] toggle button
+  ↓
+app.componentViewMode = 'qa'
+  ├─ .toggle-btn.active swaps
+  ├─ .component-stage hidden = true
+  ├─ .context-sidebar hidden = true
+  ├─ .qa-inline hidden = false
+  ├─ .state-toggles hidden = true
+  ├─ .view-toggle (Design/Code) hidden = true
+  ├─ .qa-nav-controls hidden = false
+  └─ If selectedComponentType: variantAudit.showVariants()
+```
+
+### Deep Link Routing
+```
+#docs/component/button      → docs mode, button selected
+#docs/qa/button              → qa mode, button selected
+#qa/button (legacy)          → redirects to #docs/qa/button
+```
+
+---
+
+## Component Data Flow
+
+```
+designSystem.components[]
+  │
+  ├─ app.renderDocsNav()
+  │   └─ Builds #component-select with <optgroup> hierarchy
+  │       Groups: Components | Widget Atoms | Widget Molecules | Templates
+  │
+  ├─ viewer.load(designSystem)
+  │   └─ Stores designSystem for selectComponent() rendering
+  │
+  └─ variantAudit.registerFromDesignSystem(designSystem)
+      └─ Builds this.components[] with variant/size metadata
+          (NO LONGER populates its own dropdown — uses global #component-select)
+```
+
+---
+
+## Persistence
+
+| Key | Value | Scope |
+|-----|-------|-------|
+| `selected-component:{systemId}` | Component type string | Per-system, survives refresh |
+| `component-view-mode:{systemId}` | `'docs'` or `'qa'` | Per-system, survives refresh |
+| `variant-audit:{systemId}` | Audit entries (flags, notes, preferred) | Per-system (unchanged) |
+
+---
+
+## Migration: What Gets Removed
+
+1. **`#qa-view` section** in `index.html` (lines 284-330) — entire standalone view
+2. **`<a href="#qa">QA</a>` nav link** — replaced by toggle button
+3. **`#qa-component-filter`** — replaced by global `#component-select`
+4. **`populateFilters()` in variant-audit.js** — no longer needed
+5. **`#qa` route handling** in app.js — redirects to `#docs/qa/...`
+6. **`.qa-header`** — description text moves into nav stats area
+7. **`.qa-container .filter-bar`** — controls move into nav bar
+
+## What Stays Unchanged
+
+- All variant-audit.js audit logic (flags, notes, comments, preferred, export)
+- All QA CSS for variant items, stoplight badges, blocked state, context menu
+- Grid test section
+- Audit table
+- Usage inspector (just re-mounted)

--- a/systemic/css/systemic.css
+++ b/systemic/css/systemic.css
@@ -162,6 +162,10 @@
   flex-shrink: 0;
 }
 
+.view-toggle[hidden] {
+  display: none;
+}
+
 .toggle-btn {
   flex: 1;
   padding: var(--space-2);

--- a/systemic/css/variant-audit.css
+++ b/systemic/css/variant-audit.css
@@ -3,27 +3,34 @@
    Uses CTRL Design System tokens + Systemic viewer grid
    ============================================ */
 
-/* QA View Layout */
-.qa-container {
+/* QA Inline Container (inside docs viewer-container) */
+.qa-inline {
+  grid-column: 1 / -1;
   display: flex;
   flex-direction: column;
   height: 100%;
   overflow: hidden;
 }
 
-.qa-header {
-  padding: var(--space-4) var(--space-6);
-  border-bottom: var(--border-thin) solid var(--border-subtle);
+.qa-inline[hidden] {
+  display: none;
+}
+
+/* QA Nav Controls (inline in docs nav bar) */
+.qa-nav-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   flex-shrink: 0;
 }
 
-.qa-header h2 {
-  font-family: var(--font-primary);
-  font-size: var(--text-lg);
-  font-weight: normal;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wider);
-  margin: 0 0 var(--space-1);
+.qa-nav-controls[hidden] {
+  display: none;
+}
+
+/* Mode toggle variant */
+.view-toggle--mode {
+  margin-left: var(--space-2);
 }
 
 .qa-desc {
@@ -34,6 +41,7 @@
 }
 
 /* Filter bar overrides (DS .filter-bar base in components.css) */
+.qa-inline .filter-bar,
 .qa-container .filter-bar {
   gap: var(--space-3);
   padding: var(--space-3) var(--space-6);
@@ -41,6 +49,7 @@
   flex-shrink: 0;
 }
 
+.qa-inline .filter-bar select option,
 .qa-container .filter-bar select option {
   text-transform: none;
   letter-spacing: normal;
@@ -57,6 +66,7 @@
 }
 
 /* Active state for toggle buttons in filter bar */
+.qa-inline .filter-bar .btn.active,
 .qa-container .filter-bar .btn.active {
   background: var(--fg);
   color: var(--bg);
@@ -331,10 +341,12 @@
 }
 
 /* Audit log table overrides (DS .data-table base in components.css) */
+.qa-inline .data-table,
 .qa-container .data-table {
   margin-top: var(--space-4);
 }
 
+.qa-inline .data-table th,
 .qa-container .data-table th {
   font-weight: normal;
 }

--- a/systemic/css/viewer.css
+++ b/systemic/css/viewer.css
@@ -18,6 +18,10 @@
   background: var(--bg);
 }
 
+.component-stage[hidden] {
+  display: none;
+}
+
 /* Showcase - widgets.html-style scrollable content area with grid texture */
 .showcase {
   flex: 1;
@@ -40,6 +44,10 @@
   display: flex;
   gap: var(--space-1);
   flex-shrink: 0;
+}
+
+.state-toggles[hidden] {
+  display: none;
 }
 
 .state-btn {
@@ -132,6 +140,10 @@
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+}
+
+.context-sidebar[hidden] {
+  display: none;
 }
 
 

--- a/systemic/index.html
+++ b/systemic/index.html
@@ -265,6 +265,37 @@
               </div>
             </div>
           </aside>
+
+          <!-- QA Inline Container (shown when QA mode is active) -->
+          <div class="qa-inline" id="qa-inline" hidden>
+            <div id="usage-inspector-mount-inline"></div>
+
+            <p class="qa-desc" id="qa-desc" style="padding: var(--space-3) var(--space-6); margin: 0;">Select a component to audit its variants.</p>
+
+            <div class="qa-content" id="qa-content">
+              <div class="qa-variant-grid" id="qa-grid"></div>
+
+              <div id="qa-blocked-section" style="display:none;margin-top:var(--space-6)">
+                <button class="qa-blocked-toggle" id="qa-blocked-toggle"></button>
+                <div class="qa-variant-grid" id="qa-blocked-grid" style="display:none"></div>
+              </div>
+
+              <!-- Grid Test — widgets at different column counts -->
+              <div class="qa-grid-test-section" id="qa-grid-test-section" style="display:none;margin-top:var(--space-8)">
+                <h3 class="qa-log-heading">Grid Size Permutations</h3>
+                <p class="qa-desc">Same widget at its valid grid sizes. Toggle columns to test responsiveness.</p>
+                <div class="qa-grid-controls">
+                  <button class="active" data-cols="5">5 col</button>
+                  <button data-cols="4">4 col</button>
+                  <button data-cols="3">3 col</button>
+                  <button id="qa-grid-test-lines-btn">Grid lines</button>
+                </div>
+                <div class="qa-grid-test qa-grid-test--5col" id="qa-grid-test"></div>
+              </div>
+
+              <div id="qa-audit-output" style="margin-top:var(--space-8)"></div>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -276,55 +307,6 @@
             <div class="principles-empty__icon">◈</div>
             <h3>No design system loaded</h3>
             <p>Run a scan to generate design principles for your system.</p>
-          </div>
-        </div>
-      </section>
-
-      <!-- QA / Variant Audit View -->
-      <section class="view-panel" id="qa-view">
-        <div class="qa-container">
-          <div class="qa-header">
-            <h2>Variant Audit</h2>
-            <p class="qa-desc" id="qa-desc">Select a component to audit its variants.</p>
-          </div>
-
-          <!-- Component Usage Inspector (mounted by usage-inspector.js) -->
-          <div id="usage-inspector-mount"></div>
-
-          <div class="filter-bar">
-            <select class="input select" id="qa-component-filter">
-              <option value="">— Select component —</option>
-            </select>
-            <select class="input select" id="qa-variant-filter">
-              <option value="">All variants</option>
-            </select>
-            <button class="btn" id="qa-gridlines-btn">Grid lines</button>
-            <span class="filter-bar__spacer"></span>
-            <span class="filter-bar__stats" id="qa-stats"></span>
-          </div>
-
-          <div class="qa-content" id="qa-content">
-            <div class="qa-variant-grid" id="qa-grid"></div>
-
-            <div id="qa-blocked-section" style="display:none;margin-top:var(--space-6)">
-              <button class="qa-blocked-toggle" id="qa-blocked-toggle"></button>
-              <div class="qa-variant-grid" id="qa-blocked-grid" style="display:none"></div>
-            </div>
-
-            <!-- Grid Test — widgets at different column counts -->
-            <div class="qa-grid-test-section" id="qa-grid-test-section" style="display:none;margin-top:var(--space-8)">
-              <h3 class="qa-log-heading">Grid Size Permutations</h3>
-              <p class="qa-desc">Same widget at its valid grid sizes. Toggle columns to test responsiveness.</p>
-              <div class="qa-grid-controls">
-                <button class="active" data-cols="5">5 col</button>
-                <button data-cols="4">4 col</button>
-                <button data-cols="3">3 col</button>
-                <button id="qa-grid-test-lines-btn">Grid lines</button>
-              </div>
-              <div class="qa-grid-test qa-grid-test--5col" id="qa-grid-test"></div>
-            </div>
-
-            <div id="qa-audit-output" style="margin-top:var(--space-8)"></div>
           </div>
         </div>
       </section>

--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -34,6 +34,10 @@ class SystemicApp {
     this.debugMode = true; // Enable detailed logging
     this.debugLogs = []; // Store all debug logs for export
 
+    // Unified component selection state
+    this.selectedComponentType = null;
+    this.componentViewMode = 'docs'; // 'docs' or 'qa'
+
     this.init();
   }
 
@@ -266,10 +270,6 @@ class SystemicApp {
     if (this.viewer && this.variantAudit) {
       this.viewer.variantAudit = this.variantAudit;
     }
-    // Connect component filter to Usage Inspector
-    DOMUtils.$('#qa-component-filter')?.addEventListener('change', (e) => {
-      this._onQAComponentSelect(e.target.value);
-    });
     this.initRouter();
   }
 
@@ -969,23 +969,26 @@ class SystemicApp {
         if (foundations.includes(route.section)) {
           this.viewer.selectFoundation(route.section);
         } else if (route.section === 'component' && route.detail) {
-          const comp = this.viewer.designSystem.components?.find(
-            c => c.type === route.detail
-          );
-          if (comp) {
-            this.viewer.selectComponent(comp);
-          }
+          this.selectComponentGlobal(route.detail);
         }
+      }
+      // Re-sync dropdown — viewer.selectFoundation clears it for foundation routes,
+      // but we need it to reflect the global component selection for QA mode
+      if (this.selectedComponentType) {
+        const cs = DOMUtils.$('#component-select', this.appNav);
+        if (cs) cs.value = this.selectedComponentType;
       }
     }
 
-    // Handle QA view
+    // Handle QA view — redirect to docs with QA mode
     if (route.view === 'qa') {
-      this.variantAudit?.init();
-      // Deep link to a specific component: #qa/component-name
-      if (route.section && this.variantAudit) {
-        this.variantAudit.show(route.section);
+      this.componentViewMode = 'qa';
+      if (route.section) {
+        this.selectedComponentType = route.section;
       }
+      const compPart = route.section ? `/component/${route.section}` : '';
+      window.location.hash = `docs${compPart}`;
+      return;
     }
 
     // Load systems list when switching to systems view
@@ -1034,21 +1037,6 @@ class SystemicApp {
           <span class="docs-nav__spacer"></span>
         `;
         break;
-
-      case 'qa': {
-        const qaSystemName = this.viewer?.designSystem?.name || 'System';
-        this.appNav.innerHTML = `
-          <nav class="breadcrumb" aria-label="Breadcrumb">
-            <a href="#systems" class="breadcrumb-link">Systems</a>
-            <span class="breadcrumb-sep">/</span>
-            <a href="#docs/color" class="breadcrumb-link">${qaSystemName}</a>
-            <span class="breadcrumb-sep">/</span>
-            <span class="breadcrumb-current">Variant Audit</span>
-          </nav>
-          <span class="docs-nav__spacer"></span>
-        `;
-        break;
-      }
 
       case 'principles': {
         const pSystemName = this.viewer?.designSystem?.name || 'System';
@@ -1164,7 +1152,6 @@ class SystemicApp {
       <a href="#" class="docs-nav__link" data-section="elevation">Elevation</a>
       <a href="#" class="docs-nav__link" data-section="examples">Examples</a>
       <a href="#principles" class="docs-nav__link">Principles</a>
-      <a href="#qa" class="docs-nav__link">QA</a>
       <span class="docs-nav__spacer"></span>
       <select class="docs-nav__select" id="component-select">
         <option value="">Component...</option>
@@ -1183,12 +1170,77 @@ class SystemicApp {
         <button class="toggle-btn active" data-context="design">Design</button>
         <button class="toggle-btn" data-context="code">Code</button>
       </div>
+      <div class="qa-nav-controls" hidden>
+        <select class="docs-nav__select" id="qa-variant-filter-nav">
+          <option value="">All variants</option>
+        </select>
+        <button class="btn btn--sm" id="qa-gridlines-nav">Grid lines</button>
+        <span class="filter-bar__stats" id="qa-stats-nav"></span>
+      </div>
+      <div class="view-toggle view-toggle--mode">
+        <button class="toggle-btn${this.componentViewMode === 'docs' ? ' active' : ''}" data-mode="docs">Docs</button>
+        <button class="toggle-btn${this.componentViewMode === 'qa' ? ' active' : ''}" data-mode="qa">QA</button>
+      </div>
     `;
 
     // Rebind viewer events to the newly created nav elements
     if (this.viewer) {
       this.viewer.rebindNav(this.appNav);
     }
+
+    // Override component select to use global selection
+    const componentSelect = DOMUtils.$('#component-select', this.appNav);
+    if (componentSelect) {
+      componentSelect.addEventListener('change', (e) => {
+        this.selectComponentGlobal(e.target.value);
+      });
+    }
+
+    // Wire Docs|QA mode toggle
+    DOMUtils.$$('.view-toggle--mode .toggle-btn', this.appNav).forEach(btn => {
+      btn.addEventListener('click', () => {
+        this.componentViewMode = btn.dataset.mode;
+        DOMUtils.$$('.view-toggle--mode .toggle-btn', this.appNav)
+          .forEach(b => b.classList.toggle('active', b === btn));
+        this.renderComponentViewMode();
+      });
+    });
+
+    // Wire QA nav controls to variant audit
+    DOMUtils.$('#qa-gridlines-nav', this.appNav)?.addEventListener('click', () => {
+      this.variantAudit?.toggleGridLines();
+    });
+    DOMUtils.$('#qa-variant-filter-nav', this.appNav)?.addEventListener('change', () => {
+      if (this.variantAudit) {
+        this.variantAudit.lastFilter = 'variant';
+        this.variantAudit.showVariants();
+      }
+    });
+
+    // Restore component selection
+    if (this.selectedComponentType && componentSelect) {
+      componentSelect.value = this.selectedComponentType;
+    } else {
+      // Try restoring from localStorage
+      const sysId = this.viewer?.designSystem?.id;
+      if (sysId) {
+        const saved = localStorage.getItem(`selected-component:${sysId}`);
+        if (saved && componentSelect) {
+          componentSelect.value = saved;
+          this.selectedComponentType = saved;
+        }
+        const savedMode = localStorage.getItem(`component-view-mode:${sysId}`);
+        if (savedMode === 'qa') {
+          this.componentViewMode = 'qa';
+          DOMUtils.$$('.view-toggle--mode .toggle-btn', this.appNav).forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.mode === 'qa');
+          });
+        }
+      }
+    }
+
+    // Apply current view mode
+    this.renderComponentViewMode();
 
     // Set active foundation link if applicable
     if (route.section) {
@@ -1211,19 +1263,13 @@ class SystemicApp {
    * Initialize the variant audit module
    */
   initVariantAudit() {
-    const qaContainer = DOMUtils.$('#qa-view');
+    const qaContainer = DOMUtils.$('#qa-inline');
     if (qaContainer) {
       this.variantAudit = new VariantAudit({
         container: qaContainer,
         systemId: 'default',
         onToast: (msg) => this.showToast(msg)
       });
-
-      // Wire blocked toggle button
-      const blockedToggle = DOMUtils.$('#qa-blocked-toggle');
-      if (blockedToggle) {
-        blockedToggle.addEventListener('click', () => this.variantAudit.toggleBlockedSection());
-      }
     }
   }
 
@@ -1248,10 +1294,98 @@ class SystemicApp {
   }
 
   /**
+   * Global component selection — single source of truth for both Docs and QA modes
+   */
+  selectComponentGlobal(componentType) {
+    this.selectedComponentType = componentType;
+
+    // Persist to localStorage
+    const sysId = this.viewer?.designSystem?.id;
+    if (sysId) {
+      localStorage.setItem(`selected-component:${sysId}`, componentType || '');
+    }
+
+    // Sync the dropdown
+    const select = DOMUtils.$('#component-select', this.appNav);
+    if (select && select.value !== componentType) {
+      select.value = componentType || '';
+    }
+
+    // Notify viewer
+    if (componentType && this.viewer?.designSystem) {
+      const comp = this.viewer.designSystem.components?.find(c => c.type === componentType);
+      if (comp) this.viewer.selectComponent(comp);
+    }
+
+    // Notify QA (if in QA mode, it will render; if not, it stores the selection)
+    if (componentType && this.variantAudit) {
+      this.variantAudit.setActiveComponent(componentType);
+      if (this.componentViewMode === 'qa') {
+        this.variantAudit.showVariants();
+      }
+    }
+
+    // Notify usage inspector
+    this._onQAComponentSelect(componentType);
+  }
+
+  /**
+   * Switch between Docs and QA modes within the docs view
+   */
+  renderComponentViewMode() {
+    // Sync dropdown with current selection
+    const componentSelect = DOMUtils.$('#component-select', this.appNav);
+    if (componentSelect && this.selectedComponentType && componentSelect.value !== this.selectedComponentType) {
+      componentSelect.value = this.selectedComponentType;
+    }
+
+    const stage = DOMUtils.$('#component-stage');
+    const sidebar = DOMUtils.$('#context-sidebar');
+    const qaInline = DOMUtils.$('#qa-inline');
+    const stateToggles = DOMUtils.$('.state-toggles', this.appNav);
+    const designCodeToggle = DOMUtils.$('.view-toggle:not(.view-toggle--mode)', this.appNav);
+    const variantSelect = DOMUtils.$('#variant-select', this.appNav);
+    const qaNavControls = DOMUtils.$('.qa-nav-controls', this.appNav);
+
+    if (this.componentViewMode === 'qa') {
+      if (stage) stage.hidden = true;
+      if (sidebar) sidebar.hidden = true;
+      if (qaInline) qaInline.hidden = false;
+      if (stateToggles) stateToggles.hidden = true;
+      if (designCodeToggle) designCodeToggle.hidden = true;
+      if (variantSelect) variantSelect.hidden = true;
+      if (qaNavControls) qaNavControls.hidden = false;
+
+      // Initialize QA if needed and render for current component
+      if (this.variantAudit) {
+        this.variantAudit.setContainer(qaInline);
+        this.variantAudit.init();
+        if (this.selectedComponentType) {
+          this.variantAudit.setActiveComponent(this.selectedComponentType);
+          this.variantAudit.showVariants();
+        }
+      }
+    } else {
+      if (stage) stage.hidden = false;
+      if (sidebar) sidebar.hidden = false;
+      if (qaInline) qaInline.hidden = true;
+      if (stateToggles) stateToggles.hidden = false;
+      if (designCodeToggle) designCodeToggle.hidden = false;
+      if (qaNavControls) qaNavControls.hidden = true;
+    }
+
+    // Persist mode
+    const sysId = this.viewer?.designSystem?.id;
+    if (sysId) {
+      localStorage.setItem(`component-view-mode:${sysId}`, this.componentViewMode);
+    }
+  }
+
+  /**
    * Initialize the Usage Inspector
    */
   initUsageInspector() {
-    const mount = DOMUtils.$('#usage-inspector-mount');
+    const mount = DOMUtils.$('#usage-inspector-mount-inline');
     if (mount) {
       this.usageInspector = new UsageInspector({
         container: mount,

--- a/systemic/js/variant-audit.js
+++ b/systemic/js/variant-audit.js
@@ -153,7 +153,6 @@ class VariantAudit {
    */
   registerComponents(components) {
     this.components = components;
-    this.populateFilters();
   }
 
   /**
@@ -188,20 +187,24 @@ class VariantAudit {
           : null
       };
     });
-
-    this.populateFilters();
   }
 
-  populateFilters() {
-    var select = this.els.componentFilter;
-    if (!select) return;
-    select.innerHTML = '<option value="">— Select component —</option>';
-    this.components.forEach(comp => {
-      var opt = document.createElement('option');
-      opt.value = comp.name;
-      opt.textContent = comp.label || comp.name;
-      select.appendChild(opt);
-    });
+  /**
+   * Set active component by type name (called by app.selectComponentGlobal)
+   */
+  setActiveComponent(componentType) {
+    this.currentAuditName = componentType;
+    var comp = this.components.find(c => c.name === componentType);
+    this.currentComponent = comp || null;
+  }
+
+  /**
+   * Switch container (for inline vs standalone rendering)
+   */
+  setContainer(container) {
+    if (!container || this.container === container) return;
+    this.container = container;
+    this._initialized = false;
   }
 
   // ============================================
@@ -210,10 +213,12 @@ class VariantAudit {
 
   bindElements() {
     this.els = {
-      componentFilter: this.container.querySelector('#qa-component-filter'),
-      variantFilter: this.container.querySelector('#qa-variant-filter'),
-      gridLinesBtn: this.container.querySelector('#qa-gridlines-btn'),
-      stats: this.container.querySelector('#qa-stats'),
+      variantFilter: this.container.querySelector('#qa-variant-filter') ||
+                     this.container.querySelector('#qa-variant-filter-nav'),
+      gridLinesBtn: this.container.querySelector('#qa-gridlines-btn') ||
+                    this.container.querySelector('#qa-gridlines-nav'),
+      stats: this.container.querySelector('#qa-stats') ||
+             this.container.querySelector('#qa-stats-nav'),
       content: this.container.querySelector('#qa-content'),
       grid: this.container.querySelector('#qa-grid'),
       blockedSection: this.container.querySelector('#qa-blocked-section'),
@@ -263,24 +268,14 @@ class VariantAudit {
   init() {
     // Guard against duplicate init
     if (this._initialized) {
-      // Just refresh filters and data
-      this.populateFilters();
-      this.restoreFilterState();
       this.renderAuditTable();
       return;
     }
     this._initialized = true;
 
     this.bindElements();
-    this.populateFilters();
 
-    // Bind filter events
-    if (this.els.componentFilter) {
-      this.els.componentFilter.addEventListener('change', () => {
-        this.lastFilter = 'component';
-        this.showVariants();
-      });
-    }
+    // Bind filter events (variant filter only — component selection is handled by app.js)
     if (this.els.variantFilter) {
       this.els.variantFilter.addEventListener('change', () => {
         this.lastFilter = 'variant';
@@ -289,6 +284,9 @@ class VariantAudit {
     }
     if (this.els.gridLinesBtn) {
       this.els.gridLinesBtn.addEventListener('click', () => this.toggleGridLines());
+    }
+    if (this.els.blockedToggle) {
+      this.els.blockedToggle.addEventListener('click', () => this.toggleBlockedSection());
     }
 
     // Grid test controls
@@ -323,15 +321,14 @@ class VariantAudit {
   // ============================================
 
   showVariants() {
-    var componentVal = this.els.componentFilter?.value;
+    var componentVal = this.currentAuditName;
     var variantVal = this.els.variantFilter?.value;
 
     if (!componentVal) {
-      this.els.grid.innerHTML = '';
-      this.els.blockedSection.style.display = 'none';
-      this.els.desc.textContent = 'Select a component to audit its variants.';
+      if (this.els.grid) this.els.grid.innerHTML = '';
+      if (this.els.blockedSection) this.els.blockedSection.style.display = 'none';
+      if (this.els.desc) this.els.desc.textContent = 'Select a component to audit its variants.';
       this.currentComponent = null;
-      this.currentAuditName = null;
       this.populateGridTest(null);
       this.saveFilterState();
       return;
@@ -339,8 +336,8 @@ class VariantAudit {
 
     var comp = this.components.find(c => c.name === componentVal);
     if (!comp) {
-      this.els.grid.innerHTML = '<p class="qa-empty">Component not found.</p>';
-      this.els.blockedSection.style.display = 'none';
+      if (this.els.grid) this.els.grid.innerHTML = '<p class="qa-empty">Component not found.</p>';
+      if (this.els.blockedSection) this.els.blockedSection.style.display = 'none';
       return;
     }
 
@@ -813,7 +810,11 @@ class VariantAudit {
     if (stats.red > 0) parts.push(stats.red + ' blocked');
     if (stats.yellow > 0) parts.push(stats.yellow + ' to process');
     if (stats.orange > 0) parts.push(stats.orange + ' needs review');
-    if (this.els.stats) this.els.stats.textContent = parts.join(' · ');
+    var text = parts.join(' · ');
+    if (this.els.stats) this.els.stats.textContent = text;
+    // Also update nav bar stats (outside container)
+    var navStats = document.querySelector('#qa-stats-nav');
+    if (navStats) navStats.textContent = text;
   }
 
   // ============================================
@@ -997,7 +998,7 @@ class VariantAudit {
   saveFilterState() {
     try {
       localStorage.setItem(this.FILTER_KEY, JSON.stringify({
-        component: this.els.componentFilter?.value || '',
+        component: this.currentAuditName || '',
         variant: this.els.variantFilter?.value || '',
         lastFilter: this.lastFilter,
         blockedOpen: this.blockedSectionOpen
@@ -1010,10 +1011,10 @@ class VariantAudit {
       var saved = localStorage.getItem(this.FILTER_KEY);
       if (!saved) return;
       var state = JSON.parse(saved);
-      if (state.component && this.els.componentFilter) this.els.componentFilter.value = state.component;
       if (state.variant && this.els.variantFilter) this.els.variantFilter.value = state.variant;
       if (state.lastFilter) this.lastFilter = state.lastFilter;
-      if (state.component) {
+      if (state.component && !this.currentAuditName) {
+        this.setActiveComponent(state.component);
         this.showVariants();
         if (state.blockedOpen) this.toggleBlockedSection();
       }
@@ -1025,9 +1026,7 @@ class VariantAudit {
   // ============================================
 
   show(componentName) {
-    if (this.els.componentFilter) {
-      this.els.componentFilter.value = componentName;
-    }
+    this.setActiveComponent(componentName);
     this.showVariants();
   }
 }

--- a/systemic/js/viewer.js
+++ b/systemic/js/viewer.js
@@ -93,17 +93,14 @@ class DesignSystemViewer {
       });
     });
 
-    // Component dropdown
-    this.componentSelect?.addEventListener('change', (e) => {
-      const type = e.target.value;
-      if (!type) return;
-      const comp = this.designSystem?.components?.find(c => c.type === type);
-      if (comp) this.selectComponent(comp);
-    });
+    // Component dropdown — selection is handled by app.selectComponentGlobal()
+    // (wired in app.js after rebindNav)
 
-    // View toggle (Design / Code)
-    DOMUtils.$$('.toggle-btn', navElement).forEach(btn => {
-      btn.addEventListener('click', () => this.switchContext(btn.dataset.context));
+    // View toggle (Design / Code) — only bind buttons with data-context, not data-mode
+    DOMUtils.$$('.view-toggle:not(.view-toggle--mode) .toggle-btn', navElement).forEach(btn => {
+      if (btn.dataset.context) {
+        btn.addEventListener('click', () => this.switchContext(btn.dataset.context));
+      }
     });
 
     // State toggles
@@ -118,8 +115,10 @@ class DesignSystemViewer {
 
     // Restore active states
     if (this.currentContext) {
-      DOMUtils.$$('.toggle-btn', navElement).forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.context === this.currentContext);
+      DOMUtils.$$('.view-toggle:not(.view-toggle--mode) .toggle-btn', navElement).forEach(btn => {
+        if (btn.dataset.context) {
+          btn.classList.toggle('active', btn.dataset.context === this.currentContext);
+        }
       });
     }
     if (this.currentState) {


### PR DESCRIPTION
## Summary
- Unifies two separate component selection UIs (docs viewer + QA variant audit) into a single component dropdown with a Docs|QA mode toggle in the nav bar
- Component selection persists across mode switches, page reloads, and `#qa/...` route redirects via localStorage
- Removes standalone `#qa-view` section; QA is now inlined inside the docs viewer container

## Test plan
- [ ] Load a design system, select a component from the dropdown
- [ ] Toggle between Docs and QA modes — component selection should persist
- [ ] In QA mode: verify stoplight badges, variant grid, hover actions render correctly
- [ ] Navigate to `#qa/button` — should redirect to docs view with QA mode active for button
- [ ] Refresh page — component selection and mode persist from localStorage
- [ ] Switch to Docs mode — stage, sidebar, Design/Code toggle all restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)