### PR TITLE
refactor(systemic): remove state toggles, reorder nav, simplify breadcrumb

### DIFF
--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -1160,12 +1160,12 @@ class SystemicApp {
         <span class="breadcrumb-current" id="breadcrumb-system-name">${systemName}</span>
       </nav>
       <span class="docs-nav__divider"></span>
+      <a href="#principles" class="docs-nav__link">Principles</a>
       <a href="#" class="docs-nav__link" data-section="color">Color</a>
       <a href="#" class="docs-nav__link" data-section="typography">Typography</a>
       <a href="#" class="docs-nav__link" data-section="spacing">Spacing</a>
       <a href="#" class="docs-nav__link" data-section="elevation">Elevation</a>
       <a href="#" class="docs-nav__link" data-section="examples">Examples</a>
-      <a href="#principles" class="docs-nav__link">Principles</a>
       <span class="docs-nav__spacer"></span>
       <select class="docs-nav__select" id="component-select">
         <option value="">Component...</option>
@@ -1174,12 +1174,6 @@ class SystemicApp {
       <select class="docs-nav__select" id="variant-select" hidden>
         <option value="">Variant...</option>
       </select>
-      <div class="state-toggles" id="state-toggles">
-        <button class="state-btn active" data-state="default" title="Default">○</button>
-        <button class="state-btn" data-state="hover" title="Hover">◉</button>
-        <button class="state-btn" data-state="focus" title="Focus">◎</button>
-        <button class="state-btn" data-state="disabled" title="Disabled">◌</button>
-      </div>
       <div class="view-toggle">
         <button class="toggle-btn active" data-context="design">Design</button>
         <button class="toggle-btn" data-context="code">Code</button>
@@ -1364,7 +1358,6 @@ class SystemicApp {
     const stage = DOMUtils.$('#component-stage');
     const sidebar = DOMUtils.$('#context-sidebar');
     const qaInline = DOMUtils.$('#qa-inline');
-    const stateToggles = DOMUtils.$('.state-toggles', this.appNav);
     const designCodeToggle = DOMUtils.$('.view-toggle:not(.view-toggle--mode)', this.appNav);
     const variantSelect = DOMUtils.$('#variant-select', this.appNav);
     const qaNavControls = DOMUtils.$('.qa-nav-controls', this.appNav);
@@ -1373,7 +1366,6 @@ class SystemicApp {
       if (stage) stage.hidden = true;
       if (sidebar) sidebar.hidden = true;
       if (qaInline) qaInline.hidden = false;
-      if (stateToggles) stateToggles.hidden = true;
       if (designCodeToggle) designCodeToggle.hidden = true;
       if (variantSelect) variantSelect.hidden = true;
       if (qaNavControls) qaNavControls.hidden = false;
@@ -1391,7 +1383,6 @@ class SystemicApp {
       if (stage) stage.hidden = false;
       if (sidebar) sidebar.hidden = false;
       if (qaInline) qaInline.hidden = true;
-      if (stateToggles) stateToggles.hidden = false;
       if (designCodeToggle) designCodeToggle.hidden = false;
       if (qaNavControls) qaNavControls.hidden = true;
     }

--- a/systemic/js/viewer.js
+++ b/systemic/js/viewer.js
@@ -105,11 +105,6 @@ class DesignSystemViewer {
       }
     });
 
-    // State toggles
-    DOMUtils.$$('.state-btn', navElement).forEach(btn => {
-      btn.addEventListener('click', () => this.switchState(btn.dataset.state));
-    });
-
     // Variant select
     this.variantSelect?.addEventListener('change', (e) => {
       this.selectVariant(e.target.value);
@@ -121,11 +116,6 @@ class DesignSystemViewer {
         if (btn.dataset.context) {
           btn.classList.toggle('active', btn.dataset.context === this.currentContext);
         }
-      });
-    }
-    if (this.currentState) {
-      DOMUtils.$$('.state-btn', navElement).forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.state === this.currentState);
       });
     }
   }
@@ -236,8 +226,7 @@ class DesignSystemViewer {
     // Update breadcrumb with system name
     this.renderBreadcrumb([
       { label: 'Systems', hash: '#systems' },
-      { label: this.designSystem?.name || 'System', hash: '#docs' },
-      { label: this.formatName(section) }
+      { label: this.designSystem?.name || 'System' }
     ]);
 
     // Hide variant select for foundations
@@ -295,8 +284,7 @@ class DesignSystemViewer {
     const totalUsage = component.totalUsage || 0;
     this.renderBreadcrumb([
       { label: 'Systems', hash: '#systems' },
-      { label: this.designSystem?.name || 'System', hash: '#docs' },
-      { label: component.name, meta: `${variantCount} variant${variantCount !== 1 ? 's' : ''} · ${totalUsage} usage${totalUsage !== 1 ? 's' : ''}` }
+      { label: this.designSystem?.name || 'System' }
     ]);
 
     // Show variant dropdown if multiple variants


### PR DESCRIPTION
## Summary
- Remove state toggle buttons (○ ◉ ◎ ◌) from docs nav bar
- Move Principles to first position in foundation navigation links
- Simplify breadcrumb to show only "Systems / System Name" — no longer displays the selected section or component

## Test plan
- [ ] Nav bar shows Principles first, followed by Color, Typography, etc.
- [ ] No state toggle buttons visible in docs mode
- [ ] Breadcrumb shows "Systems / System Name" regardless of selected section

🤖 Generated with [Claude Code](https://claude.com/claude-code)