### PR TITLE
feat(portfolio): design portfolio site with 6 case studies

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -1,0 +1,526 @@
+/* ============================================
+   CTRL Design System — Display Layer
+   Presentation: portfolios, marketing, decks.
+   Swiss minimalism. Type and space do the work.
+   ============================================ */
+
+/* ── Page ── */
+
+.d-page {
+  min-height: 100vh;
+  background: var(--bg, #111110);
+  color: var(--fg, #e8e6e3);
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.d-contain {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 0 clamp(20px, 5vw, 64px);
+}
+
+.d-contain--wide { max-width: 1200px; }
+
+/* ── Nav ── */
+
+.d-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px clamp(20px, 5vw, 64px);
+  background: var(--bg, #111110);
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+}
+
+.d-nav__name {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+  text-decoration: none;
+}
+
+.d-nav__links {
+  display: flex;
+  gap: 28px;
+  list-style: none;
+}
+
+.d-nav__link {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted, #8a8885);
+  text-decoration: none;
+}
+
+.d-nav__link:hover,
+.d-nav__link--active {
+  color: var(--fg, #e8e6e3);
+}
+
+/* Sub-nav */
+.d-subnav {
+  position: sticky;
+  top: 49px;
+  z-index: 49;
+  display: flex;
+  gap: 24px;
+  padding: 10px clamp(20px, 5vw, 64px);
+  background: var(--bg, #111110);
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+}
+
+.d-subnav__link {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--fg-subtle, #666560);
+  text-decoration: none;
+  padding-bottom: 6px;
+  border-bottom: 2px solid transparent;
+}
+
+.d-subnav__link:hover { color: var(--fg-muted, #8a8885); }
+.d-subnav__link--active { color: var(--fg, #e8e6e3); border-bottom-color: var(--fg, #e8e6e3); }
+
+@media (max-width: 600px) {
+  .d-nav__links { gap: 16px; }
+  .d-subnav { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  .d-subnav__link { white-space: nowrap; }
+}
+
+/* ── Sections ── */
+
+.d-section {
+  padding: 64px 0;
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+}
+
+.d-section:last-of-type { border-bottom: none; }
+
+.d-section--flush { padding: 0; border: none; }
+
+/* ── Typography ── */
+
+.d-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-subtle, #666560);
+  margin-bottom: 12px;
+}
+
+.d-headline {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--fg, #e8e6e3);
+}
+
+.d-headline--xl { font-size: 40px; }
+.d-headline--lg { font-size: 28px; }
+.d-headline--md { font-size: 20px; }
+
+.d-body {
+  font-family: var(--font-mono, monospace);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--fg-muted, #8a8885);
+  max-width: 600px;
+}
+
+.d-body strong { color: var(--fg, #e8e6e3); font-weight: 600; }
+.d-body + .d-body { margin-top: 16px; }
+.d-body a { color: var(--color-link, #00fff7); }
+
+.d-mono {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--fg-subtle, #666560);
+}
+
+@media (max-width: 600px) {
+  .d-headline--xl { font-size: 28px; }
+  .d-headline--lg { font-size: 22px; }
+}
+
+/* ── Hero ── */
+
+.d-hero {
+  padding: 80px 0 48px;
+}
+
+.d-hero .d-headline { margin-bottom: 20px; max-width: 720px; }
+.d-hero .d-body { margin-bottom: 20px; font-size: 15px; }
+
+.d-meta {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-subtle, #666560);
+}
+
+.d-meta__sep { color: var(--border-subtle, #33332f); }
+
+/* ── Cards ── */
+
+.d-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border-subtle, #33332f);
+}
+
+@media (max-width: 768px) { .d-cards { grid-template-columns: 1fr; } }
+
+.d-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 28px;
+  background: var(--bg, #111110);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s;
+}
+
+.d-card:hover { background: var(--bg-surface, #1a1a18); }
+
+.d-card__tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--fg-subtle, #666560);
+}
+
+.d-card__title {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+}
+
+.d-card__desc {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--fg-muted, #8a8885);
+  line-height: 1.6;
+}
+
+/* ── Gallery ── */
+
+.d-gallery {
+  display: grid;
+  gap: 2px;
+}
+
+.d-gallery--2 { grid-template-columns: 1fr 1fr; }
+.d-gallery--3 { grid-template-columns: 1fr 1fr 1fr; }
+.d-gallery--4 { grid-template-columns: 1fr 1fr 1fr 1fr; }
+
+@media (max-width: 768px) {
+  .d-gallery--3, .d-gallery--4 { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 480px) {
+  .d-gallery--2, .d-gallery--3, .d-gallery--4 { grid-template-columns: 1fr; }
+}
+
+.d-gallery__item { display: flex; flex-direction: column; }
+.d-gallery__item img { width: 100%; display: block; }
+.d-gallery__item--span-2 { grid-column: span 2; }
+
+.d-gallery__caption {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-subtle, #666560);
+  padding: 8px 0;
+  line-height: 1.5;
+}
+
+/* ── Phone Frame ── */
+
+.d-phone {
+  width: 260px;
+  background: #000;
+  border-radius: 32px;
+  padding: 10px;
+  flex-shrink: 0;
+}
+
+.d-phone__screen {
+  border-radius: 22px;
+  overflow: hidden;
+  aspect-ratio: 390 / 844;
+}
+
+.d-phone__screen img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+/* ── Metrics ── */
+
+.d-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--border-subtle, #33332f);
+}
+
+@media (max-width: 600px) { .d-metrics { grid-template-columns: 1fr; } }
+
+.d-metric {
+  padding: 32px 24px;
+  background: var(--bg, #111110);
+}
+
+.d-metric__value {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 36px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--fg, #e8e6e3);
+  margin-bottom: 6px;
+}
+
+.d-metric__label {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+  margin-bottom: 4px;
+}
+
+.d-metric__sub {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-subtle, #666560);
+}
+
+/* ── Personas ── */
+
+.d-personas {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1px;
+  background: var(--border-subtle, #33332f);
+  margin-top: 32px;
+}
+
+.d-persona {
+  padding: 24px;
+  background: var(--bg, #111110);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.d-persona__role {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-subtle, #666560);
+}
+
+.d-persona__name {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+}
+
+.d-persona__needs {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.d-persona__needs li {
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--fg-muted, #8a8885);
+  line-height: 1.5;
+}
+
+/* ── Decisions ── */
+
+.d-decisions {
+  display: flex;
+  flex-direction: column;
+}
+
+.d-decision {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+}
+
+.d-decision:last-child { border-bottom: none; }
+
+.d-decision__q {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+  margin-bottom: 8px;
+}
+
+.d-decision__a {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  color: var(--fg-muted, #8a8885);
+  line-height: 1.6;
+  max-width: 600px;
+}
+
+/* ── Flow ── */
+
+.d-flow {
+  display: flex;
+  align-items: flex-start;
+  gap: 0;
+  margin: 24px 0;
+}
+
+.d-flow__step {
+  flex: 1;
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.d-flow__step-num {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-subtle, #666560);
+}
+
+.d-flow__step-label {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg, #e8e6e3);
+}
+
+.d-flow__step-desc {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--fg-subtle, #666560);
+  line-height: 1.5;
+}
+
+.d-flow__arrow {
+  font-family: var(--font-mono, monospace);
+  font-size: 16px;
+  color: var(--fg-subtle, #666560);
+  padding: 20px 4px 0;
+}
+
+@media (max-width: 768px) {
+  .d-flow { flex-direction: column; }
+  .d-flow__arrow { transform: rotate(90deg); padding: 4px 0; align-self: center; }
+}
+
+/* ── Overview Table ── */
+
+.d-overview {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 0;
+  border: 1px solid var(--border-subtle, #33332f);
+  margin: 24px 0 0;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+}
+
+.d-overview dt {
+  padding: 10px 16px;
+  color: var(--fg-subtle, #666560);
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.d-overview dd {
+  padding: 10px 16px;
+  color: var(--fg-muted, #8a8885);
+  border-bottom: 1px solid var(--border-subtle, #33332f);
+  border-left: 1px solid var(--border-subtle, #33332f);
+  line-height: 1.5;
+}
+
+.d-overview dt:last-of-type,
+.d-overview dd:last-of-type { border-bottom: none; }
+
+/* ── Callout ── */
+
+.d-callout {
+  padding: 24px;
+  border-left: 2px solid var(--fg-subtle, #666560);
+  margin: 24px 0;
+}
+
+.d-callout__body {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  color: var(--fg-muted, #8a8885);
+  line-height: 1.6;
+  max-width: 600px;
+}
+
+/* ── Status ── */
+
+.d-status {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.d-status--shipped { color: var(--color-success, #22c55e); }
+.d-status--dev { color: var(--accent-amber, #ffb000); }
+.d-status--active { color: var(--accent-cyan, #00fff7); }
+
+/* ── Footer ── */
+
+.d-footer {
+  padding: 48px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.d-next {
+  font-family: var(--font-mono, monospace);
+  font-size: 13px;
+  color: var(--fg-muted, #8a8885);
+  text-decoration: none;
+}
+
+.d-next:hover { color: var(--fg, #e8e6e3); }
+
+/* ── Utilities ── */
+
+.d-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: var(--border-subtle, #33332f); }
+.d-grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; background: var(--border-subtle, #33332f); }
+.d-grid-2 > *, .d-grid-3 > * { background: var(--bg, #111110); padding: 24px; }
+
+@media (max-width: 768px) { .d-grid-2, .d-grid-3 { grid-template-columns: 1fr; } }
+
+.d-mt-0 { margin-top: 0; }
+.d-mt-4 { margin-top: 16px; }
+.d-mt-8 { margin-top: 32px; }
+.d-mt-16 { margin-top: 64px; }
+.d-pt-8 { padding-top: 32px; }
+
+.d-rule { border: none; border-top: 1px solid var(--border-subtle, #33332f); margin: 32px 0; }

--- a/portfolio/ARCHITECTURE.md
+++ b/portfolio/ARCHITECTURE.md
@@ -1,0 +1,144 @@
+# Portfolio Site Architecture
+> ctrl.rodeo/portfolio/ — static site with presentation controls
+
+## Tech Stack
+- Vanilla HTML/CSS/JS (consistent with ctrl.rodeo codebase)
+- ctrl.rodeo design system (tokens.css, components.css)
+- Portfolio-specific styles (portfolio.css)
+- No build step — direct GitHub Pages deploy
+
+## File Structure
+```
+portfolio/
+  index.html              # Home — hero, thesis, case study cards
+  field.html              # Case study: Field
+  invoy.html              # Case study: Invoy (lifecycle + DS)
+  livongo.html            # Case study: Livongo Config
+  how-i-work.html         # Process: stack, design system, AI workflow
+  portfolio.css           # Portfolio-specific styles (extends ctrl DS)
+  portfolio.js            # Nav, scroll behavior, keyboard controls
+  case-study-copy.md      # Content source
+  ARCHITECTURE.md         # This file
+  assets/
+    field/
+    invoy/
+    workflow/
+    livongo/
+```
+
+## Case Study Section Structure
+
+Four sections per case study. Consistent skeleton, flexible internals.
+
+```
+[Problem]  [Deliverable]  [Process]  [Impact]
+```
+
+### Problem
+What was broken + who was affected. Users/personas live here.
+- Business context (2-3 sentences)
+- User personas or actor descriptions (cards, not research docs)
+- The tension or constraint that made this hard
+
+### Deliverable
+What shipped. Sub-sections flex per project:
+- **User Flows** — the end-to-end experience, screens + interactions
+- **Design System** — components, tokens, governance rules
+- **Technical System** — architecture diagrams, data flows, integrations
+
+### Process
+Light narrative. How decisions were made, not a methodology diagram.
+- 3-5 key decisions with rationale
+- Tradeoffs: what was chosen, what was rejected, why
+- No double diamonds, no sticky-note photos
+
+### Impact
+Results, metrics, what changed.
+- Quantitative where available
+- What shipped, to whom, at what scale
+- What's next / what I'd do differently
+
+## Per-Project Mapping
+
+```
+FIELD
+  [Problem] — Paper forms in wilderness. Provider + Patient + ER personas.
+  [Deliverable]
+    → User Flows: voice transcript → AI extraction → SOAP note → SBAR handoff
+    → Design System: dark palette, constrained components, SF Pro, 4 tabs / 3 inputs / 2 sheets
+    → Technical System: on-device AI pipeline (Whisper + Llama), offline-first, GPS/altitude
+  [Process] — Why on-device? Why SOAP over free-text? Why stoplight confidence?
+  [Impact] — 27 screens designed. Business case. Design review doc (8 improvements).
+
+INVOY
+  [Problem] — Behavior change needs a loop, not isolated check-ins. Member + Coach personas.
+  [Deliverable]
+    → User Flows: Plan (weekly) → Execute (daily) → Reflect (weekly) → Adapt. 5 flow variants.
+    → Design System: 30 components, color system, type scale, spacing, governance rules.
+  [Process] — Why 5 variants from one entry? Why normalize rebound? Why data density on review?
+  [Impact] — Shipped at Livongo/Teladoc scale. 15+ sub-flows. 30-component library.
+
+LIVONGO CONFIG
+  [Problem] — 3,700 config decisions in a spreadsheet. Sales + Ops + Member personas.
+  [Deliverable]
+    → User Flows: 9-step original → 6-step optimized (before/after)
+    → Technical System: Salesforce → API resolution → registration pipeline
+  [Process] — Why confirm-not-enter? Why defer coaching? Why skip coverage?
+  [Impact] — 57% fields sourced, 33% fewer steps, ~5 min saved. CPQ parallel.
+
+HOW I WORK
+  [Problem] — Solo designer, 5 products, need consistent quality at speed.
+  [Deliverable]
+    → Design System: ctrl.rodeo tokens + components + AI widget templates
+    → Technical System: Systemic audit pipeline (crawl → extract → map → audit)
+  [Process] — How Intent → DS → Claude Code → Systemic → Ship works day-to-day
+  [Impact] — 5 products, 1 person. This portfolio was built with this stack.
+```
+
+## Home Page
+
+### Structure
+```
+HERO
+  Thesis headline
+  Supporting paragraph (names all projects, connects them)
+  Credentials line
+
+CASE STUDY CARDS (3)
+  Field — thumbnail + tags + one-liner → field.html
+  Invoy — thumbnail + tags + one-liner → invoy.html
+  Livongo — thumbnail + tags + one-liner → livongo.html
+
+HOW I WORK TEASER
+  Pipeline strip + one paragraph → how-i-work.html
+
+CONTACT
+```
+
+### Navigation
+- Sticky nav: `Ian Fike | Field | Invoy | Livongo | How I Work`
+- Each case study page: sticky sub-nav `[Problem] [Deliverable] [Process] [Impact]`
+- Keyboard: left/right for prev/next case study
+- Deep-linkable: `/portfolio/field.html#deliverable`
+- "Next →" link at bottom of each page
+
+## Visual Design
+- ctrl DS dark mode for shell (nav, hero, page chrome)
+- Light mode for case study content sections (reading comfort)
+- Monospace (JetBrains Mono) for nav, labels, metadata
+- Space Grotesk for headlines
+- Project-native palettes within Deliverable sections:
+  - Field: dark + orange/green clinical accents
+  - Invoy: sage green + warm neutrals
+  - Livongo: blue/purple/green data source colors
+
+## Responsive
+- Desktop: full layout
+- Tablet: stacked
+- Mobile: single column, hamburger nav
+
+## Performance
+- Lazy-load images
+- No build step
+- Inline critical CSS
+- Target: < 2s first paint

--- a/portfolio/case-study-copy.md
+++ b/portfolio/case-study-copy.md
@@ -1,0 +1,201 @@
+# Portfolio Case Study Copy
+> Draft copy for all 5 case studies. Headlines, narrative structure, key callouts.
+> Tone: Direct, technically fluent, founder-adjacent. No portfolio clichés.
+
+---
+
+## 1. FIELD — AI-First Clinical Documentation
+
+### Headline
+**Field: Replacing paper with voice in wilderness medicine**
+
+### Subhead
+An AI-powered clinical documentation app for search & rescue first responders. Voice-driven SOAP notes, on-device language models, offline-first architecture.
+
+### The Problem
+Wilderness first responders document patient encounters on paper forms — in rain, darkness, with gloves, under stress. Notes are incomplete, handoffs are error-prone, and critical clinical data gets lost between the field and the hospital.
+
+### What I Built
+Field is a native iOS app that listens to the clinical conversation and builds a structured SOAP note in real-time. The provider talks to the patient; the app extracts chief complaints, vitals, history, and assessment findings — slotting each into the correct clinical section automatically.
+
+### Key Design Decisions
+
+**Voice-first, not voice-only.** The transcript is the primary input, but every extracted field can be manually edited. AI fills the structure; the provider confirms it. This is the same "recognition over recall" pattern that makes pre-populated forms faster than blank ones.
+
+**Stoplight confidence states.** When the AI extracts a heart rate of 112 from speech, the field turns amber: "HR 112 — verify and confirm before handoff." Green means confirmed. Red means conflicting data. The provider sees at a glance which fields need attention before handing off the patient.
+
+**On-device model management.** Not every SAR team has cell service. Field runs Whisper Small (242 MB) for transcription and Llama 3.2 3B (1.8 GB) for field extraction — both on-device. The Settings screen exposes model selection, download status, and device tier requirements without requiring the user to understand ML infrastructure.
+
+**Glove-compatible vital entry.** Heart rate input uses ±1/±10 increment buttons plus quick-select chips (60, 70, 80, 90, 100, 120). No keyboard. No precision tapping. Designed for cold hands and high adrenaline.
+
+**Contextual field guidance.** Each SOAP section has an expandable guide: "What goes here," a clinical example, and Quick Insert chips for common findings (Fall from height, Twisted ankle, Chest pain). This turns junior providers into competent documenters without training.
+
+### Business Case
+The wilderness medicine documentation market is underserved. Current solutions are either paper-based or adapted from EMS software designed for ambulances with connectivity. Field targets the gap: offline-capable, AI-assisted, built for the specific constraints of backcountry and SAR environments.
+
+### Design System
+Field uses SF Pro with a dark-first palette (pure black backgrounds, orange/green accents for clinical urgency). The component system is deliberately constrained — 4 tab types, 3 input patterns, 2 sheet styles — to keep the cognitive load low in high-stress situations. The design review annotations document 8 specific improvements for the next iteration, written as a handoff to the engineering team.
+
+---
+
+## 2. INVOY — Weekly Lifecycle
+
+### Headline
+**Invoy: Designing a behavioral configuration engine**
+
+### Subhead
+A closed-loop system where members plan their week, execute daily, reflect on results, and adapt — powered by breath-test metabolic data and coach-guided interventions.
+
+### The System
+Invoy's Check-in Flow is not a single feature — it's a behavioral loop that runs weekly:
+
+**Plan** → Members set weekly intentions. The system asks about upcoming events (travel, holidays, social meals) and adapts the plan: Busy Week triggers Suggested Accelerants. A planned splurge activates the Cheat & Rebound flow. A base week generates the standard nutrition plan.
+
+**Execute** → Daily check-ins collect breath scores, feelings, events, and plan adherence. Each day's data feeds the triage engine — score drops trigger coach escalation, score increases trigger celebration and reinforcement.
+
+**Reflect** → "A Look at Your Week" synthesizes 7 days of data into weight change, plan completion rates, fat burn trends, and an AI-generated summary. The weekly activity matrix shows Check In, Base Plan, Events, Splurge & Rebound, and Accelerants across each day.
+
+**Adapt** → Trends & Changes surfaces multi-week patterns (energy, hunger, cravings, sleep) and feeds them back into the next week's plan. The coach uses the analyst portal to identify intervention points.
+
+### Why This Matters for CPQ
+This is configuration logic applied to human behavior. The "products" are interventions (nutrition plans, accelerants, coaching calls). The "pricing" is metabolic data (breath scores, weight trends). The "quote" is a personalized weekly plan that adapts based on real-time data. The structural pattern — configure → execute → measure → reconfigure — is identical to what Roadrunner is building for sales workflows.
+
+### Key Design Decisions
+
+**5 flow variants from one entry point.** Week Planning branches into Base Flow, Busy Week + Suggested Accelerants, Cheat & Rebound, Edit Base Plan, and Edit Accelerants — all documented with orange annotation cards explaining the branching logic. One question ("Tell us about upcoming events this week") routes the member into the right configuration path.
+
+**Data density without cognitive overload.** The Review of Week screen shows weight delta, 3 plan progress bars, an AI-generated natural language summary, a 7-day sparkline chart, and a 5×7 activity dot matrix — all on one scrollable mobile screen. Every data point is glanceable; nothing requires interpretation.
+
+**Rebound as a first-class flow.** Most health apps treat plan deviations as failures. Invoy designed Rebound as its own state machine: Starting Rebound → Positive/Neutral/Negative Progress → Rebound Complete. Score drops show "What we know," "Possible Causes," and actionable next steps (Schedule a Coach Call, Add Fasting Boost). This normalizes deviation and keeps members engaged.
+
+### Shipped at Scale
+This system shipped as part of Livongo's metabolic health product, serving members through the Teladoc Health platform. The component library (30 components) and page template system enabled a small design team to ship across 15+ distinct sub-flows with consistent quality.
+
+---
+
+## 3. INVOY — Design System
+
+### Headline
+**Invoy CIF Design System: Governance, not just components**
+
+### Subhead
+A 30-component mobile design system built for a behavior change product — where the rules for when and why each component is used matter more than the components themselves.
+
+### The System
+
+**Foundations**
+- **Color**: Semantic token system — colorPrimary (#477e63, sage green), colorTertiary (#5C7FB3), functional colors (Success, Error, Warning, Info), state colors (Active, Focus, Down, Disabled). Built on the Invoy Design System with explicit extension guidance.
+- **Typography**: San Francisco by Apple. 4 type categories (Headline, Body, Label, Display) × 3 sizes each. UI copy rules documented: "Down style headlines & buttons. Punctuation on sentences. No punctuation elsewhere."
+- **Spacing**: Base-4 scale (xs-12, s-16, m-24, L-32, XL-48, XXL-72).
+- **Icons**: Curated set for clinical/health context.
+
+**Components**
+- **ActionBlock**: The primary CTA pattern — 3 fill states (primary dark, secondary, accent yellow) + ghost text variant. Governs every screen's bottom action area.
+- **Selection Controls**: Radio-style rows with green check + highlight on selection. Used for single-choice questions throughout the check-in flow.
+- **Text Inputs**: Single-line (4 states) and textarea (4 states + word count + character limit). Error states with orange border + supporting text.
+- **Chip Entry**: Multi-select input with inline chips, dismissible tags, suggestion row, and error state. Used for food logging, event tagging, and symptom capture.
+- **Navigation**: Status bar (analyzing/ready states with score badge), header (back/title/close), page base templates.
+- **Page Templates**: Page/Title (intro screens), Page/Questions (data capture), Page/Breathscore (score display). These templates enforce layout consistency across 15+ sub-flows.
+
+### Governance Layer
+The design system isn't just a component library — it's a decision framework:
+
+- **When to use Page/Title vs Page/Questions**: Title pages are entry points with context-setting copy. Questions pages capture data. This distinction governs flow architecture.
+- **ActionBlock hierarchy**: Primary (dark fill) = single forward action. Secondary (light fill) = alternative path. Ghost (text only) = dismissable option ("Remind Me Later"). This hierarchy is consistent across every screen.
+- **Score state → component mapping**: Breath score values map to specific triage component combinations. Score drop → amber card + "What we know" summary + coach CTA. Score increase → green celebration card + reinforcement copy. This mapping is documented, not improvised.
+
+---
+
+## 4. TODAY'S WORKFLOW — Designing with AI
+
+### Headline
+**How I work: Design systems as the API between human intent and AI execution**
+
+### Subhead
+A solo designer's toolkit for scaling across 5+ products — where the design system is simultaneously the source of truth, the constraint engine, and the AI's instruction set.
+
+### The Stack
+
+**Design System (ctrl.rodeo)**
+The CTRL Design System is CSS-first: tokens.css defines the vocabulary, components.css defines the grammar, widgets.css defines the AI-specific patterns. Dark-first, monospace-forward, high-contrast. Used across Boards, Events, Soundscape, Systemic, and Favicon.
+
+The design system isn't a Figma library — it's executable code. When I need a new component, I write it in CSS, run `node scripts/parse-design-system.js` to regenerate the manifest, and the constraint engine picks it up automatically. No sync step. No handoff document.
+
+**Systemic (Design System Auditor)**
+Systemic is a tool I built to reverse-engineer and audit design systems. Point it at any URL → it crawls the CSS → extracts tokens (colors, type, spacing) → maps them to Material Design 3 semantics → generates documentation. For the CTRL Design System, it runs as a QA frontend with stoplight-based variant auditing: Green = approved, Yellow = needs dev action, Orange = needs review, Red = blocked.
+
+This is the governance layer. When a new widget template is added, Systemic audits it against the constraint manifest — checking sizes, component modifiers, template structure. Violations are logged, not silently accepted.
+
+**AI Widget Framework**
+The CTRL Design System includes 11 body templates for AI-powered content (verdict, list, spectrum, split, narrative, suggestion, stats, comparison, choices, checklist, grouped). Each template has defined atoms (w-text, w-badge, w-btn, w-img) and molecules (w-headline, w-tag-group, w-row, w-stat). Claude Haiku generates content constrained to these templates — the AI outputs structured data, the design system renders it.
+
+**Claude Code as Design Partner**
+I use Claude Code for: writing components, generating page layouts, building features, running tests, deploying. The design system tokens give Claude a shared vocabulary — I say "use --accent-cyan on the focus ring" and we're referencing the same value. The CLAUDE.md file in the repo gives Claude the full context: brand principles, code style, version conventions, deployment commands.
+
+### The Workflow
+```
+Intent → Design System Tokens → Claude Code generates code →
+Systemic audits compliance → Runtime constraint engine validates →
+Ship
+```
+
+### Why This Matters
+Roadrunner needs one designer who can hold the design vision and scale output. This workflow is the proof: 5 products, one person, consistent quality. The design system isn't documentation — it's the API between my intent and the AI's execution.
+
+---
+
+## 5. LIVONGO — Product Configuration (Bonus)
+
+### Headline
+**From spreadsheet to system: Taming 3,700 configuration decisions at Livongo**
+
+### Subhead
+How a 50×74 configuration matrix became a streamlined registration experience — and why this is the same problem Roadrunner is solving.
+
+### The Problem
+Livongo offered 5 health programs — Diabetes (DBT), Hypertension (HTN), Weight Management (WM), Diabetes Prevention (DPP), and Behavioral Health (BH) — sold as standalone products or bundled into "Whole Person" solutions. Each client purchased a different combination. Each combination changed which registration fields were shown, required, or hidden.
+
+The configuration lived in a spreadsheet: 50 client configurations × 74 registration fields = 3,700 decision points. Operations managed this manually. New client onboarding required cross-referencing dozens of field visibility rules, qualification criteria, eligibility checks, and billing types.
+
+### The Architecture
+Three layers of the system needed to work together:
+
+**Salesforce Configuration** — Sales reps configured client deals in Salesforce CPQ. Program bundles, pricing tiers, enrollment caps, and eligibility rules were captured at deal close.
+
+**API Translation Layer** — Configuration data flowed from Salesforce through internal APIs that resolved: Which programs is this member eligible for? What fields does their employer require? What data can we pre-populate from HR records, health records, or carrier data?
+
+**Registration Experience** — The member-facing registration flow adapted per-client configuration. For a standalone DBT client: 9 steps, all manual entry. For a Whole Person bundle with pre-registration data: 6 steps, 57% of fields pre-populated.
+
+### The Optimization
+The original registration required members to manually enter all 35 fields across 9 steps. By resolving member data from three upstream sources (Employer HR, Health Records, Carrier data) before the first screen loaded, the optimized flow:
+
+- **Sourced 57% of fields** from existing data
+- **Reduced steps from 9 to 6** (33% fewer)
+- **Saved ~5 minutes** per registration
+- Shifted the UX from **data entry to data confirmation** — recognition instead of recall
+
+### The Roadrunner Parallel
+This is structurally identical to CPQ:
+- **Configure**: Client purchases a product bundle (programs = SKUs)
+- **Price**: Qualification criteria determine eligibility (pricing rules = field visibility rules)
+- **Quote**: The registration flow is the "quote" — a personalized experience generated from configuration data
+
+The spreadsheet that governed Livongo's registration is the same kind of artifact that Salesforce CPQ generates today — and the same kind of artifact Roadrunner is replacing. The design challenge is identical: surface the right fields, in the right order, with the right defaults, for a configuration that might be one of thousands of possible combinations.
+
+---
+
+## Portfolio Shell Copy
+
+### Hero Section
+**Ian Fike** — Product Designer
+
+I design systems that tame configuration complexity — and I use AI to do it at the speed of a solo designer.
+
+Currently building Field (AI clinical documentation) and ctrl.rodeo (AI-powered curation platform). Previously Livongo/Teladoc Health, where I designed the behavioral coaching system serving members across 5 health programs.
+
+### Navigation Labels
+1. Field
+2. Weekly Lifecycle
+3. Design System
+4. Workflow
+5. Configuration (Bonus)

--- a/portfolio/design-systems.html
+++ b/portfolio/design-systems.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Design Systems & Systemic — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">CTRL.RODEO</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="./design-systems.html" class="d-nav__link d-nav__link--active">Design Systems</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--active">Active</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Systemic</p>
+    <p class="d-body" style="margin-top: 12px; font-size: 15px;">Design systems break the moment a human has to manually check if the code matches the spec. Systemic removes the human from that loop.</p>
+
+    <dl class="d-overview" style="margin-top: 24px;">
+      <dt>Role</dt>
+      <dd>Sole designer & developer</dd>
+      <dt>What</dt>
+      <dd>Automated design system auditor — crawls products, extracts tokens, checks compliance</dd>
+      <dt>Why</dt>
+      <dd>Every design system I've worked with drifted. This is the fix.</dd>
+      <dt>Status</dt>
+      <dd>In use across 5 products at ctrl.rodeo</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Design systems have three failure modes. All three are about the gap between what the system says and what actually ships.</p>
+
+    <div class="d-decisions" style="margin-top: 24px;">
+      <div class="d-decision">
+        <p class="d-decision__q">Handoff drift</p>
+        <p class="d-decision__a">A designer specs a component in Figma. An engineer builds it in code. The padding is 14px instead of 16px. The border radius is wrong. Nobody catches it because the Figma file and the codebase are two separate artifacts that nobody cross-references after launch. Over six months, hundreds of these small gaps accumulate. The system becomes a suggestion.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Token sprawl</p>
+        <p class="d-decision__a">The system defines 8 grays. An engineer adds a 9th because the existing ones don't quite work for their feature. Another team adds a 10th. Nobody removes the old ones. A year later, the codebase has 23 gray values and the Figma library still shows 8. The system is technically "adopted" but practically ignored.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Agentic generation</p>
+        <p class="d-decision__a">AI writes code fast. It can generate a full page of components in minutes. But it doesn't know your system unless you tell it — and even when you do, it hallucinates token names, invents spacing values, and creates components that look right but don't match the spec. Now drift happens at machine speed instead of human speed. Without automated checking, AI-assisted design makes the governance problem worse, not better.</p>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 24px;">
+      <p class="d-callout__body">The common thread: design systems fail when compliance depends on people remembering to check. Compliance has to be automatic or it doesn't happen.</p>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+    <p class="d-body">Systemic is a tool that reads what's actually in your product and compares it to what your design system says should be there. It finds the gaps automatically.</p>
+
+    <p class="d-label" style="margin-top: 32px;">How it works</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Crawl</span>
+        <span class="d-flow__step-desc">Point at a URL or load a local manifest. Systemic fetches the CSS.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Extract</span>
+        <span class="d-flow__step-desc">Parse every color, font, spacing value, and component pattern in use.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Map</span>
+        <span class="d-flow__step-desc">Match findings to Material Design 3 semantic tokens and your system's manifest.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Audit</span>
+        <span class="d-flow__step-desc">Stoplight scoring. Green = matches. Yellow = close. Red = drifted.</span>
+      </div>
+    </div>
+
+    <!-- Screenshots -->
+    <div class="d-gallery d-gallery--2" style="margin-top: 32px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Systems view — saved design systems with token and component counts</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Audit view — crawl progress, real-time log, export</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">QA view — stoplight variant audit with grid test</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Docs view — generated documentation with design/code split</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">What it audits</p>
+    <p class="d-body">Systemic checks the CTRL Design System — 4 CSS layers consumed by 5 products.</p>
+
+    <div style="padding: 24px; border-left: 2px solid var(--border-subtle, #33332f); margin-top: 16px; font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg-muted, #8a8885); white-space: pre; line-height: 1.8; overflow-x: auto;">tokens.css       → colors, type, spacing        (48 tokens)
+components.css   → buttons, inputs, cards        (24 components)
+widgets.css      → AI content templates          (11 templates)
+display.css      → marketing & portfolio         (this page)
+        ↓
+manifest.json    → auto-generated index
+        ↓
+Systemic         → crawl all 5 products → stoplight report</div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Design systems this thinking comes from</p>
+
+    <!-- Comparison table -->
+    <div style="margin-top: 16px; border: 1px solid var(--border-subtle, #33332f); font-family: var(--font-mono, monospace); font-size: 12px; overflow-x: auto;">
+      <table style="width: 100%; border-collapse: collapse; min-width: 600px;">
+        <thead>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;"></th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">Livongo</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">Invoy CIF</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">XP Health</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">CTRL</th>
+          </tr>
+        </thead>
+        <tbody style="color: var(--fg-muted, #8a8885);">
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Source of truth</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">CSS</td>
+          </tr>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Governance</td>
+            <td style="padding: 10px 16px;">Team review</td>
+            <td style="padding: 10px 16px;">Documented rules</td>
+            <td style="padding: 10px 16px;">Informal</td>
+            <td style="padding: 10px 16px;">Automated</td>
+          </tr>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Drift detection</td>
+            <td style="padding: 10px 16px;">Manual</td>
+            <td style="padding: 10px 16px;">Manual</td>
+            <td style="padding: 10px 16px;">None</td>
+            <td style="padding: 10px 16px;">Systemic</td>
+          </tr>
+          <tr>
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Result</td>
+            <td style="padding: 10px 16px;">Drifted over time</td>
+            <td style="padding: 10px 16px;">Held with effort</td>
+            <td style="padding: 10px 16px;">Never fully adopted</td>
+            <td style="padding: 10px 16px;">Enforced by machine</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why make the source of truth CSS instead of Figma?</p>
+        <p class="d-decision__a">When an AI writes code, it can read a CSS file. It can't read a Figma file. If the system lives in the same language the code is written in, there's no translation step. No translation means no drift from translation.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why stoplight scoring instead of pass/fail?</p>
+        <p class="d-decision__a">Real products have gray areas. A component might use the right color but the wrong spacing. Pass/fail forces you to either accept it or reject it entirely. Stoplights let you triage: fix the reds now, address the yellows this sprint, leave the greens alone.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why crawl the live product instead of checking the source code?</p>
+        <p class="d-decision__a">Source code shows what you intended. The live product shows what actually shipped. CSS overrides, runtime styles, and third-party scripts all change what the user sees. Systemic checks what's real, not what's planned.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">How does this change when AI is generating the UI?</p>
+        <p class="d-decision__a">AI makes the governance problem urgent. A designer might introduce one off-spec component per week. An AI can introduce ten per day. Without automated checking, AI-assisted design accelerates drift instead of reducing it. Systemic closes that loop — the AI generates, Systemic checks, I fix the violations.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 16px calc(-1 * clamp(20px, 5vw, 64px)) 0;">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Products audited</div>
+        <div class="d-metric__sub">Boards, Events, Soundscape, Systemic, Favicon</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">4</div>
+        <div class="d-metric__label">Systems informed the design</div>
+        <div class="d-metric__sub">Livongo, Invoy, XP Health, CTRL</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">0</div>
+        <div class="d-metric__label">Manual audits needed</div>
+        <div class="d-metric__sub">Systemic handles compliance checking</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body">The page you're reading is rendered by display.css — the newest layer of the CTRL Design System. Systemic audits it the same way it audits every other product. The portfolio is inside the system, not outside it.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="./livongo.html" class="d-next">← Livongo</a>
+  <a href="./how-i-work.html" class="d-next">How I Work →</a>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/field.html
+++ b/portfolio/field.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Field — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">CTRL.RODEO</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link d-nav__link--active">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+  <a href="#faq" class="d-subnav__link">FAQ</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header — side by side -->
+  <div style="display: flex; gap: 32px; padding: 48px 0 0; align-items: flex-start;">
+    <!-- Image placeholder -->
+    <div style="width: 400px; aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); flex-shrink: 0;"></div>
+    <!-- Content -->
+    <div style="flex: 1;">
+      <span class="d-status d-status--dev">In Beta</span>
+      <p class="d-headline d-headline--xl" style="margin-top: 12px;">Field</p>
+      <p class="d-body" style="margin-top: 12px;">An app that turns spoken conversation into structured medical notes — built for first responders who can't stop treating a patient to write things down.</p>
+
+      <dl class="d-overview" style="margin-top: 24px;">
+        <dt>Role</dt>
+        <dd>Founder, sole designer</dd>
+        <dt>Timeline</dt>
+        <dd>March 2026 – Present (5 weeks)</dd>
+        <dt>Status</dt>
+        <dd>Beta with 2 outdoor ed programs, 3 guiding agencies</dd>
+        <dt>Key tech</dt>
+        <dd>On-device AI (Whisper, Llama 3.2), offline-first, GPS</dd>
+      </dl>
+    </div>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Search and rescue teams still use paper to document patient care. They write in the rain, in the dark, wearing gloves. Important details get lost. When they hand off a patient to a hospital, the notes are often incomplete or hard to read.</p>
+    <p class="d-body">Existing software was built for ambulances with Wi-Fi and keyboards. Nothing works for the backcountry — where there's <strong>no cell service, no keyboard, and no time to type.</strong></p>
+
+    <p class="d-label" style="margin-top: 32px;">Personas</p>
+    <div class="d-personas">
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Primary user</span>
+        <span class="d-persona__name">First Responder</span>
+        <ul class="d-persona__needs">
+          <li>Has to document while treating the patient. Wearing gloves, often in bad weather. Might be new — this could be their first real call.</li>
+        </ul>
+      </div>
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Receives the note</span>
+        <span class="d-persona__name">Professional EMS</span>
+        <ul class="d-persona__needs">
+          <li>Needs organized data, not handwritten paragraphs. Wants vitals and a treatment plan in standard format.</li>
+        </ul>
+      </div>
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Information source</span>
+        <span class="d-persona__name">Patient</span>
+        <ul class="d-persona__needs">
+          <li>Describes symptoms out loud, often while in pain. Gives information out of order.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+    <p class="d-body" style="margin-bottom: 32px;">The responder talks to the patient. The app listens, logs all medical details, and creates a patient record and SOAP note automatically. When its time to handoff care, the patient record travels with the patient in a simple tap of your phone.</p>
+
+    <p class="d-label">How it works</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Voice</span>
+        <span class="d-flow__step-desc">Mic records the conversation</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Transcribe</span>
+        <span class="d-flow__step-desc">Whisper converts speech to text on-device</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Extract</span>
+        <span class="d-flow__step-desc">Llama finds medical details and sorts them</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Review</span>
+        <span class="d-flow__step-desc">Responder confirms or edits each field</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">05</span>
+        <span class="d-flow__step-label">Hand off</span>
+        <span class="d-flow__step-desc">Send via Wallet, satellite, clipboard</span>
+      </div>
+    </div>
+
+    <!-- Provider Use Cases -->
+    <p class="d-label" style="margin-top: 48px;">Provider Use Cases</p>
+    <div class="d-gallery d-gallery--3" style="margin-top: 16px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Record & Respond — Mic records the conversation</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Review — Mic records the conversation</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Hand Off — Mic records the conversation</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Key Design Decisions</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why does the AI fill in fields but still let the responder edit them?</p>
+        <p class="d-decision__a">Medical notes need human sign-off. The AI does the first pass — pulling a heart rate from the conversation, for example — but the responder has to confirm it. Faster than typing from scratch, safer than full automation.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why three colors for field status instead of just "done" or "not done"?</p>
+        <p class="d-decision__a">Green means confirmed. Amber means "check this before handoff." Red means conflicting data. Two states would hide the "probably right but double-check" category — the most common one.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why not use a regular keyboard for data entry?</p>
+        <p class="d-decision__a">Gloves make small buttons impossible. Large preset buttons at tailored intervals (ex. 60, 70, 80, 90, 100, 120 bpm for Heart Rate) and +1/-10 adjusters cover most cases in one or two taps.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 16px calc(-1 * clamp(20px, 5vw, 64px)) 0;">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Beta partners</div>
+        <div class="d-metric__sub">2 outdoor ed, 1 SAR, 2 guiding agencies</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">2</div>
+        <div class="d-metric__label">Licensing conversations</div>
+        <div class="d-metric__sub">National outdoor ed organizations</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">27</div>
+        <div class="d-metric__label">Screens designed</div>
+        <div class="d-metric__sub">Full app, patient list to handoff</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- FAQ -->
+  <div id="faq" class="d-section">
+    <p class="d-label">Frequently Asked Customer Questions</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Does it work offline?</p>
+        <p class="d-decision__a">Many rescue sites have no cell service. The app downloads two AI models and runs them locally. It works the same whether you're in town, in a canyon or 30 miles from the nearest cell tower.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Does the dictation actually work?</p>
+        <p class="d-decision__a">Our dictation model has been fine-tuned & tested using over 5000 clinical recordings. We carefully selected them for the situations you experience — high wind, rain, helicopter landings, ambient pain & multiple voices.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Is it compliant to the most recent privacy & data standards?</p>
+        <p class="d-decision__a">Field is compliant to most medical privacy & data standards (HIPAA, NEMSIS, FHIR R4, USCDI v3).</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">I am an EMT / Paramedic. Does it replace my patient care records (ePCR)?</p>
+        <p class="d-decision__a">Field works with your existing ePCR today. Its easy to send your records to your administrator to save their life easier — in a couple clicks they can add your Field Record to the right patient with all of the appropriate billing codes attached. Direct integrations are in our roadmap.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Do you support multiple casualty incidents (MCIs)?</p>
+        <p class="d-decision__a">Not yet. We are working with our search and rescue partners to follow FEMA command structures, following known best practices & participating in MCI scenarios to take the cognitive load off of all parties when managing patient care.</p>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="./" class="d-next">← Overview</a>
+  <a href="./invoy.html" class="d-next">Invoy →</a>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/how-i-work.html
+++ b/portfolio/how-i-work.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How I Work — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link d-nav__link--active">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#stack" class="d-subnav__link">Stack</a>
+  <a href="#system" class="d-subnav__link">Design System</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--active">Active</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">How I Work</p>
+    <p class="d-body" style="margin-top: 12px;">I use a design system as the shared language between me and AI tools. The system defines the rules. The AI writes code that follows them. I review and ship.</p>
+
+    <dl class="d-overview">
+      <dt>Setup</dt>
+      <dd>Solo designer, no design team</dd>
+      <dt>Products</dt>
+      <dd>Boards, Events, Soundscape, Systemic, Favicon</dd>
+      <dt>Tools</dt>
+      <dd>CTRL Design System, Systemic (auditor), Claude Code</dd>
+      <dt>Output</dt>
+      <dd>5 products with consistent quality, shipped continuously</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">One person, five products, daily shipping. The challenge isn't design skill — it's <strong>maintaining consistency at speed without a team.</strong> The answer: make the design system do the enforcement so I can focus on decisions.</p>
+  </div>
+
+  <!-- STACK -->
+  <div id="stack" class="d-section">
+    <p class="d-label">Stack</p>
+    <div class="d-grid-3" style="margin-top: 16px;">
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">CTRL DESIGN SYSTEM</p>
+        <p class="d-body" style="font-size: 12px;">CSS files that define colors, type, spacing, components, and AI widget templates. 48 tokens, 24 components, 11 widget types.</p>
+      </div>
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">SYSTEMIC</p>
+        <p class="d-body" style="font-size: 12px;">A tool I built that crawls websites, extracts their design tokens, and checks them against the design system rules. Flags violations automatically.</p>
+      </div>
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">CLAUDE CODE</p>
+        <p class="d-body" style="font-size: 12px;">AI that writes code. I give it a feature spec and the design system. It generates components that follow the system's rules. I review and ship.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- DESIGN SYSTEM -->
+  <div id="system" class="d-section">
+    <p class="d-label">Design System</p>
+    <p class="d-body">The system isn't a Figma library. It's four CSS files. Change the code, run a script, and every product picks up the update. No syncing, no handoff document.</p>
+
+    <div class="d-callout" style="margin-top: 24px; font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg-muted, #8a8885); white-space: pre; line-height: 1.8; overflow-x: auto;">tokens.css       → colors, type, spacing
+components.css   → buttons, inputs, cards
+widgets.css      → AI-generated content templates
+display.css      → marketing and portfolio pages
+        ↓
+manifest.json    → auto-generated index
+        ↓
+Systemic         → automated QA checks</div>
+
+    <div class="d-grid-2" style="margin-top: 24px;">
+      <div>
+        <p class="d-body" style="font-size: 12px;"><strong>Four layers.</strong> All use the same tokens. All follow the same naming rules. display.css — the one rendering this page — is the newest addition.</p>
+      </div>
+      <div>
+        <p class="d-body" style="font-size: 12px;"><strong>11 widget templates.</strong> AI generates content that fits into defined layouts (lists, comparisons, stats, checklists, etc.). The AI picks the format; the system controls the look.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Intent</span>
+        <span class="d-flow__step-desc">I describe what I want to build</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Design System</span>
+        <span class="d-flow__step-desc">Gives the AI rules to follow</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Claude Code</span>
+        <span class="d-flow__step-desc">Writes the code within those rules</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Systemic</span>
+        <span class="d-flow__step-desc">Checks the output against the system</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">05</span>
+        <span class="d-flow__step-label">Ship</span>
+        <span class="d-flow__step-desc">Push to GitHub Pages</span>
+      </div>
+    </div>
+
+    <p class="d-body" style="margin-top: 24px;">When I say "use --accent-cyan on the focus ring," the AI looks up the same token I defined. The design system is a shared vocabulary between me and the machine. It doesn't get stale because it's the live code — not a document about the code.</p>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Products</div>
+        <div class="d-metric__sub">Boards, Events, Soundscape, Systemic, Favicon</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">1</div>
+        <div class="d-metric__label">Designer</div>
+        <div class="d-metric__sub">Consistent quality across all five</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">4</div>
+        <div class="d-metric__label">CSS layers</div>
+        <div class="d-metric__sub">tokens → components → widgets → display</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body">This portfolio is built with this system. display.css is a permanent part of the design system, not a one-off stylesheet. Every element on this page uses the same tokens as the products.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="./livongo.html" class="d-next">← Livongo</a>
+  <a href="./" class="d-next">Overview →</a>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ian Fike — Product Designer</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">CTRL.RODEO</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-contain">
+
+  <!-- Hero -->
+  <div class="d-hero">
+    <p class="d-headline d-headline--xl">Fixing</p>
+    <p class="d-body" style="font-size: 15px;">3,700 registration rules at Livongo. A behavioral coaching engine at Invoy. Voice-to-documentation AI for wilderness medicine. Different domains, same design problem: map the complexity, build the system, let the user confirm instead of configure.</p>
+    <div class="d-meta" style="margin-top: 20px;">
+      <span>Product Designer</span>
+      <span class="d-meta__sep">·</span>
+      <span>Livongo / Teladoc Health</span>
+      <span class="d-meta__sep">·</span>
+      <span>Building with AI</span>
+    </div>
+  </div>
+
+  <!-- Suggested for You -->
+  <div class="d-section">
+    <p class="d-label">Suggested for you</p>
+    <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <a href="./field.html" class="d-card">
+        <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
+        <span class="d-card__title">Voice-First Clinical Documentation</span>
+        <span class="d-card__desc">Voice-driven clinical documentation for first responders. On-device AI, offline-first</span>
+        <span class="d-card__tag" style="margin-top: auto;">Beta</span>
+      </a>
+      <a href="./invoy.html" class="d-card">
+        <span class="d-card__tag">Behavior Change · Design System</span>
+        <span class="d-card__title">Engagement Loops & Weight Loss</span>
+        <span class="d-card__desc">Weekly behavioral coaching lifecycle. MVP design system.</span>
+        <span class="d-card__tag" style="margin-top: auto;">Shipped</span>
+      </a>
+      <a href="./livongo.html" class="d-card">
+        <span class="d-card__tag">Infrastructure · B2B · Scale</span>
+        <span class="d-card__title">B2B Sales Configuration & End User Onboarding</span>
+        <span class="d-card__desc">Simplifying product configuration at enterprise scale.</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- Utilities -->
+  <div class="d-section">
+    <p class="d-label">Utilities</p>
+    <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <a href="./how-i-work.html" class="d-card">
+        <span class="d-card__tag">AI · iOS · 0→1</span>
+        <span class="d-card__title">Design System Manager</span>
+        <span class="d-card__desc">Generate and manage your design system from Figma, Paper, Github or live code.</span>
+      </a>
+      <a href="#" class="d-card">
+        <span class="d-card__tag">Shipped · Mobile · Design System</span>
+        <span class="d-card__title">Add to Calendar</span>
+        <span class="d-card__desc">Quickly</span>
+      </a>
+      <a href="#" class="d-card">
+        <span class="d-card__tag">B2B · Configuration · Scale</span>
+        <span class="d-card__title">Favicons</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- Personal Projects -->
+  <div class="d-section">
+    <p class="d-label">Personal Projects</p>
+    <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <a href="#" class="d-card">
+        <span class="d-card__tag">AI · iOS · 0→1</span>
+        <span class="d-card__title">Boards</span>
+        <span class="d-card__desc">SF's Best events all in one place.</span>
+      </a>
+      <a href="#" class="d-card">
+        <span class="d-card__tag">Shipped · Mobile · Design System</span>
+        <span class="d-card__title">Events</span>
+        <span class="d-card__desc">SF's best events all in one place.</span>
+      </a>
+      <a href="#" class="d-card">
+        <span class="d-card__tag">B2B · Configuration · Scale</span>
+        <span class="d-card__title">Soundscape</span>
+      </a>
+    </div>
+  </div>
+
+  <!-- How I Work teaser -->
+  <div class="d-section">
+    <p class="d-label">How I Work</p>
+    <p class="d-headline d-headline--lg">One designer, five products, AI-assisted delivery.</p>
+    <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
+    <a href="./how-i-work.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <span class="d-mono">← → to navigate</span>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/invoy.html
+++ b/portfolio/invoy.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invoy — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link d-nav__link--active">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--shipped">Shipped</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy</p>
+    <p class="d-body" style="margin-top: 12px;">A weekly coaching system for metabolic health. Members plan their week, check in daily, review their progress, and adjust — with coach support when the data says they need it.</p>
+
+    <dl class="d-overview">
+      <dt>Role</dt>
+      <dd>Lead product designer</dd>
+      <dt>Company</dt>
+      <dd>Livongo / Teladoc Health</dd>
+      <dt>Platform</dt>
+      <dd>iOS, Android</dd>
+      <dt>Scope</dt>
+      <dd>15+ sub-flows, 30-component design system, 100+ screens</dd>
+      <dt>Status</dt>
+      <dd>Shipped to production</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Most health apps treat each screen as a standalone moment. You check in today, but the app doesn't connect that to what you planned this week or what happened yesterday. The member has to hold the context in their head.</p>
+    <p class="d-body">Invoy needed a <strong>loop, not a list of features</strong>. Weekly planning should shape daily actions. Daily data should trigger coaching. Weekly review should change next week's plan.</p>
+
+    <div class="d-personas">
+      <div class="d-persona">
+        <span class="d-persona__role">Primary user</span>
+        <span class="d-persona__name">Member</span>
+        <ul class="d-persona__needs">
+          <li>Wants to know what to eat today based on their plan</li>
+          <li>Needs to see progress without reading charts</li>
+          <li>Wants to get back on track after a bad day without guilt</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Secondary user</span>
+        <span class="d-persona__name">Coach</span>
+        <ul class="d-persona__needs">
+          <li>Manages 50+ members — needs to spot who needs help fast</li>
+          <li>Wants data-backed reasons to reach out</li>
+          <li>Needs to suggest specific plan changes</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+
+    <p class="d-label" style="margin-top: 24px;">The weekly loop</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Plan</span>
+        <span class="d-flow__step-desc">Set goals. Flag upcoming events. The app picks one of 5 plan types.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Execute</span>
+        <span class="d-flow__step-desc">Daily check-ins. Breath test, mood, meals, plan tracking.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Reflect</span>
+        <span class="d-flow__step-desc">End-of-week review. Weight change, plan completion, trends.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Adapt</span>
+        <span class="d-flow__step-desc">Coach reviews patterns. Next week's plan adjusts.</span>
+      </div>
+    </div>
+
+    <div class="d-gallery d-gallery--4" style="margin-top: 32px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Week Planning [screenshot]</span></div>
+        <span class="d-gallery__caption">Set intentions, flag events. 5 plan variants from one entry point.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Daily Focus [screenshot]</span></div>
+        <span class="d-gallery__caption">Daily check-in with score factors and nutrition tracking.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Review of Week [screenshot]</span></div>
+        <span class="d-gallery__caption">Weight change, progress bars, trend line, day-by-day activity grid.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Rebound [screenshot]</span></div>
+        <span class="d-gallery__caption">When the score drops: what happened, possible causes, next steps.</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Design System</p>
+    <p class="d-body">30 components with rules for when to use each one. The system tells the team which page template to start with, which button style means "go forward" vs "dismiss," and which card to show when the score drops vs. when it rises.</p>
+
+    <div class="d-decisions" style="margin-top: 16px;">
+      <div class="d-decision">
+        <p class="d-decision__q">Page/Title vs Page/Questions</p>
+        <p class="d-decision__a">Title pages explain what's coming. Questions pages collect data. A sub-flow always starts with a Title page — never a Questions page.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Button hierarchy</p>
+        <p class="d-decision__a">Dark button = main action. Light button = alternative. Text-only = dismiss. Same rule on every screen in every flow.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Score → card mapping</p>
+        <p class="d-decision__a">Score drops get an amber card with "what we know" and a coach button. Score increases get a green card with encouragement. This is documented, not decided per screen.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why does one question ("any events this week?") split into 5 different flows?</p>
+        <p class="d-decision__a">Members shouldn't need to understand the system's logic. If they have a busy week, the app gives them a lighter plan with optional boosters. If they're planning a cheat meal, the rebound flow activates. The routing is automatic — one question does the work of a settings page.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why treat a bad day as a "rebound" instead of a failure?</p>
+        <p class="d-decision__a">Most health apps make you feel bad when you go off plan. Invoy built a dedicated recovery flow: it shows what happened, suggests why, and offers specific next steps like scheduling a coach call or adding a fasting boost. Members who see a path back stay engaged. Members who feel judged stop opening the app.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why pack so much data into the weekly review screen?</p>
+        <p class="d-decision__a">People look at this once a week. It has to be complete and fast to scan. Weight change, three progress bars, a week-long trend line, a day-by-day activity grid, and an AI-written summary — all on one scroll. Every number is readable without explanation.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">↑</div>
+        <div class="d-metric__label">Daily check-in completion</div>
+        <div class="d-metric__sub">Connected weekly planning to daily engagement</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↑</div>
+        <div class="d-metric__label">Weight loss outcomes</div>
+        <div class="d-metric__sub">Closed loop between data, coaching, and plan adaptation</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">30</div>
+        <div class="d-metric__label">Components shipped</div>
+        <div class="d-metric__sub">Design system with documented governance rules</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="./field.html" class="d-next">← Field</a>
+  <a href="./livongo.html" class="d-next">Livongo →</a>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/livongo.html
+++ b/portfolio/livongo.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Livongo Config — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../design-system/tokens.css">
+  <link rel="stylesheet" href="../design-system/components.css">
+  <link rel="stylesheet" href="../design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="./" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="./field.html" class="d-nav__link">Field</a></li>
+    <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="./livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
+    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--shipped">Shipped</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Config</p>
+    <p class="d-body" style="margin-top: 12px;">Livongo sold 5 health programs in dozens of combinations. Each combination changed which fields a member saw during registration. The rules lived in a spreadsheet. We turned it into a system.</p>
+
+    <dl class="d-overview">
+      <dt>Role</dt>
+      <dd>Product designer, growth PM</dd>
+      <dt>Company</dt>
+      <dd>Livongo / Teladoc Health</dd>
+      <dt>Scope</dt>
+      <dd>50 client configs × 74 fields = 3,700 decision points</dd>
+      <dt>Platform</dt>
+      <dd>Web (registration flow), Salesforce (config), internal APIs</dd>
+      <dt>Status</dt>
+      <dd>Shipped to production</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Every time Livongo signed a new client, someone on the operations team opened a 74-column spreadsheet and figured out which registration fields to show, require, or hide for that client's program bundle. A standalone diabetes client got one set of fields. A "Whole Person" bundle with diabetes, hypertension, and weight management got a different set. <strong>The spreadsheet was the product's truth table.</strong></p>
+    <p class="d-body">This was slow, error-prone, and didn't scale. New client launches took days of manual setup. Mistakes meant members saw the wrong fields or couldn't register at all.</p>
+
+    <div class="d-personas">
+      <div class="d-persona">
+        <span class="d-persona__role">Configures the deal</span>
+        <span class="d-persona__name">Sales</span>
+        <ul class="d-persona__needs">
+          <li>Picks program bundles in Salesforce</li>
+          <li>Doesn't think about what fields that affects</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Sets up the flow</span>
+        <span class="d-persona__name">Implementation</span>
+        <ul class="d-persona__needs">
+          <li>Translates the deal into a registration config</li>
+          <li>Cross-references 74 columns for each client</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Registers</span>
+        <span class="d-persona__name">Member</span>
+        <ul class="d-persona__needs">
+          <li>Wants to sign up quickly</li>
+          <li>Should only see fields that matter to their program</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+
+    <p class="d-label" style="margin-top: 24px;">Architecture</p>
+    <p class="d-body" style="margin-bottom: 16px;">Three systems work together. Sales configures the deal. APIs resolve member data before the first screen loads. The registration flow adapts to show only what's needed.</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">SF</span>
+        <span class="d-flow__step-label">Salesforce</span>
+        <span class="d-flow__step-desc">Bundle, pricing, eligibility rules, field visibility</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">API</span>
+        <span class="d-flow__step-label">Data Resolution</span>
+        <span class="d-flow__step-desc">Employer, health records, and insurance pre-fill fields</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">UX</span>
+        <span class="d-flow__step-label">Registration</span>
+        <span class="d-flow__step-desc">6 steps. Member confirms what the system already knows.</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Before and after</p>
+    <div class="d-grid-2" style="margin-top: 16px;">
+      <div>
+        <p class="d-body"><strong>Before: 9 steps.</strong> Enter name, address, search for coverage, verify insurance, enter health info, set up coaching, complete profile. Everything typed from scratch.</p>
+      </div>
+      <div>
+        <p class="d-body"><strong>After: 6 steps.</strong> Confirm identity, create account, review program details from records, confirm health history, confirm shipping address, done. Coverage handled server-side. Coaching deferred to first use.</p>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px;">
+      <p class="d-callout__body">The full comparison with a filterable breakdown of all 35 fields is at <a href="/reg/" style="color: var(--color-link, #00fff7);">ctrl.rodeo/reg/</a></p>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why show pre-filled fields instead of blank forms?</p>
+        <p class="d-decision__a">Three services pull the member's data before they see a single screen: employer HR for name and address, health records for diagnosis, carrier data for insurance. The member confirms what's already there instead of typing it in. Faster, fewer errors.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why remove the coverage steps entirely?</p>
+        <p class="d-decision__a">If the employer sponsors the member, coverage is already verified. Asking the member to search for their employer, wait for verification, and enter insurance details added 3 steps and about 2 minutes for information the system already had.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why not ask about coaching preferences during registration?</p>
+        <p class="d-decision__a">People can't set meaningful preferences for a product they haven't used yet. We moved coaching setup to after the first use — when the member has context for what the questions mean.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">57%</div>
+        <div class="d-metric__label">Fields pre-populated</div>
+        <div class="d-metric__sub">20 of 35 fields sourced from upstream data</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↓</div>
+        <div class="d-metric__label">Registration errors</div>
+        <div class="d-metric__sub">Pre-filled data eliminated manual entry mistakes</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↓</div>
+        <div class="d-metric__label">Admin setup time</div>
+        <div class="d-metric__sub">Reduced manual configuration and dev work per client</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body"><strong>This is the same problem as CPQ.</strong> Programs are SKUs. Qualification rules are pricing rules. The registration flow is the quote. The spreadsheet is the same artifact that CPQ platforms replace with automated configuration.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="./invoy.html" class="d-next">← Invoy</a>
+  <a href="./how-i-work.html" class="d-next">How I Work →</a>
+</footer>
+
+<script src="./portfolio.js"></script>
+</body>
+</html>

--- a/portfolio/portfolio.js
+++ b/portfolio/portfolio.js
@@ -1,0 +1,246 @@
+/* ============================================
+   Portfolio — Navigation, Interaction, Edit Mode
+   ============================================ */
+
+(function () {
+  'use strict';
+
+  // ── Sub-nav scroll highlighting ──
+  function initSubnav() {
+    const links = document.querySelectorAll('.d-subnav__link');
+    if (!links.length) return;
+    const sections = [];
+    links.forEach(link => {
+      const id = link.getAttribute('href')?.replace('#', '');
+      const el = id && document.getElementById(id);
+      if (el) sections.push({ el, link });
+    });
+    if (!sections.length) return;
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          links.forEach(l => l.classList.remove('d-subnav__link--active'));
+          const match = sections.find(s => s.el === entry.target);
+          if (match) match.link.classList.add('d-subnav__link--active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+    sections.forEach(s => observer.observe(s.el));
+  }
+
+  // ── Keyboard nav between pages ──
+  function initKeyboard() {
+    const pages = [
+      '/portfolio/',
+      '/portfolio/field.html',
+      '/portfolio/invoy.html',
+      '/portfolio/livongo.html',
+      '/portfolio/how-i-work.html'
+    ];
+    const current = window.location.pathname;
+    const idx = pages.findIndex(p => current.endsWith(p) || current.endsWith(p.replace('.html', '')));
+    document.addEventListener('keydown', e => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
+      if (e.key === 'ArrowRight' && idx < pages.length - 1) window.location.href = pages[idx + 1];
+      else if (e.key === 'ArrowLeft' && idx > 0) window.location.href = pages[idx - 1];
+      // Toggle edit mode with Shift+E
+      if (e.key === 'E' && e.shiftKey && !e.metaKey && !e.ctrlKey) toggleEditMode();
+    });
+  }
+
+  // ── Smooth scroll for anchors ──
+  function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(link => {
+      link.addEventListener('click', e => {
+        const target = document.querySelector(link.getAttribute('href'));
+        if (target) {
+          e.preventDefault();
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          history.pushState(null, '', link.getAttribute('href'));
+        }
+      });
+    });
+  }
+
+  // ── Active nav link ──
+  function initNavHighlight() {
+    const links = document.querySelectorAll('.d-nav__link');
+    const path = window.location.pathname;
+    links.forEach(link => {
+      const href = link.getAttribute('href');
+      if (href && path.endsWith(href.replace('./', ''))) {
+        link.classList.add('d-nav__link--active');
+      }
+    });
+  }
+
+  // ── Edit Mode ──
+  let editModeActive = false;
+  const editStyles = document.createElement('style');
+  editStyles.textContent = `
+    body { user-select: text !important; -webkit-user-select: text !important; }
+    .edit-mode .d-body,
+    .edit-mode .d-headline,
+    .edit-mode .d-decision__q,
+    .edit-mode .d-decision__a,
+    .edit-mode .d-callout__body,
+    .edit-mode .d-card__desc,
+    .edit-mode .d-card__title,
+    .edit-mode .d-metric__label,
+    .edit-mode .d-metric__sub,
+    .edit-mode .d-gallery__caption,
+    .edit-mode .d-persona__name,
+    .edit-mode .d-persona__needs li,
+    .edit-mode .d-flow__step-desc,
+    .edit-mode .d-flow__step-label,
+    .edit-mode dd {
+      outline: 1px dashed rgba(0, 255, 247, 0.3);
+      outline-offset: 2px;
+      cursor: text;
+    }
+    .edit-mode .d-body:hover,
+    .edit-mode .d-headline:hover,
+    .edit-mode .d-decision__q:hover,
+    .edit-mode .d-decision__a:hover,
+    .edit-mode .d-callout__body:hover,
+    .edit-mode [contenteditable]:hover {
+      outline-color: rgba(0, 255, 247, 0.6);
+      background: rgba(0, 255, 247, 0.03);
+    }
+    .edit-mode [contenteditable]:focus {
+      outline: 2px solid #00fff7;
+      background: rgba(0, 255, 247, 0.05);
+    }
+    .edit-banner {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 9999;
+      background: #00fff7;
+      color: #111;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      font-weight: 600;
+      text-align: center;
+      padding: 6px;
+      letter-spacing: 0.04em;
+    }
+    .edit-banner button {
+      background: #111;
+      color: #00fff7;
+      border: none;
+      padding: 2px 10px;
+      margin-left: 12px;
+      font-family: inherit;
+      font-size: 10px;
+      cursor: pointer;
+      border-radius: 2px;
+    }
+    .comment-marker {
+      position: absolute;
+      right: -32px;
+      top: 0;
+      width: 20px;
+      height: 20px;
+      background: #ffb000;
+      color: #111;
+      font-size: 10px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      cursor: pointer;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .comment-bubble {
+      position: absolute;
+      right: -280px;
+      top: 0;
+      width: 240px;
+      background: #1a1a18;
+      border: 1px solid #ffb000;
+      border-radius: 4px;
+      padding: 8px;
+      z-index: 100;
+    }
+    .comment-bubble textarea {
+      width: 100%;
+      background: #111;
+      color: #e8e6e3;
+      border: 1px solid #33332f;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      padding: 6px;
+      resize: vertical;
+      min-height: 60px;
+      border-radius: 2px;
+    }
+    .comment-bubble button {
+      background: #ffb000;
+      color: #111;
+      border: none;
+      padding: 4px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 10px;
+      cursor: pointer;
+      margin-top: 4px;
+      border-radius: 2px;
+    }
+    .has-comment {
+      border-left: 2px solid #ffb000 !important;
+      padding-left: 8px;
+    }
+  `;
+
+  let banner = null;
+
+  function toggleEditMode() {
+    editModeActive = !editModeActive;
+    document.body.classList.toggle('edit-mode', editModeActive);
+
+    if (editModeActive) {
+      document.head.appendChild(editStyles);
+
+      // Make text editable
+      const editables = document.querySelectorAll('.d-body, .d-headline, .d-decision__q, .d-decision__a, .d-callout__body, .d-card__desc, .d-card__title, .d-metric__label, .d-metric__sub, .d-gallery__caption, .d-persona__name, .d-persona__needs li, .d-flow__step-desc, .d-flow__step-label, dd');
+      editables.forEach(el => {
+        el.setAttribute('contenteditable', 'true');
+        el.style.position = 'relative';
+        // Add comment button on click
+        el.addEventListener('dblclick', function addComment(e) {
+          if (el.querySelector('.comment-bubble')) return;
+          const bubble = document.createElement('div');
+          bubble.className = 'comment-bubble';
+          bubble.innerHTML = '<textarea placeholder="Leave a comment..."></textarea><button onclick="this.parentElement.previousElementSibling?.classList.add(\'has-comment\'); const t = this.parentElement.querySelector(\'textarea\').value; if(t) { const m = document.createElement(\'span\'); m.className=\'comment-marker\'; m.title=t; m.textContent=\'!\'; this.parentElement.parentElement.appendChild(m); } this.parentElement.remove();">Save</button>';
+          el.appendChild(bubble);
+          bubble.querySelector('textarea').focus();
+          e.stopPropagation();
+        });
+      });
+
+      // Show banner
+      banner = document.createElement('div');
+      banner.className = 'edit-banner';
+      banner.innerHTML = 'EDIT MODE — Click to edit. Double-click to comment. Shift+E to exit. <button onclick="document.querySelectorAll(\'[contenteditable]\').forEach(el => console.log(el.closest(\'[id]\')?.id || \'-\', \'|\', el.className, \'|\', el.textContent.trim().slice(0,60)))">Log changes</button>';
+      document.body.prepend(banner);
+
+    } else {
+      // Disable editing
+      document.querySelectorAll('[contenteditable]').forEach(el => {
+        el.removeAttribute('contenteditable');
+      });
+      if (editStyles.parentNode) editStyles.remove();
+      if (banner) { banner.remove(); banner = null; }
+    }
+  }
+
+  // ── Init ──
+  document.addEventListener('DOMContentLoaded', () => {
+    initSubnav();
+    initKeyboard();
+    initSmoothScroll();
+    initNavHighlight();
+  });
+})();

--- a/reg/index.html
+++ b/reg/index.html
@@ -673,13 +673,80 @@
   <a href="/" class="logo-mark">ctrl.rodeo</a>
   <div class="header-divider"></div>
   <div class="header-text">
-    <div class="header-title">Onboarding Flow Comparison</div>
-    <div class="header-subtitle">From data entry to data confirmation — fewer steps, less friction, same outcome.</div>
+    <div class="header-title">Product Configuration at Scale</div>
+    <div class="header-subtitle">From a 50×74 spreadsheet to a 6-step registration — Livongo / Teladoc Health</div>
   </div>
 </header>
 
 <!-- ────────────────────────────────────────── MAIN -->
 <main class="main">
+
+  <!-- ── CASE STUDY CONTEXT ── -->
+  <div class="section" style="margin-bottom: 48px;">
+    <div style="max-width: 720px; margin-bottom: 40px;">
+      <h1 style="font-size: 2rem; font-weight: 700; color: var(--gray-900); line-height: 1.2; margin-bottom: 12px;">From Spreadsheet to System</h1>
+      <p style="font-size: 1.0625rem; color: var(--gray-600); line-height: 1.7; margin-bottom: 24px;">Livongo offered 5 health programs — Diabetes, Hypertension, Weight Management, Diabetes Prevention, and Behavioral Health — sold standalone or bundled into "Whole Person" solutions. Each client purchased a different combination. Each combination changed which registration fields were shown, required, or hidden.</p>
+      <p style="font-size: 1.0625rem; color: var(--gray-600); line-height: 1.7;">The configuration lived in a spreadsheet: <strong style="color: var(--gray-900);">50 client configurations × 74 registration fields = 3,700 decision points.</strong> Operations managed this manually. New client onboarding required cross-referencing dozens of field visibility rules, qualification criteria, eligibility checks, and billing types.</p>
+    </div>
+
+    <!-- Architecture Pipeline -->
+    <div style="display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; gap: 0; align-items: stretch; margin-bottom: 40px;">
+      <!-- Salesforce -->
+      <div style="padding: 24px; background: var(--blue-light); border-radius: 12px 0 0 12px; border: 1px solid #BBDEFB;">
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+          <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 6px; background: var(--blue); color: white; font-size: 0.6875rem; font-weight: 700;">SF</span>
+          <span style="font-size: 0.9375rem; font-weight: 700; color: #1565C0;">Salesforce Config</span>
+        </div>
+        <ul style="list-style: none; font-size: 0.8125rem; color: var(--gray-700); line-height: 1.8;">
+          <li>Program bundle selection</li>
+          <li>Pricing tier & enrollment caps</li>
+          <li>Eligibility rules & billing type</li>
+          <li>Field visibility (Show/Require/Skip)</li>
+        </ul>
+        <div style="margin-top: 16px; padding: 8px 12px; background: white; border-radius: 6px; font-size: 0.75rem; color: var(--gray-600);">50 configs × 74 fields</div>
+      </div>
+      <!-- Arrow -->
+      <div style="display: flex; align-items: center; padding: 0 8px; color: var(--gray-400); font-size: 1.5rem;">→</div>
+      <!-- API -->
+      <div style="padding: 24px; background: #F3E5F5; border: 1px solid #E1BEE7;">
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+          <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 6px; background: #7B1FA2; color: white; font-size: 0.6875rem; font-weight: 700;">API</span>
+          <span style="font-size: 0.9375rem; font-weight: 700; color: #6A1B9A;">Data Resolution</span>
+        </div>
+        <ul style="list-style: none; font-size: 0.8125rem; color: var(--gray-700); line-height: 1.8;">
+          <li>Employer HR → name, DOB, address</li>
+          <li>Health Records → diagnosis, A1C</li>
+          <li>Carrier Data → insurance, coverage</li>
+        </ul>
+        <div style="margin-top: 16px; padding: 8px 12px; background: white; border-radius: 6px; font-size: 0.75rem; color: var(--gray-600);">57% of fields sourced before first screen</div>
+      </div>
+      <!-- Arrow -->
+      <div style="display: flex; align-items: center; padding: 0 8px; color: var(--gray-400); font-size: 1.5rem;">→</div>
+      <!-- Registration -->
+      <div style="padding: 24px; background: var(--green-light); border-radius: 0 12px 12px 0; border: 1px solid #C8E6C9;">
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+          <span style="display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border-radius: 6px; background: var(--green); color: white; font-size: 0.6875rem; font-weight: 700;">UX</span>
+          <span style="font-size: 0.9375rem; font-weight: 700; color: #2E7D32;">Registration Flow</span>
+        </div>
+        <ul style="list-style: none; font-size: 0.8125rem; color: var(--gray-700); line-height: 1.8;">
+          <li>6 steps (down from 9)</li>
+          <li>Confirm, don't enter</li>
+          <li>Adapts per client config</li>
+          <li>~5 min saved per registration</li>
+        </ul>
+        <div style="margin-top: 16px; padding: 8px 12px; background: white; border-radius: 6px; font-size: 0.75rem; color: var(--gray-600);">Recognition over recall</div>
+      </div>
+    </div>
+
+    <!-- Design Principle -->
+    <div style="background: #FAFBFC; border: 1px solid var(--gray-200); border-radius: var(--radius-lg); padding: 24px 28px; display: flex; gap: 16px; align-items: flex-start;">
+      <span style="font-size: 1.25rem;">💡</span>
+      <div>
+        <div style="font-size: 0.875rem; font-weight: 700; color: var(--gray-900); margin-bottom: 4px;">The core design principle</div>
+        <div style="font-size: 0.8125rem; color: var(--gray-600); line-height: 1.6;">Shift the member experience from <strong>data entry</strong> to <strong>data confirmation</strong>. Three upstream services resolve member data before the first screen loads. The member validates what the system already knows rather than starting from blank forms.</div>
+      </div>
+    </div>
+  </div>
 
   <!-- ── IMPACT AT A GLANCE ── -->
   <div class="section">
@@ -1336,11 +1403,34 @@
     });
   </script>
 
+<!-- ── CPQ PARALLEL ── -->
+<div class="section" style="margin-top: 48px; margin-bottom: 0;">
+  <div style="background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); border-radius: var(--radius-lg); padding: 40px 36px; color: white;">
+    <div class="section-label" style="color: rgba(255,255,255,0.5);">The Structural Parallel</div>
+    <h2 style="font-size: 1.5rem; font-weight: 700; margin-bottom: 16px; color: white;">This is a CPQ problem</h2>
+    <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 32px; margin-bottom: 24px;">
+      <div>
+        <div style="font-size: 0.75rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(255,255,255,0.4); margin-bottom: 8px;">Configure</div>
+        <div style="font-size: 0.875rem; color: rgba(255,255,255,0.8); line-height: 1.6;">Client purchases a program bundle. Programs = SKUs. Each bundle defines which fields, qualifications, and billing rules apply.</div>
+      </div>
+      <div>
+        <div style="font-size: 0.75rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(255,255,255,0.4); margin-bottom: 8px;">Price</div>
+        <div style="font-size: 0.875rem; color: rgba(255,255,255,0.8); line-height: 1.6;">Qualification criteria determine eligibility. Pricing rules = field visibility rules. The "price" is which experience the member gets.</div>
+      </div>
+      <div>
+        <div style="font-size: 0.75rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(255,255,255,0.4); margin-bottom: 8px;">Quote</div>
+        <div style="font-size: 0.875rem; color: rgba(255,255,255,0.8); line-height: 1.6;">The registration flow is the "quote" — a personalized experience generated from configuration data. One of thousands of possible combinations.</div>
+      </div>
+    </div>
+    <p style="font-size: 0.8125rem; color: rgba(255,255,255,0.5); line-height: 1.6; max-width: 680px;">The spreadsheet that governed Livongo's registration is the same kind of artifact that Salesforce CPQ generates today — and the same kind of artifact that modern CPQ platforms are replacing with guided, automated configuration.</p>
+  </div>
+</div>
+
 </main>
 
 <!-- ────────────────────────────────────────── FOOTER -->
 <footer class="site-footer">
-  <div class="footer-note">Built for presentation purposes — mock data only</div>
+  <div class="footer-note">Ian Fike — Livongo / Teladoc Health</div>
   <div class="footer-hint">
     Use
     <span class="key-chip">←</span>


### PR DESCRIPTION
## Summary
- New `display.css` layer for CTRL Design System — presentation components for portfolios, marketing, case studies
- Portfolio site at `/portfolio/` with home + 5 sub-pages (Field, Invoy, Livongo Config, Design Systems/Systemic, How I Work)
- Updated `reg/index.html` with expanded case study framing (SF → API → Registration pipeline, CPQ parallel callout)
- `portfolio.js` with sub-nav scroll highlighting, keyboard navigation (←→), smooth scroll, Shift+E edit mode

## Pages
- `portfolio/index.html` — Thesis hero, 3 card sections (Suggested/Utilities/Personal), How I Work teaser
- `portfolio/field.html` — AI clinical documentation, personas, flow diagram, FAQ, impact metrics
- `portfolio/invoy.html` — Weekly lifecycle loop, design system governance, shipped at Teladoc scale
- `portfolio/livongo.html` — Configuration → registration pipeline, before/after, CPQ parallel
- `portfolio/design-systems.html` — Systemic case study: handoff drift, token sprawl, agentic generation
- `portfolio/how-i-work.html` — CTRL DS + Systemic + Claude Code workflow

## Test plan
- [ ] Open portfolio/index.html — verify dark theme, responsive, cards link correctly
- [ ] Click through all 5 sub-pages — verify nav highlighting, section anchors
- [ ] Test keyboard nav (←→ between pages)
- [ ] Test Shift+E edit mode toggle
- [ ] Verify reg/index.html new sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)