### PR TITLE
fix(systemic): maintain view state on page refresh

### DIFF
--- a/systemic/js/app.js
+++ b/systemic/js/app.js
@@ -309,6 +309,14 @@ class SystemicApp {
       const designSystem = this.transformManifestToDesignSystem(manifest, registry, widgetRegistry);
       this.debugLog('LOCAL', `Transformed: ${designSystem.components?.length} components, first template HTML starts with: ${designSystem.components?.find(c => c.type?.startsWith('template-'))?.variants?.[0]?.html?.slice(0, 80)}...`);
 
+      // Preserve cached AI data (principles, descriptions) from previous save
+      const cached = this.loadDesignSystem(designSystem.id);
+      if (cached) {
+        if (cached.principles) designSystem.principles = cached.principles;
+        if (cached.aiDescriptions) designSystem.aiDescriptions = cached.aiDescriptions;
+        if (cached.userDescriptions) designSystem.userDescriptions = cached.userDescriptions;
+      }
+
       // Save it (update if already exists)
       const isUpdate = this.designSystems.some(ds => ds.id === designSystem.id);
       this.debugLog('LOCAL', `Saving (isUpdate: ${isUpdate})`);
@@ -318,7 +326,14 @@ class SystemicApp {
       this.setActiveSystem(designSystem);
 
       this.showToast('Local design system loaded');
-      this.navigateTo('docs/color');
+
+      // Preserve current hash route on refresh; default to docs/color for fresh loads
+      const currentHash = window.location.hash.slice(1) || '';
+      if (currentHash.startsWith('docs/') || currentHash.startsWith('qa/')) {
+        this.handleRoute();
+      } else {
+        this.navigateTo('docs/color');
+      }
 
     } catch (error) {
       this.debugLog('LOCAL', 'Error loading local design system:', error);

--- a/systemic/js/viewer.js
+++ b/systemic/js/viewer.js
@@ -171,7 +171,19 @@ class DesignSystemViewer {
    * Show default view
    */
   showDefaultView() {
-    // Show color foundation by default
+    // Respect current hash route if present (e.g. on page refresh)
+    const hash = window.location.hash.slice(1) || '';
+    const parts = hash.split('/');
+    if (parts[0] === 'docs' && parts[1]) {
+      const foundations = ['color', 'typography', 'spacing', 'elevation', 'examples', 'principles'];
+      if (foundations.includes(parts[1])) {
+        this.selectFoundation(parts[1]);
+        return;
+      }
+      // Component route — let handleRoute deal with it
+      if (parts[1] === 'component') return;
+    }
+    // Default fallback
     this.selectFoundation('color');
   }
 


### PR DESCRIPTION
## Summary
- **showDefaultView()** now respects the current URL hash instead of always resetting to `color` on load
- **loadLocalDesignSystem()** preserves the current hash route on refresh instead of always navigating to `docs/color`
- Local system rebuilds from manifest now restore cached **principles, aiDescriptions, and userDescriptions** from localStorage

## Test plan
- [ ] Navigate to `#docs/principles`, refresh — should stay on principles tab
- [ ] Navigate to `#docs/typography`, refresh — should stay on typography
- [ ] Generate AI principles, refresh — principles should persist without re-generation
- [ ] Edit a description, refresh — user edits should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)