### PR TITLE
feat: flatten portfolio pages to root

### DIFF
--- a/design-systems.html
+++ b/design-systems.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Design Systems & Systemic — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="/" class="d-nav__name">CTRL.RODEO</a>
+  <ul class="d-nav__links">
+    <li><a href="/field.html" class="d-nav__link">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="/design-systems.html" class="d-nav__link d-nav__link--active">Design Systems</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--active">Active</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Systemic</p>
+    <p class="d-body" style="margin-top: 12px; font-size: 15px;">Design systems break the moment a human has to manually check if the code matches the spec. Systemic removes the human from that loop.</p>
+
+    <dl class="d-overview" style="margin-top: 24px;">
+      <dt>Role</dt>
+      <dd>Sole designer & developer</dd>
+      <dt>What</dt>
+      <dd>Automated design system auditor — crawls products, extracts tokens, checks compliance</dd>
+      <dt>Why</dt>
+      <dd>Every design system I've worked with drifted. This is the fix.</dd>
+      <dt>Status</dt>
+      <dd>In use across 5 products at ctrl.rodeo</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Design systems have three failure modes. All three are about the gap between what the system says and what actually ships.</p>
+
+    <div class="d-decisions" style="margin-top: 24px;">
+      <div class="d-decision">
+        <p class="d-decision__q">Handoff drift</p>
+        <p class="d-decision__a">A designer specs a component in Figma. An engineer builds it in code. The padding is 14px instead of 16px. The border radius is wrong. Nobody catches it because the Figma file and the codebase are two separate artifacts that nobody cross-references after launch. Over six months, hundreds of these small gaps accumulate. The system becomes a suggestion.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Token sprawl</p>
+        <p class="d-decision__a">The system defines 8 grays. An engineer adds a 9th because the existing ones don't quite work for their feature. Another team adds a 10th. Nobody removes the old ones. A year later, the codebase has 23 gray values and the Figma library still shows 8. The system is technically "adopted" but practically ignored.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Agentic generation</p>
+        <p class="d-decision__a">AI writes code fast. It can generate a full page of components in minutes. But it doesn't know your system unless you tell it — and even when you do, it hallucinates token names, invents spacing values, and creates components that look right but don't match the spec. Now drift happens at machine speed instead of human speed. Without automated checking, AI-assisted design makes the governance problem worse, not better.</p>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 24px;">
+      <p class="d-callout__body">The common thread: design systems fail when compliance depends on people remembering to check. Compliance has to be automatic or it doesn't happen.</p>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+    <p class="d-body">Systemic is a tool that reads what's actually in your product and compares it to what your design system says should be there. It finds the gaps automatically.</p>
+
+    <p class="d-label" style="margin-top: 32px;">How it works</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Crawl</span>
+        <span class="d-flow__step-desc">Point at a URL or load a local manifest. Systemic fetches the CSS.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Extract</span>
+        <span class="d-flow__step-desc">Parse every color, font, spacing value, and component pattern in use.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Map</span>
+        <span class="d-flow__step-desc">Match findings to Material Design 3 semantic tokens and your system's manifest.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Audit</span>
+        <span class="d-flow__step-desc">Stoplight scoring. Green = matches. Yellow = close. Red = drifted.</span>
+      </div>
+    </div>
+
+    <!-- Screenshots -->
+    <div class="d-gallery d-gallery--2" style="margin-top: 32px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Systems view — saved design systems with token and component counts</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Audit view — crawl progress, real-time log, export</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">QA view — stoplight variant audit with grid test</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 16/10; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Docs view — generated documentation with design/code split</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">What it audits</p>
+    <p class="d-body">Systemic checks the CTRL Design System — 4 CSS layers consumed by 5 products.</p>
+
+    <div style="padding: 24px; border-left: 2px solid var(--border-subtle, #33332f); margin-top: 16px; font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg-muted, #8a8885); white-space: pre; line-height: 1.8; overflow-x: auto;">tokens.css       → colors, type, spacing        (48 tokens)
+components.css   → buttons, inputs, cards        (24 components)
+widgets.css      → AI content templates          (11 templates)
+display.css      → marketing & portfolio         (this page)
+        ↓
+manifest.json    → auto-generated index
+        ↓
+Systemic         → crawl all 5 products → stoplight report</div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Design systems this thinking comes from</p>
+
+    <!-- Comparison table -->
+    <div style="margin-top: 16px; border: 1px solid var(--border-subtle, #33332f); font-family: var(--font-mono, monospace); font-size: 12px; overflow-x: auto;">
+      <table style="width: 100%; border-collapse: collapse; min-width: 600px;">
+        <thead>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;"></th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">Livongo</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">Invoy CIF</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">XP Health</th>
+            <th style="padding: 12px 16px; text-align: left; font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-subtle, #666560); font-weight: 600;">CTRL</th>
+          </tr>
+        </thead>
+        <tbody style="color: var(--fg-muted, #8a8885);">
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Source of truth</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">Figma</td>
+            <td style="padding: 10px 16px;">CSS</td>
+          </tr>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Governance</td>
+            <td style="padding: 10px 16px;">Team review</td>
+            <td style="padding: 10px 16px;">Documented rules</td>
+            <td style="padding: 10px 16px;">Informal</td>
+            <td style="padding: 10px 16px;">Automated</td>
+          </tr>
+          <tr style="border-bottom: 1px solid var(--border-subtle, #33332f);">
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Drift detection</td>
+            <td style="padding: 10px 16px;">Manual</td>
+            <td style="padding: 10px 16px;">Manual</td>
+            <td style="padding: 10px 16px;">None</td>
+            <td style="padding: 10px 16px;">Systemic</td>
+          </tr>
+          <tr>
+            <td style="padding: 10px 16px; color: var(--fg-subtle, #666560); font-size: 10px; text-transform: uppercase;">Result</td>
+            <td style="padding: 10px 16px;">Drifted over time</td>
+            <td style="padding: 10px 16px;">Held with effort</td>
+            <td style="padding: 10px 16px;">Never fully adopted</td>
+            <td style="padding: 10px 16px;">Enforced by machine</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why make the source of truth CSS instead of Figma?</p>
+        <p class="d-decision__a">When an AI writes code, it can read a CSS file. It can't read a Figma file. If the system lives in the same language the code is written in, there's no translation step. No translation means no drift from translation.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why stoplight scoring instead of pass/fail?</p>
+        <p class="d-decision__a">Real products have gray areas. A component might use the right color but the wrong spacing. Pass/fail forces you to either accept it or reject it entirely. Stoplights let you triage: fix the reds now, address the yellows this sprint, leave the greens alone.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why crawl the live product instead of checking the source code?</p>
+        <p class="d-decision__a">Source code shows what you intended. The live product shows what actually shipped. CSS overrides, runtime styles, and third-party scripts all change what the user sees. Systemic checks what's real, not what's planned.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">How does this change when AI is generating the UI?</p>
+        <p class="d-decision__a">AI makes the governance problem urgent. A designer might introduce one off-spec component per week. An AI can introduce ten per day. Without automated checking, AI-assisted design accelerates drift instead of reducing it. Systemic closes that loop — the AI generates, Systemic checks, I fix the violations.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 16px calc(-1 * clamp(20px, 5vw, 64px)) 0;">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Products audited</div>
+        <div class="d-metric__sub">Boards, Events, Soundscape, Systemic, Favicon</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">4</div>
+        <div class="d-metric__label">Systems informed the design</div>
+        <div class="d-metric__sub">Livongo, Invoy, XP Health, CTRL</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">0</div>
+        <div class="d-metric__label">Manual audits needed</div>
+        <div class="d-metric__sub">Systemic handles compliance checking</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body">The page you're reading is rendered by display.css — the newest layer of the CTRL Design System. Systemic audits it the same way it audits every other product. The portfolio is inside the system, not outside it.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="/livongo.html" class="d-next">← Livongo</a>
+  <a href="/how-i-work.html" class="d-next">How I Work →</a>
+</footer>
+
+<script src="/portfolio.js"></script>
+</body>
+</html>

--- a/field.html
+++ b/field.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Field — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="/" class="d-nav__name">CTRL.RODEO</a>
+  <ul class="d-nav__links">
+    <li><a href="/field.html" class="d-nav__link d-nav__link--active">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+  <a href="#faq" class="d-subnav__link">FAQ</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header — side by side -->
+  <div style="display: flex; gap: 32px; padding: 48px 0 0; align-items: flex-start;">
+    <!-- Image placeholder -->
+    <div style="width: 400px; aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); flex-shrink: 0;"></div>
+    <!-- Content -->
+    <div style="flex: 1;">
+      <span class="d-status d-status--dev">In Beta</span>
+      <p class="d-headline d-headline--xl" style="margin-top: 12px;">Field</p>
+      <p class="d-body" style="margin-top: 12px;">An app that turns spoken conversation into structured medical notes — built for first responders who can't stop treating a patient to write things down.</p>
+
+      <dl class="d-overview" style="margin-top: 24px;">
+        <dt>Role</dt>
+        <dd>Founder, sole designer</dd>
+        <dt>Timeline</dt>
+        <dd>March 2026 – Present (5 weeks)</dd>
+        <dt>Status</dt>
+        <dd>Beta with 2 outdoor ed programs, 3 guiding agencies</dd>
+        <dt>Key tech</dt>
+        <dd>On-device AI (Whisper, Llama 3.2), offline-first, GPS</dd>
+      </dl>
+    </div>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Search and rescue teams still use paper to document patient care. They write in the rain, in the dark, wearing gloves. Important details get lost. When they hand off a patient to a hospital, the notes are often incomplete or hard to read.</p>
+    <p class="d-body">Existing software was built for ambulances with Wi-Fi and keyboards. Nothing works for the backcountry — where there's <strong>no cell service, no keyboard, and no time to type.</strong></p>
+
+    <p class="d-label" style="margin-top: 32px;">Personas</p>
+    <div class="d-personas">
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Primary user</span>
+        <span class="d-persona__name">First Responder</span>
+        <ul class="d-persona__needs">
+          <li>Has to document while treating the patient. Wearing gloves, often in bad weather. Might be new — this could be their first real call.</li>
+        </ul>
+      </div>
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Receives the note</span>
+        <span class="d-persona__name">Professional EMS</span>
+        <ul class="d-persona__needs">
+          <li>Needs organized data, not handwritten paragraphs. Wants vitals and a treatment plan in standard format.</li>
+        </ul>
+      </div>
+      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+        <span class="d-persona__role">Information source</span>
+        <span class="d-persona__name">Patient</span>
+        <ul class="d-persona__needs">
+          <li>Describes symptoms out loud, often while in pain. Gives information out of order.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+    <p class="d-body" style="margin-bottom: 32px;">The responder talks to the patient. The app listens, logs all medical details, and creates a patient record and SOAP note automatically. When its time to handoff care, the patient record travels with the patient in a simple tap of your phone.</p>
+
+    <p class="d-label">How it works</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Voice</span>
+        <span class="d-flow__step-desc">Mic records the conversation</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Transcribe</span>
+        <span class="d-flow__step-desc">Whisper converts speech to text on-device</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Extract</span>
+        <span class="d-flow__step-desc">Llama finds medical details and sorts them</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Review</span>
+        <span class="d-flow__step-desc">Responder confirms or edits each field</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">05</span>
+        <span class="d-flow__step-label">Hand off</span>
+        <span class="d-flow__step-desc">Send via Wallet, satellite, clipboard</span>
+      </div>
+    </div>
+
+    <!-- Provider Use Cases -->
+    <p class="d-label" style="margin-top: 48px;">Provider Use Cases</p>
+    <div class="d-gallery d-gallery--3" style="margin-top: 16px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Record & Respond — Mic records the conversation</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Review — Mic records the conversation</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 1/1.8; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f);"></div>
+        <span class="d-gallery__caption">Hand Off — Mic records the conversation</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Key Design Decisions</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why does the AI fill in fields but still let the responder edit them?</p>
+        <p class="d-decision__a">Medical notes need human sign-off. The AI does the first pass — pulling a heart rate from the conversation, for example — but the responder has to confirm it. Faster than typing from scratch, safer than full automation.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why three colors for field status instead of just "done" or "not done"?</p>
+        <p class="d-decision__a">Green means confirmed. Amber means "check this before handoff." Red means conflicting data. Two states would hide the "probably right but double-check" category — the most common one.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why not use a regular keyboard for data entry?</p>
+        <p class="d-decision__a">Gloves make small buttons impossible. Large preset buttons at tailored intervals (ex. 60, 70, 80, 90, 100, 120 bpm for Heart Rate) and +1/-10 adjusters cover most cases in one or two taps.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 16px calc(-1 * clamp(20px, 5vw, 64px)) 0;">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Beta partners</div>
+        <div class="d-metric__sub">2 outdoor ed, 1 SAR, 2 guiding agencies</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">2</div>
+        <div class="d-metric__label">Licensing conversations</div>
+        <div class="d-metric__sub">National outdoor ed organizations</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">27</div>
+        <div class="d-metric__label">Screens designed</div>
+        <div class="d-metric__sub">Full app, patient list to handoff</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- FAQ -->
+  <div id="faq" class="d-section">
+    <p class="d-label">Frequently Asked Customer Questions</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Does it work offline?</p>
+        <p class="d-decision__a">Many rescue sites have no cell service. The app downloads two AI models and runs them locally. It works the same whether you're in town, in a canyon or 30 miles from the nearest cell tower.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Does the dictation actually work?</p>
+        <p class="d-decision__a">Our dictation model has been fine-tuned & tested using over 5000 clinical recordings. We carefully selected them for the situations you experience — high wind, rain, helicopter landings, ambient pain & multiple voices.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Is it compliant to the most recent privacy & data standards?</p>
+        <p class="d-decision__a">Field is compliant to most medical privacy & data standards (HIPAA, NEMSIS, FHIR R4, USCDI v3).</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">I am an EMT / Paramedic. Does it replace my patient care records (ePCR)?</p>
+        <p class="d-decision__a">Field works with your existing ePCR today. Its easy to send your records to your administrator to save their life easier — in a couple clicks they can add your Field Record to the right patient with all of the appropriate billing codes attached. Direct integrations are in our roadmap.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Do you support multiple casualty incidents (MCIs)?</p>
+        <p class="d-decision__a">Not yet. We are working with our search and rescue partners to follow FEMA command structures, following known best practices & participating in MCI scenarios to take the cognitive load off of all parties when managing patient care.</p>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="/" class="d-next">← Overview</a>
+  <a href="/invoy.html" class="d-next">Invoy →</a>
+</footer>
+
+<script src="/portfolio.js"></script>
+</body>
+</html>

--- a/how-i-work.html
+++ b/how-i-work.html
@@ -1,0 +1,558 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How I Work — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="/" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="/field.html" class="d-nav__link">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link d-nav__link--active">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#stack" class="d-subnav__link">Stack</a>
+  <a href="#system" class="d-subnav__link">Design System</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#map" class="d-subnav__link">Process Map</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--active">Active</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">How I Work</p>
+    <p class="d-body" style="margin-top: 12px;">I use a design system as the shared language between me and AI tools. The system defines the rules. The AI writes code that follows them. I review and ship.</p>
+
+    <dl class="d-overview">
+      <dt>Setup</dt>
+      <dd>Solo designer, no design team</dd>
+      <dt>Products</dt>
+      <dd>Boards, Events, Soundscape, Systemic, Favicon</dd>
+      <dt>Tools</dt>
+      <dd>CTRL Design System, Systemic (auditor), Claude Code</dd>
+      <dt>Output</dt>
+      <dd>5 products with consistent quality, shipped continuously</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">One person, five products, daily shipping. The challenge isn't design skill — it's <strong>maintaining consistency at speed without a team.</strong> The answer: make the design system do the enforcement so I can focus on decisions.</p>
+  </div>
+
+  <!-- STACK -->
+  <div id="stack" class="d-section">
+    <p class="d-label">Stack</p>
+    <div class="d-grid-3" style="margin-top: 16px;">
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">CTRL DESIGN SYSTEM</p>
+        <p class="d-body" style="font-size: 12px;">CSS files that define colors, type, spacing, components, and AI widget templates. 48 tokens, 24 components, 11 widget types.</p>
+      </div>
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">SYSTEMIC</p>
+        <p class="d-body" style="font-size: 12px;">A tool I built that crawls websites, extracts their design tokens, and checks them against the design system rules. Flags violations automatically.</p>
+      </div>
+      <div>
+        <p class="d-mono" style="margin-bottom: 8px;">CLAUDE CODE</p>
+        <p class="d-body" style="font-size: 12px;">AI that writes code. I give it a feature spec and the design system. It generates components that follow the system's rules. I review and ship.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- DESIGN SYSTEM -->
+  <div id="system" class="d-section">
+    <p class="d-label">Design System</p>
+    <p class="d-body">The system isn't a Figma library. It's four CSS files. Change the code, run a script, and every product picks up the update. No syncing, no handoff document.</p>
+
+    <div class="d-callout" style="margin-top: 24px; font-family: var(--font-mono, monospace); font-size: 12px; color: var(--fg-muted, #8a8885); white-space: pre; line-height: 1.8; overflow-x: auto;">tokens.css       → colors, type, spacing
+components.css   → buttons, inputs, cards
+widgets.css      → AI-generated content templates
+display.css      → marketing and portfolio pages
+        ↓
+manifest.json    → auto-generated index
+        ↓
+Systemic         → automated QA checks</div>
+
+    <div class="d-grid-2" style="margin-top: 24px;">
+      <div>
+        <p class="d-body" style="font-size: 12px;"><strong>Four layers.</strong> All use the same tokens. All follow the same naming rules. display.css — the one rendering this page — is the newest addition.</p>
+      </div>
+      <div>
+        <p class="d-body" style="font-size: 12px;"><strong>11 widget templates.</strong> AI generates content that fits into defined layouts (lists, comparisons, stats, checklists, etc.). The AI picks the format; the system controls the look.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Intent</span>
+        <span class="d-flow__step-desc">I describe what I want to build</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Design System</span>
+        <span class="d-flow__step-desc">Gives the AI rules to follow</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Claude Code</span>
+        <span class="d-flow__step-desc">Writes the code within those rules</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Systemic</span>
+        <span class="d-flow__step-desc">Checks the output against the system</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">05</span>
+        <span class="d-flow__step-label">Ship</span>
+        <span class="d-flow__step-desc">Push to GitHub Pages</span>
+      </div>
+    </div>
+
+    <p class="d-body" style="margin-top: 24px;">When I say "use --accent-cyan on the focus ring," the AI looks up the same token I defined. The design system is a shared vocabulary between me and the machine. It doesn't get stale because it's the live code — not a document about the code.</p>
+  </div>
+
+  <!-- PROCESS MAP -->
+  <div id="map" class="d-section">
+    <p class="d-label">Process Map</p>
+    <p class="d-body" style="margin-bottom: 32px;">Click any node for detail: why it exists, the rules the AI follows, and the goals it serves.</p>
+
+    <style>
+      .pm { display: flex; flex-direction: column; gap: 32px; }
+      .pm-layer { display: flex; flex-direction: column; gap: 2px; }
+      .pm-layer__label {
+        font-family: var(--font-mono, monospace);
+        font-size: 10px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-subtle, #666560);
+        padding: 12px 0 8px;
+      }
+      .pm-layer__cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1px; background: var(--border-subtle, #33332f); }
+      .pm-card {
+        padding: 16px 20px;
+        background: var(--bg, #111110);
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+      .pm-card:hover { background: var(--bg-surface, #1a1a18); }
+      .pm-card--active { background: var(--bg-elevated, #22221f); border-left: 2px solid var(--accent-cyan, #00fff7); }
+      .pm-card__name {
+        font-family: var(--font-display, 'Space Grotesk', sans-serif);
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--fg, #e8e6e3);
+        margin-bottom: 4px;
+      }
+      .pm-card__desc {
+        font-family: var(--font-mono, monospace);
+        font-size: 11px;
+        color: var(--fg-subtle, #666560);
+        line-height: 1.5;
+      }
+      .pm-panel {
+        position: fixed;
+        top: 0; right: 0; bottom: 0;
+        width: 420px;
+        max-width: 90vw;
+        background: var(--bg-surface, #1a1a18);
+        border-left: 1px solid var(--border-subtle, #33332f);
+        z-index: 200;
+        transform: translateX(100%);
+        transition: transform 0.25s ease;
+        overflow-y: auto;
+        padding: 32px 28px;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+      .pm-panel--open { transform: translateX(0); }
+      .pm-panel__close {
+        position: absolute; top: 16px; right: 16px;
+        background: none; border: none; cursor: pointer;
+        font-family: var(--font-mono, monospace);
+        font-size: 18px; color: var(--fg-subtle, #666560);
+      }
+      .pm-panel__close:hover { color: var(--fg, #e8e6e3); }
+      .pm-panel__name {
+        font-family: var(--font-display, 'Space Grotesk', sans-serif);
+        font-size: 20px; font-weight: 600;
+        color: var(--fg, #e8e6e3);
+      }
+      .pm-panel__layer {
+        font-family: var(--font-mono, monospace);
+        font-size: 10px; letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--fg-subtle, #666560);
+      }
+      .pm-panel__section-label {
+        font-family: var(--font-mono, monospace);
+        font-size: 10px; letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--accent-cyan, #00fff7);
+        margin-bottom: 6px;
+      }
+      .pm-panel__text {
+        font-family: var(--font-mono, monospace);
+        font-size: 13px; line-height: 1.7;
+        color: var(--fg-muted, #8a8885);
+      }
+      .pm-panel__text ul { list-style: none; padding: 0; }
+      .pm-panel__text li { padding-left: 16px; position: relative; margin-bottom: 4px; }
+      .pm-panel__text li::before { content: '—'; position: absolute; left: 0; color: var(--fg-subtle, #666560); }
+      .pm-overlay {
+        position: fixed; inset: 0;
+        background: rgba(0,0,0,0.5);
+        z-index: 199;
+        opacity: 0; pointer-events: none;
+        transition: opacity 0.2s;
+      }
+      .pm-overlay--open { opacity: 1; pointer-events: auto; }
+    </style>
+
+    <div class="pm">
+
+      <!-- TOOLS -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Tools</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="claude-code">
+            <div class="pm-card__name">Claude Code</div>
+            <div class="pm-card__desc">Primary execution environment for AI-assisted design</div>
+          </div>
+          <div class="pm-card" data-node="paper">
+            <div class="pm-card__name">Paper</div>
+            <div class="pm-card__desc">Visual source of truth, kept in sync with code</div>
+          </div>
+          <div class="pm-card" data-node="systemic">
+            <div class="pm-card__name">Systemic</div>
+            <div class="pm-card__desc">Generates structured design systems from existing code</div>
+          </div>
+          <div class="pm-card" data-node="obsidian">
+            <div class="pm-card__name">Obsidian</div>
+            <div class="pm-card__desc">Stable context as portable .md files</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- CONTEXT -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Context</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="ecosystem">
+            <div class="pm-card__name">Ecosystem Context</div>
+            <div class="pm-card__desc">Business goals, founder vision, metrics, stakeholders</div>
+          </div>
+          <div class="pm-card" data-node="personas">
+            <div class="pm-card__name">Personas</div>
+            <div class="pm-card__desc">Semantic anchors for all UI generation</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DESIGN SYSTEM -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Design System</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="atomic">
+            <div class="pm-card__name">Atomic Hierarchy</div>
+            <div class="pm-card__desc">Particles → Atoms → Molecules → Organisms → Templates → Pages</div>
+          </div>
+          <div class="pm-card" data-node="philosophy">
+            <div class="pm-card__name">System Philosophy</div>
+            <div class="pm-card__desc">Intent behind decisions so AI can make judgment calls</div>
+          </div>
+          <div class="pm-card" data-node="ai-rules">
+            <div class="pm-card__name">Global AI Rules</div>
+            <div class="pm-card__desc">Constraints that prevent the most common failure modes</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- PRODUCT MAP & IA -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Product Map & IA</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="product-map">
+            <div class="pm-card__name">Product Map</div>
+            <div class="pm-card__desc">Surface inventory so AI doesn't conflict with existing structure</div>
+          </div>
+          <div class="pm-card" data-node="ia">
+            <div class="pm-card__name">IA & Workflow Architecture</div>
+            <div class="pm-card__desc">The highest-touch human step — page vs modal vs drawer</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- DESIGNING -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Designing</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="use">
+            <div class="pm-card__name">Use</div>
+            <div class="pm-card__desc">Design new flows using the existing system</div>
+          </div>
+          <div class="pm-card" data-node="extension">
+            <div class="pm-card__name">Extension</div>
+            <div class="pm-card__desc">When a new component is genuinely warranted</div>
+          </div>
+          <div class="pm-card" data-node="review">
+            <div class="pm-card__name">Review</div>
+            <div class="pm-card__desc">Quality gate before engineering handoff</div>
+          </div>
+          <div class="pm-card" data-node="auditing">
+            <div class="pm-card__name">Auditing</div>
+            <div class="pm-card__desc">Find where implementation diverged from spec</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- EXAMPLE -->
+      <div class="pm-layer">
+        <div class="pm-layer__label">Example in Practice</div>
+        <div class="pm-layer__cards">
+          <div class="pm-card" data-node="field-example">
+            <div class="pm-card__name">Field</div>
+            <div class="pm-card__desc">AI clinical documentation — extreme IA constraints in action</div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /pm -->
+
+    <!-- Overlay -->
+    <div class="pm-overlay" id="pmOverlay"></div>
+
+    <!-- Detail Panel -->
+    <div class="pm-panel" id="pmPanel">
+      <button class="pm-panel__close" id="pmClose">×</button>
+      <div class="pm-panel__layer" id="pmLayer"></div>
+      <div class="pm-panel__name" id="pmName"></div>
+      <div>
+        <div class="pm-panel__section-label">Why</div>
+        <div class="pm-panel__text" id="pmWhy"></div>
+      </div>
+      <div>
+        <div class="pm-panel__section-label">Rules</div>
+        <div class="pm-panel__text" id="pmRules"></div>
+      </div>
+      <div>
+        <div class="pm-panel__section-label">Goals</div>
+        <div class="pm-panel__text" id="pmGoals"></div>
+      </div>
+    </div>
+
+    <script>
+    (function() {
+      var nodes = {
+        'claude-code': {
+          layer: 'Tools',
+          name: 'Claude Code',
+          why: 'The primary execution environment for all AI-assisted design work. Skills extend its capabilities for specific design tasks.',
+          rules: '<ul><li>Skills are invoked explicitly per task</li><li>Claude Code never invents values or component names not present in source</li><li>All output is scoped to what exists in the design system</li></ul>',
+          goals: 'Consistent, context-aware UI generation. Reduce manual translation between design intent and code.'
+        },
+        'paper': {
+          layer: 'Tools',
+          name: 'Paper (App + MCP)',
+          why: 'Visual source of truth for the design system. Lives alongside the code implementation and is kept in sync via prompts.',
+          rules: '<ul><li>Paper is never the final source — code is</li><li>Paper is the human-readable reference</li><li>Any divergence between Paper and code must be flagged and resolved before a feature ships</li></ul>',
+          goals: 'Give designers and engineers a shared visual reference. Make design system drift visible.'
+        },
+        'systemic': {
+          layer: 'Tools',
+          name: 'Systemic',
+          why: 'Solves the cold-start problem. Most teams have either no design system or an undocumented one. Systemic reads the existing codebase and generates a structured atomic design system with dummy copy for all components.',
+          rules: '<ul><li>Output follows strict atomic hierarchy: Particles → Atoms → Molecules → Organisms → Templates → Pages</li><li>No components are invented — everything is derived from what exists in source</li><li>Dummy copy is realistic but clearly placeholder</li></ul>',
+          goals: 'Give any team a documented, structured design system within hours. Make the AI-native process immediately applicable to existing codebases.'
+        },
+        'obsidian': {
+          layer: 'Tools',
+          name: 'Obsidian',
+          why: 'All stable context — personas, ecosystem docs, system philosophy — lives as .md files. This makes context portable, versionable, and injectable into any AI prompt.',
+          rules: '<ul><li>.md files are read-only inputs to design sessions</li><li>They are updated only through deliberate decisions, not as a byproduct of design work</li><li>If home-built, Skills are used to manage and query them</li></ul>',
+          goals: 'Persistent, structured context that survives across sessions and team members.'
+        },
+        'ecosystem': {
+          layer: 'Context',
+          name: 'Ecosystem Context',
+          why: 'AI-generated design without business context produces technically correct but strategically wrong output. This layer anchors every design decision to the product\'s actual goals.',
+          rules: '<ul><li>Must include: problem space, founder vision, business goals, metrics, ownership, stakeholders</li><li>AI may not make structural design decisions without this context present</li></ul>',
+          goals: 'Ensure all design work is in service of the actual product strategy, not just user needs in isolation.'
+        },
+        'personas': {
+          layer: 'Context',
+          name: 'Personas',
+          why: 'Personas are the semantic anchor for UI generation. They define who the interface is for, what constraints they operate under, and what success looks like for them.',
+          rules: '<ul><li>Personas are stable .md documents — they do not change per session</li><li>AI uses personas as constraints, not suggestions</li><li>If a design decision conflicts with a persona\'s known constraints, it must be flagged</li></ul>',
+          goals: 'Generate UI that is fit for the actual user, not a generic one. Prevent AI from optimizing for the wrong person.'
+        },
+        'atomic': {
+          layer: 'Design System',
+          name: 'Atomic Hierarchy',
+          why: 'Atomic design creates a shared vocabulary between designers, engineers, and AI. When everyone refers to the same named components at the same level of abstraction, drift is caught earlier.',
+          rules: '<ul><li>Particles (tokens) → Atoms → Molecules → Organisms → Templates → Pages</li><li>No skipping levels</li><li>AI may only compose upward — an Atom may not contain an Organism</li><li>Tokens are the only source for values; no hardcoded colors, spacing, or typography</li></ul>',
+          goals: 'A single composable system where every element traces back to a token. Makes AI-generated UI predictable and auditable.'
+        },
+        'philosophy': {
+          layer: 'Design System',
+          name: 'System Philosophy',
+          why: 'Rules without reasoning produce brittle systems. System philosophy documents the intent behind decisions so AI can make judgment calls consistent with the system\'s values.',
+          rules: '<ul><li>Must include: system intent, transactional rules, aesthetic principles, design principles in "Given [need], do [constraint]" format</li><li>Common tradeoffs and known gaps documented</li><li>AI references this before making any non-obvious design decision</li></ul>',
+          goals: 'Give AI enough context to make good novel decisions, not just pattern-match to existing components.'
+        },
+        'ai-rules': {
+          layer: 'Design System',
+          name: 'Global AI Rules',
+          why: 'Without explicit constraints, AI optimizes for plausibility, not correctness. These rules prevent the most common failure modes.',
+          rules: '<ul><li>Extract before you write: read the full design system before generating anything</li><li>No invented values: every value must come from a token</li><li>Pixel-match check after every component</li><li>Only what exists in source: no new patterns without explicit extension approval</li><li>Values come from tokens, not screenshots</li></ul>',
+          goals: 'Eliminate drift at the generation step, before review is needed.'
+        },
+        'product-map': {
+          layer: 'Product Map & IA',
+          name: 'Product Map',
+          why: 'AI needs to know where a feature lives before it can design it. The product map gives AI a surface inventory so it doesn\'t generate UI that conflicts with existing navigation or structure.',
+          rules: '<ul><li>Must document: all surfaces, navigation structure, entry points per persona, ownership</li><li>AI may not design a new surface without the product map being updated first</li><li>New surfaces require human approval</li></ul>',
+          goals: 'Prevent AI from generating features in a vacuum. Keep the product coherent as it grows.'
+        },
+        'ia': {
+          layer: 'Product Map & IA',
+          name: 'IA & Workflow Architecture',
+          why: 'This is the highest-touch human step in the process. Before any UI is generated, a human designer decides the structural approach: page vs modal vs drawer, flow sequence, where the user comes from and where they go next.',
+          rules: '<ul><li>IA decisions are documented in .md and appended to the Paper file before any feature-level design begins</li><li>AI may suggest IA options but may not select them</li><li>The human must make the final call</li><li>No feature design begins without an IA decision on record</li></ul>',
+          goals: 'Preserve human judgment at the structural level. Ensure AI operates within a deliberate information architecture, not one it inferred.'
+        },
+        'use': {
+          layer: 'Designing',
+          name: 'Use',
+          why: 'The most common mode. Using the existing system to design new flows without extending it.',
+          rules: '<ul><li>Feature is written as a story or requirements doc first</li><li>Design system and codebase context are both present in the prompt</li><li>AI generates UI constrained to existing components and tokens only</li><li>Any deviation is flagged — not auto-resolved</li></ul>',
+          goals: 'High-velocity feature design that stays within system bounds. Zero invented components.'
+        },
+        'extension': {
+          layer: 'Designing',
+          name: 'Extension',
+          why: 'Sometimes a new component is genuinely warranted. Extension mode handles this deliberately rather than letting it happen by accident.',
+          rules: '<ul><li>AI must explicitly name the proposed new component</li><li>Justify why no existing component can serve this need</li><li>Flag it as a review item</li><li>The new component does not enter the design system until it passes a dedicated review gate</li><li>No extension happens silently</li></ul>',
+          goals: 'Controlled system growth. Every new component is a deliberate decision, not a side effect.'
+        },
+        'review': {
+          layer: 'Designing',
+          name: 'Review',
+          why: 'Design review happens before handoff to engineering, not after. This is the quality gate.',
+          rules: '<ul><li>AI flags: spacing inconsistencies, typography violations, color deviations, visual hierarchy issues, component misuse</li><li>Human reviews in Paper</li><li>Nothing moves to engineering without sign-off</li><li>Review is not optional</li></ul>',
+          goals: 'Catch quality issues before they become engineering debt. Maintain the gap between "designed" and "shipped" as a quality buffer.'
+        },
+        'auditing': {
+          layer: 'Designing',
+          name: 'Auditing',
+          why: 'Drift accumulates silently. Auditing finds where the implemented product has diverged from the design system.',
+          rules: '<ul><li>Auditing compares implemented components against design system spec</li><li>All deviations are documented</li><li>Deviations categorized: acceptable tradeoff, known gap, or violation requiring remediation</li><li>Audit results feed back into system philosophy as known gaps</li></ul>',
+          goals: 'Make drift visible and addressable. Prevent the design system from becoming aspirational rather than actual.'
+        },
+        'field-example': {
+          layer: 'Example in Practice',
+          name: 'Field',
+          why: 'Field is an AI-assisted clinical documentation app for first responders. It illustrates the IA and workflow architecture phase because the design constraints are extreme: users operate in austere environments, under stress, with one hand, often in the dark.',
+          rules: '<ul><li>Personas were defined before any UI was generated</li><li>IA decisions were made with explicit reference to operational context (no modals in a moving vehicle)</li><li>Every flow was mapped before any screen was designed</li></ul>',
+          goals: 'Show how the methodology handles high-constraint design problems where getting the IA wrong has real consequences.'
+        }
+      };
+
+      var panel = document.getElementById('pmPanel');
+      var overlay = document.getElementById('pmOverlay');
+      var activeCard = null;
+
+      function openPanel(key) {
+        var d = nodes[key];
+        if (!d) return;
+        document.getElementById('pmLayer').textContent = d.layer;
+        document.getElementById('pmName').textContent = d.name;
+        document.getElementById('pmWhy').innerHTML = d.why;
+        document.getElementById('pmRules').innerHTML = d.rules;
+        document.getElementById('pmGoals').innerHTML = d.goals;
+        panel.classList.add('pm-panel--open');
+        overlay.classList.add('pm-overlay--open');
+        if (activeCard) activeCard.classList.remove('pm-card--active');
+        activeCard = document.querySelector('[data-node="' + key + '"]');
+        if (activeCard) activeCard.classList.add('pm-card--active');
+      }
+
+      function closePanel() {
+        panel.classList.remove('pm-panel--open');
+        overlay.classList.remove('pm-overlay--open');
+        if (activeCard) { activeCard.classList.remove('pm-card--active'); activeCard = null; }
+      }
+
+      document.querySelectorAll('.pm-card').forEach(function(card) {
+        card.addEventListener('click', function() { openPanel(card.dataset.node); });
+      });
+      document.getElementById('pmClose').addEventListener('click', closePanel);
+      overlay.addEventListener('click', closePanel);
+      document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closePanel(); });
+    })();
+    </script>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">5</div>
+        <div class="d-metric__label">Products</div>
+        <div class="d-metric__sub">Boards, Events, Soundscape, Systemic, Favicon</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">1</div>
+        <div class="d-metric__label">Designer</div>
+        <div class="d-metric__sub">Consistent quality across all five</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">4</div>
+        <div class="d-metric__label">CSS layers</div>
+        <div class="d-metric__sub">tokens → components → widgets → display</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body">This portfolio is built with this system. display.css is a permanent part of the design system, not a one-off stylesheet. Every element on this page uses the same tokens as the products.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="/livongo.html" class="d-next">← Livongo</a>
+  <a href="/" class="d-next">Overview →</a>
+</footer>
+
+<script src="/portfolio.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
 <nav class="d-nav">
   <a href="/" class="d-nav__name">CTRL.RODEO</a>
   <ul class="d-nav__links">
-    <li><a href="/portfolio/field.html" class="d-nav__link">Field</a></li>
-    <li><a href="/portfolio/invoy.html" class="d-nav__link">Invoy</a></li>
-    <li><a href="/portfolio/livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="/portfolio/how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="/field.html" class="d-nav__link">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 
@@ -40,19 +40,19 @@
   <div class="d-section">
     <p class="d-label">Suggested for you</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="/portfolio/field.html" class="d-card">
+      <a href="/field.html" class="d-card">
         <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
         <span class="d-card__title">Voice-First Clinical Documentation</span>
         <span class="d-card__desc">Voice-driven clinical documentation for first responders. On-device AI, offline-first</span>
         <span class="d-card__tag" style="margin-top: auto;">Beta</span>
       </a>
-      <a href="/portfolio/invoy.html" class="d-card">
+      <a href="/invoy.html" class="d-card">
         <span class="d-card__tag">Behavior Change · Design System</span>
         <span class="d-card__title">Engagement Loops & Weight Loss</span>
         <span class="d-card__desc">Weekly behavioral coaching lifecycle. MVP design system.</span>
         <span class="d-card__tag" style="margin-top: auto;">Shipped</span>
       </a>
-      <a href="/portfolio/livongo.html" class="d-card">
+      <a href="/livongo.html" class="d-card">
         <span class="d-card__tag">Infrastructure · B2B · Scale</span>
         <span class="d-card__title">B2B Sales Configuration & End User Onboarding</span>
         <span class="d-card__desc">Simplifying product configuration at enterprise scale.</span>
@@ -64,7 +64,7 @@
   <div class="d-section">
     <p class="d-label">Utilities</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="/portfolio/how-i-work.html" class="d-card">
+      <a href="/how-i-work.html" class="d-card">
         <span class="d-card__tag">AI · iOS · 0→1</span>
         <span class="d-card__title">Design System Manager</span>
         <span class="d-card__desc">Generate and manage your design system from Figma, Paper, Github or live code.</span>
@@ -107,7 +107,7 @@
     <p class="d-label">How I Work</p>
     <p class="d-headline d-headline--lg">One designer, five products, AI-assisted delivery.</p>
     <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
-    <a href="/portfolio/how-i-work.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
+    <a href="/how-i-work.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
   </div>
 
 </div>
@@ -116,6 +116,6 @@
   <span class="d-mono">← → to navigate</span>
 </footer>
 
-<script src="/portfolio/portfolio.js"></script>
+<script src="/portfolio.js"></script>
 </body>
 </html>

--- a/invoy.html
+++ b/invoy.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Invoy — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="/" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="/field.html" class="d-nav__link">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link d-nav__link--active">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--shipped">Shipped</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy</p>
+    <p class="d-body" style="margin-top: 12px;">A weekly coaching system for metabolic health. Members plan their week, check in daily, review their progress, and adjust — with coach support when the data says they need it.</p>
+
+    <dl class="d-overview">
+      <dt>Role</dt>
+      <dd>Lead product designer</dd>
+      <dt>Company</dt>
+      <dd>Livongo / Teladoc Health</dd>
+      <dt>Platform</dt>
+      <dd>iOS, Android</dd>
+      <dt>Scope</dt>
+      <dd>15+ sub-flows, 30-component design system, 100+ screens</dd>
+      <dt>Status</dt>
+      <dd>Shipped to production</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Most health apps treat each screen as a standalone moment. You check in today, but the app doesn't connect that to what you planned this week or what happened yesterday. The member has to hold the context in their head.</p>
+    <p class="d-body">Invoy needed a <strong>loop, not a list of features</strong>. Weekly planning should shape daily actions. Daily data should trigger coaching. Weekly review should change next week's plan.</p>
+
+    <div class="d-personas">
+      <div class="d-persona">
+        <span class="d-persona__role">Primary user</span>
+        <span class="d-persona__name">Member</span>
+        <ul class="d-persona__needs">
+          <li>Wants to know what to eat today based on their plan</li>
+          <li>Needs to see progress without reading charts</li>
+          <li>Wants to get back on track after a bad day without guilt</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Secondary user</span>
+        <span class="d-persona__name">Coach</span>
+        <ul class="d-persona__needs">
+          <li>Manages 50+ members — needs to spot who needs help fast</li>
+          <li>Wants data-backed reasons to reach out</li>
+          <li>Needs to suggest specific plan changes</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+
+    <p class="d-label" style="margin-top: 24px;">The weekly loop</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">01</span>
+        <span class="d-flow__step-label">Plan</span>
+        <span class="d-flow__step-desc">Set goals. Flag upcoming events. The app picks one of 5 plan types.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">02</span>
+        <span class="d-flow__step-label">Execute</span>
+        <span class="d-flow__step-desc">Daily check-ins. Breath test, mood, meals, plan tracking.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">03</span>
+        <span class="d-flow__step-label">Reflect</span>
+        <span class="d-flow__step-desc">End-of-week review. Weight change, plan completion, trends.</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">04</span>
+        <span class="d-flow__step-label">Adapt</span>
+        <span class="d-flow__step-desc">Coach reviews patterns. Next week's plan adjusts.</span>
+      </div>
+    </div>
+
+    <div class="d-gallery d-gallery--4" style="margin-top: 32px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Week Planning [screenshot]</span></div>
+        <span class="d-gallery__caption">Set intentions, flag events. 5 plan variants from one entry point.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Daily Focus [screenshot]</span></div>
+        <span class="d-gallery__caption">Daily check-in with score factors and nutrition tracking.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Review of Week [screenshot]</span></div>
+        <span class="d-gallery__caption">Weight change, progress bars, trend line, day-by-day activity grid.</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Rebound [screenshot]</span></div>
+        <span class="d-gallery__caption">When the score drops: what happened, possible causes, next steps.</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Design System</p>
+    <p class="d-body">30 components with rules for when to use each one. The system tells the team which page template to start with, which button style means "go forward" vs "dismiss," and which card to show when the score drops vs. when it rises.</p>
+
+    <div class="d-decisions" style="margin-top: 16px;">
+      <div class="d-decision">
+        <p class="d-decision__q">Page/Title vs Page/Questions</p>
+        <p class="d-decision__a">Title pages explain what's coming. Questions pages collect data. A sub-flow always starts with a Title page — never a Questions page.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Button hierarchy</p>
+        <p class="d-decision__a">Dark button = main action. Light button = alternative. Text-only = dismiss. Same rule on every screen in every flow.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Score → card mapping</p>
+        <p class="d-decision__a">Score drops get an amber card with "what we know" and a coach button. Score increases get a green card with encouragement. This is documented, not decided per screen.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why does one question ("any events this week?") split into 5 different flows?</p>
+        <p class="d-decision__a">Members shouldn't need to understand the system's logic. If they have a busy week, the app gives them a lighter plan with optional boosters. If they're planning a cheat meal, the rebound flow activates. The routing is automatic — one question does the work of a settings page.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why treat a bad day as a "rebound" instead of a failure?</p>
+        <p class="d-decision__a">Most health apps make you feel bad when you go off plan. Invoy built a dedicated recovery flow: it shows what happened, suggests why, and offers specific next steps like scheduling a coach call or adding a fasting boost. Members who see a path back stay engaged. Members who feel judged stop opening the app.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why pack so much data into the weekly review screen?</p>
+        <p class="d-decision__a">People look at this once a week. It has to be complete and fast to scan. Weight change, three progress bars, a week-long trend line, a day-by-day activity grid, and an AI-written summary — all on one scroll. Every number is readable without explanation.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">↑</div>
+        <div class="d-metric__label">Daily check-in completion</div>
+        <div class="d-metric__sub">Connected weekly planning to daily engagement</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↑</div>
+        <div class="d-metric__label">Weight loss outcomes</div>
+        <div class="d-metric__sub">Closed loop between data, coaching, and plan adaptation</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">30</div>
+        <div class="d-metric__label">Components shipped</div>
+        <div class="d-metric__sub">Design system with documented governance rules</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="/field.html" class="d-next">← Field</a>
+  <a href="/livongo.html" class="d-next">Livongo →</a>
+</footer>
+
+<script src="/portfolio.js"></script>
+</body>
+</html>

--- a/livongo.html
+++ b/livongo.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Livongo Config — Ian Fike</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/design-system/display.css">
+</head>
+<body class="d-page">
+
+<nav class="d-nav">
+  <a href="/" class="d-nav__name">Ian Fike</a>
+  <ul class="d-nav__links">
+    <li><a href="/field.html" class="d-nav__link">Field</a></li>
+    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+    <li><a href="/livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
+    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+  </ul>
+</nav>
+
+<div class="d-subnav">
+  <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#impact" class="d-subnav__link">Impact</a>
+</div>
+
+<div class="d-contain">
+
+  <!-- Header + Overview -->
+  <div style="padding: 48px 0 0;">
+    <span class="d-status d-status--shipped">Shipped</span>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Config</p>
+    <p class="d-body" style="margin-top: 12px;">Livongo sold 5 health programs in dozens of combinations. Each combination changed which fields a member saw during registration. The rules lived in a spreadsheet. We turned it into a system.</p>
+
+    <dl class="d-overview">
+      <dt>Role</dt>
+      <dd>Product designer, growth PM</dd>
+      <dt>Company</dt>
+      <dd>Livongo / Teladoc Health</dd>
+      <dt>Scope</dt>
+      <dd>50 client configs × 74 fields = 3,700 decision points</dd>
+      <dt>Platform</dt>
+      <dd>Web (registration flow), Salesforce (config), internal APIs</dd>
+      <dt>Status</dt>
+      <dd>Shipped to production</dd>
+    </dl>
+  </div>
+
+  <!-- FRAMING -->
+  <div id="framing" class="d-section">
+    <p class="d-label">Framing</p>
+    <p class="d-body">Every time Livongo signed a new client, someone on the operations team opened a 74-column spreadsheet and figured out which registration fields to show, require, or hide for that client's program bundle. A standalone diabetes client got one set of fields. A "Whole Person" bundle with diabetes, hypertension, and weight management got a different set. <strong>The spreadsheet was the product's truth table.</strong></p>
+    <p class="d-body">This was slow, error-prone, and didn't scale. New client launches took days of manual setup. Mistakes meant members saw the wrong fields or couldn't register at all.</p>
+
+    <div class="d-personas">
+      <div class="d-persona">
+        <span class="d-persona__role">Configures the deal</span>
+        <span class="d-persona__name">Sales</span>
+        <ul class="d-persona__needs">
+          <li>Picks program bundles in Salesforce</li>
+          <li>Doesn't think about what fields that affects</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Sets up the flow</span>
+        <span class="d-persona__name">Implementation</span>
+        <ul class="d-persona__needs">
+          <li>Translates the deal into a registration config</li>
+          <li>Cross-references 74 columns for each client</li>
+        </ul>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Registers</span>
+        <span class="d-persona__name">Member</span>
+        <ul class="d-persona__needs">
+          <li>Wants to sign up quickly</li>
+          <li>Should only see fields that matter to their program</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- DELIVERABLE -->
+  <div id="deliverable" class="d-section">
+    <p class="d-label">Deliverable</p>
+
+    <p class="d-label" style="margin-top: 24px;">Architecture</p>
+    <p class="d-body" style="margin-bottom: 16px;">Three systems work together. Sales configures the deal. APIs resolve member data before the first screen loads. The registration flow adapts to show only what's needed.</p>
+    <div class="d-flow">
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">SF</span>
+        <span class="d-flow__step-label">Salesforce</span>
+        <span class="d-flow__step-desc">Bundle, pricing, eligibility rules, field visibility</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">API</span>
+        <span class="d-flow__step-label">Data Resolution</span>
+        <span class="d-flow__step-desc">Employer, health records, and insurance pre-fill fields</span>
+      </div>
+      <span class="d-flow__arrow">→</span>
+      <div class="d-flow__step">
+        <span class="d-flow__step-num">UX</span>
+        <span class="d-flow__step-label">Registration</span>
+        <span class="d-flow__step-desc">6 steps. Member confirms what the system already knows.</span>
+      </div>
+    </div>
+
+    <hr class="d-rule">
+
+    <p class="d-label">Before and after</p>
+    <div class="d-grid-2" style="margin-top: 16px;">
+      <div>
+        <p class="d-body"><strong>Before: 9 steps.</strong> Enter name, address, search for coverage, verify insurance, enter health info, set up coaching, complete profile. Everything typed from scratch.</p>
+      </div>
+      <div>
+        <p class="d-body"><strong>After: 6 steps.</strong> Confirm identity, create account, review program details from records, confirm health history, confirm shipping address, done. Coverage handled server-side. Coaching deferred to first use.</p>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px;">
+      <p class="d-callout__body">The full comparison with a filterable breakdown of all 35 fields is at <a href="/reg/" style="color: var(--color-link, #00fff7);">ctrl.rodeo/reg/</a></p>
+    </div>
+  </div>
+
+  <!-- PROCESS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why show pre-filled fields instead of blank forms?</p>
+        <p class="d-decision__a">Three services pull the member's data before they see a single screen: employer HR for name and address, health records for diagnosis, carrier data for insurance. The member confirms what's already there instead of typing it in. Faster, fewer errors.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why remove the coverage steps entirely?</p>
+        <p class="d-decision__a">If the employer sponsors the member, coverage is already verified. Asking the member to search for their employer, wait for verification, and enter insurance details added 3 steps and about 2 minutes for information the system already had.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why not ask about coaching preferences during registration?</p>
+        <p class="d-decision__a">People can't set meaningful preferences for a product they haven't used yet. We moved coaching setup to after the first use — when the member has context for what the questions mean.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- IMPACT -->
+  <div id="impact" class="d-section">
+    <p class="d-label">Impact</p>
+    <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
+      <div class="d-metric">
+        <div class="d-metric__value">57%</div>
+        <div class="d-metric__label">Fields pre-populated</div>
+        <div class="d-metric__sub">20 of 35 fields sourced from upstream data</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↓</div>
+        <div class="d-metric__label">Registration errors</div>
+        <div class="d-metric__sub">Pre-filled data eliminated manual entry mistakes</div>
+      </div>
+      <div class="d-metric">
+        <div class="d-metric__value">↓</div>
+        <div class="d-metric__label">Admin setup time</div>
+        <div class="d-metric__sub">Reduced manual configuration and dev work per client</div>
+      </div>
+    </div>
+
+    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
+      <p class="d-callout__body"><strong>This is the same problem as CPQ.</strong> Programs are SKUs. Qualification rules are pricing rules. The registration flow is the quote. The spreadsheet is the same artifact that CPQ platforms replace with automated configuration.</p>
+    </div>
+  </div>
+
+</div>
+
+<footer class="d-footer d-contain">
+  <a href="/invoy.html" class="d-next">← Invoy</a>
+  <a href="/how-i-work.html" class="d-next">How I Work →</a>
+</footer>
+
+<script src="/portfolio.js"></script>
+</body>
+</html>

--- a/portfolio.js
+++ b/portfolio.js
@@ -1,0 +1,247 @@
+/* ============================================
+   Portfolio — Navigation, Interaction, Edit Mode
+   ============================================ */
+
+(function () {
+  'use strict';
+
+  // ── Sub-nav scroll highlighting ──
+  function initSubnav() {
+    const links = document.querySelectorAll('.d-subnav__link');
+    if (!links.length) return;
+    const sections = [];
+    links.forEach(link => {
+      const id = link.getAttribute('href')?.replace('#', '');
+      const el = id && document.getElementById(id);
+      if (el) sections.push({ el, link });
+    });
+    if (!sections.length) return;
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          links.forEach(l => l.classList.remove('d-subnav__link--active'));
+          const match = sections.find(s => s.el === entry.target);
+          if (match) match.link.classList.add('d-subnav__link--active');
+        }
+      });
+    }, { rootMargin: '-20% 0px -70% 0px' });
+    sections.forEach(s => observer.observe(s.el));
+  }
+
+  // ── Keyboard nav between pages ──
+  function initKeyboard() {
+    const pages = [
+      '/',
+      '/field.html',
+      '/invoy.html',
+      '/livongo.html',
+      '/design-systems.html',
+      '/how-i-work.html'
+    ];
+    const current = window.location.pathname;
+    const idx = pages.findIndex(p => current.endsWith(p) || current.endsWith(p.replace('.html', '')));
+    document.addEventListener('keydown', e => {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
+      if (e.key === 'ArrowRight' && idx < pages.length - 1) window.location.href = pages[idx + 1];
+      else if (e.key === 'ArrowLeft' && idx > 0) window.location.href = pages[idx - 1];
+      // Toggle edit mode with Shift+E
+      if (e.key === 'E' && e.shiftKey && !e.metaKey && !e.ctrlKey) toggleEditMode();
+    });
+  }
+
+  // ── Smooth scroll for anchors ──
+  function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(link => {
+      link.addEventListener('click', e => {
+        const target = document.querySelector(link.getAttribute('href'));
+        if (target) {
+          e.preventDefault();
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          history.pushState(null, '', link.getAttribute('href'));
+        }
+      });
+    });
+  }
+
+  // ── Active nav link ──
+  function initNavHighlight() {
+    const links = document.querySelectorAll('.d-nav__link');
+    const path = window.location.pathname;
+    links.forEach(link => {
+      const href = link.getAttribute('href');
+      if (href && path.endsWith(href.replace('./', ''))) {
+        link.classList.add('d-nav__link--active');
+      }
+    });
+  }
+
+  // ── Edit Mode ──
+  let editModeActive = false;
+  const editStyles = document.createElement('style');
+  editStyles.textContent = `
+    body { user-select: text !important; -webkit-user-select: text !important; }
+    .edit-mode .d-body,
+    .edit-mode .d-headline,
+    .edit-mode .d-decision__q,
+    .edit-mode .d-decision__a,
+    .edit-mode .d-callout__body,
+    .edit-mode .d-card__desc,
+    .edit-mode .d-card__title,
+    .edit-mode .d-metric__label,
+    .edit-mode .d-metric__sub,
+    .edit-mode .d-gallery__caption,
+    .edit-mode .d-persona__name,
+    .edit-mode .d-persona__needs li,
+    .edit-mode .d-flow__step-desc,
+    .edit-mode .d-flow__step-label,
+    .edit-mode dd {
+      outline: 1px dashed rgba(0, 255, 247, 0.3);
+      outline-offset: 2px;
+      cursor: text;
+    }
+    .edit-mode .d-body:hover,
+    .edit-mode .d-headline:hover,
+    .edit-mode .d-decision__q:hover,
+    .edit-mode .d-decision__a:hover,
+    .edit-mode .d-callout__body:hover,
+    .edit-mode [contenteditable]:hover {
+      outline-color: rgba(0, 255, 247, 0.6);
+      background: rgba(0, 255, 247, 0.03);
+    }
+    .edit-mode [contenteditable]:focus {
+      outline: 2px solid #00fff7;
+      background: rgba(0, 255, 247, 0.05);
+    }
+    .edit-banner {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 9999;
+      background: #00fff7;
+      color: #111;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      font-weight: 600;
+      text-align: center;
+      padding: 6px;
+      letter-spacing: 0.04em;
+    }
+    .edit-banner button {
+      background: #111;
+      color: #00fff7;
+      border: none;
+      padding: 2px 10px;
+      margin-left: 12px;
+      font-family: inherit;
+      font-size: 10px;
+      cursor: pointer;
+      border-radius: 2px;
+    }
+    .comment-marker {
+      position: absolute;
+      right: -32px;
+      top: 0;
+      width: 20px;
+      height: 20px;
+      background: #ffb000;
+      color: #111;
+      font-size: 10px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      cursor: pointer;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .comment-bubble {
+      position: absolute;
+      right: -280px;
+      top: 0;
+      width: 240px;
+      background: #1a1a18;
+      border: 1px solid #ffb000;
+      border-radius: 4px;
+      padding: 8px;
+      z-index: 100;
+    }
+    .comment-bubble textarea {
+      width: 100%;
+      background: #111;
+      color: #e8e6e3;
+      border: 1px solid #33332f;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 11px;
+      padding: 6px;
+      resize: vertical;
+      min-height: 60px;
+      border-radius: 2px;
+    }
+    .comment-bubble button {
+      background: #ffb000;
+      color: #111;
+      border: none;
+      padding: 4px 8px;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 10px;
+      cursor: pointer;
+      margin-top: 4px;
+      border-radius: 2px;
+    }
+    .has-comment {
+      border-left: 2px solid #ffb000 !important;
+      padding-left: 8px;
+    }
+  `;
+
+  let banner = null;
+
+  function toggleEditMode() {
+    editModeActive = !editModeActive;
+    document.body.classList.toggle('edit-mode', editModeActive);
+
+    if (editModeActive) {
+      document.head.appendChild(editStyles);
+
+      // Make text editable
+      const editables = document.querySelectorAll('.d-body, .d-headline, .d-decision__q, .d-decision__a, .d-callout__body, .d-card__desc, .d-card__title, .d-metric__label, .d-metric__sub, .d-gallery__caption, .d-persona__name, .d-persona__needs li, .d-flow__step-desc, .d-flow__step-label, dd');
+      editables.forEach(el => {
+        el.setAttribute('contenteditable', 'true');
+        el.style.position = 'relative';
+        // Add comment button on click
+        el.addEventListener('dblclick', function addComment(e) {
+          if (el.querySelector('.comment-bubble')) return;
+          const bubble = document.createElement('div');
+          bubble.className = 'comment-bubble';
+          bubble.innerHTML = '<textarea placeholder="Leave a comment..."></textarea><button onclick="this.parentElement.previousElementSibling?.classList.add(\'has-comment\'); const t = this.parentElement.querySelector(\'textarea\').value; if(t) { const m = document.createElement(\'span\'); m.className=\'comment-marker\'; m.title=t; m.textContent=\'!\'; this.parentElement.parentElement.appendChild(m); } this.parentElement.remove();">Save</button>';
+          el.appendChild(bubble);
+          bubble.querySelector('textarea').focus();
+          e.stopPropagation();
+        });
+      });
+
+      // Show banner
+      banner = document.createElement('div');
+      banner.className = 'edit-banner';
+      banner.innerHTML = 'EDIT MODE — Click to edit. Double-click to comment. Shift+E to exit. <button onclick="document.querySelectorAll(\'[contenteditable]\').forEach(el => console.log(el.closest(\'[id]\')?.id || \'-\', \'|\', el.className, \'|\', el.textContent.trim().slice(0,60)))">Log changes</button>';
+      document.body.prepend(banner);
+
+    } else {
+      // Disable editing
+      document.querySelectorAll('[contenteditable]').forEach(el => {
+        el.removeAttribute('contenteditable');
+      });
+      if (editStyles.parentNode) editStyles.remove();
+      if (banner) { banner.remove(); banner = null; }
+    }
+  }
+
+  // ── Init ──
+  document.addEventListener('DOMContentLoaded', () => {
+    initSubnav();
+    initKeyboard();
+    initSmoothScroll();
+    initNavHighlight();
+  });
+})();


### PR DESCRIPTION
## Summary
- Moves all portfolio HTML pages from /portfolio/ to root
- Pages now accessible at: /field.html, /invoy.html, /livongo.html, /design-systems.html, /how-i-work.html
- portfolio.js moved to root
- All nav links and CSS paths updated to absolute
- /portfolio/ originals retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)