### PR TITLE
Accordion nav + clean up portfolio pages to match Paper

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -63,6 +63,47 @@
   color: var(--fg, #e8e6e3);
 }
 
+/* Nav accordion — Case Studies expandable group */
+.d-nav__group {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+
+.d-nav__group-label {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--fg, #e8e6e3);
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.d-nav__group-items {
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 8px 25px;
+  list-style: none;
+  overflow: hidden;
+  max-width: 0;
+  opacity: 0;
+  padding-inline: 0;
+  transition: max-width 0.3s ease, opacity 0.2s ease, padding-inline 0.3s ease;
+}
+
+.d-nav__group--expanded .d-nav__group-items {
+  max-width: 300px;
+  opacity: 1;
+  padding-inline: 25px;
+}
+
+.d-nav__group-items .d-nav__link {
+  white-space: nowrap;
+}
+
 /* Sub-nav */
 .d-subnav {
   position: sticky;
@@ -180,7 +221,9 @@
   background: var(--border-subtle, #33332f);
 }
 
-@media (max-width: 768px) { .d-cards { grid-template-columns: 1fr; } }
+.d-cards--2 { grid-template-columns: repeat(2, 1fr); }
+
+@media (max-width: 768px) { .d-cards, .d-cards--2 { grid-template-columns: 1fr; } }
 
 .d-card {
   display: flex;

--- a/field.html
+++ b/field.html
@@ -15,10 +15,14 @@
 <nav class="d-nav">
   <a href="/" class="d-nav__name">CTRL.RODEO</a>
   <ul class="d-nav__links">
-    <li><span style="font-size: var(--text-sm, 13px); color: var(--fg-muted, #8a8885);">Case Studies</span></li>
-    <li><a href="/field.html" class="d-nav__link d-nav__link--active">Field</a></li>
-    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
-    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+    <li class="d-nav__group d-nav__group--expanded" data-nav-accordion>
+      <span class="d-nav__group-label">Case Studies</span>
+      <ul class="d-nav__group-items">
+        <li><a href="/field.html" class="d-nav__link d-nav__link--active">Field</a></li>
+        <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+        <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+      </ul>
+    </li>
     <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,16 @@
 <nav class="d-nav">
   <a href="/" class="d-nav__name">CTRL.RODEO</a>
   <ul class="d-nav__links">
-    <li><a href="/field.html" class="d-nav__link">Field</a></li>
-    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
-    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="/design-systems.html" class="d-nav__link">Design Systems</a></li>
-    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li class="d-nav__group" data-nav-accordion>
+      <span class="d-nav__group-label">Case Studies</span>
+      <ul class="d-nav__group-items">
+        <li><a href="/field.html" class="d-nav__link">Field</a></li>
+        <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+        <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+      </ul>
+    </li>
+    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 
@@ -37,39 +42,46 @@
     </div>
   </div>
 
-  <!-- Suggested for You -->
+  <!-- Case Studies -->
   <div class="d-section">
-    <p class="d-label">Suggested for you</p>
+    <p class="d-label">Case Studies</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="/field.html" class="d-card">
         <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
-        <span class="d-card__title">Voice-First Clinical Documentation</span>
+        <span class="d-card__title">Field</span>
         <span class="d-card__desc">Voice-driven clinical documentation for first responders. On-device AI, offline-first</span>
         <span class="d-card__tag" style="margin-top: auto;">Beta</span>
       </a>
       <a href="/invoy.html" class="d-card">
-        <span class="d-card__tag">Behavior Change · Design System</span>
-        <span class="d-card__title">Engagement Loops & Weight Loss</span>
-        <span class="d-card__desc">Weekly behavioral coaching lifecycle. MVP design system.</span>
-        <span class="d-card__tag" style="margin-top: auto;">Shipped</span>
+        <span class="d-card__tag">Weight · Design System</span>
+        <span class="d-card__title">Invoy' Weekly Weight Loop</span>
+        <span class="d-card__desc">Creading</span>
+        <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>
       </a>
       <a href="/livongo.html" class="d-card">
         <span class="d-card__tag">Infrastructure · B2B · Scale</span>
-        <span class="d-card__title">B2B Sales Configuration & End User Onboarding</span>
-        <span class="d-card__desc">Simplifying product configuration at enterprise scale.</span>
+        <span class="d-card__title">Livongo</span>
+        <span class="d-card__desc">Client configuration stability while growing</span>
       </a>
     </div>
   </div>
 
-  <!-- Utilities -->
+  <!-- Philosophies -->
   <div class="d-section">
-    <p class="d-label">Utilities</p>
-    <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="/how-i-work.html" class="d-card">
-        <span class="d-card__tag">AI · iOS · 0→1</span>
-        <span class="d-card__title">Design System Manager</span>
-        <span class="d-card__desc">Generate and manage your design system from Figma, Paper, Github or live code.</span>
-      </a>
+    <p class="d-label">Philosophies</p>
+  </div>
+
+  <!-- How I Work -->
+  <div class="d-section" style="background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
+    <p class="d-label">How I Work</p>
+    <p class="d-headline d-headline--lg">Scaling Design with AI</p>
+    <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
+  </div>
+
+  <!-- Personal Projects -->
+  <div class="d-section">
+    <p class="d-label">Personal Projects</p>
+    <div class="d-cards d-cards--2" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="#" class="d-card">
         <span class="d-card__tag">Shipped · Mobile · Design System</span>
         <span class="d-card__title">Add to Calendar</span>
@@ -78,37 +90,26 @@
       <a href="#" class="d-card">
         <span class="d-card__tag">B2B · Configuration · Scale</span>
         <span class="d-card__title">Favicons</span>
+        <span class="d-card__desc">Generate a favicon from AI, Photo or Type. GUI or API.</span>
       </a>
     </div>
-  </div>
-
-  <!-- Personal Projects -->
-  <div class="d-section">
-    <p class="d-label">Personal Projects</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="#" class="d-card">
         <span class="d-card__tag">AI · iOS · 0→1</span>
         <span class="d-card__title">Boards</span>
-        <span class="d-card__desc">SF's Best events all in one place.</span>
+        <span class="d-card__desc">A link manager - Contextual, beautiful, actionable.</span>
       </a>
       <a href="#" class="d-card">
         <span class="d-card__tag">Shipped · Mobile · Design System</span>
         <span class="d-card__title">Events</span>
-        <span class="d-card__desc">SF's best events all in one place.</span>
+        <span class="d-card__desc">Curated local events. Personalized based on Boards.</span>
       </a>
       <a href="#" class="d-card">
         <span class="d-card__tag">B2B · Configuration · Scale</span>
         <span class="d-card__title">Soundscape</span>
+        <span class="d-card__desc">Visualizer that responds to your music.</span>
       </a>
     </div>
-  </div>
-
-  <!-- How I Work teaser -->
-  <div class="d-section">
-    <p class="d-label">How I Work</p>
-    <p class="d-headline d-headline--lg">One designer, five products, AI-assisted delivery.</p>
-    <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
-    <a href="/how-i-work.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
   </div>
 
 </div>

--- a/invoy.html
+++ b/invoy.html
@@ -12,20 +12,28 @@
 <body class="d-page">
 
 <nav class="d-nav">
-  <a href="/" class="d-nav__name">Ian Fike</a>
+  <a href="/" class="d-nav__name">CTRL.RODEO</a>
   <ul class="d-nav__links">
-    <li><a href="/field.html" class="d-nav__link">Field</a></li>
-    <li><a href="/invoy.html" class="d-nav__link d-nav__link--active">Invoy</a></li>
-    <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li class="d-nav__group d-nav__group--expanded" data-nav-accordion>
+      <span class="d-nav__group-label">Case Studies</span>
+      <ul class="d-nav__group-items">
+        <li><a href="/field.html" class="d-nav__link">Field</a></li>
+        <li><a href="/invoy.html" class="d-nav__link d-nav__link--active">Invoy</a></li>
+        <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
+      </ul>
+    </li>
+    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 
 <div class="d-subnav">
   <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
-  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#experience" class="d-subnav__link">Experience</a>
   <a href="#process" class="d-subnav__link">Process</a>
+  <a href="#design-system" class="d-subnav__link">Design System</a>
   <a href="#impact" class="d-subnav__link">Impact</a>
+  <a href="#learnings" class="d-subnav__link">Learnings</a>
 </div>
 
 <div class="d-contain">
@@ -33,20 +41,18 @@
   <!-- Header + Overview -->
   <div style="padding: 48px 0 0;">
     <span class="d-status d-status--shipped">Shipped</span>
-    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy</p>
-    <p class="d-body" style="margin-top: 12px;">A weekly coaching system for metabolic health. Members plan their week, check in daily, review their progress, and adjust — with coach support when the data says they need it.</p>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy's Weekly Plans</p>
+    <p class="d-body" style="margin-top: 12px;">A weekly coaching system for weight management. Members plan their week, check in daily, review progress, and adjust — with coach support when the data says they need it.</p>
 
     <dl class="d-overview">
       <dt>Role</dt>
-      <dd>Lead product designer</dd>
+      <dd>Lead product designer (Senior PM)</dd>
       <dt>Company</dt>
-      <dd>Livongo / Teladoc Health</dd>
-      <dt>Platform</dt>
-      <dd>iOS, Android</dd>
+      <dd>Invoy Health</dd>
       <dt>Scope</dt>
-      <dd>15+ sub-flows, 30-component design system, 100+ screens</dd>
+      <dd>Concept Design, Feature UI, Design System</dd>
       <dt>Status</dt>
-      <dd>Shipped to production</dd>
+      <dd>Shipped to production, ~CTR M3</dd>
     </dl>
   </div>
 
@@ -58,93 +64,126 @@
 
     <div class="d-personas">
       <div class="d-persona">
-        <span class="d-persona__role">Primary user</span>
-        <span class="d-persona__name">Member</span>
+        <span class="d-persona__role">Motivation: Structure</span>
+        <span class="d-persona__name">Direction Me</span>
         <ul class="d-persona__needs">
-          <li>Wants to know what to eat today based on their plan</li>
-          <li>Needs to see progress without reading charts</li>
-          <li>Wants to get back on track after a bad day without guilt</li>
+          <li>Decision fatigue is the enemy. Defaults to the easiest option without a clear plan. Needs to know what today looks like.</li>
         </ul>
+        <span class="d-mono" style="margin-top: 8px;">→ Week Planning, Daily Focus, Base Plan</span>
       </div>
       <div class="d-persona">
-        <span class="d-persona__role">Secondary user</span>
-        <span class="d-persona__name">Coach</span>
+        <span class="d-persona__role">Motivation: Support</span>
+        <span class="d-persona__name">"Don't Let Me Do This Alone"</span>
         <ul class="d-persona__needs">
-          <li>Manages 50+ members — needs to spot who needs help fast</li>
-          <li>Wants data-backed reasons to reach out</li>
-          <li>Needs to suggest specific plan changes</li>
+          <li>Knows their triggers. Struggles when unseen. Previous attempts failed not because the plan was wrong but because they were doing it alone.</li>
         </ul>
+        <span class="d-mono" style="margin-top: 8px;">→ Rebound flow, Coach triage, Score Drop CTA</span>
+      </div>
+      <div class="d-persona">
+        <span class="d-persona__role">Motivation: Understanding</span>
+        <span class="d-persona__name">"Help Me Understand Why"</span>
+        <ul class="d-persona__needs">
+          <li>Asks "why" before "what." Won't follow rules they don't understand. The moment the underlying logic is better motivating than any slogan.</li>
+        </ul>
+        <span class="d-mono" style="margin-top: 8px;">→ Review of Week, Score Factors, Trends</span>
       </div>
     </div>
   </div>
 
-  <!-- DELIVERABLE -->
-  <div id="deliverable" class="d-section">
-    <p class="d-label">Deliverable</p>
-
-    <p class="d-label" style="margin-top: 24px;">The weekly loop</p>
-    <div class="d-flow">
+  <!-- HOW IT WORKS -->
+  <div class="d-section">
+    <p class="d-label">How It works</p>
+    <p class="d-body">Description of how it works</p>
+    <div class="d-flow" style="margin-top: 24px;">
       <div class="d-flow__step">
         <span class="d-flow__step-num">01</span>
         <span class="d-flow__step-label">Plan</span>
-        <span class="d-flow__step-desc">Set goals. Flag upcoming events. The app picks one of 5 plan types.</span>
+        <span class="d-flow__step-desc">Set goals. Flag events. Connect to all plan types.</span>
       </div>
       <span class="d-flow__arrow">→</span>
       <div class="d-flow__step">
         <span class="d-flow__step-num">02</span>
-        <span class="d-flow__step-label">Execute</span>
-        <span class="d-flow__step-desc">Daily check-ins. Breath test, mood, meals, plan tracking.</span>
+        <span class="d-flow__step-label">Check In</span>
+        <span class="d-flow__step-desc">Daily data: AI, breath, food, mood, meals.</span>
       </div>
       <span class="d-flow__arrow">→</span>
       <div class="d-flow__step">
         <span class="d-flow__step-num">03</span>
-        <span class="d-flow__step-label">Reflect</span>
-        <span class="d-flow__step-desc">End-of-week review. Weight change, plan completion, trends.</span>
+        <span class="d-flow__step-label">Review</span>
+        <span class="d-flow__step-desc">End-of-week review. Weight, progress, trends.</span>
       </div>
       <span class="d-flow__arrow">→</span>
       <div class="d-flow__step">
         <span class="d-flow__step-num">04</span>
         <span class="d-flow__step-label">Adapt</span>
-        <span class="d-flow__step-desc">Coach reviews patterns. Next week's plan adjusts.</span>
+        <span class="d-flow__step-desc">Coach reviews. Adaption, loop adjustments.</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- EXPERIENCE -->
+  <div id="experience" class="d-section">
+    <p class="d-label">Core Experience</p>
+
+    <!-- Weekly Planning -->
+    <div class="d-grid-2" style="margin-top: 24px;">
+      <div style="background: #1a1a18; aspect-ratio: 4/5; display: flex; align-items: center; justify-content: center;">
+        <span class="d-mono">[screenshot]</span>
+      </div>
+      <div>
+        <p class="d-label">01</p>
+        <p class="d-headline d-headline--md">Weekly Planning</p>
+        <p class="d-mono" style="margin-top: 4px;">Your week, planned around real life</p>
+        <p class="d-body" style="margin-top: 16px;">"Any events this week?" routes into one of five plan variants. The member answers one question. The system does the branching.</p>
+        <div style="margin-top: 20px;">
+          <p class="d-label">Jobs to be done</p>
+          <ul class="d-persona__needs">
+            <li>As a member, I need my plan to account for travel and social events, so I'm not set up to fail.</li>
+            <li>As a member, I need lighter goals when life is busy, so I stay engaged instead of giving up.</li>
+            <li>As a member, I need a rebound plan activated automatically when I plan a cheat meal.</li>
+          </ul>
+        </div>
       </div>
     </div>
 
-    <div class="d-gallery d-gallery--4" style="margin-top: 32px;">
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Week Planning [screenshot]</span></div>
-        <span class="d-gallery__caption">Set intentions, flag events. 5 plan variants from one entry point.</span>
+    <!-- Week in Review -->
+    <div class="d-grid-2" style="margin-top: 24px;">
+      <div style="background: #1a1a18; aspect-ratio: 4/5; display: flex; align-items: center; justify-content: center;">
+        <span class="d-mono">[screenshot]</span>
       </div>
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Daily Focus [screenshot]</span></div>
-        <span class="d-gallery__caption">Daily check-in with score factors and nutrition tracking.</span>
-      </div>
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Review of Week [screenshot]</span></div>
-        <span class="d-gallery__caption">Weight change, progress bars, trend line, day-by-day activity grid.</span>
-      </div>
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 9/19; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">Rebound [screenshot]</span></div>
-        <span class="d-gallery__caption">When the score drops: what happened, possible causes, next steps.</span>
+      <div>
+        <p class="d-label">02</p>
+        <p class="d-headline d-headline--md">Week in Review</p>
+        <p class="d-mono" style="margin-top: 4px;">See what worked without reading charts</p>
+        <p class="d-body" style="margin-top: 16px;">Weight delta, progress bars, sparkline, activity matrix, AI summary — one scroll. Every number reads without explanation.</p>
+        <div style="margin-top: 20px;">
+          <p class="d-label">Jobs to be done</p>
+          <ul class="d-persona__needs">
+            <li>As a member, I need to see whether my weight moved and why, so I connect actions to results.</li>
+            <li>As a member, I need a summary I can absorb in under a minute, even when the data is complex.</li>
+          </ul>
+        </div>
       </div>
     </div>
 
-    <hr class="d-rule">
-
-    <p class="d-label">Design System</p>
-    <p class="d-body">30 components with rules for when to use each one. The system tells the team which page template to start with, which button style means "go forward" vs "dismiss," and which card to show when the score drops vs. when it rises.</p>
-
-    <div class="d-decisions" style="margin-top: 16px;">
-      <div class="d-decision">
-        <p class="d-decision__q">Page/Title vs Page/Questions</p>
-        <p class="d-decision__a">Title pages explain what's coming. Questions pages collect data. A sub-flow always starts with a Title page — never a Questions page.</p>
+    <!-- Updated Checkin Flow -->
+    <div class="d-grid-2" style="margin-top: 24px;">
+      <div style="background: #1a1a18; aspect-ratio: 4/5; display: flex; align-items: center; justify-content: center;">
+        <span class="d-mono">[screenshot]</span>
       </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Button hierarchy</p>
-        <p class="d-decision__a">Dark button = main action. Light button = alternative. Text-only = dismiss. Same rule on every screen in every flow.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Score → card mapping</p>
-        <p class="d-decision__a">Score drops get an amber card with "what we know" and a coach button. Score increases get a green card with encouragement. This is documented, not decided per screen.</p>
+      <div>
+        <p class="d-label">03</p>
+        <p class="d-headline d-headline--md">Updated Checkin Flow</p>
+        <p class="d-mono" style="margin-top: 4px;">Every day connects to the week</p>
+        <p class="d-body" style="margin-top: 16px;">Daily check-ins capture score, mood, meals, adherence — then feed into the weekly loop. Score drops trigger triage. Increases trigger reinforcement.</p>
+        <div style="margin-top: 20px;">
+          <p class="d-label">Jobs to be done</p>
+          <ul class="d-persona__needs">
+            <li>As a member, I need today's check-in to connect to what I planned this week, so each day feels purposeful.</li>
+            <li>As a member, I need to understand why my score dropped and what to do about it.</li>
+            <li>As a member, I need going off plan to lead to a recovery path, not a guilt message.</li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -152,18 +191,42 @@
   <!-- PROCESS -->
   <div id="process" class="d-section">
     <p class="d-label">Process</p>
-    <div class="d-decisions">
+    <p class="d-label" style="margin-top: 16px;">01</p>
+    <p class="d-headline d-headline--md">Design Decisions</p>
+    <p class="d-mono" style="margin-top: 4px;">TBD</p>
+    <div class="d-decisions" style="margin-top: 16px;">
       <div class="d-decision">
-        <p class="d-decision__q">Why does one question ("any events this week?") split into 5 different flows?</p>
-        <p class="d-decision__a">Members shouldn't need to understand the system's logic. If they have a busy week, the app gives them a lighter plan with optional boosters. If they're planning a cheat meal, the rebound flow activates. The routing is automatic — one question does the work of a settings page.</p>
+        <p class="d-decision__q">Why does one question split into 5 different flows?</p>
+        <p class="d-decision__a">Members shouldn't need to understand the system's logic. "Any events this week?" routes automatically into Base, Busy Week, Cheat & Rebound, Edit Plan, or Accelerate.</p>
       </div>
       <div class="d-decision">
         <p class="d-decision__q">Why treat a bad day as a "rebound" instead of a failure?</p>
-        <p class="d-decision__a">Most health apps make you feel bad when you go off plan. Invoy built a dedicated recovery flow: it shows what happened, suggests why, and offers specific next steps like scheduling a coach call or adding a fasting boost. Members who see a path back stay engaged. Members who feel judged stop opening the app.</p>
+        <p class="d-decision__a">Members who see a path back stay engaged. Members who feel judged stop opening the app.</p>
       </div>
       <div class="d-decision">
-        <p class="d-decision__q">Why pack so much data into the weekly review screen?</p>
-        <p class="d-decision__a">People look at this once a week. It has to be complete and fast to scan. Weight change, three progress bars, a week-long trend line, a day-by-day activity grid, and an AI-written summary — all on one scroll. Every number is readable without explanation.</p>
+        <p class="d-decision__q">Why pack so much data into the weekly review?</p>
+        <p class="d-decision__a">People look at this once a week. It has to be complete and fast to scan.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- DESIGN SYSTEM -->
+  <div id="design-system" class="d-section">
+    <p class="d-label">02</p>
+    <p class="d-headline d-headline--md">Design Systems</p>
+    <p class="d-mono" style="margin-top: 4px;">TBD</p>
+    <div class="d-gallery d-gallery--3" style="margin-top: 24px;">
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
+        <span class="d-gallery__caption">Score classes</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
+        <span class="d-gallery__caption">Type & Options</span>
+      </div>
+      <div class="d-gallery__item">
+        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
+        <span class="d-gallery__caption">Components</span>
       </div>
     </div>
   </div>
@@ -180,12 +243,12 @@
       <div class="d-metric">
         <div class="d-metric__value">↑</div>
         <div class="d-metric__label">Weight loss outcomes</div>
-        <div class="d-metric__sub">Closed loop between data, coaching, and plan adaptation</div>
+        <div class="d-metric__sub">Closed loop between data, coaching, adaptation</div>
       </div>
       <div class="d-metric">
         <div class="d-metric__value">30</div>
         <div class="d-metric__label">Components shipped</div>
-        <div class="d-metric__sub">Design system with documented governance rules</div>
+        <div class="d-metric__sub">With documented governance rules</div>
       </div>
     </div>
   </div>

--- a/livongo.html
+++ b/livongo.html
@@ -12,18 +12,24 @@
 <body class="d-page">
 
 <nav class="d-nav">
-  <a href="/" class="d-nav__name">Ian Fike</a>
+  <a href="/" class="d-nav__name">CTRL.RODEO</a>
   <ul class="d-nav__links">
-    <li><a href="/field.html" class="d-nav__link">Field</a></li>
-    <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
-    <li><a href="/livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
-    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li class="d-nav__group d-nav__group--expanded" data-nav-accordion>
+      <span class="d-nav__group-label">Case Studies</span>
+      <ul class="d-nav__group-items">
+        <li><a href="/field.html" class="d-nav__link">Field</a></li>
+        <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
+        <li><a href="/livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
+      </ul>
+    </li>
+    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 
 <div class="d-subnav">
   <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
-  <a href="#deliverable" class="d-subnav__link">Deliverable</a>
+  <a href="#deliverable" class="d-subnav__link">Deliverables</a>
   <a href="#process" class="d-subnav__link">Process</a>
   <a href="#impact" class="d-subnav__link">Impact</a>
 </div>
@@ -34,19 +40,15 @@
   <div style="padding: 48px 0 0;">
     <span class="d-status d-status--shipped">Shipped</span>
     <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Config</p>
-    <p class="d-body" style="margin-top: 12px;">Livongo sold 5 health programs in dozens of combinations. Each combination changed which fields a member saw during registration. The rules lived in a spreadsheet. We turned it into a system.</p>
+    <p class="d-body" style="margin-top: 12px;">50 client configurations × 74 registration fields = 3,700 decisions managed in a spreadsheet. We turned it into a 6-step registration.</p>
 
     <dl class="d-overview">
       <dt>Role</dt>
-      <dd>Product designer, growth PM</dd>
-      <dt>Company</dt>
-      <dd>Livongo / Teladoc Health</dd>
+      <dd>Senior PM, Member Growth</dd>
       <dt>Scope</dt>
-      <dd>50 client configs × 74 fields = 3,700 decision points</dd>
+      <dd>50 configs × 74 fields = 3,700 decision points</dd>
       <dt>Platform</dt>
-      <dd>Web (registration flow), Salesforce (config), internal APIs</dd>
-      <dt>Status</dt>
-      <dd>Shipped to production</dd>
+      <dd>Web registration, Salesforce config, internal APIs</dd>
     </dl>
   </div>
 
@@ -61,24 +63,21 @@
         <span class="d-persona__role">Configures the deal</span>
         <span class="d-persona__name">Sales</span>
         <ul class="d-persona__needs">
-          <li>Picks program bundles in Salesforce</li>
-          <li>Doesn't think about what fields that affects</li>
+          <li>Picks bundles in Salesforce. Doesn't think about field implications.</li>
         </ul>
       </div>
       <div class="d-persona">
         <span class="d-persona__role">Sets up the flow</span>
         <span class="d-persona__name">Implementation</span>
         <ul class="d-persona__needs">
-          <li>Translates the deal into a registration config</li>
-          <li>Cross-references 74 columns for each client</li>
+          <li>Translates deal config into registration. Cross-references 74 columns.</li>
         </ul>
       </div>
       <div class="d-persona">
         <span class="d-persona__role">Registers</span>
         <span class="d-persona__name">Member</span>
         <ul class="d-persona__needs">
-          <li>Wants to sign up quickly</li>
-          <li>Should only see fields that matter to their program</li>
+          <li>Wants to sign up quickly. Only sees relevant fields.</li>
         </ul>
       </div>
     </div>

--- a/portfolio.js
+++ b/portfolio.js
@@ -35,7 +35,6 @@
       '/field.html',
       '/invoy.html',
       '/livongo.html',
-      '/design-systems.html',
       '/how-i-work.html'
     ];
     const current = window.location.pathname;
@@ -72,6 +71,20 @@
       if (href && path.endsWith(href.replace('./', ''))) {
         link.classList.add('d-nav__link--active');
       }
+    });
+  }
+
+  // ── Nav accordion ──
+  function initNavAccordion() {
+    const groups = document.querySelectorAll('[data-nav-accordion]');
+    groups.forEach(group => {
+      const label = group.querySelector('.d-nav__group-label');
+      if (!label) return;
+
+      // Toggle on click
+      label.addEventListener('click', () => {
+        group.classList.toggle('d-nav__group--expanded');
+      });
     });
   }
 
@@ -243,5 +256,6 @@
     initKeyboard();
     initSmoothScroll();
     initNavHighlight();
+    initNavAccordion();
   });
 })();


### PR DESCRIPTION
## Summary
- Nav across all pages now uses an expanding accordion for Case Studies (Field/Invoy/Livongo pill) — collapsed on home, expanded on case study pages
- index.html, invoy.html, livongo.html content updated to match Paper designs (titles, descriptions, personas, sections)
- field.html nav updated to match new accordion pattern

## Test plan
- [ ] Home page: nav shows "Case Studies" collapsed, click expands pill
- [ ] Case study pages: accordion expanded with active page highlighted
- [ ] Invoy page: new title, subnav, personas, experience section
- [ ] Livongo page: updated overview table, persona descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)