### PR TITLE
Fix nav alignment, home borders, Invoy hero/flow/decisions

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -46,6 +46,7 @@
 
 .d-nav__links {
   display: flex;
+  align-items: center;
   gap: 28px;
   list-style: none;
 }

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
   </div>
 
   <!-- Case Studies -->
-  <div class="d-section">
+  <div class="d-section" style="border-bottom: none;">
     <p class="d-label">Case Studies</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="/field.html" class="d-card">
@@ -67,19 +67,19 @@
   </div>
 
   <!-- Philosophies -->
-  <div class="d-section">
-    <p class="d-label">Philosophies</p>
+  <div style="padding: 20px 0 12px; border-bottom: 1px solid var(--border-subtle, #33332f);">
+    <p class="d-label" style="margin-bottom: 0;">Philosophies</p>
   </div>
 
   <!-- How I Work -->
-  <div class="d-section" style="background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
+  <div class="d-section" style="border-bottom: none; background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
     <p class="d-label">How I Work</p>
     <p class="d-headline d-headline--lg">Scaling Design with AI</p>
     <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
   </div>
 
   <!-- Personal Projects -->
-  <div class="d-section">
+  <div class="d-section" style="border-bottom: none;">
     <p class="d-label">Personal Projects</p>
     <div class="d-cards d-cards--2" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="#" class="d-card">

--- a/invoy.html
+++ b/invoy.html
@@ -39,21 +39,26 @@
 <div class="d-contain">
 
   <!-- Header + Overview -->
-  <div style="padding: 48px 0 0;">
-    <span class="d-status d-status--shipped">Shipped</span>
-    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy's Weekly Plans</p>
-    <p class="d-body" style="margin-top: 12px;">A weekly coaching system for weight management. Members plan their week, check in daily, review progress, and adjust — with coach support when the data says they need it.</p>
+  <div style="padding: 48px 0 0; display: flex; gap: 48px; align-items: flex-start;">
+    <div style="width: 400px; aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); flex-shrink: 0; display: flex; align-items: center; justify-content: center;">
+      <span class="d-mono">[hero image]</span>
+    </div>
+    <div style="flex: 1;">
+      <span class="d-status d-status--shipped">Shipped</span>
+      <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy's Weekly Plans</p>
+      <p class="d-body" style="margin-top: 12px;">A weekly coaching system for weight management. Members plan their week, check in daily, review progress, and adjust — with coach support when the data says they need it.</p>
 
-    <dl class="d-overview">
-      <dt>Role</dt>
-      <dd>Lead product designer (Senior PM)</dd>
-      <dt>Company</dt>
-      <dd>Invoy Health</dd>
-      <dt>Scope</dt>
-      <dd>Concept Design, Feature UI, Design System</dd>
-      <dt>Status</dt>
-      <dd>Shipped to production, ~CTR M3</dd>
-    </dl>
+      <dl class="d-overview">
+        <dt>Role</dt>
+        <dd>Lead product designer (Senior PM)</dd>
+        <dt>Company</dt>
+        <dd>Invoy Health</dd>
+        <dt>Scope</dt>
+        <dd>Concept Design, Feature UI, Design System</dd>
+        <dt>Status</dt>
+        <dd>Shipped to production, ~17K MAU</dd>
+      </dl>
+    </div>
   </div>
 
   <!-- FRAMING -->
@@ -116,8 +121,12 @@
       <div class="d-flow__step">
         <span class="d-flow__step-num">04</span>
         <span class="d-flow__step-label">Adapt</span>
-        <span class="d-flow__step-desc">Coach reviews. Adaption, loop adjustments.</span>
+        <span class="d-flow__step-desc">Coach reviews. Next week adjusts. Loop restarts.</span>
       </div>
+    </div>
+    <div style="display: flex; align-items: center; gap: 12px; margin-top: 16px;">
+      <span class="d-mono" style="white-space: nowrap;">← Back to Plan</span>
+      <div style="flex: 1; height: 1px; background: var(--fg-subtle, #666560);"></div>
     </div>
   </div>
 
@@ -194,7 +203,7 @@
     <p class="d-label" style="margin-top: 16px;">01</p>
     <p class="d-headline d-headline--md">Design Decisions</p>
     <p class="d-mono" style="margin-top: 4px;">TBD</p>
-    <div class="d-decisions" style="margin-top: 16px;">
+    <div class="d-decisions" style="margin-top: 16px; padding-left: 48px;">
       <div class="d-decision">
         <p class="d-decision__q">Why does one question split into 5 different flows?</p>
         <p class="d-decision__a">Members shouldn't need to understand the system's logic. "Any events this week?" routes automatically into Base, Busy Week, Cheat & Rebound, Edit Plan, or Accelerate.</p>


### PR DESCRIPTION
## Summary
- Nav: add align-items:center to d-nav__links for vertical alignment
- Home: remove extra section borders, Philosophies label gets own border-bottom
- Invoy: side-by-side hero with image placeholder, "← Back to Plan" loop line on flow chart, 48px indent on design decisions

## Test plan
- [ ] Nav items vertically aligned on all pages
- [ ] Home page borders match Paper (no extra separators)
- [ ] Invoy hero: image left, content right
- [ ] Invoy flow: loop line visible below Adapt
- [ ] Invoy decisions: indented from left

🤖 Generated with [Claude Code](https://claude.com/claude-code)