### PR TITLE
feat(portfolio): add project modals for personal projects

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -568,3 +568,97 @@
 .d-pt-8 { padding-top: 32px; }
 
 .d-rule { border: none; border-top: 1px solid var(--border-subtle, #33332f); margin: 32px 0; }
+
+/* ── Project Modal ── */
+
+.d-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.d-modal-overlay--open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.d-modal {
+  width: 960px;
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+  background: var(--bg, #111110);
+  border: 1px solid var(--border-subtle, #33332f);
+  transform: translateY(12px);
+  transition: transform 0.2s ease;
+}
+
+.d-modal-overlay--open .d-modal {
+  transform: translateY(0);
+}
+
+.d-modal__hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 32px;
+  padding: 48px;
+}
+
+.d-modal__image {
+  width: 400px;
+  aspect-ratio: 4 / 5;
+  background: var(--bg-surface, #1a1a18);
+  border: 1px solid var(--border-subtle, #33332f);
+  flex-shrink: 0;
+}
+
+.d-modal__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.d-modal__tag {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-amber, #ffb000);
+}
+
+.d-modal__title {
+  font-family: var(--font-display, 'Space Grotesk', sans-serif);
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--fg, #e8e6e3);
+  margin-top: 12px;
+}
+
+.d-modal__desc {
+  font-family: var(--font-mono, monospace);
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--fg-muted, #8a8885);
+  margin-top: 12px;
+  max-width: 468px;
+}
+
+.d-modal__footer {
+  border-top: 1px solid var(--border-subtle, #33332f);
+  padding: 48px;
+}
+
+@media (max-width: 768px) {
+  .d-modal__hero { flex-direction: column; padding: 24px; }
+  .d-modal__image { width: 100%; }
+  .d-modal__title { font-size: 28px; }
+  .d-modal__footer { padding: 24px; }
+}

--- a/index.html
+++ b/index.html
@@ -82,29 +82,29 @@
   <div class="d-section" style="border-bottom: none;">
     <p class="d-label">Personal Projects</p>
     <div class="d-cards d-cards--2" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="#" class="d-card">
+      <a href="#" class="d-card" data-modal="modal-calendar">
         <span class="d-card__tag">Shipped · Mobile · Design System</span>
         <span class="d-card__title">Add to Calendar</span>
         <span class="d-card__desc">Quickly</span>
       </a>
-      <a href="#" class="d-card">
+      <a href="#" class="d-card" data-modal="modal-favicons">
         <span class="d-card__tag">B2B · Configuration · Scale</span>
         <span class="d-card__title">Favicons</span>
         <span class="d-card__desc">Generate a favicon from AI, Photo or Type. GUI or API.</span>
       </a>
     </div>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="#" class="d-card">
+      <a href="#" class="d-card" data-modal="modal-boards">
         <span class="d-card__tag">AI · iOS · 0→1</span>
         <span class="d-card__title">Boards</span>
         <span class="d-card__desc">A link manager - Contextual, beautiful, actionable.</span>
       </a>
-      <a href="#" class="d-card">
+      <a href="#" class="d-card" data-modal="modal-events">
         <span class="d-card__tag">Shipped · Mobile · Design System</span>
         <span class="d-card__title">Events</span>
         <span class="d-card__desc">Curated local events. Personalized based on Boards.</span>
       </a>
-      <a href="#" class="d-card">
+      <a href="#" class="d-card" data-modal="modal-soundscape">
         <span class="d-card__tag">B2B · Configuration · Scale</span>
         <span class="d-card__title">Soundscape</span>
         <span class="d-card__desc">Visualizer that responds to your music.</span>
@@ -112,6 +112,153 @@
     </div>
   </div>
 
+</div>
+
+<!-- Project Modals -->
+
+<!-- Add to Calendar -->
+<div class="d-modal-overlay" id="modal-calendar">
+  <div class="d-modal">
+    <div class="d-modal__hero">
+      <div class="d-modal__image"></div>
+      <div class="d-modal__content">
+        <span class="d-modal__tag">Personal Project</span>
+        <p class="d-modal__title">Add to Calendar</p>
+        <p class="d-modal__desc">Open a browser window. Scan for events. Add to your Google Calendar.</p>
+        <dl class="d-overview" style="margin-top: 24px;">
+          <dt>Role</dt>
+          <dd>Lead product designer (Senior PM)</dd>
+          <dt>Platform</dt>
+          <dd>Chrome Extension</dd>
+          <dt>Key Tech</dt>
+          <dd>Google APIs, Claude APIs</dd>
+          <dt>Tools</dt>
+          <dd>Claude Code</dd>
+        </dl>
+        <a href="/calendar/" class="d-next" style="display: inline-block; margin-top: 20px;">View project →</a>
+      </div>
+    </div>
+    <div class="d-modal__footer">
+      <p class="d-label">Learnings</p>
+      <p class="d-body" style="margin-top: 12px;">Building a Chrome extension that reads arbitrary web pages taught me how fragile scraping is. Claude handles the ambiguity — it reads the page like a person would and extracts event data that regex never could.</p>
+    </div>
+  </div>
+</div>
+
+<!-- Favicons -->
+<div class="d-modal-overlay" id="modal-favicons">
+  <div class="d-modal">
+    <div class="d-modal__hero">
+      <div class="d-modal__image"></div>
+      <div class="d-modal__content">
+        <span class="d-modal__tag">Personal Project</span>
+        <p class="d-modal__title">Favicons</p>
+        <p class="d-modal__desc">Generate a favicon from AI, Photo or Type. GUI or API.</p>
+        <dl class="d-overview" style="margin-top: 24px;">
+          <dt>Role</dt>
+          <dd>Solo builder</dd>
+          <dt>Platform</dt>
+          <dd>Web app + REST API</dd>
+          <dt>Key Tech</dt>
+          <dd>Claude Vision, Canvas API</dd>
+          <dt>Tools</dt>
+          <dd>Claude Code, Supabase</dd>
+        </dl>
+        <a href="/favicon/" class="d-next" style="display: inline-block; margin-top: 20px;">View project →</a>
+      </div>
+    </div>
+    <div class="d-modal__footer">
+      <p class="d-label">Learnings</p>
+      <p class="d-body" style="margin-top: 12px;">Favicons are deceptively hard at small sizes. AI generation needs heavy post-processing to look sharp at 16x16. The API mode turned out to be more useful than the GUI — developers want a curl command, not a UI.</p>
+    </div>
+  </div>
+</div>
+
+<!-- Boards -->
+<div class="d-modal-overlay" id="modal-boards">
+  <div class="d-modal">
+    <div class="d-modal__hero">
+      <div class="d-modal__image"></div>
+      <div class="d-modal__content">
+        <span class="d-modal__tag">Personal Project</span>
+        <p class="d-modal__title">Boards</p>
+        <p class="d-modal__desc">A link manager. Contextual, beautiful, actionable.</p>
+        <dl class="d-overview" style="margin-top: 24px;">
+          <dt>Role</dt>
+          <dd>Solo founder, designer, developer</dd>
+          <dt>Platform</dt>
+          <dd>iOS, Web</dd>
+          <dt>Key Tech</dt>
+          <dd>Claude Haiku, Supabase, Vanilla JS</dd>
+          <dt>Tools</dt>
+          <dd>Claude Code, Paper</dd>
+        </dl>
+        <a href="/boards/" class="d-next" style="display: inline-block; margin-top: 20px;">View project →</a>
+      </div>
+    </div>
+    <div class="d-modal__footer">
+      <p class="d-label">Learnings</p>
+      <p class="d-body" style="margin-top: 12px;">AI categorization works best when it augments existing behavior instead of replacing it. Members save links the same way they always did — Boards just organizes them automatically and surfaces patterns across interests.</p>
+    </div>
+  </div>
+</div>
+
+<!-- Events -->
+<div class="d-modal-overlay" id="modal-events">
+  <div class="d-modal">
+    <div class="d-modal__hero">
+      <div class="d-modal__image"></div>
+      <div class="d-modal__content">
+        <span class="d-modal__tag">Personal Project</span>
+        <p class="d-modal__title">Events</p>
+        <p class="d-modal__desc">Curated local events. Personalized based on Boards.</p>
+        <dl class="d-overview" style="margin-top: 24px;">
+          <dt>Role</dt>
+          <dd>Solo founder, designer, developer</dd>
+          <dt>Platform</dt>
+          <dd>Web</dd>
+          <dt>Key Tech</dt>
+          <dd>Event scraping, Claude Haiku, Supabase</dd>
+          <dt>Tools</dt>
+          <dd>Claude Code</dd>
+        </dl>
+        <a href="/events/" class="d-next" style="display: inline-block; margin-top: 20px;">View project →</a>
+      </div>
+    </div>
+    <div class="d-modal__footer">
+      <p class="d-label">Learnings</p>
+      <p class="d-body" style="margin-top: 12px;">Event data is messy — every source formats differently. The real product insight was connecting events to what someone already saves in Boards, so recommendations feel personal instead of algorithmic.</p>
+    </div>
+  </div>
+</div>
+
+<!-- Soundscape -->
+<div class="d-modal-overlay" id="modal-soundscape">
+  <div class="d-modal">
+    <div class="d-modal__hero">
+      <div class="d-modal__image"></div>
+      <div class="d-modal__content">
+        <span class="d-modal__tag">Personal Project</span>
+        <p class="d-modal__title">Soundscape</p>
+        <p class="d-modal__desc">Visualizer that responds to your music.</p>
+        <dl class="d-overview" style="margin-top: 24px;">
+          <dt>Role</dt>
+          <dd>Solo builder</dd>
+          <dt>Platform</dt>
+          <dd>Web (WebGL)</dd>
+          <dt>Key Tech</dt>
+          <dd>Web Audio API, Three.js, GLSL shaders</dd>
+          <dt>Tools</dt>
+          <dd>Claude Code</dd>
+        </dl>
+        <a href="/soundscape/" class="d-next" style="display: inline-block; margin-top: 20px;">View project →</a>
+      </div>
+    </div>
+    <div class="d-modal__footer">
+      <p class="d-label">Learnings</p>
+      <p class="d-body" style="margin-top: 12px;">Real-time audio analysis is surprisingly accessible with the Web Audio API. The challenge was making the visuals feel connected to the music rather than just reactive — frequency mapping to visual parameters required hand-tuning, not just math.</p>
+    </div>
+  </div>
 </div>
 
 <footer class="d-footer d-contain">

--- a/portfolio.js
+++ b/portfolio.js
@@ -250,6 +250,35 @@
     }
   }
 
+  // ── Project Modals ──
+  function initModals() {
+    // Open modal on card click
+    document.querySelectorAll('[data-modal]').forEach(trigger => {
+      trigger.addEventListener('click', e => {
+        e.preventDefault();
+        const id = trigger.getAttribute('data-modal');
+        const overlay = document.getElementById(id);
+        if (overlay) overlay.classList.add('d-modal-overlay--open');
+      });
+    });
+
+    // Close on overlay click (not modal content)
+    document.querySelectorAll('.d-modal-overlay').forEach(overlay => {
+      overlay.addEventListener('click', e => {
+        if (e.target === overlay) overlay.classList.remove('d-modal-overlay--open');
+      });
+    });
+
+    // Close on Escape
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') {
+        document.querySelectorAll('.d-modal-overlay--open').forEach(o => {
+          o.classList.remove('d-modal-overlay--open');
+        });
+      }
+    });
+  }
+
   // ── Init ──
   document.addEventListener('DOMContentLoaded', () => {
     initSubnav();
@@ -257,5 +286,6 @@
     initSmoothScroll();
     initNavHighlight();
     initNavAccordion();
+    initModals();
   });
 })();


### PR DESCRIPTION
## Summary
- Added modal overlays for all 5 personal projects (Add to Calendar, Favicons, Boards, Events, Soundscape)
- Each modal includes hero image placeholder, overview table (role/platform/tech/tools), project link, and learnings section
- Modal CSS with fade-in overlay + slide-up panel transitions
- JS open/close: card click opens, backdrop click closes, Escape key closes

## Test plan
- [x] Click each project card → modal opens with correct content
- [x] Click backdrop → modal closes
- [x] Press Escape → modal closes
- [x] Modal content scrolls if taller than viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)