### PR TITLE
Rename how-i-work.html to philosophy.html

### DIFF
--- a/design-systems.html
+++ b/design-systems.html
@@ -18,7 +18,7 @@
     <li><a href="/invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
     <li><a href="/design-systems.html" class="d-nav__link d-nav__link--active">Design Systems</a></li>
-    <li><a href="/how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 
@@ -243,7 +243,7 @@ Systemic         → crawl all 5 products → stoplight report</div>
 
 <footer class="d-footer d-contain">
   <a href="/livongo.html" class="d-next">← Livongo</a>
-  <a href="/how-i-work.html" class="d-next">How I Work →</a>
+  <a href="/philosophy.html" class="d-next">How I Work →</a>
 </footer>
 
 <script src="/portfolio.js"></script>

--- a/field.html
+++ b/field.html
@@ -23,7 +23,7 @@
         <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/invoy.html
+++ b/invoy.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/livongo.html
+++ b/livongo.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/how-i-work.html" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
@@ -223,7 +223,7 @@
 
 <footer class="d-footer d-contain">
   <a href="/invoy.html" class="d-next">← Invoy</a>
-  <a href="/how-i-work.html" class="d-next">How I Work →</a>
+  <a href="/philosophy.html" class="d-next">How I Work →</a>
 </footer>
 
 <script src="/portfolio.js"></script>

--- a/philosophy.html
+++ b/philosophy.html
@@ -47,7 +47,7 @@
         <li><a href="/livongo.html" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/how-i-work.html" class="d-nav__link d-nav__link--active">Philosophy</a></li>
+    <li><a href="/philosophy.html" class="d-nav__link d-nav__link--active">Philosophy</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/portfolio.js
+++ b/portfolio.js
@@ -35,7 +35,7 @@
       '/field.html',
       '/invoy.html',
       '/livongo.html',
-      '/how-i-work.html'
+      '/philosophy.html'
     ];
     const current = window.location.pathname;
     const idx = pages.findIndex(p => current.endsWith(p) || current.endsWith(p.replace('.html', '')));

--- a/portfolio/ARCHITECTURE.md
+++ b/portfolio/ARCHITECTURE.md
@@ -14,7 +14,7 @@ portfolio/
   field.html              # Case study: Field
   invoy.html              # Case study: Invoy (lifecycle + DS)
   livongo.html            # Case study: Livongo Config
-  how-i-work.html         # Process: stack, design system, AI workflow
+  philosophy.html         # Process: stack, design system, AI workflow
   portfolio.css           # Portfolio-specific styles (extends ctrl DS)
   portfolio.js            # Nav, scroll behavior, keyboard controls
   case-study-copy.md      # Content source
@@ -110,7 +110,7 @@ CASE STUDY CARDS (3)
   Livongo — thumbnail + tags + one-liner → livongo.html
 
 HOW I WORK TEASER
-  Pipeline strip + one paragraph → how-i-work.html
+  Pipeline strip + one paragraph → philosophy.html
 
 CONTACT
 ```

--- a/portfolio/design-systems.html
+++ b/portfolio/design-systems.html
@@ -18,7 +18,7 @@
     <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
     <li><a href="./design-systems.html" class="d-nav__link d-nav__link--active">Design Systems</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 
@@ -243,7 +243,7 @@ Systemic         → crawl all 5 products → stoplight report</div>
 
 <footer class="d-footer d-contain">
   <a href="./livongo.html" class="d-next">← Livongo</a>
-  <a href="./how-i-work.html" class="d-next">How I Work →</a>
+  <a href="./philosophy.html" class="d-next">How I Work →</a>
 </footer>
 
 <script src="./portfolio.js"></script>

--- a/portfolio/field.html
+++ b/portfolio/field.html
@@ -17,7 +17,7 @@
     <li><a href="./field.html" class="d-nav__link d-nav__link--active">Field</a></li>
     <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -17,7 +17,7 @@
     <li><a href="./field.html" class="d-nav__link">Field</a></li>
     <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 
@@ -64,7 +64,7 @@
   <div class="d-section">
     <p class="d-label">Utilities</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="./how-i-work.html" class="d-card">
+      <a href="./philosophy.html" class="d-card">
         <span class="d-card__tag">AI · iOS · 0→1</span>
         <span class="d-card__title">Design System Manager</span>
         <span class="d-card__desc">Generate and manage your design system from Figma, Paper, Github or live code.</span>
@@ -107,7 +107,7 @@
     <p class="d-label">How I Work</p>
     <p class="d-headline d-headline--lg">One designer, five products, AI-assisted delivery.</p>
     <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
-    <a href="./how-i-work.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
+    <a href="./philosophy.html" class="d-next" style="display: inline-block; margin-top: 16px;">Read more →</a>
   </div>
 
 </div>

--- a/portfolio/invoy.html
+++ b/portfolio/invoy.html
@@ -17,7 +17,7 @@
     <li><a href="./field.html" class="d-nav__link">Field</a></li>
     <li><a href="./invoy.html" class="d-nav__link d-nav__link--active">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 

--- a/portfolio/livongo.html
+++ b/portfolio/livongo.html
@@ -17,7 +17,7 @@
     <li><a href="./field.html" class="d-nav__link">Field</a></li>
     <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link d-nav__link--active">Livongo</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link">How I Work</a></li>
   </ul>
 </nav>
 
@@ -176,7 +176,7 @@
 
 <footer class="d-footer d-contain">
   <a href="./invoy.html" class="d-next">← Invoy</a>
-  <a href="./how-i-work.html" class="d-next">How I Work →</a>
+  <a href="./philosophy.html" class="d-next">How I Work →</a>
 </footer>
 
 <script src="./portfolio.js"></script>

--- a/portfolio/philosophy.html
+++ b/portfolio/philosophy.html
@@ -17,7 +17,7 @@
     <li><a href="./field.html" class="d-nav__link">Field</a></li>
     <li><a href="./invoy.html" class="d-nav__link">Invoy</a></li>
     <li><a href="./livongo.html" class="d-nav__link">Livongo</a></li>
-    <li><a href="./how-i-work.html" class="d-nav__link d-nav__link--active">How I Work</a></li>
+    <li><a href="./philosophy.html" class="d-nav__link d-nav__link--active">How I Work</a></li>
   </ul>
 </nav>
 

--- a/portfolio/portfolio.js
+++ b/portfolio/portfolio.js
@@ -35,7 +35,7 @@
       '/portfolio/field.html',
       '/portfolio/invoy.html',
       '/portfolio/livongo.html',
-      '/portfolio/how-i-work.html'
+      '/portfolio/philosophy.html'
     ];
     const current = window.location.pathname;
     const idx = pages.findIndex(p => current.endsWith(p) || current.endsWith(p.replace('.html', '')));


### PR DESCRIPTION
## Summary
- Rename `how-i-work.html` → `philosophy.html` (root and portfolio/)
- Update all 21 references across 15 files (nav links, JS routing, docs, next-page links)
- Zero references to `how-i-work` remain in the codebase

## Test plan
- [x] `grep -r "how-i-work" .` returns 0 matches
- [x] All navigation links updated to `/philosophy.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)