### PR TITLE
Fix nav header padding to match Paper spec

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -31,8 +31,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 27px;
-  padding: 0 clamp(20px, 5vw, 64px);
+  padding: 16px 36px;
   background: var(--bg, #111110);
   border-bottom: 1px solid var(--border-subtle, #33332f);
 }


### PR DESCRIPTION
## Summary
- Remove fixed `height: 27px` from `.d-nav`
- Update padding from `0 clamp(20px, 5vw, 64px)` to `16px 36px`
- Matches the nav spec across all Paper artboards (Home, Field, Invoy, Livongo, Philosophy)

## Test plan
- [x] Philosophy page nav matches Paper spec
- [x] Home page nav matches Paper spec
- [x] Single CSS change applies to all portfolio pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)