### PR TITLE
Fix subnav overlap on scroll

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -108,7 +108,7 @@
 /* Sub-nav */
 .d-subnav {
   position: sticky;
-  top: 27px;
+  top: 71px; /* JS overrides with actual nav height */
   z-index: 100;
   display: flex;
   gap: 24px;

--- a/design-system/display.css
+++ b/design-system/display.css
@@ -31,8 +31,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 27px;
-  padding: 0 clamp(20px, 5vw, 64px);
+  padding: 16px 36px;
   background: var(--bg, #111110);
   border-bottom: 1px solid var(--border-subtle, #33332f);
 }

--- a/portfolio.js
+++ b/portfolio.js
@@ -279,6 +279,14 @@
     });
   }
 
+  // ── Lock subnav below primary nav ──
+  function initStickyOffsets() {
+    const nav = document.querySelector('.d-nav');
+    const subnav = document.querySelector('.d-subnav');
+    if (!nav || !subnav) return;
+    subnav.style.top = nav.offsetHeight + 'px';
+  }
+
   // ── Init ──
   document.addEventListener('DOMContentLoaded', () => {
     initSubnav();
@@ -287,5 +295,6 @@
     initNavHighlight();
     initNavAccordion();
     initModals();
+    initStickyOffsets();
   });
 })();


### PR DESCRIPTION
## Summary
- Subnav had `top: 27px` (old nav height) causing it to slide under the 71px nav on scroll
- Added `initStickyOffsets()` in portfolio.js to dynamically set subnav top from actual nav height
- Updated CSS fallback from 27px to 71px

## Test plan
- [x] Scroll on philosophy.html — subnav sits directly below nav, no overlap
- [x] Both bars remain sticky and stack correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)