### PR TITLE
Cache-bust display.css for full-width dividers

### DIFF
--- a/design-systems.html
+++ b/design-systems.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
 </head>
 <body class="d-page">
 

--- a/field.html
+++ b/field.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
 </head>
 <body class="d-page">
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
 </head>
 <body class="d-page">
 

--- a/invoy.html
+++ b/invoy.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
 </head>
 <body class="d-page">
 

--- a/livongo.html
+++ b/livongo.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
 </head>
 <body class="d-page">
 

--- a/philosophy.html
+++ b/philosophy.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css">
+  <link rel="stylesheet" href="/design-system/display.css?v=506">
   <style>
     /* Page-specific styles matching Paper design exactly */
     .hiw { max-width: 960px; margin: 0 auto; background: #111110; font-size: 12px; line-height: 16px; -webkit-font-smoothing: antialiased; }


### PR DESCRIPTION
## Summary
- Add `?v=506` to display.css link tags so browsers load the updated CSS with full-width dividers

🤖 Generated with [Claude Code](https://claude.com/claude-code)