### PR TITLE
fix(portfolio): intent-based step headers and tighter spacing

### DIFF
--- a/livongo.html
+++ b/livongo.html
@@ -318,74 +318,44 @@
       <div class="d-sticky-scroll__text">
         <div class="d-sticky-scroll__step is-active" data-step="0">
           <p class="d-mono">01</p>
-          <p class="d-headline d-headline--md">Let's Get Started</p>
-          <p class="d-mono d-text--subtle">Identity reduced to 3 fields</p>
-          <p class="d-body">The welcome banner names the employer — the member knows the system already knows who they are. First name, last name, date of birth. Everything else resolved upstream.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• 9 identity fields → 3</li>
-            <li class="d-body" style="font-size: 12px;">• Employer context shown immediately</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Identity</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Show the member we already know them</p>
+          <p class="d-body">The welcome banner names the employer — the system already knows who they are. First name, last name, date of birth. Everything else resolved upstream. Nine identity fields became three.</p>
         </div>
 
         <div class="d-sticky-scroll__step" data-step="1">
           <p class="d-mono">02</p>
-          <p class="d-headline d-headline--md">Create Your Account</p>
-          <p class="d-mono d-text--subtle">"We found you!" replaces 3 manual steps</p>
-          <p class="d-body">Eligibility auto-confirmed. The system matched the member against employer HR data before they entered a single field. The green banner builds trust — you're already in, just set up your login.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Sponsor & insurance steps eliminated</li>
-            <li class="d-body" style="font-size: 12px;">• Eligibility verified server-side</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Eligibility</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Confirm membership before they ask</p>
+          <p class="d-body">The system matched the member against employer HR data before they entered a single field. "We found you!" replaces three manual verification steps. Sponsor and insurance questions eliminated — eligibility verified server-side.</p>
         </div>
 
         <div class="d-sticky-scroll__step" data-step="2">
           <p class="d-mono">03</p>
-          <p class="d-headline d-headline--md">Set Up Your Program</p>
-          <p class="d-mono d-text--subtle">Pre-filled from health records</p>
-          <p class="d-body">Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion shows 7 fields the system already knows: diabetes type, diagnosis year, medications, exam dates. The member reviews and corrects. They don't re-enter.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Product selection automated via Salesforce config</li>
-            <li class="d-body" style="font-size: 12px;">• 21% drop-off at this step → eliminated</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Program Setup</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Let the system make the product decisions</p>
+          <p class="d-body">Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion shows 7 fields the system already knows. The member reviews and corrects. They don't re-enter. This single change addressed the 21% product selection drop-off.</p>
         </div>
 
         <div class="d-sticky-scroll__step" data-step="3">
           <p class="d-mono">04</p>
-          <p class="d-headline d-headline--md">Health History</p>
-          <p class="d-mono d-text--subtle">Confirm, don't enter</p>
-          <p class="d-body">Two banners — personal records and health records — show the member what the system already knows. Height, weight, and health conditions pre-filled with blue dot indicators. Checkboxes animate in as the system populates them.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Pre-filled from upstream health data</li>
-            <li class="d-body" style="font-size: 12px;">• Source attribution builds trust</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Health History</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Show your sources, earn their trust</p>
+          <p class="d-body">Two banners — personal records and health records — show the member what the system already knows. Height, weight, and health conditions pre-filled with source attribution. The member confirms what's there rather than entering from scratch.</p>
         </div>
 
         <div class="d-sticky-scroll__step" data-step="4">
           <p class="d-mono">05</p>
-          <p class="d-headline d-headline--md">Receiving Your Device</p>
-          <p class="d-mono d-text--subtle">Shipping from employer HR</p>
-          <p class="d-body">Kit preview shows what's coming. Shipping address cascades in from employer HR data — name, street, city, state, zip, each field filling with a blue dot pop animation. The member confirms or corrects.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Address pre-filled from HR records</li>
-            <li class="d-body" style="font-size: 12px;">• Kit preview sets expectations</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Shipping</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Set expectations for what arrives</p>
+          <p class="d-body">Kit preview shows what's coming. Shipping address cascades in from employer HR data. The member confirms or corrects. Every field that auto-fills is one fewer reason to drop off.</p>
         </div>
 
         <div class="d-sticky-scroll__step" data-step="5">
           <p class="d-mono">06</p>
-          <p class="d-headline d-headline--md">You're In!</p>
-          <p class="d-mono d-text--subtle">Completion as a beginning</p>
-          <p class="d-body">The final screen reframes enrollment as the start of a relationship, not the end of a form. Three concrete next steps — download the app, meet your coach, set up your kit — bridge the gap between registration and first use. This is where the activation metric lives.</p>
-          <p class="d-label">What changed</p>
-          <ul style="list-style: none; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Onboarding framed as partnership, not completion</li>
-            <li class="d-body" style="font-size: 12px;">• Clear next steps drive activation</li>
-          </ul>
+          <p class="d-headline d-headline--md" style="margin-top: 4px;">Activation</p>
+          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Bridge the gap between signup and first use</p>
+          <p class="d-body">The final screen reframes enrollment as the start of a relationship. Three concrete next steps — download the app, meet your coach, set up your kit. This is where the activation metric lives. Everything in the flow is designed to get the member here with enough trust to take the next step.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace page titles with intent descriptions (Identity, Eligibility, Program Setup, Health History, Shipping, Activation)
- Add consistent `margin-top: 4px` spacing to step headlines and subtitles matching Field's pattern
- Remove verbose "What changed" bullet lists for cleaner deliverable section

## Test plan
- [ ] Verify livongo.html loads with updated step headers
- [ ] Confirm sticky-scroll parallax still functions correctly
- [ ] Check spacing consistency across all 6 steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)