### PR TITLE
fix(portfolio): progress bars, no-fade UI, scroll-to-reveal

### DIFF
--- a/animations/reg/step1.html
+++ b/animations/reg/step1.html
@@ -15,24 +15,17 @@
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 12s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 4% { opacity: 0; transform: translateY(12px); }
-    8%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
   .progress-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #1976D2; white-space: nowrap; }
   .progress-label--dim { color: #bbb; }
   .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 0; animation: progressFill 1s 0.3s ease forwards; }
-  @keyframes progressFill { to { width: 50%; } }
+  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 50%; }
 
   .content { padding: 32px 28px 28px; }
-  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; opacity: 0; animation: fadeUp 0.5s 0.2s ease forwards; }
-  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; opacity: 0; animation: fadeUp 0.5s 0.35s ease forwards; }
+  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
+  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; }
 
   .welcome {
     background: #faf8f5;
@@ -40,8 +33,6 @@
     border-radius: 10px;
     padding: 16px 20px;
     margin-bottom: 24px;
-    opacity: 0;
-    animation: fadeUp 0.5s 0.5s ease forwards;
   }
   .welcome-greeting { font-size: 15px; font-weight: 600; color: #2d2a26; margin-bottom: 8px; }
   .welcome-body { font-size: 13px; color: #4a4540; line-height: 1.6; }
@@ -72,10 +63,6 @@
     box-shadow: none;
   }
 
-  .field-1 { opacity: 0; animation: fadeUp 0.4s 0.7s ease forwards; }
-  .field-2 { opacity: 0; animation: fadeUp 0.4s 0.85s ease forwards; }
-  .field-3 { opacity: 0; animation: fadeUp 0.4s 1.0s ease forwards; }
-
   .cta {
     width: 100%;
     padding: 14px;
@@ -88,16 +75,9 @@
     font-family: 'Roboto', sans-serif;
     cursor: pointer;
     margin-top: 8px;
-    opacity: 0;
-    animation: fadeUp 0.4s 1.2s ease forwards;
   }
 
-  .privacy { font-size: 11px; color: #999; text-align: center; padding: 12px 28px; display: flex; align-items: center; justify-content: center; gap: 6px; opacity: 0; animation: fadeUp 0.3s 1.4s ease forwards; }
-
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(8px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
+  .privacy { font-size: 11px; color: #999; text-align: center; padding: 12px 28px; display: flex; align-items: center; justify-content: center; gap: 6px; }
 </style>
 </head>
 <body>

--- a/animations/reg/step1.html
+++ b/animations/reg/step1.html
@@ -18,10 +18,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .progress-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #1976D2; white-space: nowrap; }
-  .progress-label--dim { color: #bbb; }
-  .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 50%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 32px 28px 28px; }
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
@@ -84,11 +85,11 @@
 
 <div class="card">
   <div class="progress">
-    <span class="progress-label">Sign Up</span>
-    <div class="progress-bar"><div class="progress-fill"></div></div>
-    <span class="progress-label--dim">About You</span>
-    <div class="progress-bar"></div>
-    <span class="progress-label--dim">Welcome</span>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:50%"></div></div>
+    <span class="pl pl--off">About You</span>
+    <div class="pb"></div>
+    <span class="pl pl--off">Welcome</span>
   </div>
 
   <div class="content">

--- a/animations/reg/step2.html
+++ b/animations/reg/step2.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
   body { background: transparent; font-family: 'Roboto', sans-serif; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; -webkit-font-smoothing: antialiased; }
 
   .card {
@@ -18,12 +19,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .progress-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #1976D2; white-space: nowrap; }
-  .progress-label--dim { color: #bbb; }
-  .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; }
-  .progress-fill--full { width: 100%; }
-  .progress-fill--partial { width: 60%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 32px 28px 28px; }
 
@@ -124,11 +124,11 @@
 
 <div class="card">
   <div class="progress">
-    <span class="progress-label">Sign Up</span>
-    <div class="progress-bar"><div class="progress-fill progress-fill--full"></div></div>
-    <span class="progress-label">About You</span>
-    <div class="progress-bar"><div class="progress-fill progress-fill--partial"></div></div>
-    <span class="progress-label--dim">Welcome</span>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--off">About You</span>
+    <div class="pb"></div>
+    <span class="pl pl--off">Welcome</span>
   </div>
 
   <div class="content">
@@ -251,18 +251,24 @@
       document.getElementById('rule3').classList.add('passed');
     }, 7200);
 
-    // t=7.5s: terms + checkbox
+    // t=2.2s: terms visible
     setTimeout(function() {
       document.getElementById('terms').classList.add('visible');
     }, 2200);
+    // t=2.4s: CTA visible
+    setTimeout(function() {
+      document.getElementById('cta-btn').classList.add('visible');
+    }, 2400);
+
+    // t=7.8s: checkbox checked
     setTimeout(function() {
       document.getElementById('checkbox').classList.add('checked');
     }, 7800);
 
-    // t=8s: CTA
+    // t=8.5s: scroll down to reveal CTA button
     setTimeout(function() {
-      document.getElementById('cta-btn').classList.add('visible');
-    }, 2400);
+      window.scrollTo({ top: 200, behavior: 'smooth' });
+    }, 8500);
   }
 
   setTimeout(runSequence, 0);
@@ -281,6 +287,7 @@
     document.getElementById('checkbox').classList.remove('checked');
     document.getElementById('terms').classList.remove('visible');
     document.getElementById('cta-btn').classList.remove('visible');
+    window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(runSequence, 500);
   }, 16000);
 })();

--- a/animations/reg/step2.html
+++ b/animations/reg/step2.html
@@ -15,12 +15,6 @@
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 16s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 3% { opacity: 0; transform: translateY(12px); }
-    6%, 87% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
@@ -29,12 +23,11 @@
   .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
   .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; }
   .progress-fill--full { width: 100%; }
-  .progress-fill--partial { width: 0; animation: progressFill 0.8s 0.5s ease forwards; }
-  @keyframes progressFill { to { width: 60%; } }
+  .progress-fill--partial { width: 60%; }
 
   .content { padding: 32px 28px 28px; }
 
-  /* Banner — starts visible immediately */
+  /* Banner */
   .verified {
     background: #f5f9f9;
     border: 1px solid #d3d9d9;
@@ -44,25 +37,15 @@
     display: flex;
     align-items: flex-start;
     gap: 12px;
-    opacity: 0;
-    transform: translateY(12px) scale(0.95);
-    animation: verifiedPop 0.7s 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-  }
-  @keyframes verifiedPop {
-    to { opacity: 1; transform: translateY(0) scale(1); }
   }
   .verified-icon { font-size: 20px; flex-shrink: 0; }
   .verified-text { font-size: 13px; color: #333; line-height: 1.6; }
   .verified-text strong { font-weight: 700; }
   .verified-check {
     display: inline-block; color: #2e7d32; font-weight: 700;
-    opacity: 0; transform: scale(0);
-    animation: checkPop 0.3s 1.0s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
   }
-  @keyframes checkPop { to { opacity: 1; transform: scale(1); } }
 
-  /* Rest of content hidden until after banner */
-  .below-banner { opacity: 0; transform: translateY(12px); animation: fadeUp 0.5s 1.4s ease forwards; }
+  .below-banner { }
 
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
   .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; }
@@ -134,12 +117,7 @@
   }
   .cta.visible { opacity: 1; }
 
-  .privacy { font-size: 11px; color: #999; text-align: center; padding: 12px 28px; display: flex; align-items: center; justify-content: center; gap: 6px; opacity: 0; animation: fadeUp 0.3s 1.8s ease forwards; }
-
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(8px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
+  .privacy { font-size: 11px; color: #999; text-align: center; padding: 12px 28px; display: flex; align-items: center; justify-content: center; gap: 6px; }
 </style>
 </head>
 <body>

--- a/animations/reg/step3-select.html
+++ b/animations/reg/step3-select.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
   body { background: transparent; font-family: 'Roboto', sans-serif; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; -webkit-font-smoothing: antialiased; }
 
   .card {
@@ -18,12 +19,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .progress-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #1976D2; white-space: nowrap; }
-  .progress-label--dim { color: #bbb; }
-  .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; }
-  .fill-full { width: 100%; }
-  .fill-half { width: 50%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 32px 28px 28px; }
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
@@ -80,11 +80,11 @@
 
 <div class="card">
   <div class="progress">
-    <span class="progress-label">Sign Up</span>
-    <div class="progress-bar"><div class="progress-fill fill-full"></div></div>
-    <span class="progress-label">About You</span>
-    <div class="progress-bar"><div class="progress-fill fill-half"></div></div>
-    <span class="progress-label--dim">Welcome</span>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--on">About You</span>
+    <div class="pb"><div class="pf" style="width:25%"></div></div>
+    <span class="pl pl--off">Welcome</span>
   </div>
 
   <div class="content">
@@ -139,12 +139,17 @@
     setTimeout(function() { document.getElementById('prog1').classList.add('selected'); }, 2000);
     setTimeout(function() { document.getElementById('prog2').classList.add('selected'); }, 2800);
     // prog3 stays unselected (optional)
+    // t=4s: scroll down to reveal CTA button
+    setTimeout(function() {
+      window.scrollTo({ top: 100, behavior: 'smooth' });
+    }, 4000);
   }
 
   setTimeout(run, 0);
 
   setInterval(function() {
     document.querySelectorAll('.program').forEach(function(p) { p.classList.remove('selected'); });
+    window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(run, 500);
   }, 14000);
 })();

--- a/animations/reg/step3-select.html
+++ b/animations/reg/step3-select.html
@@ -15,12 +15,6 @@
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 14s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 3% { opacity: 0; transform: translateY(12px); }
-    7%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
@@ -32,15 +26,14 @@
   .fill-half { width: 50%; }
 
   .content { padding: 32px 28px 28px; }
-  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; opacity: 0; animation: fadeUp 0.5s 0.2s ease forwards; }
-  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 24px; opacity: 0; animation: fadeUp 0.5s 0.35s ease forwards; }
+  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
+  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 24px; }
 
   .source-banner {
     background: #e8f5e9; border: 1px solid #c8e6c9; border-radius: 8px;
     padding: 12px 16px; margin-bottom: 20px;
     display: flex; align-items: center; gap: 10px;
     font-size: 13px; color: #2e7d32; font-weight: 500;
-    opacity: 0; animation: fadeUp 0.5s 0.5s ease forwards;
   }
   .source-banner__icon { font-size: 16px; }
   .source-banner__sub { font-size: 11px; color: #558b2f; font-weight: 400; margin-top: 2px; }
@@ -51,12 +44,8 @@
     border: 1px solid #e0e0e0; border-radius: 10px; padding: 16px 20px;
     display: flex; align-items: center; gap: 14px;
     transition: border-color 0.3s, background 0.3s;
-    opacity: 0;
   }
   .program.selected { border-color: #1976D2; background: #f5f9ff; }
-  .prog-1 { animation: fadeUp 0.4s 0.7s ease forwards; }
-  .prog-2 { animation: fadeUp 0.4s 0.9s ease forwards; }
-  .prog-3 { animation: fadeUp 0.4s 1.1s ease forwards; }
 
   .program__check {
     width: 24px; height: 24px; border-radius: 50%; border: 2px solid #ddd;
@@ -80,16 +69,10 @@
   .cta {
     width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
-    margin-top: 20px; opacity: 0; animation: fadeUp 0.4s 1.3s ease forwards;
+    margin-top: 20px;
   }
   .help-text {
     font-size: 11px; color: #999; text-align: center; margin-top: 12px;
-    opacity: 0; animation: fadeUp 0.3s 1.5s ease forwards;
-  }
-
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(8px); }
-    to { opacity: 1; transform: translateY(0); }
   }
 </style>
 </head>

--- a/animations/reg/step3.html
+++ b/animations/reg/step3.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
   body { background: transparent; font-family: 'Roboto', sans-serif; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; -webkit-font-smoothing: antialiased; }
 
   .card {
@@ -18,12 +19,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .progress-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: #1976D2; white-space: nowrap; }
-  .progress-label--dim { color: #bbb; }
-  .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; }
-  .fill-full { width: 100%; }
-  .fill-grow { width: 30%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 32px 28px 28px; }
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
@@ -99,11 +99,11 @@
 
 <div class="card">
   <div class="progress">
-    <span class="progress-label">Sign Up</span>
-    <div class="progress-bar"><div class="progress-fill fill-full"></div></div>
-    <span class="progress-label">About You</span>
-    <div class="progress-bar"><div class="progress-fill fill-grow"></div></div>
-    <span class="progress-label--dim">Welcome</span>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--on">About You</span>
+    <div class="pb"><div class="pf" style="width:40%"></div></div>
+    <span class="pl pl--off">Welcome</span>
   </div>
 
   <div class="content">
@@ -186,6 +186,11 @@
       document.getElementById('records-body').classList.add('open');
       document.getElementById('chevron').style.transform = 'rotate(90deg)';
     }, 3800);
+
+    // t=5s: scroll down to reveal CTA button
+    setTimeout(function() {
+      window.scrollTo({ top: 240, behavior: 'smooth' });
+    }, 5000);
   }
 
   setTimeout(run, 0);
@@ -196,6 +201,7 @@
     document.getElementById('dot2').classList.remove('visible');
     document.getElementById('records-body').classList.remove('open');
     document.getElementById('chevron').style.transform = '';
+    window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(run, 500);
   }, 14000);
 })();

--- a/animations/reg/step3.html
+++ b/animations/reg/step3.html
@@ -15,12 +15,6 @@
     border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 14s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 3% { opacity: 0; transform: translateY(12px); }
-    7%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
@@ -29,17 +23,15 @@
   .progress-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
   .progress-fill { height: 100%; background: #1976D2; border-radius: 2px; }
   .fill-full { width: 100%; }
-  .fill-grow { width: 0; animation: grow 0.8s 0.4s ease forwards; }
-  @keyframes grow { to { width: 30%; } }
+  .fill-grow { width: 30%; }
 
   .content { padding: 32px 28px 28px; }
-  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; opacity: 0; animation: fadeUp 0.5s 0.2s ease forwards; }
-  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; opacity: 0; animation: fadeUp 0.5s 0.35s ease forwards; }
+  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
+  .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; }
 
   .value-card {
     background: #faf8f5; border: 1px solid #ede8e1; border-radius: 10px;
     padding: 16px 20px; margin-bottom: 24px;
-    opacity: 0; animation: fadeUp 0.5s 0.5s ease forwards;
   }
   .value-greeting { font-size: 15px; font-weight: 600; color: #2d2a26; margin-bottom: 8px; }
   .value-body { font-size: 13px; color: #4a4540; line-height: 1.6; }
@@ -60,7 +52,7 @@
     border-color: #1976D2; background: #1976D2; box-shadow: inset 0 0 0 3px #fff;
   }
 
-  .q1 { opacity: 0; animation: fadeUp 0.4s 0.8s ease forwards; }
+  .q1 { }
 
   .section-label { font-size: 10px; font-weight: 600; color: #666; margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.04em; }
   .form-group { display: flex; flex-direction: column; margin-bottom: 14px; }
@@ -74,12 +66,8 @@
   .prefill-dot { width: 8px; height: 8px; border-radius: 50%; background: #1976D2; flex-shrink: 0; opacity: 0; transition: all 0.3s; }
   .prefill-dot.visible { opacity: 1; }
 
-  .sel-1 { opacity: 0; animation: fadeUp 0.4s 1.0s ease forwards; }
-  .sel-2 { opacity: 0; animation: fadeUp 0.4s 1.15s ease forwards; }
-
   .records {
     border: 1px solid #e0e0e0; border-radius: 10px; overflow: hidden; margin-top: 8px;
-    opacity: 0; animation: fadeUp 0.4s 1.4s ease forwards;
   }
   .records-header {
     padding: 14px 16px; font-size: 13px; font-weight: 600; color: #555;
@@ -103,12 +91,7 @@
   .cta {
     width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
-    margin-top: 16px; opacity: 0; animation: fadeUp 0.4s 1.6s ease forwards;
-  }
-
-  @keyframes fadeUp {
-    from { opacity: 0; transform: translateY(8px); }
-    to { opacity: 1; transform: translateY(0); }
+    margin-top: 16px;
   }
 </style>
 </head>

--- a/animations/reg/step4.html
+++ b/animations/reg/step4.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
   body { background: transparent; font-family: 'Roboto', sans-serif; display: flex; justify-content: center; -webkit-font-smoothing: antialiased; }
 
   .card {
@@ -15,11 +16,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .p-label { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
-  .p-label--on { color: #1976D2; } .p-label--off { color: #bbb; }
-  .p-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
-  .p-fill { height: 100%; background: #1976D2; border-radius: 2px; }
-  .p-full { width: 100%; } .p-grow { width: 70%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 32px 28px 28px; }
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
@@ -64,11 +65,11 @@
 <body>
 <div class="card">
   <div class="progress">
-    <span class="p-label p-label--on">Sign Up</span>
-    <div class="p-bar"><div class="p-fill p-full"></div></div>
-    <span class="p-label p-label--on">About You</span>
-    <div class="p-bar"><div class="p-fill p-grow"></div></div>
-    <span class="p-label p-label--off">Welcome</span>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--on">About You</span>
+    <div class="pb"><div class="pf" style="width:60%"></div></div>
+    <span class="pl pl--off">Welcome</span>
   </div>
   <div class="content">
     <div class="title">Health History</div>
@@ -152,6 +153,11 @@
       document.getElementById('check2').classList.add('checked');
       document.getElementById('dot3').classList.add('visible');
     }, 4200);
+
+    // t=5.5s: scroll down to reveal CTA button
+    setTimeout(function() {
+      window.scrollTo({ top: 120, behavior: 'smooth' });
+    }, 5500);
   }
 
   setTimeout(run, 0);
@@ -163,6 +169,7 @@
     var wt = document.getElementById('weight-text');
     wt.textContent = 'e.g. 185';
     wt.style.color = '#bbb';
+    window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(run, 500);
   }, 13000);
 })();

--- a/animations/reg/step4.html
+++ b/animations/reg/step4.html
@@ -12,12 +12,6 @@
   .card {
     width: 480px; background: #fff; border-radius: 16px; overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 13s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 4% { opacity: 0; transform: translateY(12px); }
-    8%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
@@ -25,16 +19,15 @@
   .p-label--on { color: #1976D2; } .p-label--off { color: #bbb; }
   .p-bar { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
   .p-fill { height: 100%; background: #1976D2; border-radius: 2px; }
-  .p-full { width: 100%; } .p-grow { width: 0; animation: g 0.8s 0.4s ease forwards; }
-  @keyframes g { to { width: 70%; } }
+  .p-full { width: 100%; } .p-grow { width: 70%; }
 
   .content { padding: 32px 28px 28px; }
-  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; opacity: 0; animation: fu 0.5s 0.2s ease forwards; }
-  .sub { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; opacity: 0; animation: fu 0.5s 0.35s ease forwards; }
+  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
+  .sub { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; }
 
-  .banner { border-radius: 10px; padding: 14px 18px; margin-bottom: 16px; display: flex; align-items: flex-start; gap: 12px; opacity: 0; }
-  .banner--warm { background: #faf8f5; border: 1px solid #ede8e1; animation: fu 0.5s 0.5s ease forwards; }
-  .banner--blue { background: #f0f7ff; border: 1px solid #d0e3f8; border-left: 3px solid #1976D2; animation: fu 0.5s 0.7s ease forwards; }
+  .banner { border-radius: 10px; padding: 14px 18px; margin-bottom: 16px; display: flex; align-items: flex-start; gap: 12px; }
+  .banner--warm { background: #faf8f5; border: 1px solid #ede8e1; }
+  .banner--blue { background: #f0f7ff; border: 1px solid #d0e3f8; border-left: 3px solid #1976D2; }
   .banner-icon { font-size: 18px; flex-shrink: 0; }
   .banner-text { font-size: 13px; color: #444; line-height: 1.6; }
   .banner-text strong { font-weight: 600; }
@@ -53,12 +46,9 @@
   .dot { width: 8px; height: 8px; border-radius: 50%; background: #1976D2; flex-shrink: 0; opacity: 0; transition: all 0.3s; }
   .dot.visible { opacity: 1; }
 
-  .f1 { opacity: 0; animation: fu 0.4s 0.9s ease forwards; }
-  .f2 { opacity: 0; animation: fu 0.4s 1.05s ease forwards; }
+  .section-label { font-size: 10px; font-weight: 600; color: #666; text-transform: uppercase; letter-spacing: 0.04em; margin: 16px 0 10px; }
 
-  .section-label { font-size: 10px; font-weight: 600; color: #666; text-transform: uppercase; letter-spacing: 0.04em; margin: 16px 0 10px; opacity: 0; animation: fu 0.4s 1.2s ease forwards; }
-
-  .check-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid #f0f0f0; font-size: 14px; color: #333; opacity: 0; }
+  .check-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid #f0f0f0; font-size: 14px; color: #333; }
   .check-box {
     width: 18px; height: 18px; border: 1.5px solid #ccc; border-radius: 4px; flex-shrink: 0;
     display: flex; align-items: center; justify-content: center;
@@ -68,12 +58,7 @@
   .check-box.checked::after { content: "✓"; color: #fff; font-size: 11px; font-weight: 700; }
   .check-pre { display: flex; align-items: center; gap: 6px; margin-left: auto; font-size: 10px; color: #1976D2; }
 
-  .c1 { animation: fu 0.4s 1.4s ease forwards; }
-  .c2 { animation: fu 0.4s 1.55s ease forwards; }
-
-  .cta { width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none; border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif; margin-top: 16px; opacity: 0; animation: fu 0.4s 1.7s ease forwards; }
-
-  @keyframes fu { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+  .cta { width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none; border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif; margin-top: 16px; }
 </style>
 </head>
 <body>

--- a/animations/reg/step5.html
+++ b/animations/reg/step5.html
@@ -7,6 +7,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; }
   body { background: transparent; font-family: 'Roboto', sans-serif; display: flex; justify-content: center; -webkit-font-smoothing: antialiased; }
 
   .card {
@@ -16,11 +17,10 @@
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
   .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
-  .pl--on { color: #1976D2; } .pl--off { color: #bbb; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
   .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
   .pf { height: 100%; background: #1976D2; border-radius: 2px; }
-  .pf-full { width: 100%; }
-  .pf-grow { width: 85%; }
 
   .content { padding: 32px 28px 28px; }
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
@@ -65,9 +65,9 @@
 <div class="card">
   <div class="progress">
     <span class="pl pl--on">Sign Up</span>
-    <div class="pb"><div class="pf pf-full"></div></div>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
     <span class="pl pl--on">About You</span>
-    <div class="pb"><div class="pf pf-grow"></div></div>
+    <div class="pb"><div class="pf" style="width:85%"></div></div>
     <span class="pl pl--off">Welcome</span>
   </div>
   <div class="content">
@@ -124,6 +124,11 @@
   ];
 
   function run() {
+    // t=4.5s: scroll down to reveal CTA button
+    setTimeout(function() {
+      window.scrollTo({ top: 80, behavior: 'smooth' });
+    }, 4500);
+
     fills.forEach(function(f) {
       setTimeout(function() {
         var el = document.getElementById(f.textId);
@@ -149,6 +154,7 @@
       fi.style.color = '';
       document.getElementById(f.dotId).classList.remove('visible');
     });
+    window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(run, 500);
   }, 12000);
 })();

--- a/animations/reg/step5.html
+++ b/animations/reg/step5.html
@@ -12,12 +12,6 @@
   .card {
     width: 480px; background: #fff; border-radius: 16px; overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 12s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 4% { opacity: 0; transform: translateY(12px); }
-    8%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
@@ -26,18 +20,16 @@
   .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
   .pf { height: 100%; background: #1976D2; border-radius: 2px; }
   .pf-full { width: 100%; }
-  .pf-grow { width: 0; animation: gr 0.8s 0.4s ease forwards; }
-  @keyframes gr { to { width: 85%; } }
+  .pf-grow { width: 85%; }
 
   .content { padding: 32px 28px 28px; }
-  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; opacity: 0; animation: fu 0.5s 0.2s ease forwards; }
-  .sub { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; opacity: 0; animation: fu 0.5s 0.35s ease forwards; }
+  .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
+  .sub { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 20px; }
   .sub strong { font-weight: 700; }
 
   .kit {
     background: #f5f9ff; border: 1px solid #e0eaf5; border-radius: 10px;
-    padding: 16px 20px; margin-bottom: 20px; opacity: 0;
-    animation: fu 0.5s 0.5s ease forwards;
+    padding: 16px 20px; margin-bottom: 20px;
   }
   .kit-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; color: #333; }
   .kit-check { color: #1976D2; font-weight: 700; }
@@ -46,7 +38,6 @@
     background: #f0f7ff; border: 1px solid #d0e3f8; border-left: 3px solid #1976D2;
     border-radius: 10px; padding: 12px 16px; margin-bottom: 20px;
     font-size: 12px; color: #555; line-height: 1.5; display: flex; align-items: flex-start; gap: 10px;
-    opacity: 0; animation: fu 0.5s 0.7s ease forwards;
   }
   .source-icon { font-size: 16px; flex-shrink: 0; }
 
@@ -63,17 +54,11 @@
   .form-row { display: flex; gap: 12px; margin-bottom: 14px; }
   .form-row .fg { flex: 1; margin-bottom: 0; }
 
-  .af1 { opacity: 0; animation: fu 0.4s 0.9s ease forwards; }
-  .af2 { opacity: 0; animation: fu 0.4s 1.05s ease forwards; }
-  .af3 { opacity: 0; animation: fu 0.4s 1.2s ease forwards; }
-
   .cta {
     width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
-    margin-top: 8px; opacity: 0; animation: fu 0.4s 1.4s ease forwards;
+    margin-top: 8px;
   }
-
-  @keyframes fu { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 </style>
 </head>
 <body>

--- a/animations/reg/step6.html
+++ b/animations/reg/step6.html
@@ -15,10 +15,11 @@
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
-  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; color: #1976D2; }
-  .pb { flex: 1; height: 3px; background: #1976D2; border-radius: 2px; }
-  .pb-grow { background: #e8e8e8; overflow: hidden; }
-  .pb-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 100%; }
+  .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; }
+  .pl--on { color: #1976D2; }
+  .pl--off { color: #bbb; }
+  .pb { flex: 1; height: 3px; background: #e8e8e8; border-radius: 2px; overflow: hidden; }
+  .pf { height: 100%; background: #1976D2; border-radius: 2px; }
 
   .content { padding: 28px 28px 24px; }
 
@@ -68,12 +69,11 @@
 <body>
 <div class="card">
   <div class="progress">
-    <span class="pl">Sign Up</span>
-    <div class="pb"></div>
-    <span class="pl">About You</span>
-    <div class="pb"></div>
-    <span class="pl">Welcome</span>
-    <div class="pb-grow"><div class="pb-fill"></div></div>
+    <span class="pl pl--on">Sign Up</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--on">About You</span>
+    <div class="pb"><div class="pf" style="width:100%"></div></div>
+    <span class="pl pl--on">Welcome</span>
   </div>
   <div class="content">
     <div class="hero">

--- a/animations/reg/step6.html
+++ b/animations/reg/step6.html
@@ -12,20 +12,13 @@
   .card {
     width: 480px; background: #fff; border-radius: 16px; overflow: hidden;
     box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-    animation: cardLoop 11s ease infinite;
-  }
-  @keyframes cardLoop {
-    0%, 4% { opacity: 0; transform: translateY(12px); }
-    8%, 85% { opacity: 1; transform: translateY(0); }
-    95%, 100% { opacity: 0; transform: translateY(-4px); }
   }
 
   .progress { display: flex; align-items: center; gap: 10px; padding: 16px 28px; border-bottom: 1px solid #eee; }
   .pl { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; white-space: nowrap; color: #1976D2; }
   .pb { flex: 1; height: 3px; background: #1976D2; border-radius: 2px; }
   .pb-grow { background: #e8e8e8; overflow: hidden; }
-  .pb-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 0; animation: gr 0.6s 0.3s ease forwards; }
-  @keyframes gr { to { width: 100%; } }
+  .pb-fill { height: 100%; background: #1976D2; border-radius: 2px; width: 100%; }
 
   .content { padding: 28px 28px 24px; }
 
@@ -34,30 +27,21 @@
     background: #f5f9f9; border: 1px solid #d3d9d9; border-radius: 12px;
     padding: 24px; display: flex; align-items: flex-start; gap: 16px;
     margin-bottom: 28px;
-    opacity: 0; transform: scale(0.95);
-    animation: heroPop 0.7s 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-  }
-  @keyframes heroPop {
-    to { opacity: 1; transform: scale(1); }
   }
   .hero-icon { font-size: 28px; flex-shrink: 0; }
   .hero-title { font-size: 20px; font-weight: 700; color: #222; margin-bottom: 4px; }
   .hero-text { font-size: 14px; color: #555; line-height: 1.5; }
 
   /* Journey section */
-  .section-title { font-size: 18px; font-weight: 600; color: #222; margin-bottom: 4px; opacity: 0; animation: fu 0.5s 1.0s ease forwards; }
-  .section-sub { font-size: 13px; color: #888; margin-bottom: 20px; opacity: 0; animation: fu 0.5s 1.1s ease forwards; }
+  .section-title { font-size: 18px; font-weight: 600; color: #222; margin-bottom: 4px; }
+  .section-sub { font-size: 13px; color: #888; margin-bottom: 20px; }
 
   /* Three cards */
   .cards { display: flex; gap: 12px; margin-bottom: 28px; }
   .next-card {
     flex: 1; border: 1px solid #e8e8e8; border-radius: 10px;
     padding: 16px 14px; text-align: center;
-    opacity: 0; transform: translateY(12px);
   }
-  .nc1 { animation: fu 0.5s 1.3s ease forwards; }
-  .nc2 { animation: fu 0.5s 1.5s ease forwards; }
-  .nc3 { animation: fu 0.5s 1.7s ease forwards; }
   .nc-icon { font-size: 24px; margin-bottom: 8px; }
   .nc-title { font-size: 13px; font-weight: 700; color: #222; margin-bottom: 6px; }
   .nc-body { font-size: 11px; color: #666; line-height: 1.5; margin-bottom: 10px; }
@@ -67,7 +51,6 @@
   .stats {
     display: flex; gap: 0; border-radius: 10px; overflow: hidden;
     background: linear-gradient(135deg, #f0f7ff 0%, #e8f5e9 100%);
-    opacity: 0; animation: fu 0.5s 2.0s ease forwards;
   }
   .stat {
     flex: 1; text-align: center; padding: 16px 8px;
@@ -78,10 +61,8 @@
   .cta {
     width: 100%; padding: 14px; background: #fff; color: #1976D2; border: 2px solid #1976D2;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
-    margin-top: 20px; cursor: pointer; opacity: 0; animation: fu 0.4s 2.3s ease forwards;
+    margin-top: 20px; cursor: pointer;
   }
-
-  @keyframes fu { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Standardize progress bar classes across all 7 registration animations (unified `.pl/.pb/.pf` naming, consistent blue=active/gray=inactive labels)
- Progress bars now correctly advance: steps 1-2 under Sign Up, steps 3-5 under About You, step 6 completes Welcome
- Remove all UI fade-in animations — content renders instantly on load
- Add smooth scroll-to-reveal for CTA buttons on taller animations (steps 2-5) so no content is cut off

## Test plan
- [ ] Verify each animation shows consistent progress bar styling
- [ ] Confirm progress fills advance logically across all 7 steps
- [ ] Check that CTA buttons are visible (via scroll animation) on all steps
- [ ] Verify animation loops reset cleanly (scroll resets to top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)