### PR TITLE
feat(invoy): apply Paper rewrite to /invoy/

### DIFF
--- a/invoy/index.html
+++ b/invoy/index.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css?v=506">
+  <link rel="stylesheet" href="/design-system/display.css?v=507">
 </head>
 <body class="d-page">
 
@@ -30,14 +30,13 @@
 <div class="d-subnav">
   <a href="#framing" class="d-subnav__link d-subnav__link--active">Framing</a>
   <a href="#experience" class="d-subnav__link">Experience</a>
-  <a href="#content" class="d-subnav__link">Content</a>
   <a href="#process" class="d-subnav__link">Process</a>
   <a href="#impact" class="d-subnav__link">Impact</a>
 </div>
 
 <div class="d-contain">
 
-  <!-- Header -->
+  <!-- Header + Overview -->
   <div style="padding: 48px 0 0;">
     <span class="d-status d-status--shipped">Shipped</span>
     <p class="d-headline d-headline--xl" style="margin-top: 12px;">Invoy</p>
@@ -45,17 +44,17 @@
 
     <dl class="d-overview">
       <dt>Role</dt>
-      <dd>Designer & PM, 3-person eng team</dd>
+      <dd>Designer &amp; PM, 3-person eng team</dd>
       <dt>Scope</dt>
       <dd>Weekly planning flow, daily check-in redesign, push notification system, design system foundation</dd>
       <dt>Timeline</dt>
-      <dd>2 weeks planning, 2 sprints dev — design and engineering ran in parallel</dd>
+      <dd>2 weeks planning, 2 sprints — design and engineering ran in parallel</dd>
     </dl>
   </div>
 
   <!-- WHY THIS PROJECT -->
-  <div class="d-why d-why--shipped" style="margin-top: 32px;">
-    <p class="d-why__label">Why this Project?</p>
+  <div class="d-why d-why--shipped" style="margin-top: 48px;">
+    <p class="d-why__label">Why this project?</p>
     <p class="d-why__headline">The data existed. The coaching worked. Members just couldn't see it.</p>
     <p class="d-why__body">Invoy already had the hard pieces — a breath sensor that measured fat burn, coaches who built weekly plans, and a carb-restriction protocol that worked. But the member-facing app didn't reflect any of it. Coaches set goals behind the scenes in an internal tool. Members checked in daily without knowing what they were working toward. Roughly 30% engaged beyond breath tests. The product had depth. The interface didn't.</p>
   </div>
@@ -63,166 +62,79 @@
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>
-    <p class="d-body">Invoy was a metabolic health startup with a breath sensor that could detect fat burn. 20,000 members, a clinical protocol that produced real results for members who engaged, and a coaching model that was buckling under its own weight — each coach managed 100–200 members manually. The product worked. Engagement didn't. Roughly 30% of members interacted beyond the daily breath test, and the coaching team couldn't scale without automation.</p>
-    <p class="d-body" style="margin-top: 12px;">Five problems defined the project. Each was a design problem, not a science problem — the clinical model worked, but the interface was getting in the way.</p>
+    <p class="d-body">Most health apps treat each screen as a standalone moment. You check in today, but the app doesn't connect that to what you planned this week or what happened yesterday. The member has to hold the context in their head.</p>
+    <p class="d-body">Invoy needed a <strong>loop, not a list of features</strong>. Weekly planning should shape daily actions. Daily data should trigger coaching. Weekly review should change next week's plan.</p>
 
-    <div class="d-decisions" style="margin-top: 24px;">
-      <div class="d-decision">
-        <p class="d-decision__q">No engagement rhythm beyond breath tests</p>
-        <p class="d-decision__a">One daily push notification. Members who missed a day had no reason to come back. We needed a weekly cadence — planning, check-in, mid-week boost, review — so the daily notification became one beat in a larger rhythm.</p>
+    <div class="d-personas">
+      <div class="d-persona">
+        <span class="d-persona__role">Primary user</span>
+        <span class="d-persona__name">Member</span>
+        <ul class="d-persona__needs">
+          <li>Wants to know what to eat today based on their plan</li>
+          <li>Needs to see progress without reading charts</li>
+          <li>Wants to get back on track after a bad day without guilt</li>
+        </ul>
       </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Coaching knowledge trapped in internal tools</p>
-        <p class="d-decision__a">Coaches built weekly plans through an internal tool. Members never saw any of it. The goal: surface the plan and extract enough of the coach's decision-making to suggest goals automatically.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Scientific language that didn't land</p>
-        <p class="d-decision__a">Actions stayed precise — "Less than 20g Carbs" kept its name. But the structure around them was impenetrable. "Accelerants" became "Weekly Goals." "Base plan adherence" became "Your Plan."</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Clinical tone, no warmth</p>
-        <p class="d-decision__a">A medical product distributed through doctors — the voice had calcified into clinical and cold. We needed the authority of a clinical partner with the warmth of a coach who knows your name.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">No design system, every screen bespoke</p>
-        <p class="d-decision__a">We carved out the weekly planning flow as the system's proving ground. Color, type, and spacing applied universally first, then components formalized from the patterns that emerged.</p>
+      <div class="d-persona">
+        <span class="d-persona__role">Secondary user</span>
+        <span class="d-persona__name">Coach</span>
+        <ul class="d-persona__needs">
+          <li>Manages 100–200 members — needs to spot who needs help fast</li>
+          <li>Wants data-backed reasons to reach out</li>
+          <li>Needs to suggest specific plan changes, not generic nudges</li>
+        </ul>
       </div>
     </div>
   </div>
 
   <!-- EXPERIENCE -->
-  <div id="experience" class="d-section">
+  <div id="experience" class="d-section" style="border-bottom: none;">
     <p class="d-label">Experience</p>
-    <p class="d-body">The weekly planning flow is the core deliverable. It takes what coaches were doing manually — reviewing a member's base plan, suggesting goals, and scheduling the week — and turns it into a 4-step flow the member completes in under 2 minutes.</p>
+    <p class="d-body" style="margin-top: 12px;">The weekly planning flow is the core deliverable. It takes what coaches were doing manually — reviewing a member's base plan, suggesting goals, and scheduling the week — and turns it into a 2-step flow the member completes in under 2 minutes. The daily check-in drops alongside it, rebuilt to reflect the new weekly plan.</p>
 
-    <div class="d-sticky-scroll" style="margin-top: 24px;">
-      <!-- Sticky phone column -->
-      <div class="d-sticky-scroll__phone" id="stickyPhone">
-        <div class="d-sticky-scroll__layers">
-          <!-- Layer 0: Daily check-in (no engagement rhythm) -->
-          <div class="d-sticky-scroll__layer is-active" data-step="0">
-            <div class="d-anim-phone" style="overflow: hidden; border-radius: 48px;">
-              <iframe data-src="/animations/daily-checkin.html?paused" style="width: 404px; height: 856px; border: none; pointer-events: none; display: block;" id="checkinFrame"></iframe>
-            </div>
-          </div>
-          <!-- Layer 1: Weekly planning -->
-          <div class="d-sticky-scroll__layer" data-step="1">
-            <div class="d-anim-phone" style="overflow: hidden; border-radius: 48px;">
-              <iframe data-src="/animations/weekly-plan.html?paused" style="width: 404px; height: 856px; border: none; pointer-events: none; display: block;" id="planningFrame"></iframe>
-            </div>
-          </div>
+    <!-- Weekly Planning -->
+    <div style="display: flex; gap: 48px; align-items: flex-start; margin-top: 48px; flex-wrap: wrap;">
+      <div style="flex-shrink: 0;">
+        <div style="overflow: hidden; border-radius: 48px;">
+          <iframe data-src="/animations/weekly-plan.html?paused&embedded" style="width: 402px; height: 856px; border: none; pointer-events: none; display: block;" id="weeklyPlanFrame"></iframe>
         </div>
       </div>
+      <div style="flex: 1; min-width: 320px;">
+        <p class="d-mono" style="color: var(--fg-subtle, #666560);">01</p>
+        <p class="d-headline d-headline--md" style="margin-top: 4px;">Weekly Planning</p>
+        <p class="d-mono" style="color: var(--fg-subtle, #666560); margin-top: 4px;">Your week, planned around real life</p>
+        <p class="d-body" style="margin-top: 12px;">The flow starts by showing the member their base plan — the carb restriction or fasting protocol their coach set up. Then it surfaces weekly goals the system recommends based on last week's data, past habits, and people with similar profiles. The member reviews, adjusts, and commits.</p>
 
-      <!-- Scrolling text column -->
-      <div class="d-sticky-scroll__text">
-        <!-- Step 0: No engagement rhythm -->
-        <div class="d-sticky-scroll__step is-active" data-step="0">
-          <p class="d-mono" style="color: var(--fg-subtle, #666560);">01</p>
-          <p class="d-headline d-headline--md" style="margin-top: 4px;">Daily Check-in</p>
-          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Yesterday's actions, today's plan</p>
-          <p class="d-body" style="margin-top: 12px;">The daily check-in was redesigned to reflect the weekly plan. Instead of a generic "how did you do" question, the check-in now shows the member's specific goals — their carb target, daily focus items, and weekly boosts — and asks them to mark each one. The slider for carbs replaced the old icon-tap pattern, making the input faster and more precise.</p>
-          <p class="d-label" style="margin-top: 20px;">What Changed</p>
-          <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Carb target shown inline with a 3-point slider (On Plan / About / Over) — replaces the old multi-icon grid</li>
-            <li class="d-body" style="font-size: 12px;">• Daily Focus and Weekly Boosts appear as checkable items with completion counts</li>
-            <li class="d-body" style="font-size: 12px;">• "Reflect on Yesterday" framing shifts tone from grading to learning</li>
-            <li class="d-body" style="font-size: 12px;">• Weekly goal review link at the bottom creates a bridge back to the planning flow</li>
-          </ul>
-        </div>
+        <p class="d-label" style="margin-top: 24px;">Design Decisions</p>
+        <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 6px;">
+          <li class="d-body" style="font-size: 13px;">• "Review Your Base Plan" makes the coach's work visible for the first time — members see what they're on and why.</li>
+          <li class="d-body" style="font-size: 13px;">• Goals split into three tiers: Coach Recommended, Daily Focus, and Weekly Boosts — escalating commitment without overwhelming.</li>
+          <li class="d-body" style="font-size: 13px;">• Confirmation screen shows the full week at a glance and day-by-day, so the member knows exactly what they're signing up for.</li>
+          <li class="d-body" style="font-size: 13px;">• "Skip this week" is always available — no guilt, no friction.</li>
+        </ul>
+      </div>
+    </div>
 
-        <!-- Step 1: Weekly Planning -->
-        <div class="d-sticky-scroll__step" data-step="1">
-          <p class="d-mono" style="color: var(--fg-subtle, #666560);">02</p>
-          <p class="d-headline d-headline--md" style="margin-top: 4px;">Weekly Planning</p>
-          <p class="d-mono d-text--subtle" style="margin-top: 4px;">Your week, planned around real life</p>
-          <p class="d-body" style="margin-top: 12px;">The flow starts by showing the member their base plan — the carb restriction or fasting protocol their coach set up. Then it surfaces weekly goals the system recommends based on last week's data, past habits, and people with similar profiles. The member reviews, adjusts, and commits.</p>
-          <p class="d-label" style="margin-top: 20px;">Design Decisions</p>
-          <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• "Review Your Base Plan" makes the coach's work visible for the first time — members see what they're on and why</li>
-            <li class="d-body" style="font-size: 12px;">• Goals split into three tiers: Coach Recommended, Daily Focus, and Weekly Boosts — escalating commitment without overwhelming</li>
-            <li class="d-body" style="font-size: 12px;">• Confirmation screen shows the full week at a glance and day-by-day</li>
-            <li class="d-body" style="font-size: 12px;">• "Skip this week" is always available — no guilt, no friction</li>
-          </ul>
+    <!-- Daily Check-in -->
+    <div style="display: flex; gap: 48px; align-items: flex-start; margin-top: 96px; flex-wrap: wrap;">
+      <div style="flex-shrink: 0;">
+        <div style="overflow: hidden; border-radius: 48px;">
+          <iframe data-src="/animations/daily-checkin.html?paused&embedded" style="width: 402px; height: 856px; border: none; pointer-events: none; display: block;" id="dailyCheckinFrame"></iframe>
         </div>
       </div>
-    </div>
-  </div>
+      <div style="flex: 1; min-width: 320px;">
+        <p class="d-mono" style="color: var(--fg-subtle, #666560);">02</p>
+        <p class="d-headline d-headline--md" style="margin-top: 4px;">Daily Check-in</p>
+        <p class="d-mono" style="color: var(--fg-subtle, #666560); margin-top: 4px;">Yesterday's actions, today's focus</p>
+        <p class="d-body" style="margin-top: 12px;">The daily check-in was redesigned to reflect the weekly plan. Instead of a generic "how did you do" question, the check-in now shows the member's specific goals — their carb target, daily focus items, and weekly boosts — and asks them to mark each one. The slider for carbs replaced the old icon-tap pattern, making the input faster and more precise.</p>
 
-  <!-- CONTENT: How It Works + Voice -->
-  <div id="content" class="d-section">
-    <p class="d-label">Content</p>
-    <p class="d-body">The product loop is simple: plan your week, check in daily, review at the end. The design challenge was making each moment feel like coaching, not compliance.</p>
-
-    <div class="d-flow" style="margin-top: 24px;">
-      <div class="d-flow__step">
-        <span class="d-flow__step-num">01</span>
-        <span class="d-flow__step-label">Plan</span>
-        <span class="d-flow__step-desc">Review base plan. Add weekly goals. Commit to the week.</span>
-      </div>
-      <span class="d-flow__arrow">→</span>
-      <div class="d-flow__step">
-        <span class="d-flow__step-num">02</span>
-        <span class="d-flow__step-label">Check In</span>
-        <span class="d-flow__step-desc">Breath test. Mark yesterday's goals. Reflect.</span>
-      </div>
-      <span class="d-flow__arrow">→</span>
-      <div class="d-flow__step">
-        <span class="d-flow__step-num">03</span>
-        <span class="d-flow__step-label">Review</span>
-        <span class="d-flow__step-desc">End-of-week: weight trend, plan adherence, fat burn chart.</span>
-      </div>
-      <span class="d-flow__arrow">→</span>
-      <div class="d-flow__step">
-        <span class="d-flow__step-num">04</span>
-        <span class="d-flow__step-label">Adapt</span>
-        <span class="d-flow__step-desc">New goals for next week based on what just happened.</span>
-      </div>
-    </div>
-    <div style="display: flex; align-items: center; gap: 12px; margin-top: 16px;">
-      <span class="d-mono" style="white-space: nowrap;">← Back to Plan</span>
-      <div style="flex: 1; height: 1px; background: var(--fg-subtle, #666560);"></div>
-    </div>
-
-    <p class="d-label" style="margin-top: 32px;">Voice & Language</p>
-    <p class="d-body">We drew a line: keep scientific precision in the actions, use human language in the structure.</p>
-
-    <div class="d-grid-2" style="margin-top: 16px; gap: 16px;">
-      <div style="padding: 20px; border: 1px solid var(--border-subtle, #33332f); border-radius: 8px;">
-        <p class="d-mono" style="color: var(--fg-dim, #666560); font-size: 10px; margin-bottom: 8px;">BEFORE</p>
-        <p class="d-body" style="color: var(--fg-dim, #666560);">Accelerants</p>
-        <p class="d-body" style="color: var(--fg-dim, #666560);">Base Plan Adherence</p>
-        <p class="d-body" style="color: var(--fg-dim, #666560);">Caloric deficit protocol</p>
-        <p class="d-body" style="color: var(--fg-dim, #666560);">Compliance score</p>
-      </div>
-      <div style="padding: 20px; border: 1px solid var(--accent-cyan, #00fff7); border-radius: 8px;">
-        <p class="d-mono" style="color: var(--accent-cyan, #00fff7); font-size: 10px; margin-bottom: 8px;">AFTER</p>
-        <p class="d-body">Weekly Goals</p>
-        <p class="d-body">Your Plan</p>
-        <p class="d-body">Less than 20g Carbs <span style="color: var(--fg-dim, #666560);">(kept precise)</span></p>
-        <p class="d-body">4 out of 7 days in fat burn</p>
-      </div>
-    </div>
-
-    <p class="d-label" style="margin-top: 32px;">Push Notification System</p>
-    <p class="d-body">Before: one daily push for check-in. After: a weekly cadence that mirrors the planning flow.</p>
-
-    <div style="margin-top: 16px; display: flex; flex-direction: column; gap: 8px;">
-      <div style="display: flex; gap: 12px; align-items: baseline; padding: 12px 16px; border-left: 2px solid var(--accent-cyan, #00fff7);">
-        <span class="d-mono" style="flex-shrink: 0; width: 60px; color: var(--fg-dim, #666560);">MON</span>
-        <span class="d-body"><strong>Plan your week</strong> — opens weekly planning flow</span>
-      </div>
-      <div style="display: flex; gap: 12px; align-items: baseline; padding: 12px 16px; border-left: 2px solid var(--fg-subtle, #666560);">
-        <span class="d-mono" style="flex-shrink: 0; width: 60px; color: var(--fg-dim, #666560);">DAILY</span>
-        <span class="d-body">Check-in reminder — breath test + goal reflection</span>
-      </div>
-      <div style="display: flex; gap: 12px; align-items: baseline; padding: 12px 16px; border-left: 2px solid #F5A623;">
-        <span class="d-mono" style="flex-shrink: 0; width: 60px; color: var(--fg-dim, #666560);">WED</span>
-        <span class="d-body"><strong>Mid-week boost</strong> — if weekly goals are behind pace</span>
-      </div>
-      <div style="display: flex; gap: 12px; align-items: baseline; padding: 12px 16px; border-left: 2px solid var(--accent-cyan, #00fff7);">
-        <span class="d-mono" style="flex-shrink: 0; width: 60px; color: var(--fg-dim, #666560);">SUN</span>
-        <span class="d-body"><strong>Your week in review</strong> — opens weekly review</span>
+        <p class="d-label" style="margin-top: 24px;">What Changed</p>
+        <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 6px;">
+          <li class="d-body" style="font-size: 13px;">• Carb target shown inline with a 3-point slider (On Plan / About / Over) — replaces the old multi-icon grid.</li>
+          <li class="d-body" style="font-size: 13px;">• Daily Focus and Weekly Boosts appear as checkable items with completion counts.</li>
+          <li class="d-body" style="font-size: 13px;">• "Reflect on Yesterday" framing shifts tone from grading to learning.</li>
+          <li class="d-body" style="font-size: 13px;">• Weekly goal review link at the bottom creates a bridge back to the planning flow.</li>
+        </ul>
       </div>
     </div>
   </div>
@@ -231,47 +143,132 @@
   <div id="process" class="d-section">
     <p class="d-label">Process</p>
 
-    <p class="d-label" style="margin-top: 16px;">01</p>
-    <p class="d-headline d-headline--md">Design Decisions</p>
-    <div class="d-decisions" style="margin-top: 16px; padding-left: 48px;">
-      <div class="d-decision">
-        <p class="d-decision__q">Why does one question split into 5 different flows?</p>
-        <p class="d-decision__a">Members shouldn't need to understand the system's logic. "Any events this week?" routes automatically into Base, Busy Week, Cheat & Rebound, Edit Plan, or Accelerate.</p>
+    <!-- 01 Plan & Goal Design -->
+    <div class="d-subsection" style="margin-top: 24px;">
+      <p class="d-subsection__num">01</p>
+      <p class="d-subsection__title">Plan &amp; Goal Design</p>
+      <p class="d-subsection__kicker">Pulling the coach's playbook into the product.</p>
+      <p class="d-body" style="margin-top: 16px;">The real product at Invoy was the coach. Each one ran 100–200 members through an internal admin tool — choosing protocols, setting carbs per day, deciding when to step someone down. The plan existed. It just didn't exist for the member.</p>
+
+      <div class="d-beat" style="margin-top: 40px;">
+        <span class="d-beat__label">Surface</span>
+        <p class="d-beat__headline">Show members the plan they were already on.</p>
+        <p class="d-beat__body">Members were already on a plan they couldn't see — carb restriction as the default entry point, calorie restriction or intermittent fasting as alternates. Internally called "Accelerates," these weekly structures got a member-facing facelift and a plainer name: <strong>Goals</strong>. Target, duration, definition of a good week — now visible inside the app, not buried in a coach's spreadsheet.</p>
       </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why treat a bad day as a "rebound" instead of a failure?</p>
-        <p class="d-decision__a">Members who see a path back stay engaged. Members who feel judged stop opening the app.</p>
+
+      <div class="d-beat">
+        <span class="d-beat__label">Extract</span>
+        <p class="d-beat__headline">Get the coach's logic out of their head.</p>
+        <p class="d-beat__body">Two weeks of planning sat between the design team and engineering — mapping the decisions coaches made manually, separating the procedural from the judgment calls. Stepping a member down in carbs after two clean weeks. Flagging a stall. Suggesting next week's target from last week's adherence. The app could now propose the plan a coach would have proposed. Coach approves, or overrides. The 60% of their week that was data entry went back to the members who actually needed a human.</p>
       </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why pack so much data into the weekly review?</p>
-        <p class="d-decision__a">People look at this once a week. It has to be complete and fast to scan.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why surface the base plan to members?</p>
-        <p class="d-decision__a">Members didn't know what program they were on or what their targets were. Making the plan visible turned a black box into a partnership. Coaches could still adjust behind the scenes, but now the member understood the why.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why build the design system inside this project?</p>
-        <p class="d-decision__a">A standalone design system initiative would have stalled. By carving out the weekly planning flow as the system's proving ground, we got both the feature and the foundation. The surrounding screens adopted the system's type and color immediately to avoid jarring transitions, then components formalized over time.</p>
+
+      <div class="d-pullquote">
+        <p class="d-pullquote__body">"The unlock wasn't replacing the coach. It was freeing them from the 60% of their week that was copy-paste."</p>
       </div>
     </div>
 
-    <p class="d-label" style="margin-top: 32px;">02</p>
-    <p class="d-headline d-headline--md">Design System</p>
-    <p class="d-mono" style="margin-top: 4px;">Started here, applied everywhere</p>
-    <p class="d-body" style="margin-top: 16px;">The weekly planning flow was the seed. We built goal cards, plan summaries, and progress indicators as reusable components from day one. Then we applied the visual language — type scale, color system, spacing rhythm — to the daily check-in and home screen to create continuity. The system grew from the product, not ahead of it.</p>
-    <div class="d-gallery d-gallery--3" style="margin-top: 24px;">
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
-        <span class="d-gallery__caption">Goal cards</span>
+    <!-- 02 Voice & Tone -->
+    <div class="d-subsection">
+      <p class="d-subsection__num">02</p>
+      <p class="d-subsection__title">Voice &amp; Tone</p>
+      <p class="d-subsection__kicker">Direct where it counts. Friendly everywhere else.</p>
+      <p class="d-body" style="margin-top: 16px;">Invoy earned trust with science — the breath device doesn't lie, and the copy around it shouldn't either. But scientific had crept into corners where it was just friction. We drew a line: keep precise language in the actions we were asking members to take, simplify every structural term around the program itself.</p>
+
+      <div class="d-compare">
+        <div class="d-compare__col">
+          <span class="d-compare__label">Before</span>
+          <span class="d-compare__item">Accelerates</span>
+          <span class="d-compare__item">Base Plan</span>
+          <span class="d-compare__item">Protocol</span>
+          <span class="d-compare__item">Compliance score</span>
+        </div>
+        <div class="d-compare__col d-compare__col--after">
+          <span class="d-compare__label">After</span>
+          <span class="d-compare__item">Weekly Goals</span>
+          <span class="d-compare__item">Your Plan</span>
+          <span class="d-compare__item">Plan</span>
+          <span class="d-compare__item">On track / Off pace</span>
+        </div>
       </div>
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
-        <span class="d-gallery__caption">Type & color system</span>
+
+      <div class="d-kept">
+        <span class="d-kept__label">Kept precise — the science stays where it matters</span>
+        <span class="d-kept__items">Caloric deficit · Fat-burn range · Carbs per day · Breath score</span>
+        <span class="d-kept__note">These terms members had to internalize to run the program well. Softening them would have broken the trust the device built.</span>
       </div>
-      <div class="d-gallery__item">
-        <div style="aspect-ratio: 3/4; background: #1a1a18; display: flex; align-items: center; justify-content: center;"><span class="d-mono">[screenshot]</span></div>
-        <span class="d-gallery__caption">Component inventory</span>
+    </div>
+
+    <!-- 03 Engagement Strategy -->
+    <div class="d-subsection">
+      <p class="d-subsection__num">03</p>
+      <p class="d-subsection__title">Engagement Strategy</p>
+      <p class="d-subsection__kicker">A notification system shaped like the week, not just the day.</p>
+      <p class="d-body" style="margin-top: 16px;">The old cadence was one push: the daily check-in. A heartbeat, not a program. Members who slipped had nothing pulling them back; members who stayed had no sense of the larger arc. We mapped four beats to the new weekly loop so each trigger landed at a moment that actually mattered.</p>
+
+      <div class="d-push-list">
+        <div class="d-push">
+          <div class="d-push__meta">
+            <span class="d-push__time">Monday · 9:00 AM</span>
+            <span class="d-push__type">Weekly Planning</span>
+          </div>
+          <div class="d-push__body">
+            <span class="d-push__title">Let's set this week's goal.</span>
+            <span class="d-push__detail">Two minutes. Based on how last week went. → opens weekly planning</span>
+          </div>
+        </div>
+        <div class="d-push">
+          <div class="d-push__meta">
+            <span class="d-push__time">Daily · 8:00 AM</span>
+            <span class="d-push__type">Daily Check-in</span>
+          </div>
+          <div class="d-push__body">
+            <span class="d-push__title">Quick breath, then on with your day.</span>
+            <span class="d-push__detail">See yesterday's goal. Log today's. → opens daily check-in</span>
+          </div>
+        </div>
+        <div class="d-push">
+          <div class="d-push__meta">
+            <span class="d-push__time">Thursday · 2:00 PM</span>
+            <span class="d-push__type">Mid-week Boost</span>
+          </div>
+          <div class="d-push__body">
+            <span class="d-push__title">3 days left to hit this week's goal.</span>
+            <span class="d-push__detail">You're slightly off pace. Here's where you stand. → opens progress view</span>
+          </div>
+        </div>
+        <div class="d-push">
+          <div class="d-push__meta">
+            <span class="d-push__time">Sunday · 7:00 PM</span>
+            <span class="d-push__type">Weekly Review</span>
+          </div>
+          <div class="d-push__body">
+            <span class="d-push__title">Your week's in. Let's see how it went.</span>
+            <span class="d-push__detail">Weight trend, plan adherence, fat-burn days. → opens weekly review</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 04 Design System -->
+    <div class="d-subsection">
+      <p class="d-subsection__num">04</p>
+      <p class="d-subsection__title">Introducing A Design System</p>
+      <p class="d-subsection__kicker">Started inside the feature. Applied everywhere.</p>
+      <p class="d-body" style="margin-top: 16px;">Every screen had been built bespoke. A system would pay for itself — the question was how to start one without stopping shipping. This project was the wedge. We built the weekly planning and Goal surfaces on a new foundation — type scale, color tokens, component primitives — then applied the visual layer to the surrounding screens so members never crossed a jarring seam. After this project, shipping on the system was the default, not a negotiation.</p>
+
+      <div class="d-gallery d-gallery--3" style="margin-top: 32px;">
+        <div class="d-gallery__item">
+          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Goal cards [screenshot]</span></div>
+          <span class="d-gallery__caption">Goal cards — the core component that carried the system out to neighboring screens.</span>
+        </div>
+        <div class="d-gallery__item">
+          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Type &amp; color [screenshot]</span></div>
+          <span class="d-gallery__caption">Type and color tokens applied to surrounding screens first. Components followed.</span>
+        </div>
+        <div class="d-gallery__item">
+          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Components [screenshot]</span></div>
+          <span class="d-gallery__caption">Component inventory grew outward from the weekly planning flow as adjacent work got touched.</span>
+        </div>
       </div>
     </div>
   </div>
@@ -281,24 +278,24 @@
     <p class="d-label">Impact</p>
     <div class="d-metrics" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <div class="d-metric">
-        <div class="d-metric__value">30%→?</div>
-        <div class="d-metric__label">Daily engagement</div>
-        <div class="d-metric__sub">From breath-test-only to full check-in + goals</div>
+        <div class="d-metric__value">30% → ?</div>
+        <div class="d-metric__label">Daily check-in completion</div>
+        <div class="d-metric__sub">Prior baseline on breath checks alone; new baseline uninstrumented at launch.</div>
       </div>
       <div class="d-metric">
         <div class="d-metric__value">100:1</div>
-        <div class="d-metric__label">Coach leverage</div>
-        <div class="d-metric__sub">Automated goal suggestions replaced manual setup for 100–200 members per coach</div>
+        <div class="d-metric__label">Coach → member ratio</div>
+        <div class="d-metric__sub">Weekly planning automated the 60% of a coach's week that was plan setup.</div>
       </div>
       <div class="d-metric">
         <div class="d-metric__value">30</div>
         <div class="d-metric__label">Components shipped</div>
-        <div class="d-metric__sub">Design system started inside the feature, applied across the app</div>
+        <div class="d-metric__sub">Design system seeded inside the feature, applied across adjacent screens.</div>
       </div>
     </div>
 
-    <div class="d-callout" style="margin-top: 32px; border-left-color: var(--accent-cyan, #00fff7);">
-      <p class="d-callout__body"><strong>Early-stage metrics caveat.</strong> Invoy was a seed-stage startup. We didn't have the instrumentation for controlled A/B tests or statistically significant lift measurements. The engagement baseline (30% of members checking in beyond breath tests) was directional. What we could measure: coaches spent meaningfully less time on manual plan setup, and the weekly planning flow became the most-used feature within two weeks of launch.</p>
+    <div class="d-callout" style="margin-top: 48px;">
+      <p class="d-callout__body"><strong style="color: var(--fg, #e8e6e3);">Early-stage metrics caveat.</strong> Invoy was a seed-stage startup. We didn't have the instrumentation for controlled A/B tests or statistically significant lift measurements. The engagement baseline (30% of members checking in beyond breath tests) was directional. What we could measure: coaches ran twice as many members through manual plan setup, and the weekly planning flow became the most-used feature within two weeks of launch.</p>
     </div>
   </div>
 
@@ -311,129 +308,35 @@
 
 <script src="/portfolio.js"></script>
 <script>
-(function() {
-  var PHONE_W = 404, PHONE_H = 856;
-  var NAV_H = 71, SUBNAV_H = 54, CHROME = NAV_H + SUBNAV_H;
+  // Trigger embedded animations on scroll-into-view
+  (function() {
+    var frames = document.querySelectorAll('iframe[data-src]');
+    var started = {};
 
-  var stickyPhone = document.getElementById('stickyPhone');
-  var layers = document.querySelectorAll('.d-sticky-scroll__layer');
-  var steps = document.querySelectorAll('.d-sticky-scroll__step');
-  var started = {};
-  var activeStep = 0;
-  var PAD = 48;
-
-  function sizePhones() {
-    var phones = document.querySelectorAll('.d-anim-phone');
-    for (var i = 0; i < phones.length; i++) {
-      var layer = phones[i].parentElement;
-      var availW = layer.offsetWidth - PAD * 2;
-      var availH = layer.offsetHeight - PAD * 2;
-      var scale = Math.min(availW / PHONE_W, availH / PHONE_H);
-      phones[i].style.width = (PHONE_W * scale) + 'px';
-      phones[i].style.height = (PHONE_H * scale) + 'px';
-      phones[i].style.borderRadius = (48 * scale) + 'px';
-      var iframe = phones[i].querySelector('iframe');
-      if (iframe) {
-        iframe.style.transform = 'scale(' + scale + ')';
-        iframe.style.transformOrigin = 'top left';
-      }
-    }
-  }
-
-  function setStickyTop() {
-    if (!stickyPhone) return;
-    stickyPhone.style.top = CHROME + 'px';
-  }
-
-  function resetIframe(index) {
-    started[index] = false;
-    var iframe = layers[index] ? layers[index].querySelector('iframe') : null;
-    if (iframe && iframe.dataset.src) {
-      iframe.src = '';
-    }
-  }
-
-  function triggerIframe(index) {
-    if (started[index]) return;
-    started[index] = true;
-    var iframe = layers[index] ? layers[index].querySelector('iframe') : null;
-    if (!iframe || !iframe.dataset.src) return;
-    function send() {
-      try { iframe.contentWindow.postMessage('start', '*'); } catch(e) {}
-    }
-    iframe.addEventListener('load', send);
-    iframe.src = iframe.dataset.src;
-    setTimeout(send, 100);
-  }
-
-  function onScroll() {
-    var vcenter = CHROME + (window.innerHeight - CHROME) / 2;
-    var closest = 0;
-    var minDist = Infinity;
-
-    for (var i = 0; i < steps.length; i++) {
-      var rect = steps[i].getBoundingClientRect();
-      var center = rect.top + rect.height / 2;
-      var dist = Math.abs(center - vcenter);
-      var fadeRange = rect.height * 0.4;
-      var opacity = dist < fadeRange ? 1 : Math.max(0.15, 1 - (dist - fadeRange) / (rect.height * 0.3));
-      steps[i].style.opacity = opacity;
-      if (dist < minDist) { minDist = dist; closest = i; }
+    function load(frame) {
+      if (started[frame.id]) return;
+      started[frame.id] = true;
+      var send = function() {
+        try { frame.contentWindow.postMessage('start', '*'); } catch(e) {}
+      };
+      frame.addEventListener('load', send);
+      frame.src = frame.dataset.src;
     }
 
-    var isVisible = false;
-    if (stickyPhone) {
-      var phoneRect = stickyPhone.getBoundingClientRect();
-      var phoneCenter = phoneRect.top + phoneRect.height / 2;
-      var distFromCenter = Math.abs(phoneCenter - vcenter);
-      var viewH = window.innerHeight - CHROME;
-      isVisible = distFromCenter < viewH * 0.6;
+    if ('IntersectionObserver' in window) {
+      var io = new IntersectionObserver(function(entries) {
+        entries.forEach(function(e) {
+          if (e.isIntersecting) {
+            load(e.target);
+            io.unobserve(e.target);
+          }
+        });
+      }, { threshold: 0.2 });
+      frames.forEach(function(f) { io.observe(f); });
+    } else {
+      frames.forEach(load);
     }
-
-    if (closest !== activeStep) {
-      resetIframe(activeStep);
-      activeStep = closest;
-      for (var j = 0; j < layers.length; j++) {
-        layers[j].classList.toggle('is-active', j === closest);
-      }
-      if (isVisible) triggerIframe(closest);
-    } else if (isVisible && !started[closest]) {
-      triggerIframe(closest);
-    }
-  }
-
-  var ticking = false;
-  window.addEventListener('scroll', function() {
-    if (!ticking) {
-      ticking = true;
-      requestAnimationFrame(function() { onScroll(); ticking = false; });
-    }
-  }, { passive: true });
-
-  var snapTimer = null;
-  var SNAP_THRESHOLD = 80;
-  function snapToStep() {
-    var vcenter = CHROME + (window.innerHeight - CHROME) / 2;
-    var step = steps[activeStep];
-    if (!step) return;
-    var rect = step.getBoundingClientRect();
-    var stepCenter = rect.top + rect.height / 2;
-    var offset = stepCenter - vcenter;
-    if (Math.abs(offset) > 10 && Math.abs(offset) < SNAP_THRESHOLD) {
-      window.scrollBy({ top: offset, behavior: 'smooth' });
-    }
-  }
-
-  window.addEventListener('scroll', function() {
-    clearTimeout(snapTimer);
-    snapTimer = setTimeout(snapToStep, 200);
-  }, { passive: true });
-
-  sizePhones();
-  setStickyTop();
-  onScroll();
-  window.addEventListener('resize', function() { sizePhones(); setStickyTop(); });
-})();
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace /invoy/ content with Paper-based rewrite (Framing / Experience / Process / Impact)
- Process restructured into 4 subsections: Plan & Goal Design, Voice & Tone, Engagement Strategy, Design System
- Side-by-side iframe layout for weekly planning + daily check-in animations
- Uses display.css editorial classes added in PR #527

## Test plan
- [ ] /invoy/ renders new structure
- [ ] Iframe animations trigger on scroll
- [ ] Pullquote, compare (before/after), push notification list render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)