### PR TITLE
copy(field): sharpen AI decision question to clinical framing

### DIFF
--- a/field/index.html
+++ b/field/index.html
@@ -261,7 +261,7 @@
         <p class="d-decision__a">Every AI-extracted value shows where it came from. Grey means confident, amber means check it, red means missing. Each value traces to the exact moment in the transcript. The provider always knows what to trust.</p>
       </div>
       <div class="d-decision">
-        <p class="d-decision__q">Why not let AI decide?</p>
+        <p class="d-decision__q">Why not let AI make clinical decisions?</p>
         <p class="d-decision__a">When it comes to suggesting what to do with a patient, Field shows recommendations but never pre-selects. The provider makes every clinical call. This keeps us on the right side of FDA regulation and keeps humans in charge of decisions where terrain, weather, and context matter more than data.</p>
       </div>
       <div class="d-decision">


### PR DESCRIPTION
Updates Field page copy: 'Why not let AI decide?' → 'Why not let AI make clinical decisions?' — matches the answer's framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)