### PR TITLE
copy(field): remove MCI FAQ entry

### DIFF
--- a/field/index.html
+++ b/field/index.html
@@ -468,10 +468,6 @@
         <p class="d-decision__q">Does it replace my ePCR?</p>
         <p class="d-decision__a">Works with your existing ePCR. Send records to your administrator — they can add your Field Record with billing codes attached. Direct integrations in our roadmap.</p>
       </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Multiple casualty incidents (MCIs)?</p>
-        <p class="d-decision__a">Not yet. Working with SAR partners to follow FEMA command structures and participating in MCI scenarios.</p>
-      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Removes the 'Multiple casualty incidents (MCIs)?' decision since it's not yet supported. Will return once SAR/FEMA work is shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)