### PR TITLE
fix(portfolio): Weekly Plan spacing + Paper-verbatim bullets

### DIFF
--- a/animations/weekly-plan.html
+++ b/animations/weekly-plan.html
@@ -23,7 +23,7 @@
   .ios-status__battery { width: 24px; height: 11px; border-radius: 3px; background: #191919; }
 
   /* Persistent nav overlay */
-  .persistent-nav { position: absolute; top: 44px; left: 0; right: 0; z-index: 10; background: white; padding: 12px 36px 0; display: flex; align-items: center; justify-content: space-between; }
+  .persistent-nav { position: absolute; top: 44px; left: 0; right: 0; z-index: 10; background: white; padding: 24px 36px 0; display: flex; align-items: center; justify-content: space-between; }
   .nav-el { color: #B2B2B2; font-family: "SF Pro Text", system-ui, sans-serif; font-size: 17px; line-height: 22px; }
   .nav-label { letter-spacing: -0.41px; }
 
@@ -46,7 +46,7 @@
   .plan-banner-arrow { font-family: "SF Pro Text", sans-serif; font-size: 17px; color: white; }
 
   /* Card container — below nav */
-  .card { padding: 80px 36px 36px; display: flex; flex-direction: column; gap: 24px; flex: 1; overflow-y: auto; scroll-behavior: smooth; }
+  .card { padding: 92px 36px 36px; display: flex; flex-direction: column; gap: 24px; flex: 1; overflow-y: auto; scroll-behavior: smooth; }
   .card::-webkit-scrollbar { display: none; }
   .card-fade-out { animation: cardFadeOut 0.35s ease forwards; }
   .card-fade-in { animation: cardFadeIn 0.35s ease forwards; }
@@ -157,7 +157,7 @@
       <!-- SCREEN 0: Home (from Paper JSX) -->
       <div class="screen active" id="screen0" style="background:white;border-radius:30px;">
         <!-- Top nav (below iOS status bar) -->
-        <div style="display:flex;flex-direction:column;flex-shrink:0;padding:54px 26px 0;">
+        <div style="display:flex;flex-direction:column;flex-shrink:0;padding:66px 26px 0;">
           <div style="display:flex;justify-content:space-between;align-items:center;">
             <div style="width:28px;height:28px;border-radius:14px;background:#2A3C56;position:relative;">
               <div style="width:8px;height:8px;border-radius:4px;background:#6FCC9F;border:2px solid white;position:absolute;right:-2px;top:-2px;"></div>

--- a/invoy/index.html
+++ b/invoy/index.html
@@ -121,12 +121,12 @@
           <p class="d-body" style="margin-top: 12px;">Finding a minimum viable weekly plan meant a deep accounting of the base plans we supported behind the scenes — carb restriction, calorie restriction, and intermittent fasting — and exposing the weekly tools a coach used to drive a member's breath scores in the right direction.</p>
           <p class="d-label" style="margin-top: 20px;">Key Decisions</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Shape as an MVP we could expand — shipped weekly, layered in after launch.</li>
-            <li class="d-body" style="font-size: 12px;">• Articulate and reinforce base plans every week, not just at onboarding.</li>
-            <li class="d-body" style="font-size: 12px;">• Two tiers of weekly goals — Daily Focus and Boosts — escalate commitment without overwhelming.</li>
-            <li class="d-body" style="font-size: 12px;">• Coach involvement via "Coach Recommended," with attached coach notes added post-launch.</li>
-            <li class="d-body" style="font-size: 12px;">• Ask for commitment based on internal and external behavior-change studies.</li>
-            <li class="d-body" style="font-size: 12px;">• "Skip this week" is always available — no guilt, no friction.</li>
+            <li class="d-body" style="font-size: 12px;">• Shape as MVP we could expand</li>
+            <li class="d-body" style="font-size: 12px;">• Articulate and reinforce base plans weekly</li>
+            <li class="d-body" style="font-size: 12px;">• Add two tiers of weekly goals: Daily Focus and Boosts to escalating commitment without overwhelming</li>
+            <li class="d-body" style="font-size: 12px;">• Allow coach involvement through "Coach Recommended", followed by attached coach notes after launch</li>
+            <li class="d-body" style="font-size: 12px;">• Ask for commitment based on internal and external studies</li>
+            <li class="d-body" style="font-size: 12px;">• "Skip this week" is always available — no guilt, no friction</li>
           </ul>
         </div>
 


### PR DESCRIPTION
- +12px spacing between iOS status bar and card header on Weekly Plan cards
- Weekly Planning Key Decisions bullets restored to Paper verbatim

🤖 Generated with [Claude Code](https://claude.com/claude-code)