### PR TITLE
fix(animations): Weekly Plan card header/headline spacing

### DIFF
--- a/animations/weekly-plan.html
+++ b/animations/weekly-plan.html
@@ -46,7 +46,7 @@
   .plan-banner-arrow { font-family: "SF Pro Text", sans-serif; font-size: 17px; color: white; }
 
   /* Card container — below nav */
-  .card { padding: 92px 36px 36px; display: flex; flex-direction: column; gap: 24px; flex: 1; overflow-y: auto; scroll-behavior: smooth; }
+  .card { padding: 104px 36px 36px; display: flex; flex-direction: column; gap: 24px; flex: 1; overflow-y: auto; scroll-behavior: smooth; }
   .card::-webkit-scrollbar { display: none; }
   .card-fade-out { animation: cardFadeOut 0.35s ease forwards; }
   .card-fade-in { animation: cardFadeIn 0.35s ease forwards; }


### PR DESCRIPTION
+12px spacing between card header and page headline on Weekly Plan cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)