### PR TITLE
feat(animations): tab bar icons as rounded boxes

### DIFF
--- a/animations/weekly-plan.html
+++ b/animations/weekly-plan.html
@@ -215,20 +215,20 @@
         </div>
         <!-- Tab bar -->
         <div style="display:flex;justify-content:space-around;align-items:flex-start;padding:10px 0 28px;border-top:1px solid #F0F0F0;flex-shrink:0;">
-          <div style="display:flex;flex-direction:column;align-items:center;gap:4px;">
-            <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:20px;color:#2A3C56;">⌂</span>
+          <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
+            <div style="width:28px;height:28px;border-radius:8px;background:rgba(42,60,86,0.12);"></div>
             <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:10px;font-weight:600;color:#2A3C56;letter-spacing:-0.41px;">Home</span>
           </div>
-          <div style="display:flex;flex-direction:column;align-items:center;gap:4px;">
-            <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:20px;color:#B2B2B2;">📊</span>
+          <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
+            <div style="width:28px;height:28px;border-radius:8px;background:#ECEAE6;"></div>
             <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:10px;color:#B2B2B2;letter-spacing:-0.41px;">Journey</span>
           </div>
-          <div style="display:flex;flex-direction:column;align-items:center;gap:4px;">
-            <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:20px;color:#B2B2B2;">🍴</span>
+          <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
+            <div style="width:28px;height:28px;border-radius:8px;background:#ECEAE6;"></div>
             <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:10px;color:#B2B2B2;letter-spacing:-0.41px;">Food</span>
           </div>
-          <div style="display:flex;flex-direction:column;align-items:center;gap:4px;">
-            <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:20px;color:#B2B2B2;">💬</span>
+          <div style="display:flex;flex-direction:column;align-items:center;gap:6px;">
+            <div style="width:28px;height:28px;border-radius:8px;background:#ECEAE6;"></div>
             <span style="font-family:'SF Pro Text',system-ui,sans-serif;font-size:10px;color:#B2B2B2;letter-spacing:-0.41px;">Support</span>
           </div>
         </div>


### PR DESCRIPTION
Replace homescreen tab bar emoji icons with soft grey rounded boxes; Home uses translucent primary blue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)