### PR TITLE
copy(livongo): typo + grammar cleanup, sync Paper

### DIFF
--- a/livongo/index.html
+++ b/livongo/index.html
@@ -209,8 +209,8 @@
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>
-    <p class="d-body">Livongo, a chronic conditions management company, was in growing pains. In 2 years, it grown from a one to five health programs sold in dozens of combinations. Every combination changed which registration fields a member saw. The rules for 50 unique client configurations lived in a spreadsheet that operations cross-referenced manually for every new launch. Complexity ballooned & metrics suffered.</p>
-    <p class="d-body">No where was the downstream product pain felt more than during onboarding members. The registration flow grew from 20 standard questions to 74 possible fields.</p>
+    <p class="d-body">Livongo, a chronic conditions management company, was in growing pains. In 2 years, it had grown from one to five health programs sold in dozens of combinations. Every combination changed which registration fields a member saw. The rules for 50 unique client configurations lived in a spreadsheet that operations cross-referenced manually for every new launch. Complexity ballooned & metrics suffered.</p>
+    <p class="d-body">Nowhere was the downstream product pain felt more than during onboarding members. The registration flow grew from 20 standard questions to 74 possible fields.</p>
 
     <p class="d-body">The data told the story. Every step bled members, but the reasons weren't what anyone expected.</p>
 
@@ -261,15 +261,15 @@
       </div>
     </div>
 
-    <p class="d-body" style="margin-top: 32px;">The program steps were one unsurprising culprit — historically, 11% dropoff this had balloned to more than 33% drop-off for our multi-program members. Moreover, people werent signing up for all of the program they were offered. At a step where the system already knew which programs the member qualified for, The product was overoptimizing for choice. This left revenue, but more importantly, benefits on the table for people who already enrolled.</p>
+    <p class="d-body" style="margin-top: 32px;">The program steps were one unsurprising culprit — historically 11% drop-off, this had ballooned to more than 33% for our multi-program members. Moreover, people weren't signing up for all of the programs they were offered. At a step where the system already knew which programs the member qualified for, the product was overoptimizing for choice. This left revenue, but more importantly, benefits on the table for people who already enrolled.</p>
     <p class="d-body">How could we reduce the friction in registration? How could we minimize what we asked?</p>
   </div>
 
   <!-- DELIVERABLE -->
   <div id="deliverable" class="d-section" style="border-bottom: none;">
     <p class="d-label">Deliverable</p>
-    <p class="d-body">At its core, the solution was simple, but a large technical lift. Due to the nature of our client relationships, We had information upstream about members - demographics, health conditions, even specific health data.</p>
-    <p class="d-body">This led us to build a system that, given member verification, would allow us prefill, confirm or skip the information we needed during onboarding. The art was keeping the member in control & maintaining transparency so the process built trust rather than eroded it.</p>
+    <p class="d-body">At its core, the solution was simple, but a large technical lift. Due to the nature of our client relationships, we had information upstream about members — demographics, health conditions, even specific health data.</p>
+    <p class="d-body">This led us to build a system that, given member verification, would allow us to prefill, confirm, or skip the information we needed during onboarding. The art was keeping the member in control & maintaining transparency so the process built trust rather than eroded it.</p>
 
     <div class="d-sticky-scroll">
       <!-- Sticky animation column -->
@@ -319,7 +319,7 @@
           <p class="d-mono">01</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Verification</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Confirm membership & identity</p>
-          <p class="d-body" style="margin-top: 12px;">To prefill information, we needed to know with high confidence that the person. We passed this through assets, but we needed to verify with confidence to reduce the risk of PII leakage</p>
+          <p class="d-body" style="margin-top: 12px;">To prefill information, we needed to know with high confidence who the person was. We passed this through several signals, but had to verify with confidence to reduce the risk of PII leakage.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Employer name and sponsorship status from HR feed</li>
@@ -328,7 +328,7 @@
           <p class="d-label" style="margin-top: 16px;">What changed</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Reduced data to the minimum needed to PII match a member</li>
-            <li class="d-body" style="font-size: 12px;">• Build trust eary by surfacing employer — "we know who you are"</li>
+            <li class="d-body" style="font-size: 12px;">• Build trust early by surfacing employer — "we know who you are"</li>
             <li class="d-body" style="font-size: 12px;">• Privacy footer with encryption disclosure</li>
           </ul>
         </div>
@@ -337,7 +337,7 @@
           <p class="d-mono">02</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Account</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Shifting control to the member</p>
-          <p class="d-body" style="margin-top: 12px;">Employer data gave us email and phone — but not always the right ones. Work emails and desk phones don't help a member manage diabetes at home. The account step introduced the independent relationship with Livongo, but enforced that their employer was a partner</p>
+          <p class="d-body" style="margin-top: 12px;">Employer data gave us email and phone — but not always the right ones. Work emails and desk phones don't help a member manage diabetes at home. The account step introduced the independent relationship with Livongo, but reinforced that their employer was a partner.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Email and phone pre-filled from employer HR data</li>
@@ -362,7 +362,7 @@
           </ul>
           <p class="d-label" style="margin-top: 16px;">What changed</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Reframed as a unified program for all eligible programs.</li>
+            <li class="d-body" style="font-size: 12px;">• Reframed as a unified plan covering all eligible programs</li>
             <li class="d-body" style="font-size: 12px;">• "Qualified" vs "Optional" badges set clear expectations</li>
           </ul>
         </div>
@@ -371,7 +371,7 @@
           <p class="d-mono">04</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Program Setup</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Personalize without interrogating</p>
-          <p class="d-body" style="margin-top: 12px;">Historically a growing drop off, Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion set a pattern for trust - showing what system already knows and how it knows it. Members always had the ability edit or change information.</p>
+          <p class="d-body" style="margin-top: 12px;">Historically a growing drop-off step. Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion set a pattern for trust — showing what the system already knows and how it knows it. Members always had the ability to edit or change information.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Monitoring frequency from health records</li>


### PR DESCRIPTION
## Summary
- Fixes typos and grammar issues in `livongo/index.html` Framing, Deliverable, and Steps 01–04 copy that were carried over verbatim from Paper in #525
- Paper "Livongo — Full Page" artboard updated in parallel via Paper MCP — both sources now match
- Conservative edits: preserves voice, no meaning changes
- Also brings Paper subnav up to date: Framing→Problem, Process→Decisions (matches the HTML labels from #526)

## Changes
- `it grown` → `it had grown`; `No where` → `Nowhere`
- `balloned` → `ballooned`; `werent` → `weren't`; `eary` → `early`
- Truncated Step 01 body sentence completed
- Step 02 missing period; `enforced` → `reinforced`
- Step 03 bullet de-duplicated ("unified program for all eligible programs" → "unified plan covering all eligible programs")
- Step 04 comma splice + missing articles

## Test plan
- [x] HTML renders in preview panel
- [x] Paper screenshot review on Framing, Deliverable, Step 01, Subnav — all correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)