### PR TITLE
feat(portfolio): Ethos-forward hero + portfolio-grounded Philosophies

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
 
   <!-- Hero -->
   <div class="d-hero">
-    <p class="d-headline d-headline--xl">Fixing</p>
-    <p class="d-body" style="font-size: 15px;">3,700 registration rules at Livongo. A behavioral coaching engine at Invoy. Voice-to-documentation AI for wilderness medicine. Different domains, same design problem: map the complexity, build the system, let the user confirm instead of configure.</p>
+    <p class="d-headline d-headline--xl">Taking on complexity</p>
+    <p class="d-body" style="font-size: 15px;">Design avoids complexity — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy data, the entangled rules, and the users mid-task with no patience for friction. That's the work. Stay in it long enough to see the shape underneath. Build the system that holds it. Leave the user a clear way forward. Less configure. More confirm.</p>
     <div class="d-meta" style="margin-top: 20px;">
       <span>Product Designer</span>
       <span class="d-meta__sep">·</span>
@@ -49,19 +49,20 @@
       <a href="/field/" class="d-card">
         <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
         <span class="d-card__title">Field</span>
-        <span class="d-card__desc">Voice-driven clinical documentation for first responders. On-device AI, offline-first</span>
+        <span class="d-card__desc">Voice-first clinical reports for remote first responders. Offline.</span>
         <span class="d-card__tag" style="margin-top: auto;">Beta</span>
       </a>
       <a href="/invoy/" class="d-card">
         <span class="d-card__tag">Weight · Design System</span>
-        <span class="d-card__title">Invoy' Weekly Weight Loop</span>
-        <span class="d-card__desc">Creading</span>
+        <span class="d-card__title">Invoy Weekly Goals</span>
+        <span class="d-card__desc">A weekly weight-management engagement loop from daily habits and manual coaching.</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>
       </a>
       <a href="/livongo/" class="d-card">
         <span class="d-card__tag">Infrastructure · B2B · Scale</span>
-        <span class="d-card__title">Livongo</span>
+        <span class="d-card__title">Livongo Onboarding</span>
         <span class="d-card__desc">Client configuration stability while growing</span>
+        <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>
       </a>
     </div>
   </div>
@@ -75,7 +76,7 @@
   <div class="d-section" style="border-bottom: none; background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
     <p class="d-label">How I Work</p>
     <p class="d-headline d-headline--lg">Scaling Design with AI</p>
-    <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
+    <p class="d-body" style="margin-top: 12px;">Across Field, Invoy, and Livongo, the same pattern: messy domain input, structured compliant output, design carrying the judgment between. AI handles the volume. The design system enforces quality. I decide what should exist.</p>
   </div>
 
   <!-- Personal Projects -->
@@ -260,10 +261,6 @@
     </div>
   </div>
 </div>
-
-<footer class="d-footer d-contain">
-  <span class="d-mono">← → to navigate</span>
-</footer>
 
 <script src="/portfolio.js"></script>
 </body>

--- a/philosophy/index.html
+++ b/philosophy/index.html
@@ -73,8 +73,8 @@
   <!-- WHY DOES THIS MATTER -->
   <div class="d-why d-why--active" style="margin: 32px 0 0;">
     <p class="d-why__label">Why does this matter?</p>
-    <p class="d-why__headline">Roadrunner is a small team rebuilding an entire category. Process is the multiplier.</p>
-    <p class="d-why__body">AI-native startups win the two-year window by shipping faster than incumbents can rebuild. But speed without craft produces throwaway work. My process treats AI as the execution layer and a design system as the quality layer — the same leverage a seed-stage team needs to ship enterprise-grade product without enterprise-stage headcount.</p>
+    <p class="d-why__headline">Messy domain input, structured compliant output. Design carries the judgment between.</p>
+    <p class="d-why__body">Field turns first-responder voice into SOAP notes. Invoy turned coach-led plans into a weekly member loop. Livongo turned 3,700 configuration rules into a stable platform. Same shape every time — map the complexity, build the system, let the user confirm instead of configure. AI is the execution layer. A design system is the quality layer. The designer decides what should exist and whether it feels right.</p>
   </div>
 
   <!-- FRAMING -->


### PR DESCRIPTION
## Summary
- Hero headline: **Taking on complexity** — new ethos body about staying in the messy middle, building the system, leaving a clear way forward. No first-person, no product references.
- Philosophies / How I Work block rewritten around the Field / Invoy / Livongo pattern ("messy domain input, structured compliant output, design carrying the judgment between").
- Philosophy page Thesis: new portfolio-grounded headline + body pulling specific case studies.
- Homepage case study cards synced to Paper: Invoy card title/desc, Livongo status + title, Field desc tightened.
- Removed "← → to navigate" footer from homepage per user request.
- Paper artboards (Home `9WJ-0`, Philosophy Thesis `AJ3-0`) updated in parallel.

## Test plan
- [ ] Visit / and confirm hero copy + no footer
- [ ] Visit /philosophy/ and confirm Thesis headline/body
- [ ] Confirm case study cards on homepage match Paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)