### PR TITLE
feat(portfolio): remove hero meta line + Philosophies surface bg

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,13 +33,6 @@
   <div class="d-hero">
     <p class="d-headline d-headline--xl">Taking on complexity</p>
     <p class="d-body" style="font-size: 15px;">Design avoids complexity — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy data, the entangled rules, and the users mid-task with no patience for friction. That's the work. Stay in it long enough to see the shape underneath. Build the system that holds it. Leave the user a clear way forward. Less configure. More confirm.</p>
-    <div class="d-meta" style="margin-top: 20px;">
-      <span>Product Designer</span>
-      <span class="d-meta__sep">·</span>
-      <span>Livongo / Teladoc Health</span>
-      <span class="d-meta__sep">·</span>
-      <span>Building with AI</span>
-    </div>
   </div>
 
   <!-- Case Studies -->
@@ -73,7 +66,7 @@
   </div>
 
   <!-- How I Work -->
-  <div class="d-section" style="border-bottom: none; background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
+  <div class="d-section" style="border-bottom: none;">
     <p class="d-label">How I Work</p>
     <p class="d-headline d-headline--lg">Scaling Design with AI</p>
     <p class="d-body" style="margin-top: 12px;">Across Field, Invoy, and Livongo, the same pattern: messy domain input, structured compliant output, design carrying the judgment between. AI handles the volume. The design system enforces quality. I decide what should exist.</p>


### PR DESCRIPTION
## Summary
- Drop "Product Designer · Livongo / Teladoc Health · Building with AI" meta strip from hero
- Remove dark surface background + horizontal bleed on How I Work block

Paper Home artboard synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)