### PR TITLE
feat(portfolio): bold ethos anchors in hero; drop headline

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
 
   <!-- Hero -->
   <div class="d-hero">
-    <p class="d-headline d-headline--xl">Taking on complexity</p>
-    <p class="d-body" style="font-size: 15px;">Design avoids complexity — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy data, the entangled rules, and the users mid-task with no patience for friction. That's the work. Stay in it long enough to see the shape underneath. Build the system that holds it. Leave the user a clear way forward. Less configure. More confirm.</p>
+    <p class="d-body" style="font-size: 15px;">Design avoids <strong>complexity</strong> — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy data, the entangled rules, and the users mid-task with no patience for friction. <strong>That's the work.</strong> Stay in it long enough to see the <strong>shape underneath</strong>. <strong>Build the system that holds it.</strong> Leave the user a clear way forward. <strong>Less configure. More confirm.</strong></p>
   </div>
 
   <!-- Case Studies -->


### PR DESCRIPTION
## Summary
- Remove "Taking on complexity" headline so the body copy carries the hero
- Bold 5 anchor phrases in the body

Paper Home artboard synced (headline node deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)