### PR TITLE
feat(portfolio): hero copy update; beta marigold; hide Personal Projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,11 +31,9 @@
 
   <!-- Hero -->
   <div class="d-hero">
-    <p class="d-body" style="font-size: 15px;">Design avoids <strong>complexity</strong> — smooths it over, abstracts it away, hides it behind a clean facade.</p>
-    <p class="d-body" style="font-size: 15px; margin-top: 16px;">But the real problems live in the regulations, the legacy data, the entangled rules, and the users mid-task with no patience for friction.</p>
+    <p class="d-body" style="font-size: 15px;">Design manages <strong>complexity</strong> — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy structures, the entangled rules, and the users mid-task with no patience for friction.</p>
     <p class="d-body" style="font-size: 15px; margin-top: 20px;"><strong>That's the work.</strong></p>
-    <p class="d-body" style="font-size: 15px; margin-top: 20px;">Stay in it long enough to see the <strong>shape underneath</strong>.<br><strong>Build the system that holds it.</strong><br>Leave the user a clear way forward.</p>
-    <p class="d-body" style="font-size: 15px; margin-top: 20px;"><strong>Less configure. More confirm.</strong></p>
+    <p class="d-body" style="font-size: 15px; margin-top: 20px;">Stay in it long enough to see the <strong>shape underneath</strong>. <strong>Build the system that holds the complexity.</strong> Make the path for people obvious and intuitive.</p>
   </div>
 
   <!-- Case Studies -->
@@ -46,7 +44,7 @@
         <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
         <span class="d-card__title">Field</span>
         <span class="d-card__desc">Voice-first clinical reports for remote first responders. Offline.</span>
-        <span class="d-card__tag" style="margin-top: auto;">Beta</span>
+        <span class="d-card__tag" style="margin-top: auto; color: var(--accent-amber, #ffb000);">Beta</span>
       </a>
       <a href="/invoy/" class="d-card">
         <span class="d-card__tag">Weight · Design System</span>
@@ -76,7 +74,7 @@
   </div>
 
   <!-- Personal Projects -->
-  <div class="d-section" style="border-bottom: none;">
+  <div class="d-section" style="border-bottom: none; display: none;">
     <p class="d-label">Personal Projects</p>
     <div class="d-cards d-cards--2" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="#" class="d-card" data-modal="modal-calendar">


### PR DESCRIPTION
## Summary
- Hero body: new "Design manages complexity…" copy, bolds preserved on the 4 anchor phrases
- Field beta tag recolored to marigold (`var(--accent-amber)`) to match Field page status
- Personal Projects section hidden with `display: none` (markup retained)
- Process block + background left intact per master

🤖 Generated with [Claude Code](https://claude.com/claude-code)