### PR TITLE
fix(nav): even spacing + uniform label color in global nav

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -70,17 +70,21 @@
 .d-nav__group {
   display: flex;
   align-items: center;
-  gap: 28px;
 }
 
 .d-nav__group-label {
   font-family: var(--font-mono, monospace);
   font-size: 11px;
   letter-spacing: 0.04em;
-  color: var(--fg, #e8e6e3);
+  color: var(--fg-muted, #8a8885);
   text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
+}
+
+.d-nav__group-label:hover,
+.d-nav__group--expanded .d-nav__group-label {
+  color: var(--fg, #e8e6e3);
 }
 
 .d-nav__group-items {

--- a/design-systems/index.html
+++ b/design-systems/index.html
@@ -18,7 +18,7 @@
     <li><a href="/invoy/" class="d-nav__link">Invoy</a></li>
     <li><a href="/livongo/" class="d-nav__link">Livongo</a></li>
     <li><a href="/design-systems/" class="d-nav__link d-nav__link--active">Design Systems</a></li>
-    <li><a href="/philosophy/" class="d-nav__link">How I Work</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
   </ul>
 </nav>
 
@@ -250,7 +250,7 @@ Systemic         → crawl all 5 products → stoplight report</div>
 
 <footer class="d-footer d-contain">
   <a href="/livongo/" class="d-next">← Livongo</a>
-  <a href="/philosophy/" class="d-next">How I Work →</a>
+  <a href="/philosophy/" class="d-next">Process →</a>
 </footer>
 
 <script src="/portfolio.js"></script>

--- a/field/index.html
+++ b/field/index.html
@@ -23,7 +23,7 @@
         <li><a href="/livongo/" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo/" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
@@ -71,9 +71,9 @@
     <p class="d-label" style="margin-bottom: 0;">Philosophies</p>
   </div>
 
-  <!-- How I Work -->
+  <!-- Process -->
   <div class="d-section" style="border-bottom: none; background: var(--bg-surface, #1a1a18); margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
-    <p class="d-label">How I Work</p>
+    <p class="d-label">Process</p>
     <p class="d-headline d-headline--lg">Scaling Design with AI</p>
     <p class="d-body" style="margin-top: 12px;">The design system is the source of truth, the constraint engine, and the AI's instruction set. Claude Code writes components constrained to the system. Systemic audits compliance. I govern.</p>
   </div>

--- a/invoy/index.html
+++ b/invoy/index.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo/" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>

--- a/livongo-config/index.html
+++ b/livongo-config/index.html
@@ -22,7 +22,7 @@
         <li><a href="/livongo/" class="d-nav__link d-nav__link--active">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
@@ -182,7 +182,7 @@
 
 <footer class="d-footer d-contain">
   <a href="/livongo/" class="d-next">← Livongo Registration</a>
-  <a href="/philosophy/" class="d-next">How I Work →</a>
+  <a href="/philosophy/" class="d-next">Process →</a>
 </footer>
 
 <script src="/portfolio.js"></script>

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -209,8 +209,8 @@
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>
-    <p class="d-body">Livongo, a chronic conditions management company, was in growing pains. In 2 years, it grown from a one to five health programs sold in dozens of combinations. Every combination changed which registration fields a member saw. The rules for 50 unique client configurations lived in a spreadsheet that operations cross-referenced manually for every new launch. Complexity ballooned & metrics suffered.</p>
-    <p class="d-body">No where was the downstream product pain felt more than during onboarding members. The registration flow grew from 20 standard questions to 74 possible fields.</p>
+    <p class="d-body">Livongo, a chronic conditions management company, was in growing pains. In 2 years, it had grown from one to five health programs sold in dozens of combinations. Every combination changed which registration fields a member saw. The rules for 50 unique client configurations lived in a spreadsheet that operations cross-referenced manually for every new launch. Complexity ballooned & metrics suffered.</p>
+    <p class="d-body">Nowhere was the downstream product pain felt more than during onboarding members. The registration flow grew from 20 standard questions to 74 possible fields.</p>
 
     <p class="d-body">The data told the story. Every step bled members, but the reasons weren't what anyone expected.</p>
 
@@ -261,15 +261,15 @@
       </div>
     </div>
 
-    <p class="d-body" style="margin-top: 32px;">The program steps were one unsurprising culprit — historically, 11% dropoff this had balloned to more than 33% drop-off for our multi-program members. Moreover, people werent signing up for all of the program they were offered. At a step where the system already knew which programs the member qualified for, The product was overoptimizing for choice. This left revenue, but more importantly, benefits on the table for people who already enrolled.</p>
+    <p class="d-body" style="margin-top: 32px;">The program steps were one unsurprising culprit — historically 11% drop-off, this had ballooned to more than 33% for our multi-program members. Moreover, people weren't signing up for all of the programs they were offered. At a step where the system already knew which programs the member qualified for, the product was overoptimizing for choice. This left revenue, but more importantly, benefits on the table for people who already enrolled.</p>
     <p class="d-body">How could we reduce the friction in registration? How could we minimize what we asked?</p>
   </div>
 
   <!-- DELIVERABLE -->
   <div id="deliverable" class="d-section" style="border-bottom: none;">
     <p class="d-label">Deliverable</p>
-    <p class="d-body">At its core, the solution was simple, but a large technical lift. Due to the nature of our client relationships, We had information upstream about members - demographics, health conditions, even specific health data.</p>
-    <p class="d-body">This led us to build a system that, given member verification, would allow us prefill, confirm or skip the information we needed during onboarding. The art was keeping the member in control & maintaining transparency so the process built trust rather than eroded it.</p>
+    <p class="d-body">At its core, the solution was simple, but a large technical lift. Due to the nature of our client relationships, we had information upstream about members — demographics, health conditions, even specific health data.</p>
+    <p class="d-body">This led us to build a system that, given member verification, would allow us to prefill, confirm, or skip the information we needed during onboarding. The art was keeping the member in control & maintaining transparency so the process built trust rather than eroded it.</p>
 
     <div class="d-sticky-scroll">
       <!-- Sticky animation column -->
@@ -319,7 +319,7 @@
           <p class="d-mono">01</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Verification</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Confirm membership & identity</p>
-          <p class="d-body" style="margin-top: 12px;">To prefill information, we needed to know with high confidence that the person. We passed this through assets, but we needed to verify with confidence to reduce the risk of PII leakage</p>
+          <p class="d-body" style="margin-top: 12px;">To prefill information, we needed to know with high confidence who the person was. We passed this through several signals, but had to verify with confidence to reduce the risk of PII leakage.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Employer name and sponsorship status from HR feed</li>
@@ -328,7 +328,7 @@
           <p class="d-label" style="margin-top: 16px;">What changed</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Reduced data to the minimum needed to PII match a member</li>
-            <li class="d-body" style="font-size: 12px;">• Build trust eary by surfacing employer — "we know who you are"</li>
+            <li class="d-body" style="font-size: 12px;">• Build trust early by surfacing employer — "we know who you are"</li>
             <li class="d-body" style="font-size: 12px;">• Privacy footer with encryption disclosure</li>
           </ul>
         </div>
@@ -337,7 +337,7 @@
           <p class="d-mono">02</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Account</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Shifting control to the member</p>
-          <p class="d-body" style="margin-top: 12px;">Employer data gave us email and phone — but not always the right ones. Work emails and desk phones don't help a member manage diabetes at home. The account step introduced the independent relationship with Livongo, but enforced that their employer was a partner</p>
+          <p class="d-body" style="margin-top: 12px;">Employer data gave us email and phone — but not always the right ones. Work emails and desk phones don't help a member manage diabetes at home. The account step introduced the independent relationship with Livongo, but reinforced that their employer was a partner.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Email and phone pre-filled from employer HR data</li>
@@ -362,7 +362,7 @@
           </ul>
           <p class="d-label" style="margin-top: 16px;">What changed</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
-            <li class="d-body" style="font-size: 12px;">• Reframed as a unified program for all eligible programs.</li>
+            <li class="d-body" style="font-size: 12px;">• Reframed as a unified plan covering all eligible programs</li>
             <li class="d-body" style="font-size: 12px;">• "Qualified" vs "Optional" badges set clear expectations</li>
           </ul>
         </div>
@@ -371,7 +371,7 @@
           <p class="d-mono">04</p>
           <p class="d-headline d-headline--md" style="margin-top: 4px;">Program Setup</p>
           <p class="d-mono d-text--subtle" style="margin-top: 4px;">Personalize without interrogating</p>
-          <p class="d-body" style="margin-top: 12px;">Historically a growing drop off, Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion set a pattern for trust - showing what system already knows and how it knows it. Members always had the ability edit or change information.</p>
+          <p class="d-body" style="margin-top: 12px;">Historically a growing drop-off step. Blue dots mark pre-filled fields — data sourced from health records and employer HR. The "From Your Records" accordion set a pattern for trust — showing what the system already knows and how it knows it. Members always had the ability to edit or change information.</p>
           <p class="d-label" style="margin-top: 20px;">Data Sourced</p>
           <ul style="list-style: none; margin-top: 8px; display: flex; flex-direction: column; gap: 4px;">
             <li class="d-body" style="font-size: 12px;">• Monitoring frequency from health records</li>

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -174,7 +174,7 @@
         <li><a href="/livongo/" class="d-nav__link d-nav__link--active">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
@@ -204,6 +204,13 @@
     </dl>
 
     <p class="d-body" style="margin-top: 16px;"><a href="/livongo-config/" style="color: var(--accent-cyan, #00fff7); text-decoration: none;">Livongo Product Suite (Config) →</a></p>
+  </div>
+
+  <!-- WHY THIS PROJECT — CPQ angle -->
+  <div class="d-why d-why--shipped" style="margin-top: 32px;">
+    <p class="d-why__label">Why this project?</p>
+    <p class="d-why__headline">This is the same problem as CPQ.</p>
+    <p class="d-why__body">Programs are SKUs. Qualification rules are pricing rules. The registration flow is the quote. The spreadsheet is the same artifact that CPQ platforms replace with automated configuration. We replaced it with a system that reads upstream data and adapts the flow in real time.</p>
   </div>
 
   <!-- FRAMING -->
@@ -502,8 +509,8 @@
 </div>
 
 <footer class="d-footer d-contain">
-  <a href="/livongo-config/" class="d-next">← Livongo Config</a>
-  <a href="/philosophy/" class="d-next">How I Work →</a>
+  <a href="/invoy/" class="d-next">← Invoy</a>
+  <a href="/philosophy/" class="d-next">Process →</a>
 </footer>
 
 <script src="/portfolio.js"></script>

--- a/philosophy/index.html
+++ b/philosophy/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How I Work — Ian Fike</title>
+  <title>Process — Ian Fike</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
@@ -47,7 +47,7 @@
         <li><a href="/livongo/" class="d-nav__link">Livongo</a></li>
       </ul>
     </li>
-    <li><a href="/philosophy/" class="d-nav__link d-nav__link--active">Philosophy</a></li>
+    <li><a href="/philosophy/" class="d-nav__link d-nav__link--active">Process</a></li>
     <li><a href="#" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
## Summary
- Removes a redundant 28px gap inside \`.d-nav__group\` so the collapsed "Case Studies" no longer adds extra space before "Process"
- Drops the group label color to muted gray so Case Studies / Process / Contact all read at the same weight on the home page; label brightens on hover or when the group is expanded

## Test plan
- [ ] Home page: Case Studies, Process, and Contact appear at equal spacing and equal color
- [ ] Case study pages: expanding Case Studies still highlights the label and items
- [ ] Hovering Case Studies brightens the label