### PR TITLE
feat(portfolio): rename Philosophies to Process; full-width divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,14 +65,13 @@
     </div>
   </div>
 
-  <!-- Philosophies -->
-  <div style="padding: 20px 0 12px; border-bottom: 1px solid var(--border-subtle, #33332f);">
-    <p class="d-label" style="margin-bottom: 0;">Philosophies</p>
+  <!-- Process label -->
+  <div class="d-section" style="padding: 20px 0 12px;">
+    <p class="d-label" style="margin-bottom: 0;">Process</p>
   </div>
 
   <!-- Process -->
-  <a href="/philosophy/" class="d-section process-section" style="display: block; text-decoration: none; color: inherit; border-bottom: none; margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
-    <p class="d-label">Process</p>
+  <a href="/philosophy/" class="d-section process-section" style="display: block; text-decoration: none; color: inherit; margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
     <p class="d-headline d-headline--lg">Scaling Design with AI</p>
     <p class="d-body" style="margin-top: 12px;">AI owns divergence — generating options, exploring the space. I own convergence — deciding what ships, refining what's right. A design system validates the seam between. Claude Code generates inside its constraints. Systemic audits drift. Paper is where the final 10% gets refined by hand. The double diamond is durable; the division of labor is new.</p>
     <p class="d-mono" style="margin-top: 16px; color: var(--fg-muted, #8a8885);">Read the full Process →</p>


### PR DESCRIPTION
## Summary
- Rename homepage label Philosophies → Process
- Drop duplicate Process label inside the card
- Use .d-section so divider is full-width, matching Case Studies

🤖 Generated with [Claude Code](https://claude.com/claude-code)