### PR TITLE
fix(invoy): remove placeholder screenshot boxes under Introducing A Design System

### DIFF
--- a/invoy/index.html
+++ b/invoy/index.html
@@ -184,20 +184,6 @@
       <p class="d-subsection__kicker">Started inside the feature. Applied everywhere.</p>
       <p class="d-body" style="margin-top: 16px;">Every screen had been built bespoke. A system would pay for itself — the question was how to start one without stopping shipping. This project was the wedge. We built the weekly planning and Goal surfaces on a new foundation — type scale, color tokens, component primitives — then applied the visual layer to the surrounding screens so members never crossed a jarring seam. After this project, shipping on the system was the default, not a negotiation.</p>
 
-      <div class="d-gallery d-gallery--3" style="margin-top: 32px;">
-        <div class="d-gallery__item">
-          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Goal cards [screenshot]</span></div>
-          <span class="d-gallery__caption">Goal cards — the core component that carried the system out to neighboring screens.</span>
-        </div>
-        <div class="d-gallery__item">
-          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Type &amp; color [screenshot]</span></div>
-          <span class="d-gallery__caption">Type and color tokens applied to surrounding screens first. Components followed.</span>
-        </div>
-        <div class="d-gallery__item">
-          <div style="aspect-ratio: 4/5; background: var(--bg-surface, #1a1a18); border: 1px solid var(--border-subtle, #33332f); display: flex; align-items: center; justify-content: center;"><span class="d-mono">Components [screenshot]</span></div>
-          <span class="d-gallery__caption">Component inventory grew outward from the weekly planning flow as adjacent work got touched.</span>
-        </div>
-      </div>
     </div>
 
     <!-- Voice & Tone -->


### PR DESCRIPTION
Removes the 3-item placeholder gallery (Goal cards / Type & color / Components) under '02 Introducing A Design System' on the Invoy case study page.