### PR TITLE
feat(home): retune case study tags for roadrunner.ai audience

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,19 +45,19 @@
     <p class="d-label">Case Studies</p>
     <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
       <a href="/field/" class="d-card">
-        <span class="d-card__tag">Solo Founder · AI · High Complexity</span>
+        <span class="d-card__tag">0→1 · AI-Native · Founder Partnership</span>
         <span class="d-card__title">Field</span>
         <span class="d-card__desc">Voice-first clinical reports for remote first responders. Offline.</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--accent-amber, #ffb000);">Beta</span>
       </a>
       <a href="/invoy/" class="d-card">
-        <span class="d-card__tag">Weight · Design System</span>
+        <span class="d-card__tag">Early Stage · Retention Loop · Design System</span>
         <span class="d-card__title">Invoy Weekly Goals</span>
         <span class="d-card__desc">A weekly weight-management engagement loop from daily habits and manual coaching.</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>
       </a>
       <a href="/livongo/" class="d-card">
-        <span class="d-card__tag">Infrastructure · B2B · Scale</span>
+        <span class="d-card__tag">Scale · Platform Complexity · Configuration</span>
         <span class="d-card__title">Livongo Onboarding</span>
         <span class="d-card__desc">Client configuration stability while growing</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>


### PR DESCRIPTION
Updates the three case study tags so they ladder for early-stage AI founders:

- **Field**: 0→1 · AI-Native · Founder Partnership
- **Invoy**: Early Stage · Retention Loop · Design System
- **Livongo**: Scale · Platform Complexity · Configuration

Tells a progression (0→1 → early growth → scale) and swaps in language that resonates with Roadrunner-stage concerns: founder partnership, AI-native craft, retention, and systems that hold complexity.