### PR TITLE
fix(livongo): rename 'Livongo Registration' to 'Livongo Onboarding'

### DIFF
--- a/livongo-config/index.html
+++ b/livongo-config/index.html
@@ -181,7 +181,7 @@
 </div>
 
 <footer class="d-footer d-contain">
-  <a href="/livongo/" class="d-next">← Livongo Registration</a>
+  <a href="/livongo/" class="d-next">← Livongo Onboarding</a>
   <a href="/philosophy/" class="d-next">Process →</a>
 </footer>
 

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Livongo Registration — Ian Fike</title>
+  <title>Livongo Onboarding — Ian Fike</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
@@ -191,7 +191,7 @@
   <!-- Header -->
   <div style="padding: 48px 0 0;">
     <span class="d-status d-status--shipped">Shipped</span>
-    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Registration</p>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Onboarding</p>
     <p class="d-body" style="margin-top: 12px;">Reshaping onboarding as a tool for trust and partnership. 9 steps became 6. A spreadsheet became an API. Completion metrics became activation metrics.</p>
 
     <dl class="d-overview">


### PR DESCRIPTION
Matches the homepage card title. Updates:
- /livongo/ page title
- /livongo/ H1 headline
- /livongo-config/ back-link