### PR TITLE
fix(livongo): remove Decisions section and subnav link

### DIFF
--- a/livongo/index.html
+++ b/livongo/index.html
@@ -182,7 +182,6 @@
 <div class="d-subnav">
   <a href="#framing" class="d-subnav__link d-subnav__link--active">Problem</a>
   <a href="#deliverable" class="d-subnav__link">Experience</a>
-  <a href="#process" class="d-subnav__link">Decisions</a>
   <a href="#impact" class="d-subnav__link">Impact</a>
 </div>
 
@@ -454,25 +453,6 @@
         <a href="/reg/standard.html" class="interactive-cta__link interactive-cta__link--dim">Original flow (9 steps) →</a>
         <a href="/reg/prereg.html" class="interactive-cta__link interactive-cta__link--accent">Optimized flow (6 steps) →</a>
         <a href="/reg/" class="interactive-cta__link interactive-cta__link--accent">Side-by-side comparison →</a>
-      </div>
-    </div>
-  </div>
-
-  <!-- PROCESS -->
-  <div id="process" class="d-section">
-    <p class="d-label">Process</p>
-    <div class="d-decisions">
-      <div class="d-decision">
-        <p class="d-decision__q">Why was product configuration the root cause?</p>
-        <p class="d-decision__a">Each program bundle changed which fields appeared, which were required, and which qualification rules applied. The spreadsheet couldn't scale. New bundles broke old assumptions. Registration errors weren't UX problems — they were configuration problems surfacing as bad member experiences.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why did more context increase completion?</p>
-        <p class="d-decision__a">The org assumed shorter = better. But members weren't dropping off because of length — they were dropping off because they didn't understand why they were being asked. Transparency banners, data source attribution, and partnership-oriented copy gave people a reason to keep going.</p>
-      </div>
-      <div class="d-decision">
-        <p class="d-decision__q">Why reframe onboarding as trust, not completion?</p>
-        <p class="d-decision__a">Enrollment drove 6 months of revenue. But activation — 6+ blood sugar checks in 3 weeks — drove 12+ month retention and 18 months of revenue. The org bias was "less is more" and "completion, not context." But for someone newly diagnosed, onboarding is the first trust moment. Partnership over authority.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removes the 'Decisions' (Process) section and its subnav entry from the Livongo case study page.