### PR TITLE
fix(field): personas match case study card style with 8px gaps

### DIFF
--- a/field/index.html
+++ b/field/index.html
@@ -78,22 +78,22 @@
     <p class="d-body">Existing software was built for ambulances with Wi-Fi and keyboards. Nothing works for the backcountry — where there's no cell service, no keyboard, and no time to type.</p>
 
     <p class="d-label" style="margin-top: 32px;">Personas</p>
-    <div class="d-personas">
-      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+    <div class="d-personas" style="gap: 8px; background: transparent;">
+      <div class="d-persona" style="padding: 28px;">
         <span class="d-persona__role">Primary user</span>
         <span class="d-persona__name">First Responder</span>
         <ul class="d-persona__needs">
           <li>Has to document while treating the patient. Wearing gloves, often in bad weather. Might be new — this could be their first real call.</li>
         </ul>
       </div>
-      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+      <div class="d-persona" style="padding: 28px;">
         <span class="d-persona__role">Receives the note</span>
         <span class="d-persona__name">Professional EMS</span>
         <ul class="d-persona__needs">
           <li>Needs organized data, not handwritten paragraphs. Wants vitals and a treatment plan in standard format.</li>
         </ul>
       </div>
-      <div class="d-persona" style="border: 1px solid var(--border-subtle, #33332f);">
+      <div class="d-persona" style="padding: 28px;">
         <span class="d-persona__role">Information source</span>
         <span class="d-persona__name">Patient</span>
         <ul class="d-persona__needs">


### PR DESCRIPTION
Restyles the 3-persona block on the Field page to match the homepage case study card container:

- Removes per-tile border (was creating boxed look)
- Bumps padding 24→28px to match .d-card
- 8px gap between tiles, transparent wrapper background