### PR TITLE
feat(home): case study cards get borders, respect global padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,20 +43,20 @@
   <!-- Case Studies -->
   <div class="d-section" style="border-bottom: none;">
     <p class="d-label">Case Studies</p>
-    <div class="d-cards" style="margin: 0 calc(-1 * clamp(20px, 5vw, 64px));">
-      <a href="/field/" class="d-card">
+    <div class="d-cards" style="gap: 8px; background: transparent;">
+      <a href="/field/" class="d-card" style="border: 1px solid var(--border-subtle, #33332f);">
         <span class="d-card__tag">0→1 · AI-Native · Founder</span>
         <span class="d-card__title">Field</span>
         <span class="d-card__desc">Voice-first clinical reports for remote first responders. Offline.</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--accent-amber, #ffb000);">Beta</span>
       </a>
-      <a href="/invoy/" class="d-card">
+      <a href="/invoy/" class="d-card" style="border: 1px solid var(--border-subtle, #33332f);">
         <span class="d-card__tag">Early Stage · Retention Loop · Design System</span>
         <span class="d-card__title">Invoy Weekly Goals</span>
         <span class="d-card__desc">A weekly weight-management engagement loop from daily habits and manual coaching.</span>
         <span class="d-card__tag" style="margin-top: auto; color: var(--color-success, #22c55e);">Shipped</span>
       </a>
-      <a href="/livongo/" class="d-card">
+      <a href="/livongo/" class="d-card" style="border: 1px solid var(--border-subtle, #33332f);">
         <span class="d-card__tag">Scale · Platform Complexity · Configuration</span>
         <span class="d-card__title">Livongo Onboarding</span>
         <span class="d-card__desc">Client configuration stability while growing</span>


### PR DESCRIPTION
Case Studies grid on home:
- Per-card 1px border (matches personas style)
- 8px gap between cards
- Removes negative horizontal margin so cards sit inside the global page padding