### PR TITLE
fix(home): match 'Scaling Design with AI' headline to case study header size

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
 
   <!-- Process -->
   <a href="/philosophy/" class="d-section process-section" style="display: block; text-decoration: none; color: inherit; margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
-    <p class="d-headline d-headline--lg">Scaling Design with AI</p>
+    <p class="d-headline d-headline--xl">Scaling Design with AI</p>
     <p class="d-body" style="margin-top: 12px;">AI owns divergence — generating options, exploring the space. I own convergence — deciding what ships, refining what's right. A design system validates the seam between. Claude Code generates inside its constraints. Systemic audits drift. Paper is where the final 10% gets refined by hand. The double diamond is durable; the division of labor is new.</p>
     <p class="d-mono" style="margin-top: 16px; color: var(--fg-muted, #8a8885);">Read the full Process →</p>
   </a>


### PR DESCRIPTION
Bumps the Process block headline from d-headline--lg to d-headline--xl so it matches the Field/Invoy/Livongo case study headers. Description styling was already consistent.