### PR TITLE
fix(home): Scaling Design block uses card title/desc treatment

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
 
   <!-- Process -->
   <a href="/philosophy/" class="d-section process-section" style="display: block; text-decoration: none; color: inherit; margin: 0 calc(-1 * clamp(20px, 5vw, 64px)); padding: 64px clamp(20px, 5vw, 64px);">
-    <p class="d-headline d-headline--xl">Scaling Design with AI</p>
-    <p class="d-body" style="margin-top: 12px;">AI owns divergence — generating options, exploring the space. I own convergence — deciding what ships, refining what's right. A design system validates the seam between. Claude Code generates inside its constraints. Systemic audits drift. Paper is where the final 10% gets refined by hand. The double diamond is durable; the division of labor is new.</p>
+    <p class="d-card__title">Scaling Design with AI</p>
+    <p class="d-card__desc" style="margin-top: 12px;">AI owns divergence — generating options, exploring the space. I own convergence — deciding what ships, refining what's right. A design system validates the seam between. Claude Code generates inside its constraints. Systemic audits drift. Paper is where the final 10% gets refined by hand. The double diamond is durable; the division of labor is new.</p>
     <p class="d-mono" style="margin-top: 16px; color: var(--fg-muted, #8a8885);">Read the full Process →</p>
   </a>
 


### PR DESCRIPTION
Corrects previous miss — 'Case study headers' meant the card titles on home (18px, d-card__title), not the case study page H1. Updates both headline and description classes to match.