### PR TITLE
feat(home): hero takes 70vh with centered content

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 <div class="d-contain">
 
   <!-- Hero -->
-  <div class="d-hero">
+  <div class="d-hero" style="min-height: 70vh; display: flex; flex-direction: column; justify-content: center; padding: 0;">
     <p class="d-body" style="font-size: 15px;">Design manages <strong>complexity</strong> — smooths it over, abstracts it away, hides it behind a clean facade. But the real problems live in the regulations, the legacy structures, the entangled rules, and the users mid-task with no patience for friction.</p>
     <p class="d-body" style="font-size: 15px; margin-top: 20px;"><strong>That's the work.</strong></p>
     <p class="d-body" style="font-size: 15px; margin-top: 20px;">Stay in it long enough to see the <strong>shape underneath</strong>. <strong>Build the system that holds the complexity.</strong> Make the path for people obvious and intuitive.</p>


### PR DESCRIPTION
Sets home hero to min-height: 70vh, flex-column-centers the body copy, removes prior 80px top padding.