### PR TITLE
feat(personas): unified 1px stroke + 12px gap across all pages

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -376,14 +376,15 @@
 .d-personas {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1px;
-  background: var(--border-subtle, #33332f);
+  gap: 12px;
+  background: transparent;
   margin-top: 32px;
 }
 
 .d-persona {
   padding: 24px;
   background: var(--bg, #111110);
+  border: 1px solid var(--border-subtle, #33332f);
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/field/index.html
+++ b/field/index.html
@@ -78,22 +78,22 @@
     <p class="d-body">Existing software was built for ambulances with Wi-Fi and keyboards. Nothing works for the backcountry — where there's no cell service, no keyboard, and no time to type.</p>
 
     <p class="d-label" style="margin-top: 32px;">Personas</p>
-    <div class="d-personas" style="gap: 8px; background: transparent;">
-      <div class="d-persona" style="padding: 28px;">
+    <div class="d-personas">
+      <div class="d-persona">
         <span class="d-persona__role">Primary user</span>
         <span class="d-persona__name">First Responder</span>
         <ul class="d-persona__needs">
           <li>Has to document while treating the patient. Wearing gloves, often in bad weather. Might be new — this could be their first real call.</li>
         </ul>
       </div>
-      <div class="d-persona" style="padding: 28px;">
+      <div class="d-persona">
         <span class="d-persona__role">Receives the note</span>
         <span class="d-persona__name">Professional EMS</span>
         <ul class="d-persona__needs">
           <li>Needs organized data, not handwritten paragraphs. Wants vitals and a treatment plan in standard format.</li>
         </ul>
       </div>
-      <div class="d-persona" style="padding: 28px;">
+      <div class="d-persona">
         <span class="d-persona__role">Information source</span>
         <span class="d-persona__name">Patient</span>
         <ul class="d-persona__needs">


### PR DESCRIPTION
Moves persona styling from per-page inline overrides to the shared design system:

- .d-personas: 12px gap, transparent background (was: 1px hairline grid trick)
- .d-persona: adds 1px border-subtle stroke
- Drops Field-specific inline padding/gap/background overrides

Applies consistently to Field, Invoy, and Livongo-config persona blocks.