### PR TITLE
fix(invoy): remove early-stage metrics caveat from Impact section

### DIFF
--- a/invoy/index.html
+++ b/invoy/index.html
@@ -286,9 +286,6 @@
       </div>
     </div>
 
-    <div class="d-callout" style="margin-top: 48px;">
-      <p class="d-callout__body"><strong style="color: var(--fg, #e8e6e3);">Early-stage metrics caveat.</strong> Invoy was a seed-stage startup. We didn't have the instrumentation for controlled A/B tests or statistically significant lift measurements. What we could measure: coaches ran twice as many members through manual plan setup, and the weekly planning flow became the most-used feature within two weeks of launch.</p>
-    </div>
   </div>
 
 </div>


### PR DESCRIPTION
Removes the d-callout block below the Impact metrics on the Invoy case study page.