### PR TITLE
copy(reg): simplify Programs banner to single line + cream palette

### DIFF
--- a/animations/reg/step3-select.html
+++ b/animations/reg/step3-select.html
@@ -30,13 +30,12 @@
   .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 24px; }
 
   .source-banner {
-    background: #e8f5e9; border: 1px solid #c8e6c9; border-radius: 8px;
+    background: #faf8f5; border: 1px solid #ede8e1; border-radius: 8px;
     padding: 12px 16px; margin-bottom: 20px;
     display: flex; align-items: center; gap: 10px;
-    font-size: 13px; color: #2e7d32; font-weight: 500;
+    font-size: 13px; color: #5a4a2e; font-weight: 500;
   }
-  .source-banner__icon { font-size: 16px; }
-  .source-banner__sub { font-size: 11px; color: #558b2f; font-weight: 400; margin-top: 2px; }
+  .source-banner__icon { width: 18px; height: 18px; flex-shrink: 0; color: #8a6d3a; }
 
   .programs { display: flex; flex-direction: column; gap: 12px; }
 
@@ -92,11 +91,11 @@
     <div class="subtitle">Based on your employer's plan and your health records, you qualify for the following programs.</div>
 
     <div class="source-banner">
-      <span class="source-banner__icon">✓</span>
-      <div>
-        <div>Matched from Pilot Trucking LLC benefits</div>
-        <div class="source-banner__sub">Programs selected based on your eligibility and health records</div>
-      </div>
+      <svg class="source-banner__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        <path d="m9 12 2 2 4-4"/>
+      </svg>
+      <div>Programs selected based on your benefits</div>
     </div>
 
     <div class="programs">


### PR DESCRIPTION
## Summary
- Drops the "Matched from Pilot Trucking LLC benefits" lead and the small sub-line; banner now reads simply: **Programs selected based on your benefits**
- Replaces the ✓ glyph with an inline shield-check SVG icon
- Switches the banner to the cream palette (\`#faf8f5\` / \`#ede8e1\`) used elsewhere in the registration animation, so it reads as informational context rather than a success state

## Test plan
- [ ] Open animations/reg/step3-select.html — banner appears above the program list, single-line copy, cream background, shield-check icon