### PR TITLE
fix(animations): match Daily Check-in heading weight to Weekly Plan

### DIFF
--- a/animations/daily-checkin.html
+++ b/animations/daily-checkin.html
@@ -6,7 +6,7 @@
 <title>Invoy — Daily Reflection Flow</title>
 <style>
   * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { background: #0A0A0A; display: flex; justify-content: center; padding: 60px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+  body { background: #0A0A0A; display: flex; justify-content: center; padding: 60px; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-synthesis: none; }
   body.embedded { padding: 0; background: transparent; }
   body.embedded .phone__label { display: none; }
 


### PR DESCRIPTION
Adds `font-synthesis: none` to the Daily Check-in body so 'Reflect on Yesterday' (font-weight: 510) renders at its true SF Pro weight instead of being faux-bolded by the browser. Weekly Plan already has this rule — now both animations' headings match.