### PR TITLE
feat(reg): step3 Programs reveal — Heart & Diabetes bundle, plain copy, banner above CTA

### DIFF
--- a/animations/reg/step3-select.html
+++ b/animations/reg/step3-select.html
@@ -29,46 +29,73 @@
   .title { font-size: 24px; font-weight: 600; color: #222; margin-bottom: 6px; }
   .subtitle { font-size: 14px; color: #666; line-height: 1.5; margin-bottom: 24px; }
 
+  /* Bundle card */
+  .bundle {
+    border: 1px solid #eaeaea; border-radius: 12px; overflow: hidden;
+    opacity: 0; transform: translateY(8px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+  }
+  .bundle.in { opacity: 1; transform: translateY(0); }
+
+  .bundle__header {
+    padding: 14px 18px; background: #fafafa; border-bottom: 1px solid #f0f0f0;
+    display: flex; flex-direction: column; gap: 2px;
+  }
+  .bundle__eyebrow { font-size: 10px; font-weight: 600; letter-spacing: 0.06em; color: #888; }
+  .bundle__title { font-size: 16px; font-weight: 600; color: #222; }
+
+  .bundle__items { display: flex; flex-direction: column; }
+  .item {
+    display: flex; align-items: center; gap: 14px;
+    padding: 16px 20px; border-bottom: 1px solid #f0f0f0;
+  }
+  .item:last-child { border-bottom: none; }
+  .item__check {
+    width: 22px; height: 22px; border-radius: 50%; background: #e8f5e9;
+    flex-shrink: 0; display: flex; align-items: center; justify-content: center;
+    color: #2e7d32;
+  }
+  .item__body { flex: 1; }
+  .item__name { font-size: 14px; font-weight: 600; color: #222; }
+  .item__desc { font-size: 12px; color: #777; margin-top: 2px; line-height: 1.4; }
+
+  /* Also consider section */
+  .consider { margin-top: 24px; }
+  .consider__label {
+    font-size: 11px; font-weight: 600; letter-spacing: 0.06em; color: #999;
+    margin-bottom: 10px;
+  }
+  .consider__card {
+    display: flex; align-items: center; gap: 14px;
+    padding: 16px 20px; border: 1px dashed #c8c8c8; background: #fafafa;
+    border-radius: 10px;
+    opacity: 0; transform: translateY(8px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+  }
+  .consider__card.in { opacity: 1; transform: translateY(0); }
+  .consider__body { flex: 1; }
+  .consider__name { font-size: 14px; font-weight: 600; color: #222; }
+  .consider__desc { font-size: 12px; color: #777; margin-top: 2px; line-height: 1.4; }
+  .consider__link {
+    display: flex; align-items: center; gap: 4px; flex-shrink: 0;
+    font-size: 13px; font-weight: 600; color: #1976D2;
+    text-decoration: none;
+  }
+  .consider__link svg { width: 14px; height: 14px; }
+
+  /* Banner — now sits just above CTA */
   .source-banner {
     background: #faf8f5; border: 1px solid #ede8e1; border-radius: 8px;
-    padding: 12px 16px; margin-bottom: 20px;
+    padding: 12px 16px; margin-top: 24px;
     display: flex; align-items: center; gap: 10px;
     font-size: 13px; color: #5a4a2e; font-weight: 500;
   }
   .source-banner__icon { width: 18px; height: 18px; flex-shrink: 0; color: #8a6d3a; }
 
-  .programs { display: flex; flex-direction: column; gap: 12px; }
-
-  .program {
-    border: 1px solid #e0e0e0; border-radius: 10px; padding: 16px 20px;
-    display: flex; align-items: center; gap: 14px;
-    transition: border-color 0.3s, background 0.3s;
-  }
-  .program.selected { border-color: #1976D2; background: #f5f9ff; }
-
-  .program__check {
-    width: 24px; height: 24px; border-radius: 50%; border: 2px solid #ddd;
-    flex-shrink: 0; display: flex; align-items: center; justify-content: center;
-    transition: all 0.3s;
-  }
-  .program.selected .program__check { border-color: #1976D2; background: #1976D2; }
-  .program__checkmark {
-    color: #fff; font-size: 14px; font-weight: 700;
-    opacity: 0; transform: scale(0); transition: all 0.3s;
-  }
-  .program.selected .program__checkmark { opacity: 1; transform: scale(1); }
-
-  .program__info { flex: 1; }
-  .program__name { font-size: 15px; font-weight: 600; color: #222; }
-  .program__desc { font-size: 12px; color: #777; margin-top: 2px; line-height: 1.4; }
-  .program__badge { font-size: 10px; font-weight: 600; padding: 3px 10px; border-radius: 10px; flex-shrink: 0; }
-  .program__badge--qualified { background: #e8f5e9; color: #2e7d32; }
-  .program__badge--optional { background: #fff3e0; color: #e65100; }
-
   .cta {
     width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
-    margin-top: 20px;
+    margin-top: 12px;
   }
   .help-text {
     font-size: 11px; color: #999; text-align: center; margin-top: 12px;
@@ -88,57 +115,67 @@
 
   <div class="content">
     <div class="title">Your Programs</div>
-    <div class="subtitle">Based on your employer's plan and your health records, you qualify for the following programs.</div>
+    <div class="subtitle">Based on your job's plan and your health info, you can join these programs.</div>
+
+    <div class="bundle" id="bundle">
+      <div class="bundle__header">
+        <div class="bundle__eyebrow">FOUND FOR YOU</div>
+        <div class="bundle__title">Heart &amp; Diabetes Care</div>
+      </div>
+      <div class="bundle__items">
+        <div class="item">
+          <div class="item__check">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+          </div>
+          <div class="item__body">
+            <div class="item__name">Diabetes Care</div>
+            <div class="item__desc">A meter, free test strips, and a coach to help</div>
+          </div>
+        </div>
+        <div class="item">
+          <div class="item__check">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+          </div>
+          <div class="item__body">
+            <div class="item__name">Blood Pressure Care</div>
+            <div class="item__desc">A blood pressure cuff and tips made for you</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="consider">
+      <div class="consider__label">ALSO CONSIDER…</div>
+      <div class="consider__card" id="consider">
+        <div class="consider__body">
+          <div class="consider__name">Healthy Weight</div>
+          <div class="consider__desc">A smart scale, weight-loss meds option, and a coach</div>
+        </div>
+        <a class="consider__link" href="#" onclick="return false;">
+          See if I qualify
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+        </a>
+      </div>
+    </div>
 
     <div class="source-banner">
       <svg class="source-banner__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
         <path d="m9 12 2 2 4-4"/>
       </svg>
-      <div>Programs selected based on your benefits</div>
+      <div>Picked for you based on your benefits</div>
     </div>
 
-    <div class="programs">
-      <div class="program prog-1" id="prog1">
-        <div class="program__check"><span class="program__checkmark">✓</span></div>
-        <div class="program__info">
-          <div class="program__name">Diabetes Management</div>
-          <div class="program__desc">Connected meter, unlimited strips, personal coaching</div>
-        </div>
-        <span class="program__badge program__badge--qualified">Qualified</span>
-      </div>
-
-      <div class="program prog-2" id="prog2">
-        <div class="program__check"><span class="program__checkmark">✓</span></div>
-        <div class="program__info">
-          <div class="program__name">Hypertension</div>
-          <div class="program__desc">Connected blood pressure monitor, personalized insights</div>
-        </div>
-        <span class="program__badge program__badge--qualified">Qualified</span>
-      </div>
-
-      <div class="program prog-3" id="prog3">
-        <div class="program__check"><span class="program__checkmark">✓</span></div>
-        <div class="program__info">
-          <div class="program__name">Weight Management</div>
-          <div class="program__desc">Connected scale, nutrition coaching, activity tracking</div>
-        </div>
-        <span class="program__badge program__badge--optional">Optional</span>
-      </div>
-    </div>
-
-    <button class="cta">Review my programs</button>
-    <div class="help-text">You can add or remove programs later in your account settings.</div>
+    <button class="cta">Continue</button>
+    <div class="help-text">You can add or change programs later in your account settings.</div>
   </div>
 </div>
 
 <script>
 (function() {
   function run() {
-    setTimeout(function() { document.getElementById('prog1').classList.add('selected'); }, 2000);
-    setTimeout(function() { document.getElementById('prog2').classList.add('selected'); }, 2800);
-    // prog3 stays unselected (optional)
-    // t=4s: scroll down to reveal CTA button
+    setTimeout(function() { document.getElementById('bundle').classList.add('in'); }, 600);
+    setTimeout(function() { document.getElementById('consider').classList.add('in'); }, 1800);
     setTimeout(function() {
       window.scrollTo({ top: 100, behavior: 'smooth' });
     }, 4000);
@@ -147,7 +184,8 @@
   setTimeout(run, 0);
 
   setInterval(function() {
-    document.querySelectorAll('.program').forEach(function(p) { p.classList.remove('selected'); });
+    document.getElementById('bundle').classList.remove('in');
+    document.getElementById('consider').classList.remove('in');
     window.scrollTo({ top: 0, behavior: 'auto' });
     setTimeout(run, 500);
   }, 14000);


### PR DESCRIPTION
## Summary
- Replaces the 3-card selection list with a reveal pattern from Paper variant **v4**:
  - Diabetes + Hypertension folded into one **Heart & Diabetes Care** bundle with a soft gray header (no strong blue band) and passive green checks
  - Weight Management moved into an **Also consider…** card with a **See if I qualify** link instead of an opt-in toggle
- Source banner reworded to "Picked for you based on your benefits" and moved to sit just above the **Continue** CTA
- Copy rewritten at ~4th-grade reading level (e.g. "A meter, free test strips, and a coach to help")
- Animation: bundle card fades in first, then the "Also consider" card

## Test plan
- [ ] Open animations/reg/step3-select.html — bundle appears, then the Healthy Weight card; banner sits above Continue
- [ ] Loop restarts cleanly every 14s