### PR TITLE
fix(livongo): remove Livongo Product Suite (Config) link from page

### DIFF
--- a/livongo/index.html
+++ b/livongo/index.html
@@ -201,8 +201,6 @@
       <dt>Platform</dt>
       <dd>Web registration, Salesforce config, internal APIs</dd>
     </dl>
-
-    <p class="d-body" style="margin-top: 16px;"><a href="/livongo-config/" style="color: var(--accent-cyan, #00fff7); text-decoration: none;">Livongo Product Suite (Config) →</a></p>
   </div>
 
   <!-- WHY THIS PROJECT — CPQ angle -->


### PR DESCRIPTION
## Summary
- Removes the cyan **Livongo Product Suite (Config) →** link below the overview table on /livongo/

## Test plan
- [ ] Open /livongo/ — no cyan link appears between the overview \`<dl>\` and the "Why this project?" banner