### PR TITLE
fix(animations): Daily Check-in callout — lighter bg, marigold-derived yellows

### DIFF
--- a/animations/daily-checkin.html
+++ b/animations/daily-checkin.html
@@ -57,8 +57,8 @@
 
   /* Callout */
   .callout { display: flex; align-items: center; gap: 12px; border-radius: 26px; padding: 14px 20px; }
-  .callout-warm { background: #FEF3E2; }
-  .callout-icon { width: 28px; height: 28px; border-radius: 14px; background: #E8D5B0; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-family: "SF Pro Text", sans-serif; font-size: 13px; color: #78613A; }
+  .callout-warm { background: rgba(250, 181, 42, 0.08); }
+  .callout-icon { width: 28px; height: 28px; border-radius: 14px; background: #FCD876; display: flex; align-items: center; justify-content: center; flex-shrink: 0; font-family: "SF Pro Text", sans-serif; font-size: 13px; color: #7A5A0F; }
 
   /* CTA */
   .cta { background: #2A3C56; border-radius: 26px; padding: 16px; text-align: center; }


### PR DESCRIPTION
Fixes muddy cream/tan palette on the 'Your goal is less than 20 carbs' callout:

- Background ~50% lighter and derived from the marigold token
- Icon bg/text now offshoots of #FAB52A instead of browns