### PR TITLE
fix(animations): Daily Check-in doesn't check off items

### DIFF
--- a/animations/daily-checkin.html
+++ b/animations/daily-checkin.html
@@ -181,15 +181,6 @@
 
   async function runAnimation() {
     await wait(1200);
-    // Select first segment (less than 20g)
-    document.getElementById('seg1').style.background = '#78A8C8';
-    await wait(800);
-    // Check greens
-    document.getElementById('check1').classList.add('checked');
-    await wait(600);
-    // Check exercise
-    document.getElementById('check2').classList.add('checked');
-    await wait(600);
     // Scroll down
     var card = document.getElementById('reflectCard');
     card.scrollTo({ top: card.scrollHeight, behavior: 'smooth' });


### PR DESCRIPTION
Removes animated state changes (carb segment fill + greens/exercise checkboxes) from the Daily Check-in animation. Scroll and submit-pulse preserved.