### PR TITLE
feat(animations): Daily Check-in fills 'high' carb segment

### DIFF
--- a/animations/daily-checkin.html
+++ b/animations/daily-checkin.html
@@ -181,6 +181,9 @@
 
   async function runAnimation() {
     await wait(1200);
+    // Fill last segment (greater than 20g — went high)
+    document.getElementById('seg3').style.background = '#F68C50';
+    await wait(800);
     // Scroll down
     var card = document.getElementById('reflectCard');
     card.scrollTo({ top: card.scrollHeight, behavior: 'smooth' });


### PR DESCRIPTION
Fills seg3 (greater than 20g) with #F68C50 so the animation shows the member selecting they went over their carb goal. Checkboxes remain unchecked.