### PR TITLE
fix(nav): consistent 28px spacing in Case Studies accordion (open + closed)

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -70,6 +70,12 @@
 .d-nav__group {
   display: flex;
   align-items: center;
+  gap: 0;
+  transition: gap 0.3s ease;
+}
+
+.d-nav__group--expanded {
+  gap: 28px;
 }
 
 .d-nav__group-label {
@@ -104,7 +110,7 @@
 .d-nav__group--expanded .d-nav__group-items {
   max-width: 300px;
   opacity: 1;
-  padding-inline: 25px;
+  padding-inline: 28px;
 }
 
 .d-nav__group-items .d-nav__link {


### PR DESCRIPTION
## Summary
- **Closed:** Case Studies → Process stays 28px (no change — \`.d-nav__links\` gap)
- **Open:** \`.d-nav__group\` animates to \`gap: 28px\`, and the items panel's \`padding-inline\` goes 25 → 28px. Result: Case Studies → items bounding box is 28px, and Case Studies → Field is 56px (28 + 28).

## Test plan
- [ ] Closed accordion: 28px between Case Studies and Process
- [ ] Open accordion: 28px between Case Studies and the bounding box of the items panel
- [ ] Open accordion: 56px between Case Studies and Field
- [ ] Items panel still sits 28px before Process when expanded