### PR TITLE
feat(design-system): 36px leading padding above .d-sticky-scroll

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -631,6 +631,7 @@
 .d-sticky-scroll {
   display: flex;
   gap: 48px;
+  margin-top: 36px;
   align-items: flex-start;
 }
 


### PR DESCRIPTION
Adds margin-top: 36px to .d-sticky-scroll in the design system, giving consistent breathing room after the intro copy for Invoy, Livongo, and Field Experience sections.