### PR TITLE
fix(nav): Contact opens Gmail web compose (not native mail app)

### DIFF
--- a/field/index.html
+++ b/field/index.html
@@ -24,7 +24,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 

--- a/invoy/index.html
+++ b/invoy/index.html
@@ -23,7 +23,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 

--- a/livongo-config/index.html
+++ b/livongo-config/index.html
@@ -23,7 +23,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -175,7 +175,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 

--- a/philosophy/index.html
+++ b/philosophy/index.html
@@ -48,7 +48,7 @@
       </ul>
     </li>
     <li><a href="/philosophy/" class="d-nav__link d-nav__link--active">Process</a></li>
-    <li><a href="mailto:Fike101@gmail.com" class="d-nav__link">Contact</a></li>
+    <li><a href="https://mail.google.com/mail/?view=cm&amp;fs=1&amp;to=Fike101@gmail.com" target="_blank" rel="noopener" class="d-nav__link">Contact</a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION
## Summary
- Replaced \`mailto:Fike101@gmail.com\` with Gmail web compose URL across all nav Contact links
- Added \`target=\"_blank\" rel=\"noopener\"\` so it opens in a new browser tab

## Test plan
- [ ] Click Contact in nav → opens Gmail compose in new tab (not Mail.app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)