### PR TITLE
feat(livongo): sync to Paper — funnel, copy, Decisions; clean reg animations

### DIFF
--- a/animations/reg/step1.html
+++ b/animations/reg/step1.html
@@ -104,18 +104,18 @@
     <div class="form-row field-1">
       <div class="form-group">
         <label>Legal First Name <span class="req">*</span></label>
-        <div class="form-input" id="fname">First name</div>
+        <div class="form-input filled" id="fname">Sarah</div>
       </div>
       <div class="form-group">
         <label>Legal Last Name <span class="req">*</span></label>
-        <div class="form-input" id="lname">Last name</div>
+        <div class="form-input filled" id="lname">Chen</div>
       </div>
     </div>
 
     <div class="form-row field-2">
       <div class="form-group">
         <label>Date of Birth <span class="req">*</span></label>
-        <div class="form-input" id="dob">MM / DD / YYYY</div>
+        <div class="form-input filled" id="dob">04 / 15 / 1988</div>
       </div>
     </div>
 
@@ -125,60 +125,5 @@
   <div class="privacy">🔒 Your data is encrypted and never shared outside of your care team.</div>
 </div>
 
-<script>
-(function() {
-  var fields = [
-    { id: 'fname', value: 'Sarah', delay: 2000 },
-    { id: 'lname', value: 'Chen', delay: 3200 },
-    { id: 'dob', value: '04 / 15 / 1988', delay: 4400 }
-  ];
-
-  function typeField(el, value, callback) {
-    el.classList.add('typing');
-    el.textContent = '';
-    var i = 0;
-    var interval = setInterval(function() {
-      el.textContent = value.slice(0, i + 1);
-      i++;
-      if (i >= value.length) {
-        clearInterval(interval);
-        setTimeout(function() {
-          el.classList.remove('typing');
-          el.classList.add('filled');
-          if (callback) callback();
-        }, 300);
-      }
-    }, 60);
-  }
-
-  function runSequence() {
-    fields.forEach(function(f) {
-      setTimeout(function() {
-        var el = document.getElementById(f.id);
-        if (el) typeField(el, f.value);
-      }, f.delay);
-    });
-  }
-
-  // Run on load and repeat with card loop (12s)
-  setTimeout(runSequence, 0);
-  setInterval(function() {
-    fields.forEach(function(f) {
-      var el = document.getElementById(f.id);
-      if (el) {
-        el.classList.remove('typing', 'filled');
-        el.style.color = '';
-      }
-    });
-    document.getElementById('fname').textContent = 'First name';
-    document.getElementById('fname').style.color = '#bbb';
-    document.getElementById('lname').textContent = 'Last name';
-    document.getElementById('lname').style.color = '#bbb';
-    document.getElementById('dob').textContent = 'MM / DD / YYYY';
-    document.getElementById('dob').style.color = '#bbb';
-    setTimeout(runSequence, 500);
-  }, 12000);
-})();
-</script>
 </body>
 </html>

--- a/animations/reg/step2.html
+++ b/animations/reg/step2.html
@@ -74,17 +74,14 @@
     border-color: #ddd;
     box-shadow: none;
   }
-  .dot { width: 8px; height: 8px; border-radius: 50%; background: #1976D2; flex-shrink: 0; opacity: 0; transition: opacity 0.3s, transform 0.3s; }
-  .dot.visible { opacity: 1; transform: scale(1); }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: #1976D2; flex-shrink: 0; }
 
   .source-label {
     font-size: 10px; color: #1976D2; margin-top: 4px;
     display: flex; align-items: center; gap: 4px;
-    opacity: 0; transition: opacity 0.3s;
   }
-  .source-label.visible { opacity: 1; }
 
-  .field-group { opacity: 0; transform: translateY(8px); }
+  .field-group { }
 
   /* Password */
   .pw-wrap { position: relative; }
@@ -96,8 +93,7 @@
   .pw-rule.passed::before { content: "✓"; color: #2e7d32; }
 
   /* Terms */
-  .terms { display: flex; align-items: flex-start; gap: 8px; margin: 16px 0 8px; opacity: 0; transition: opacity 0.3s; }
-  .terms.visible { opacity: 1; }
+  .terms { display: flex; align-items: flex-start; gap: 8px; margin: 16px 0 8px; }
   .checkbox {
     width: 16px; height: 16px; border: 1.5px solid #ccc; border-radius: 3px;
     flex-shrink: 0; margin-top: 2px;
@@ -113,9 +109,7 @@
     width: 100%; padding: 14px; background: #1976D2; color: #fff;
     border: none; border-radius: 8px; font-size: 15px; font-weight: 600;
     font-family: 'Roboto', sans-serif; margin-top: 12px;
-    opacity: 0; transition: opacity 0.3s;
   }
-  .cta.visible { opacity: 1; }
 
   .privacy { font-size: 11px; color: #999; text-align: center; padding: 12px 28px; display: flex; align-items: center; justify-content: center; gap: 6px; }
 </style>
@@ -145,16 +139,14 @@
 
       <div class="form-group field-group" id="fg-email">
         <label>Email Address <span class="req">*</span></label>
-        <div class="form-input" id="email-input">
-          <span id="email-text">s.chen@pilottrucking.com</span>
-          <div class="dot" id="dot-email"></div>
+        <div class="form-input filled" id="email-input">
+          <span id="email-text">sarah.chen@gmail.com</span>
         </div>
-        <div class="source-label" id="src-email">● From employer records</div>
       </div>
 
       <div class="form-group field-group" id="fg-phone">
         <label>Mobile Phone Number <span class="req">*</span></label>
-        <div class="form-input" id="phone-input">
+        <div class="form-input filled" id="phone-input">
           <span>(817) 555-0142</span>
           <div class="dot" id="dot-phone"></div>
         </div>
@@ -164,18 +156,18 @@
       <div class="form-group field-group" id="fg-pw">
         <label>Password <span class="req">*</span></label>
         <div class="pw-wrap">
-          <div class="form-input" id="pw-input"><span id="pw-text">Create a password</span></div>
+          <div class="form-input filled" id="pw-input"><span id="pw-text">••••••••••</span></div>
           <span class="pw-toggle">👁</span>
         </div>
         <div class="pw-rules">
-          <span class="pw-rule" id="rule1">8+ characters</span>
-          <span class="pw-rule" id="rule2">1 number</span>
-          <span class="pw-rule" id="rule3">1 uppercase</span>
+          <span class="pw-rule passed" id="rule1">8+ characters</span>
+          <span class="pw-rule passed" id="rule2">1 number</span>
+          <span class="pw-rule passed" id="rule3">1 uppercase</span>
         </div>
       </div>
 
       <div class="terms" id="terms">
-        <div class="checkbox" id="checkbox"></div>
+        <div class="checkbox checked" id="checkbox"></div>
         <div class="terms-text">By continuing, I accept Livongo Health's <a href="#">Terms of Service</a> and <a href="#">Privacy Policy</a></div>
       </div>
 
@@ -186,111 +178,5 @@
   <div class="privacy">🔒 Your data is encrypted and never shared outside of your care team.</div>
 </div>
 
-<script>
-(function() {
-  function typeText(el, value, callback) {
-    var parent = el.closest('.form-input');
-    if (parent) parent.classList.add('typing');
-    el.textContent = '';
-    var i = 0;
-    var interval = setInterval(function() {
-      el.textContent = value.slice(0, i + 1);
-      i++;
-      if (i >= value.length) {
-        clearInterval(interval);
-        setTimeout(function() {
-          if (parent) { parent.classList.remove('typing'); parent.classList.add('filled'); }
-          if (callback) callback();
-        }, 200);
-      }
-    }, 50);
-  }
-
-  function showEl(el) { el.classList.add('visible'); }
-
-  function runSequence() {
-    // t=1.6s: fields fade in staggered
-    var fgs = document.querySelectorAll('.field-group');
-    setTimeout(function() {
-      fgs[0].style.opacity = '1'; fgs[0].style.transform = 'translateY(0)'; fgs[0].style.transition = 'all 0.4s ease';
-    }, 1600);
-    setTimeout(function() {
-      fgs[1].style.opacity = '1'; fgs[1].style.transform = 'translateY(0)'; fgs[1].style.transition = 'all 0.4s ease';
-    }, 1800);
-    setTimeout(function() {
-      fgs[2].style.opacity = '1'; fgs[2].style.transform = 'translateY(0)'; fgs[2].style.transition = 'all 0.4s ease';
-    }, 2000);
-
-    // t=2.5s: dots appear on pre-filled fields
-    setTimeout(function() { showEl(document.getElementById('dot-email')); }, 2500);
-    setTimeout(function() { showEl(document.getElementById('dot-phone')); }, 2700);
-    // t=2.8s: source labels
-    setTimeout(function() { showEl(document.getElementById('src-email')); }, 2800);
-    setTimeout(function() { showEl(document.getElementById('src-phone')); }, 3000);
-
-    // t=3.5s: email gets cleared and retyped with personal address
-    setTimeout(function() {
-      document.getElementById('src-email').classList.remove('visible');
-      document.getElementById('dot-email').classList.remove('visible');
-      typeText(document.getElementById('email-text'), 'sarah.chen@gmail.com');
-    }, 4000);
-
-    // t=5.5s: password types in
-    setTimeout(function() {
-      var pwText = document.getElementById('pw-text');
-      pwText.style.color = '#bbb';
-      typeText(pwText, '••••••••••', function() {
-        pwText.style.color = '#333';
-      });
-    }, 6000);
-
-    // t=7s: password rules pass
-    setTimeout(function() {
-      document.getElementById('rule1').classList.add('passed');
-      document.getElementById('rule2').classList.add('passed');
-      document.getElementById('rule3').classList.add('passed');
-    }, 7200);
-
-    // t=2.2s: terms visible
-    setTimeout(function() {
-      document.getElementById('terms').classList.add('visible');
-    }, 2200);
-    // t=2.4s: CTA visible
-    setTimeout(function() {
-      document.getElementById('cta-btn').classList.add('visible');
-    }, 2400);
-
-    // t=7.8s: checkbox checked
-    setTimeout(function() {
-      document.getElementById('checkbox').classList.add('checked');
-    }, 7800);
-
-    // t=8.5s: scroll down to reveal CTA button
-    setTimeout(function() {
-      window.scrollTo({ top: 200, behavior: 'smooth' });
-    }, 8500);
-  }
-
-  setTimeout(runSequence, 0);
-
-  // Reset and loop with card animation (16s)
-  setInterval(function() {
-    document.querySelectorAll('.field-group').forEach(function(el) {
-      el.style.opacity = '0'; el.style.transform = 'translateY(8px)'; el.style.transition = 'none';
-    });
-    document.querySelectorAll('.dot, .source-label').forEach(function(el) { el.classList.remove('visible'); });
-    document.getElementById('email-text').textContent = 's.chen@pilottrucking.com';
-    document.getElementById('pw-text').textContent = 'Create a password';
-    document.getElementById('pw-text').style.color = '#bbb';
-    document.querySelectorAll('.pw-rule').forEach(function(el) { el.classList.remove('passed'); });
-    document.querySelectorAll('.form-input').forEach(function(el) { el.classList.remove('typing', 'filled'); });
-    document.getElementById('checkbox').classList.remove('checked');
-    document.getElementById('terms').classList.remove('visible');
-    document.getElementById('cta-btn').classList.remove('visible');
-    window.scrollTo({ top: 0, behavior: 'auto' });
-    setTimeout(runSequence, 500);
-  }, 16000);
-})();
-</script>
 </body>
 </html>

--- a/animations/reg/step3-select.html
+++ b/animations/reg/step3-select.html
@@ -32,10 +32,7 @@
   /* Bundle card */
   .bundle {
     border: 1px solid #eaeaea; border-radius: 12px; overflow: hidden;
-    opacity: 0; transform: translateY(8px);
-    transition: opacity 0.5s ease, transform 0.5s ease;
   }
-  .bundle.in { opacity: 1; transform: translateY(0); }
 
   .bundle__header {
     padding: 14px 18px; background: #fafafa; border-bottom: 1px solid #f0f0f0;
@@ -69,10 +66,7 @@
     display: flex; align-items: center; gap: 14px;
     padding: 16px 20px; border: 1px dashed #c8c8c8; background: #fafafa;
     border-radius: 10px;
-    opacity: 0; transform: translateY(8px);
-    transition: opacity 0.5s ease, transform 0.5s ease;
   }
-  .consider__card.in { opacity: 1; transform: translateY(0); }
   .consider__body { flex: 1; }
   .consider__name { font-size: 14px; font-weight: 600; color: #222; }
   .consider__desc { font-size: 12px; color: #777; margin-top: 2px; line-height: 1.4; }
@@ -171,25 +165,5 @@
   </div>
 </div>
 
-<script>
-(function() {
-  function run() {
-    setTimeout(function() { document.getElementById('bundle').classList.add('in'); }, 600);
-    setTimeout(function() { document.getElementById('consider').classList.add('in'); }, 1800);
-    setTimeout(function() {
-      window.scrollTo({ top: 100, behavior: 'smooth' });
-    }, 4000);
-  }
-
-  setTimeout(run, 0);
-
-  setInterval(function() {
-    document.getElementById('bundle').classList.remove('in');
-    document.getElementById('consider').classList.remove('in');
-    window.scrollTo({ top: 0, behavior: 'auto' });
-    setTimeout(run, 500);
-  }, 14000);
-})();
-</script>
 </body>
 </html>

--- a/animations/reg/step5.html
+++ b/animations/reg/step5.html
@@ -87,7 +87,7 @@
 
     <div class="fg af1">
       <label>Street Address *</label>
-      <div class="fi fi--dim" id="addr"><span id="addr-text">Street address</span><div class="dot" id="d1"></div></div>
+      <div class="fi" id="addr"><span id="addr-text">1847 Oak Ridge Drive</span><div class="dot visible" id="d1"></div></div>
     </div>
 
     <div class="fg af2" style="margin-bottom: 0;">
@@ -98,15 +98,15 @@
     <div class="form-row af3" style="margin-top: 14px;">
       <div class="fg">
         <label>City *</label>
-        <div class="fi fi--dim" id="city"><span id="city-text">City</span><div class="dot" id="d2"></div></div>
+        <div class="fi" id="city"><span id="city-text">Fort Worth</span><div class="dot visible" id="d2"></div></div>
       </div>
       <div class="fg" style="max-width: 100px;">
         <label>State *</label>
-        <div class="fi fi--dim" id="state"><span id="state-text">State</span><div class="dot" id="d3"></div></div>
+        <div class="fi" id="state"><span id="state-text">TX</span><div class="dot visible" id="d3"></div></div>
       </div>
       <div class="fg" style="max-width: 120px;">
         <label>Zip Code *</label>
-        <div class="fi fi--dim" id="zip"><span id="zip-text">Zip</span><div class="dot" id="d4"></div></div>
+        <div class="fi" id="zip"><span id="zip-text">76102</span><div class="dot visible" id="d4"></div></div>
       </div>
     </div>
 
@@ -114,50 +114,5 @@
   </div>
 </div>
 
-<script>
-(function() {
-  var fills = [
-    { textId: 'addr-text', fiId: 'addr', dotId: 'd1', value: '1847 Oak Ridge Drive', delay: 2000 },
-    { textId: 'city-text', fiId: 'city', dotId: 'd2', value: 'Fort Worth', delay: 2800 },
-    { textId: 'state-text', fiId: 'state', dotId: 'd3', value: 'TX', delay: 3200 },
-    { textId: 'zip-text', fiId: 'zip', dotId: 'd4', value: '76102', delay: 3600 }
-  ];
-
-  function run() {
-    // t=4.5s: scroll down to reveal CTA button
-    setTimeout(function() {
-      window.scrollTo({ top: 80, behavior: 'smooth' });
-    }, 4500);
-
-    fills.forEach(function(f) {
-      setTimeout(function() {
-        var el = document.getElementById(f.textId);
-        var fi = document.getElementById(f.fiId);
-        el.textContent = f.value;
-        fi.classList.remove('fi--dim');
-        fi.style.color = '#333';
-        setTimeout(function() {
-          document.getElementById(f.dotId).classList.add('visible');
-        }, 200);
-      }, f.delay);
-    });
-  }
-
-  setTimeout(run, 0);
-
-  setInterval(function() {
-    fills.forEach(function(f) {
-      var el = document.getElementById(f.textId);
-      var fi = document.getElementById(f.fiId);
-      el.textContent = f.textId === 'addr-text' ? 'Street address' : f.textId === 'city-text' ? 'City' : f.textId === 'state-text' ? 'State' : 'Zip';
-      fi.classList.add('fi--dim');
-      fi.style.color = '';
-      document.getElementById(f.dotId).classList.remove('visible');
-    });
-    window.scrollTo({ top: 0, behavior: 'auto' });
-    setTimeout(run, 500);
-  }, 12000);
-})();
-</script>
 </body>
 </html>

--- a/animations/reg/step6.html
+++ b/animations/reg/step6.html
@@ -60,7 +60,7 @@
   .stat-label { font-size: 10px; color: #666; line-height: 1.4; }
 
   .cta {
-    width: 100%; padding: 14px; background: #fff; color: #1976D2; border: 2px solid #1976D2;
+    width: 100%; padding: 14px; background: #1976D2; color: #fff; border: none;
     border-radius: 8px; font-size: 15px; font-weight: 600; font-family: 'Roboto', sans-serif;
     margin-top: 20px; cursor: pointer;
   }
@@ -123,7 +123,7 @@
       </div>
     </div>
 
-    <button class="cta">Open the app</button>
+    <button class="cta">Go to Desktop App</button>
   </div>
 </div>
 </body>

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Livongo Onboarding — Ian Fike</title>
+  <title>Livongo Registration — Ian Fike</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
@@ -182,6 +182,7 @@
 <div class="d-subnav">
   <a href="#framing" class="d-subnav__link d-subnav__link--active">Problem</a>
   <a href="#deliverable" class="d-subnav__link">Experience</a>
+  <a href="#process" class="d-subnav__link">Decisions</a>
   <a href="#impact" class="d-subnav__link">Impact</a>
 </div>
 
@@ -190,14 +191,14 @@
   <!-- Header -->
   <div style="padding: 48px 0 0;">
     <span class="d-status d-status--shipped">Shipped</span>
-    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Onboarding</p>
-    <p class="d-body" style="margin-top: 12px;">Reshaping onboarding as a tool for trust and partnership. 9 steps became 6. A spreadsheet became an API. Completion metrics became activation metrics.</p>
+    <p class="d-headline d-headline--xl" style="margin-top: 12px;">Livongo Registration</p>
+    <p class="d-body" style="margin-top: 12px;">Reshaping onboarding as a high conversion tool for trust and partnership.</p>
 
     <dl class="d-overview">
       <dt>Role</dt>
       <dd>Senior PM, Member Growth</dd>
       <dt>Scope</dt>
-      <dd>50 configs × 74 fields = 3,700 decision points</dd>
+      <dd>Strategy, Product Design, Stakeholder management</dd>
       <dt>Platform</dt>
       <dd>Web registration, Salesforce config, internal APIs</dd>
     </dl>
@@ -219,7 +220,7 @@
     <p class="d-body">The data told the story. Every step bled members, but the reasons weren't what anyone expected.</p>
 
     <div class="funnel">
-      <!-- 100% start → 91% remain (9% loss) -->
+      <!-- 100% → 91% remain (−9%) -->
       <div class="funnel-row">
         <span class="funnel-label">Identity & Basic Info</span>
         <div class="funnel-bar">
@@ -228,40 +229,50 @@
         </div>
         <span class="funnel-pct funnel-pct--low">−9%</span>
       </div>
-      <!-- 91% → 69% remain (22% loss) -->
+      <!-- 91% → 80% remain (−12%) -->
       <div class="funnel-row">
         <span class="funnel-label">Sponsor</span>
         <div class="funnel-bar">
-          <div class="funnel-remaining" style="width: 69%;"></div>
-          <div class="funnel-loss funnel-loss--mid" style="left: 69%; width: 22%;"></div>
+          <div class="funnel-remaining" style="width: 80%;"></div>
+          <div class="funnel-loss funnel-loss--mid" style="left: 80%; width: 12%;"></div>
         </div>
-        <span class="funnel-pct funnel-pct--mid">−22%</span>
+        <span class="funnel-pct funnel-pct--mid">−12%</span>
       </div>
-      <!-- 69% → 37% remain (32% loss) -->
+      <!-- 80% → 65% remain (−19%) -->
       <div class="funnel-row">
         <span class="funnel-label">Insurance</span>
         <div class="funnel-bar">
-          <div class="funnel-remaining" style="width: 37%;"></div>
-          <div class="funnel-loss funnel-loss--high" style="left: 37%; width: 32%;"></div>
+          <div class="funnel-remaining" style="width: 65%;"></div>
+          <div class="funnel-loss funnel-loss--mid" style="left: 65%; width: 19%;"></div>
         </div>
-        <span class="funnel-pct funnel-pct--high">−32%</span>
+        <span class="funnel-pct funnel-pct--mid">−19%</span>
       </div>
-      <!-- 37% → 16% remain (21% loss) -->
+      <!-- 65% → 57% remain (−12%) -->
       <div class="funnel-row">
-        <span class="funnel-label funnel-label--highlight">Product Selection</span>
+        <span class="funnel-label">Program Selection</span>
         <div class="funnel-bar">
-          <div class="funnel-remaining" style="width: 16%;"></div>
-          <div class="funnel-loss funnel-loss--high" style="left: 16%; width: 21%;"></div>
+          <div class="funnel-remaining" style="width: 57%;"></div>
+          <div class="funnel-loss funnel-loss--mid" style="left: 57%; width: 12%;"></div>
+        </div>
+        <span class="funnel-pct funnel-pct--mid">−12%</span>
+      </div>
+      <!-- 57% → 45% remain (−21%) — highlight: multi-program pain -->
+      <div class="funnel-row">
+        <span class="funnel-label funnel-label--highlight">Program Setup</span>
+        <div class="funnel-bar">
+          <div class="funnel-remaining" style="width: 45%;"></div>
+          <div class="funnel-loss funnel-loss--high" style="left: 45%; width: 21%;"></div>
         </div>
         <span class="funnel-pct funnel-pct--high">−21%</span>
       </div>
-      <!-- 16% → ~0% remain (18% loss, but capped) -->
+      <!-- 45% → 37% remain (−8%) -->
       <div class="funnel-row">
         <span class="funnel-label">Health Intake</span>
         <div class="funnel-bar">
-          <div class="funnel-loss funnel-loss--mid" style="left: 0; width: 16%;"></div>
+          <div class="funnel-remaining" style="width: 37%;"></div>
+          <div class="funnel-loss funnel-loss--low" style="left: 37%; width: 8%;"></div>
         </div>
-        <span class="funnel-pct funnel-pct--mid">−18%</span>
+        <span class="funnel-pct funnel-pct--low">−8%</span>
       </div>
     </div>
 
@@ -455,6 +466,21 @@
     </div>
   </div>
 
+  <!-- PROCESS / DECISIONS -->
+  <div id="process" class="d-section">
+    <p class="d-label">Process</p>
+    <div class="d-decisions">
+      <div class="d-decision">
+        <p class="d-decision__q">Why did more context increase completion?</p>
+        <p class="d-decision__a">The org assumed shorter = better. But members weren't dropping off because of length — they were dropping off because they didn't understand why they were being asked. Transparency banners, data source attribution, and partnership-oriented copy gave people a reason to keep going.</p>
+      </div>
+      <div class="d-decision">
+        <p class="d-decision__q">Why reframe onboarding as trust, not completion?</p>
+        <p class="d-decision__a">Enrollment drove 6 months of revenue. But activation — 6+ blood sugar checks in 3 weeks — drove 12+ month retention and 18 months of revenue. The org bias was "less is more" and "completion, not context." But for someone newly diagnosed, onboarding is the first trust moment. Partnership over authority.</p>
+      </div>
+    </div>
+  </div>
+
   <!-- IMPACT -->
   <div id="impact" class="d-section">
     <p class="d-label">Impact</p>
@@ -529,7 +555,13 @@
     var pad = 24; // breathing room above and below
     var availH = window.innerHeight - CHROME - pad * 2;
     var layersEl = stickyReg.querySelector('.d-sticky-scroll__layers');
-    if (layersEl) layersEl.style.height = availH + 'px';
+    if (layersEl) {
+      // Cap height at max aspect ratio 3:4 (h/w) so container doesn't get too tall on large screens
+      var MAX_H_OVER_W = 4 / 3;
+      var w = layersEl.offsetWidth;
+      var maxH = w * MAX_H_OVER_W;
+      layersEl.style.height = Math.min(availH, maxH) + 'px';
+    }
     stickyReg.style.top = (CHROME + pad) + 'px';
   }
 
@@ -583,10 +615,10 @@
     }
   }, { passive: true });
 
-  sizeFrames();
   setStickyTop();
+  sizeFrames();
   onScroll();
-  window.addEventListener('resize', function() { sizeFrames(); setStickyTop(); });
+  window.addEventListener('resize', function() { setStickyTop(); sizeFrames(); });
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Livongo copy & structure synced to Paper canonical
- Reg animations stripped of per-field entrance + auto-scroll (except Program Setup & Health History)
- step6 CTA updated to filled blue "Go to Desktop App"
- Sticky phone container capped at max 4:3 h/w aspect so it doesn't over-stretch

## livongo/index.html
- Rename to "Livongo Registration" (title + headline)
- Single-sentence header body per Paper
- Scope: strategy/design/stakeholder (Paper)
- Subnav: add Decisions link
- Funnel: 5 rows → 6 rows with Paper data; "Program Selection" label + "Program Setup" highlighted row
- Restore Process section with 2 Paper decisions

## animations/reg/
- step1, step2, step3-select, step5: pre-filled final state; no typing, no scrollTo
- step3 & step4: unchanged (only two steps allowed to scroll-as-complete)
- step6: CTA filled blue with copy "Go to Desktop App"

## Test plan
- [ ] Load /livongo/ — verify "Livongo Registration" title, new subnav, 6-row funnel, Process section visible, Decisions subnav link jumps correctly
- [ ] Scroll through sticky experience — verify phone container stays at ≤ 4:3 aspect on tall screens, frames crossfade between the 7 steps
- [ ] Each reg step 1/2/3-select/5/6 shows pre-filled final state without internal scroll animation
- [ ] Steps 3 (Program Setup) and 4 (Health History) still animate and scroll as before
- [ ] step6 CTA is solid blue with white text saying "Go to Desktop App"

🤖 Generated with [Claude Code](https://claude.com/claude-code)