### PR TITLE
fix(design-system): .d-sticky-scroll top margin 36→60px

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -631,7 +631,7 @@
 .d-sticky-scroll {
   display: flex;
   gap: 48px;
-  margin-top: 36px;
+  margin-top: 60px;
   align-items: flex-start;
 }
 


### PR DESCRIPTION
Bumps leading padding above sticky scroll components from 36px to 60px.