### PR TITLE
fix(animations): align text colors to Paper screens

### DIFF
--- a/animations/manual-entry.html
+++ b/animations/manual-entry.html
@@ -18,7 +18,7 @@
   /* Fixed header */
   .fixed-header { position: absolute; top: 0; left: 0; right: 0; z-index: 10; background: #0A0A0A; }
   .tabs { display: flex; border-bottom: 1px solid #1C1C1E; background: #0A0A0A; }
-  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #9E97B1; }
+  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #A79EAF; }
   .tab--active { color: #EEF8FE; font-weight: 700; border-bottom: 2.5px solid #EEF8FE; }
 
   /* Scrollable SOAP body */
@@ -38,17 +38,17 @@
   /* Vitals table */
   .vitals-table { border-radius: 8px; overflow: hidden; margin-top: 8px; }
   .vitals-header { display: flex; background: #0A0A0A; padding: 8px; }
-  .vitals-header span { flex: 1; text-align: center; color: #A79EAF; font-size: 11px; font-weight: 500; }
+  .vitals-header span { flex: 1; text-align: center; color: #B0B0B0; font-size: 11px; font-weight: 500; }
   .vitals-header span:first-child { flex-shrink: 0; width: 29px; text-align: left; }
   .vitals-row { display: flex; align-items: center; padding: 3px 8px; min-height: 48px; }
-  .vitals-row-time { flex-shrink: 0; width: 30px; color: #A79EAF; font-size: 11px; font-weight: 500; }
+  .vitals-row-time { flex-shrink: 0; width: 30px; color: #B0B0B0; font-size: 11px; font-weight: 500; }
   .vitals-row-cells { display: flex; gap: 6px; flex: 1; }
   .vital-cell { flex: 1; border-radius: 8px; padding: 8px; text-align: center; font-size: 13px; font-weight: 600; font-variant-numeric: tabular-nums; }
-  .vital-cell--normal { background: #101010; color: #A79EAF; }
+  .vital-cell--normal { background: #101010; color: #AAAAAA; }
   .vital-cell--red { background: #411B1F; color: #FE1844; }
   .vital-cell--amber { background: #363430; color: #F9CE86; }
   .vital-cell--empty { color: rgba(255,255,255,0.2); font-family: monospace; font-size: 17px; }
-  .add-vitals-btn { background: #1F1F23; border-radius: 20px; height: 36px; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 600; color: #9E97B1; cursor: pointer; transition: background 0.15s; }
+  .add-vitals-btn { background: #1F1F23; border-radius: 20px; height: 36px; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 600; color: #B0B0B0; cursor: pointer; transition: background 0.15s; }
   .add-vitals-btn.tapped { background: #2A2A2E; }
 
   /* ═══ Bottom sheet drawer ═══ */
@@ -61,7 +61,7 @@
   .drawer-handle { width: 36px; height: 5px; border-radius: 3px; background: #3A3A3C; margin: 8px auto 12px; }
   .drawer-header { display: flex; align-items: center; justify-content: space-between; padding: 16px 0 12px; }
   .drawer-skip { color: #B0B0B0; font-size: 14px; font-weight: 500; }
-  .drawer-title { color: #9E99AD; font-size: 13px; font-weight: 600; letter-spacing: 0.1px; }
+  .drawer-title { color: #7D788B; font-size: 13px; font-weight: 600; letter-spacing: 0.1px; }
   .drawer-step { color: #6B6571; font-size: 11px; font-weight: 500; text-align: right; width: 40px; }
 
   /* Content crossfade */
@@ -124,7 +124,7 @@
         <div style="display: flex; align-items: center; padding: 12px 16px; gap: 16px;">
           <span style="color: #CAC4D0; font-size: 20px; width: 18px;">←</span>
           <div>
-            <div style="color: #A79EAF; font-size: 14px;">INC-2024-0847</div>
+            <div style="color: #EEF8FE; font-size: 14px;">INC-2024-0847</div>
             <div style="color: #A79EAF; font-size: 11px; font-weight: 500;">Apr 2, 2026</div>
           </div>
           <div style="margin-left: auto; display: flex; align-items: center; gap: 5px; background: #DF1B41; border-radius: 20px; padding: 4px 11px; height: 22px;">
@@ -150,8 +150,8 @@
           </div>
           <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
             <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Fall from 15ft onto rock slab</div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
           </div>
           <div style="border-top: 1px solid #232323; margin: 24px 0 8px;"></div>
           <div style="display: flex; align-items: center; gap: 6px; padding-left: 6px; padding-top: 6px;">
@@ -170,13 +170,13 @@
           <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
             <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">PHYSICAL EXAM</div>
             <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Injury to Left Leg & Back</div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">No injuries to neck, head, torso or arms</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">No injuries to neck, head, torso or arms</span></div>
             <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
             <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">MEDICAL HISTORY</div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">Allergies: Penicillin</span></div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Medications: None reported</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">Allergies: Penicillin</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Medications: None reported</span></div>
           </div>
           <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
           <div style="display: flex; align-items: center; gap: 6px; padding: 12px 6px 6px;">
@@ -251,7 +251,7 @@
             <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span class="soap-bullet-text">Lumbar pain</span></div>
             <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
             <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">POSSIBLE PROGRESSIONS</div>
-            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Spinal Injury,</span></div>
+            <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Spinal Injury,</span></div>
           </div>
           <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
           <div style="display: flex; align-items: center; gap: 6px; padding: 6px 6px 0;">

--- a/animations/share.html
+++ b/animations/share.html
@@ -18,7 +18,7 @@
   /* Fixed header */
   .fixed-header { position: absolute; top: 0; left: 0; right: 0; z-index: 10; background: #0A0A0A; }
   .tabs { display: flex; border-bottom: 1px solid #1C1C1E; background: #0A0A0A; }
-  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #9E97B1; transition: all 0.3s; }
+  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #A79EAF; transition: all 0.3s; }
   .tab--active { color: #EEF8FE; font-weight: 700; border-bottom: 2.5px solid #EEF8FE; }
 
   /* Swipe container */
@@ -44,11 +44,11 @@
 
   .share-warning { display: flex; align-items: center; background: #161618; border-radius: 10px; padding: 14px 16px; gap: 10px; }
   .share-card { background: #101012; border-radius: 12px; padding: 14px 16px; display: flex; flex-direction: column; }
-  .share-section-label { color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 8px; }
-  .share-text { color: #A79EAF; font-size: 14px; line-height: 1.5; padding-left: 6px; }
+  .share-section-label { color: #7D788B; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 8px; }
+  .share-text { color: #EEF8FE; font-size: 14px; line-height: 1.5; padding-left: 6px; }
   .share-bullet { display: flex; gap: 8px; padding-left: 6px; margin-top: 4px; }
   .share-bullet-dot { color: #6B6877; font-size: 13px; margin-top: 1px; }
-  .share-bullet-text { color: #A79EAF; font-size: 14px; line-height: 1.5; }
+  .share-bullet-text { color: #EEF8FE; font-size: 14px; line-height: 1.5; }
   .share-divider { border-top: 1px solid #232323; margin: 16px 0 8px; }
 
   .share-btn { display: flex; align-items: center; justify-content: center; gap: 8px; background: #1F1F23; border-radius: 9999px; height: 48px; padding: 0 16px; transition: background 0.15s; }
@@ -63,7 +63,7 @@
   .export-sheet.show { transform: translateY(0); }
 
   .export-handle { width: 36px; height: 4px; border-radius: 2px; background: #3A3A3C; margin: 0 auto 20px; }
-  .export-label { color: #6B6571; font-size: 10px; font-weight: 800; letter-spacing: 1px; margin-bottom: 12px; }
+  .export-label { color: #7D788B; font-size: 10px; font-weight: 800; letter-spacing: 1px; margin-bottom: 12px; }
   .export-btn { display: flex; align-items: center; justify-content: center; gap: 8px; background: #1F1F23; border-radius: 9999px; padding: 14px; margin-bottom: 8px; transition: background 0.15s; }
   .export-btn.tapped { background: #2A2A2E; }
   .export-btn-icon { color: #B0B0B0; font-size: 15px; }
@@ -100,7 +100,7 @@
         <div style="display: flex; align-items: center; padding: 12px 16px; gap: 16px;">
           <span style="color: #CAC4D0; font-size: 20px; width: 18px;">←</span>
           <div>
-            <div style="color: #A79EAF; font-size: 14px;">INC-2024-0847</div>
+            <div style="color: #EEF8FE; font-size: 14px;">INC-2024-0847</div>
             <div style="color: #A79EAF; font-size: 11px; font-weight: 500;">Apr 2, 2026</div>
           </div>
           <div style="margin-left: auto; display: flex; align-items: center; gap: 5px; background: #DF1B41; border-radius: 20px; padding: 4px 11px; height: 22px;">
@@ -129,8 +129,8 @@
               </div>
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
                 <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Fall from 15ft onto rock slab</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
               </div>
               <div style="border-top: 1px solid #232323; margin: 24px 0 8px;"></div>
               <div style="display: flex; align-items: center; gap: 6px; padding-left: 6px; padding-top: 6px;">
@@ -149,13 +149,13 @@
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
                 <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">PHYSICAL EXAM</div>
                 <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Injury to Left Leg & Back</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
               </div>
               <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
               <div style="display: flex; align-items: center; gap: 6px; padding: 12px 6px 6px;">
                 <span style="color: #F9CE86; font-size: 13px; width: 9px;">⚠</span>
-                <span style="color: #A79EAF; font-size: 11px; font-weight: 500;">3 Fields Need Review</span>
+                <span style="color: #F9CE86; font-size: 11px; font-weight: 500;">3 Fields Need Review</span>
                 <span style="flex: 1;"></span>
                 <span class="soap-footer-btn">Review</span>
               </div>
@@ -164,7 +164,7 @@
             <!-- Assessment (truncated) -->
             <div class="soap-card">
               <div class="soap-card-header" style="padding-bottom: 8px;">
-                <span class="soap-card-title" style="color: #615D6D;">Assessment</span>
+                <span class="soap-card-title" style="color: #7D788B;">Assessment</span>
                 <span class="soap-counter">3/4</span>
               </div>
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
@@ -231,7 +231,7 @@
 
       <!-- Nearby panel — floats at top, slides down -->
       <div id="nearbyPanel" style="position: absolute; top: 0; left: 0; right: 0; z-index: 25; background: #0A0A0A; padding: 16px 16px 12px; border-radius: 42px 42px 0 0; transform: translateY(-100%); transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1); display: flex; flex-direction: column;">
-        <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; padding: 8px 0 12px;">Nearby</div>
+        <div style="color: #7D788B; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase; padding: 8px 0 12px;">Nearby</div>
         <div style="display: flex; align-items: center; background: #161618; border-radius: 10px; padding: 14px 16px; gap: 10px; margin-bottom: 8px;">
           <div style="display: flex; flex-direction: column; gap: 3px;">
             <span style="color: #EEF8FE; font-size: 12px; font-weight: 700; letter-spacing: 0.3px;">Nadia Allendes</span>
@@ -321,7 +321,7 @@
     var tabRecord = document.getElementById('tabRecord');
     var tabShare = document.getElementById('tabShare');
     tabRecord.classList.remove('tab--active');
-    tabRecord.style.color = '#9E97B1';
+    tabRecord.style.color = '#A79EAF';
     tabRecord.style.fontWeight = '400';
     tabRecord.style.borderBottom = 'none';
     tabShare.classList.add('tab--active');

--- a/animations/soap-note.html
+++ b/animations/soap-note.html
@@ -40,7 +40,7 @@
 
   /* Tab styles */
   .tabs { display: flex; border-bottom: 1px solid #1C1C1E; background: #0A0A0A; }
-  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #9E97B1; cursor: pointer; transition: color 0.3s; }
+  .tab { padding: 10px 16px; font-size: 12px; letter-spacing: 0.3px; color: #A79EAF; cursor: pointer; transition: color 0.3s; }
   .tab--active { color: #EEF8FE; font-weight: 700; border-bottom: 2.5px solid #EEF8FE; }
 
   /* ===== TRANSCRIPT SCREEN (last frame) ===== */
@@ -51,7 +51,7 @@
   .msg-left { display: flex; align-items: center; gap: 5px; flex-shrink: 0; height: 21px; }
   .msg-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
   .msg-speaker { font-size: 10px; font-weight: 700; width: 22px; flex-shrink: 0; line-height: 21px; }
-  .msg-text { color: #EEF8FE; font-size: 14px; line-height: 1.5; flex: 1; }
+  .msg-text { color: #EFF8FF; font-size: 14px; line-height: 1.5; flex: 1; }
   .msg-content { flex: 1; min-width: 0; }
 
   .badge { display: inline-flex; align-items: center; gap: 6px; background: #111112; border: 1px solid #2C2C2E; border-radius: 8px; padding: 6px 10px; margin-top: 8px; width: fit-content; }
@@ -66,7 +66,7 @@
   .extract-header-text { color: #A79EAF; font-size: 11px; font-weight: 600; letter-spacing: 0.05em; }
   .extract-chevron { color: #3A3A3C; font-size: 12px; transform: rotate(180deg); }
   .extract-field { padding: 10px 12px; }
-  .extract-field-label { color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; }
+  .extract-field-label { color: #A79EAF; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; }
   .extract-field-value { color: #EBEBF5; font-size: 13px; line-height: 1.45; margin-top: 4px; }
 
   .typing { display: flex; gap: 10px; padding: 16px 20px 0; align-items: center; }
@@ -99,7 +99,7 @@
   .soap-bullet { display: flex; gap: 8px; padding-left: 6px; }
   .soap-bullet-dot { color: #6B6877; font-size: 13px; margin-top: 1px; }
   .soap-bullet-text { color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5; }
-  .soap-bullet-text--dim { color: #A79EAF; font-weight: 400; }
+  .soap-bullet-text--dim { color: #E5DAEF; font-weight: 400; }
 
   .soap-divider { border-top: 1px solid #232323; margin: 16px 0 8px; }
   .soap-footer { display: flex; align-items: center; gap: 6px; padding: 6px 6px 0; }
@@ -115,15 +115,15 @@
   /* Vitals table */
   .vitals-table { border-radius: 8px; overflow: hidden; margin-top: 8px; }
   .vitals-header { display: flex; background: #0A0A0A; padding: 8px; }
-  .vitals-header span { flex: 1; text-align: center; color: #A79EAF; font-size: 11px; font-weight: 500; }
+  .vitals-header span { flex: 1; text-align: center; color: #B0B0B0; font-size: 11px; font-weight: 500; }
   .vitals-header span:first-child { flex-shrink: 0; width: 29px; text-align: left; }
   .vitals-row { display: flex; align-items: center; padding: 3px 8px; min-height: 48px; }
   .vitals-row:nth-child(odd) { background: #101010; }
   .vitals-row:nth-child(even) { background: #1A1A1B; }
-  .vitals-row-time { flex-shrink: 0; width: 30px; color: #A79EAF; font-size: 11px; font-weight: 500; }
+  .vitals-row-time { flex-shrink: 0; width: 30px; color: #B0B0B0; font-size: 11px; font-weight: 500; }
   .vitals-row-cells { display: flex; gap: 6px; flex: 1; }
   .vital-cell { flex: 1; border-radius: 8px; padding: 8px; text-align: center; font-size: 13px; font-weight: 600; font-variant-numeric: tabular-nums; }
-  .vital-cell--normal { background: #101010; color: #A79EAF; }
+  .vital-cell--normal { background: #101010; color: #AAAAAA; }
   .vital-cell--red { background: #411B1F; color: #FE1844; }
   .vital-cell--amber { background: #363430; color: #F9CE86; }
   .vital-cell--empty { color: rgba(255,255,255,0.2); font-family: monospace; font-size: 17px; }
@@ -153,7 +153,7 @@
         <div style="display: flex; align-items: center; padding: 12px 16px; gap: 16px;">
           <span style="color: #CAC4D0; font-size: 20px; width: 18px;">←</span>
           <div>
-            <div style="color: #A79EAF; font-size: 14px;">INC-2024-0847</div>
+            <div style="color: #EEF8FE; font-size: 14px;">INC-2024-0847</div>
             <div style="color: #A79EAF; font-size: 11px; font-weight: 500;">Apr 2, 2026</div>
           </div>
           <div style="margin-left: auto; display: flex; align-items: center; gap: 5px; background: #DF1B41; border-radius: 20px; padding: 4px 11px; height: 22px;">
@@ -234,8 +234,8 @@
               </div>
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
                 <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Fall from 15ft onto rock slab</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">MOI: Height impact onto rock surface</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">Activity: rock climbing</span></div>
               </div>
               <div style="border-top: 1px solid #232323; margin: 24px 0 8px;"></div>
               <div class="soap-footer">
@@ -253,18 +253,18 @@
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
                 <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">PHYSICAL EXAM</div>
                 <div style="color: #EEF8FE; font-size: 14px; font-weight: 700; line-height: 1.5;">Injury to Left Leg & Back</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">No injuries to neck, head, torso or arms</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Ankle: Acute Pain (Left), Non-weight bearing</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Back: Tenderness in Lumbar</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">No injuries to neck, head, torso or arms</span></div>
                 <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
                 <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">MEDICAL HISTORY</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 15px; line-height: 1.5;">Allergies: Penicillin</span></div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Medications: None reported</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 15px; line-height: 1.5;">Allergies: Penicillin</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Medications: None reported</span></div>
               </div>
               <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
               <div style="display: flex; align-items: center; gap: 6px; padding: 12px 6px 6px;">
                 <span style="color: #F9CE86; font-size: 13px; width: 9px;">⚠</span>
-                <span style="color: #A79EAF; font-size: 12px;">3 Fields Need Review</span>
+                <span style="color: #F9CE86; font-size: 12px;">3 Fields Need Review</span>
                 <span style="flex: 1;"></span>
                 <span class="soap-footer-btn">Review</span>
               </div>
@@ -318,7 +318,7 @@
               <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
               <div style="display: flex; align-items: center; padding: 16px 6px 6px;">
                 <div style="background: #1F1F23; border-radius: 20px; padding: 0 16px; height: 36px; display: flex; align-items: center; flex: 1; justify-content: center; min-width: 32px;">
-                  <span style="color: #9E97B1; font-size: 11px; font-weight: 600;">Add Vitals</span>
+                  <span style="color: #B0B0B0; font-size: 11px; font-weight: 600;">Add Vitals</span>
                 </div>
               </div>
             </div>
@@ -326,7 +326,7 @@
             <!-- Assessment -->
             <div class="soap-card" style="background: #101012;">
               <div class="soap-card-header" style="padding-bottom: 8px;">
-                <span class="soap-card-title" style="color: #615D6D;">Assessment</span>
+                <span class="soap-card-title" style="color: #7D788B;">Assessment</span>
                 <span class="soap-counter">3/4</span>
               </div>
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
@@ -335,7 +335,7 @@
                 <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span class="soap-bullet-text">Lumbar pain</span></div>
                 <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
                 <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 10px;">POSSIBLE PROGRESSIONS</div>
-                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #A79EAF; font-size: 14px; line-height: 1.5;">Spinal Injury,</span></div>
+                <div class="soap-bullet"><span class="soap-bullet-dot">•</span><span style="color: #E5DAEF; font-size: 14px; line-height: 1.5;">Spinal Injury,</span></div>
               </div>
               <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
               <div style="display: flex; align-items: center; gap: 6px; padding: 6px 6px 0;">
@@ -348,7 +348,7 @@
             <!-- Plan -->
             <div class="soap-card" style="background: #101012;">
               <div class="soap-card-header" style="padding-bottom: 8px;">
-                <span class="soap-card-title" style="color: #6B6571;">Plan</span>
+                <span class="soap-card-title" style="color: #7D788B;">Plan</span>
                 <span class="soap-counter">4/6</span>
               </div>
               <div style="display: flex; flex-direction: column; gap: 6px; padding-left: 6px;">
@@ -359,7 +359,7 @@
                 <div style="border-top: 1px solid #232323; margin: 16px 0 6px;"></div>
                 <div style="color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; padding: 6px 0 12px;">EVACUATION</div>
                 <div style="background: #1F1F23; border-radius: 20px; padding: 0 16px; height: 36px; display: inline-flex; align-items: center;">
-                  <span style="color: #9E97B1; font-size: 11px; font-weight: 600;">Add Evacuation Plan</span>
+                  <span style="color: #B0B0B0; font-size: 11px; font-weight: 600;">Add Evacuation Plan</span>
                 </div>
               </div>
             </div>
@@ -436,7 +436,7 @@
       var recBar = document.getElementById('recBar');
       recBar.style.opacity = '0';
       recBar.style.transform = 'translateY(20px)';
-      tabTranscript.style.color = '#9E97B1';
+      tabTranscript.style.color = '#A79EAF';
       tabTranscript.style.fontWeight = '400';
       tabTranscript.style.borderBottom = 'none';
       tabHealth.style.color = '#EEF8FE';

--- a/animations/transcript.html
+++ b/animations/transcript.html
@@ -36,7 +36,7 @@
   /* Field design tokens */
   .ts-header { display: flex; align-items: center; padding: 12px 16px; gap: 16px; }
   .ts-back { color: #A79EAF; font-size: 20px; width: 18px; }
-  .ts-id { color: #A79EAF; font-size: 14px; line-height: 1.5; }
+  .ts-id { color: #EEF8FE; font-size: 14px; line-height: 1.5; }
   .ts-date { color: #A79EAF; font-size: 11px; font-weight: 500; }
   .ts-rec-pill { display: flex; align-items: center; gap: 5px; background: #DF1B41; border-radius: 20px; padding: 4px 11px; height: 22px; margin-left: auto; }
   .ts-rec-pill span { color: #fff; font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; }
@@ -64,7 +64,7 @@
   .msg-speaker--mc { color: #F9CE86; }
   .msg-speaker--p2 { color: #009CC0; }
   .msg-content { flex: 1; min-width: 0; }
-  .msg-text { color: #EEF8FE; font-size: 14px; line-height: 1.5; }
+  .msg-text { color: #EFF8FF; font-size: 14px; line-height: 1.5; }
 
   /* Badge (collapsed extraction tag) */
   .badge { display: none; align-items: center; gap: 6px; background: #161618; border: 1px solid #2C2C2E; border-radius: 8px; padding: 6px 10px; margin-top: 8px; cursor: pointer; width: fit-content; position: relative; overflow: hidden; }
@@ -98,7 +98,7 @@
   .extract-chevron { color: #3A3A3C; font-size: 12px; transition: transform 0.3s; }
   .extract-card.open .extract-chevron { transform: rotate(180deg); }
   .extract-field { padding: 10px 12px; }
-  .extract-field-label { color: #6B6571; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; }
+  .extract-field-label { color: #A79EAF; font-size: 10px; font-weight: 600; letter-spacing: 0.05em; }
   .extract-field-value { color: #EBEBF5; font-size: 13px; line-height: 1.45; margin-top: 4px; }
 
   /* Typing indicator */
@@ -109,9 +109,9 @@
   .typing-speaker { font-size: 10px; font-weight: 700; width: 22px; color: #3A3A3C; }
   .typing-dots { display: flex; gap: 4px; }
   .typing-dots span { width: 5px; height: 5px; border-radius: 50%; background: #3A3A3C; }
-  .typing-dots span:nth-child(1) { animation: dotPulse 1s infinite 0s; }
-  .typing-dots span:nth-child(2) { animation: dotPulse 1s infinite 0.15s; }
-  .typing-dots span:nth-child(3) { animation: dotPulse 1s infinite 0.3s; }
+  .typing-dots span:nth-child(1) { background: #3A3A3C; animation: dotPulse 1s infinite 0s; }
+  .typing-dots span:nth-child(2) { background: #2C2C2E; animation: dotPulse 1s infinite 0.15s; }
+  .typing-dots span:nth-child(3) { background: #1C1C1E; animation: dotPulse 1s infinite 0.3s; }
 
   /* Recording bar — floating pill */
   .rec-bar { position: absolute; bottom: 28px; left: 16px; right: 16px; height: 52px; background: #1C1C1E; border: 1px solid #2C2C2E; border-radius: 16px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }


### PR DESCRIPTION
## Summary
- Sweep all four `/animations/*.html` files so every text color matches the JSX of the corresponding Paper screens (navigation-header, section-card, chip · expanded, alert-banner, sheet-header, etc.).
- Color-only changes — no sizes, weights, or letter-spacing touched.

## Key swaps
- Nav title `#A79EAF` → `#EEF8FE`
- Transcript body `#EEF8FE` → `#EFF8FF`
- AI-extract field label `#6B6571` → `#A79EAF`
- Typing dots single `#3A3A3C` → fade `#3A3A3C` / `#2C2C2E` / `#1C1C1E`
- Inactive tab `#9E97B1` → `#A79EAF`
- SOAP secondary bullet `#A79EAF` → `#E5DAEF`
- Vitals header + time `#A79EAF` → `#B0B0B0`
- Vitals normal cell `#A79EAF` → `#AAAAAA`
- Add Vitals / Add Evacuation pill `#9E97B1` → `#B0B0B0`
- SOAP "3 Fields Need Review" `#A79EAF` → `#F9CE86`
- Section titles Assessment `#615D6D` / Plan `#6B6571` → `#7D788B`
- Drawer title `#9E99AD` → `#7D788B`
- Share SBAR labels `#6B6571` → `#7D788B`
- Share SBAR body `#A79EAF` → `#EEF8FE`
- Export sheet / Nearby overline `#6B6571` → `#7D788B`

## Test plan
- [ ] Open `/field` and scroll each animation; verify text colors read as intended
- [ ] Compare each animation side-by-side against its Paper screen (navigation-header, section-card, chip · expanded, sheet-header, etc.)
- [ ] Confirm no layout shift (sizes/weights unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)