### PR TITLE
fix(animations): remove outlines from transcript chips

### DIFF
--- a/animations/soap-note.html
+++ b/animations/soap-note.html
@@ -54,12 +54,12 @@
   .msg-text { color: #EFF8FF; font-size: 14px; line-height: 1.5; flex: 1; }
   .msg-content { flex: 1; min-width: 0; }
 
-  .badge { display: inline-flex; align-items: center; gap: 6px; background: #111112; border: 1px solid #2C2C2E; border-radius: 8px; padding: 6px 10px; margin-top: 8px; width: fit-content; }
+  .badge { display: inline-flex; align-items: center; gap: 6px; background: #111112; border-radius: 8px; padding: 6px 10px; margin-top: 8px; width: fit-content; }
   .badge-dot { width: 5px; height: 5px; border-radius: 50%; background: #3A3A3C; flex-shrink: 0; }
   .badge-text { color: #A79EAF; font-size: 11px; font-weight: 500; line-height: 14px; }
 
   /* Extraction card (open state) */
-  .extract-card { background: #111112; border: 1px solid #2C2C2E; border-radius: 10px; margin-top: 8px; overflow: hidden; }
+  .extract-card { background: #111112; border-radius: 10px; margin-top: 8px; overflow: hidden; }
   .extract-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; border-bottom: 1px solid #2C2C2E; }
   .extract-header-left { display: flex; align-items: center; gap: 6px; }
   .extract-header-dot { width: 5px; height: 5px; border-radius: 50%; background: #3A3A3C; }

--- a/animations/transcript.html
+++ b/animations/transcript.html
@@ -67,7 +67,7 @@
   .msg-text { color: #EFF8FF; font-size: 14px; line-height: 1.5; }
 
   /* Badge (collapsed extraction tag) */
-  .badge { display: none; align-items: center; gap: 6px; background: #161618; border: 1px solid #2C2C2E; border-radius: 8px; padding: 6px 10px; margin-top: 8px; cursor: pointer; width: fit-content; position: relative; overflow: hidden; }
+  .badge { display: none; align-items: center; gap: 6px; background: #161618; border-radius: 8px; padding: 6px 10px; margin-top: 8px; cursor: pointer; width: fit-content; position: relative; overflow: hidden; }
   .badge.show { display: inline-flex; animation: scaleIn 0.3s ease forwards; }
   .badge-dot { width: 5px; height: 5px; border-radius: 50%; background: #3A3A3C; flex-shrink: 0; }
   .badge-text { color: #A79EAF; font-size: 11px; font-weight: 500; line-height: 14px; transition: opacity 0.3s; }
@@ -89,7 +89,7 @@
   .badge.tapping { animation: tapPulse 0.2s ease; }
 
   /* Expanded extraction card */
-  .extract-card { background: #161618; border: 1px solid #2C2C2E; border-radius: 10px; margin-top: 8px; overflow: hidden; max-height: 0; opacity: 0; transition: max-height 0.4s ease, opacity 0.3s ease; }
+  .extract-card { background: #161618; border-radius: 10px; margin-top: 8px; overflow: hidden; max-height: 0; opacity: 0; transition: max-height 0.4s ease, opacity 0.3s ease; }
   .extract-card.open { max-height: 320px; opacity: 1; }
   .extract-header { display: flex; justify-content: space-between; align-items: center; padding: 8px 12px; border-bottom: 1px solid #2C2C2E; }
   .extract-header-left { display: flex; align-items: center; gap: 6px; }


### PR DESCRIPTION
## Summary
- Drop the 1px `#2C2C2E` border on the collapsed "Added: …" badge and the expanded AI-extract card
- Applied in both `animations/transcript.html` and `animations/soap-note.html` (SOAP-note screen 1 renders the same transcript chips)

## Test plan
- [ ] Open `/field` and scroll to the transcription animation — chips are borderless
- [ ] Swipe to Incident Record in the SOAP animation — transcript chips in the last frame also borderless

🤖 Generated with [Claude Code](https://claude.com/claude-code)