### PR TITLE
feat(events): add Luma SF; remove Bonobo + Commonwealth

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -88,7 +88,8 @@
       "WebFetch(domain:www.docusign.com)",
       "WebFetch(domain:docs.readwise.io)",
       "WebFetch(domain:www.moesif.com)",
-      "mcp__Claude_Preview__preview_start"
+      "mcp__Claude_Preview__preview_start",
+      "mcp__Claude_in_Chrome__tabs_context_mcp"
     ]
   }
 }

--- a/events/index.html
+++ b/events/index.html
@@ -1610,7 +1610,7 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.7.1';
+  const VERSION = '1.8.0';
   console.log(`[events] v${VERSION} - SFMOMA HTML scraper, multi-day events, exhibitions rail`);
 
   // ============================================
@@ -1643,14 +1643,14 @@ body {
     { id: '19hz-seattle', name: '19hz Seattle', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_Seattle.php', region: 'seattle', description: 'Electronic music & nightlife' },
     // Bay Area — Tech & Networking
     { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
-    { id: 'bonobo-sf', name: 'Bonobo Network', category: 'social', type: 'bonobo', url: 'https://www.bonobonetwork.com/events', region: 'bay-area', description: 'Social & community events' },
     // Bay Area — Art
     { id: 'sfmoma-events', name: 'SFMOMA', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/events/', region: 'bay-area', description: 'Museum events & artist talks' },
     { id: 'sfmoma-exhibitions', name: 'SFMOMA Exhibitions', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/exhibitions/', region: 'bay-area', description: 'Current & upcoming exhibitions' },
     { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'html', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
     // Bay Area — Literary
     { id: 'sfpl-events', name: 'SF Public Library', category: 'literary', type: 'html', url: 'https://sfpl.org/events', region: 'bay-area', description: 'Library programs & author talks' },
-    { id: 'commonwealthclub-sf', name: 'Commonwealth Club', category: 'literary', type: 'html', url: 'https://www.commonwealthclub.org/events', region: 'bay-area', description: 'Speaker events & public affairs' },
+    // Bay Area — Social (Luma discover feed)
+    { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
     // New York — Tech & Networking
     { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
   ];

--- a/supabase/functions/scrape-events/sources.ts
+++ b/supabase/functions/scrape-events/sources.ts
@@ -25,14 +25,14 @@ export const STOCK_SOURCES: EventSource[] = [
   { id: '19hz-seattle', name: '19hz Seattle', category: 'music', type: 'html', url: 'https://19hz.info/eventlisting_Seattle.php', region: 'seattle', description: 'Electronic music & nightlife' },
   // Bay Area — Tech & Networking
   { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
-  { id: 'bonobo-sf', name: 'Bonobo Network', category: 'social', type: 'bonobo', url: 'https://www.bonobonetwork.com/events', region: 'bay-area', description: 'Social & community events' },
   // Bay Area — Art
   { id: 'sfmoma-events', name: 'SFMOMA', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/events/', region: 'bay-area', description: 'Museum events & artist talks' },
   { id: 'sfmoma-exhibitions', name: 'SFMOMA Exhibitions', category: 'art', type: 'sfmoma', url: 'https://www.sfmoma.org/exhibitions/', region: 'bay-area', description: 'Current & upcoming exhibitions' },
   { id: 'famsf-events', name: 'de Young / Legion of Honor', category: 'art', type: 'famsf', url: 'https://www.famsf.org/calendar', region: 'bay-area', description: 'Fine arts museum events' },
   // Bay Area — Literary
   { id: 'sfpl-events', name: 'SF Public Library', category: 'literary', type: 'sfpl', url: 'https://sfpl.org/events', region: 'bay-area', description: 'Library programs & author talks' },
-  { id: 'commonwealthclub-sf', name: 'Commonwealth Club', category: 'literary', type: 'commonwealth', url: 'https://www.commonwealthclub.org/events', region: 'bay-area', description: 'Speaker events & public affairs' },
+  // Bay Area — Social (Luma discover feed)
+  { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
   // New York — Tech & Networking
   { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
 ]


### PR DESCRIPTION
## Summary
- Add **Luma SF** — discover ICS feed (https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka). Uses existing `ical` parser.
- Remove **Bonobo Network** (bonobo-sf) and **Commonwealth Club** (commonwealthclub-sf). Commonwealth has been broken; Bonobo removed per request.
- Bump events `v1.7.1 → v1.8.0`.

Note: user also requested adding `garysguide.com/events?region=sf` — that source already exists as `garysguide-sf`, so no change needed.

## Test plan
- [ ] Merge + deploy `scrape-events` → verify Luma SF events populate
- [ ] Bonobo/Commonwealth no longer appear in source selector