### PR TITLE
fix(events): Luma URL fallback + reconcile removed sources

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1610,7 +1610,7 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.8.1';
+  const VERSION = '1.8.2';
   console.log(`[events] v${VERSION} - SFMOMA HTML scraper, multi-day events, exhibitions rail`);
 
   // ============================================
@@ -1864,8 +1864,16 @@ body {
         log('Cloud sync: no saved sources found' + (error ? ' (' + error.message + ')' : ''));
         return false;
       }
-      const cloudSources = data.sources;
+      let cloudSources = data.sources;
       if (!Array.isArray(cloudSources) || cloudSources.length === 0) return false;
+
+      // Reconcile: drop sources removed from the stock registry.
+      const REMOVED_STOCK_IDS = new Set(['bonobo-sf', 'commonwealthclub-sf', 'sfmoma-events', 'sfmoma-exhibitions', 'famsf-events', 'sfpl-events']);
+      const before = cloudSources.length;
+      cloudSources = cloudSources.filter(s => !REMOVED_STOCK_IDS.has(s.id));
+      if (cloudSources.length !== before) {
+        log(`Cloud sync: dropped ${before - cloudSources.length} removed stock source(s)`);
+      }
 
       // Use cloud sources as the source of truth
       state.sources = cloudSources;

--- a/supabase/functions/scrape-events/parsers/ical.ts
+++ b/supabase/functions/scrape-events/parsers/ical.ts
@@ -24,6 +24,14 @@ function parseIcal(text: string, sourceId: string): ScrapedEvent[] {
     const dtstart = get('DTSTART')
     const loc = parseLocationString(get('LOCATION'))
 
+    // URL: prefer URL field, else first https link in DESCRIPTION (Luma, etc.)
+    let url = get('URL')
+    if (!url) {
+      const desc = get('DESCRIPTION')
+      const m = desc.match(/https?:\/\/[^\s\\]+/)
+      if (m) url = m[0]
+    }
+
     events.push({
       date: dtstart ? parseIcalDate(dtstart) : '',
       time: '',
@@ -32,7 +40,7 @@ function parseIcal(text: string, sourceId: string): ScrapedEvent[] {
       address: loc.address,
       city: loc.city,
       genre: '', price: '', ages: '',
-      url: get('URL') || '',
+      url: url || '',
       source: sourceId,
     })
   }


### PR DESCRIPTION
Luma events scraped but never inserted (no URL: field). Added DESCRIPTION fallback. Also reconciles cloud user_event_sources against STOCK_SOURCES so removed sources drop from saved lists. Bumps v1.8.1 → v1.8.2.