### PR TITLE
soundscape-v3: publish stage-3 audio-reactive visualizer

### DIFF
--- a/soundscape-v3/README.md
+++ b/soundscape-v3/README.md
@@ -1,0 +1,44 @@
+# SoundScape v3
+
+Prompt-steerable, audio-reactive visuals. Live at **[ctrl.rodeo/soundscape-v3](https://ctrl.rodeo/soundscape-v3/)**.
+
+Source: [github.com/fikei/soundscape](https://github.com/fikei/soundscape)
+
+## What works without any setup
+
+- Fast-path audio features (mic/line-in → energy, transient, beat, brightness) via Web Audio API
+- Hydra visuals (two presets: Drift + Pulse)
+- Stage 2 CLAP semantic axes (~170 MB model downloads on first run, cached by the browser)
+- Draggable axis sliders for manual override
+- Source picker with live device switching
+
+## What needs a backend
+
+Stage 3 **prompt compiler** (text + image → axes + palette) calls the Anthropic API, which requires a key — so it can't run fully client-side. Options:
+
+### Local dev
+
+Run the proxy on your machine:
+
+```bash
+cd soundscape
+ANTHROPIC_API_KEY=sk-ant-... node server/proxy.js
+```
+
+Then click **Compile** in the sidebar. Proxy defaults to `http://localhost:8787`.
+
+### Hosted
+
+Point the page at a hosted compile endpoint (Cloudflare Worker / Vercel function wrapping the same `/compile` contract). Once per browser:
+
+```js
+localStorage.setItem("ss.proxyUrl", "https://your-worker.workers.dev/compile");
+```
+
+Or pass `?proxy=https://...` in the URL.
+
+If no proxy is reachable, Compile shows a descriptive error; everything else keeps working.
+
+## CTRL design system
+
+UI uses tokens from `design-system/tokens.css`. Local `css/app.css` adds component styles following the same language (Space Grotesk + JetBrains Mono, 1px white borders, square corners, black background).

--- a/soundscape-v3/audio/capture-worklet.js
+++ b/soundscape-v3/audio/capture-worklet.js
@@ -1,0 +1,39 @@
+// Captures raw mono audio samples and posts them back to the main thread
+// in fixed-size chunks. Used to feed the 4-second ring buffer that CLAP
+// inference draws from.
+//
+// This runs on the audio thread (128 samples per `process` call) so it must
+// never allocate in the hot path.
+
+const CHUNK_SAMPLES = 4800; // ~100ms at 48kHz
+
+class CaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._buf = new Float32Array(CHUNK_SAMPLES);
+    this._pos = 0;
+  }
+
+  process(inputs) {
+    const ch = inputs[0] && inputs[0][0];
+    if (!ch) return true;
+    const n = ch.length;
+    let i = 0;
+    while (i < n) {
+      const room = CHUNK_SAMPLES - this._pos;
+      const take = Math.min(room, n - i);
+      this._buf.set(ch.subarray(i, i + take), this._pos);
+      this._pos += take;
+      i += take;
+      if (this._pos >= CHUNK_SAMPLES) {
+        // transfer ownership, allocate a fresh buffer
+        this.port.postMessage(this._buf, [this._buf.buffer]);
+        this._buf = new Float32Array(CHUNK_SAMPLES);
+        this._pos = 0;
+      }
+    }
+    return true;
+  }
+}
+
+registerProcessor("capture", CaptureProcessor);

--- a/soundscape-v3/audio/clap.js
+++ b/soundscape-v3/audio/clap.js
@@ -1,0 +1,314 @@
+// Stage 2 — in-browser CLAP.
+//
+// - Loads Xenova/clap-htsat-unfused via transformers.js (WebGPU, q8).
+// - Keeps a rolling 4-second ring buffer of the mic signal via an
+//   AudioWorkletNode.
+// - Runs audio-feature inference every ~1s.
+// - Caches text-feature embeddings per axis; recomputes only on prompt change.
+// - Publishes cosine-similarity-based axis values into window.viz.axis.
+//
+// Graceful degradation: if load or inference fails, axes stay at 0 and the
+// fast path continues untouched.
+
+import {
+  env,
+  AutoTokenizer,
+  AutoProcessor,
+  ClapTextModelWithProjection,
+  ClapAudioModelWithProjection,
+} from "https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.0.2/dist/transformers.min.js";
+
+// Do not let transformers.js try to load from local paths — use the HF hub.
+env.allowLocalModels = false;
+env.useBrowserCache = true;
+
+const MODEL_ID = "Xenova/clap-htsat-unfused";
+const RING_SECONDS = 4;
+const INFERENCE_PERIOD_MS = 1000;
+const CLAP_SAMPLE_RATE = 48000;
+
+function cosine(a, b) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-9);
+}
+
+export async function startClap({
+  ctx,
+  source,
+  axes,             // [{ name, positive, negative }, ...]
+  onAxis,           // (name, value ∈ [-1,1]) => void
+  onStatus = () => {},
+  onProgress = () => {},
+} = {}) {
+  const state = {
+    textModel: null,
+    audioModel: null,
+    tokenizer: null,
+    processor: null,
+    textCache: new Map(), // name -> { pos: Float32Array, neg: Float32Array, posKey, negKey }
+    ring: new Float32Array(ctx.sampleRate * RING_SECONDS),
+    writePtr: 0,
+    samplesSeen: 0,
+    axes,
+    running: false,
+    inferenceInFlight: false,
+    inferenceCount: 0,
+    lastInferenceMs: 0,
+    lastRingRms: 0,
+    lastRawAxes: {},   // per-axis {sp, sn, raw}
+    lastEmbedMag: 0,
+  };
+
+  // Expose for live debugging from the browser console:
+  //    clapDiag()  -> snapshot
+  window.clapDiag = () => ({
+    inferenceCount: state.inferenceCount,
+    lastInferenceMs: state.lastInferenceMs,
+    samplesSeen: state.samplesSeen,
+    ringRms: state.lastRingRms,
+    embedMag: state.lastEmbedMag,
+    raw: state.lastRawAxes,
+  });
+  window.viz.clap = window.viz.clap || {};
+
+  // ----- attach the capture worklet -----
+  onStatus("audio capture…");
+  // Relative path so the app works from any subpath (e.g.
+  // ctrl.rodeo/soundscape-v3/). Resolved against the module's own URL.
+  const workletUrl = new URL("./capture-worklet.js", import.meta.url);
+  await ctx.audioWorklet.addModule(workletUrl.href);
+  const capture = new AudioWorkletNode(ctx, "capture");
+  source.connect(capture);
+  // NOTE: we don't connect to destination — we're only tapping the signal.
+
+  capture.port.onmessage = (ev) => {
+    const chunk = ev.data; // Float32Array
+    const n = chunk.length;
+    state.samplesSeen += n;
+    const end = state.writePtr + n;
+    if (end <= state.ring.length) {
+      state.ring.set(chunk, state.writePtr);
+    } else {
+      const first = state.ring.length - state.writePtr;
+      state.ring.set(chunk.subarray(0, first), state.writePtr);
+      state.ring.set(chunk.subarray(first), 0);
+    }
+    state.writePtr = end % state.ring.length;
+  };
+  // Some browsers only pull through an AudioWorkletNode when its output is
+  // connected to an active sink. Route to a muted gain -> destination so the
+  // processor actually runs even though we don't want to hear anything.
+  const sink = ctx.createGain();
+  sink.gain.value = 0;
+  capture.connect(sink).connect(ctx.destination);
+
+  // ----- load models -----
+  //
+  // transformers.js v3 splits CLAP into two projection models — one each
+  // for text and audio. Docs:
+  //   https://huggingface.co/Xenova/clap-htsat-unfused
+  // Each returns { text_embeds } / { audio_embeds } with dims [batch, 512].
+  async function loadWithFallback(Cls, tag) {
+    try {
+      return await Cls.from_pretrained(MODEL_ID, {
+        dtype: "q8",
+        device: "webgpu",
+        progress_callback: (p) => onProgress(p),
+      });
+    } catch (err) {
+      console.warn(`[clap] ${tag} webgpu failed, falling back to wasm:`, err);
+      return await Cls.from_pretrained(MODEL_ID, {
+        dtype: "q8",
+        device: "wasm",
+        progress_callback: (p) => onProgress(p),
+      });
+    }
+  }
+
+  onStatus("loading clap…");
+  try {
+    state.tokenizer = await AutoTokenizer.from_pretrained(MODEL_ID, {
+      progress_callback: (p) => onProgress(p),
+    });
+    state.processor = await AutoProcessor.from_pretrained(MODEL_ID, {
+      progress_callback: (p) => onProgress(p),
+    });
+    state.textModel = await loadWithFallback(ClapTextModelWithProjection, "text");
+    state.audioModel = await loadWithFallback(ClapAudioModelWithProjection, "audio");
+  } catch (e) {
+    console.error("[clap] model load failed:", e);
+    onStatus("clap disabled");
+    return { state, ready: false };
+  }
+  onStatus("clap ready");
+
+  // Extracts a flat Float32Array from whatever shape the model returns.
+  // transformers.js v3 has returned both `{ audio_embeds: Tensor }` and raw
+  // Tensors from CLAP across versions, so be defensive.
+  function extractEmbedding(out) {
+    if (!out) return null;
+    if (out.audio_embeds?.data) return out.audio_embeds.data;
+    if (out.text_embeds?.data) return out.text_embeds.data;
+    if (out.embeds?.data) return out.embeds.data;
+    if (out.last_hidden_state?.data) return out.last_hidden_state.data;
+    if (out.data) return out.data;
+    // dict-like single key
+    const first = Object.values(out)[0];
+    if (first?.data) return first.data;
+    return null;
+  }
+
+  // ----- text embedding cache -----
+  async function ensureTextEmbeddings() {
+    for (const ax of state.axes) {
+      const posKey = ax.positive;
+      const negKey = ax.negative;
+      const existing = state.textCache.get(ax.name);
+      if (existing && existing.posKey === posKey && existing.negKey === negKey) continue;
+
+      const inputs = state.tokenizer([posKey, negKey], {
+        padding: true,
+        truncation: true,
+      });
+      const out = await state.textModel(inputs);
+      const flat = extractEmbedding(out);
+      if (!flat) {
+        console.warn("[clap] text features returned unexpected shape:", out);
+        continue;
+      }
+      const dim = flat.length / 2;
+      const pos = new Float32Array(flat.slice(0, dim));
+      const neg = new Float32Array(flat.slice(dim));
+      state.textCache.set(ax.name, { pos, neg, posKey, negKey });
+    }
+  }
+
+  function snapshotRing() {
+    // return contiguous buffer ending at the latest sample
+    const out = new Float32Array(state.ring.length);
+    const tail = state.ring.length - state.writePtr;
+    out.set(state.ring.subarray(state.writePtr), 0);
+    out.set(state.ring.subarray(0, state.writePtr), tail);
+    return out;
+  }
+
+  async function maybeResample(buf, fromSr, toSr) {
+    if (fromSr === toSr) return buf;
+    const offline = new OfflineAudioContext(
+      1,
+      Math.ceil((buf.length * toSr) / fromSr),
+      toSr,
+    );
+    const ab = offline.createBuffer(1, buf.length, fromSr);
+    ab.getChannelData(0).set(buf);
+    const src = offline.createBufferSource();
+    src.buffer = ab;
+    src.connect(offline.destination);
+    src.start();
+    const rendered = await offline.startRendering();
+    return rendered.getChannelData(0).slice();
+  }
+
+  function rms(buf) {
+    let s = 0;
+    for (let i = 0; i < buf.length; i++) s += buf[i] * buf[i];
+    return Math.sqrt(s / buf.length);
+  }
+
+  async function inferOnce() {
+    if (state.inferenceInFlight) return;
+    state.inferenceInFlight = true;
+    const t0 = performance.now();
+    try {
+      await ensureTextEmbeddings();
+      const raw = snapshotRing();
+      state.lastRingRms = rms(raw);
+      // Skip inference if the ring is basically silent — saves compute.
+      if (state.lastRingRms < 1e-4) {
+        state.inferenceInFlight = false;
+        return;
+      }
+      const audio = await maybeResample(raw, ctx.sampleRate, CLAP_SAMPLE_RATE);
+      const audioInputs = await state.processor(audio);
+      const audioOut = await state.audioModel(audioInputs);
+      const audioEmb = extractEmbedding(audioOut);
+      if (!audioEmb) {
+        console.warn("[clap] audio features returned unexpected shape:", audioOut);
+        state.inferenceInFlight = false;
+        return;
+      }
+      let mag = 0;
+      for (let i = 0; i < audioEmb.length; i++) mag += audioEmb[i] * audioEmb[i];
+      state.lastEmbedMag = Math.sqrt(mag);
+
+      for (const ax of state.axes) {
+        const cached = state.textCache.get(ax.name);
+        if (!cached) continue;
+        const sp = cosine(audioEmb, cached.pos);
+        const sn = cosine(audioEmb, cached.neg);
+        const diff = sp - sn;
+        // Soft saturation. Native cosine diffs typically range ~[-0.2, +0.2].
+        // Gain 4 + tanh gives headroom without railing: diff=0.25 -> ~0.76,
+        // diff=0.1 -> ~0.38, diff=0.05 -> ~0.20. Smooth near zero, soft at
+        // the extremes instead of a hard clamp.
+        const val = Math.tanh(diff * 4);
+        state.lastRawAxes[ax.name] = {
+          sp: +sp.toFixed(4),
+          sn: +sn.toFixed(4),
+          diff: +diff.toFixed(4),
+          val: +val.toFixed(3),
+        };
+        onAxis(ax.name, val);
+      }
+      state.inferenceCount += 1;
+      state.lastInferenceMs = performance.now() - t0;
+      if (state.inferenceCount <= 3) {
+        console.log("[clap] inference ok", state.inferenceCount, "ms=", Math.round(state.lastInferenceMs),
+                    "ringRms=", state.lastRingRms.toFixed(4), "embedMag=", state.lastEmbedMag.toFixed(3),
+                    "raw=", state.lastRawAxes);
+      }
+    } catch (e) {
+      console.warn("[clap] inference failed:", e);
+    } finally {
+      state.inferenceInFlight = false;
+    }
+  }
+
+  // ----- inference loop -----
+  state.running = true;
+  let nextAt = performance.now() + INFERENCE_PERIOD_MS;
+  async function loop() {
+    if (!state.running) return;
+    const now = performance.now();
+    if (now >= nextAt) {
+      nextAt = now + INFERENCE_PERIOD_MS;
+      await inferOnce();
+    }
+    setTimeout(loop, 50);
+  }
+  loop();
+
+  function rewireSource(nextSource) {
+    // The source node changed (e.g. user switched input devices). Reconnect
+    // the capture worklet to the new source.
+    try { source.disconnect(capture); } catch (e) {}
+    nextSource.connect(capture);
+    source = nextSource;
+    // clear the ring so we don't mix inputs
+    state.ring.fill(0);
+    state.writePtr = 0;
+  }
+
+  return {
+    state,
+    ready: true,
+    setAxes(next) { state.axes = next; },
+    stop() { state.running = false; },
+    rewireSource,
+  };
+}

--- a/soundscape-v3/audio/features.js
+++ b/soundscape-v3/audio/features.js
@@ -1,0 +1,311 @@
+// SoundScape Stage 1.5 — web-native audio feature extractor.
+//
+// Reads user mic (or a synthetic loopback source), computes the /viz/ fast
+// params, and writes them into window.viz on every animation frame.
+//
+// Contract (same as PARAMS.md):
+//   viz.energy       0..1   RMS, adaptive-gain normalized, fast EMA
+//   viz.transient    0..1   onset envelope, τ≈200ms decay
+//   viz.beat_phase   0..1   sawtooth between detected beats
+//   viz.brightness   0..1   spectral centroid, exponential-scaled
+//   viz.bpm          40..220
+//
+// No server, no Python, no WebSocket. All in-tab.
+
+const ONSET_THRESHOLD_DEFAULT = 0.3;
+const ONSET_DEBOUNCE = 0.08;
+const TRANSIENT_TAU = 0.2;
+const ALPHA_FAST = 0.3;
+const ALPHA_SLOW = 0.02;
+// Absolute silence floor. Below this raw RMS (roughly -50 dBFS) the fast
+// params are forced to decay: adaptive gain alone would chase the noise
+// floor down and start reporting "activity" during silence.
+const SILENCE_RMS = 0.003;
+// Don't let the adaptive-gain reference fall below this: prevents energy ~ 1
+// when the room is dead quiet.
+const MIN_ENERGY_MAX = 0.02;
+const MIN_FLUX_MAX = 0.8;
+
+// Synthetic 120 BPM kick + drone, mirrors audio_worker.py's --loopback mode.
+function createLoopbackSource(ctx) {
+  const node = ctx.createGain();
+  node.gain.value = 1.0;
+
+  // kick: triggered by a periodic pulse
+  const kickOsc = ctx.createOscillator();
+  kickOsc.type = "sine";
+  kickOsc.frequency.value = 60;
+  const kickGain = ctx.createGain();
+  kickGain.gain.value = 0;
+  kickOsc.connect(kickGain).connect(node);
+  kickOsc.start();
+
+  // drone
+  const drone = ctx.createOscillator();
+  drone.type = "sine";
+  drone.frequency.value = 220;
+  const droneGain = ctx.createGain();
+  droneGain.gain.value = 0.15;
+  drone.connect(droneGain).connect(node);
+  drone.start();
+
+  // 120 BPM = 0.5s per beat. Schedule exponential-decay kick envelopes.
+  const bpm = 120;
+  const period = 60 / bpm;
+  let next = ctx.currentTime + 0.1;
+  function schedule() {
+    while (next < ctx.currentTime + 1.0) {
+      kickGain.gain.setValueAtTime(0.9, next);
+      kickGain.gain.exponentialRampToValueAtTime(0.0001, next + 0.25);
+      next += period;
+    }
+  }
+  setInterval(schedule, 250);
+  schedule();
+
+  return node;
+}
+
+export async function listInputDevices() {
+  try {
+    const devs = await navigator.mediaDevices.enumerateDevices();
+    return devs
+      .filter((d) => d.kind === "audioinput")
+      .map((d) => ({ deviceId: d.deviceId, label: d.label, groupId: d.groupId }));
+  } catch (e) {
+    return [];
+  }
+}
+
+export async function startAudio({
+  loopback = false,
+  deviceId = null,
+  onsetThreshold = ONSET_THRESHOLD_DEFAULT,
+  onStatus = () => {},
+} = {}) {
+  const Ctx = window.AudioContext || window.webkitAudioContext;
+  const ctx = new Ctx({ latencyHint: "interactive" });
+
+  let source;
+  let currentStream = null;
+  if (loopback) {
+    onStatus("loopback — synthetic 120 BPM kick");
+    source = createLoopbackSource(ctx);
+  } else {
+    onStatus("requesting mic…");
+    const constraints = {
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        channelCount: 1,
+      },
+    };
+    if (deviceId && deviceId !== "default") {
+      constraints.audio.deviceId = { exact: deviceId };
+    }
+    currentStream = await navigator.mediaDevices.getUserMedia(constraints);
+    const track = currentStream.getAudioTracks()[0];
+    const label = track?.label || "default input";
+    onStatus(`${label} @ ${ctx.sampleRate} Hz`);
+    source = ctx.createMediaStreamSource(currentStream);
+  }
+
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = 1024;
+  analyser.smoothingTimeConstant = 0.0; // we smooth ourselves
+  source.connect(analyser);
+
+  // Audio graph demand: OscillatorNode (loopback) and AudioWorkletNode
+  // (CLAP capture) only process samples when something downstream pulls.
+  // Route the source through a permanently-muted gain to ctx.destination
+  // so the graph always runs, regardless of whether CLAP is active.
+  const mute = ctx.createGain();
+  mute.gain.value = 0;
+  source.connect(mute).connect(ctx.destination);
+
+  // Browsers create AudioContexts in a suspended state until a user gesture.
+  // Start was clicked so this should succeed.
+  if (ctx.state !== "running") {
+    try { await ctx.resume(); } catch (e) { console.warn("[audio] resume failed:", e); }
+  }
+
+  // Expose for debugging.
+  window.__ctx = ctx;
+  window.__source = source;
+  window.__analyser = analyser;
+
+  const bins = analyser.frequencyBinCount; // 512
+  const freqBuf = new Float32Array(bins); // dB
+  const magBuf = new Float32Array(bins);
+  const prevMag = new Float32Array(bins);
+  const timeBuf = new Float32Array(analyser.fftSize);
+
+  const nyq = ctx.sampleRate / 2;
+  const freqs = new Float32Array(bins);
+  for (let i = 0; i < bins; i++) freqs[i] = (i / bins) * nyq;
+  const logNyq = Math.log1p(nyq);
+
+  const state = {
+    energy: 0,
+    energy_slow: 0,
+    transient: 0,
+    beat_phase: 0,
+    brightness: 0.3,
+    brightness_slow: 0.3,
+    bpm: 120,
+    lastOnsetTime: 0,
+    lastBeatTime: performance.now() / 1000,
+    beatInterval: 0.5,
+    fluxRunningMax: 1e-6,
+    energyRunningMax: 1e-6,
+    onsetTimes: [],
+    prevCallTime: performance.now() / 1000,
+  };
+
+  function tick() {
+    const now = performance.now() / 1000;
+    const dt = Math.max(0.001, now - state.prevCallTime);
+    state.prevCallTime = now;
+
+    analyser.getFloatTimeDomainData(timeBuf);
+    analyser.getFloatFrequencyData(freqBuf);
+
+    // --- RMS energy with adaptive gain ------------------------------------
+    let ssq = 0;
+    for (let i = 0; i < timeBuf.length; i++) ssq += timeBuf[i] * timeBuf[i];
+    const rms = Math.sqrt(ssq / timeBuf.length);
+    const isSilent = rms < SILENCE_RMS;
+    // Running max decays slowly but never below MIN_ENERGY_MAX, so in silence
+    // we don't divide by noise floor and fake activity.
+    state.energyRunningMax = Math.max(
+      MIN_ENERGY_MAX,
+      Math.max(state.energyRunningMax * 0.9995, rms)
+    );
+    const energyNorm = isSilent
+      ? 0
+      : Math.min(1, (rms - SILENCE_RMS) / (state.energyRunningMax + 1e-9));
+
+    // --- Spectral centroid + flux ----------------------------------------
+    let total = 0;
+    let centroidAcc = 0;
+    let flux = 0;
+    for (let i = 0; i < bins; i++) {
+      // dB → linear
+      const m = Math.pow(10, freqBuf[i] / 20);
+      magBuf[i] = m;
+      total += m;
+      centroidAcc += freqs[i] * m;
+      const d = m - prevMag[i];
+      if (d > 0) flux += d;
+      prevMag[i] = m;
+    }
+    const centroid = total > 1e-9 ? centroidAcc / total : 0;
+    const bright = Math.max(0, Math.min(1, Math.log1p(centroid) / logNyq));
+
+    state.fluxRunningMax = Math.max(
+      MIN_FLUX_MAX,
+      Math.max(state.fluxRunningMax * 0.999, flux)
+    );
+    const fluxNorm = flux / (state.fluxRunningMax + 1e-9);
+
+    // --- Onset detect ----------------------------------------------------
+    // Gate onset firing on absolute silence so we don't interpret noise-floor
+    // spectral flicker as kicks.
+    const onsetFired =
+      !isSilent &&
+      fluxNorm > onsetThreshold &&
+      now - state.lastOnsetTime > ONSET_DEBOUNCE;
+
+    if (onsetFired) {
+      state.lastOnsetTime = now;
+      state.transient = Math.max(state.transient, Math.min(1, fluxNorm));
+
+      // Feed into simple inter-onset-interval beat tracker.
+      state.onsetTimes.push(now);
+      const cutoff = now - 8;
+      while (state.onsetTimes.length && state.onsetTimes[0] < cutoff) {
+        state.onsetTimes.shift();
+      }
+      if (state.onsetTimes.length >= 4) {
+        const iois = [];
+        for (let i = 1; i < state.onsetTimes.length; i++) {
+          iois.push(state.onsetTimes[i] - state.onsetTimes[i - 1]);
+        }
+        iois.sort((a, b) => a - b);
+        let med = iois[Math.floor(iois.length / 2)];
+        // fold to sensible BPM range (60..200)
+        while (med > 1.0) med /= 2;
+        while (med < 0.3) med *= 2;
+        const newBpm = 60 / med;
+        if (newBpm >= 40 && newBpm <= 220) {
+          state.bpm = state.bpm * 0.7 + newBpm * 0.3;
+          state.beatInterval = 60 / state.bpm;
+          state.lastBeatTime = now;
+        }
+      }
+    }
+
+    // transient decay
+    state.transient *= Math.exp(-dt / TRANSIENT_TAU);
+
+    // EMAs
+    state.energy = (1 - ALPHA_FAST) * state.energy + ALPHA_FAST * energyNorm;
+    state.energy_slow =
+      (1 - ALPHA_SLOW) * state.energy_slow + ALPHA_SLOW * energyNorm;
+    state.brightness = (1 - ALPHA_FAST) * state.brightness + ALPHA_FAST * bright;
+    state.brightness_slow =
+      (1 - ALPHA_SLOW) * state.brightness_slow + ALPHA_SLOW * bright;
+
+    // beat phase
+    if (state.beatInterval > 0.05) {
+      state.beat_phase =
+        ((now - state.lastBeatTime) / state.beatInterval) % 1;
+    }
+
+    // publish
+    const viz = window.viz;
+    viz.energy = state.energy;
+    viz.transient = state.transient;
+    viz.beat_phase = state.beat_phase;
+    viz.brightness = state.brightness;
+    viz.bpm = state.bpm;
+
+    requestAnimationFrame(tick);
+  }
+  requestAnimationFrame(tick);
+
+  // Live source switching: tear down the old MediaStreamSource, build a new
+  // one from the requested input device, and return the new source node so
+  // downstream consumers (CLAP capture worklet) can re-wire themselves.
+  async function switchDevice(newDeviceId) {
+    if (loopback) throw new Error("cannot switch device while in loopback");
+    const nextConstraints = {
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        channelCount: 1,
+      },
+    };
+    if (newDeviceId && newDeviceId !== "default") {
+      nextConstraints.audio.deviceId = { exact: newDeviceId };
+    }
+    const nextStream = await navigator.mediaDevices.getUserMedia(nextConstraints);
+    const nextSource = ctx.createMediaStreamSource(nextStream);
+    // swap connections
+    try { source.disconnect(); } catch (e) {}
+    try { currentStream?.getTracks().forEach((t) => t.stop()); } catch (e) {}
+    currentStream = nextStream;
+    nextSource.connect(analyser);
+    nextSource.connect(mute).connect(ctx.destination);
+    source = nextSource;
+    window.__source = nextSource;
+    const label = nextStream.getAudioTracks()[0]?.label || "default input";
+    onStatus(`${label} @ ${ctx.sampleRate} Hz`);
+    // consumers can call returned.getSource() to get the latest node
+    return nextSource;
+  }
+
+  return { ctx, source, state, switchDevice, getSource: () => source };
+}

--- a/soundscape-v3/control/axes.js
+++ b/soundscape-v3/control/axes.js
@@ -1,0 +1,88 @@
+// Stage 2 — semantic-axis control layer.
+//
+// Owns three hardcoded CLAP axes (LLM will override in Stage 3). Smooths
+// incoming raw axis values with a slow EMA and publishes them to
+// `window.viz.axis[name]`. Also exposes the current axis definitions so UI
+// can render editable prompts.
+
+export const DEFAULT_AXES = [
+  {
+    name: "warmth",
+    positive: "warm, organic, analog, vintage, wooden",
+    negative: "cold, digital, synthetic, metallic, sterile",
+  },
+  {
+    name: "rhythmic",
+    positive: "rhythmic, percussive, beat-driven, kick drum, groove",
+    negative: "ambient, drone, sustained, atmospheric, stillness",
+  },
+  {
+    name: "density",
+    positive: "dense, busy, layered, full, packed arrangement",
+    negative: "sparse, minimal, empty, solo instrument, quiet",
+  },
+];
+
+const ALPHA_SLOW = 0.25; // axis values update at ~1Hz, smoothing is light
+
+export function createAxisBus(initial = DEFAULT_AXES) {
+  const axes = initial.map((a) => ({ ...a }));
+  const raw = Object.fromEntries(axes.map((a) => [a.name, 0]));
+  const smoothed = Object.fromEntries(axes.map((a) => [a.name, 0]));
+
+  // Shared viz.axis object — dynamic presets read it every rAF.
+  window.viz = window.viz || {};
+  window.viz.axis = window.viz.axis || {};
+  for (const a of axes) window.viz.axis[a.name] = 0;
+
+  // Per-axis manual override. While `overrideUntil[name] > now`, CLAP writes
+  // are ignored. Users drag a slider -> we pin the value for a couple seconds
+  // so CLAP doesn't immediately fight them, then slowly hand control back.
+  const overrideValue = {};
+  const overrideUntil = {};
+  const OVERRIDE_HOLD_MS = 2500;
+
+  function onAxis(name, value) {
+    if (overrideUntil[name] && performance.now() < overrideUntil[name]) {
+      // during manual hold, ignore CLAP but keep `smoothed` tracking the
+      // manual value so the hand-back is continuous
+      smoothed[name] = overrideValue[name];
+      window.viz.axis[name] = overrideValue[name];
+      return;
+    }
+    raw[name] = value;
+    smoothed[name] =
+      (1 - ALPHA_SLOW) * smoothed[name] + ALPHA_SLOW * value;
+    window.viz.axis[name] = smoothed[name];
+  }
+
+  function setManual(name, value) {
+    const v = Math.max(-1, Math.min(1, value));
+    overrideValue[name] = v;
+    overrideUntil[name] = performance.now() + OVERRIDE_HOLD_MS;
+    smoothed[name] = v;
+    raw[name] = v;
+    window.viz.axis[name] = v;
+  }
+
+  function get(name) { return smoothed[name] ?? 0; }
+  function setAxes(next) {
+    const keepNames = new Set(next.map((a) => a.name));
+    axes.length = 0;
+    for (const a of next) axes.push({ ...a });
+    // Prune entries whose axis no longer exists so viz.axis.* doesn't ghost
+    // old values into presets.
+    for (const k of Object.keys(raw)) if (!keepNames.has(k)) delete raw[k];
+    for (const k of Object.keys(smoothed)) if (!keepNames.has(k)) delete smoothed[k];
+    for (const k of Object.keys(window.viz.axis)) if (!keepNames.has(k)) delete window.viz.axis[k];
+    for (const k of Object.keys(overrideValue)) if (!keepNames.has(k)) delete overrideValue[k];
+    for (const k of Object.keys(overrideUntil)) if (!keepNames.has(k)) delete overrideUntil[k];
+    for (const a of axes) {
+      if (!(a.name in raw)) raw[a.name] = 0;
+      if (!(a.name in smoothed)) smoothed[a.name] = 0;
+      if (!(a.name in window.viz.axis)) window.viz.axis[a.name] = 0;
+    }
+  }
+
+  return { axes, onAxis, get, setAxes, setManual };
+}

--- a/soundscape-v3/css/app.css
+++ b/soundscape-v3/css/app.css
@@ -1,0 +1,479 @@
+/* ============================================
+   SoundScape app styles
+   Built on the CTRL design system (tokens.css).
+   ============================================ */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  width: 100%; height: 100%;
+  background: var(--color-black);
+  color: var(--color-white);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+:root { color-scheme: dark; }
+
+#hydra-canvas {
+  position: fixed; inset: 0; width: 100vw; height: 100vh;
+  display: block; z-index: 1;
+}
+
+/* ============================================
+   Loading / start screen
+   ============================================ */
+.start {
+  position: fixed; inset: 0; z-index: var(--z-modal);
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  background: var(--color-black);
+  gap: var(--space-6);
+}
+
+.start__title {
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-widest);
+  color: var(--color-white);
+}
+
+.start__subtitle {
+  font-size: var(--text-xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  max-width: 44ch;
+  text-align: center;
+  line-height: var(--leading-relaxed);
+}
+
+.start__controls {
+  display: flex; flex-direction: column;
+  align-items: center; gap: var(--space-4);
+  min-width: 280px;
+}
+.start__source {
+  display: flex; flex-direction: column;
+  gap: var(--space-2);
+  width: 100%;
+}
+.start__source-label {
+  font-size: var(--text-xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+.select {
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  padding: var(--space-2) var(--space-3);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23fff' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--space-2) center;
+  padding-right: var(--space-8);
+  cursor: pointer;
+}
+.select:focus { outline: none; box-shadow: 0 0 0 1px var(--color-white); }
+.select:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ============================================
+   Prompt section (Stage 3)
+   ============================================ */
+.prompt__text {
+  width: 100%;
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  padding: var(--space-2) var(--space-3);
+  resize: vertical;
+  min-height: 60px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.prompt__text:focus {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--color-white);
+}
+.prompt__drop {
+  border: 1px dashed var(--gray-400);
+  padding: var(--space-2);
+  margin-top: var(--space-2);
+  min-height: 60px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-2);
+  transition: border-color var(--duration-normal) var(--ease-default);
+}
+.prompt__drop.is-dragging {
+  border-color: var(--color-white);
+  border-style: solid;
+}
+.prompt__drop-hint {
+  font-size: var(--text-2xs);
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  pointer-events: none;
+}
+.prompt__thumbs {
+  display: flex; flex-wrap: wrap; gap: var(--space-1);
+  width: 100%;
+}
+.prompt__thumb {
+  position: relative;
+  width: 48px; height: 48px;
+  border: 1px solid var(--gray-400);
+}
+.prompt__thumb img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.prompt__thumb-x {
+  position: absolute; top: -6px; right: -6px;
+  width: 16px; height: 16px;
+  border: 1px solid var(--color-white);
+  background: var(--color-black);
+  color: var(--color-white);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+.prompt__thumb-x:hover {
+  background: var(--color-white);
+  color: var(--color-black);
+}
+.prompt__status {
+  margin-top: var(--space-2);
+  font-size: var(--text-2xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  min-height: 1em;
+  line-height: var(--leading-tight);
+}
+
+.start__options {
+  display: flex; gap: var(--space-4);
+  font-size: var(--text-xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.start__options label {
+  cursor: pointer; user-select: none;
+  display: inline-flex; align-items: center; gap: var(--space-2);
+}
+
+.start__options input[type="checkbox"] {
+  appearance: none;
+  width: 10px; height: 10px;
+  background: var(--color-black);
+  border: 1px solid var(--color-white);
+  cursor: pointer;
+  position: relative;
+}
+.start__options input[type="checkbox"]:checked {
+  background: var(--color-white);
+}
+
+.start__err {
+  color: var(--color-error);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  max-width: 50ch; text-align: center;
+}
+
+.start__progress {
+  font-size: var(--text-xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+
+.spinner {
+  width: 14px; height: 14px;
+  border: 1px solid var(--gray-400);
+  border-top-color: var(--color-white);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ============================================
+   Buttons
+   ============================================ */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-6);
+  font-family: var(--font-display);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-widest);
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 1px solid var(--color-white);
+  cursor: pointer;
+  transition: background var(--duration-normal) var(--ease-default),
+              color var(--duration-normal) var(--ease-default);
+}
+.btn:hover { background: var(--color-white); color: var(--color-black); }
+.btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.btn--filled { background: var(--color-white); color: var(--color-black); }
+.btn--filled:hover { background: var(--color-black); color: var(--color-white); }
+
+.btn--icon {
+  width: 30px; height: 30px;
+  padding: 0;
+  font-size: var(--text-md);
+  letter-spacing: 0;
+}
+
+/* ============================================
+   Status bar (top-left live indicator)
+   ============================================ */
+.status-bar {
+  position: fixed; top: var(--space-4); left: var(--space-4);
+  z-index: var(--z-sticky);
+  display: none; align-items: center; gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-black);
+  border: 1px solid var(--color-white);
+  font-size: var(--text-xs);
+  color: var(--color-white);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+.status-bar.active { display: inline-flex; }
+.status-bar__indicator {
+  width: 6px; height: 6px;
+  background: var(--color-white);
+  animation: blink 1s step-start infinite;
+}
+.status-bar__indicator--error { background: var(--color-error); }
+
+/* ============================================
+   Sidebar (right, controls)
+   ============================================ */
+.sidebar {
+  position: fixed; top: 0; right: 0;
+  width: 280px; height: 100vh;
+  background: var(--color-black);
+  border-left: 1px solid var(--color-white);
+  z-index: var(--z-sticky);
+  transform: translateX(100%);
+  transition: transform var(--duration-slow) var(--ease-default);
+  overflow-y: auto;
+  padding: var(--space-6) var(--space-4);
+}
+.sidebar.open { transform: translateX(0); }
+
+.sidebar__title {
+  font-size: var(--text-xs);
+  font-weight: 400;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  margin-bottom: var(--space-6);
+}
+
+.section {
+  border-top: 1px solid var(--gray-400);
+  padding-top: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.section__title {
+  font-size: var(--text-xs);
+  font-weight: 400;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--color-white);
+  margin-bottom: var(--space-3);
+}
+
+.axis {
+  margin-bottom: var(--space-4);
+}
+.axis__header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: var(--space-1);
+}
+.axis__name {
+  font-size: var(--text-xs);
+  color: var(--gray-600);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+}
+.axis__value {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-white);
+}
+.axis__track {
+  height: 20px;                          /* larger hit target */
+  position: relative;
+  cursor: ew-resize;
+  touch-action: none;                    /* enable pointer drag on touch */
+  display: flex; align-items: center;
+}
+.axis__track-rail {
+  position: absolute; left: 0; right: 0; top: 50%;
+  height: 2px; transform: translateY(-50%);
+  background: var(--gray-400);
+  pointer-events: none;
+}
+.axis__track-tick {
+  position: absolute; left: 50%; top: 4px; bottom: 4px;
+  width: 1px; background: var(--gray-500);
+  pointer-events: none;
+}
+.axis__fill {
+  position: absolute; top: 50%; left: 50%;
+  height: 2px; transform: translateY(-50%);
+  background: var(--color-white);
+  pointer-events: none;
+  transform-origin: left center;
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+.axis__handle {
+  position: absolute; top: 50%;
+  width: 8px; height: 12px;
+  background: var(--color-white);
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  transition: left var(--duration-normal) var(--ease-out);
+}
+.axis__track.is-manual .axis__handle {
+  background: var(--accent-amber);
+}
+.axis__manual-dot {
+  display: none;
+  width: 6px; height: 6px;
+  background: var(--accent-amber);
+  margin-left: var(--space-2);
+}
+.axis.is-manual .axis__manual-dot { display: inline-block; }
+.axis__prompts {
+  display: flex; gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+.axis__prompts input {
+  flex: 1; min-width: 0;
+  background: var(--color-black);
+  border: 1px solid var(--gray-400);
+  color: var(--color-white);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.axis__prompts input:focus {
+  outline: none; border-color: var(--color-white);
+}
+
+/* ============================================
+   Icon buttons (corners)
+   ============================================ */
+.corner-btn {
+  position: fixed; z-index: var(--z-sticky);
+  width: 30px; height: 30px;
+  background: var(--color-black);
+  border: 1px solid var(--color-white);
+  color: var(--color-white);
+  font-family: var(--font-display);
+  font-size: var(--text-md);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background var(--duration-normal) var(--ease-default),
+              color var(--duration-normal) var(--ease-default),
+              right var(--duration-slow) var(--ease-default);
+}
+.corner-btn:hover {
+  background: var(--color-white);
+  color: var(--color-black);
+}
+.corner-btn--sidebar { top: var(--space-4); right: var(--space-4); }
+.corner-btn--sidebar.sidebar-is-open { right: calc(280px + var(--space-4)); }
+.corner-btn--hud { bottom: var(--space-4); left: var(--space-4); }
+.corner-btn--fullscreen { bottom: var(--space-4); left: calc(30px + var(--space-4) + var(--space-2)); }
+
+/* ============================================
+   Debug HUD
+   ============================================ */
+.hud {
+  position: fixed; top: var(--space-4); left: var(--space-4);
+  z-index: var(--z-sticky);
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-black);
+  border: 1px solid var(--color-white);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-white);
+  pointer-events: none;
+  display: none;
+  min-width: 240px;
+}
+.hud.show { display: block; }
+.hud__row {
+  display: flex; justify-content: space-between; align-items: center;
+  gap: var(--space-4);
+  line-height: var(--leading-tight);
+  padding: 2px 0;
+}
+.hud__k { color: var(--gray-600); text-transform: uppercase; letter-spacing: var(--tracking-wide); }
+.hud__v { color: var(--color-white); }
+.hud__bar {
+  display: inline-block; width: 80px; height: 2px;
+  background: var(--gray-400); margin-left: var(--space-2);
+  position: relative;
+}
+.hud__bar > span {
+  display: block; height: 100%; background: var(--color-white);
+}
+.hud__bar--signed {
+  background: var(--gray-400);
+}
+.hud__bar--signed::before {
+  content: ""; position: absolute; top: -1px; bottom: -1px;
+  left: 50%; width: 1px; background: var(--gray-500);
+}
+.hud__hr {
+  border: none;
+  border-top: 1px solid var(--gray-400);
+  margin: var(--space-2) 0;
+}
+
+/* ============================================
+   Utility
+   ============================================ */
+.hidden { display: none !important; }
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}

--- a/soundscape-v3/css/tokens.css
+++ b/soundscape-v3/css/tokens.css
@@ -1,0 +1,201 @@
+/* ============================================
+   CTRL Design System
+   A unified design language for ctrl.rodeo projects
+   ============================================ */
+
+/* ============================================
+   Color Tokens
+   ============================================ */
+:root {
+  /* Core palette */
+  --color-black: #000;
+  --color-white: #fff;
+
+  /* Grays - 10 step scale */
+  --gray-100: #111;
+  --gray-200: #1a1a1a;
+  --gray-300: #222;
+  --gray-400: #333;
+  --gray-500: #666;
+  --gray-600: #999;
+  --gray-700: #999;
+  --gray-800: #ccc;
+  --gray-900: #e0e0e0;
+
+  /* Status colors */
+  --color-success: #22c55e;
+  --color-error: #ef4444;
+  --color-warning: #f59e0b;
+
+  /* Terminal accent colors */
+  --accent-amber: #ffb000;
+  --accent-green: #39ff14;
+  --accent-cyan: #00fff7;
+  --accent-magenta: #ff44ff;
+
+  /* Platform colors (music) */
+  --color-spotify: #1DB954;
+  --color-soundcloud: #FF5500;
+  --color-apple-music: #FC3C44;
+  --color-bandcamp: #1DA0C3;
+  --color-tidal: #00FFFF;
+  --color-youtube-music: #FF0000;
+
+  /* Overlays */
+  --overlay-light: rgba(0, 0, 0, 0.5);
+  --overlay-medium: rgba(0, 0, 0, 0.8);
+  --overlay-heavy: rgba(0, 0, 0, 0.95);
+}
+
+/* ============================================
+   Semantic Color Tokens (Theme-aware)
+   ============================================ */
+:root {
+  /* Dark mode (default) */
+  --bg: #111110;
+  --bg-surface: #1a1a18;
+  --bg-elevated: #22221f;
+
+  --fg: #e8e6e3;
+  --fg-muted: #8a8885;
+  --fg-subtle: #666560;
+
+  --border: #e8e6e3;
+  --border-subtle: #33332f;
+
+  --interactive: #e8e6e3;
+  --interactive-hover: #111110;
+  --color-link: #00fff7;
+  --bg-code: #1a1a1e;
+}
+
+:root.light {
+  /* Light mode */
+  --bg: #faf9f7;
+  --bg-surface: #faf9f7;
+  --bg-elevated: #e8e6e3;
+
+  --fg: #1a1a18;
+  --fg-muted: #8a8885;
+  --fg-subtle: #666560;
+
+  --border: #1a1a18;
+  --border-subtle: #ccc8c0;
+
+  --interactive: #1a1a18;
+  --interactive-hover: #faf9f7;
+  --color-link: #0055aa;
+  --bg-code: #f5f5f0;
+}
+
+/* ============================================
+   Typography Tokens
+   ============================================ */
+:root {
+  /* Font families */
+  --font-mono: "JetBrains Mono", "Fira Code", "SF Mono", "Cascadia Code", "Consolas", monospace;
+  --font-primary: var(--font-mono);
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-serif: Georgia, "Times New Roman", Times, serif;
+
+  /* Base font size */
+  --text-base: 14px;
+
+  /* Font sizes — unified scale (replaces both DS and Boards scales) */
+  --text-2xs: 8px;
+  --text-xs: 10px;
+  --text-sm: 12px;
+  --text-md: 14px;
+  --text-lg: 18px;
+  --text-xl: 24px;
+  --text-2xl: 32px;
+  --text-3xl: 40px;
+  --text-4xl: 48px;
+
+  /* Line heights */
+  --leading-none: 1;
+  --leading-tight: 1.2;
+  --leading-normal: 1.6;
+  --leading-relaxed: 1.8;
+
+  /* Letter spacing */
+  --tracking-tight: -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.05em;
+  --tracking-wider: 0.1em;
+  --tracking-widest: 0.3em;
+  --tracking-mono: 0;
+  --tracking-display: -0.03em;
+}
+
+/* ============================================
+   Spacing Tokens
+   ============================================ */
+:root {
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+}
+
+/* ============================================
+   Animation Tokens
+   ============================================ */
+:root {
+  /* Durations */
+  --duration-fast: 0.1s;
+  --duration-normal: 0.15s;
+  --duration-slow: 0.2s;
+  --duration-slower: 0.3s;
+  --duration-slowest: 0.5s;
+
+  /* Easings */
+  --ease-default: ease;
+  --ease-linear: linear;
+  --ease-in: ease-in;
+  --ease-out: ease-out;
+  --ease-in-out: ease-in-out;
+}
+
+/* ============================================
+   Layout Tokens
+   ============================================ */
+:root {
+  --radius-none: 0;
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 8px;
+  --radius-full: 9999px;
+
+  --border-thin: 1px;
+  --border-medium: 2px;
+  --border-thick: 4px;
+
+  --z-base: 0;
+  --z-dropdown: 10;
+  --z-sticky: 50;
+  --z-modal: 100;
+  --z-overlay: 200;
+  --z-toast: 300;
+
+  /* Focus */
+  --focus-ring: 2px solid #00fff7;
+  --focus-ring-offset: 2px;
+}
+
+/* ============================================
+   Breakpoint Tokens
+   ============================================ */
+:root {
+  --bp-sm: 600px;
+  --bp-md: 900px;
+  --bp-lg: 1200px;
+  --container-terminal: 80ch;
+  --gutter-page: clamp(16px, 5vw, 64px);
+}

--- a/soundscape-v3/index.html
+++ b/soundscape-v3/index.html
@@ -1,0 +1,601 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SoundScape</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="description" content="Prompt-steerable audio-reactive visuals, in the browser.">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/tokens.css">
+  <link rel="stylesheet" href="css/app.css">
+</head>
+<body>
+  <canvas id="hydra-canvas"></canvas>
+
+  <!-- Start / loading screen -->
+  <div class="start" id="start">
+    <div class="start__title">SoundScape</div>
+    <div class="start__subtitle">audio-reactive visuals · click start and allow mic</div>
+    <div class="start__controls">
+      <div class="start__source">
+        <label for="source-sel" class="start__source-label">Source</label>
+        <select class="select" id="source-sel">
+          <option value="__default">system default</option>
+          <option value="__synthetic">synthetic (no mic)</option>
+        </select>
+      </div>
+      <button class="btn" id="start-btn">Start</button>
+      <div class="start__options">
+        <label><input type="checkbox" id="clap-chk" checked> semantic axes</label>
+      </div>
+    </div>
+    <div class="start__progress" id="progress"></div>
+    <div class="start__err" id="err"></div>
+  </div>
+
+  <!-- Live controls -->
+  <div class="status-bar" id="status-bar">
+    <span class="status-bar__indicator" id="status-dot"></span>
+    <span id="status-text">ready</span>
+  </div>
+
+  <button class="corner-btn corner-btn--sidebar" id="sidebar-toggle" title="Controls" aria-label="Toggle controls">
+    <span id="sidebar-caret">‹</span>
+  </button>
+  <button class="corner-btn corner-btn--hud" id="hud-toggle" title="Debug HUD (d)" aria-label="Toggle debug HUD">D</button>
+  <button class="corner-btn corner-btn--fullscreen" id="fs-toggle" title="Fullscreen" aria-label="Toggle fullscreen">⛶</button>
+
+  <aside class="sidebar" id="sidebar">
+    <div class="sidebar__title">Controls</div>
+
+    <section class="section">
+      <h3 class="section__title">Prompt</h3>
+      <textarea class="prompt__text" id="prompt-text" rows="3" placeholder="e.g. foggy forest at dawn, meditative drift"></textarea>
+      <div class="prompt__drop" id="prompt-drop">
+        <input type="file" id="prompt-file" accept="image/*" multiple hidden>
+        <div class="prompt__drop-hint" id="prompt-drop-hint">drop 1–5 images · or click</div>
+        <div class="prompt__thumbs" id="prompt-thumbs"></div>
+      </div>
+      <div style="display:flex;gap:var(--space-2);margin-top:var(--space-2)">
+        <button class="btn" id="compile-btn">Compile</button>
+        <button class="btn" id="refine-btn" title="Regenerate with same inputs">Refine</button>
+      </div>
+      <div class="prompt__status" id="prompt-status"></div>
+    </section>
+
+    <section class="section">
+      <h3 class="section__title">Source</h3>
+      <select class="select" id="source-sel-live" style="width:100%"></select>
+      <div style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--gray-600);text-transform:uppercase;letter-spacing:var(--tracking-wide)" id="source-info"></div>
+    </section>
+
+    <section class="section">
+      <h3 class="section__title">Semantic axes</h3>
+      <div id="axes-panel"></div>
+    </section>
+
+    <section class="section">
+      <h3 class="section__title">Preset</h3>
+      <div style="display:flex;gap:var(--space-2);flex-wrap:wrap" id="preset-buttons">
+        <button class="btn" data-preset="drift">Drift</button>
+        <button class="btn" data-preset="pulse">Pulse</button>
+      </div>
+    </section>
+  </aside>
+
+  <div class="hud" id="hud"></div>
+
+  <!-- Runtime -->
+  <script src="https://unpkg.com/hydra-synth@1.3.29/dist/hydra-synth.js"></script>
+  <script src="visuals/drift.js"></script>
+  <script src="visuals/pulse.js"></script>
+
+  <script type="module">
+    import { startAudio, listInputDevices } from "./audio/features.js";
+    import { startClap } from "./audio/clap.js";
+    import { DEFAULT_AXES, createAxisBus } from "./control/axes.js";
+    import { compilePrompt, fileToImage, hexToNormRGB } from "./llm/compiler.js";
+
+    // ---------- shared /viz/ state ----------
+    window.viz = {
+      energy: 0, transient: 0, beat_phase: 0, brightness: 0.3, bpm: 120,
+      axis: {},
+      palette: [],       // raw hex strings from Stage 3 LLM
+      paletteRGB: [],    // parallel array of [r,g,b] in [0,1]
+    };
+    function setPalette(hexes) {
+      if (!Array.isArray(hexes)) return;
+      window.viz.palette = hexes.slice();
+      window.viz.paletteRGB = hexes.map(hexToNormRGB);
+    }
+
+    const $ = (id) => document.getElementById(id);
+    const startEl = $("start");
+    const startBtn = $("start-btn");
+    const sourceSel = $("source-sel");
+    const sourceSelLive = $("source-sel-live");
+    const sourceInfo = $("source-info");
+    const clapChk = $("clap-chk");
+    const errEl = $("err");
+    const progEl = $("progress");
+    const statusBar = $("status-bar");
+    const statusDot = $("status-dot");
+    const statusText = $("status-text");
+    const axesPanel = $("axes-panel");
+    const sidebar = $("sidebar");
+    const sidebarToggle = $("sidebar-toggle");
+    const sidebarCaret = $("sidebar-caret");
+    const hudToggle = $("hud-toggle");
+    const fsToggle = $("fs-toggle");
+    const hud = $("hud");
+
+    // URL flags
+    const urlParams = new URLSearchParams(location.search);
+    if (urlParams.get("loopback") === "1") sourceSel.value = "__synthetic";
+    if (urlParams.get("clap") === "0") clapChk.checked = false;
+
+    // Populate device list at page load (labels will be masked until the
+    // first mic-permission grant; after that a reload will show full labels).
+    async function refreshDevices(selectedId = null) {
+      const devs = await listInputDevices();
+      // Rebuild the start-screen dropdown while preserving the special entries.
+      const startSpecial = ['__default', '__synthetic'];
+      sourceSel.innerHTML =
+        `<option value="__default">system default</option>` +
+        `<option value="__synthetic">synthetic (no mic)</option>` +
+        devs.map((d) => `<option value="${d.deviceId}">${d.label || 'unnamed input'}</option>`).join('');
+      sourceSelLive.innerHTML =
+        `<option value="__default">system default</option>` +
+        devs.map((d) => `<option value="${d.deviceId}">${d.label || 'unnamed input'}</option>`).join('');
+      // Preserve selection if possible
+      const stored = localStorage.getItem('ss.source');
+      if (selectedId) sourceSel.value = selectedId;
+      else if (stored) sourceSel.value = stored;
+      return devs;
+    }
+    refreshDevices();
+    navigator.mediaDevices?.addEventListener?.('devicechange', () => refreshDevices(sourceSel.value));
+
+    // ---------- axis bus + panel ----------
+    const axisBus = createAxisBus(DEFAULT_AXES);
+    const axisEls = new Map();
+
+    function renderAxisPanel() {
+      axesPanel.innerHTML = "";
+      axisEls.clear();
+      for (const ax of axisBus.axes) {
+        const root = document.createElement("div");
+        root.className = "axis";
+        root.innerHTML = `
+          <div class="axis__header">
+            <span class="axis__name">${ax.name}<span class="axis__manual-dot" title="manual override"></span></span>
+            <span class="axis__value" data-axis-v>+0.00</span>
+          </div>
+          <div class="axis__track" data-axis-track role="slider" aria-label="${ax.name}" aria-valuemin="-1" aria-valuemax="1" aria-valuenow="0" tabindex="0">
+            <div class="axis__track-rail"></div>
+            <div class="axis__track-tick"></div>
+            <span class="axis__fill" data-axis-f></span>
+            <span class="axis__handle" data-axis-h></span>
+          </div>
+          <div class="axis__prompts">
+            <input data-pole="positive" value="${ax.positive.replace(/"/g, "&quot;")}" aria-label="${ax.name} positive pole">
+            <input data-pole="negative" value="${ax.negative.replace(/"/g, "&quot;")}" aria-label="${ax.name} negative pole">
+          </div>
+        `;
+        axesPanel.appendChild(root);
+        const track = root.querySelector("[data-axis-track]");
+        axisEls.set(ax.name, {
+          root,
+          value: root.querySelector("[data-axis-v]"),
+          fill: root.querySelector("[data-axis-f]"),
+          handle: root.querySelector("[data-axis-h]"),
+          track,
+        });
+        wireDrag(track, ax.name, root);
+      }
+    }
+
+    // Pointer-driven manual override. Dragging writes through axisBus.setManual
+    // which pins the value for a couple seconds before CLAP resumes. The
+    // dot + handle color flip signals "manual override active".
+    function wireDrag(track, name, root) {
+      let hold = null;
+      function setFromPointer(ev) {
+        const rect = track.getBoundingClientRect();
+        const x = (ev.clientX - rect.left) / rect.width;
+        const v = Math.max(-1, Math.min(1, (x - 0.5) * 2));
+        axisBus.setManual(name, v);
+        track.setAttribute("aria-valuenow", v.toFixed(2));
+        track.classList.add("is-manual");
+        root.classList.add("is-manual");
+        if (hold) clearTimeout(hold);
+        hold = setTimeout(() => {
+          track.classList.remove("is-manual");
+          root.classList.remove("is-manual");
+        }, 2800);
+      }
+      track.addEventListener("pointerdown", (e) => {
+        track.setPointerCapture(e.pointerId);
+        setFromPointer(e);
+      });
+      track.addEventListener("pointermove", (e) => {
+        if (e.buttons & 1) setFromPointer(e);
+      });
+      // Keyboard: arrow keys nudge by 0.1, shift for 0.25.
+      track.addEventListener("keydown", (e) => {
+        const step = e.shiftKey ? 0.25 : 0.1;
+        const cur = parseFloat(track.getAttribute("aria-valuenow")) || 0;
+        let v = cur;
+        if (e.key === "ArrowRight" || e.key === "ArrowUp") v = Math.min(1, cur + step);
+        else if (e.key === "ArrowLeft" || e.key === "ArrowDown") v = Math.max(-1, cur - step);
+        else if (e.key === "Home") v = -1;
+        else if (e.key === "End") v = 1;
+        else if (e.key === "0" || e.key === " ") v = 0;
+        else return;
+        e.preventDefault();
+        axisBus.setManual(name, v);
+        track.setAttribute("aria-valuenow", v.toFixed(2));
+        track.classList.add("is-manual");
+        root.classList.add("is-manual");
+        if (hold) clearTimeout(hold);
+        hold = setTimeout(() => {
+          track.classList.remove("is-manual");
+          root.classList.remove("is-manual");
+        }, 2800);
+      });
+    }
+    renderAxisPanel();
+
+    function paintAxis(name, v) {
+      const el = axisEls.get(name);
+      if (!el) return;
+      el.value.textContent = (v >= 0 ? "+" : "") + v.toFixed(2);
+      // Fill goes from center (50%) outward. Positive → right, negative → left.
+      const half = Math.abs(v) * 50;
+      if (v >= 0) {
+        el.fill.style.left = "50%";
+        el.fill.style.width = half + "%";
+      } else {
+        el.fill.style.left = (50 - half) + "%";
+        el.fill.style.width = half + "%";
+      }
+      el.handle.style.left = (50 + v * 50) + "%";
+    }
+
+    // ---------- UI wiring ----------
+    function openSidebar(open) {
+      sidebar.classList.toggle("open", open);
+      sidebarToggle.classList.toggle("sidebar-is-open", open);
+      sidebarCaret.textContent = open ? "›" : "‹";
+    }
+    sidebarToggle.addEventListener("click", () => openSidebar(!sidebar.classList.contains("open")));
+
+    let hudOn = false;
+    function toggleHud() {
+      hudOn = !hudOn;
+      hud.classList.toggle("show", hudOn);
+    }
+    hudToggle.addEventListener("click", toggleHud);
+    document.addEventListener("keydown", (e) => {
+      if (e.target && /input|textarea/i.test(e.target.tagName)) return;
+      if (e.key === "d" || e.key === "D") toggleHud();
+      if (e.key === "c" || e.key === "C") openSidebar(!sidebar.classList.contains("open"));
+    });
+
+    fsToggle.addEventListener("click", () => {
+      if (!document.fullscreenElement) document.documentElement.requestFullscreen();
+      else document.exitFullscreen();
+    });
+
+    function setStatus(text, ok = true) {
+      statusText.textContent = text;
+      statusDot.classList.toggle("status-bar__indicator--error", !ok);
+      statusBar.classList.add("active");
+    }
+
+    const PRESETS = {
+      drift: () => window.loadDrift && window.loadDrift(),
+      pulse: () => window.loadPulse && window.loadPulse(),
+    };
+    let currentPreset = localStorage.getItem("ss.preset") || "pulse";
+
+    function loadPreset(name) {
+      if (!PRESETS[name]) return;
+      currentPreset = name;
+      localStorage.setItem("ss.preset", name);
+      PRESETS[name]();
+      // highlight active button
+      document.querySelectorAll("#preset-buttons [data-preset]").forEach((b) => {
+        b.classList.toggle("btn--filled", b.dataset.preset === name);
+      });
+    }
+
+    function initHydra() {
+      const canvas = $("hydra-canvas");
+      function sizeCanvas() {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+      }
+      sizeCanvas();
+      window.addEventListener("resize", sizeCanvas);
+      new Hydra({ canvas, detectAudio: false, enableStreamCapture: false });
+      loadPreset(currentPreset);
+    }
+
+    document.getElementById("preset-buttons").addEventListener("click", (e) => {
+      const name = e.target?.dataset?.preset;
+      if (name) loadPreset(name);
+    });
+
+    // ---------- runtime refs (set once started) ----------
+    let audioHandle = null;  // returned by startAudio
+    let clapHandle = null;   // returned by startClap
+
+    // ---------- start handler ----------
+    startBtn.addEventListener("click", async () => {
+      errEl.textContent = "";
+      progEl.textContent = "";
+      startBtn.disabled = true;
+      startBtn.textContent = "starting…";
+      try {
+        initHydra();
+        const sel = sourceSel.value;
+        const loopback = sel === "__synthetic";
+        const deviceId = (sel === "__default" || loopback) ? null : sel;
+        if (!loopback) localStorage.setItem("ss.source", sel);
+
+        audioHandle = await startAudio({
+          loopback, deviceId,
+          onStatus: (s) => setStatus(s),
+        });
+        // refresh labels now that permission was granted
+        if (!loopback) {
+          await refreshDevices(sel === "__default" ? "__default" : sel);
+          sourceSelLive.value = sel === "__default" ? "__default" : sel;
+          sourceInfo.textContent = `sr ${audioHandle.ctx.sampleRate} Hz`;
+        } else {
+          sourceSelLive.innerHTML = `<option>synthetic</option>`;
+          sourceSelLive.disabled = true;
+          sourceInfo.textContent = `synthetic · ${audioHandle.ctx.sampleRate} Hz`;
+        }
+
+        startEl.style.display = "none";
+
+        if (clapChk.checked) {
+          setStatus("loading CLAP…");
+          progEl.textContent = "";
+          clapHandle = await startClap({
+            ctx: audioHandle.ctx,
+            source: audioHandle.getSource(),
+            axes: axisBus.axes,
+            onAxis: (name, v) => axisBus.onAxis(name, v),
+            onStatus: (s) => setStatus(s),
+            onProgress: (p) => {
+              if (p && p.status === "progress" && p.progress != null) {
+                const pct = Math.round(p.progress);
+                const name = (p.file || "").split("/").pop() || "";
+                progEl.textContent = `${name} ${pct}%`;
+              } else if (p && p.status === "done") {
+                progEl.textContent = "";
+              }
+            },
+          }).catch((e) => {
+            console.warn("[clap] disabled:", e);
+            setStatus("CLAP disabled — fast path only", false);
+            return null;
+          });
+        }
+      } catch (e) {
+        console.error(e);
+        errEl.textContent = (e && e.message) || String(e);
+        startBtn.disabled = false;
+        startBtn.textContent = "retry";
+      }
+    });
+
+    // ---------- Stage 3: prompt compiler UI ----------
+    const promptText = $("prompt-text");
+    const promptDrop = $("prompt-drop");
+    const promptDropHint = $("prompt-drop-hint");
+    const promptFile = $("prompt-file");
+    const promptThumbs = $("prompt-thumbs");
+    const promptStatus = $("prompt-status");
+    const compileBtn = $("compile-btn");
+    const refineBtn = $("refine-btn");
+
+    let pendingImages = [];  // [{name, media_type, size, data}]
+
+    function renderThumbs() {
+      promptThumbs.innerHTML = "";
+      pendingImages.forEach((img, i) => {
+        const div = document.createElement("div");
+        div.className = "prompt__thumb";
+        div.innerHTML =
+          `<img src="data:${img.media_type};base64,${img.data}" alt="${img.name}">` +
+          `<button class="prompt__thumb-x" data-i="${i}" aria-label="remove">×</button>`;
+        promptThumbs.appendChild(div);
+      });
+      promptDropHint.style.display = pendingImages.length ? "none" : "block";
+    }
+    promptThumbs.addEventListener("click", (e) => {
+      const i = e.target?.dataset?.i;
+      if (i != null) {
+        pendingImages.splice(Number(i), 1);
+        renderThumbs();
+      }
+    });
+
+    async function addFiles(files) {
+      for (const f of files) {
+        if (!f.type.startsWith("image/")) continue;
+        if (pendingImages.length >= 5) break;
+        try {
+          pendingImages.push(await fileToImage(f));
+        } catch (e) {
+          console.warn("[prompt] skip", f.name, e);
+        }
+      }
+      renderThumbs();
+    }
+    promptDrop.addEventListener("click", (e) => {
+      if (e.target === promptFile) return;
+      promptFile.click();
+    });
+    promptFile.addEventListener("change", (e) => {
+      addFiles(e.target.files || []);
+      e.target.value = "";
+    });
+    ["dragenter", "dragover"].forEach((ev) =>
+      promptDrop.addEventListener(ev, (e) => {
+        e.preventDefault();
+        promptDrop.classList.add("is-dragging");
+      }),
+    );
+    ["dragleave", "drop"].forEach((ev) =>
+      promptDrop.addEventListener(ev, (e) => {
+        e.preventDefault();
+        promptDrop.classList.remove("is-dragging");
+      }),
+    );
+    promptDrop.addEventListener("drop", (e) => {
+      addFiles(e.dataTransfer?.files || []);
+    });
+
+    function applyConfig(config, meta = {}) {
+      // Swap axes — CLAP's ensureTextEmbeddings() will invalidate its cache
+      // on name/prompt change automatically.
+      const nextAxes = config.axes.map((a) => ({
+        name: a.name,
+        positive: a.positive,
+        negative: a.negative,
+      }));
+      axisBus.setAxes(nextAxes);
+      if (clapHandle?.setAxes) clapHandle.setAxes(axisBus.axes);
+      renderAxisPanel();
+
+      // Palette plumbs through to presets via viz.paletteRGB
+      if (Array.isArray(config.palette)) setPalette(config.palette);
+
+      // Preset hint: surface as a suggestion, do NOT auto-switch. The user
+      // picked a preset intentionally — flipping it out from under them
+      // breaks flow. Stage 4 adds an explicit "lock preset" toggle; for now
+      // the hint is displayed and the user can click the preset button.
+      const hint = config.preset_hint;
+      const hintNote =
+        hint && hint !== currentPreset
+          ? ` · hint: ${hint} (click preset to switch)`
+          : "";
+
+      promptStatus.textContent =
+        `axes: ${config.axes.map((a) => a.name).join(", ")} · ` +
+        `palette: ${(config.palette || []).length} colors${hintNote} · ` +
+        `${meta._cacheHit ? "cached" : meta.model || "live"}`;
+    }
+
+    async function runCompile({ nonce = null } = {}) {
+      const text = promptText.value.trim();
+      if (!text && pendingImages.length === 0) {
+        promptStatus.textContent = "type a prompt or drop an image";
+        return;
+      }
+      compileBtn.disabled = true;
+      refineBtn.disabled = true;
+      promptStatus.textContent = "compiling…";
+      try {
+        const result = await compilePrompt({
+          text,
+          images: pendingImages,
+          nonce,
+        });
+        applyConfig(result.config, result);
+      } catch (e) {
+        console.error("[compile]", e);
+        promptStatus.textContent = "error: " + (e.message || String(e));
+      } finally {
+        compileBtn.disabled = false;
+        refineBtn.disabled = false;
+      }
+    }
+    compileBtn.addEventListener("click", () => runCompile());
+    refineBtn.addEventListener("click", () =>
+      runCompile({ nonce: String(Math.random()).slice(2, 10) }),
+    );
+
+    // ---------- Live device switch from the sidebar dropdown. ----------
+    sourceSelLive.addEventListener("change", async () => {
+      if (!audioHandle || !audioHandle.switchDevice) return;
+      const next = sourceSelLive.value;
+      localStorage.setItem("ss.source", next);
+      try {
+        setStatus("switching source…");
+        const newSource = await audioHandle.switchDevice(next);
+        if (clapHandle && clapHandle.rewireSource) clapHandle.rewireSource(newSource);
+        sourceInfo.textContent = `sr ${audioHandle.ctx.sampleRate} Hz`;
+      } catch (e) {
+        console.error("[source] switch failed:", e);
+        setStatus("switch failed: " + (e.message || e), false);
+      }
+    });
+
+    // ---------- Debug HUD render loop ----------
+    function bar(v) {
+      const pct = Math.max(0, Math.min(1, v)) * 100;
+      return `<span class="hud__bar"><span style="width:${pct.toFixed(0)}%"></span></span>`;
+    }
+    function sbar(v) {
+      const pct = Math.max(-1, Math.min(1, v));
+      const half = Math.abs(pct) * 50;
+      const left = pct >= 0 ? 50 : (50 - half);
+      return `<span class="hud__bar hud__bar--signed"><span style="width:${half}%;margin-left:${left}%;background:#fff"></span></span>`;
+    }
+    function fmt(n, d = 3) {
+      return (Math.round(n * Math.pow(10, d)) / Math.pow(10, d)).toFixed(d);
+    }
+    let frames = 0, fpsLast = performance.now(), fps = 0;
+
+    function updateHud() {
+      frames++;
+      const now = performance.now();
+      if (now - fpsLast > 500) {
+        fps = (frames * 1000) / (now - fpsLast);
+        frames = 0; fpsLast = now;
+      }
+      if (hudOn) {
+        const v = window.viz;
+        const axes = v.axis || {};
+        let axRows = "";
+        for (const [name, val] of Object.entries(axes)) {
+          axRows += `<div class="hud__row"><span class="hud__k">${name}</span><span class="hud__v">${(val >= 0 ? "+" : "") + fmt(val, 2)}</span>${sbar(val)}</div>`;
+        }
+        const clap = (window.clapDiag && window.clapDiag()) || null;
+        let clapRows = "";
+        if (clap) {
+          const secIn = (clap.samplesSeen / 48000);  // approximate
+          clapRows =
+            `<hr class="hud__hr">` +
+            `<div class="hud__row"><span class="hud__k">clap · infers</span><span class="hud__v">${clap.inferenceCount}</span></div>` +
+            `<div class="hud__row"><span class="hud__k">clap · last</span><span class="hud__v">${Math.round(clap.lastInferenceMs || 0)}ms</span></div>` +
+            `<div class="hud__row"><span class="hud__k">clap · ring rms</span><span class="hud__v">${(clap.ringRms || 0).toFixed(4)}</span></div>` +
+            `<div class="hud__row"><span class="hud__k">clap · samples in</span><span class="hud__v">${secIn.toFixed(1)}s</span></div>`;
+        }
+        hud.innerHTML =
+          `<div class="hud__row"><span class="hud__k">energy</span><span class="hud__v">${fmt(v.energy)}</span>${bar(v.energy)}</div>` +
+          `<div class="hud__row"><span class="hud__k">transient</span><span class="hud__v">${fmt(v.transient)}</span>${bar(v.transient)}</div>` +
+          `<div class="hud__row"><span class="hud__k">beat_phase</span><span class="hud__v">${fmt(v.beat_phase)}</span>${bar(v.beat_phase)}</div>` +
+          `<div class="hud__row"><span class="hud__k">brightness</span><span class="hud__v">${fmt(v.brightness)}</span>${bar(v.brightness)}</div>` +
+          `<div class="hud__row"><span class="hud__k">bpm</span><span class="hud__v">${fmt(v.bpm, 1)}</span></div>` +
+          (axRows ? `<hr class="hud__hr">${axRows}` : "") +
+          clapRows +
+          `<hr class="hud__hr"><div class="hud__row"><span class="hud__k">fps</span><span class="hud__v">${fmt(fps, 1)}</span></div>`;
+      }
+      // also update the sidebar axis meters at rAF rate (values change slowly)
+      for (const [name, v] of Object.entries(window.viz.axis || {})) paintAxis(name, v);
+      requestAnimationFrame(updateHud);
+    }
+    requestAnimationFrame(updateHud);
+  </script>
+</body>
+</html>

--- a/soundscape-v3/llm/compiler.js
+++ b/soundscape-v3/llm/compiler.js
@@ -1,0 +1,134 @@
+// Stage 3 — prompt compiler client.
+//
+// Calls the local proxy at /compile (proxied server holds the Anthropic key).
+// Caches compiler output by sha256(text + image hashes) in localStorage so
+// identical prompts don't re-spend tokens.
+
+// Proxy URL discovery in priority order:
+//   1. localStorage.ss.proxyUrl      — user override in prod (e.g. Cloudflare Worker)
+//   2. window.SS_PROXY_URL            — baked-in override (set in a <script> tag)
+//   3. URL query ?proxy=...           — one-shot override for testing
+//   4. http://<hostname>:8787/compile — local dev default
+function resolveProxyUrl() {
+  try {
+    const q = new URLSearchParams(location.search).get("proxy");
+    if (q) return q;
+  } catch (e) {}
+  try {
+    const stored = localStorage.getItem("ss.proxyUrl");
+    if (stored) return stored;
+  } catch (e) {}
+  if (typeof window !== "undefined" && window.SS_PROXY_URL) return window.SS_PROXY_URL;
+  return `http://${location.hostname || "localhost"}:8787/compile`;
+}
+const DEFAULT_PROXY = resolveProxyUrl();
+const CACHE_PREFIX = "ss.compile.v1.";
+
+export function getProxyUrl() { return DEFAULT_PROXY; }
+
+async function sha256Hex(str) {
+  const enc = new TextEncoder().encode(str);
+  const hash = await crypto.subtle.digest("SHA-256", enc);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function cacheKey(text, images) {
+  const parts = [(text || "").trim()];
+  for (const img of images || []) {
+    // Hash the base64 data so the key is stable but compact.
+    parts.push(await sha256Hex(img.data).then((h) => h.slice(0, 32)));
+  }
+  const combined = parts.join("|");
+  return (await sha256Hex(combined)).slice(0, 32);
+}
+
+export async function compilePrompt({
+  text,
+  images = [],
+  proxyUrl = DEFAULT_PROXY,
+  useCache = true,
+  nonce = null,   // pass a random string to bypass cache ("refine")
+} = {}) {
+  if (!text?.trim() && images.length === 0) {
+    throw new Error("need text or at least one image");
+  }
+
+  const key = await cacheKey((text || "") + (nonce ? "|" + nonce : ""), images);
+  if (useCache && !nonce) {
+    const cached = localStorage.getItem(CACHE_PREFIX + key);
+    if (cached) {
+      try {
+        return { ...JSON.parse(cached), _cacheHit: true };
+      } catch (e) {
+        localStorage.removeItem(CACHE_PREFIX + key);
+      }
+    }
+  }
+
+  let res;
+  try {
+    res = await fetch(proxyUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ text, images }),
+    });
+  } catch (e) {
+    // Network failure (proxy not running, CORS, offline). Surface a useful
+    // message; this is the common case in a fresh production deploy.
+    throw new Error(
+      `proxy unreachable at ${proxyUrl} — run server/proxy.js locally, ` +
+      `or set localStorage.ss.proxyUrl to a hosted compile endpoint`
+    );
+  }
+  let data;
+  try {
+    data = await res.json();
+  } catch (e) {
+    throw new Error(`proxy returned non-JSON (${res.status})`);
+  }
+  if (!res.ok || !data.ok) {
+    const msg = data?.error || `compile failed (${res.status})`;
+    const err = new Error(msg);
+    err.detail = data?.detail;
+    throw err;
+  }
+
+  const out = {
+    config: data.config,
+    model: data.model,
+    usage: data.usage,
+  };
+  try {
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(out));
+  } catch (e) {
+    // quota exceeded — just skip
+  }
+  return { ...out, _cacheHit: false };
+}
+
+// Convenience: read a dropped/selected File into an { media_type, data } image.
+export async function fileToImage(file) {
+  if (!file.type.startsWith("image/")) {
+    throw new Error(`${file.name} is not an image`);
+  }
+  const ab = await file.arrayBuffer();
+  const bytes = new Uint8Array(ab);
+  // base64 encode
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  const data = btoa(bin);
+  return {
+    name: file.name,
+    media_type: file.type,
+    size: file.size,
+    data,
+  };
+}
+
+export function hexToNormRGB(hex) {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex || "");
+  if (!m) return [0.5, 0.5, 0.5];
+  return [parseInt(m[1], 16) / 255, parseInt(m[2], 16) / 255, parseInt(m[3], 16) / 255];
+}

--- a/soundscape-v3/visuals/drift.js
+++ b/soundscape-v3/visuals/drift.js
@@ -1,0 +1,52 @@
+// Drift: default preset.
+//
+// Slow, particle-like noise field that breathes with the music.
+// Reads:
+//   viz.energy           overall intensity / density (fast EMA)
+//   viz.transient        kick/snare pulses, fast decay
+//   viz.beat_phase       0..1 sawtooth between beats
+//   viz.brightness       spectral centroid -> hue temperature
+//   viz.axis.warmth      -1..1 cold↔warm (CLAP, Stage 2)
+//   viz.axis.rhythmic    -1..1 ambient↔rhythmic
+//   viz.axis.density     -1..1 sparse↔dense
+//
+// Every dynamic value must be a function: () => viz.x.
+// Axis reads use ?? 0 so they degrade cleanly when CLAP isn't loaded.
+
+window.loadDrift = function loadDrift() {
+  // A low, slow noise field. Baseline is dark and calm. Music nudges it —
+  // it never shouts. Transients are felt, not flashed. Rotation is a fraction
+  // of a radian per beat, not a full revolution. Saturation stays well under 1.
+
+  const base = osc(
+    () => 1.2 + viz.energy * 1.8,               // was 4 + energy*10
+    () => 0.008 + viz.beat_phase * 0.02,        // was 0.02 + phase*0.08
+    () => 0.25 + viz.brightness * 0.3
+  )
+    .rotate(() => viz.beat_phase * 0.35, 0.01)  // was full 2π per beat
+    .modulate(
+      noise(
+        () => 0.8 + viz.energy * 1.0,
+        () => 0.04 + viz.transient * 0.08
+      ),
+      () => 0.05 + viz.transient * 0.12         // was up to 0.67
+    )
+    .modulateScale(
+      noise(1.2, 0.02),
+      () => 0.02 + viz.transient * 0.06
+    )
+    .color(
+      // warmth axis: warm nudges red, cold nudges blue — gentle amount
+      () => 0.18 + viz.brightness * 0.35 + (viz.axis?.warmth ?? 0) * 0.12,
+      () => 0.22 + viz.energy * 0.18,
+      () => 0.42 + (1.0 - viz.brightness) * 0.22 - (viz.axis?.warmth ?? 0) * 0.12
+    )
+    .saturate(() => 0.55 + viz.energy * 0.2)    // was up to 1.5, now max ~0.75
+    // rhythmic axis tightens contrast; ambient softens
+    .contrast(() => 0.85 + viz.transient * 0.35 + Math.max(0, viz.axis?.rhythmic ?? 0) * 0.15)
+    .brightness(-0.08);                         // darker baseline — meditative
+
+  // Feedback blend softens transients into afterimages. This is the single
+  // biggest "quiet" knob: heavier blend = more smear, less intensity.
+  base.blend(o0, () => 0.55 + viz.transient * 0.15).out();
+};

--- a/soundscape-v3/visuals/pulse.js
+++ b/soundscape-v3/visuals/pulse.js
@@ -1,0 +1,104 @@
+// Pulse: reactive preset.
+//
+// Designed to make musical-part transitions visible. Every visible axis and
+// fast param pushes a separate knob, so when the axes shift (ambient → drop,
+// sparse → dense, warm → cold) the overall image reconfigures, not just
+// nudges. Use this when you want to debug or show off; use drift when you
+// want calm.
+//
+// Knobs mapped:
+//   viz.axis.density     → number of repeat tiles            (1 .. 6)
+//   viz.axis.rhythmic    → edge hardness + symmetry stacks   (2 .. 6)
+//   viz.axis.warmth      → hue temperature across full band
+//   viz.energy           → pattern size + color saturation + "alive" gate
+//   viz.transient        → per-onset flash / displacement
+//   viz.beat_phase       → rotation speed and pulse timing
+//   viz.brightness       → baseline luminance
+//
+// Silence behavior: energy's silence gate (features.js) collapses to 0
+// below -50 dBFS. Everything that should quiet in silence multiplies by
+// alive() and therefore comes to rest smoothly.
+
+window.loadPulse = function loadPulse() {
+  const axis = (n) => viz.axis?.[n] ?? 0;
+  const pos = (n) => Math.max(0, axis(n));
+  const abs = (n) => Math.abs(axis(n));
+
+  // Smoothed silence gate. Saturates to 1 above ~energy 0.55, falls cleanly
+  // to 0 when features.js hard-gates energy to 0 on silence.
+  const alive = () => Math.min(1, viz.energy * 1.8);
+
+  // Shape morphs from circle (ambient) -> triangle (rhythmic).
+  const sides = () => 3 + (1 - Math.max(0, axis("rhythmic"))) * 45;
+  const tileCount = () => Math.max(1, Math.round(1.5 + (axis("density") + 1) * 2.2));
+  const kaleidN = () => 2 + Math.floor(pos("rhythmic") * 4);
+
+  // Pseudo-beat: gentle pulse at detected tempo for music without a kick.
+  // Scales with alive(), so silence removes it entirely. Real transients
+  // dominate when present.
+  const pseudoBeat = () => Math.max(0, Math.sin(viz.beat_phase * Math.PI)) * 0.25 * alive();
+  const pulseAmt = () => Math.max(viz.transient, pseudoBeat());
+
+  // Rotation and scroll: drive only the *speed* (second arg), scaled by
+  // alive(). During silence the continuous motion winds down smoothly. No
+  // offset in the first arg, so nothing snaps back to 0.
+  const rotSpeed = () => alive() * 0.08;
+  const scrollXSpeed = () => alive() * 0.03;
+  const scrollYSpeed = () => alive() * 0.025;
+
+  const base = shape(
+    sides,
+    () => 0.22 + viz.energy * 0.2,
+    () => 0.015 + (1 - pos("rhythmic")) * 0.06    // soft when ambient, sharp when rhythmic
+  )
+    .repeat(tileCount, tileCount)
+    .rotate(0, rotSpeed)
+    .scrollX(0, scrollXSpeed)
+    .scrollY(0, scrollYSpeed)
+    .modulate(
+      noise(
+        () => 1.2 + viz.energy * 2.5,
+        () => 0.06 * alive() + pulseAmt() * 0.2
+      ),
+      () => (0.03 + pulseAmt() * 0.35) * alive()
+    )
+    .modulateScale(
+      noise(() => 1.5 + abs("density") * 1.5, () => 0.05 * alive()),
+      () => pulseAmt() * 0.15
+    );
+
+  // Color layer. Two modes:
+  //  - If the LLM supplied a palette (Stage 3), crossfade between its colors
+  //    by beat_phase and energy — the palette becomes the whole hue identity.
+  //  - Otherwise fall back to the old warmth-axis-driven gradient.
+  const warm = axis("warmth");
+  function pal(i, def) {
+    const p = viz.paletteRGB;
+    if (!p || p.length === 0) return def;
+    return p[(i + p.length) % p.length];
+  }
+  const hasPalette = () => (viz.paletteRGB?.length ?? 0) >= 2;
+  const colored = base
+    .color(
+      () => hasPalette()
+        ? pal(0, [0.5, 0, 0])[0] * (0.6 + viz.energy * 0.4) +
+          pal(1, [0.5, 0, 0])[0] * (0.2 + Math.sin(viz.beat_phase * Math.PI * 2) * 0.1)
+        : 0.5 + warm * 0.4 + viz.brightness * 0.12,
+      () => hasPalette()
+        ? pal(0, [0, 0.5, 0])[1] * (0.6 + viz.energy * 0.4) +
+          pal(1, [0, 0.5, 0])[1] * (0.2 + Math.sin(viz.beat_phase * Math.PI * 2) * 0.1)
+        : 0.38 + viz.energy * 0.28 + warm * 0.04,
+      () => hasPalette()
+        ? pal(0, [0, 0, 0.5])[2] * (0.6 + viz.energy * 0.4) +
+          pal(1, [0, 0, 0.5])[2] * (0.2 + Math.sin(viz.beat_phase * Math.PI * 2) * 0.1)
+        : 0.55 - warm * 0.45 + (1 - viz.brightness) * 0.2
+    )
+    .saturate(() => 0.7 + viz.energy * 0.35)
+    .contrast(() => 0.95 + pulseAmt() * 0.55 + pos("rhythmic") * 0.2)
+    .brightness(() => 0.02 + pulseAmt() * 0.1)
+    .kaleid(kaleidN);
+
+  colored
+    .blend(o0, () => 0.2 + viz.energy * 0.25)
+    .out();
+};


### PR DESCRIPTION
## Summary
- New `/soundscape-v3/` mount alongside the existing `/soundscape/` Meyda experiment
- Full rebuild: Web Audio fast path, in-browser CLAP via transformers.js, Claude-powered prompt compiler (text + image → axes + palette)
- CTRL design system throughout (Space Grotesk, JetBrains Mono, 1px borders, square corners)
- Two Hydra presets (Drift, Pulse) with draggable axis sliders, live source switching, BlackHole-compatible

Source repo: github.com/fikei/soundscape, commit `6232cfb`.

## Test plan
- [ ] Visit https://ctrl.rodeo/soundscape-v3/ after deploy
- [ ] Click Start with "synthetic audio" — visuals come up, axes populate within ~10s after CLAP loads (~170MB first-run)
- [ ] Click Start with real mic/BlackHole — same plus live music reactivity
- [ ] Press `d` — debug HUD shows energy/transient/beat_phase/brightness/axes/fps
- [ ] Press `c` — sidebar opens; drag axis sliders, switch presets, change source device
- [ ] Compile button without a local proxy → clear error message ("proxy unreachable…")
- [ ] With local proxy (`ANTHROPIC_API_KEY=… node server/proxy.js`) → prompt like "foggy forest at dawn" produces new axes + palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)