### PR TITLE
fix(cache-events): de-dupe batch inserts by event_key

### DIFF
--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -270,9 +270,19 @@ serve(async (req: Request) => {
       }
     }
 
-    // Split into inserts and updates
-    const toInsert = validRows.filter(r => !existingMap.has(r.event_key as string))
-    const toUpdate = validRows.filter(r => existingMap.has(r.event_key as string))
+    // Split into inserts and updates. De-dupe within batch by event_key so a
+    // single intra-batch collision doesn't abort the whole insert (Postgres
+    // unique-constraint violation kills a multi-row insert atomically).
+    const seenKeys = new Set<string>()
+    const toInsert: Record<string, unknown>[] = []
+    const toUpdate: Record<string, unknown>[] = []
+    for (const r of validRows) {
+      const k = r.event_key as string
+      if (existingMap.has(k)) { toUpdate.push(r); continue }
+      if (seenKeys.has(k)) continue
+      seenKeys.add(k)
+      toInsert.push(r)
+    }
 
     // Batch insert new events
     if (toInsert.length > 0) {


### PR DESCRIPTION
Intra-batch event_key duplicates were aborting the whole insert (Postgres atomic-fail on unique-constraint violation in multi-row INSERT). 19hz-seattle had 0 inserts from 336 scraped events until de-duped. Fixed by skipping repeat keys within the batch.