### PR TITLE
soundscape-v3: lockable primitives

### DIFF
--- a/soundscape-v3/control/knobs.js
+++ b/soundscape-v3/control/knobs.js
@@ -71,10 +71,30 @@ export const DEFAULT_TRANSITION = "smooth";
 // Manual override: while active, ignore LLM/preset writes to this knob.
 const OVERRIDE_HOLD_MS = 2500;
 
+const LOCK_STORAGE_KEY = "ss.knobLocks.v1";
+const TRANS_STORAGE_KEY = "ss.transition";
+
+function loadLocks() {
+  try {
+    const raw = localStorage.getItem(LOCK_STORAGE_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch (e) {
+    return new Set();
+  }
+}
+function persistLocks(set) {
+  try {
+    localStorage.setItem(LOCK_STORAGE_KEY, JSON.stringify([...set]));
+  } catch (e) {}
+}
+
 export function createKnobBus(initial = DEFAULT_KNOBS) {
   const current = {};
   const target = {};
   const overrideUntil = {};
+  const locked = loadLocks();        // Set<knobName>
   let transitionMode = DEFAULT_TRANSITION;
 
   window.viz = window.viz || {};
@@ -86,17 +106,22 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
     window.viz.knob[name] = current[name];
   }
 
-  // LLM / preset button path — respects manual override hold.
+  // LLM / preset button path. A write is rejected if:
+  //   - the knob is explicitly locked, OR
+  //   - the user manually dragged it within the override window.
   function setTargets(next) {
     const now = performance.now();
     for (const [name, v] of Object.entries(next || {})) {
       if (!(name in current)) continue;
+      if (locked.has(name)) continue;
       if (overrideUntil[name] && overrideUntil[name] > now) continue;
       target[name] = Math.max(0, Math.min(1, v));
     }
   }
 
-  // Manual slider path — snaps current to the value and holds.
+  // Manual slider path — always applies, even for locked knobs (a lock
+  // without manual control would be useless). Dragging is how you set
+  // the held value.
   function setManual(name, v) {
     if (!(name in current)) return;
     const clamped = Math.max(0, Math.min(1, v));
@@ -104,6 +129,30 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
     target[name] = clamped;
     overrideUntil[name] = performance.now() + OVERRIDE_HOLD_MS;
     window.viz.knob[name] = clamped;
+  }
+
+  // Lock / unlock individual primitives. Locks persist to localStorage.
+  function lock(name) {
+    if (!(name in current)) return;
+    locked.add(name);
+    persistLocks(locked);
+  }
+  function unlock(name) {
+    locked.delete(name);
+    persistLocks(locked);
+  }
+  function toggleLock(name) {
+    if (locked.has(name)) locked.delete(name);
+    else if (name in current) locked.add(name);
+    persistLocks(locked);
+    return locked.has(name);
+  }
+  function isLocked(name) { return locked.has(name); }
+  function lockedNames() { return [...locked]; }
+  function setAllLocked(shouldLock) {
+    if (shouldLock) for (const n of KNOB_NAMES) locked.add(n);
+    else locked.clear();
+    persistLocks(locked);
   }
 
   // Call once per animation frame. Eases every knob toward its target
@@ -134,5 +183,6 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
   return {
     setTargets, setManual, tick, get, getTarget, snapshot,
     setTransition, getTransition,
+    lock, unlock, toggleLock, isLocked, lockedNames, setAllLocked,
   };
 }

--- a/soundscape-v3/css/app.css
+++ b/soundscape-v3/css/app.css
@@ -260,6 +260,23 @@ html, body {
   letter-spacing: var(--tracking-wide);
 }
 
+/* Section header with an action button on the right */
+.section__head {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: var(--space-3);
+}
+.section__head .section__title { margin-bottom: 0; }
+.btn--ghost {
+  background: transparent;
+  border-color: var(--gray-500);
+  color: var(--gray-600);
+}
+.btn--ghost:hover {
+  background: transparent;
+  color: var(--color-white);
+  border-color: var(--color-white);
+}
+
 /* Knob sliders (Stage 3.5) — 0..1 one-sided version of the axis track */
 .knob { margin-bottom: var(--space-3); }
 .knob__header {
@@ -271,7 +288,25 @@ html, body {
   color: var(--gray-600);
   text-transform: uppercase;
   letter-spacing: var(--tracking-wide);
+  display: inline-flex; align-items: center; gap: var(--space-2);
 }
+/* Per-knob lock toggle — circle glyph, fills when locked */
+.knob__lock {
+  background: transparent;
+  border: none;
+  color: var(--gray-500);
+  font-size: 10px;
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  transition: color var(--duration-normal) var(--ease-default);
+}
+.knob__lock:hover { color: var(--color-white); }
+.knob.is-locked .knob__lock { color: var(--accent-amber); }
+.knob.is-locked .knob__lock:hover { color: var(--color-white); }
+/* Locked handle takes on the amber accent so it's unmistakable at a glance */
+.knob.is-locked .knob__handle { background: var(--accent-amber); }
+.knob.is-locked .knob__fill { background: var(--accent-amber); }
 .knob__value {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/soundscape-v3/index.html
+++ b/soundscape-v3/index.html
@@ -88,7 +88,10 @@
     </section>
 
     <section class="section">
-      <h3 class="section__title">Primitives</h3>
+      <div class="section__head">
+        <h3 class="section__title">Primitives</h3>
+        <button class="btn btn--sm btn--ghost" id="knobs-lock-all" title="Lock / unlock all primitives">lock all</button>
+      </div>
       <div id="knobs-panel"></div>
     </section>
 
@@ -185,9 +188,15 @@
       for (const name of KNOB_NAMES) {
         const row = document.createElement("div");
         row.className = "knob";
+        if (knobBus.isLocked(name)) row.classList.add("is-locked");
         row.innerHTML = `
           <div class="knob__header">
-            <span class="knob__name">${name}</span>
+            <span class="knob__name">
+              <button class="knob__lock" data-knob-lock aria-label="lock ${name}" title="lock ${name}">
+                <span class="knob__lock-icon">${knobBus.isLocked(name) ? "●" : "○"}</span>
+              </button>
+              ${name}
+            </span>
             <span class="knob__value" data-knob-v>0.50</span>
           </div>
           <div class="knob__track" data-knob-track role="slider"
@@ -199,16 +208,50 @@
         `;
         knobsPanel.appendChild(row);
         const track = row.querySelector("[data-knob-track]");
+        const lockBtn = row.querySelector("[data-knob-lock]");
+        const lockIcon = row.querySelector(".knob__lock-icon");
         knobEls.set(name, {
           row,
           value: row.querySelector("[data-knob-v]"),
           fill: row.querySelector("[data-knob-f]"),
           handle: row.querySelector("[data-knob-h]"),
           track,
+          lockBtn,
+          lockIcon,
+        });
+        lockBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          const isNowLocked = knobBus.toggleLock(name);
+          row.classList.toggle("is-locked", isNowLocked);
+          lockIcon.textContent = isNowLocked ? "●" : "○";
+          updateLockAllButton();
         });
         wireKnobDrag(track, name);
       }
+      updateLockAllButton();
     }
+
+    // Bulk lock/unlock affordance in the section header. Label reflects
+    // the current state: "lock all" when everything's unlocked or mixed,
+    // "unlock all" when everything's locked.
+    const lockAllBtn = $("knobs-lock-all");
+    function updateLockAllButton() {
+      const all = KNOB_NAMES.every((n) => knobBus.isLocked(n));
+      lockAllBtn.textContent = all ? "unlock all" : "lock all";
+    }
+    lockAllBtn.addEventListener("click", () => {
+      const all = KNOB_NAMES.every((n) => knobBus.isLocked(n));
+      knobBus.setAllLocked(!all);
+      // Sync every row's UI
+      for (const name of KNOB_NAMES) {
+        const el = knobEls.get(name);
+        if (!el) continue;
+        const isNowLocked = knobBus.isLocked(name);
+        el.row.classList.toggle("is-locked", isNowLocked);
+        el.lockIcon.textContent = isNowLocked ? "●" : "○";
+      }
+      updateLockAllButton();
+    });
     function wireKnobDrag(track, name) {
       function setFromPointer(ev) {
         const rect = track.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Each primitive in the sidebar now has a per-knob lock toggle (small circle → filled amber circle).
- Locked knobs ignore LLM compile results and preset-button clicks. Manual drags still work (that's how you set the held value).
- Bulk 'lock all' / 'unlock all' button in the Primitives section header.
- State persists to `localStorage.ss.knobLocks.v1` — survives refresh.
- Visually: locked knobs use the amber accent color on both the fill and handle, so it's unmistakable at a glance.

Source: github.com/fikei/soundscape commit `1f9566a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)