### PR TITLE
soundscape-v3: per-primitive audio routing (patch-bay)

### DIFF
--- a/soundscape-v3/control/knobs.js
+++ b/soundscape-v3/control/knobs.js
@@ -71,8 +71,11 @@ export const DEFAULT_TRANSITION = "smooth";
 // Manual override: while active, ignore LLM/preset writes to this knob.
 const OVERRIDE_HOLD_MS = 2500;
 
+import { sampleSource, DEFAULT_ROUTING, AUDIO_SOURCES } from "./sources.js";
+
 const LOCK_STORAGE_KEY = "ss.knobLocks.v1";
 const TRANS_STORAGE_KEY = "ss.transition";
+const ROUTING_STORAGE_KEY = "ss.knobRouting.v1";
 
 function loadLocks() {
   try {
@@ -90,20 +93,60 @@ function persistLocks(set) {
   } catch (e) {}
 }
 
+function loadRouting() {
+  try {
+    const raw = localStorage.getItem(ROUTING_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return typeof parsed === "object" ? parsed : null;
+  } catch (e) {
+    return null;
+  }
+}
+function persistRouting(routing) {
+  try {
+    localStorage.setItem(ROUTING_STORAGE_KEY, JSON.stringify(routing));
+  } catch (e) {}
+}
+
 export function createKnobBus(initial = DEFAULT_KNOBS) {
-  const current = {};
+  const current = {};        // final routed value (what engine reads)
+  const baseline = {};       // eased-toward-target static value before routing
   const target = {};
   const overrideUntil = {};
   const locked = loadLocks();        // Set<knobName>
+  // Per-knob audio-source routing. Each entry is { source, intensity }.
+  // Loaded from localStorage if present, else the built-in defaults that
+  // mirror the hardcoded reactivity engine.js used to have.
+  const routing = Object.fromEntries(
+    KNOB_NAMES.map((n) => {
+      const d = DEFAULT_ROUTING[n] || { source: "none", intensity: 0 };
+      return [n, { source: d.source, intensity: d.intensity }];
+    }),
+  );
+  const stored = loadRouting();
+  if (stored) {
+    for (const n of KNOB_NAMES) {
+      if (!stored[n]) continue;
+      if (typeof stored[n].source === "string" && AUDIO_SOURCES[stored[n].source]) {
+        routing[n].source = stored[n].source;
+      }
+      if (typeof stored[n].intensity === "number") {
+        routing[n].intensity = Math.max(0, Math.min(1, stored[n].intensity));
+      }
+    }
+  }
   let transitionMode = DEFAULT_TRANSITION;
 
   window.viz = window.viz || {};
   window.viz.knob = window.viz.knob || {};
 
   for (const name of KNOB_NAMES) {
-    current[name] = initial[name] ?? 0.5;
-    target[name] = initial[name] ?? 0.5;
-    window.viz.knob[name] = current[name];
+    const v = initial[name] ?? 0.5;
+    current[name] = v;
+    baseline[name] = v;
+    target[name] = v;
+    window.viz.knob[name] = v;
   }
 
   // LLM / preset button path. A write is rejected if:
@@ -121,15 +164,22 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
 
   // Manual slider path — always applies, even for locked knobs (a lock
   // without manual control would be useless). Dragging is how you set
-  // the held value.
+  // the held value. Snaps baseline + target so routing wraps around the
+  // new set-point on the next tick.
   function setManual(name, v) {
     if (!(name in current)) return;
     const clamped = Math.max(0, Math.min(1, v));
+    baseline[name] = clamped;
     current[name] = clamped;
     target[name] = clamped;
     overrideUntil[name] = performance.now() + OVERRIDE_HOLD_MS;
     window.viz.knob[name] = clamped;
   }
+
+  // Baseline = static set-point after target easing but before audio
+  // routing. This is what the sidebar slider should display, so the
+  // handle reflects "what's set" without jiggling with every kick.
+  function getBaseline(name) { return baseline[name] ?? 0; }
 
   // Lock / unlock individual primitives. Locks persist to localStorage.
   function lock(name) {
@@ -155,19 +205,32 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
     persistLocks(locked);
   }
 
-  // Call once per animation frame. Eases every knob toward its target
-  // at the currently selected transition rate.
+  // Call once per animation frame. Two-stage update:
+  //   1. baseline eases toward target at the user-selected transition rate
+  //      (this is the slow, intent-driven layer — LLM, preset, drag).
+  //   2. final = clamp(baseline + audioSource * intensity, 0, 1)
+  //      (fast, music-reactive layer — no easing so music response is live).
+  // The engine reads window.viz.knob which always contains the final value.
   function tick() {
     const ease = TRANSITION_MODES[transitionMode]?.ease ?? 0.04;
     for (const name of KNOB_NAMES) {
-      const c = current[name];
+      // Stage 1: baseline
+      const b = baseline[name];
       const t = target[name];
-      if (Math.abs(t - c) < 1e-4 || ease >= 1) {
-        current[name] = t;
+      if (Math.abs(t - b) < 1e-4 || ease >= 1) {
+        baseline[name] = t;
       } else {
-        current[name] = c + (t - c) * ease;
+        baseline[name] = b + (t - b) * ease;
       }
-      window.viz.knob[name] = current[name];
+      // Stage 2: apply audio-source routing on top
+      const r = routing[name] || { source: "none", intensity: 0 };
+      const sig = r.intensity > 0 ? sampleSource(r.source) : 0;
+      const final = Math.max(
+        0,
+        Math.min(1, baseline[name] + sig * r.intensity),
+      );
+      current[name] = final;
+      window.viz.knob[name] = final;
     }
   }
 
@@ -175,6 +238,20 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
     if (TRANSITION_MODES[mode]) transitionMode = mode;
   }
   function getTransition() { return transitionMode; }
+
+  function setSource(name, sourceKey) {
+    if (!(name in routing)) return;
+    if (!AUDIO_SOURCES[sourceKey]) return;
+    routing[name].source = sourceKey;
+    persistRouting(routing);
+  }
+  function setIntensity(name, v) {
+    if (!(name in routing)) return;
+    routing[name].intensity = Math.max(0, Math.min(1, v));
+    persistRouting(routing);
+  }
+  function getSource(name) { return routing[name]?.source ?? "none"; }
+  function getIntensity(name) { return routing[name]?.intensity ?? 0; }
 
   function get(name) { return current[name] ?? 0; }
   function getTarget(name) { return target[name] ?? 0; }
@@ -184,5 +261,7 @@ export function createKnobBus(initial = DEFAULT_KNOBS) {
     setTargets, setManual, tick, get, getTarget, snapshot,
     setTransition, getTransition,
     lock, unlock, toggleLock, isLocked, lockedNames, setAllLocked,
+    setSource, setIntensity, getSource, getIntensity,
+    getBaseline,
   };
 }

--- a/soundscape-v3/control/sources.js
+++ b/soundscape-v3/control/sources.js
@@ -1,0 +1,110 @@
+// Audio-source routing catalog.
+//
+// Each knob in the primitives bus can be bound to one of these sources.
+// Per frame the engine resolves each knob as
+//   final = clamp(target + normalize(source, viz) * intensity, 0, 1)
+// so the source effectively adds a live wobble on top of the LLM/preset-set
+// baseline value. A source of "none" (intensity 0) means the knob stays at
+// its static target.
+//
+// Every normalize() must return a value in roughly [-1, +1] so the
+// intensity slider has consistent meaning across sources.
+
+export const AUDIO_SOURCES = {
+  none: {
+    label: "none",
+    group: "basic",
+    description: "static, no music modulation",
+    normalize: () => 0,
+  },
+
+  // --- loudness / level -------------------------------------------------
+  energy: {
+    label: "energy",
+    group: "level",
+    description: "broadband loudness (RMS)",
+    // 0..1 → -1..+1 so the knob is nudged up when louder than average,
+    // down when quieter.
+    normalize: (v) => (v.energy ?? 0) * 2 - 1,
+  },
+
+  // --- frequency bands --------------------------------------------------
+  low: {
+    label: "bass (low)",
+    group: "bands",
+    description: "20–250 Hz — kick, sub, bassline",
+    normalize: (v) => (v.low ?? 0) * 2 - 1,
+  },
+  mid: {
+    label: "mid",
+    group: "bands",
+    description: "250 Hz–4 kHz — vocals, body",
+    normalize: (v) => (v.mid ?? 0) * 2 - 1,
+  },
+  high: {
+    label: "high",
+    group: "bands",
+    description: "4 kHz+ — hats, shimmer, air",
+    normalize: (v) => (v.high ?? 0) * 2 - 1,
+  },
+
+  // --- rhythm / transients ---------------------------------------------
+  transient: {
+    label: "transient",
+    group: "rhythm",
+    description: "kick/snare onset envelope (fast decay)",
+    // 0..1 envelope; peaks at onsets, decays. Always additive (+), so
+    // transient pushes knobs UP on hits and returns to baseline.
+    normalize: (v) => v.transient ?? 0,
+  },
+  beat: {
+    label: "beat",
+    group: "rhythm",
+    description: "sine pulse aligned to detected tempo",
+    // Oscillates -1..+1 once per beat. Good for breathing/swing effects.
+    normalize: (v) => Math.sin((v.beat_phase ?? 0) * Math.PI * 2),
+  },
+
+  // --- spectral ---------------------------------------------------------
+  brightness: {
+    label: "brightness",
+    group: "spectral",
+    description: "spectral centroid (bright ↔ dark)",
+    normalize: (v) => (v.brightness ?? 0.3) * 2 - 1,
+  },
+};
+
+// Ordered groups for the dropdown UI.
+export const SOURCE_GROUPS = [
+  { id: "basic", label: "basic" },
+  { id: "level", label: "level" },
+  { id: "bands", label: "frequency bands" },
+  { id: "rhythm", label: "rhythm" },
+  { id: "spectral", label: "spectral" },
+];
+
+export function sampleSource(sourceKey, viz = window.viz) {
+  const src = AUDIO_SOURCES[sourceKey];
+  if (!src) return 0;
+  try {
+    return src.normalize(viz);
+  } catch (e) {
+    return 0;
+  }
+}
+
+// Default per-knob routing — matches the hardcoded routing that engine.js
+// used to have, so behavior with zero user config is equivalent to before.
+// LLM compiles / preset clicks can override these.
+export const DEFAULT_ROUTING = {
+  speed:      { source: "beat",       intensity: 0.1 },
+  response:   { source: "energy",     intensity: 0.15 },
+  density:    { source: "low",        intensity: 0.12 },
+  symmetry:   { source: "none",       intensity: 0 },
+  softness:   { source: "none",       intensity: 0 },
+  noise:      { source: "high",       intensity: 0.2 },
+  scale:      { source: "mid",        intensity: 0.1 },
+  saturation: { source: "energy",     intensity: 0.1 },
+  contrast:   { source: "transient",  intensity: 0.25 },
+  feedback:   { source: "none",       intensity: 0 },
+};

--- a/soundscape-v3/css/app.css
+++ b/soundscape-v3/css/app.css
@@ -307,6 +307,50 @@ html, body {
 /* Locked handle takes on the amber accent so it's unmistakable at a glance */
 .knob.is-locked .knob__handle { background: var(--accent-amber); }
 .knob.is-locked .knob__fill { background: var(--accent-amber); }
+
+/* Per-knob audio routing: source dropdown + intensity mini-slider */
+.knob__route {
+  display: flex; align-items: center; gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+.knob__source {
+  flex: 0 0 auto;
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 1px solid var(--gray-400);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  padding: 2px var(--space-2);
+  appearance: none;
+  -webkit-appearance: none;
+  text-transform: none;
+  letter-spacing: 0;
+  max-width: 110px;
+  cursor: pointer;
+}
+.knob__source:hover { border-color: var(--color-white); }
+.knob__source:focus { outline: none; box-shadow: 0 0 0 1px var(--color-white); }
+.knob__intensity {
+  flex: 1 1 auto;
+  position: relative;
+  height: 12px;
+  cursor: ew-resize;
+  touch-action: none;
+  display: flex; align-items: center;
+}
+.knob__intensity-rail {
+  position: absolute; left: 0; right: 0; top: 50%;
+  height: 1px; transform: translateY(-50%);
+  background: var(--gray-400);
+  pointer-events: none;
+}
+.knob__intensity-fill {
+  position: absolute; top: 50%; left: 0;
+  height: 1px; width: 0;
+  transform: translateY(-50%);
+  background: var(--color-white);
+  pointer-events: none;
+}
 .knob__value {
   font-family: var(--font-mono);
   font-size: var(--text-xs);

--- a/soundscape-v3/index.html
+++ b/soundscape-v3/index.html
@@ -117,6 +117,7 @@
       createKnobBus, DEFAULT_KNOBS, KNOB_NAMES, KNOB_PRESETS,
       TRANSITION_MODES, DEFAULT_TRANSITION,
     } from "./control/knobs.js";
+    import { AUDIO_SOURCES, SOURCE_GROUPS } from "./control/sources.js";
     import { compilePrompt, fileToImage, hexToNormRGB } from "./llm/compiler.js";
 
     // ---------- shared /viz/ state ----------
@@ -188,6 +189,33 @@
     const knobBus = createKnobBus(DEFAULT_KNOBS);
     const knobsPanel = $("knobs-panel");
     const knobEls = new Map();
+    // Build grouped <option> tags once — same for every knob row.
+    function buildSourceOptionsHtml() {
+      const byGroup = {};
+      for (const [key, s] of Object.entries(AUDIO_SOURCES)) {
+        (byGroup[s.group] ||= []).push({ key, ...s });
+      }
+      let html = "";
+      for (const g of SOURCE_GROUPS) {
+        const items = byGroup[g.id];
+        if (!items || items.length === 0) continue;
+        if (g.id === "basic") {
+          // "none" at top with no group label
+          html += items
+            .map((s) => `<option value="${s.key}">${s.label}</option>`)
+            .join("");
+        } else {
+          html += `<optgroup label="${g.label}">`;
+          html += items
+            .map((s) => `<option value="${s.key}">${s.label}</option>`)
+            .join("");
+          html += `</optgroup>`;
+        }
+      }
+      return html;
+    }
+    const sourceOptionsHtml = buildSourceOptionsHtml();
+
     function renderKnobPanel() {
       knobsPanel.innerHTML = "";
       knobEls.clear();
@@ -195,6 +223,8 @@
         const row = document.createElement("div");
         row.className = "knob";
         if (knobBus.isLocked(name)) row.classList.add("is-locked");
+        const curSource = knobBus.getSource(name);
+        const curIntensity = knobBus.getIntensity(name);
         row.innerHTML = `
           <div class="knob__header">
             <span class="knob__name">
@@ -211,11 +241,28 @@
             <span class="knob__fill" data-knob-f></span>
             <span class="knob__handle" data-knob-h></span>
           </div>
+          <div class="knob__route">
+            <select class="knob__source" data-knob-source aria-label="${name} audio source">
+              ${sourceOptionsHtml}
+            </select>
+            <div class="knob__intensity" data-knob-intensity-track role="slider"
+                 aria-label="${name} intensity" aria-valuemin="0" aria-valuemax="1"
+                 aria-valuenow="${curIntensity.toFixed(2)}" tabindex="0"
+                 title="how strongly '${curSource}' modulates ${name}">
+              <div class="knob__intensity-rail"></div>
+              <span class="knob__intensity-fill" data-knob-intensity-fill></span>
+            </div>
+          </div>
         `;
         knobsPanel.appendChild(row);
         const track = row.querySelector("[data-knob-track]");
         const lockBtn = row.querySelector("[data-knob-lock]");
         const lockIcon = row.querySelector(".knob__lock-icon");
+        const sourceSel = row.querySelector("[data-knob-source]");
+        const intensityTrack = row.querySelector("[data-knob-intensity-track]");
+        const intensityFill = row.querySelector("[data-knob-intensity-fill]");
+        sourceSel.value = curSource;
+        intensityFill.style.width = (curIntensity * 100) + "%";
         knobEls.set(name, {
           row,
           value: row.querySelector("[data-knob-v]"),
@@ -224,6 +271,9 @@
           track,
           lockBtn,
           lockIcon,
+          sourceSel,
+          intensityTrack,
+          intensityFill,
         });
         lockBtn.addEventListener("click", (e) => {
           e.stopPropagation();
@@ -232,7 +282,13 @@
           lockIcon.textContent = isNowLocked ? "●" : "○";
           updateLockAllButton();
         });
+        sourceSel.addEventListener("change", () => {
+          knobBus.setSource(name, sourceSel.value);
+          intensityTrack.title =
+            `how strongly '${sourceSel.value}' modulates ${name}`;
+        });
         wireKnobDrag(track, name);
+        wireIntensityDrag(intensityTrack, intensityFill, name);
       }
       updateLockAllButton();
     }
@@ -283,6 +339,39 @@
         else return;
         e.preventDefault();
         knobBus.setManual(name, v);
+      });
+    }
+
+    // Intensity mini-slider: 0..1, clicked+dragged inline. Writes straight
+    // through to knobBus.setIntensity which persists to localStorage.
+    function wireIntensityDrag(track, fill, name) {
+      function setFromPointer(ev) {
+        const rect = track.getBoundingClientRect();
+        const x = (ev.clientX - rect.left) / rect.width;
+        const v = Math.max(0, Math.min(1, x));
+        knobBus.setIntensity(name, v);
+        fill.style.width = (v * 100) + "%";
+        track.setAttribute("aria-valuenow", v.toFixed(2));
+      }
+      track.addEventListener("pointerdown", (e) => {
+        track.setPointerCapture(e.pointerId);
+        setFromPointer(e);
+      });
+      track.addEventListener("pointermove", (e) => {
+        if (e.buttons & 1) setFromPointer(e);
+      });
+      track.addEventListener("keydown", (e) => {
+        const step = e.shiftKey ? 0.1 : 0.04;
+        const cur = knobBus.getIntensity(name);
+        let v = cur;
+        if (e.key === "ArrowRight" || e.key === "ArrowUp") v = Math.min(1, cur + step);
+        else if (e.key === "ArrowLeft" || e.key === "ArrowDown") v = Math.max(0, cur - step);
+        else if (e.key === "Home") v = 0;
+        else if (e.key === "End") v = 1;
+        else return;
+        e.preventDefault();
+        knobBus.setIntensity(name, v);
+        fill.style.width = (v * 100) + "%";
       });
     }
     renderKnobPanel();
@@ -763,13 +852,16 @@
           clapRows +
           `<hr class="hud__hr"><div class="hud__row"><span class="hud__k">fps</span><span class="hud__v">${fmt(fps, 1)}</span></div>`;
       }
-      // Tick knob bus — every frame eases current knob values toward their
-      // targets at the active transition rate. This is what makes every
-      // visual change a glide instead of a cut.
+      // Tick knob bus — every frame eases baseline toward target and
+      // applies audio-source routing. window.viz.knob holds the final
+      // routed values the engine actually reads.
       knobBus.tick();
-      // Repaint sidebar meters (axes + knobs) at rAF rate.
+      // Repaint sidebar meters: axes use their smoothed values. Knob
+      // sliders show BASELINE (the user/LLM set-point) so the handle
+      // doesn't jiggle with music routing — routing moves the visual,
+      // not the UI.
       for (const [name, v] of Object.entries(window.viz.axis || {})) paintAxis(name, v);
-      for (const [name, v] of Object.entries(window.viz.knob || {})) paintKnob(name, v);
+      for (const name of Object.keys(window.viz.knob || {})) paintKnob(name, knobBus.getBaseline(name));
       requestAnimationFrame(updateHud);
     }
     requestAnimationFrame(updateHud);

--- a/soundscape-v3/visuals/engine.js
+++ b/soundscape-v3/visuals/engine.js
@@ -61,21 +61,17 @@ window.loadEngine = function loadEngine() {
     alive() * (speedK() * 0.03 + Math.sin(viz.beat_phase * Math.PI * 2) * 0.01 * responseK());
   const scrollYSpeed = () => alive() * speedK() * 0.025;
 
-  // Frequency-band response: bass drives low-freq modulation, highs drive
-  // texture detail. Each weighted by `response` so the LLM can turn down
-  // music-reactivity without zeroing out the musical information.
-  const lowDrive = () => (viz.low ?? 0) * responseK();
-  const midDrive = () => (viz.mid ?? 0) * responseK();
-  const highDrive = () => (viz.high ?? 0) * responseK();
+  // Per-band routing is no longer hardcoded — users (and eventually the
+  // LLM) route audio sources to specific knobs via the Primitives panel.
+  // Each knob's `viz.knob[name]` already reflects baseline + routing,
+  // so here we just read k(...) and trust the routing layer. The engine
+  // still reads energy / transient / beat_phase directly because they're
+  // inherent to the visual language (alive-gate on silence, onset flash).
 
-  // Noise parameters: `noise` knob sets depth; bass modulates speed (slow
-  // bass → slow wobble), highs add fine texture.
-  const noiseSpeedF = () => 0.04 + speedK() * 0.15 + highDrive() * 0.3;
-  const noiseFreqF = () => 1 + k("noise") * 2.5 + lowDrive() * 1.5;
+  const noiseSpeedF = () => 0.04 + speedK() * 0.2;
+  const noiseFreqF = () => 1 + k("noise") * 3.5;
   const modAmount = () =>
-    k("noise") * 0.35 * alive() +
-    pulseAmt() * 0.25 * responseK() +
-    midDrive() * 0.08;
+    k("noise") * 0.4 * alive() + pulseAmt() * 0.25 * responseK();
 
   // ----- color --------------------------------------------------------------
 


### PR DESCRIPTION
Brings the v1 soundscape control-panel pattern to v3: each primitive knob has a user-assignable audio source and intensity. Source catalog: energy, low/mid/high freq bands, transient, beat, brightness. Engine no longer hardcodes band routing; user (and eventually LLM) decides which primitive responds to which audio dimension.

Source: github.com/fikei/soundscape commit `2534f73`.