### PR TITLE
soundscape-v3: hue primitive + fullscreen/resize fix

### DIFF
--- a/soundscape-v3/control/knobs.js
+++ b/soundscape-v3/control/knobs.js
@@ -20,6 +20,7 @@ export const KNOB_NAMES = [
   "noise",        // 0..1  noise modulation depth
   "scale",        // 0..1  pattern size
   // Appearance
+  "hue",          // 0..1  hue rotation; 0.5 = neutral, 0 = -π, 1 = +π
   "saturation",   // 0..1
   "contrast",     // 0..1
   "feedback",     // 0..1  persistence / frame blend
@@ -35,6 +36,7 @@ export const DEFAULT_KNOBS = {
   softness: 0.85,
   noise: 0.35,
   scale: 0.55,
+  hue: 0.5,           // 0.5 = no rotation; 0 = -π, 1 = +π
   saturation: 0.55,
   contrast: 0.45,
   feedback: 0.65,
@@ -45,15 +47,15 @@ export const DEFAULT_KNOBS = {
 export const KNOB_PRESETS = {
   drift: {
     speed: 0.2, response: 0.55, density: 0.3, symmetry: 0.2, softness: 0.92,
-    noise: 0.4, scale: 0.55, saturation: 0.5, contrast: 0.4, feedback: 0.78,
+    noise: 0.4, scale: 0.55, hue: 0.5, saturation: 0.5, contrast: 0.4, feedback: 0.78,
   },
   pulse: {
     speed: 0.55, response: 0.8, density: 0.7, symmetry: 0.55, softness: 0.25,
-    noise: 0.5, scale: 0.5, saturation: 0.68, contrast: 0.65, feedback: 0.4,
+    noise: 0.5, scale: 0.5, hue: 0.5, saturation: 0.68, contrast: 0.65, feedback: 0.4,
   },
   minimal: {
     speed: 0.15, response: 0.45, density: 0.15, symmetry: 0.15, softness: 0.95,
-    noise: 0.2, scale: 0.7, saturation: 0.35, contrast: 0.35, feedback: 0.85,
+    noise: 0.2, scale: 0.7, hue: 0.5, saturation: 0.35, contrast: 0.35, feedback: 0.85,
   },
 };
 

--- a/soundscape-v3/control/sources.js
+++ b/soundscape-v3/control/sources.js
@@ -104,6 +104,7 @@ export const DEFAULT_ROUTING = {
   softness:   { source: "none",       intensity: 0 },
   noise:      { source: "high",       intensity: 0.2 },
   scale:      { source: "mid",        intensity: 0.1 },
+  hue:        { source: "none",       intensity: 0 },
   saturation: { source: "energy",     intensity: 0.1 },
   contrast:   { source: "transient",  intensity: 0.25 },
   feedback:   { source: "none",       intensity: 0 },

--- a/soundscape-v3/index.html
+++ b/soundscape-v3/index.html
@@ -561,20 +561,45 @@
       localStorage.setItem("ss.transition", transitionSel.value);
     });
 
+    let hydraInstance = null;
     function initHydra() {
       const canvas = $("hydra-canvas");
+      // Size the canvas to the viewport, tell Hydra to resize its internal
+      // framebuffers, and reinstall the engine chain (Hydra drops the
+      // chain when resolution changes — buffer size changes are destructive).
       function sizeCanvas() {
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        canvas.width = w;
+        canvas.height = h;
+        if (hydraInstance) {
+          try {
+            // Hydra exposes setResolution for buffer resize. We pass the
+            // CSS pixel size; pixelDensity is baked in.
+            if (typeof hydraInstance.setResolution === "function") {
+              hydraInstance.setResolution(w, h);
+            } else if (hydraInstance.synth && hydraInstance.synth.setResolution) {
+              hydraInstance.synth.setResolution(w, h);
+            }
+            // Reinstall the chain so the new resolution takes effect.
+            if (typeof window.loadEngine === "function") window.loadEngine();
+          } catch (e) {
+            console.warn("[resize] hydra resize failed:", e);
+          }
+        }
       }
       sizeCanvas();
       window.addEventListener("resize", sizeCanvas);
+      // fullscreenchange doesn't always trigger resize on every browser —
+      // wire it explicitly so entering/leaving fullscreen updates the canvas.
+      document.addEventListener("fullscreenchange", sizeCanvas);
+      document.addEventListener("webkitfullscreenchange", sizeCanvas);
+
       // pixelDensity 0.6 renders the Hydra chain at ~36% of the native
-      // pixel count, then CSS upscales. That's a 2.8× GPU speedup — huge
-      // on large canvases (1440×756 = 1.1M px) — and invisible for the
-      // abstract visuals we're producing. Bump up if the image looks too
-      // blurry on a specific machine (up to 1.0).
-      new Hydra({
+      // pixel count, then CSS upscales. ~2.8× GPU speedup; invisible for
+      // the abstract visuals we're producing. Bump to 1.0 if sharpness
+      // matters on a specific machine.
+      hydraInstance = new Hydra({
         canvas,
         detectAudio: false,
         enableStreamCapture: false,

--- a/soundscape-v3/visuals/engine.js
+++ b/soundscape-v3/visuals/engine.js
@@ -138,6 +138,11 @@ window.loadEngine = function loadEngine() {
     .saturate(saturate)
     .contrast(contrastF)
     .brightness(brightnessAdj)
+    // `hue` knob rotates the color wheel post-color. 0.5 = neutral,
+    // 0 = -π (backward), 1 = +π (forward). Since hue is circular, 0 and
+    // 1 land on the same visual result; the knob just lets the user
+    // slide in either direction from neutral.
+    .hue(() => (k("hue") - 0.5) * Math.PI * 2)
     .kaleid(kaleidN)
     .blend(o0, feedbackAmt)
     .out();


### PR DESCRIPTION
Adds hue as the 11th primitive knob (rotates Hydra .hue() post-color) and fixes the reported canvas resize/fullscreen centering issue by calling hydra.setResolution + reinstalling the engine chain on window resize.

Source: github.com/fikei/soundscape commit `013091f`.