### PR TITLE
soundscape-v3: better prod error; worker port available for deploy

### DIFF
--- a/soundscape-v3/llm/compiler.js
+++ b/soundscape-v3/llm/compiler.js
@@ -81,12 +81,20 @@ export async function compilePrompt({
       body: JSON.stringify({ text, images }),
     });
   } catch (e) {
-    // Network failure (proxy not running, CORS, offline). Surface a useful
-    // message; this is the common case in a fresh production deploy.
-    throw new Error(
-      `proxy unreachable at ${proxyUrl} — run server/proxy.js locally, ` +
-      `or set localStorage.ss.proxyUrl to a hosted compile endpoint`
-    );
+    // Network failure — tailor the message to the context. On a deployed
+    // host "run server/proxy.js locally" is useless advice; point at the
+    // hosted proxy config. On localhost, the usual local-dev advice applies.
+    const isLocal =
+      location.hostname === "localhost" || location.hostname === "127.0.0.1";
+    const msg = isLocal
+      ? `proxy unreachable at ${proxyUrl} — run server/proxy.js locally, ` +
+        `or set localStorage.ss.proxyUrl to a hosted compile endpoint`
+      : `compile backend not configured for this deployment. ` +
+        `The site owner needs to either (a) deploy server/worker.js to ` +
+        `Cloudflare and set window.SS_PROXY_URL on the page, or (b) you ` +
+        `can run a local proxy and set localStorage.ss.proxyUrl to point ` +
+        `at it. See server/DEPLOY.md.`;
+    throw new Error(msg);
   }
   let data;
   try {


### PR DESCRIPTION
Two pieces:

1. Client: error message on prod no longer tells the user to 'run server/proxy.js locally' — that's useless advice on a deployed site. Now points at DEPLOY.md and explains the options.

2. Repo-side (not this PR): github.com/fikei/soundscape has a new server/worker.js + wrangler.toml + DEPLOY.md that you can deploy to Cloudflare Workers. Once deployed, add `<script>window.SS_PROXY_URL = '...'</script>` to soundscape-v3/index.html and Compile works for all visitors without a local process.

Source: github.com/fikei/soundscape commit `6415ae6`.