### PR TITLE
Remove 'Why this project' sections from case studies

### DIFF
--- a/design-systems/index.html
+++ b/design-systems/index.html
@@ -49,13 +49,6 @@
     </dl>
   </div>
 
-  <!-- WHY THIS PROJECT -->
-  <div class="d-why d-why--active" style="margin-top: 32px;">
-    <p class="d-why__label">Why this Project?</p>
-    <p class="d-why__headline">Early-stage velocity without early-stage debt.</p>
-    <p class="d-why__body">Roadrunner is in the two-year window where AI-native startups out-sprint incumbents. Shipping fast is the priority — but fast breaks consistency. Systemic is a tool I built to catch design drift automatically. It proves I think about the systems that let a small team scale quality without slowing down — exactly what a seed-stage product org needs.</p>
-  </div>
-
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>

--- a/field/index.html
+++ b/field/index.html
@@ -64,13 +64,6 @@
     </div>
   </div>
 
-  <!-- WHY THIS PROJECT -->
-  <div class="d-why d-why--dev" style="margin-top: 32px;">
-    <p class="d-why__label">Why this Project?</p>
-    <p class="d-why__headline">AI that structures messy input into compliant output — the same pattern as CPQ.</p>
-    <p class="d-why__body">Field takes unstructured voice and extracts structured, validated data in real time. That's the core challenge Roadrunner is solving: take a complex, ambiguous input (a deal) and produce a compliant, structured output (a quote). At an early-stage company co-developing with design partners, the interface IS the product. This project proves I can design AI-native flows from zero — where the model does the heavy lifting and the user confirms.</p>
-  </div>
-
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>

--- a/invoy/index.html
+++ b/invoy/index.html
@@ -52,13 +52,6 @@
     </dl>
   </div>
 
-  <!-- WHY THIS PROJECT — CPQ / Roadrunner angle -->
-  <div class="d-why d-why--shipped" style="margin-top: 48px; background: rgba(34, 197, 94, 0.06); border-left: 2px solid #22C55E;">
-    <p class="d-why__label" style="color: #22C55E;">Why this project?</p>
-    <p class="d-why__headline">Designing for lifecycle complexity — not just the first click.</p>
-    <p class="d-why__body">CPQ doesn't end at the quote. Renewals, upsells, and config changes are where the real complexity lives. Roadrunner is rebuilding the data model from the ground up — that means the full deal lifecycle, not just initial quoting. Invoy was the same problem: a multi-phase journey where each stage had different rules, motivations, and failure modes. This proves I can design for the full arc, not just the first screen.</p>
-  </div>
-
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>

--- a/livongo/index.html
+++ b/livongo/index.html
@@ -204,13 +204,6 @@
     </dl>
   </div>
 
-  <!-- WHY THIS PROJECT — CPQ angle -->
-  <div class="d-why d-why--shipped" style="margin-top: 32px;">
-    <p class="d-why__label">Why this project?</p>
-    <p class="d-why__headline">This is the same problem as CPQ.</p>
-    <p class="d-why__body">Programs are SKUs. Qualification rules are pricing rules. The registration flow is the quote. The spreadsheet is the same artifact that CPQ platforms replace with automated configuration. We replaced it with a system that reads upstream data and adapts the flow in real time.</p>
-  </div>
-
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>

--- a/portfolio/invoy-deprecated.html
+++ b/portfolio/invoy-deprecated.html
@@ -46,13 +46,6 @@
     </dl>
   </div>
 
-  <!-- WHY THIS PROJECT -->
-  <div class="d-why d-why--shipped" style="margin-top: 48px;">
-    <p class="d-why__label">Why this project?</p>
-    <p class="d-why__headline">The data existed. The coaching worked. Members just couldn't see it.</p>
-    <p class="d-why__body">Invoy already had the hard pieces — a breath sensor that measured fat burn, coaches who built weekly plans, and a carb-restriction protocol that worked. But the member-facing app didn't reflect any of it. Coaches set goals behind the scenes in an internal tool. Members checked in daily without knowing what they were working toward. Roughly 30% engaged beyond breath tests. The product had depth. The interface didn't.</p>
-  </div>
-
   <!-- FRAMING -->
   <div id="framing" class="d-section">
     <p class="d-label">Framing</p>


### PR DESCRIPTION
## Summary
- Removed "Why this project" blocks from invoy, livongo, field, design-systems, and portfolio/invoy-deprecated case studies

🤖 Generated with [Claude Code](https://claude.com/claude-code)