### PR TITLE
docs: PRD + technical design for /job product

### DIFF
--- a/docs/infrastructure/technical-design/job-product.md
+++ b/docs/infrastructure/technical-design/job-product.md
@@ -1,0 +1,472 @@
+# Technical Design: `/job` — Career KB + Pipeline Web Product
+
+**Version:** 1.0
+**Date:** 2026-05-08
+**Status:** Draft
+**PRD:** [`docs/strategy/prds/job-product.md`](../../strategy/prds/job-product.md)
+
+---
+
+## System overview
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  ctrl.rodeo/job/  (Jekyll-served static + vanilla JS)                    │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐                      │
+│  │ History     │  │ Vision      │  │ Jobs        │                      │
+│  │ (3-level    │  │ (resume     │  │ (pipeline + │                      │
+│  │  drilldown) │  │  + intent)  │  │  fit score) │                      │
+│  └─────────────┘  └─────────────┘  └─────────────┘                      │
+└────────────┬─────────────────┬─────────────────┬─────────────────────────┘
+             │                 │                 │
+             ▼                 ▼                 ▼
+   ┌───────────────────────────────────────────────────────┐
+   │  Supabase Edge Functions (Boards project)             │
+   │  ┌──────────┐  ┌──────────┐  ┌────────────┐  ┌─────┐ │
+   │  │ kb-read  │  │ kb-write │  │ jobs-pipe  │  │ fit │ │
+   │  └──────────┘  └──────────┘  └────────────┘  └─────┘ │
+   └────┬────────────────┬────────────────┬────────┬───────┘
+        │                │                │        │
+        ▼                ▼                ▼        │
+   ┌──────────┐   ┌──────────┐    ┌──────────┐    │
+   │ GitHub   │   │ GitHub   │    │ Google   │    │
+   │ raw.md   │   │ commit   │    │ Sheets   │    │
+   │ (read)   │   │ (write)  │    │ API      │    │
+   └──────────┘   └──────────┘    └──────────┘    │
+   fikei/job      fikei/job        Job Search      │
+                                  spreadsheet      │
+                                                   ▼
+                                          (computed in-process,
+                                           no external call)
+```
+
+---
+
+## Stack decisions
+
+| Layer | Choice | Why |
+|---|---|---|
+| Front-end | Jekyll + vanilla JS (no framework) | Matches existing ctrl.rodeo apps (Boards, Soundscape). No new tooling. |
+| Routing | Jekyll-generated HTML pages | Static at build time; pages exist on disk so SEO/sharing works. |
+| Data fetching | `fetch()` against Edge Functions | Same pattern as Boards. |
+| Auth | `auth/ctrl-auth.js` (existing) | Reuses session across ctrl.rodeo. Allowlist Ian's email. |
+| Backend | Supabase Edge Functions (Deno) | Existing infra. Service-account secrets live here. |
+| Styles | CSS custom properties + token files | Theme-swap via `data-theme` attr. |
+| Design system | Wise tokens (default) + CTRL tokens (alternate) | Both as separate `tokens-*.css` files. Component CSS reads from the abstract `--color-bg`, `--font-body`, etc. |
+
+---
+
+## Routes
+
+```
+/job/                    → redirect to /job/jobs/ (default landing)
+/job/history/            → resume view
+/job/history/{company}/  → company detail
+/job/history/{company}/{project}/ → project detail
+/job/history/skills/{skill}/      → skill detail
+/job/history/wins/{win}/          → win detail
+/job/vision/             → goals + intents view
+/job/jobs/               → pipeline table
+/job/jobs/{role-slug}/   → per-role detail (fit-score breakdown + linked KB)
+```
+
+Each route is a Jekyll layout that fetches data on load via Edge Function calls.
+
+---
+
+## Edge Functions
+
+All hosted on the **Boards Supabase project** (`yfhudwakpgzswiylhfbh`) for v1. Promote to dedicated project in v2.
+
+### `kb-read`
+
+`GET /functions/v1/kb-read?path={file_path}`
+
+Reads a markdown file from the `fikei/job` GitHub repo (private). Used by the Job History + Job Vision views.
+
+**Auth:** caller must be a signed-in allowlisted user.
+**Secrets:** `GITHUB_PAT` (read-only on `fikei/job`).
+**Response:** `{ content: string, sha: string, path: string }` — sha needed for safe writes (optimistic concurrency).
+
+**Caching:** Edge Function caches per-path response for 60 seconds (LRU in-memory) to avoid hammering GitHub raw on rapid drilldown navigation.
+
+### `kb-write`
+
+`POST /functions/v1/kb-write`
+Body: `{ path: string, content: string, baseSha: string, message?: string }`
+
+Writes a markdown file back to `fikei/job` via GitHub Contents API. Uses `baseSha` for optimistic concurrency — if the file changed since read, returns 409 with the new content for client-side merge.
+
+**Auth:** allowlisted user only.
+**Secrets:** `GITHUB_PAT` (read+write on `fikei/job`).
+**Commit:** authored as Ian via the PAT user. Commit message defaults to `chore: edit {path} via /job product`.
+**Cache invalidation:** clears the `kb-read` cache for that path on success.
+
+### `jobs-pipe`
+
+`GET /functions/v1/jobs-pipe`
+
+Returns the full pipeline view. In v1: reads from the Google Sheet via service account; computes fit scores; returns JSON.
+
+**Auth:** allowlisted user.
+**Secrets:**
+- `SHEETS_SERVICE_ACCOUNT_JSON` (the `claude-sheets@...` service account already shared with the Job Search sheet).
+- `JOB_SEARCH_SHEET_ID` (`1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU`).
+
+**Process:**
+1. Fetch Companies tab (`gid=0`) and Roles tab (`gid=958939782`) via the Sheets API.
+2. Pull current Vision (Goals & Intents markdown files) via `kb-read`.
+3. For each role: compute fit score (see `fit` function below).
+4. Return enriched rows: `{ ...rowFromSheet, fitScore, fitBreakdown, companyData }`.
+
+**Caching:** 5-minute response cache. The `/jobs` skill is the canonical writer to the sheet; cache TTL bounds staleness.
+
+`POST /functions/v1/jobs-pipe`
+Body: `{ row: number, status?: string, fitScoreOverride?: number, ... }`
+
+Writes back to a specific Roles row. Used for Status changes (Pass / Apply / Talking).
+
+### `fit`
+
+Internal module imported by `jobs-pipe`. Pure function:
+
+```ts
+function computeFitScore(role: Role, vision: Vision): {
+  score: number;       // 0–100
+  breakdown: {
+    title: number;     // 0–25
+    stage: number;     // 0–20
+    sector: number;    // 0–20
+    geo: number;       // 0–15
+    comp: number;      // 0–10
+    source: number;    // 0–5
+    network: number;   // 0–5
+  };
+  hardFails: string[]; // e.g. ['below seniority floor']
+}
+```
+
+**Hard fails** cap the score at 30. Otherwise, sum of weighted components.
+
+**Title scoring** (max 25):
+- "Founding PM" / "Product Lead" / "Senior PM" exact → 25
+- "Staff PM" / "Principal PM" / "Group PM" → 20
+- "Head of Product" → 22 (if co < 50 ppl) else 12
+- "Director of Product" → 15
+- "Product Manager" (no senior prefix) → 10 (cap if Ian's vision floor is "Senior+")
+- Anything containing deal-breaker terms → 0 with hardFail
+
+**Stage scoring** (max 20):
+- Pre-seed / seed / A / B / C → 20
+- D / E → 10
+- Public / mega-cap (without breakout) → 5 with hardFail
+
+**Sector scoring** (max 20):
+- Health / EdTech → 20
+- AI-native / SaaS / Fintech (in nice-to-have list) → 15
+- Adjacent → 10
+- Off-thesis → 0
+
+**Geo scoring** (max 15):
+- SF Bay Area / Remote US / NYC → 15
+- Hybrid elsewhere → 0 with hardFail
+
+**Comp scoring** (max 10):
+- Meets floor ($200k+ base) → 10
+- Below → 0
+- Unknown → 5
+
+**Source scoring** (max 5):
+- Network → 5
+- LinkedIn Saved → 4
+- LinkedIn Recommended → 3
+- From Company Pages → 2
+- Manual → 1
+
+**Network scoring** (max 5):
+- Investor in Ian's VCs tab → +3
+- Direct connection at the company (Network tab match) → +5
+
+---
+
+## Data sources (v1)
+
+| What | Where | Read by | Write by |
+|---|---|---|---|
+| Companies (KB) | `fikei/job/01-job-history/companies/*.md` | `kb-read` | `kb-write` |
+| Projects (KB) | `fikei/job/01-job-history/projects/*.md` | `kb-read` | `kb-write` |
+| Skills (KB) | `fikei/job/01-job-history/skills/*.md` | `kb-read` | `kb-write` |
+| Wins (KB) | `fikei/job/01-job-history/wins/*.md` | `kb-read` | `kb-write` |
+| Vision | `fikei/job/02-goals-intents/*.md` | `kb-read` | `kb-write` |
+| RELEVANCE (skill) | `~/.claude/skills/jobs/RELEVANCE.md` | local file (skill side) | manual sync |
+| Companies (pipeline) | Google Sheet, Companies tab | `jobs-pipe` | (read-only in v1; user edits sheet directly) |
+| Roles (pipeline) | Google Sheet, Roles tab | `jobs-pipe` | `jobs-pipe POST` (Status only) |
+
+**Vision ↔ RELEVANCE.md sync (v1):** out of band. When Ian edits Vision in the product, he separately edits `~/.claude/skills/jobs/RELEVANCE.md` to match. v2 unifies these.
+
+---
+
+## Data sources (v2 — Supabase-backed)
+
+Migrate to Postgres tables in the Boards project (or a new `career` project):
+
+```sql
+-- Career KB
+create table companies (
+  slug text primary key,
+  name text not null,
+  sector text,
+  stage_at_time text,
+  tenure_start date,
+  tenure_end date,         -- null = "Present"
+  location text,
+  body_md text,            -- the long-form narrative
+  updated_at timestamptz default now()
+);
+
+create table projects (
+  slug text primary key,
+  company_slug text references companies(slug),
+  title text not null,
+  start_date date,
+  end_date date,
+  role text,
+  team_size text,
+  status text,
+  body_md text,
+  updated_at timestamptz default now()
+);
+
+create table skills (
+  slug text primary key,
+  name text not null,
+  type text,               -- 'craft' | 'strategic' | 'technical' | 'leadership'
+  level text,              -- 'foundational' | 'working' | 'expert' | 'world-class'
+  years_practiced int,
+  body_md text,
+  updated_at timestamptz default now()
+);
+
+create table wins (
+  slug text primary key,
+  company_slug text references companies(slug),
+  project_slug text references projects(slug),
+  headline text not null,
+  body_md text,
+  metric_value text,       -- '+12%' / '10x' / '$X' for quick display
+  updated_at timestamptz default now()
+);
+
+create table project_skills (
+  project_slug text references projects(slug),
+  skill_slug text references skills(slug),
+  primary key (project_slug, skill_slug)
+);
+
+-- Vision (single-row table for v2; multi-vision in v3)
+create table vision (
+  id int primary key default 1 check (id = 1),
+  narrative_arc text,
+  target_titles text[],
+  target_stages text[],
+  target_sectors text[],
+  target_geographies text[],
+  comp_floor_base int,
+  comp_floor_total int,
+  deal_breakers text[],
+  raw_md text,             -- full markdown for round-trip with skill RELEVANCE.md
+  updated_at timestamptz default now()
+);
+
+-- Pipeline
+create table tracked_companies (
+  slug text primary key,
+  name text not null,
+  sector text,
+  presence text,
+  website_url text,
+  careers_url text,
+  ats text,                -- 'Greenhouse' | 'Ashby' | 'Lever' | 'Workday' | 'Other'
+  ats_slug text,           -- the company-specific slug
+  notes text,
+  updated_at timestamptz default now()
+);
+
+create table pipeline_roles (
+  id uuid primary key default gen_random_uuid(),
+  company_slug text references tracked_companies(slug),
+  title text not null,
+  url text not null unique,
+  source text not null,    -- 'LinkedIn Saved' | 'LinkedIn Recommended' | 'From Company Pages' | 'Network' | 'Manual'
+  status text not null default 'New', -- 'New' | 'Apply' | 'Talking' | 'Applied' | 'Pass' | 'Rejected' | 'Closed' | 'Not Listed'
+  salary_range text,
+  sector text,             -- redundant with company.sector but allows per-role override
+  fit_score int,           -- cached, recomputed by trigger or job
+  fit_breakdown jsonb,
+  hard_fails text[],
+  first_seen date default current_date,
+  last_seen date,
+  miss_count int default 0,
+  notes_md text,           -- per-role prep notes (used to be in fikei/job/03-jobs/)
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+```
+
+**Migration path:** a one-time import Edge Function reads the Google Sheet + the markdown KB files, populates the tables, then flips the front-end to read from Postgres. The sheet becomes a download/export, not a source of truth.
+
+**Fit-score recompute:** trigger on `vision` update → recompute `fit_score` for all `pipeline_roles`. Trigger on `pipeline_roles` insert → compute fit on insert.
+
+**RELEVANCE.md sync:** an Edge Function (`vision-sync`) writes the `vision.raw_md` field out to `~/.claude/skills/jobs/RELEVANCE.md` via the GitHub API on every vision update. (Or restructure RELEVANCE to read from a small endpoint.)
+
+---
+
+## Theme system
+
+```
+/job/css/
+├── base.css              # layout, reset, primitives that don't depend on theme
+├── components.css        # uses var(--*) custom properties
+├── tokens-wise-light.css # Wise design tokens, light variant
+├── tokens-wise-dark.css  # Wise design tokens, dark variant
+├── tokens-ctrl-light.css # CTRL design tokens, light (sourced from existing design-system/)
+└── tokens-ctrl-dark.css  # CTRL design tokens, dark
+```
+
+**Switch mechanism:**
+
+```html
+<html data-theme="wise-dark">
+```
+
+```css
+/* base.css */
+@import "components.css";
+
+[data-theme="wise-light"] { @import "tokens-wise-light.css"; }
+[data-theme="wise-dark"]  { @import "tokens-wise-dark.css"; }
+[data-theme="ctrl-light"] { @import "tokens-ctrl-light.css"; }
+[data-theme="ctrl-dark"]  { @import "tokens-ctrl-dark.css"; }
+```
+
+JS in nav:
+
+```js
+const themeToggle = document.querySelector('#theme-toggle');
+themeToggle.addEventListener('change', e => {
+  document.documentElement.dataset.theme = e.target.value;
+  localStorage.setItem('job:theme', e.target.value);
+});
+
+document.documentElement.dataset.theme =
+  localStorage.getItem('job:theme') ||
+  (matchMedia('(prefers-color-scheme: dark)').matches ? 'wise-dark' : 'wise-light');
+```
+
+**Token contract** — both Wise and CTRL token files MUST expose at least these custom properties (full list in a separate `theme-contract.md`):
+
+```
+--bg, --bg-surface, --bg-elevated
+--fg, --fg-muted, --fg-subtle
+--accent, --accent-fg, --accent-muted
+--border, --border-strong
+--success, --error, --warning
+--font-body, --font-display, --font-mono
+--radius-sm, --radius-md, --radius-lg
+--shadow-sm, --shadow-md, --shadow-lg
+--space-1 through --space-8
+```
+
+Components written against this contract render correctly in either theme.
+
+---
+
+## Auth
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script src="/auth/ctrl-auth.js"></script>
+<script>
+  CtrlAuth.init({
+    supabaseUrl: 'https://yfhudwakpgzswiylhfbh.supabase.co',
+    supabaseAnonKey: '...',
+    redirectTo: window.location.origin + '/job/',
+    adminEmails: ['fike101@gmail.com']  // single-user allowlist for v1+v2
+  });
+
+  document.addEventListener('ctrl:auth:signedin', async (e) => {
+    if (e.detail.email !== 'fike101@gmail.com') {
+      // gracefully kick the unrelated user
+      window.location.href = '/job/not-authorized.html';
+      return;
+    }
+    // load the page data
+    initJobApp();
+  });
+</script>
+```
+
+---
+
+## Edge Function security
+
+| Function | Auth check | Validation |
+|---|---|---|
+| `kb-read` | Verify Supabase JWT, check email is in allowlist | Path must match `^[a-z0-9-_/]+\.md$`; reject `..` |
+| `kb-write` | Same | Same path validation; size cap 64KB; require `baseSha` |
+| `jobs-pipe GET` | Same | None |
+| `jobs-pipe POST` | Same | `row` must be int 2–500; `status` must be in enum |
+
+**Secrets storage:** Supabase Edge Function secrets (`supabase secrets set GITHUB_PAT=...`).
+
+**Service account key:** stored as `SHEETS_SERVICE_ACCOUNT_JSON` (the same key already used by the local Sheets MCP).
+
+---
+
+## Build + deployment
+
+**Frontend:**
+- Lives in `job/` at the repo root, alongside `boards/`, `soundscape/`.
+- Jekyll picks it up at build. New routes added to the site automatically.
+- Push to `main` → GitHub Pages deploys in ~30s.
+
+**Edge Functions:**
+- Live in `supabase/functions/kb-read/`, `kb-write/`, `jobs-pipe/`.
+- Deploy: `supabase functions deploy kb-read --project-ref yfhudwakpgzswiylhfbh` (etc.).
+- Per repo CLAUDE.md: include `const VERSION = 'X.Y.Z'` + `console.log` at entry, bump on changes.
+
+---
+
+## Open technical questions
+
+1. **GitHub raw-content latency on deep drilldowns.** A user clicking from Jobs → Role → Linked Project → Linked Skill triggers 3+ `kb-read` calls in sequence. Cache TTL of 60s helps, but consider prefetching adjacent files when a parent is loaded.
+
+2. **Sheet write latency.** Status updates from the pipeline view round-trip ~1.5s through the Sheets API. Consider optimistic UI (update locally, reconcile on response).
+
+3. **Markdown rendering.** Use `marked` or `markdown-it` client-side for rendering. Sanitize with `DOMPurify` before injection. Both libraries are small and CDN-deliverable.
+
+4. **Wiki-link resolution.** The KB uses Obsidian-style `[[slug]]` links. The renderer must resolve these to in-app routes (`/job/history/companies/livongo-teladoc/`). Implement as a marked extension or post-process.
+
+5. **Phase 2 cutover.** When migrating to Supabase, do we keep the markdown files in `fikei/job` as a backup/export? Recommendation: yes, with an Edge Function that writes the markdown back to GitHub on every Postgres mutation. The repo becomes the durable export; Postgres is the live source.
+
+---
+
+## Estimated build effort
+
+| Phase | Frontend | Backend (Edge Funcs) | Design / theme | Auth + secrets | Total |
+|---|---|---|---|---|---|
+| Phase 1 (sheet-driven) | ~5d | ~3d | ~2d | ~0.5d | **~10–12d** |
+| Phase 2 (Supabase-backed) | ~3d | ~5d | ~1d | ~0.5d | **~9–11d** |
+
+Effort assumes solo + AI-assisted; adjust accordingly.
+
+---
+
+## Decision log (to be filled)
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-08 | Default theme = Wise; CTRL as alternate. | Wise is more product-feeling for a job-search tool; CTRL is the house style and worth previewing. |
+| 2026-05-08 | Edge Functions live on the existing Boards Supabase project for v1. | Reuse auth + simpler ops. Promote to dedicated project if scaling needs warrant. |
+| 2026-05-08 | Phase 1 Jobs reads directly from Google Sheet. | Fastest path to value; no migration cost; the sheet is already authoritative. |
+| 2026-05-08 | Editing model = markdown textarea, not structured form. | Preserves voice; lower build cost; aligns with how Ian already writes. |

--- a/docs/strategy/prds/job-product.md
+++ b/docs/strategy/prds/job-product.md
@@ -1,0 +1,305 @@
+# PRD: Job — Career Knowledge Base + Pipeline Web Product
+
+**Version:** 1.0
+**Date:** 2026-05-08
+**Status:** Draft
+**Owner:** Ian
+**Tech design:** [`docs/infrastructure/technical-design/job-product.md`](../../infrastructure/technical-design/job-product.md)
+
+---
+
+## Overview
+
+Ian's job search produces three concentric layers of artifact: **work history** (the truth of what he's done), **goals + intents** (what he wants next), and **active pipeline** (which roles are live). Today these live in three disconnected places: a private GitHub repo (`fikei/job` — markdown KB), a Google Sheet (Companies + Roles tabs), and a `/jobs` skill that scans careers pages on a schedule.
+
+`/job` is the web product that pulls all three into one navigable surface at `ctrl.rodeo/job/`. It's a personal tool first — Ian as the only user — but it's built using the same ctrl.rodeo stack as Boards, Soundscape, and Systemic so it inherits auth, design tokens, and deployment patterns.
+
+The product replaces three spreadsheet/file workflows with one product Ian can use end-to-end during a job search: read his story, refine his goals, prioritize the pipeline, draft assets.
+
+---
+
+## Goals
+
+1. **Surface the career knowledge base** as a navigable resume (Job → Projects → Skills) instead of a folder of markdown files.
+2. **Make Goals & Intents living state** — visible, editable, source-of-truth for the `/jobs` skill's relevance filter.
+3. **Show the active pipeline with a relative fit score** so Ian can prioritize next-action without re-reading every row.
+4. **Keep all knowledge editable in-place** so the markdown source files in `fikei/job` and the spreadsheet stay in sync with what's shown.
+5. **Inherit ctrl.rodeo design + auth** so it feels native to the rest of the site and doesn't require duplicate infrastructure.
+6. **Theme-swappable** between Wise and CTRL design systems via a single config flag, so Ian can preview the product in either visual language.
+
+---
+
+## Non-goals
+
+- **Not a public-facing portfolio.** `/job` is auth-gated. The portfolio lives at `ctrl.rodeo/` root.
+- **Not a job board.** It's a pipeline manager, not a discovery surface. Discovery happens via the `/jobs` skill (LinkedIn + ATS scrapes) and feeds in.
+- **Not a multi-user product** for v1 or v2. Single-user (Ian). Could become multi-user later but auth + sharing are out of scope here.
+- **Not a resume builder/PDF exporter** for v1. Drafting cover letters and resumes is a separate flow that consumes from this KB, not produces from it.
+
+---
+
+## Who this serves
+
+| Persona | Why |
+|---|---|
+| **Ian during an active search** | Daily-driver tool. Open in the morning, see new pipeline + fit scores, drill into a role, pull supporting wins/projects to draft a cover letter. |
+| **Ian between searches** | Lower-frequency. Capture wins as they happen so the KB stays current. Tweak Goals & Intents as priorities shift. |
+| **Future iteration: collaborators** | If Ian opens this up to a small group (e.g. peer review of cover letters or fit-scoring), it inherits ctrl.rodeo auth so adding a collaborator is just sharing a link. |
+
+---
+
+## Three features
+
+### 1. Job History
+
+A LinkedIn-style resume view that drills three levels deep.
+
+**Top level — Resume:**
+- Header (name, title, location, contact)
+- Career timeline (companies + role + dates), most recent on top
+- Skills cluster (chips of top 6–8 skills)
+- Awards + education
+
+**Tap a company → Company detail:**
+- Full company file (sector, stage at the time, tenure, why joined / why left, connections)
+- Tabs or stacked sections: **Roles held**, **Projects**, **Wins**
+
+**Tap a project → Project detail:**
+- Full project narrative (problem / constraint / what I did / decisions / outcome / lessons / why-it-matters)
+- Linked skills (which crafts this project demonstrates)
+- Linked wins (quantifiable outcomes)
+
+**Tap a skill → Skill detail:**
+- Skill narrative
+- Evidence (project + win backlinks)
+- "How I talk about this" snippet (for cover letters)
+
+**Editable views:** every detail page has an "Edit" affordance that opens a markdown editor against the source file in `fikei/job`. Save → commits to the repo via GitHub API. (See tech design for security model.)
+
+**Source of truth:** the markdown files in `fikei/job`. The product reads them at build time + via Edge Function for live edits.
+
+### 2. Job Vision
+
+The "what I want next" surface, drawn from `fikei/job/02-goals-intents/`.
+
+**Sections:**
+- **Narrative arc** — the one-paragraph story Ian tells. Resume summary, LinkedIn About, intro DM source.
+- **Stage + sector targets** — pre-seed → Series C, healthtech / edtech focus, etc.
+- **Role titles** — what's primary, what's adjacent, what's not pursued.
+- **Compensation** — base floor, equity expectations, fractional structure.
+- **Geography** — SF / NYC / Remote US.
+- **Deal-breakers** — hard filters.
+- **Voice + cover letter rules** — referenced when drafting.
+
+**Editable:** same model as Job History. Every section has an Edit button → opens the source markdown file → save commits to repo.
+
+**Why this matters operationally:** the `/jobs` skill reads `RELEVANCE.md` for filtering. Updating Job Vision should propagate to the skill's RELEVANCE.md (either the file IS RELEVANCE.md, or the product writes both). See tech design for the sync approach.
+
+### 3. Jobs
+
+The active pipeline, driven by the existing **Job Search** Google Sheet for the MVP.
+
+**View: pipeline table**
+Columns:
+- **Status** (New / Apply / Talking / Applied / Pass / Rejected / Closed / Not Listed)
+- **Fit score** (0–100, computed; see below)
+- **Company** (link → opens company tracking detail)
+- **Role title** (link → opens role detail with full JD if scraped)
+- **Source** (LinkedIn Saved / LinkedIn Recommended / From Company Pages / Network / Manual)
+- **Salary** (when known)
+- **Sector**
+- **Last seen** (from sheet col M)
+- **Posting URL** (external link icon)
+
+**Sort:** default by Fit Score desc, then by Last Seen desc.
+
+**Filter:** by Status (multi-select), Source (multi-select), Sector (free text), Fit Score range (slider).
+
+**Quick actions per row:**
+- Mark Applied / Pass / Rejected → updates sheet
+- Open posting → external link
+- Promote to "prep mode" → opens per-role prep page (links to `03-jobs/{slug}.md` in the KB)
+
+**Per-role detail:**
+- Full JD (cached from the original posting if available)
+- Computed fit-score breakdown: which factors helped, which hurt
+- Linked KB sections (which projects, skills, wins map to this role)
+- Cover letter drafting handoff (links to existing cover letter or "Start new")
+
+#### Fit Score (the core innovation of this view)
+
+A 0–100 score showing how well a role matches Ian's Goals & Intents. Recomputed when:
+- A new role is added
+- Job Vision is edited
+- Status changes
+
+**Inputs:**
+- Title match — "Founding PM" / "Product Lead" / "Senior PM" → strong; "Director of Product" → moderate; "Group PM" → weaker; below seniority floor → 0.
+- Stage match — pre-seed/seed/A/B/C → +; D+ → -; public → drop.
+- Sector match — Health/Health AI / EdTech → +; AI-native / SaaS / Fintech → +; ad-tech / crypto → drop.
+- Geography match — SF / Remote US / NYC → +; hybrid elsewhere → drop.
+- Compensation match — meets floor → +; below → -; missing → neutral.
+- Source weighting — Network > LinkedIn Saved > LinkedIn Recommended > From Company Pages > Manual.
+- Connection signal — investors/contacts the user knows (KPCB, a16z, etc. in the VCs tab).
+
+**Formula:** weighted sum normalized to 0–100. Hard filters (geo fail, below seniority floor) cap the score at 30 regardless of other factors so the user can still see the role but it stays out of the top quintile.
+
+**Algorithm lives server-side** (Edge Function) so it's deterministic and computed once per role+vision pairing rather than re-run by every client.
+
+---
+
+## User flows
+
+### Daily flow during active search
+
+1. Open `ctrl.rodeo/job/`.
+2. Land on Jobs view, sorted by Fit Score desc.
+3. New roles since last visit show a "New" badge.
+4. Drill into the highest-fit new role → see fit breakdown + linked KB sections.
+5. Click "Draft cover letter" → handoff to the existing `/job-assets` skill which pulls voice rules + relevant projects from the KB.
+
+### Refining Job Vision
+
+1. Open Job Vision tab.
+2. Edit `narrative-arc.md` — adjust the one-paragraph version.
+3. Save → commit to `fikei/job` repo.
+4. (Phase 2) Trigger fit-score recompute across the pipeline.
+
+### Capturing a new win
+
+1. Open Job History → Companies → current/most-recent company.
+2. Click "Add Win" → opens a new markdown file in the appropriate `wins/` folder.
+3. Fill in the template (headline / story / interview version / what made it possible).
+4. Save → commit. Win immediately appears in linked project + skill detail pages.
+
+---
+
+## Phasing
+
+### Phase 1 — MVP (Sheet-driven Jobs)
+
+**Scope:**
+- Job History — full read view, basic edit (textarea → save → GitHub API commit). Drilldown navigation.
+- Job Vision — full read view, basic edit.
+- Jobs — pipeline table reading directly from the Google Sheet via Edge Function. Fit Score computed in Edge Function. Status changes write back to the sheet.
+
+**Out of scope:**
+- Real-time sync (sheet edits show after page refresh, not live)
+- Per-role prep notes UI (use `fikei/job/03-jobs/` markdown files for now)
+- Fit Score breakdown UI (just show the score; explain it later)
+- Mobile-optimized layout (desktop-first; mobile responsive but not redesigned)
+
+**Time estimate:** ~2 weeks of focused build time (frontend + edge functions + service-account wiring).
+
+**Success criteria:**
+- Ian uses `/job` instead of opening the sheet for daily pipeline review.
+- One full cover letter drafted using the KB drilldown as context.
+- Fit Score correlates with Ian's gut: top-5 by fit should be the same top-5 he'd pick by hand.
+
+### Phase 2 — Supabase-backed
+
+**Scope:**
+- Migrate Job History from markdown → Postgres tables. Markdown files stay in repo for portability + grep, but Supabase is the live data store.
+- Migrate Goals & Intents → Postgres `vision` table.
+- Migrate Jobs → Postgres `roles_pipeline` table.
+- Real-time fit-score recompute via Edge Function triggered on RELEVANCE changes.
+- Per-role prep notes UI stored in Postgres (`role_notes` table).
+- The Google Sheet becomes a one-way export target, not source of truth (export on demand for backups + sharing).
+- Better mobile layout.
+- (Stretch) Multi-vision support — save multiple "Vision configurations" and switch the active one to see how the pipeline reranks.
+
+**Time estimate:** ~3 weeks after Phase 1 lands.
+
+**Success criteria:**
+- The `/jobs` skill reads `RELEVANCE.md` from Supabase, not the local file.
+- Job Vision changes propagate to fit scores within seconds.
+- Sheet is read-only / archive — all live changes happen through the product.
+
+### Phase 3 (out of scope for this PRD, kept for context)
+
+- Multi-user collaboration — share a vision with a peer for feedback, share a role for "should I apply?" advice.
+- Public-facing portfolio mode — render the Job History as a hireable-looking resume page that can be shared via link.
+- AI-assisted edit suggestions — "your narrative arc is 70% similar to Q3's; here's what changed."
+
+---
+
+## Design
+
+### Design system
+
+**Default:** [Wise design system](https://transferwise.github.io/neptune-css/) — open-source, has light + dark token sets, well-documented.
+
+**Swappable:** the existing CTRL design system at `design-system/` (already built for ctrl.rodeo's other apps). A single config flag at the app entry switches all token resolution to CTRL.
+
+**Mechanism:** all components consume CSS custom properties (`var(--color-bg)`, `var(--font-body)`, etc.). Wise tokens and CTRL tokens both expose the same property names but with different values. Switching is `<html data-theme="wise-light">` → `<html data-theme="ctrl">`.
+
+**Why both:** Wise is mature and product-feeling; CTRL is the existing house style. Building against tokens (not Wise components directly) means we can swap or A/B without rewrites.
+
+### Light / dark
+
+Both Wise and CTRL provide light + dark variants. User toggle in nav; remembered per device. Default follows OS preference.
+
+### Layout
+
+Three-pane on desktop:
+- **Left rail:** persistent nav (History / Vision / Jobs) + theme toggle + sign-out.
+- **Center:** primary view content.
+- **Right rail (optional, contextual):** related links, e.g. when viewing a project show backlinks to skills/wins; when viewing a role show fit-score breakdown.
+
+Single-column on mobile with bottom-nav.
+
+---
+
+## Auth
+
+**Standard ctrl.rodeo auth** via `auth/ctrl-auth.js`. Email magic link primary; Google OAuth supported. Session persists across the site so signing in once at `ctrl.rodeo/boards/` carries to `ctrl.rodeo/job/`.
+
+**Authorization:** single allowlisted user (Ian's email) for v1 + v2. Anyone else hitting the page sees a "this is Ian's tool" message and a link back to `ctrl.rodeo/`.
+
+---
+
+## Open questions
+
+1. **Editing UX — markdown textarea vs. structured form?**
+   - Textarea is faster to build, preserves voice quirks, lets Ian edit in his own pattern.
+   - Structured form (per template field) is friendlier on mobile, harder to mis-format, but constrains voice.
+   - Recommendation: textarea for v1, evaluate structured for v2 if mobile editing becomes a need.
+
+2. **Which Supabase project hosts the Edge Functions?**
+   - Boards (`yfhudwakpgzswiylhfbh`) — already has auth wiring, simplest reuse.
+   - New project (`job` or `career`) — cleaner separation, more work to set up.
+   - Recommendation: Boards for v1; promote to its own project in v2 if scale or auth scoping warrants.
+
+3. **Service account for Sheets — local file vs. Edge Function secret?**
+   - For v1 the Edge Function needs to read the sheet. Service account JSON should live as a Supabase Edge Function secret (`SHEETS_SERVICE_ACCOUNT_JSON`), not committed.
+
+4. **GitHub commit on edit — PAT vs. GitHub App?**
+   - PAT (Ian's personal access token) is simplest. Stored as Edge Function secret.
+   - GitHub App is more correct (scoped, revocable, per-org). Overkill for a single-user product.
+   - Recommendation: PAT for v1.
+
+5. **Fit Score weights — fixed vs. user-tunable?**
+   - Fixed: ship a sane default, iterate as Ian uses it.
+   - User-tunable: a "tune your fit-score" section in Job Vision.
+   - Recommendation: fixed for v1, expose tuning in v2.
+
+---
+
+## Success metrics
+
+| Metric | Phase 1 target | Phase 2 target |
+|---|---|---|
+| Daily-active usage during active search | 1 session/day | 2+ sessions/day |
+| Time to drill from pipeline → KB content backing a role | < 30s | < 10s |
+| Fit-score top-5 match Ian's intuition (manual gut-rank) | 4 of 5 overlap | 5 of 5 overlap |
+| Cover letters drafted with KB as primary context source | 1+ per week during search | 3+ per week |
+| Markdown source files edited via the product (vs. IDE) | 50% | 80% |
+
+---
+
+## Dependencies
+
+- **Existing:** ctrl.rodeo Jekyll site, ctrl-auth.js, Supabase (Boards project), `fikei/job` repo, `/jobs` skill + RELEVANCE.md, Job Search Google Sheet.
+- **New:** Wise design system tokens + components (npm install), service-account JSON for Sheets API in Edge Function secrets, GitHub PAT in Edge Function secrets.
+
+See [tech design](../../infrastructure/technical-design/job-product.md) for implementation specifics.


### PR DESCRIPTION
## Summary

- **PRD:** `docs/strategy/prds/job-product.md` — 3 features (Job History, Job Vision, Jobs), phased rollout, Wise/CTRL theme swap, fit-score mechanic
- **Tech design:** `docs/infrastructure/technical-design/job-product.md` — routes, Edge Functions, fit-score algorithm, Phase 2 Postgres schema, theme system

Phase 1 is sheet-driven; Phase 2 migrates to Supabase. Estimated ~10–12d for Phase 1.

## Test plan

- [ ] Read both docs end-to-end
- [ ] Confirm or push back on the 5 open questions in the PRD
- [ ] Decide which milestone to greenlight as the first PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)