### PR TITLE
docs: lock in /job PRD decisions before build kickoff

### DIFF
--- a/docs/infrastructure/technical-design/job-product.md
+++ b/docs/infrastructure/technical-design/job-product.md
@@ -462,11 +462,14 @@ Effort assumes solo + AI-assisted; adjust accordingly.
 
 ---
 
-## Decision log (to be filled)
+## Decision log
 
 | Date | Decision | Rationale |
 |---|---|---|
 | 2026-05-08 | Default theme = Wise; CTRL as alternate. | Wise is more product-feeling for a job-search tool; CTRL is the house style and worth previewing. |
-| 2026-05-08 | Edge Functions live on the existing Boards Supabase project for v1. | Reuse auth + simpler ops. Promote to dedicated project if scaling needs warrant. |
+| 2026-05-08 | Edge Functions live on the existing Boards Supabase project for v1+v2. | Reuse auth + simpler ops. Promote to dedicated project only if scaling needs warrant. |
 | 2026-05-08 | Phase 1 Jobs reads directly from Google Sheet. | Fastest path to value; no migration cost; the sheet is already authoritative. |
 | 2026-05-08 | Editing model = markdown textarea, not structured form. | Preserves voice; lower build cost; aligns with how Ian already writes. |
+| 2026-05-08 | Service account = reuse `claude-sheets@claude-jobs-494219` JSON. | Already shared with the Job Search sheet; no new GCP setup. Stored as Edge Function secret `SHEETS_SERVICE_ACCOUNT_JSON`. |
+| 2026-05-08 | GitHub auth for `kb-write` = PAT scoped to `fikei/job` only. | Simplest path for a single-user product. GitHub App overkill at this scope. Stored as `GITHUB_PAT`. |
+| 2026-05-08 | Fit-score weights = fixed in v1; tuning surface deferred to v2. | Ship a sane default + iterate from real use rather than over-design upfront. |

--- a/docs/strategy/prds/job-product.md
+++ b/docs/strategy/prds/job-product.md
@@ -258,30 +258,15 @@ Single-column on mobile with bottom-nav.
 
 ---
 
-## Open questions
+## Decisions locked in (2026-05-08)
 
-1. **Editing UX — markdown textarea vs. structured form?**
-   - Textarea is faster to build, preserves voice quirks, lets Ian edit in his own pattern.
-   - Structured form (per template field) is friendlier on mobile, harder to mis-format, but constrains voice.
-   - Recommendation: textarea for v1, evaluate structured for v2 if mobile editing becomes a need.
+These were the open questions in v1.0 — resolved before build kickoff so the next session can focus on implementation.
 
-2. **Which Supabase project hosts the Edge Functions?**
-   - Boards (`yfhudwakpgzswiylhfbh`) — already has auth wiring, simplest reuse.
-   - New project (`job` or `career`) — cleaner separation, more work to set up.
-   - Recommendation: Boards for v1; promote to its own project in v2 if scale or auth scoping warrants.
-
-3. **Service account for Sheets — local file vs. Edge Function secret?**
-   - For v1 the Edge Function needs to read the sheet. Service account JSON should live as a Supabase Edge Function secret (`SHEETS_SERVICE_ACCOUNT_JSON`), not committed.
-
-4. **GitHub commit on edit — PAT vs. GitHub App?**
-   - PAT (Ian's personal access token) is simplest. Stored as Edge Function secret.
-   - GitHub App is more correct (scoped, revocable, per-org). Overkill for a single-user product.
-   - Recommendation: PAT for v1.
-
-5. **Fit Score weights — fixed vs. user-tunable?**
-   - Fixed: ship a sane default, iterate as Ian uses it.
-   - User-tunable: a "tune your fit-score" section in Job Vision.
-   - Recommendation: fixed for v1, expose tuning in v2.
+1. **Editing UX:** **Markdown textarea** for v1+v2. Preserves voice quirks. Re-evaluate structured forms only if mobile editing becomes a real need.
+2. **Supabase project home:** **Boards (`yfhudwakpgzswiylhfbh`)**. Reuses auth wiring. Promote to a dedicated project only if scale demands it.
+3. **Service account for Sheets:** **Reuse the existing `claude-sheets@claude-jobs-494219` JSON** that's already shared with the Job Search sheet. Stored as Edge Function secret `SHEETS_SERVICE_ACCOUNT_JSON`. No new GCP setup needed.
+4. **GitHub commit on edit:** **Personal Access Token** scoped read+write on `fikei/job` only. Stored as Edge Function secret `GITHUB_PAT`.
+5. **Fit-score weights:** **Fixed in v1.** Tunable knobs in Job Vision deferred to v2.
 
 ---
 


### PR DESCRIPTION
## Summary

- Resolves the 5 open questions in the /job PRD
- Updates the tech design decision log to match

The next session can now focus on Phase 1 implementation without re-litigating these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)