### PR TITLE
Add /job skeleton: routes, theme tokens, Lit rail

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,0 +1,86 @@
+@import url("./tokens-generic-light.css");
+@import url("./tokens-generic-dark.css");
+@import url("./components.css");
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.app__rail {
+  border-right: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: var(--space-5) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  position: sticky;
+  top: 0;
+  height: 100vh;
+}
+
+.app__main {
+  padding: var(--space-6) var(--space-7);
+  max-width: 1200px;
+}
+
+.brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+
+.brand__sub {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--fg-subtle);
+  margin-top: 2px;
+}
+
+.rail-foot {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+@media (max-width: 720px) {
+  .app { grid-template-columns: 1fr; }
+  .app__rail {
+    position: static;
+    height: auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+  }
+  .app__main { padding: var(--space-4); }
+  .rail-foot { margin-top: 0; flex-direction: row; gap: var(--space-3); }
+}

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1,0 +1,117 @@
+/* Component CSS — written against the abstract token contract.
+   Both generic-* and ctrl-* token sets must expose the same vars. */
+
+.nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nav-list a {
+  display: block;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font-weight: 500;
+}
+
+.nav-list a:hover {
+  background: var(--bg-elevated);
+  text-decoration: none;
+}
+
+.nav-list a[aria-current="page"] {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+}
+
+.theme-toggle select {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  font-weight: 500;
+}
+.btn:hover { border-color: var(--border-strong); }
+
+.btn--primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+.btn--primary:hover { background: var(--accent); opacity: 0.92; }
+
+.placeholder {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-7) var(--space-5);
+  color: var(--fg-muted);
+  text-align: center;
+  background: var(--bg-surface);
+}
+
+.placeholder h2 {
+  margin: 0 0 var(--space-2);
+  color: var(--fg);
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+
+.placeholder p { margin: 0; max-width: 56ch; margin-inline: auto; }
+
+.page-header {
+  margin-bottom: var(--space-5);
+}
+.page-header h1 {
+  margin: 0;
+  font-size: 28px;
+  letter-spacing: -0.02em;
+}
+.page-header p {
+  margin: var(--space-1) 0 0;
+  color: var(--fg-muted);
+}
+
+.gate {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+  text-align: center;
+}
+.gate__card {
+  max-width: 460px;
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+.gate h1 { margin: 0 0 var(--space-3); font-size: 22px; }
+.gate p { margin: 0 0 var(--space-4); color: var(--fg-muted); }

--- a/job/css/tokens-generic-dark.css
+++ b/job/css/tokens-generic-dark.css
@@ -1,0 +1,42 @@
+/* Generic design system tokens — dark variant. */
+[data-theme="generic-dark"] {
+  --bg: #0d1117;
+  --bg-surface: #161b22;
+  --bg-elevated: #1f2630;
+
+  --fg: #f0f6fc;
+  --fg-muted: #8b949e;
+  --fg-subtle: #6e7681;
+
+  --accent: #58a6ff;
+  --accent-fg: #0d1117;
+  --accent-muted: #1f2937;
+
+  --border: #30363d;
+  --border-strong: #484f58;
+
+  --success: #3fb950;
+  --error: #f85149;
+  --warning: #d29922;
+
+  --font-body: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-display: var(--font-body);
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.4);
+  --shadow-lg: 0 12px 32px rgba(0,0,0,0.55);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+}

--- a/job/css/tokens-generic-light.css
+++ b/job/css/tokens-generic-light.css
@@ -1,0 +1,43 @@
+/* Generic design system tokens — light variant.
+   Default theme for /job. CTRL alternate lives in tokens-ctrl-*.css. */
+[data-theme="generic-light"] {
+  --bg: #ffffff;
+  --bg-surface: #f7f8fa;
+  --bg-elevated: #ffffff;
+
+  --fg: #0e1116;
+  --fg-muted: #57606a;
+  --fg-subtle: #8c959f;
+
+  --accent: #2563eb;
+  --accent-fg: #ffffff;
+  --accent-muted: #dbeafe;
+
+  --border: #d0d7de;
+  --border-strong: #afb8c1;
+
+  --success: #1a7f37;
+  --error: #cf222e;
+  --warning: #9a6700;
+
+  --font-body: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-display: var(--font-body);
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
+  --shadow-lg: 0 12px 32px rgba(0,0,0,0.12);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+}

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>History — /job</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/job/css/base.css">
+  <script src="/job/js/theme.js"></script>
+</head>
+<body>
+  <div class="app">
+    <job-rail></job-rail>
+    <main class="app__main">
+      <header class="page-header">
+        <h1>History</h1>
+        <p>LinkedIn-style resume. Drilldown: Company → Project → Skill.</p>
+      </header>
+      <div class="placeholder">
+        <h2>Resume view coming after Jobs</h2>
+        <p>Lands with the kb-read Edge Function. Source of truth is fikei/job markdown files.</p>
+      </div>
+    </main>
+  </div>
+  <script type="module" src="/job/js/app.js"></script>
+</body>
+</html>

--- a/job/index.html
+++ b/job/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>/job — ctrl.rodeo</title>
+  <meta http-equiv="refresh" content="0; url=/job/jobs/">
+  <link rel="canonical" href="/job/jobs/">
+  <meta name="robots" content="noindex">
+  <style>body{font-family:system-ui;padding:40px;color:#666}</style>
+</head>
+<body>
+  <p>Redirecting to <a href="/job/jobs/">/job/jobs/</a>…</p>
+  <script>location.replace('/job/jobs/');</script>
+</body>
+</html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Jobs — /job</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/job/css/base.css">
+  <script src="/job/js/theme.js"></script>
+</head>
+<body>
+  <div class="app">
+    <job-rail></job-rail>
+    <main class="app__main">
+      <header class="page-header">
+        <h1>Jobs</h1>
+        <p>Pipeline, fit-scored. Reads from Job Search sheet.</p>
+      </header>
+      <div class="placeholder">
+        <h2>Pipeline coming next</h2>
+        <p>This is the skeleton. The pipeline table, fit score, and status writeback land in the next PR (jobs-pipe Edge Function + read-only table).</p>
+      </div>
+    </main>
+  </div>
+  <script type="module" src="/job/js/app.js"></script>
+</body>
+</html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -1,0 +1,5 @@
+// app.js — boot the shell. Auth is deferred to a later milestone.
+const VERSION = '0.1.0';
+console.log(`[job] v${VERSION} - skeleton (no auth)`);
+
+import('./components/job-rail.js');

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -1,0 +1,79 @@
+// job-rail — left rail nav + theme toggle. Light DOM (uses global tokens/components.css).
+// Pages compose: <div class="app"><job-rail></job-rail><main class="app__main">…</main></div>
+import { LitElement, html } from 'https://esm.run/lit@3';
+
+const ROUTES = [
+  { href: '/job/jobs/',    label: 'Jobs',    match: /^\/job\/jobs\/?/ },
+  { href: '/job/history/', label: 'History', match: /^\/job\/history\/?/ },
+  { href: '/job/vision/',  label: 'Vision',  match: /^\/job\/vision\/?/ }
+];
+
+const THEMES = [
+  { value: 'generic-light', label: 'Generic · Light' },
+  { value: 'generic-dark',  label: 'Generic · Dark' },
+  { value: 'ctrl-light',    label: 'CTRL · Light (soon)', disabled: true },
+  { value: 'ctrl-dark',     label: 'CTRL · Dark (soon)',  disabled: true }
+];
+
+export class JobRail extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    theme: { state: true },
+    path:  { state: true }
+  };
+
+  constructor() {
+    super();
+    this.theme = window.JobTheme?.get() || 'generic-light';
+    this.path = location.pathname;
+    this._onTheme = (e) => { this.theme = e.detail.theme; };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('job:theme:changed', this._onTheme);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('job:theme:changed', this._onTheme);
+    super.disconnectedCallback();
+  }
+
+  _setTheme(e) { window.JobTheme?.set(e.target.value); }
+
+  render() {
+    return html`
+      <aside class="app__rail">
+        <div class="brand">
+          ctrl.rodeo
+          <span class="brand__sub">/ job</span>
+        </div>
+        <nav>
+          <ul class="nav-list">
+            ${ROUTES.map(r => html`
+              <li>
+                <a href=${r.href}
+                   aria-current=${r.match.test(this.path) ? 'page' : 'false'}>
+                  ${r.label}
+                </a>
+              </li>
+            `)}
+          </ul>
+        </nav>
+        <div class="rail-foot">
+          <label class="theme-toggle">
+            Theme
+            <select @change=${this._setTheme} .value=${this.theme}>
+              ${THEMES.map(t => html`
+                <option value=${t.value} ?disabled=${t.disabled}>${t.label}</option>
+              `)}
+            </select>
+          </label>
+          <div style="font-size:12px;color:var(--fg-subtle);">v0.1.0 · skeleton</div>
+        </div>
+      </aside>
+    `;
+  }
+}
+
+customElements.define('job-rail', JobRail);

--- a/job/js/theme.js
+++ b/job/js/theme.js
@@ -1,0 +1,20 @@
+// Theme bootstrap — runs synchronously before paint to avoid flash.
+const STORAGE_KEY = 'job:theme';
+const DEFAULT_LIGHT = 'generic-light';
+const DEFAULT_DARK = 'generic-dark';
+
+const stored = localStorage.getItem(STORAGE_KEY);
+const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches;
+document.documentElement.dataset.theme =
+  stored || (prefersDark ? DEFAULT_DARK : DEFAULT_LIGHT);
+
+window.JobTheme = {
+  set(value) {
+    document.documentElement.dataset.theme = value;
+    localStorage.setItem(STORAGE_KEY, value);
+    document.dispatchEvent(new CustomEvent('job:theme:changed', { detail: { theme: value } }));
+  },
+  get() {
+    return document.documentElement.dataset.theme;
+  }
+};

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Vision — /job</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/job/css/base.css">
+  <script src="/job/js/theme.js"></script>
+</head>
+<body>
+  <div class="app">
+    <job-rail></job-rail>
+    <main class="app__main">
+      <header class="page-header">
+        <h1>Vision</h1>
+        <p>Goals and intents. The same source the /jobs skill reads for relevance.</p>
+      </header>
+      <div class="placeholder">
+        <h2>Vision view ships after History</h2>
+        <p>Reads fikei/job/02-goals-intents/ via kb-read. Edits commit through kb-write.</p>
+      </div>
+    </main>
+  </div>
+  <script type="module" src="/job/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

First milestone of the `/job` product (PRD: `docs/strategy/prds/job-product.md`). Ships the static shell that the next PRs (jobs-pipe, kb-read, kb-write, fit score, etc.) plug data into. No auth, no Edge Functions, no data — that's all next.

- **Routes:** `/job/`, `/job/jobs/`, `/job/history/`, `/job/vision/`. Root redirects to `/job/jobs/`.
- **Design tokens:** `tokens-generic-light.css` + `tokens-generic-dark.css` exposing the abstract token contract from the tech design (`--bg`, `--fg`, `--accent`, etc.). Theme switches via `data-theme` on `<html>`. The `tokens-ctrl-*.css` slots are reserved in the picker (disabled) and land when CTRL is migrated.
- **Components:** Lit-via-CDN `<job-rail>` web component for the persistent left rail (nav + theme toggle + version chip). Light DOM so global CSS applies. **No build step** — Lit is imported from `esm.run` inside the component module.
- **Theme bootstrap:** `job/js/theme.js` runs synchronously before paint to set `data-theme` from localStorage or OS preference.

## Decisions worth flagging

- Component model: **Lit web components**, not React. Path A from this session's discussion — keeps Jekyll-as-host, makes a future Astro migration painless because custom elements survive any framework switch.
- Token rename: **`tokens-generic-*`**, not `tokens-wise-*`. Generic name decouples the default theme from a specific design-system vendor.
- **Auth deferred.** Stripped CtrlAuth wiring per direction. Will re-add when needed.
- VERSION starts at `0.1.0`, console signature `[job] v0.1.0 - skeleton (no auth)` per repo convention.

## Test plan

- [x] `/job/` redirects to `/job/jobs/`
- [x] All three routes render with the rail nav and current-page highlight
- [x] Theme toggle switches generic-light ↔ generic-dark, persists across reloads
- [x] CTRL theme options visible but disabled (placeholder for next migration)
- [x] No console errors; `[job] v0.1.0` logs once per page load
- [x] Verified in Chrome MCP at desktop width
- [ ] Spot-check on mobile width after merge (responsive CSS is in but not tested in viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)