### PR TITLE
Restore CtrlAuth gate on /job routes

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -23,6 +23,15 @@ button {
   cursor: pointer;
 }
 
+/* Auth gating: signin card visible until allowlisted user is signed in. */
+body[data-auth-state="in"] #signin-gate { display: none; }
+body:not([data-auth-state="in"]) .app { display: none; }
+
+/* Hide the floating CtrlAuth top-right Login button when not signed in —
+   we own the sign-in CTA inside the gate card. Keep the bar visible once
+   signed in so the user has a sign-out path. */
+body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
+
 .app {
   display: grid;
   grid-template-columns: 240px 1fr;

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -5,10 +5,23 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>History — /job</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css">
   <script src="/job/js/theme.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
+  <script src="/auth/ctrl-auth.js"></script>
 </head>
-<body>
+<body data-auth-state="loading">
+
+  <section id="signin-gate" class="gate">
+    <div class="gate__card">
+      <h1>/job</h1>
+      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in</button>
+      <div id="ctrl-auth-root"></div>
+    </div>
+  </section>
+
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
@@ -22,6 +35,7 @@
       </div>
     </main>
   </div>
+
   <script type="module" src="/job/js/app.js"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -5,10 +5,23 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css">
   <script src="/job/js/theme.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
+  <script src="/auth/ctrl-auth.js"></script>
 </head>
-<body>
+<body data-auth-state="loading">
+
+  <section id="signin-gate" class="gate">
+    <div class="gate__card">
+      <h1>/job</h1>
+      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in</button>
+      <div id="ctrl-auth-root"></div>
+    </div>
+  </section>
+
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
@@ -22,6 +35,7 @@
       </div>
     </main>
   </div>
+
   <script type="module" src="/job/js/app.js"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -1,5 +1,42 @@
-// app.js — boot the shell. Auth is deferred to a later milestone.
-const VERSION = '0.1.0';
-console.log(`[job] v${VERSION} - skeleton (no auth)`);
+// app.js — boot auth, gate the page, mount the rail.
+const VERSION = '0.2.0';
+console.log(`[job] v${VERSION} - auth restored`);
+
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+const ALLOWED_EMAIL = 'fike101@gmail.com';
 
 import('./components/job-rail.js');
+
+// CtrlAuth mounts magic-link + Google sign-in into #ctrl-auth-root.
+window.CtrlAuth.init({
+  supabaseUrl: SUPABASE_URL,
+  supabaseAnonKey: SUPABASE_ANON_KEY,
+  redirectTo: window.location.origin + window.location.pathname,
+  adminEmails: [ALLOWED_EMAIL],
+  mountTo: '#ctrl-auth-root'
+});
+
+document.addEventListener('ctrl:auth:signedin', (e) => {
+  const email = e.detail?.user?.email || '';
+  if (email !== ALLOWED_EMAIL) {
+    location.replace('/job/not-authorized.html');
+    return;
+  }
+  document.body.dataset.authState = 'in';
+});
+
+document.addEventListener('ctrl:auth:signedout', () => {
+  document.body.dataset.authState = 'out';
+});
+
+// Wire the gate-card sign-in button + auto-open the modal on first arrival.
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('signin-btn');
+  if (btn) btn.addEventListener('click', () => window.CtrlAuth.openLoginModal());
+  setTimeout(() => {
+    if (document.body.dataset.authState !== 'in') {
+      window.CtrlAuth.openLoginModal();
+    }
+  }, 250);
+});

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Not authorized — /job</title>
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/job/css/base.css">
+  <script src="/job/js/theme.js"></script>
+</head>
+<body>
+  <section class="gate">
+    <div class="gate__card">
+      <h1>This is Ian's tool.</h1>
+      <p>/job is a single-user career workspace. The rest of ctrl.rodeo is open.</p>
+      <a class="btn btn--primary" href="/">Back to ctrl.rodeo</a>
+    </div>
+  </section>
+</body>
+</html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -5,10 +5,23 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css">
   <script src="/job/js/theme.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
+  <script src="/auth/ctrl-auth.js"></script>
 </head>
-<body>
+<body data-auth-state="loading">
+
+  <section id="signin-gate" class="gate">
+    <div class="gate__card">
+      <h1>/job</h1>
+      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in</button>
+      <div id="ctrl-auth-root"></div>
+    </div>
+  </section>
+
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
@@ -22,6 +35,7 @@
       </div>
     </main>
   </div>
+
   <script type="module" src="/job/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Wires CtrlAuth + single-user allowlist gating that was deferred from the skeleton PR (#633). All three /job routes now require sign-in as `fike101@gmail.com`; anyone else lands on `/job/not-authorized.html`.

- Bumped to v0.2.0 (Y bump for new feature).
- Sign-in card visible until allowlisted user is signed in. Has a primary CTA that opens CtrlAuth's modal; the modal also auto-opens on first arrival.
- Hides the shared floating CtrlAuth login bar while signed-out (avoid two competing CTAs) and re-shows it after sign-in for the sign-out path.
- `not-authorized.html` for kicked-out users.

## Test plan

- [x] Modal opens on first load and on the gate's "Sign in" click
- [x] Console shows `[job] v0.2.0 - auth restored`, no errors
- [x] Verified in Chrome MCP (light theme)
- [ ] Confirm magic-link sign-in completes the flow into the rail+main view
- [ ] Confirm a non-allowlisted email is redirected to /job/not-authorized.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)