### PR TITLE
Add kb-read Edge Function + History resume view

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -99,6 +99,63 @@
   color: var(--fg-muted);
 }
 
+.company-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-4);
+}
+
+.company-card {
+  display: block;
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  text-decoration: none;
+  transition: border-color 80ms ease;
+}
+.company-card:hover {
+  border-color: var(--border-strong);
+  text-decoration: none;
+}
+
+.company-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.company-card__head h3 {
+  margin: 0;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.company-card__tenure {
+  font-size: 13px;
+  color: var(--fg-subtle);
+  white-space: nowrap;
+}
+
+.company-card__meta {
+  margin: 0;
+  display: grid;
+  gap: var(--space-1);
+  font-size: 13px;
+}
+.company-card__meta div { display: flex; gap: var(--space-2); }
+.company-card__meta dt {
+  margin: 0;
+  color: var(--fg-subtle);
+  flex-shrink: 0;
+  width: 64px;
+}
+.company-card__meta dd {
+  margin: 0;
+  color: var(--fg-muted);
+}
+
 .gate {
   min-height: 100vh;
   display: grid;

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -29,10 +29,7 @@
         <h1>History</h1>
         <p>LinkedIn-style resume. Drilldown: Company → Project → Skill.</p>
       </header>
-      <div class="placeholder">
-        <h2>Resume view coming after Jobs</h2>
-        <p>Lands with the kb-read Edge Function. Source of truth is fikei/job markdown files.</p>
-      </div>
+      <job-history-resume></job-history-resume>
     </main>
   </div>
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -1,12 +1,17 @@
 // app.js — boot auth, gate the page, mount the rail.
-const VERSION = '0.2.0';
-console.log(`[job] v${VERSION} - auth restored`);
+const VERSION = '0.3.0';
+console.log(`[job] v${VERSION} - kb-read + history resume`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
 const ALLOWED_EMAIL = 'fike101@gmail.com';
 
 import('./components/job-rail.js');
+import('./kb.js');
+// Route-specific components — small enough to load on every page for now.
+if (location.pathname.startsWith('/job/history')) {
+  import('./components/job-history-resume.js');
+}
 
 // CtrlAuth mounts magic-link + Google sign-in into #ctrl-auth-root.
 window.CtrlAuth.init({

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -1,0 +1,125 @@
+// job-history-resume — top-level resume view: list of companies pulled from
+// fikei/job/01-job-history/companies/ via kb-read.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { renderMarkdown } from '../markdown.js';
+
+const COMPANIES_DIR = '01-job-history/companies/';
+
+// Pull a small set of fields from the markdown front-block.
+// The KB convention: H1 then a list of "**Field:** value" lines.
+function parseHeader(md) {
+  const out = { title: '', fields: {} };
+  const lines = md.split(/\r?\n/);
+  for (const line of lines) {
+    if (!out.title) {
+      const h1 = line.match(/^#\s+(.+)$/);
+      if (h1) { out.title = h1[1].trim(); continue; }
+    }
+    const m = line.match(/^\*\*([^*:]+):\*\*\s*(.+)$/);
+    if (m) out.fields[m[1].trim()] = m[2].trim();
+    if (line.startsWith('## ')) break; // first section starts → stop scanning
+  }
+  return out;
+}
+
+export class JobHistoryResume extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    error: { state: true },
+    companies: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    this.companies = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      const { entries } = await window.JobKB.listDir(COMPANIES_DIR);
+      const files = entries.filter(e => e.type === 'file' && e.name.endsWith('.md'));
+      const loaded = await Promise.all(files.map(async f => {
+        try {
+          const { content } = await window.JobKB.readFile(f.path);
+          return { ...f, ...parseHeader(content), content };
+        } catch (e) {
+          return { ...f, title: f.name.replace(/\.md$/, ''), fields: {}, content: '', error: String(e) };
+        }
+      }));
+      // Sort: those with a tenure-end of 'Present' first, then by tenure-start desc, then by name.
+      loaded.sort((a, b) => {
+        const aPresent = /Present/i.test(a.fields['My tenure'] || a.fields['Tenure'] || '');
+        const bPresent = /Present/i.test(b.fields['My tenure'] || b.fields['Tenure'] || '');
+        if (aPresent !== bPresent) return aPresent ? -1 : 1;
+        return (b.fields['My tenure'] || '').localeCompare(a.fields['My tenure'] || '');
+      });
+      this.companies = loaded;
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e);
+      this.state = 'error';
+    }
+  }
+
+  _renderCard(c) {
+    const slug = c.name.replace(/\.md$/, '');
+    const tenure = c.fields['My tenure'] || c.fields['Tenure'] || '';
+    const sector = c.fields['Sector'] || '';
+    const stage = c.fields['Stage at the time of joining'] || c.fields['Stage of clients'] || c.fields['Stage at the time'] || '';
+    const location = c.fields['Location'] || '';
+    return html`
+      <a class="company-card" href="/job/history/companies/${slug}/">
+        <div class="company-card__head">
+          <h3>${c.title}</h3>
+          ${tenure ? html`<span class="company-card__tenure">${tenure}</span>` : nothing}
+        </div>
+        <dl class="company-card__meta">
+          ${sector ? html`<div><dt>Sector</dt><dd>${sector}</dd></div>` : nothing}
+          ${stage ? html`<div><dt>Stage</dt><dd>${stage}</dd></div>` : nothing}
+          ${location ? html`<div><dt>Location</dt><dd>${location}</dd></div>` : nothing}
+        </dl>
+      </a>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`<div class="placeholder"><h2>Loading resume…</h2><p>Reading from fikei/job via kb-read.</p></div>`;
+    }
+    if (this.state === 'error') {
+      return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">
+        <h2>Couldn't load companies</h2>
+        <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
+      </div>`;
+    }
+    if (!this.companies.length) {
+      return html`<div class="placeholder"><h2>No companies found</h2><p>Expected files in ${COMPANIES_DIR}</p></div>`;
+    }
+    return html`
+      <section class="company-grid">
+        ${this.companies.map(c => this._renderCard(c))}
+      </section>
+    `;
+  }
+}
+
+customElements.define('job-history-resume', JobHistoryResume);

--- a/job/js/kb.js
+++ b/job/js/kb.js
@@ -1,0 +1,30 @@
+// kb.js — thin client for the kb-read Edge Function.
+// Auth: forwards the current Supabase access token from CtrlAuth.
+
+const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/kb-read';
+
+async function authHeader() {
+  const supabase = window.CtrlAuth?.getSupabaseClient?.();
+  if (!supabase) throw new Error('CtrlAuth not ready');
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('not signed in');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function readFile(path) {
+  const headers = await authHeader();
+  const res = await fetch(`${FN_URL}?path=${encodeURIComponent(path)}`, { headers });
+  if (!res.ok) throw new Error(`kb-read ${res.status}: ${await res.text()}`);
+  return res.json(); // { path, sha, content }
+}
+
+export async function listDir(path) {
+  const dirPath = path.endsWith('/') ? path : path + '/';
+  const headers = await authHeader();
+  const res = await fetch(`${FN_URL}?path=${encodeURIComponent(dirPath)}`, { headers });
+  if (!res.ok) throw new Error(`kb-read ${res.status}: ${await res.text()}`);
+  return res.json(); // { path, entries: [{name,path,type,size}] }
+}
+
+window.JobKB = { readFile, listDir };

--- a/job/js/markdown.js
+++ b/job/js/markdown.js
@@ -1,0 +1,49 @@
+// markdown.js — render KB markdown to safe HTML, with [[wiki-link]] support.
+// Loads marked + DOMPurify from CDN as ES modules.
+
+import { marked } from 'https://esm.run/marked@13';
+import DOMPurify from 'https://esm.run/dompurify@3';
+
+// Map a wiki-link slug to an in-app route.
+// Heuristic for v1: slug shapes determine the destination directory.
+//   role-*           → /job/history/roles/{slug}/
+//   project-* / *-project → /job/history/projects/{slug}/
+//   skill-*          → /job/history/skills/{slug}/
+//   win-*            → /job/history/wins/{slug}/
+//   otherwise        → /job/history/companies/{slug}/  (best-effort)
+// A future PR replaces this with a real manifest fetched from kb-read.
+export function resolveSlug(slug) {
+  const s = slug.toLowerCase().trim();
+  if (s.startsWith('role-')) return `/job/history/roles/${s}/`;
+  if (s.startsWith('project-') || s.endsWith('-project')) return `/job/history/projects/${s}/`;
+  if (s.startsWith('skill-')) return `/job/history/skills/${s}/`;
+  if (s.startsWith('win-')) return `/job/history/wins/${s}/`;
+  return `/job/history/companies/${s}/`;
+}
+
+// Pre-process [[slug]] and [[slug|label]] before marked sees the text.
+function expandWikiLinks(md) {
+  return md.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, slug, label) => {
+    const href = resolveSlug(slug);
+    const text = (label || slug).trim();
+    return `[${text}](${href})`;
+  });
+}
+
+const renderer = new marked.Renderer();
+// Force external links open in new tab (heuristic: anything starting with http).
+const origLink = renderer.link.bind(renderer);
+renderer.link = (href, title, text) => {
+  const html = origLink(href, title, text);
+  return /^https?:/.test(href || '')
+    ? html.replace('<a ', '<a target="_blank" rel="noopener noreferrer" ')
+    : html;
+};
+
+export function renderMarkdown(md) {
+  const expanded = expandWikiLinks(md);
+  const html = marked.parse(expanded, { renderer, breaks: false, gfm: true });
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: ['target', 'rel'],
+  });
+}

--- a/supabase/functions/kb-read/index.ts
+++ b/supabase/functions/kb-read/index.ts
@@ -1,0 +1,124 @@
+// kb-read — read markdown files (and directory listings) from the private
+// fikei/job repo on behalf of an allowlisted user.
+//
+// Modes:
+//   GET ?path=foo/bar.md  → { content, sha, path }
+//   GET ?path=foo/        → { entries: [{ name, path, type, size }] }
+//
+// Auth: Authorization: Bearer <Supabase JWT>; user email must be in ALLOWLIST.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
+
+const VERSION = '0.1.0';
+console.log(`[kb-read] v${VERSION} - initial`);
+
+const REPO = 'fikei/job';
+const REF = 'main';
+const ALLOWLIST = ['fike101@gmail.com'];
+
+const PATH_RE = /^[a-zA-Z0-9_\-./]+$/;
+const FILE_PATH_RE = /^[a-zA-Z0-9_\-./]+\.md$/;
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+function err(message: string, status = 400) {
+  return json({ error: message }, status);
+}
+
+async function verifyAllowlistedUser(req: Request): Promise<string | null> {
+  const authHeader = req.headers.get('Authorization') || '';
+  const token = authHeader.replace(/^Bearer\s+/i, '');
+  if (!token) return null;
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user?.email) return null;
+  const email = data.user.email.toLowerCase();
+  if (!ALLOWLIST.includes(email)) return null;
+  return email;
+}
+
+function isPathSafe(p: string): boolean {
+  if (!p || p.length > 256) return false;
+  if (p.includes('..')) return false;
+  if (p.startsWith('/')) return false;
+  return PATH_RE.test(p);
+}
+
+async function ghContents(path: string) {
+  const pat = Deno.env.get('GITHUB_PAT');
+  if (!pat) throw new Error('GITHUB_PAT not configured');
+  const url = `https://api.github.com/repos/${REPO}/contents/${path}?ref=${REF}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'ctrl-rodeo-kb-read',
+    },
+  });
+  if (res.status === 404) return { notFound: true } as const;
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return { data: await res.json() } as const;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'GET') return err('GET only', 405);
+
+  try {
+    const email = await verifyAllowlistedUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const url = new URL(req.url);
+    const path = (url.searchParams.get('path') || '').trim();
+    if (!isPathSafe(path)) return err('invalid path', 400);
+
+    const isDir = path.endsWith('/');
+    const ghPath = isDir ? path.replace(/\/$/, '') : path;
+
+    if (!isDir && !FILE_PATH_RE.test(path)) {
+      return err('files must end in .md', 400);
+    }
+
+    const result = await ghContents(ghPath);
+    if ('notFound' in result) return err('not found', 404);
+    const data = result.data;
+
+    if (isDir) {
+      if (!Array.isArray(data)) return err('expected directory', 400);
+      const entries = data.map((e: { name: string; path: string; type: string; size: number }) => ({
+        name: e.name,
+        path: e.path,
+        type: e.type, // 'file' | 'dir'
+        size: e.size,
+      }));
+      return json({ path, entries });
+    } else {
+      if (Array.isArray(data) || data.type !== 'file') return err('expected file', 400);
+      const content = data.encoding === 'base64' ? atob(data.content.replace(/\n/g, '')) : data.content;
+      return json({ path: data.path, sha: data.sha, content });
+    }
+  } catch (e) {
+    console.error('[kb-read] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});


### PR DESCRIPTION
## Summary

Milestone (b): private-repo markdown reader + the top-level LinkedIn-style resume page populated from `fikei/job`.

### Edge Function — `supabase/functions/kb-read` (v0.1.0)
- `GET ?path=foo/bar.md` → `{ content, sha, path }`
- `GET ?path=foo/` → `{ entries[] }` (directory listing)
- Auth: Supabase JWT verified server-side; user email must be in the hard-coded allowlist (matches the front-end gate).
- Reads from the private `fikei/job` repo using a server-only `GITHUB_PAT`. PAT never reaches the browser.
- Path validation: rejects `..`, absolute paths, and non-`.md` files in file mode.

### Frontend (app `v0.3.0`)
- `job/js/kb.js` — KB client; forwards the current Supabase access token as Bearer.
- `job/js/markdown.js` — `marked` + `DOMPurify` with an Obsidian `[[slug]]` / `[[slug|label]]` resolver. Slug shape (`role-`, `project-`, `skill-`, `win-`) maps to in-app routes; default is company. Heuristic for v1; a manifest endpoint replaces this in a follow-up.
- `job/js/components/job-history-resume.js` — Lit component listing `01-job-history/companies/`. Parses the `H1` + `**Field:** value` header block of each company file; renders a card grid sorted by tenure (Present first).
- `/job/history/` placeholder is gone, replaced by the live component.

## ⚠️ Required before kb-read returns data — needs your hands

CLAUDE.md flags secrets as a guardrail, so I can't set these.

1. **Create a GitHub Personal Access Token** (fine-grained, 1-yr max) scoped to `fikei/job` only:
   - Repository access: only `fikei/job`
   - Permissions: `Contents: Read-only` (Read + Write later when `kb-write` lands)
2. **Set the Edge Function secret:**
   ```bash
   supabase secrets set GITHUB_PAT=<token> --project-ref yfhudwakpgzswiylhfbh
   ```
3. After merge, I'll deploy with `supabase functions deploy kb-read --project-ref yfhudwakpgzswiylhfbh`.

Until those are done, signing in and visiting `/job/history/` will show a red error card (function 404 or 401) — by design.

## Test plan

- [x] Front-end loads cleanly, console: `[job] v0.3.0 - kb-read + history resume`
- [x] Auth gate still works
- [ ] After deploy + secret: `/job/history/` shows three company cards (Independent Consulting, Livongo/Teladoc, Remind) sorted with Present first
- [ ] Cards link to `/job/history/companies/{slug}/` (404s expected — drilldown is the next milestone)
- [ ] Path traversal blocked (`?path=../something.md` returns 400)
- [ ] Unauthenticated request returns 401
- [ ] Non-allowlisted JWT returns 401

## Risks I'm flagging

1. **Heuristic wiki-link resolver** misroutes any slug not matching the four prefix patterns. Real fix: a `kb-manifest` endpoint that returns `{ slug → route }`. Tracked for the next PR.
2. **Header parser is regex-based.** Any company file that drops the `**Field:** value` convention will surface as a card with a missing meta row. Acceptable for v1; if it becomes a problem we move parsing server-side.
3. **No client-side caching.** Every History page load re-fetches the directory + each company file (4 round-trips). Edge Function caching is intentionally deferred per the earlier risk discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)