### PR TITLE
Rework /job/history into full-width company cards

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -100,60 +100,87 @@
 }
 
 .company-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: var(--space-4);
+  max-width: 920px;
 }
 
 .company-card {
   display: block;
-  padding: var(--space-5);
+  padding: var(--space-6);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--fg);
   text-decoration: none;
-  transition: border-color 80ms ease;
+  transition: border-color 80ms ease, box-shadow 80ms ease;
 }
 .company-card:hover {
   border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
   text-decoration: none;
 }
 
-.company-card__head {
+.company-card__top {
   display: flex;
-  align-items: baseline;
   justify-content: space-between;
-  gap: var(--space-3);
+  align-items: flex-start;
+  gap: var(--space-4);
   margin-bottom: var(--space-3);
 }
-.company-card__head h3 {
+.company-card__title { min-width: 0; }
+.company-card__title h3 {
   margin: 0;
-  font-size: 18px;
-  letter-spacing: -0.01em;
+  font-size: 22px;
+  letter-spacing: -0.015em;
+  line-height: 1.25;
+}
+.company-card__sub {
+  margin: var(--space-1) 0 0;
+  font-size: 14px;
+  color: var(--fg-muted);
+  line-height: 1.4;
 }
 .company-card__tenure {
   font-size: 13px;
   color: var(--fg-subtle);
   white-space: nowrap;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+  margin-top: 4px;
 }
 
-.company-card__meta {
-  margin: 0;
-  display: grid;
-  gap: var(--space-1);
-  font-size: 13px;
-}
-.company-card__meta div { display: flex; gap: var(--space-2); }
-.company-card__meta dt {
-  margin: 0;
-  color: var(--fg-subtle);
-  flex-shrink: 0;
-  width: 64px;
-}
-.company-card__meta dd {
-  margin: 0;
+.company-card__summary {
+  margin: 0 0 var(--space-4);
+  font-size: 15px;
+  line-height: 1.55;
   color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.company-card__chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.company-card__chips li {
+  font-size: 12px;
+  padding: 2px var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--fg-muted);
+  background: var(--bg-surface);
+  max-width: 380px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gate {

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -1,6 +1,6 @@
 // app.js — boot auth, gate the page, mount the rail.
-const VERSION = '0.3.0';
-console.log(`[job] v${VERSION} - kb-read + history resume`);
+const VERSION = '0.4.0';
+console.log(`[job] v${VERSION} - history full-width cards`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -5,20 +5,57 @@ import { renderMarkdown } from '../markdown.js';
 
 const COMPANIES_DIR = '01-job-history/companies/';
 
-// Pull a small set of fields from the markdown front-block.
-// The KB convention: H1 then a list of "**Field:** value" lines.
-function parseHeader(md) {
-  const out = { title: '', fields: {} };
+// Strip wiki-link / markdown link / bold syntax for plain-text snippets.
+function plainify(s) {
+  return s
+    .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
+    .replace(/\[\[([^\]]+)\]\]/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .trim();
+}
+
+// Pull title, "**Field:** value" header, and a 1-2 sentence summary
+// (first prose paragraph; prefers the body of "## Context" if present).
+function parseDoc(md) {
+  const out = { title: '', fields: {}, summary: '' };
   const lines = md.split(/\r?\n/);
-  for (const line of lines) {
+  let i = 0;
+  for (; i < lines.length; i++) {
+    const line = lines[i];
     if (!out.title) {
       const h1 = line.match(/^#\s+(.+)$/);
       if (h1) { out.title = h1[1].trim(); continue; }
     }
     const m = line.match(/^\*\*([^*:]+):\*\*\s*(.+)$/);
-    if (m) out.fields[m[1].trim()] = m[2].trim();
-    if (line.startsWith('## ')) break; // first section starts → stop scanning
+    if (m) { out.fields[m[1].trim()] = m[2].trim(); continue; }
+    if (line.startsWith('## ')) break;
   }
+
+  // Find "## Context" first, otherwise first non-heading paragraph after metadata.
+  let bodyStart = -1;
+  for (let j = i; j < lines.length; j++) {
+    if (/^##\s+Context\b/i.test(lines[j])) { bodyStart = j + 1; break; }
+  }
+  if (bodyStart === -1) bodyStart = i;
+
+  const para = [];
+  for (let j = bodyStart; j < lines.length; j++) {
+    const line = lines[j].trim();
+    if (!line) {
+      if (para.length) break;
+      continue;
+    }
+    if (line.startsWith('#')) {
+      if (para.length) break;
+      continue;
+    }
+    if (/^\*\*[^*]+:\*\*/.test(line)) continue;
+    para.push(line);
+  }
+  out.summary = plainify(para.join(' '));
   return out;
 }
 
@@ -60,9 +97,9 @@ export class JobHistoryResume extends LitElement {
       const loaded = await Promise.all(files.map(async f => {
         try {
           const { content } = await window.JobKB.readFile(f.path);
-          return { ...f, ...parseHeader(content), content };
+          return { ...f, ...parseDoc(content), content };
         } catch (e) {
-          return { ...f, title: f.name.replace(/\.md$/, ''), fields: {}, content: '', error: String(e) };
+          return { ...f, title: f.name.replace(/\.md$/, ''), fields: {}, summary: '', content: '', error: String(e) };
         }
       }));
       // Sort: those with a tenure-end of 'Present' first, then by tenure-start desc, then by name.
@@ -86,17 +123,29 @@ export class JobHistoryResume extends LitElement {
     const sector = c.fields['Sector'] || '';
     const stage = c.fields['Stage at the time of joining'] || c.fields['Stage of clients'] || c.fields['Stage at the time'] || '';
     const location = c.fields['Location'] || '';
+    const operating = c.fields['Operating mode'] || '';
+    const rolesHeld = c.fields['Roles held'] || '';
+    const subline = operating || rolesHeld
+      ? plainify(operating || rolesHeld)
+      : '';
+
+    const chips = [sector, stage, location].filter(Boolean);
+
     return html`
       <a class="company-card" href="/job/history/companies/${slug}/">
-        <div class="company-card__head">
-          <h3>${c.title}</h3>
+        <div class="company-card__top">
+          <div class="company-card__title">
+            <h3>${c.title}</h3>
+            ${subline ? html`<p class="company-card__sub">${subline}</p>` : nothing}
+          </div>
           ${tenure ? html`<span class="company-card__tenure">${tenure}</span>` : nothing}
         </div>
-        <dl class="company-card__meta">
-          ${sector ? html`<div><dt>Sector</dt><dd>${sector}</dd></div>` : nothing}
-          ${stage ? html`<div><dt>Stage</dt><dd>${stage}</dd></div>` : nothing}
-          ${location ? html`<div><dt>Location</dt><dd>${location}</dd></div>` : nothing}
-        </dl>
+        ${c.summary ? html`<p class="company-card__summary">${c.summary}</p>` : nothing}
+        ${chips.length ? html`
+          <ul class="company-card__chips">
+            ${chips.map(t => html`<li>${t}</li>`)}
+          </ul>
+        ` : nothing}
       </a>
     `;
   }


### PR DESCRIPTION
## Summary

Each company gets a full-width card (max-width 920px) instead of the tight grid. Cards carry enough context to scan without clicking through.

- Larger title (22px) with an optional subline pulled from "Operating mode" or "Roles held" (wiki-links plain-text-ified).
- Tenure pinned top-right, tabular numerals.
- 3-line clamp summary from "## Context" or the first prose paragraph after metadata.
- Sector / stage / location as chips at the foot.

`parseDoc` replaces `parseHeader` — same field extraction plus a body summary. Wiki-link / bold / md-link syntax stripped for snippets.

App bumped to 0.4.0.

## Test plan

- [x] Page loads, no console errors
- [ ] Three full-width cards render after sign-in
- [ ] Summaries are populated for all three companies
- [ ] Cards link to /job/history/companies/{slug}/ (404s expected — drilldown lands later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)