### PR TITLE
Cache-bust /job assets so deploys aren't shadowed by Pages cache

### DIFF
--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css">
-  <script src="/job/js/theme.js"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.7.0">
+  <script src="/job/js/theme.js?v=0.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js"></script>
+  <script type="module" src="/job/js/app.js?v=0.7.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css">
-  <script src="/job/js/theme.js"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.7.0">
+  <script src="/job/js/theme.js?v=0.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js"></script>
+  <script type="module" src="/job/js/app.js?v=0.7.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css">
-  <script src="/job/js/theme.js"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.7.0">
+  <script src="/job/js/theme.js?v=0.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js"></script>
+  <script type="module" src="/job/js/app.js?v=0.7.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -1,21 +1,25 @@
 // app.js — boot auth, gate the page, mount the rail.
-const VERSION = '0.6.0';
-console.log(`[job] v${VERSION} - history drilldown`);
+// Bump VERSION on every PR that touches /job/js. The HTML loads this file
+// with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
+// query to dynamic imports so the component graph stays consistent.
+const VERSION = '0.7.0';
+console.log(`[job] v${VERSION} - cache-bust + drilldown`);
+const V = `?v=${VERSION}`;
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
 const ALLOWED_EMAIL = 'fike101@gmail.com';
 
-import('./components/job-rail.js');
-import('./kb.js');
+import('./components/job-rail.js' + V);
+import('./kb.js' + V);
 // Route-specific components.
 if (location.pathname.startsWith('/job/history/_drill')) {
-  import('./components/job-detail.js');
+  import('./components/job-detail.js' + V);
 } else if (location.pathname.startsWith('/job/history')) {
-  import('./components/job-history-resume.js');
+  import('./components/job-history-resume.js' + V);
 }
 if (location.pathname.startsWith('/job/jobs')) {
-  import('./components/job-pipeline.js');
+  import('./components/job-pipeline.js' + V);
 }
 
 // CtrlAuth mounts magic-link + Google sign-in into #ctrl-auth-root.

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css">
-  <script src="/job/js/theme.js"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.7.0">
+  <script src="/job/js/theme.js?v=0.7.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css">
-  <script src="/job/js/theme.js"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.7.0">
+  <script src="/job/js/theme.js?v=0.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js"></script>
+  <script type="module" src="/job/js/app.js?v=0.7.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Bug

Reported: `/job/jobs/` empty, no console logging present.

## Root cause

GitHub Pages sets `cache-control: max-age=600` on /job/js and /job/css. After back-to-back deploys (skeleton → auth → kb-read → history rework → jobs-pipe → drilldown), Chrome served a cached `app.js v0.4.0` for up to 10 minutes after each deploy. The old app.js didn't import `<job-pipeline>`, so the new HTML's `<job-pipeline>` element rendered as an undefined custom element (blank), and the console only showed `[job] v0.4.0`.

## Fix

- `app.js` exposes `V = '?v=' + VERSION` and appends it to every dynamic import.
- Each route HTML loads `base.css`, `theme.js`, `app.js` with `?v=0.7.0`.
- VERSION bumped to 0.7.0. Convention: bump on every PR that touches `/job/js` or `/job/css`.

## Test plan

- [ ] After deploy, hard-reload `/job/jobs/` → console: `[job] v0.7.0 - cache-bust + drilldown`
- [ ] Pipeline table renders post-sign-in
- [ ] Subsequent PRs that bump VERSION are picked up immediately, no force-refresh needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)