### PR TITLE
Tap fit pill on /job/jobs to see the score breakdown

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -352,6 +352,137 @@
 .fit-pill--weak   { background: rgba(237,200,67,0.20); color: #6E5400; }
 .fit-pill--poor   { background: rgba(168,32,13,0.12); color: var(--error); }
 
+.fit-pill--button {
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  font-weight: var(--fw-semibold);
+}
+.fit-pill--button:hover { filter: brightness(0.97); }
+
+/* --- Fit breakdown modal --- */
+.fit-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 15, 12, 0.45);
+  display: grid;
+  place-items: center;
+  padding: var(--space-5);
+  z-index: 1000;
+  animation: fit-fade 120ms ease-out;
+}
+[data-theme="generic-dark"] .fit-modal__backdrop { background: rgba(0, 0, 0, 0.55); }
+
+@keyframes fit-fade { from { opacity: 0 } to { opacity: 1 } }
+
+.fit-modal {
+  width: min(560px, 100%);
+  max-height: calc(100vh - 96px);
+  overflow: auto;
+  background: var(--bg-elevated);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-6);
+  animation: fit-pop 140ms ease-out;
+}
+
+@keyframes fit-pop { from { transform: translateY(8px); opacity: 0 } to { transform: none; opacity: 1 } }
+
+.fit-modal__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.fit-modal__eyebrow {
+  margin: 0 0 4px;
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  font-weight: var(--fw-medium);
+}
+.fit-modal__head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-2);
+  letter-spacing: -0.018em;
+  line-height: var(--lh-title);
+}
+.fit-modal__close {
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 28px;
+  line-height: 1;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+.fit-modal__close:hover { background: var(--bg-surface); color: var(--fg); }
+
+.fit-modal__score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-5);
+}
+.fit-modal__score .fit-pill {
+  font-size: var(--font-size-title-2);
+  min-width: 64px;
+  padding: var(--space-2) var(--space-4);
+}
+.fit-modal__score-label {
+  margin: 0;
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body-lg);
+}
+.fit-modal__score-sub {
+  margin: 4px 0 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+
+.fit-modal__fails {
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid rgba(168,32,13,0.22);
+  border-radius: var(--radius-sm);
+  background: rgba(168,32,13,0.06);
+  color: var(--error);
+  font-size: var(--font-size-small);
+  margin-bottom: var(--space-5);
+}
+
+.fit-breakdown { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-4); }
+.fit-breakdown__row { display: flex; flex-direction: column; gap: var(--space-2); }
+.fit-breakdown__head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-size: var(--font-size-small);
+}
+.fit-breakdown__label { font-weight: var(--fw-semibold); color: var(--fg); }
+.fit-breakdown__value { color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+.fit-breakdown__bar {
+  height: 8px; border-radius: var(--radius-pill); background: var(--bg-surface); overflow: hidden;
+}
+.fit-breakdown__bar > span {
+  display: block; height: 100%; background: var(--accent-strong); border-radius: var(--radius-pill);
+  transition: width 200ms ease;
+}
+.fit-breakdown__hint { margin: 0; font-size: var(--font-size-caption); color: var(--fg-subtle); line-height: var(--lh-tight); }
+
+.fit-modal__foot {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.fit-modal__foot .muted { font-size: var(--font-size-caption); color: var(--fg-subtle); margin: 0; }
+
 /* --- Breadcrumb + KB document rendering --- */
 .breadcrumb {
   display: flex;

--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.8.0">
-  <script src="/job/js/theme.js?v=0.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
+  <script src="/job/js/theme.js?v=0.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.8.0">
-  <script src="/job/js/theme.js?v=0.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
+  <script src="/job/js/theme.js?v=0.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.8.0">
-  <script src="/job/js/theme.js?v=0.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
+  <script src="/job/js/theme.js?v=0.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.8.0';
-console.log(`[job] v${VERSION} - wise design system`);
+const VERSION = '0.9.0';
+console.log(`[job] v${VERSION} - fit explainer`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -1,9 +1,17 @@
 // job-pipeline — pipeline table view. Reads from jobs-pipe and renders
-// rows sorted by Fit Score desc.
+// rows sorted by Fit Score desc. Click a fit pill to see the breakdown.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { fetchPipeline } from '../pipeline.js';
 
-const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
+const DIM_LABELS = {
+  title:   { label: 'Title match',   max: 25, hint: 'Founding/Senior/Staff PM scores higher; below seniority hard-fails.' },
+  stage:   { label: 'Stage',         max: 20, hint: 'Inferred from investors. Pre-seed → C scores high; public/mega-cap hard-fails.' },
+  sector:  { label: 'Sector',        max: 20, hint: 'Health and EdTech are top; AI-native / SaaS / Fintech middle.' },
+  geo:     { label: 'Geography',     max: 15, hint: 'Sheet has no geo column — neutral default for now.' },
+  comp:    { label: 'Compensation',  max: 10, hint: 'Top of range ≥ $200k = full marks.' },
+  source:  { label: 'Source',        max: 5,  hint: 'Network > LinkedIn Saved > LinkedIn Recommended > Company Pages > Manual.' },
+  network: { label: 'Network',       max: 5,  hint: 'A named contact in the row gets +5.' },
+};
 
 export class JobPipeline extends LitElement {
   createRenderRoot() { return this; }
@@ -16,6 +24,7 @@ export class JobPipeline extends LitElement {
     sourceFilter: { state: true },
     minFit: { state: true },
     sectorQuery: { state: true },
+    selectedRow: { state: true },
   };
 
   constructor() {
@@ -27,6 +36,7 @@ export class JobPipeline extends LitElement {
     this.sourceFilter = new Set();
     this.minFit = 0;
     this.sectorQuery = '';
+    this.selectedRow = null;
   }
 
   connectedCallback() {
@@ -34,9 +44,12 @@ export class JobPipeline extends LitElement {
     this._maybeLoad();
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    this._onKey = (e) => { if (e.key === 'Escape') this._closeFitModal(); };
+    document.addEventListener('keydown', this._onKey);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('keydown', this._onKey);
     super.disconnectedCallback();
   }
 
@@ -104,7 +117,7 @@ export class JobPipeline extends LitElement {
           </div>
         </div>
         <div class="pipeline-filters__group">
-          <label>Min Fit ${this.minFit}</label>
+          <label>Min fit ${this.minFit}</label>
           <input type="range" min="0" max="100" .value=${String(this.minFit)}
             @input=${(e) => { this.minFit = parseInt(e.target.value, 10); }}>
         </div>
@@ -125,10 +138,23 @@ export class JobPipeline extends LitElement {
     return 'fit-pill fit-pill--poor';
   }
 
+  _openFitModal(r) { this.selectedRow = r; }
+  _closeFitModal() { this.selectedRow = null; }
+  _onBackdropClick(e) {
+    if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal();
+  }
+
   _renderRow(r) {
     return html`
       <tr>
-        <td><span class=${this._scoreClass(r.score)} title=${r.hardFails.length ? 'Hard fails: ' + r.hardFails.join(', ') : ''}>${r.score}</span></td>
+        <td>
+          <button
+            class=${this._scoreClass(r.score) + ' fit-pill--button'}
+            title="Tap to see the breakdown"
+            @click=${() => this._openFitModal(r)}>
+            ${r.score}
+          </button>
+        </td>
         <td>${r.status || html`<span class="muted">—</span>`}</td>
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
@@ -139,6 +165,64 @@ export class JobPipeline extends LitElement {
           ${r.url ? html`<a href=${r.url} target="_blank" rel="noopener noreferrer">↗</a>` : nothing}
         </td>
       </tr>
+    `;
+  }
+
+  _renderFitModal() {
+    const r = this.selectedRow;
+    if (!r) return nothing;
+    const dims = Object.keys(DIM_LABELS);
+    return html`
+      <div class="fit-modal__backdrop" @click=${this._onBackdropClick}>
+        <div class="fit-modal" role="dialog" aria-modal="true" aria-label="Fit score breakdown">
+          <header class="fit-modal__head">
+            <div>
+              <p class="fit-modal__eyebrow">${r.company}</p>
+              <h2>${r.title || 'Untitled role'}</h2>
+            </div>
+            <button class="fit-modal__close" @click=${this._closeFitModal} aria-label="Close">×</button>
+          </header>
+
+          <div class="fit-modal__score">
+            <span class=${this._scoreClass(r.score)}>${r.score}</span>
+            <div>
+              <p class="fit-modal__score-label">Fit score</p>
+              <p class="fit-modal__score-sub">Out of 100. Sum of seven weighted dimensions; hard fails cap at 30.</p>
+            </div>
+          </div>
+
+          ${r.hardFails && r.hardFails.length ? html`
+            <div class="fit-modal__fails">
+              <strong>Hard fail${r.hardFails.length > 1 ? 's' : ''}:</strong>
+              ${r.hardFails.join(', ')}. Score capped at 30.
+            </div>
+          ` : nothing}
+
+          <ul class="fit-breakdown">
+            ${dims.map(k => {
+              const meta = DIM_LABELS[k];
+              const v = (r.breakdown && r.breakdown[k]) || 0;
+              const pct = Math.max(0, Math.min(100, (v / meta.max) * 100));
+              return html`
+                <li class="fit-breakdown__row">
+                  <div class="fit-breakdown__head">
+                    <span class="fit-breakdown__label">${meta.label}</span>
+                    <span class="fit-breakdown__value">${v} / ${meta.max}</span>
+                  </div>
+                  <div class="fit-breakdown__bar">
+                    <span style=${`width:${pct}%`}></span>
+                  </div>
+                  <p class="fit-breakdown__hint">${meta.hint}</p>
+                </li>
+              `;
+            })}
+          </ul>
+
+          <footer class="fit-modal__foot">
+            <p class="muted">Weights are fixed in v1. Tunable in v2 once Vision integration lands.</p>
+          </footer>
+        </div>
+      </div>
     `;
   }
 
@@ -156,7 +240,7 @@ export class JobPipeline extends LitElement {
     return html`
       ${this._renderFilters()}
       <div class="pipeline-meta">
-        Showing <strong>${rows.length}</strong> of ${this.roles.length} roles, sorted by Fit Score.
+        Showing <strong>${rows.length}</strong> of ${this.roles.length} roles, sorted by fit score.
       </div>
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">
@@ -175,6 +259,7 @@ export class JobPipeline extends LitElement {
           <tbody>${rows.map(r => this._renderRow(r))}</tbody>
         </table>
       </div>
+      ${this._renderFitModal()}
     `;
   }
 }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.8.0">
-  <script src="/job/js/theme.js?v=0.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
+  <script src="/job/js/theme.js?v=0.9.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.8.0">
-  <script src="/job/js/theme.js?v=0.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
+  <script src="/job/js/theme.js?v=0.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Each fit pill is now a button. Tap → modal shows the score split into its seven weighted dimensions (title 25 / stage 20 / sector 20 / geo 15 / comp 10 / source 5 / network 5) with a filled bar per dimension and a one-line explainer.

Hard fails (below-seniority title, public/mega-cap, geo fail) get their own callout above the breakdown when present, so the cap-at-30 rule isn't silent.

Frontend-only — score data already came back from jobs-pipe.

App bumped to 0.9.0.

## Test plan

- [x] Tap a pill: modal opens with the role's company + title
- [x] Backdrop click closes
- [x] Esc closes
- [x] Bars proportional to value/max
- [x] Hard-fail callout appears for capped roles
- [x] Light + dark theme both readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)