### PR TITLE
Editable status + Apply flow on /job/jobs

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -352,6 +352,49 @@
 .fit-pill--weak   { background: rgba(237,200,67,0.20); color: #6E5400; }
 .fit-pill--poor   { background: rgba(168,32,13,0.12); color: var(--error); }
 
+/* --- Status select + apply cell --- */
+.status-cell { display: flex; align-items: center; gap: var(--space-2); }
+.status-select {
+  font: inherit;
+  font-size: var(--font-size-small);
+  padding: 6px var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%236A6C6A' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 26px;
+}
+.status-select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.status-select.is-saving { opacity: 0.6; }
+.status-cell__err {
+  display: inline-grid;
+  place-items: center;
+  width: 18px; height: 18px;
+  border-radius: var(--radius-pill);
+  background: rgba(168,32,13,0.14);
+  color: var(--error);
+  font-size: 12px;
+  font-weight: var(--fw-semibold);
+  cursor: help;
+}
+
+.btn--sm {
+  height: 32px;
+  padding: 0 var(--space-3);
+  font-size: var(--font-size-small);
+}
+.apply-cell { display: flex; flex-direction: column; gap: 2px; line-height: 1.2; }
+.apply-cell .link-subtle { font-size: var(--font-size-caption); }
+
+.link-subtle { color: var(--fg-muted); }
+.link-subtle:hover { color: var(--fg); text-decoration: underline; }
+
 .fit-pill--button {
   border: 0;
   cursor: pointer;

--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
-  <script src="/job/js/theme.js?v=0.9.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
+  <script src="/job/js/theme.js?v=0.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
-  <script src="/job/js/theme.js?v=0.9.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
+  <script src="/job/js/theme.js?v=0.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
-  <script src="/job/js/theme.js?v=0.9.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
+  <script src="/job/js/theme.js?v=0.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.9.0';
-console.log(`[job] v${VERSION} - fit explainer`);
+const VERSION = '0.10.0';
+console.log(`[job] v${VERSION} - editable status + apply flow`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -1,7 +1,11 @@
 // job-pipeline — pipeline table view. Reads from jobs-pipe and renders
 // rows sorted by Fit Score desc. Click a fit pill to see the breakdown.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-import { fetchPipeline } from '../pipeline.js';
+import { fetchPipeline, setStatus } from '../pipeline.js';
+
+const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
+const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
+const APPLIED_STATUSES = new Set(['Applied', 'Talking']);
 
 const DIM_LABELS = {
   title:   { label: 'Title match',   max: 25, hint: 'Founding/Senior/Staff PM scores higher; below seniority hard-fails.' },
@@ -140,8 +144,56 @@ export class JobPipeline extends LitElement {
 
   _openFitModal(r) { this.selectedRow = r; }
   _closeFitModal() { this.selectedRow = null; }
+
+  async _changeStatus(r, status) {
+    if (status === r.status) return;
+    const prev = r.status;
+    r.status = status;
+    r._saving = true;
+    this.requestUpdate();
+    try {
+      await setStatus(r.rowNumber, status);
+      r._saving = false;
+      r._error = '';
+    } catch (e) {
+      r.status = prev;
+      r._saving = false;
+      r._error = String(e);
+    }
+    this.requestUpdate();
+  }
+
+  async _onApplyClick(r) {
+    // Open the posting in a new tab even if status update fails.
+    if (r.url) window.open(r.url, '_blank', 'noopener,noreferrer');
+    if (!APPLIED_STATUSES.has(r.status) && !TERMINAL_STATUSES.has(r.status)) {
+      await this._changeStatus(r, 'Applied');
+    }
+  }
   _onBackdropClick(e) {
     if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal();
+  }
+
+  _renderApplyCell(r) {
+    if (TERMINAL_STATUSES.has(r.status)) {
+      return r.url
+        ? html`<a class="link-subtle" href=${r.url} target="_blank" rel="noopener noreferrer">Posting ↗</a>`
+        : html`<span class="muted">—</span>`;
+    }
+    if (APPLIED_STATUSES.has(r.status)) {
+      return html`
+        <div class="apply-cell apply-cell--applied">
+          <span class="muted">Applied</span>
+          ${r.url ? html`<a class="link-subtle" href=${r.url} target="_blank" rel="noopener noreferrer">Posting ↗</a>` : nothing}
+        </div>
+      `;
+    }
+    if (!r.url) return html`<span class="muted">—</span>`;
+    return html`
+      <button class="btn btn--sm btn--accent" @click=${() => this._onApplyClick(r)}>
+        Apply ↗
+      </button>
+    `;
   }
 
   _renderRow(r) {
@@ -155,15 +207,24 @@ export class JobPipeline extends LitElement {
             ${r.score}
           </button>
         </td>
-        <td>${r.status || html`<span class="muted">—</span>`}</td>
+        <td class="status-cell">
+          <select
+            class="status-select ${r._saving ? 'is-saving' : ''}"
+            ?disabled=${r._saving}
+            .value=${r.status || ''}
+            @change=${(e) => this._changeStatus(r, e.target.value)}>
+            ${STATUS_OPTIONS.map(s => html`
+              <option value=${s} ?selected=${(r.status || '') === s}>${s || '—'}</option>
+            `)}
+          </select>
+          ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
+        </td>
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
+        <td>${this._renderApplyCell(r)}</td>
         <td><span class="muted">${r.sector || ''}</span></td>
         <td><span class="muted">${r.salary || ''}</span></td>
         <td><span class="muted">${r.source || ''}</span></td>
-        <td>
-          ${r.url ? html`<a href=${r.url} target="_blank" rel="noopener noreferrer">↗</a>` : nothing}
-        </td>
       </tr>
     `;
   }
@@ -250,10 +311,10 @@ export class JobPipeline extends LitElement {
               <th>Status</th>
               <th>Company</th>
               <th>Role</th>
+              <th>Apply</th>
               <th>Sector</th>
               <th>Salary</th>
               <th>Source</th>
-              <th></th>
             </tr>
           </thead>
           <tbody>${rows.map(r => this._renderRow(r))}</tbody>

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -17,4 +17,15 @@ export async function fetchPipeline() {
   return res.json();
 }
 
-window.JobPipeline = { fetchPipeline };
+export async function setStatus(rowNumber, status) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rowNumber, status }),
+  });
+  if (!res.ok) throw new Error(`set-status ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+window.JobPipeline = { fetchPipeline, setStatus };

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
-  <script src="/job/js/theme.js?v=0.9.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
+  <script src="/job/js/theme.js?v=0.10.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.9.0">
-  <script src="/job/js/theme.js?v=0.9.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
+  <script src="/job/js/theme.js?v=0.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.9.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -3,19 +3,22 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
-import { readSheetValues } from './sheets.ts';
+import { readSheetValues, writeSheetCell } from './sheets.ts';
 import { computeFit, RoleRow } from './fit.ts';
 
-const VERSION = '0.1.0';
-console.log(`[jobs-pipe] v${VERSION} - sheet read + fit score`);
+const VERSION = '0.2.0';
+console.log(`[jobs-pipe] v${VERSION} - status writeback`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const ALLOWLIST = ['fike101@gmail.com'];
+const STATUS_ENUM = new Set([
+  '', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network',
+]);
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
 };
 
 function json(body: unknown, status = 200) {
@@ -68,27 +71,40 @@ function rowToRole(row: string[], rowNumber: number): { role: RoleRow; rowNumber
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
-  if (req.method !== 'GET') return err('GET only', 405);
 
   try {
     const email = await verifyAllowlistedUser(req);
     if (!email) return err('unauthorized', 401);
 
-    const values = await readSheetValues(SHEET_ID, 'Roles!A2:M1000');
-    const enriched = values
-      .map((row, idx) => rowToRole(row, idx + 2))
-      .filter(({ role }) => role.company || role.title)
-      .map(({ role, rowNumber }) => ({
-        rowNumber,
-        ...role,
-        ...computeFit(role),
-      }));
+    if (req.method === 'GET') {
+      const values = await readSheetValues(SHEET_ID, 'Roles!A2:M1000');
+      const enriched = values
+        .map((row, idx) => rowToRole(row, idx + 2))
+        .filter(({ role }) => role.company || role.title)
+        .map(({ role, rowNumber }) => ({
+          rowNumber,
+          ...role,
+          ...computeFit(role),
+        }));
+      return json({ version: VERSION, count: enriched.length, roles: enriched });
+    }
 
-    return json({
-      version: VERSION,
-      count: enriched.length,
-      roles: enriched,
-    });
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const rowNumber = Number(body.rowNumber);
+      const status = String(body.status ?? '');
+      if (!Number.isInteger(rowNumber) || rowNumber < 2 || rowNumber > 5000) {
+        return err('rowNumber must be int 2..5000', 400);
+      }
+      if (!STATUS_ENUM.has(status)) {
+        return err(`status must be one of: ${Array.from(STATUS_ENUM).filter(Boolean).join(', ')}`, 400);
+      }
+      // Status lives in column C of the Roles tab.
+      await writeSheetCell(SHEET_ID, `Roles!C${rowNumber}`, status);
+      return json({ ok: true, rowNumber, status });
+    }
+
+    return err('GET or POST only', 405);
   } catch (e) {
     console.error('[jobs-pipe] error', e);
     return err((e as Error).message || 'server error', 500);

--- a/supabase/functions/jobs-pipe/sheets.ts
+++ b/supabase/functions/jobs-pipe/sheets.ts
@@ -83,11 +83,13 @@ async function getAccessToken(scope: string): Promise<string> {
   return data.access_token;
 }
 
+const RW_SCOPE = 'https://www.googleapis.com/auth/spreadsheets';
+
 export async function readSheetValues(
   spreadsheetId: string,
   range: string,
 ): Promise<string[][]> {
-  const token = await getAccessToken('https://www.googleapis.com/auth/spreadsheets.readonly');
+  const token = await getAccessToken(RW_SCOPE);
   const url = `${SHEETS_BASE}/${spreadsheetId}/values/${encodeURIComponent(range)}`;
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!res.ok) {
@@ -96,4 +98,25 @@ export async function readSheetValues(
   }
   const data = await res.json() as { values?: string[][] };
   return data.values || [];
+}
+
+export async function writeSheetCell(
+  spreadsheetId: string,
+  range: string,
+  value: string,
+): Promise<void> {
+  const token = await getAccessToken(RW_SCOPE);
+  const url = `${SHEETS_BASE}/${spreadsheetId}/values/${encodeURIComponent(range)}?valueInputOption=USER_ENTERED`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ range, values: [[value]] }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`sheets write failed ${res.status}: ${text.slice(0, 300)}`);
+  }
 }


### PR DESCRIPTION
## Summary

Pipeline rows can now move through statuses without opening the sheet.

### Edge Function — `jobs-pipe v0.2.0`
- `POST { rowNumber, status }` writes column C of the Roles tab.
- Service-account scope bumped from `spreadsheets.readonly` to `spreadsheets` (read + write).
- Validates `rowNumber` (2..5000) and `status` against the shared enum server-side.

### Frontend — app `v0.10.0`
- Status column is an inline pill `<select>` with the full status enum. Change → optimistic UI, POST to jobs-pipe, revert on failure. Errors surface as a small `!` indicator with the message in the hover title.
- New **Apply** column:
  - **pre-applied** → "Apply ↗" Bright Green button. Click opens the posting in a new tab AND optimistically sets status to Applied.
  - **applied** → "Applied" label + subtle "Posting ↗" link.
  - **pass / rejected / closed** → muted "Posting ↗" link only.
  - **no url** → em dash.

After merge I'll deploy `jobs-pipe`.

## Test plan

- [x] Status select changes status and writes back to the sheet
- [x] Apply button opens new tab + flips status to Applied
- [x] Already-Applied row shows the right state without re-promoting
- [x] Failed write reverts the visible status and surfaces an error indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)