### PR TITLE
Fix /job auth race + design polish on new components

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -355,9 +355,11 @@
 /* --- Status select + apply cell --- */
 .status-cell { display: flex; align-items: center; gap: var(--space-2); }
 .status-select {
+  /* Wise small-component size: 32px height, body-small typography. */
   font: inherit;
   font-size: var(--font-size-small);
-  padding: 6px var(--space-3);
+  height: 32px;
+  padding: 0 var(--space-5) 0 var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
   background: var(--bg);
@@ -365,21 +367,26 @@
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' fill='none' stroke='%236A6C6A' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  /* Chevron uses a CSS mask so it picks up the current text colour and
+     stays correct across light + dark themes. */
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(-45deg, transparent 50%, currentColor 50%);
+  background-position: calc(100% - 14px) calc(50% + 2px),
+                       calc(100% - 10px) calc(50% + 2px);
+  background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 26px;
 }
+.status-select:hover { border-color: var(--border-strong); }
 .status-select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
 .status-select.is-saving { opacity: 0.6; }
 .status-cell__err {
   display: inline-grid;
   place-items: center;
-  width: 18px; height: 18px;
+  width: 20px; height: 20px;
   border-radius: var(--radius-pill);
   background: rgba(168,32,13,0.14);
   color: var(--error);
-  font-size: 12px;
+  font-size: var(--font-size-caption);
   font-weight: var(--fw-semibold);
   cursor: help;
 }
@@ -458,10 +465,10 @@
   border: 0;
   background: transparent;
   color: var(--fg-muted);
-  font-size: 28px;
+  font-size: var(--font-size-title-2);
   line-height: 1;
-  width: 32px;
-  height: 32px;
+  width: var(--space-6);
+  height: var(--space-6);
   border-radius: var(--radius-pill);
   cursor: pointer;
 }

--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
-  <script src="/job/js/theme.js?v=0.10.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
+  <script src="/job/js/theme.js?v=0.11.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
-  <script src="/job/js/theme.js?v=0.10.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
+  <script src="/job/js/theme.js?v=0.11.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
-  <script src="/job/js/theme.js?v=0.10.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
+  <script src="/job/js/theme.js?v=0.11.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.10.0';
-console.log(`[job] v${VERSION} - editable status + apply flow`);
+const VERSION = '0.11.0';
+console.log(`[job] v${VERSION} - auth race fix + design polish`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -23,6 +23,26 @@ if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);
 }
 
+function applySignedInState(email) {
+  if (email !== ALLOWED_EMAIL) {
+    location.replace('/job/not-authorized.html');
+    return;
+  }
+  document.body.dataset.authState = 'in';
+  // Notify components that may have mounted before the event arrived.
+  document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
+}
+
+// Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when
+// it restores an existing session, so we must already be subscribed.
+document.addEventListener('ctrl:auth:signedin', (e) => {
+  const email = e.detail?.user?.email || '';
+  applySignedInState(email);
+});
+document.addEventListener('ctrl:auth:signedout', () => {
+  document.body.dataset.authState = 'out';
+});
+
 // CtrlAuth mounts magic-link + Google sign-in into #ctrl-auth-root.
 window.CtrlAuth.init({
   supabaseUrl: SUPABASE_URL,
@@ -32,20 +52,16 @@ window.CtrlAuth.init({
   mountTo: '#ctrl-auth-root'
 });
 
-document.addEventListener('ctrl:auth:signedin', (e) => {
-  const email = e.detail?.user?.email || '';
-  if (email !== ALLOWED_EMAIL) {
-    location.replace('/job/not-authorized.html');
-    return;
+// Belt-and-braces: even with the listener attached early, some CtrlAuth code
+// paths can settle a restored session without dispatching to a fresh listener.
+// Reconcile from the canonical source after a tick.
+setTimeout(() => {
+  const u = window.CtrlAuth?.getUser?.();
+  if (u?.email && document.body.dataset.authState !== 'in') {
+    applySignedInState(u.email);
   }
-  document.body.dataset.authState = 'in';
-});
+}, 0);
 
-document.addEventListener('ctrl:auth:signedout', () => {
-  document.body.dataset.authState = 'out';
-});
-
-// Wire the gate-card sign-in button + auto-open the modal on first arrival.
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('signin-btn');
   if (btn) btn.addEventListener('click', () => window.CtrlAuth.openLoginModal());

--- a/job/js/components/job-detail.js
+++ b/job/js/components/job-detail.js
@@ -59,9 +59,11 @@ export class JobDetail extends LitElement {
     this._maybeLoad();
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
     super.disconnectedCallback();
   }
 

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -80,10 +80,12 @@ export class JobHistoryResume extends LitElement {
     this._maybeLoad();
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
   }
 
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
     super.disconnectedCallback();
   }
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -48,11 +48,13 @@ export class JobPipeline extends LitElement {
     this._maybeLoad();
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
     this._onKey = (e) => { if (e.key === 'Escape') this._closeFitModal(); };
     document.addEventListener('keydown', this._onKey);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('keydown', this._onKey);
     super.disconnectedCallback();
   }

--- a/job/js/slug.js
+++ b/job/js/slug.js
@@ -1,0 +1,12 @@
+// Shared role-slug helper. Mirror the server-side logic in gen-asset.
+// Format: {company}-{first-3-words-of-title}, lowercased + hyphenated.
+export function roleSlug(company, title) {
+  const norm = (s) => String(s || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const c = norm(company);
+  const titleWords = norm(title).split('-').filter(Boolean).slice(0, 3).join('-');
+  return [c, titleWords].filter(Boolean).join('-');
+}

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
-  <script src="/job/js/theme.js?v=0.10.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
+  <script src="/job/js/theme.js?v=0.11.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.10.0">
-  <script src="/job/js/theme.js?v=0.10.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
+  <script src="/job/js/theme.js?v=0.11.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.10.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Reported bugs
- Tap on score doesn't work
- Design changed from initial rev

## Root cause

`CtrlAuth.init()` can synchronously dispatch `ctrl:auth:signedin` while restoring an existing session. `app.js` was attaching its listener AFTER calling `init`, so the event fired into the void → `body[data-auth-state]` stayed `loading` → the gate stayed visible → the table never rendered → tapping a fit pill did nothing because the table wasn't there. The "design changed" report was the gate showing instead of the rail+table.

## Fix

- Listeners attach FIRST, then `init`. Plus a one-tick reconcile from `window.CtrlAuth.getUser()` and a new `job:auth:ready` event so components that mount before the original signedin can still pick up the state.
- `<job-pipeline>`, `<job-history-resume>`, `<job-detail>` all listen to both `ctrl:auth:signedin` and `job:auth:ready`.

## Design polish (this fixes the comment about new components drifting from the rev)

- **status-select** was using a hardcoded `#6A6C6A` SVG chevron — invisible in dark theme. Now a CSS-mask chevron driven by `currentColor`. Height moved to Wise small-button size (32px). Padding on 4px grid.
- **status error indicator**: 18×18 → 20×20 (on grid). 12px font → `--font-size-caption`.
- **fit-modal close button**: 28px font → `--font-size-title-2`; 32px → `--space-6`.
- No new `text-transform: uppercase`, no hex colours bypassing tokens.

App bumped to 0.11.0.

## Test plan
- [ ] After hard-refresh of /job/jobs/, table renders and fit pill is tappable
- [ ] Light + dark themes both show a working chevron on status select
- [ ] Status select height matches Apply button height visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)