### PR TITLE
Resume + Cover Letter generation, columns, per-role page

### DIFF
--- a/404.html
+++ b/404.html
@@ -51,6 +51,16 @@ permalink: /404.html
         return;
       }
 
+      // /job/jobs/{slug}/ — per-role detail handled by /job/jobs/_drill/
+      var roleMatch = path.match(/^\/job\/jobs\/([a-z0-9_-]+)\/?$/);
+      if (roleMatch) {
+        sessionStorage.setItem('job:prettyPath', path);
+        var qs = window.location.search.replace(/^\?/, '');
+        var sep = qs ? '&' : '';
+        window.location.replace('/job/jobs/_drill/?slug=' + roleMatch[1] + sep + qs);
+        return;
+      }
+
       // Pin short link: /p/{short_code} -> fetch pin URL from Supabase, redirect
       var pinMatch = path.match(/^\/p\/([a-zA-Z0-9]{6,12})\/?$/);
       if (pinMatch) {

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -597,3 +597,56 @@
   color: var(--fg-muted);
 }
 .kb-doc hr { border: 0; border-top: 1px solid var(--border); margin: var(--space-7) 0; }
+
+/* --- Per-role detail tabs + editor (job/jobs/_drill) --- */
+.asset-tabs {
+  display: flex;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-5);
+}
+.asset-tabs__tab {
+  font: inherit;
+  font-size: var(--font-size-body);
+  font-weight: var(--fw-semibold);
+  padding: var(--space-3) var(--space-4);
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.asset-tabs__tab:hover { color: var(--fg); }
+.asset-tabs__tab.is-active {
+  color: var(--fg);
+  border-bottom-color: var(--accent-strong);
+}
+
+.asset-panel { min-height: 320px; }
+
+.asset-toolbar {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+.asset-toolbar .muted { font-size: var(--font-size-small); }
+
+.asset-editor {
+  width: 100%;
+  min-height: 60vh;
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-small);
+  line-height: var(--lh-body);
+  resize: vertical;
+}
+.asset-editor:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+
+.asset-doc { max-width: 720px; }

--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
-  <script src="/job/js/theme.js?v=0.11.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
+  <script src="/job/js/theme.js?v=0.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
-  <script src="/job/js/theme.js?v=0.11.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
+  <script src="/job/js/theme.js?v=0.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
 </body>
 </html>

--- a/job/jobs/_drill/index.html
+++ b/job/jobs/_drill/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Vision — /job</title>
+  <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
@@ -25,14 +25,7 @@
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
-      <header class="page-header">
-        <h1>Vision</h1>
-        <p>Goals and intents. The same source the /jobs skill reads for relevance.</p>
-      </header>
-      <div class="placeholder">
-        <h2>Vision view ships after History</h2>
-        <p>Reads fikei/job/02-goals-intents/ via kb-read. Edits commit through kb-write.</p>
-      </div>
+      <job-role-detail></job-role-detail>
     </main>
   </div>
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
-  <script src="/job/js/theme.js?v=0.11.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
+  <script src="/job/js/theme.js?v=0.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.11.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.11.0';
-console.log(`[job] v${VERSION} - auth race fix + design polish`);
+const VERSION = '0.12.0';
+console.log(`[job] v${VERSION} - resume + cover letter assets`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -19,7 +19,9 @@ if (location.pathname.startsWith('/job/history/_drill')) {
 } else if (location.pathname.startsWith('/job/history')) {
   import('./components/job-history-resume.js' + V);
 }
-if (location.pathname.startsWith('/job/jobs')) {
+if (location.pathname.startsWith('/job/jobs/_drill')) {
+  import('./components/job-role-detail.js' + V);
+} else if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);
 }
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -1,7 +1,7 @@
 // job-pipeline — pipeline table view. Reads from jobs-pipe and renders
 // rows sorted by Fit Score desc. Click a fit pill to see the breakdown.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-import { fetchPipeline, setStatus } from '../pipeline.js';
+import { fetchPipeline, setStatus, generateAsset } from '../pipeline.js';
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -172,6 +172,27 @@ export class JobPipeline extends LitElement {
       await this._changeStatus(r, 'Applied');
     }
   }
+
+  async _onGenerate(r, kind) {
+    const flag = kind === 'resume' ? '_genResume' : '_genCover';
+    if (r[flag]) return;
+    r[flag] = true;
+    this.requestUpdate();
+    try {
+      await generateAsset(r.rowNumber, kind);
+      if (kind === 'resume') r.hasResume = true;
+      else r.hasCoverLetter = true;
+    } catch (e) {
+      r._error = String(e);
+    } finally {
+      r[flag] = false;
+      this.requestUpdate();
+    }
+  }
+
+  _detailHref(r, tab) {
+    return `/job/jobs/${r.slug}/?row=${r.rowNumber}&tab=${tab}`;
+  }
   _onBackdropClick(e) {
     if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal();
   }
@@ -194,6 +215,23 @@ export class JobPipeline extends LitElement {
     return html`
       <button class="btn btn--sm btn--accent" @click=${() => this._onApplyClick(r)}>
         Apply ↗
+      </button>
+    `;
+  }
+
+  _renderAssetCell(r, kind) {
+    const has = kind === 'resume' ? r.hasResume : r.hasCoverLetter;
+    const generating = kind === 'resume' ? r._genResume : r._genCover;
+    if (has) {
+      return html`
+        <a class="link-subtle" href=${this._detailHref(r, kind)} target="_blank" rel="noopener">
+          View / Edit
+        </a>
+      `;
+    }
+    return html`
+      <button class="btn btn--sm" ?disabled=${generating} @click=${() => this._onGenerate(r, kind)}>
+        ${generating ? 'Generating…' : 'Create'}
       </button>
     `;
   }
@@ -224,6 +262,8 @@ export class JobPipeline extends LitElement {
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
         <td>${this._renderApplyCell(r)}</td>
+        <td>${this._renderAssetCell(r, 'resume')}</td>
+        <td>${this._renderAssetCell(r, 'cover-letter')}</td>
         <td><span class="muted">${r.sector || ''}</span></td>
         <td><span class="muted">${r.salary || ''}</span></td>
         <td><span class="muted">${r.source || ''}</span></td>
@@ -314,6 +354,8 @@ export class JobPipeline extends LitElement {
               <th>Company</th>
               <th>Role</th>
               <th>Apply</th>
+              <th>Resume</th>
+              <th>Cover</th>
               <th>Sector</th>
               <th>Salary</th>
               <th>Source</th>

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -1,0 +1,249 @@
+// job-role-detail — per-role detail page with Resume / Cover Letter tabs.
+// Reads /job/jobs/{slug}/?row=&tab= and renders both assets from
+// 03-jobs/{slug}/{kind}.md via kb-read; saves edits via kb-write.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+import { renderMarkdown } from '../markdown.js';
+import { generateAsset } from '../pipeline.js';
+import { writeFile } from '../kbwrite.js';
+
+const TABS = [
+  { id: 'resume', label: 'Resume', file: 'resume.md' },
+  { id: 'cover-letter', label: 'Cover letter', file: 'cover-letter.md' },
+];
+
+export class JobRoleDetail extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    error: { state: true },
+    slug: { state: true },
+    rowNumber: { state: true },
+    activeTab: { state: true },
+    assets: { state: true },        // { 'resume': { content, sha, draft, mode, saving, dirty } }
+    role: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    const params = new URLSearchParams(location.search);
+    this.slug = (params.get('slug') || '').toLowerCase();
+    this.rowNumber = Number(params.get('row')) || null;
+    const tab = params.get('tab');
+    this.activeTab = TABS.find(t => t.id === tab)?.id || 'resume';
+    this.assets = { 'resume': null, 'cover-letter': null };
+    this.role = null;
+
+    const pretty = sessionStorage.getItem('job:prettyPath');
+    if (pretty && /^\/job\/jobs\/[a-z0-9_-]+\/?$/.test(pretty)) {
+      sessionStorage.removeItem('job:prettyPath');
+      history.replaceState(null, '', pretty + (this.activeTab !== 'resume' ? `?tab=${this.activeTab}` : ''));
+    } else if (this.slug) {
+      history.replaceState(null, '', `/job/jobs/${this.slug}/${this.activeTab !== 'resume' ? `?tab=${this.activeTab}` : ''}`);
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    if (!this.slug) {
+      this.state = 'error';
+      this.error = 'Missing slug';
+      return;
+    }
+    this.state = 'loading';
+    try {
+      // Load both assets in parallel; tolerate 404 (asset not yet generated).
+      const [resume, cover] = await Promise.all([
+        this._loadAsset('resume'),
+        this._loadAsset('cover-letter'),
+      ]);
+      this.assets = { 'resume': resume, 'cover-letter': cover };
+      this.state = 'loaded';
+      document.title = `${this.slug} — /job`;
+    } catch (e) {
+      this.state = 'error';
+      this.error = String(e);
+    }
+  }
+
+  async _loadAsset(kind) {
+    const file = TABS.find(t => t.id === kind).file;
+    const path = `03-jobs/${this.slug}/${file}`;
+    try {
+      const r = await window.JobKB.readFile(path);
+      return { path, content: r.content, sha: r.sha, draft: r.content, mode: 'view', saving: false, dirty: false, error: '' };
+    } catch (e) {
+      return { path, content: '', sha: '', draft: '', mode: 'empty', saving: false, dirty: false, error: '' };
+    }
+  }
+
+  _switchTab(id) {
+    this.activeTab = id;
+    history.replaceState(null, '', `/job/jobs/${this.slug}/${id !== 'resume' ? `?tab=${id}` : ''}`);
+  }
+
+  async _onGenerate(kind) {
+    if (!this.rowNumber) {
+      this._setAssetError(kind, 'Missing row reference. Open this page from the pipeline.');
+      return;
+    }
+    const a = this.assets[kind] || {};
+    a.saving = true;
+    a.error = '';
+    this.assets = { ...this.assets, [kind]: { ...a } };
+    try {
+      const res = await generateAsset(this.rowNumber, kind);
+      const file = TABS.find(t => t.id === kind).file;
+      const path = `03-jobs/${this.slug}/${file}`;
+      this.assets = {
+        ...this.assets,
+        [kind]: {
+          path,
+          content: res.content,
+          sha: res.sha,
+          draft: res.content,
+          mode: 'view',
+          saving: false,
+          dirty: false,
+          error: '',
+        },
+      };
+    } catch (e) {
+      this._setAssetError(kind, String(e));
+    }
+  }
+
+  _setAssetError(kind, msg) {
+    const a = this.assets[kind] || {};
+    this.assets = { ...this.assets, [kind]: { ...a, saving: false, error: msg } };
+  }
+
+  _enterEdit(kind) {
+    const a = this.assets[kind];
+    this.assets = { ...this.assets, [kind]: { ...a, mode: 'edit', draft: a.content } };
+  }
+
+  _cancelEdit(kind) {
+    const a = this.assets[kind];
+    this.assets = { ...this.assets, [kind]: { ...a, mode: 'view', draft: a.content, dirty: false, error: '' } };
+  }
+
+  _onDraftInput(kind, e) {
+    const a = this.assets[kind];
+    this.assets = { ...this.assets, [kind]: { ...a, draft: e.target.value, dirty: e.target.value !== a.content } };
+  }
+
+  async _saveEdit(kind) {
+    const a = this.assets[kind];
+    if (!a.dirty) return;
+    this.assets = { ...this.assets, [kind]: { ...a, saving: true, error: '' } };
+    try {
+      const res = await writeFile(a.path, a.draft, a.sha);
+      this.assets = {
+        ...this.assets,
+        [kind]: { ...a, content: a.draft, sha: res.sha, mode: 'view', saving: false, dirty: false },
+      };
+    } catch (e) {
+      this._setAssetError(kind, String(e));
+    }
+  }
+
+  _renderTabBody(kind) {
+    const a = this.assets[kind];
+    if (!a) return html`<div class="placeholder"><h2>Loading…</h2></div>`;
+
+    if (a.mode === 'empty') {
+      return html`
+        <div class="placeholder">
+          <h2>No ${kind === 'resume' ? 'resume' : 'cover letter'} yet</h2>
+          <p>Generate one tailored to this role using your career KB and voice rules.</p>
+          <div style="margin-top:var(--space-4);display:flex;justify-content:center;gap:var(--space-3);">
+            <button class="btn btn--primary" ?disabled=${a.saving} @click=${() => this._onGenerate(kind)}>
+              ${a.saving ? 'Generating…' : `Generate ${kind === 'resume' ? 'resume' : 'cover letter'}`}
+            </button>
+          </div>
+          ${a.error ? html`<p class="muted" style="color:var(--error);margin-top:var(--space-3);">${a.error}</p>` : nothing}
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="asset-toolbar">
+        ${a.mode === 'view' ? html`
+          <button class="btn btn--sm" @click=${() => this._enterEdit(kind)}>Edit</button>
+          <button class="btn btn--sm" ?disabled=${a.saving} @click=${() => this._onGenerate(kind)}>
+            ${a.saving ? 'Regenerating…' : 'Regenerate'}
+          </button>
+        ` : html`
+          <button class="btn btn--sm btn--primary" ?disabled=${!a.dirty || a.saving} @click=${() => this._saveEdit(kind)}>
+            ${a.saving ? 'Saving…' : 'Save'}
+          </button>
+          <button class="btn btn--sm" @click=${() => this._cancelEdit(kind)}>Cancel</button>
+        `}
+        ${a.error ? html`<span class="muted" style="color:var(--error);">${a.error}</span>` : nothing}
+      </div>
+
+      ${a.mode === 'edit'
+        ? html`<textarea class="asset-editor" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)}></textarea>`
+        : html`<article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(a.content))}</article>`
+      }
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`<div class="placeholder"><h2>Loading…</h2></div>`;
+    }
+    if (this.state === 'error') {
+      return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">
+        <h2>Couldn't load this role</h2>
+        <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
+      </div>`;
+    }
+
+    return html`
+      <nav class="breadcrumb">
+        <a href="/job/jobs/">Jobs</a>
+        <span>›</span>
+        <span>${this.slug}</span>
+      </nav>
+
+      <header class="page-header">
+        <h1>${this.slug}</h1>
+        <p>Resume and cover letter for this role. Each draft is committed to fikei/job/03-jobs/${this.slug}/.</p>
+      </header>
+
+      <div class="asset-tabs">
+        ${TABS.map(t => html`
+          <button class="asset-tabs__tab ${this.activeTab === t.id ? 'is-active' : ''}"
+                  @click=${() => this._switchTab(t.id)}>
+            ${t.label}
+          </button>
+        `)}
+      </div>
+
+      <section class="asset-panel">
+        ${this._renderTabBody(this.activeTab)}
+      </section>
+    `;
+  }
+}
+
+customElements.define('job-role-detail', JobRoleDetail);

--- a/job/js/kbwrite.js
+++ b/job/js/kbwrite.js
@@ -1,0 +1,22 @@
+// kbwrite.js — kb-write Edge Function client.
+const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/kb-write';
+
+async function authHeader() {
+  const supabase = window.CtrlAuth?.getSupabaseClient?.();
+  if (!supabase) throw new Error('CtrlAuth not ready');
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('not signed in');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function writeFile(path, content, baseSha) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ path, content, baseSha }),
+  });
+  if (!res.ok) throw new Error(`kb-write ${res.status}: ${await res.text()}`);
+  return res.json();
+}

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -28,4 +28,17 @@ export async function setStatus(rowNumber, status) {
   return res.json();
 }
 
-window.JobPipeline = { fetchPipeline, setStatus };
+const GEN_ASSET_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gen-asset';
+
+export async function generateAsset(rowNumber, kind) {
+  const headers = await authHeader();
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ rowNumber, kind }),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  return res.json(); // { slug, path, sha, content }
+}
+
+window.JobPipeline = { fetchPipeline, setStatus, generateAsset };

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.11.0">
-  <script src="/job/js/theme.js?v=0.11.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
+  <script src="/job/js/theme.js?v=0.12.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/supabase/functions/_shared/job-auth.ts
+++ b/supabase/functions/_shared/job-auth.ts
@@ -1,0 +1,50 @@
+// Shared auth check for /job product Edge Functions.
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
+
+const ALLOWLIST = ['fike101@gmail.com'];
+
+export async function verifyJobUser(req: Request): Promise<string | null> {
+  const auth = req.headers.get('Authorization') || '';
+  const token = auth.replace(/^Bearer\s+/i, '');
+  if (!token) return null;
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseAnonKey) return null;
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data?.user?.email) return null;
+  const email = data.user.email.toLowerCase();
+  if (!ALLOWLIST.includes(email)) return null;
+  return email;
+}
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+};
+
+export function jsonResp(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+export function err(message: string, status = 400) { return jsonResp({ error: message }, status); }
+
+export function slugify(s: string): string {
+  return String(s || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function roleSlug(company: string, title: string): string {
+  const c = slugify(company);
+  const t = slugify(title).split('-').filter(Boolean).slice(0, 3).join('-');
+  return [c, t].filter(Boolean).join('-');
+}

--- a/supabase/functions/_shared/job-github.ts
+++ b/supabase/functions/_shared/job-github.ts
@@ -1,0 +1,83 @@
+// Shared GitHub Contents API helpers for the /job product.
+// All functions read/write the private fikei/job repo on the user's behalf
+// using a server-only GITHUB_PAT secret.
+
+const REPO = 'fikei/job';
+const REF = 'main';
+const API = 'https://api.github.com';
+
+function pat(): string {
+  const t = Deno.env.get('GITHUB_PAT');
+  if (!t) throw new Error('GITHUB_PAT not configured');
+  return t;
+}
+
+const HEADERS = () => ({
+  Authorization: `Bearer ${pat()}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'ctrl-rodeo-job-product',
+});
+
+export interface FileResult { path: string; sha: string; content: string; }
+
+export async function ghReadFile(path: string): Promise<FileResult | null> {
+  const res = await fetch(`${API}/repos/${REPO}/contents/${path}?ref=${REF}`, { headers: HEADERS() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`gh read ${path} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const data = await res.json();
+  if (Array.isArray(data) || data.type !== 'file') throw new Error(`expected file at ${path}`);
+  const content = data.encoding === 'base64' ? atob(data.content.replace(/\n/g, '')) : data.content;
+  return { path: data.path, sha: data.sha, content };
+}
+
+export async function ghReadDir(path: string): Promise<{ name: string; path: string; type: string; size: number }[]> {
+  const res = await fetch(`${API}/repos/${REPO}/contents/${path.replace(/\/$/, '')}?ref=${REF}`, { headers: HEADERS() });
+  if (res.status === 404) return [];
+  if (!res.ok) throw new Error(`gh dir ${path} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const data = await res.json();
+  if (!Array.isArray(data)) throw new Error(`expected directory at ${path}`);
+  return data.map((e: { name: string; path: string; type: string; size: number }) => ({
+    name: e.name, path: e.path, type: e.type, size: e.size,
+  }));
+}
+
+// Recursive tree listing (one API call). Returns file blobs only.
+export async function ghTree(path = ''): Promise<{ path: string; sha: string }[]> {
+  const res = await fetch(`${API}/repos/${REPO}/git/trees/${REF}?recursive=1`, { headers: HEADERS() });
+  if (!res.ok) throw new Error(`gh tree ${res.status}`);
+  const data = await res.json() as { tree: { path: string; type: string; sha: string }[] };
+  return (data.tree || [])
+    .filter(t => t.type === 'blob' && (!path || t.path.startsWith(path)))
+    .map(t => ({ path: t.path, sha: t.sha }));
+}
+
+export async function ghWriteFile(path: string, content: string, message: string, baseSha?: string): Promise<{ path: string; sha: string }> {
+  const body: Record<string, string> = {
+    message,
+    content: btoa(unescape(encodeURIComponent(content))),
+    branch: REF,
+  };
+  if (baseSha) body.sha = baseSha;
+  // If no baseSha and the file already exists, GitHub returns 422; fetch the
+  // existing sha and retry once.
+  let res = await fetch(`${API}/repos/${REPO}/contents/${path}`, {
+    method: 'PUT',
+    headers: { ...HEADERS(), 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 422 && !baseSha) {
+    const existing = await ghReadFile(path);
+    if (existing) {
+      body.sha = existing.sha;
+      res = await fetch(`${API}/repos/${REPO}/contents/${path}`, {
+        method: 'PUT',
+        headers: { ...HEADERS(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+  }
+  if (!res.ok) throw new Error(`gh write ${path} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const data = await res.json() as { content: { path: string; sha: string } };
+  return { path: data.content.path, sha: data.content.sha };
+}

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -1,0 +1,126 @@
+// gen-asset — generate a resume or cover letter for a pipeline role using
+// Ian's career KB + Anthropic Claude, then commit the result to fikei/job.
+//
+// POST { rowNumber: int, kind: 'resume' | 'cover-letter' }
+//   → { slug, path, sha, content }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders, roleSlug } from '../_shared/job-auth.ts';
+import { ghReadFile, ghTree, ghWriteFile } from '../_shared/job-github.ts';
+import { readSheetValues } from '../jobs-pipe/sheets.ts';
+import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
+
+const VERSION = '0.1.0';
+console.log(`[gen-asset] v${VERSION} - initial`);
+
+const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const KB_DIRS = ['01-job-history/', '02-goals-intents/'];
+
+interface SheetRole {
+  rowNumber: number;
+  company: string;
+  title: string;
+  url: string;
+  sector: string;
+  salary: string;
+}
+
+async function fetchRole(rowNumber: number): Promise<SheetRole | null> {
+  const values = await readSheetValues(SHEET_ID, `Roles!A${rowNumber}:M${rowNumber}`);
+  const row = values[0];
+  if (!row) return null;
+  return {
+    rowNumber,
+    company: (row[3] || '').trim(),
+    title: (row[4] || '').trim(),
+    url: (row[5] || '').trim(),
+    salary: (row[8] || '').trim(),
+    sector: (row[9] || '').trim(),
+  };
+}
+
+async function loadKb(): Promise<string> {
+  const tree = await ghTree();
+  const files = tree.filter(t => /\.md$/.test(t.path) && KB_DIRS.some(d => t.path.startsWith(d)));
+  // Cap to a reasonable size — total KB shouldn't blow past 200KB.
+  const fetched = await Promise.all(files.map(async f => {
+    try {
+      const r = await ghReadFile(f.path);
+      return r ? `## ${f.path}\n\n${r.content}` : null;
+    } catch { return null; }
+  }));
+  return fetched.filter(Boolean).join('\n\n---\n\n');
+}
+
+async function callClaude(system: string, user: string): Promise<string> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 4096,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`anthropic ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  const text = (data.content || [])
+    .filter(c => c.type === 'text')
+    .map(c => c.text)
+    .join('\n')
+    .trim();
+  if (!text) throw new Error('empty model output');
+  return text;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const body = await req.json().catch(() => ({}));
+    const rowNumber = Number(body.rowNumber);
+    const kind = body.kind === 'cover-letter' ? 'cover-letter' : (body.kind === 'resume' ? 'resume' : null);
+    if (!Number.isInteger(rowNumber) || rowNumber < 2 || rowNumber > 5000) return err('rowNumber must be int 2..5000', 400);
+    if (!kind) return err('kind must be "resume" or "cover-letter"', 400);
+
+    const role = await fetchRole(rowNumber);
+    if (!role || !role.company) return err('role not found at that row', 404);
+
+    const slug = roleSlug(role.company, role.title);
+    if (!slug) return err('could not derive slug for role', 400);
+
+    const [kb] = await Promise.all([loadKb()]);
+    const system = buildSystemPrompt(kind);
+    const user = buildUserMessage(kind, kb, role);
+
+    const content = await callClaude(system, user);
+
+    const path = `03-jobs/${slug}/${kind}.md`;
+    const written = await ghWriteFile(
+      path,
+      content,
+      `chore: generate ${kind} for ${role.company} ${role.title} via /job`,
+    );
+
+    return jsonResp({ ok: true, slug, path: written.path, sha: written.sha, content });
+  } catch (e) {
+    console.error('[gen-asset] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -1,0 +1,96 @@
+// Prompts for resume + cover-letter generation.
+// Cover-letter rules are mirrored from Ian's memory file
+// (~/.claude/projects/...memory/cover_letter_rules.md). Keep these in sync.
+
+export const COVER_LETTER_VOICE = `Write like a smart, dry, confident senior PM. NOT a template.
+
+STRUCTURAL RULES (apply on first draft):
+1. Never open with "I'm applying for the X role." Open with a concrete moment, observation, or specific claim.
+2. Lead with one specific story, not a list. Pick the single hardest/most-relevant thing he's done; tell it as a moment.
+3. No bulleted sales pitches. Fold the same content into prose paragraphs that respond to the JD's themes without naming them.
+4. Address gaps directly, briefly, without apology.
+5. Close in two sentences. Logistics + one offer. No "Thank you for your consideration." No "Sincerely." Sign as "Ian." not "Ian Fike,".
+6. ONE PAGE, ~350 words. If longer, something is performing rather than informing.
+
+VOICE RULES — cut on sight:
+- Mission-parroting / quoting the company's own copy back at them.
+- JD recitation (listing the role's pillars verbatim).
+- Try-hard cleverness; if the line sounds quotable, it's a tell.
+- Jargon-as-personality ("highest-leverage growth lever," "force multiplier," "compound returns").
+- Investor name-dropping as a bullet. Weave once into prose or omit.
+- Staccato over-correction (three short "I" sentences in a row).
+- Hedging adverbs: "really," "very," "deeply," "extremely." Cut them all.
+- Banned phrases: "Excited to," "passionate about."
+- Suffering language ("hardest," "toughest," "most painful"). Use "most formative," "biggest stretch," "longest-running," or describe the work directly.
+- Section-announcers: "On the engineering question:", "On the topic of X,", "As for Y,", "To your point about Z,", "That said,". Just say the thing.
+- Meta-hinges: "A few things in the role stood out," "There are a few reasons," "Let me explain," "I want to highlight." Skip and dive in.
+- VC/operator clichés: "the whole game," "the holy grail," "the real magic," "where the rubber meets the road," "compounds," "high-leverage," "force multiplier," "asymmetric upside," "step function," "10x," "moat." Out on sight.
+- Punditry sentences (briefly leaving the letter to play columnist).
+- Hedge-around-self-praise ("I'm probably at my best at X").
+- Stacked metaphors; one metaphor at a time, or none.
+- Folksy-tough phrasing ("whichever scaling problem you're staring at," "whatever fire you're putting out").
+- Generic CTAs: "I'd love to talk," "I'd love to chat," "I'd appreciate the opportunity." Replace with a specific offer ("Happy to walk through X").
+- EM DASHES (—) BANNED. Use periods, commas, parentheses, or colons.
+
+POSITIVE MOVES:
+- Earned numbers, de-emphasized — drop in mid-paragraph then disclaim.
+- Specificity beats abstraction.
+- Show technical fluency through verbs and nouns, not claims.
+- Respond to the role's actual problem, not its title.
+- End with an offer, not a request.
+
+Make a point, not an observation. Every paragraph advances a claim.
+
+If a sentence could survive being deleted without changing the argument, cut it.`;
+
+export const RESUME_VOICE = `Write a one-page resume in markdown. Sections in order:
+1. Header: "# Ian Fike", a single italic line for current role/title, then a contact line ("San Francisco · fike101@gmail.com · ianfike.com").
+2. Brief 1-2 sentence summary in plain prose (no "results-driven", no "passionate about", no buzzwords).
+3. ## Experience — most recent role first. For each: "### Title, Company (start–end)" then 2–4 bullets of OUTCOMES with verbs first ("Owned", "Shipped", "Scaled"), specific surfaces/metrics, and the why behind the work.
+4. ## Skills — a single line of comma-separated craft labels (no bullets).
+5. ## Education — line per item.
+
+VOICE RULES (same as cover letter):
+- No em dashes (—). Periods, commas, parentheses, or colons.
+- No "passionate about", "excited to", "results-driven", "team player".
+- Specificity beats abstraction. Name the surface (registration, eligibility infra) over the abstraction (platform infrastructure).
+- Earned numbers de-emphasized — mid-paragraph or mid-bullet, never as a headline.
+- Tighten ruthlessly. If a bullet survives being cut without weakening the argument for hiring, cut it.
+- Tailor to the target role: emphasize the past work that maps to what THIS role is trying to ship next.
+
+Output ONLY the markdown. No preamble. No "Here is your resume." Start with "# Ian Fike".`;
+
+export function buildSystemPrompt(kind: 'resume' | 'cover-letter'): string {
+  const voice = kind === 'cover-letter' ? COVER_LETTER_VOICE : RESUME_VOICE;
+  return `You are drafting a ${kind === 'cover-letter' ? 'cover letter' : 'resume'} for Ian Fike, a senior PM. Your job: produce final-quality markdown that Ian could submit without further editing.
+
+${voice}
+
+Below is Ian's career knowledge base — companies, projects, skills, wins, and goals/intents. Use it as the source of truth for facts. Do not invent.`;
+}
+
+export function buildUserMessage(kind: 'resume' | 'cover-letter', kbContext: string, role: { company: string; title: string; sector?: string; salary?: string; url?: string }): string {
+  const meta = [
+    `Company: ${role.company}`,
+    `Title: ${role.title}`,
+    role.sector ? `Sector: ${role.sector}` : '',
+    role.salary ? `Salary: ${role.salary}` : '',
+    role.url ? `Posting: ${role.url}` : '',
+  ].filter(Boolean).join('\n');
+
+  const ask = kind === 'cover-letter'
+    ? 'Draft the cover letter as markdown. ~350 words, one page. Address it to the company by name.'
+    : 'Draft the resume as markdown. One page. Tailored emphasis for this role.';
+
+  return `# Career knowledge base
+
+${kbContext}
+
+# Target role
+
+${meta}
+
+# Ask
+
+${ask}`;
+}

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -5,9 +5,11 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
 import { readSheetValues, writeSheetCell } from './sheets.ts';
 import { computeFit, RoleRow } from './fit.ts';
+import { ghTree } from '../_shared/job-github.ts';
+import { roleSlug } from '../_shared/job-auth.ts';
 
-const VERSION = '0.2.0';
-console.log(`[jobs-pipe] v${VERSION} - status writeback`);
+const VERSION = '0.3.0';
+console.log(`[jobs-pipe] v${VERSION} - asset flags`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const ALLOWLIST = ['fike101@gmail.com'];
@@ -77,15 +79,34 @@ serve(async (req) => {
     if (!email) return err('unauthorized', 401);
 
     if (req.method === 'GET') {
-      const values = await readSheetValues(SHEET_ID, 'Roles!A2:M1000');
+      const [values, tree] = await Promise.all([
+        readSheetValues(SHEET_ID, 'Roles!A2:M1000'),
+        ghTree('03-jobs/').catch(() => []),
+      ]);
+      // Build slug → asset-flags map.
+      const assets = new Map<string, { hasResume: boolean; hasCoverLetter: boolean }>();
+      for (const t of tree) {
+        const m = t.path.match(/^03-jobs\/([^/]+)\/(resume|cover-letter)\.md$/);
+        if (!m) continue;
+        const cur = assets.get(m[1]) || { hasResume: false, hasCoverLetter: false };
+        if (m[2] === 'resume') cur.hasResume = true;
+        else cur.hasCoverLetter = true;
+        assets.set(m[1], cur);
+      }
       const enriched = values
         .map((row, idx) => rowToRole(row, idx + 2))
         .filter(({ role }) => role.company || role.title)
-        .map(({ role, rowNumber }) => ({
-          rowNumber,
-          ...role,
-          ...computeFit(role),
-        }));
+        .map(({ role, rowNumber }) => {
+          const slug = roleSlug(role.company, role.title);
+          const flags = assets.get(slug) || { hasResume: false, hasCoverLetter: false };
+          return {
+            rowNumber,
+            slug,
+            ...role,
+            ...computeFit(role),
+            ...flags,
+          };
+        });
       return json({ version: VERSION, count: enriched.length, roles: enriched });
     }
 

--- a/supabase/functions/kb-write/index.ts
+++ b/supabase/functions/kb-write/index.ts
@@ -1,0 +1,41 @@
+// kb-write — write a markdown file to the private fikei/job repo.
+// POST { path, content, baseSha?, message? } → { path, sha }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { ghWriteFile } from '../_shared/job-github.ts';
+
+const VERSION = '0.1.0';
+console.log(`[kb-write] v${VERSION} - initial`);
+
+const PATH_RE = /^[a-zA-Z0-9_\-./]+\.md$/;
+const MAX_CONTENT_BYTES = 64 * 1024;
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const body = await req.json().catch(() => ({}));
+    const path = String(body.path || '').trim();
+    const content = String(body.content ?? '');
+    const baseSha = body.baseSha ? String(body.baseSha) : undefined;
+    const message = String(body.message || `chore: edit ${path} via /job product`);
+
+    if (!path || path.includes('..') || !PATH_RE.test(path) || path.startsWith('/')) {
+      return err('invalid path; must be a relative *.md path', 400);
+    }
+    if (content.length > MAX_CONTENT_BYTES) {
+      return err(`content exceeds ${MAX_CONTENT_BYTES} bytes`, 413);
+    }
+
+    const result = await ghWriteFile(path, content, message, baseSha);
+    return jsonResp({ ok: true, ...result });
+  } catch (e) {
+    console.error('[kb-write] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});


### PR DESCRIPTION
## Summary

PR C of the asks. Score-explainer (#642) and editable status + Apply (#643) already shipped. This PR adds the asset workflow: tailored resume + cover letter generation per role, columns in the pipeline, and a per-role detail page with tabs and edit-in-place.

## Backend

### Shared modules (`supabase/functions/_shared/`)
- **`job-auth.ts`** — allowlist JWT verifier, `jsonResp` / `err` helpers, canonical `roleSlug` used both server- and client-side.
- **`job-github.ts`** — GitHub Contents read/write + recursive tree listing on the private `fikei/job` repo using `GITHUB_PAT`.

### `kb-write` (v0.1.0)
- `POST { path, content, baseSha?, message? }` commits a markdown file.
- Path validation (only `*.md` under the repo root), 64KB cap, auto-resolves `baseSha` if not provided.

### `gen-asset` (v0.1.0)
- `POST { rowNumber, kind }` where kind is `resume` or `cover-letter`.
- Pulls the role from the sheet, loads the full `01-job-history/` + `02-goals-intents/` KB in parallel via the GitHub tree API.
- Calls **Claude Haiku 4.5** with the cover-letter voice rules baked into the system prompt (mirrored from `~/.claude/projects/.../memory/cover_letter_rules.md`).
- Commits the output to `03-jobs/{slug}/{kind}.md`. Returns the generated content + sha.

### `jobs-pipe` (v0.3.0)
- GET response now includes `slug`, `hasResume`, `hasCoverLetter` per role. Computed by scanning `03-jobs/` via the GitHub tree API once per request.

## Frontend (app v0.12.0)

### Pipeline
- Two new columns: **Resume** and **Cover**. Each cell:
  - **No asset yet** → "Create" button. Click → `gen-asset`. Cell flips to View/Edit on success.
  - **Asset exists** → "View / Edit" link opening `/job/jobs/{slug}/?row=&tab=...` in a new tab.

### Per-role detail page
- Pretty URL `/job/jobs/{slug}/` handled via the same 404-router pattern as History drilldown.
- `<job-role-detail>` mounts breadcrumb + tabs (Resume / Cover letter).
- **View** mode: rendered markdown via the existing `marked` + `DOMPurify` + wiki-link pipeline.
- **Edit** mode: monospace textarea. Save → `kb-write` with optimistic-concurrency `baseSha`. Cancel reverts.
- **Regenerate** button on each tab calls `gen-asset` again to refresh the file.

## Deploy plan

After merge I'll deploy `kb-write`, `gen-asset`, and the `jobs-pipe` update.

## Test plan
- [ ] Create button on a New row → resume + cover letter appear in the pipeline cell within ~30s
- [ ] View/Edit opens /job/jobs/{slug}/ with the new tab pre-selected
- [ ] Edit + Save round-trips through kb-write; new sha is honoured
- [ ] Regenerate produces a fresh draft
- [ ] Cover letter follows the voice rules (no em dashes, no "passionate about")

🤖 Generated with [Claude Code](https://claude.com/claude-code)