### PR TITLE
Propagate /job cache-bust through static imports

### DIFF
--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
 </body>
 </html>

--- a/job/jobs/_drill/index.html
+++ b/job/jobs/_drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.12.0';
-console.log(`[job] v${VERSION} - resume + cover letter assets`);
+const VERSION = '0.12.1';
+console.log(`[job] v${VERSION} - propagate cache-bust to static imports`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-detail.js
+++ b/job/js/components/job-detail.js
@@ -4,7 +4,8 @@
 // the pretty URL via history.replaceState.
 import { LitElement, html } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
-import { renderMarkdown } from '../markdown.js';
+const V = (new URL(import.meta.url)).search;
+const { renderMarkdown } = await import('../markdown.js' + V);
 
 const KIND_DIR = {
   companies: '01-job-history/companies',

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -1,7 +1,6 @@
 // job-history-resume — top-level resume view: list of companies pulled from
 // fikei/job/01-job-history/companies/ via kb-read.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-import { renderMarkdown } from '../markdown.js';
 
 const COMPANIES_DIR = '01-job-history/companies/';
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -1,7 +1,10 @@
 // job-pipeline — pipeline table view. Reads from jobs-pipe and renders
 // rows sorted by Fit Score desc. Click a fit pill to see the breakdown.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-import { fetchPipeline, setStatus, generateAsset } from '../pipeline.js';
+// Carry the cache-bust query from this module's own URL through to siblings;
+// otherwise static imports below would hit the 10-min Pages cache.
+const V = (new URL(import.meta.url)).search;
+const { fetchPipeline, setStatus, generateAsset } = await import('../pipeline.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -3,9 +3,12 @@
 // 03-jobs/{slug}/{kind}.md via kb-read; saves edits via kb-write.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
-import { renderMarkdown } from '../markdown.js';
-import { generateAsset } from '../pipeline.js';
-import { writeFile } from '../kbwrite.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { generateAsset }, { writeFile }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../pipeline.js' + V),
+  import('../kbwrite.js' + V),
+]);
 
 const TABS = [
   { id: 'resume', label: 'Resume', file: 'resume.md' },

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.0">
-  <script src="/job/js/theme.js?v=0.12.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
+  <script src="/job/js/theme.js?v=0.12.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Bug

`/job/jobs/` table not loading. Console:
```
Uncaught (in promise) SyntaxError: The requested module '../pipeline.js' does not provide an export named 'generateAsset'
```

## Root cause

`app.js?v=0.12.0` is fresh and dynamic-imports components with the version query (also fresh). But components use **static** imports for siblings — `import { generateAsset } from '../pipeline.js'` — no query. The browser served whatever was in its 10-min Pages cache. For users who'd visited at v0.10.0 (before `generateAsset` was added), that cached older `pipeline.js` lacked the export and threw.

## Fix

Each component derives `V = (new URL(import.meta.url)).search` at the top of the file and dynamic-imports its sibling modules with that query appended. `import.meta.url` carries the same `?v=N` the parent used to load the component, so the version flows through the whole graph automatically.

App bumped to 0.12.1.

## Test plan
- [ ] Hard-refresh /job/jobs/ → table renders, no console errors
- [ ] Subsequent VERSION bumps in any module are picked up immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)