### PR TITLE
Cut /job pipeline + assets over to Postgres

### DIFF
--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
 </body>
 </html>

--- a/job/jobs/_drill/index.html
+++ b/job/jobs/_drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.12.1';
-console.log(`[job] v${VERSION} - propagate cache-bust to static imports`);
+const VERSION = '0.13.0';
+console.log(`[job] v${VERSION} - postgres pipeline cutover`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -65,15 +65,23 @@ export class JobPipeline extends LitElement {
   async _maybeLoad() {
     if (document.body.dataset.authState !== 'in') return;
     if (this.state === 'loading' || this.state === 'loaded') return;
+    await this._load(false);
+  }
+
+  async _load(sync) {
     this.state = 'loading';
     try {
-      const data = await fetchPipeline();
-      this.roles = (data.roles || []).slice().sort((a, b) => b.score - a.score);
+      const data = await fetchPipeline({ sync });
+      this.roles = (data.roles || []).slice();
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
       this.state = 'error';
     }
+  }
+
+  async _onSync() {
+    await this._load(true);
   }
 
   _toggleSet(set, value, prop) {
@@ -157,7 +165,7 @@ export class JobPipeline extends LitElement {
     r._saving = true;
     this.requestUpdate();
     try {
-      await setStatus(r.rowNumber, status);
+      await setStatus({ slug: r.slug, rowNumber: r.rowNumber }, status);
       r._saving = false;
       r._error = '';
     } catch (e) {
@@ -182,7 +190,7 @@ export class JobPipeline extends LitElement {
     r[flag] = true;
     this.requestUpdate();
     try {
-      await generateAsset(r.rowNumber, kind);
+      await generateAsset(r.slug, kind);
       if (kind === 'resume') r.hasResume = true;
       else r.hasCoverLetter = true;
     } catch (e) {
@@ -194,7 +202,7 @@ export class JobPipeline extends LitElement {
   }
 
   _detailHref(r, tab) {
-    return `/job/jobs/${r.slug}/?row=${r.rowNumber}&tab=${tab}`;
+    return `/job/jobs/${r.slug}/?tab=${tab}`;
   }
   _onBackdropClick(e) {
     if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal();
@@ -347,6 +355,9 @@ export class JobPipeline extends LitElement {
       ${this._renderFilters()}
       <div class="pipeline-meta">
         Showing <strong>${rows.length}</strong> of ${this.roles.length} roles, sorted by fit score.
+        <button class="btn btn--sm" style="margin-left:var(--space-3);" @click=${() => this._onSync()}>
+          Sync from sheet
+        </button>
       </div>
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -1,18 +1,18 @@
 // job-role-detail — per-role detail page with Resume / Cover Letter tabs.
-// Reads /job/jobs/{slug}/?row=&tab= and renders both assets from
-// 03-jobs/{slug}/{kind}.md via kb-read; saves edits via kb-write.
+// Reads /job/jobs/{slug}/?tab= and renders/edits assets from job.role_assets
+// via the role-asset endpoint.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset }, { writeFile }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
-  import('../kbwrite.js' + V),
+  import('../roleAsset.js' + V),
 ]);
 
 const TABS = [
-  { id: 'resume', label: 'Resume', file: 'resume.md' },
-  { id: 'cover-letter', label: 'Cover letter', file: 'cover-letter.md' },
+  { id: 'resume', label: 'Resume' },
+  { id: 'cover-letter', label: 'Cover letter' },
 ];
 
 export class JobRoleDetail extends LitElement {
@@ -87,14 +87,11 @@ export class JobRoleDetail extends LitElement {
   }
 
   async _loadAsset(kind) {
-    const file = TABS.find(t => t.id === kind).file;
-    const path = `03-jobs/${this.slug}/${file}`;
-    try {
-      const r = await window.JobKB.readFile(path);
-      return { path, content: r.content, sha: r.sha, draft: r.content, mode: 'view', saving: false, dirty: false, error: '' };
-    } catch (e) {
-      return { path, content: '', sha: '', draft: '', mode: 'empty', saving: false, dirty: false, error: '' };
+    const r = await readRoleAsset(this.slug, kind);
+    if (!r) {
+      return { content: '', draft: '', mode: 'empty', saving: false, dirty: false, error: '' };
     }
+    return { content: r.content_md, draft: r.content_md, mode: 'view', saving: false, dirty: false, error: '' };
   }
 
   _switchTab(id) {
@@ -103,24 +100,16 @@ export class JobRoleDetail extends LitElement {
   }
 
   async _onGenerate(kind) {
-    if (!this.rowNumber) {
-      this._setAssetError(kind, 'Missing row reference. Open this page from the pipeline.');
-      return;
-    }
     const a = this.assets[kind] || {};
     a.saving = true;
     a.error = '';
     this.assets = { ...this.assets, [kind]: { ...a } };
     try {
-      const res = await generateAsset(this.rowNumber, kind);
-      const file = TABS.find(t => t.id === kind).file;
-      const path = `03-jobs/${this.slug}/${file}`;
+      const res = await generateAsset(this.slug, kind);
       this.assets = {
         ...this.assets,
         [kind]: {
-          path,
           content: res.content,
-          sha: res.sha,
           draft: res.content,
           mode: 'view',
           saving: false,
@@ -158,10 +147,10 @@ export class JobRoleDetail extends LitElement {
     if (!a.dirty) return;
     this.assets = { ...this.assets, [kind]: { ...a, saving: true, error: '' } };
     try {
-      const res = await writeFile(a.path, a.draft, a.sha);
+      await writeRoleAsset(this.slug, kind, a.draft);
       this.assets = {
         ...this.assets,
-        [kind]: { ...a, content: a.draft, sha: res.sha, mode: 'view', saving: false, dirty: false },
+        [kind]: { ...a, content: a.draft, mode: 'view', saving: false, dirty: false },
       };
     } catch (e) {
       this._setAssetError(kind, String(e));

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -10,19 +10,22 @@ async function authHeader() {
   return { Authorization: `Bearer ${token}` };
 }
 
-export async function fetchPipeline() {
+export async function fetchPipeline({ sync = false } = {}) {
   const headers = await authHeader();
-  const res = await fetch(FN_URL, { headers });
+  const url = sync ? `${FN_URL}?sync=1` : FN_URL;
+  const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`jobs-pipe ${res.status}: ${await res.text()}`);
   return res.json();
 }
 
-export async function setStatus(rowNumber, status) {
+export async function setStatus(role, status) {
+  // role can be { slug, rowNumber } or just a slug string for backward compat.
+  const body = typeof role === 'string' ? { slug: role, status } : { slug: role.slug, rowNumber: role.rowNumber, status };
   const headers = await authHeader();
   const res = await fetch(FN_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ rowNumber, status }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`set-status ${res.status}: ${await res.text()}`);
   return res.json();
@@ -30,15 +33,15 @@ export async function setStatus(rowNumber, status) {
 
 const GEN_ASSET_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gen-asset';
 
-export async function generateAsset(rowNumber, kind) {
+export async function generateAsset(slug, kind) {
   const headers = await authHeader();
   const res = await fetch(GEN_ASSET_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ rowNumber, kind }),
+    body: JSON.stringify({ slug, kind }),
   });
   if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
-  return res.json(); // { slug, path, sha, content }
+  return res.json(); // { slug, kind, content }
 }
 
 window.JobPipeline = { fetchPipeline, setStatus, generateAsset };

--- a/job/js/roleAsset.js
+++ b/job/js/roleAsset.js
@@ -1,0 +1,30 @@
+// roleAsset.js — read + write per-role assets via the role-asset Edge Function.
+const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/role-asset';
+
+async function authHeader() {
+  const supabase = window.CtrlAuth?.getSupabaseClient?.();
+  if (!supabase) throw new Error('CtrlAuth not ready');
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('not signed in');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function readRoleAsset(slug, kind) {
+  const headers = await authHeader();
+  const res = await fetch(`${FN_URL}?slug=${encodeURIComponent(slug)}&kind=${encodeURIComponent(kind)}`, { headers });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`role-asset ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function writeRoleAsset(slug, kind, content_md) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, kind, content_md }),
+  });
+  if (!res.ok) throw new Error(`role-asset ${res.status}: ${await res.text()}`);
+  return res.json();
+}

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.12.1">
-  <script src="/job/js/theme.js?v=0.12.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
+  <script src="/job/js/theme.js?v=0.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.12.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/job-db.ts
+++ b/supabase/functions/_shared/job-db.ts
@@ -1,0 +1,13 @@
+// Shared Postgres helper for /job Edge Functions.
+// Lazy-init a single connection per function instance.
+import postgres from 'https://deno.land/x/postgresjs@v3.4.4/mod.js';
+
+let _sql: ReturnType<typeof postgres> | null = null;
+
+export function db() {
+  if (_sql) return _sql;
+  const url = Deno.env.get('SUPABASE_DB_URL');
+  if (!url) throw new Error('SUPABASE_DB_URL not configured');
+  _sql = postgres(url, { prepare: false, max: 4 });
+  return _sql;
+}

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -1,57 +1,59 @@
 // gen-asset — generate a resume or cover letter for a pipeline role using
-// Ian's career KB + Anthropic Claude, then commit the result to fikei/job.
+// Ian's career KB + Anthropic Claude, then commit the result to Postgres
+// (job.role_assets). KB is read from job.* tables (cutover from GitHub).
 //
-// POST { rowNumber: int, kind: 'resume' | 'cover-letter' }
-//   → { slug, path, sha, content }
+// POST { slug?, rowNumber?, kind: 'resume' | 'cover-letter' }
+//   → { slug, kind, content }
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { verifyJobUser, jsonResp, err, corsHeaders, roleSlug } from '../_shared/job-auth.ts';
-import { ghReadFile, ghTree, ghWriteFile } from '../_shared/job-github.ts';
-import { readSheetValues } from '../jobs-pipe/sheets.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.1.0';
-console.log(`[gen-asset] v${VERSION} - initial`);
+const VERSION = '0.2.0';
+console.log(`[gen-asset] v${VERSION} - Postgres cutover`);
 
-const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
-const KB_DIRS = ['01-job-history/', '02-goals-intents/'];
 
-interface SheetRole {
-  rowNumber: number;
-  company: string;
-  title: string;
-  url: string;
-  sector: string;
-  salary: string;
-}
-
-async function fetchRole(rowNumber: number): Promise<SheetRole | null> {
-  const values = await readSheetValues(SHEET_ID, `Roles!A${rowNumber}:M${rowNumber}`);
-  const row = values[0];
-  if (!row) return null;
-  return {
-    rowNumber,
-    company: (row[3] || '').trim(),
-    title: (row[4] || '').trim(),
-    url: (row[5] || '').trim(),
-    salary: (row[8] || '').trim(),
-    sector: (row[9] || '').trim(),
-  };
+async function loadRole(slug: string | null, rowNumber: number | null) {
+  const sql = db();
+  const rows = await sql`
+    select slug, source_row, company_name as company, title, url, sector, salary_range as salary
+    from job.pipeline_roles
+    where (${slug}::text is not null and slug = ${slug})
+       or (${rowNumber}::int is not null and source_row = ${rowNumber})
+    limit 1;
+  `;
+  return rows[0] || null;
 }
 
 async function loadKb(): Promise<string> {
-  const tree = await ghTree();
-  const files = tree.filter(t => /\.md$/.test(t.path) && KB_DIRS.some(d => t.path.startsWith(d)));
-  // Cap to a reasonable size — total KB shouldn't blow past 200KB.
-  const fetched = await Promise.all(files.map(async f => {
-    try {
-      const r = await ghReadFile(f.path);
-      return r ? `## ${f.path}\n\n${r.content}` : null;
-    } catch { return null; }
-  }));
-  return fetched.filter(Boolean).join('\n\n---\n\n');
+  const sql = db();
+  const [companies, projects, skills, wins, vision] = await Promise.all([
+    sql`select slug, name, sector, stage_at_time, location, body_md from job.companies`,
+    sql`select slug, company_slug, title, role, body_md, metric_value from job.projects`,
+    sql`select slug, name, type, level, years_practiced, body_md, cover_letter_blurb from job.skills`,
+    sql`select slug, company_slug, project_slug, headline, body_md, metric_value from job.wins`,
+    sql`select narrative_arc, voice_rules_md, raw_md from job.vision where id = 1`,
+  ]);
+
+  const sections: string[] = [];
+
+  if (vision[0]?.raw_md) sections.push(`## Vision\n\n${vision[0].raw_md}`);
+  for (const c of companies) {
+    sections.push(`## Company: ${c.name} (${c.slug})\n\n${c.body_md || ''}`);
+  }
+  for (const p of projects) {
+    sections.push(`## Project: ${p.title} (${p.slug}) — company=${p.company_slug || 'n/a'}\n\n${p.body_md || ''}`);
+  }
+  for (const s of skills) {
+    sections.push(`## Skill: ${s.name} (${s.slug}) — ${s.type || ''} ${s.level || ''}\n\n${s.body_md || ''}`);
+  }
+  for (const w of wins) {
+    sections.push(`## Win: ${w.headline} (${w.slug}) — metric=${w.metric_value || 'n/a'}\n\n${w.body_md || ''}`);
+  }
+  return sections.join('\n\n---\n\n');
 }
 
 async function callClaude(system: string, user: string): Promise<string> {
@@ -94,31 +96,39 @@ serve(async (req) => {
     if (!email) return err('unauthorized', 401);
 
     const body = await req.json().catch(() => ({}));
-    const rowNumber = Number(body.rowNumber);
+    const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
+    const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kind = body.kind === 'cover-letter' ? 'cover-letter' : (body.kind === 'resume' ? 'resume' : null);
-    if (!Number.isInteger(rowNumber) || rowNumber < 2 || rowNumber > 5000) return err('rowNumber must be int 2..5000', 400);
+    if (!slugIn && !rowIn) return err('slug or rowNumber required', 400);
     if (!kind) return err('kind must be "resume" or "cover-letter"', 400);
 
-    const role = await fetchRole(rowNumber);
-    if (!role || !role.company) return err('role not found at that row', 404);
+    const role = await loadRole(slugIn, rowIn);
+    if (!role) return err('role not found', 404);
 
-    const slug = roleSlug(role.company, role.title);
-    if (!slug) return err('could not derive slug for role', 400);
-
-    const [kb] = await Promise.all([loadKb()]);
+    const kb = await loadKb();
     const system = buildSystemPrompt(kind);
-    const user = buildUserMessage(kind, kb, role);
+    const user = buildUserMessage(kind, kb, {
+      company: role.company,
+      title: role.title,
+      sector: role.sector,
+      salary: role.salary,
+      url: role.url,
+    });
 
     const content = await callClaude(system, user);
 
-    const path = `03-jobs/${slug}/${kind}.md`;
-    const written = await ghWriteFile(
-      path,
-      content,
-      `chore: generate ${kind} for ${role.company} ${role.title} via /job`,
-    );
+    const sql = db();
+    await sql`
+      insert into job.role_assets (role_slug, kind, content_md, generated_by, generated_at)
+      values (${role.slug}, ${kind}, ${content}, ${ANTHROPIC_MODEL}, now())
+      on conflict (role_slug, kind) do update set
+        content_md = excluded.content_md,
+        generated_by = excluded.generated_by,
+        generated_at = excluded.generated_at,
+        updated_at = now();
+    `;
 
-    return jsonResp({ ok: true, slug, path: written.path, sha: written.sha, content });
+    return jsonResp({ ok: true, slug: role.slug, kind, content });
   } catch (e) {
     console.error('[gen-asset] error', e);
     return err((e as Error).message || 'server error', 500);

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -1,128 +1,165 @@
-// jobs-pipe — read the Job Search sheet, enrich with Fit Score, return JSON.
-// v1: GET only. Status writeback (POST) is in the next milestone.
+// jobs-pipe — read pipeline from Postgres, sync from Sheet on demand,
+// write status changes back to both.
+//
+//   GET                          → list pipeline_roles (Postgres)
+//   GET ?sync=1                  → sheet → Postgres upsert, then list
+//   POST { rowNumber|slug, status } → updates Postgres + sheet (dual-write)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
 import { readSheetValues, writeSheetCell } from './sheets.ts';
 import { computeFit, RoleRow } from './fit.ts';
-import { ghTree } from '../_shared/job-github.ts';
-import { roleSlug } from '../_shared/job-auth.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.3.0';
-console.log(`[jobs-pipe] v${VERSION} - asset flags`);
+const VERSION = '0.4.0';
+console.log(`[jobs-pipe] v${VERSION} - Postgres cutover + sheet sync`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
-const ALLOWLIST = ['fike101@gmail.com'];
 const STATUS_ENUM = new Set([
   '', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network',
 ]);
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-};
-
-function json(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  });
-}
-
-function err(message: string, status = 400) { return json({ error: message }, status); }
-
-async function verifyAllowlistedUser(req: Request): Promise<string | null> {
-  const auth = req.headers.get('Authorization') || '';
-  const token = auth.replace(/^Bearer\s+/i, '');
-  if (!token) return null;
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
-  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-    global: { headers: { Authorization: `Bearer ${token}` } },
-  });
-  const { data, error } = await supabase.auth.getUser(token);
-  if (error || !data?.user?.email) return null;
-  const email = data.user.email.toLowerCase();
-  if (!ALLOWLIST.includes(email)) return null;
-  return email;
-}
-
-// Sheet column layout (1-based): A Status (header), B Rank, C Status,
-// D Company, E Role Title, F Job Postings (URL), G Source, H Contact,
-// I Salary Range, J Sector, K Investors, L Website, M Crunchbase.
-function rowToRole(row: string[], rowNumber: number): { role: RoleRow; rowNumber: number } {
+function rowToRole(row: string[]): RoleRow {
   return {
-    rowNumber,
-    role: {
-      status: (row[2] || '').trim(),
-      rank: (row[1] || '').trim(),
-      company: (row[3] || '').trim(),
-      title: (row[4] || '').trim(),
-      url: (row[5] || '').trim(),
-      source: (row[6] || '').trim(),
-      contact: (row[7] || '').trim(),
-      salary: (row[8] || '').trim(),
-      sector: (row[9] || '').trim(),
-      investors: (row[10] || '').trim(),
-      website: (row[11] || '').trim(),
-      crunchbase: (row[12] || '').trim(),
-    },
+    status: (row[2] || '').trim(),
+    rank: (row[1] || '').trim(),
+    company: (row[3] || '').trim(),
+    title: (row[4] || '').trim(),
+    url: (row[5] || '').trim(),
+    source: (row[6] || '').trim(),
+    contact: (row[7] || '').trim(),
+    salary: (row[8] || '').trim(),
+    sector: (row[9] || '').trim(),
+    investors: (row[10] || '').trim(),
+    website: (row[11] || '').trim(),
+    crunchbase: (row[12] || '').trim(),
   };
+}
+
+function parseSalary(s: string | undefined): { low: number | null; high: number | null } {
+  if (!s) return { low: null, high: null };
+  const norm = s.toLowerCase().replace(/[,$]/g, '').replace(/\s+/g, '');
+  const nums = Array.from(norm.matchAll(/(\d+(?:\.\d+)?)(k)?/g)).map(m => {
+    const n = parseFloat(m[1]);
+    return m[2] === 'k' ? Math.round(n * 1000) : Math.round(n);
+  }).filter(n => n >= 1000);
+  if (!nums.length) return { low: null, high: null };
+  if (nums.length === 1) return { low: nums[0], high: nums[0] };
+  return { low: Math.min(...nums), high: Math.max(...nums) };
+}
+
+async function syncFromSheet() {
+  const sql = db();
+  const rows = await readSheetValues(SHEET_ID, 'Roles!A2:M1000');
+  let upserted = 0;
+  for (let idx = 0; idx < rows.length; idx++) {
+    const r = rows[idx];
+    const role = rowToRole(r);
+    if (!role.company && !role.title) continue;
+    const slug = roleSlug(role.company, role.title);
+    if (!slug) continue;
+    const fit = computeFit(role);
+    const { low, high } = parseSalary(role.salary);
+    const investors = role.investors ? role.investors.split(/,|;/).map(s => s.trim()).filter(Boolean) : [];
+
+    await sql`
+      insert into job.pipeline_roles (
+        slug, source_row, company_slug, company_name, title, url, source, status,
+        contact, salary_range, salary_low, salary_high, sector, investors,
+        fit_score, fit_breakdown, hard_fails
+      ) values (
+        ${slug}, ${idx + 2}, ${slugify(role.company)}, ${role.company}, ${role.title},
+        ${role.url || null}, ${role.source || null}, ${role.status || 'New'},
+        ${role.contact || null}, ${role.salary || null}, ${low}, ${high},
+        ${role.sector || null}, ${investors},
+        ${fit.score}, ${sql.json(fit.breakdown)}, ${fit.hardFails}
+      )
+      on conflict (slug) do update set
+        source_row = excluded.source_row,
+        company_name = excluded.company_name, title = excluded.title,
+        url = excluded.url, source = excluded.source, status = excluded.status,
+        contact = excluded.contact, salary_range = excluded.salary_range,
+        salary_low = excluded.salary_low, salary_high = excluded.salary_high,
+        sector = excluded.sector, investors = excluded.investors,
+        fit_score = excluded.fit_score, fit_breakdown = excluded.fit_breakdown,
+        hard_fails = excluded.hard_fails,
+        updated_at = now();
+    `;
+    upserted += 1;
+  }
+  return upserted;
+}
+
+async function listRoles() {
+  const sql = db();
+  const rows = await sql`
+    select
+      r.slug, r.source_row as "rowNumber",
+      r.company_name as company, r.title, r.url, r.source, r.status,
+      r.contact, r.salary_range as salary, r.salary_low, r.salary_high,
+      r.sector, r.investors, r.fit_score as score, r.fit_breakdown as breakdown,
+      r.hard_fails as "hardFails", r.applied_at, r.status_changed_at,
+      coalesce(ra_resume.role_slug is not null, false) as "hasResume",
+      coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter"
+    from job.pipeline_roles r
+    left join job.role_assets ra_resume on ra_resume.role_slug = r.slug and ra_resume.kind = 'resume'
+    left join job.role_assets ra_cover  on ra_cover.role_slug = r.slug and ra_cover.kind = 'cover-letter'
+    order by r.fit_score desc nulls last, r.title asc;
+  `;
+  return rows;
 }
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
 
   try {
-    const email = await verifyAllowlistedUser(req);
+    const email = await verifyJobUser(req);
     if (!email) return err('unauthorized', 401);
 
     if (req.method === 'GET') {
-      const [values, tree] = await Promise.all([
-        readSheetValues(SHEET_ID, 'Roles!A2:M1000'),
-        ghTree('03-jobs/').catch(() => []),
-      ]);
-      // Build slug → asset-flags map.
-      const assets = new Map<string, { hasResume: boolean; hasCoverLetter: boolean }>();
-      for (const t of tree) {
-        const m = t.path.match(/^03-jobs\/([^/]+)\/(resume|cover-letter)\.md$/);
-        if (!m) continue;
-        const cur = assets.get(m[1]) || { hasResume: false, hasCoverLetter: false };
-        if (m[2] === 'resume') cur.hasResume = true;
-        else cur.hasCoverLetter = true;
-        assets.set(m[1], cur);
-      }
-      const enriched = values
-        .map((row, idx) => rowToRole(row, idx + 2))
-        .filter(({ role }) => role.company || role.title)
-        .map(({ role, rowNumber }) => {
-          const slug = roleSlug(role.company, role.title);
-          const flags = assets.get(slug) || { hasResume: false, hasCoverLetter: false };
-          return {
-            rowNumber,
-            slug,
-            ...role,
-            ...computeFit(role),
-            ...flags,
-          };
-        });
-      return json({ version: VERSION, count: enriched.length, roles: enriched });
+      const url = new URL(req.url);
+      const sync = url.searchParams.get('sync') === '1';
+      let synced = 0;
+      if (sync) synced = await syncFromSheet();
+      const roles = await listRoles();
+      return jsonResp({ version: VERSION, count: roles.length, synced, roles });
     }
 
     if (req.method === 'POST') {
       const body = await req.json().catch(() => ({}));
-      const rowNumber = Number(body.rowNumber);
       const status = String(body.status ?? '');
-      if (!Number.isInteger(rowNumber) || rowNumber < 2 || rowNumber > 5000) {
-        return err('rowNumber must be int 2..5000', 400);
-      }
       if (!STATUS_ENUM.has(status)) {
         return err(`status must be one of: ${Array.from(STATUS_ENUM).filter(Boolean).join(', ')}`, 400);
       }
-      // Status lives in column C of the Roles tab.
-      await writeSheetCell(SHEET_ID, `Roles!C${rowNumber}`, status);
-      return json({ ok: true, rowNumber, status });
+      let slug = body.slug ? String(body.slug) : '';
+      let rowNumber = Number(body.rowNumber);
+      const sql = db();
+
+      if (!slug && Number.isInteger(rowNumber)) {
+        const r = await sql`select slug from job.pipeline_roles where source_row = ${rowNumber} limit 1`;
+        slug = r[0]?.slug || '';
+      } else if (slug && !rowNumber) {
+        const r = await sql`select source_row from job.pipeline_roles where slug = ${slug} limit 1`;
+        rowNumber = r[0]?.source_row || 0;
+      }
+      if (!slug) return err('role not found (provide slug or rowNumber)', 404);
+
+      // Update Postgres first.
+      await sql`
+        update job.pipeline_roles
+        set status = ${status},
+            applied_at = case when ${status} in ('Applied','Talking') and applied_at is null then now() else applied_at end,
+            status_changed_at = now(),
+            status_history = coalesce(status_history, '[]'::jsonb) || ${sql.json([{ status, at: new Date().toISOString() }])}
+        where slug = ${slug};
+      `;
+      // Mirror to the sheet so the /jobs skill stays in sync. Best-effort.
+      if (Number.isInteger(rowNumber) && rowNumber >= 2) {
+        try { await writeSheetCell(SHEET_ID, `Roles!C${rowNumber}`, status); } catch (e) {
+          console.warn('[jobs-pipe] sheet writeback failed', e);
+        }
+      }
+      return jsonResp({ ok: true, slug, rowNumber, status });
     }
 
     return err('GET or POST only', 405);

--- a/supabase/functions/role-asset/index.ts
+++ b/supabase/functions/role-asset/index.ts
@@ -1,0 +1,77 @@
+// role-asset — read + write per-role assets from job.role_assets.
+//
+//   GET  ?slug=&kind=        → { content_md, source_path, generated_by, ... }
+//   POST { slug, kind, content_md } → upserts the row
+//
+// Replaces the kb-read / kb-write round-trip for fikei/job/03-jobs/{slug}/{kind}.md.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[role-asset] v${VERSION}`);
+
+const KIND_RE = /^(resume|cover-letter|notes)$/;
+const SLUG_RE = /^[a-z0-9_-]+$/;
+const MAX_BYTES = 64 * 1024;
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const url = new URL(req.url);
+      const slug = (url.searchParams.get('slug') || '').toLowerCase();
+      const kind = (url.searchParams.get('kind') || '').toLowerCase();
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+      if (!KIND_RE.test(kind)) return err('invalid kind', 400);
+      const rows = await sql`
+        select role_slug as slug, kind, content_md, source_path, generated_by,
+               generated_at, edited_at, updated_at
+        from job.role_assets
+        where role_slug = ${slug} and kind = ${kind}
+        limit 1;
+      `;
+      if (rows.length === 0) return err('not found', 404);
+      return jsonResp(rows[0]);
+    }
+
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const slug = String(body.slug || '').toLowerCase();
+      const kind = String(body.kind || '').toLowerCase();
+      const content_md = String(body.content_md ?? '');
+      const source_path = body.source_path ? String(body.source_path) : null;
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+      if (!KIND_RE.test(kind)) return err('invalid kind', 400);
+      if (content_md.length > MAX_BYTES) return err(`content exceeds ${MAX_BYTES} bytes`, 413);
+
+      // Confirm the role exists; we don't auto-create here.
+      const role = await sql`select 1 from job.pipeline_roles where slug = ${slug} limit 1`;
+      if (role.length === 0) return err('role not found', 404);
+
+      const result = await sql`
+        insert into job.role_assets (role_slug, kind, content_md, source_path, generated_by, edited_at)
+        values (${slug}, ${kind}, ${content_md}, ${source_path}, 'manual', now())
+        on conflict (role_slug, kind) do update set
+          content_md = excluded.content_md,
+          source_path = coalesce(excluded.source_path, job.role_assets.source_path),
+          edited_at = now(),
+          updated_at = now()
+        returning kind, updated_at, edited_at;
+      `;
+      return jsonResp({ ok: true, ...result[0] });
+    }
+
+    return err('GET or POST only', 405);
+  } catch (e) {
+    console.error('[role-asset] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});


### PR DESCRIPTION
## Summary

Phase 2A migration. `jobs-pipe`, `gen-asset`, and the per-role detail page all read/write the new `job.*` tables instead of the Sheet + `fikei/job` repo. The Sheet stays as a dual-write target for status changes so the `/jobs` scrape skill keeps working.

### Backend
- `supabase/functions/_shared/job-db.ts` — shared lazy postgresjs connection.
- `jobs-pipe` **v0.4.0**:
  - **GET** → reads `job.pipeline_roles` + `role_assets`, ordered by fit_score desc nulls last. Returns `slug`, `hasResume`, `hasCoverLetter` per row.
  - **GET ?sync=1** → upserts every `Roles!A2:M1000` row into Postgres, recomputing fit_score in-process.
  - **POST** → status writeback to Postgres (with `applied_at` + `status_history`) AND mirrored to the Sheet best-effort.
- `role-asset` **v0.1.0**: `GET ?slug=&kind=` and `POST { slug, kind, content_md }` against `job.role_assets`. Edits update `edited_at`.
- `gen-asset` **v0.2.0**: reads the role + entire KB from Postgres, calls Claude Haiku 4.5, upserts into `job.role_assets`.

### Frontend (app v0.13.0)
- `pipeline.js`: `fetchPipeline` accepts `{sync:true}`. `setStatus` accepts `{slug, rowNumber}`. `generateAsset` takes slug.
- `job-pipeline`: "Sync from sheet" button next to the meta row.
- New `roleAsset.js` client. `job-role-detail` uses `readRoleAsset` / `writeRoleAsset` instead of `kb-read`/`kb-write`. Edit flow writes to Postgres directly.

## Source of truth

After this merge, **the displayed pipeline is from Postgres**, not the Sheet. The Sheet is now a secondary input feed (the `/jobs` scrape skill still writes there) and a status mirror (for read-friendliness in the spreadsheet). Click **Sync from sheet** to pull new rows in.

## Smoke-test results
- `jobs-pipe v0.4.0` returns 47 roles ranked by fit
- Top of pipeline at sync time: Abridge + Ambience Healthcare AI roles at 76
- `role-asset` returns the imported Ambience cover letter (2,676 chars, generated_by=imported-pdf)
- POST status flips Postgres + Sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)