### PR TITLE
Fix /job/jobs/{slug}/ 404 (Jekyll _drill exclusion) + per-column filters

### DIFF
--- a/404.html
+++ b/404.html
@@ -44,15 +44,18 @@ permalink: /404.html
       }
 
       // /job/history/{kind}/{slug}/ — drilldown route handled by /job/history/_drill/
-      var jobMatch = path.match(/^\/job\/history\/(companies|projects|skills|wins|roles)\/([a-z0-9_-]+)\/?$/);
+      var jobMatch = path.match(/^\/job\/history\/(companies|projects|skills|wins|roles)\/([a-z0-9-]+)\/?$/);
       if (jobMatch) {
         sessionStorage.setItem('job:prettyPath', path);
         window.location.replace('/job/history/_drill/?kind=' + jobMatch[1] + '&slug=' + jobMatch[2]);
         return;
       }
 
-      // /job/jobs/{slug}/ — per-role detail handled by /job/jobs/_drill/
-      var roleMatch = path.match(/^\/job\/jobs\/([a-z0-9_-]+)\/?$/);
+      // /job/jobs/{slug}/ — per-role detail handled by /job/jobs/_drill/.
+      // Slugs are produced by slugify() which never includes underscores;
+      // requiring [a-z0-9-]+ (no underscore) prevents the router from
+      // matching `_drill` itself and entering a redirect loop.
+      var roleMatch = path.match(/^\/job\/jobs\/([a-z0-9-]+)\/?$/);
       if (roleMatch) {
         sessionStorage.setItem('job:prettyPath', path);
         var qs = window.location.search.replace(/^\?/, '');

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,8 @@
 theme: jekyll-theme-minimal
-include: [".well-known"]
+# Jekyll excludes any directory starting with `_` by default. The /job
+# product uses _drill subdirectories as SPA-routed targets, so they must
+# be explicitly included for GitHub Pages to serve them.
+include:
+  - .well-known
+  - "job/jobs/_drill"
+  - "job/history/_drill"

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -402,6 +402,44 @@
 .link-subtle { color: var(--fg-muted); }
 .link-subtle:hover { color: var(--fg); text-decoration: underline; }
 
+/* --- Per-column header filters (pipeline) --- */
+.pipeline-table__filters th {
+  background: var(--bg);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+  font-weight: 400;
+}
+.col-filter {
+  width: 100%;
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+.col-filter:hover { border-color: var(--border-strong); }
+.col-filter:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+.col-filter--num { max-width: 90px; }
+select.col-filter {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 26px;
+  background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
+                    linear-gradient(-45deg, transparent 50%, currentColor 50%);
+  background-position: calc(100% - 14px) calc(50% + 2px),
+                       calc(100% - 10px) calc(50% + 2px);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  cursor: pointer;
+}
+
 .fit-pill--button {
   border: 0;
   cursor: pointer;

--- a/job/history/_drill/index.html
+++ b/job/history/_drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
 </body>
 </html>

--- a/job/jobs/_drill/index.html
+++ b/job/jobs/_drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.13.0';
-console.log(`[job] v${VERSION} - postgres pipeline cutover`);
+const VERSION = '0.14.0';
+console.log(`[job] v${VERSION} - jekyll _drill fix + column filters`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -1,8 +1,6 @@
 // job-pipeline — pipeline table view. Reads from jobs-pipe and renders
-// rows sorted by Fit Score desc. Click a fit pill to see the breakdown.
+// rows sorted by Fit Score desc. Per-column filters live in the header row.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-// Carry the cache-bust query from this module's own URL through to siblings;
-// otherwise static imports below would hit the 10-min Pages cache.
 const V = (new URL(import.meta.url)).search;
 const { fetchPipeline, setStatus, generateAsset } = await import('../pipeline.js' + V);
 
@@ -20,6 +18,18 @@ const DIM_LABELS = {
   network: { label: 'Network',       max: 5,  hint: 'A named contact in the row gets +5.' },
 };
 
+const EMPTY_FILTERS = () => ({
+  minFit: 0,
+  status: '',         // '' = any
+  company: '',
+  title: '',
+  source: '',
+  sector: '',
+  salary: '',
+  hasResume: 'any',   // 'any' | 'has' | 'missing'
+  hasCover: 'any',
+});
+
 export class JobPipeline extends LitElement {
   createRenderRoot() { return this; }
 
@@ -27,10 +37,7 @@ export class JobPipeline extends LitElement {
     state: { state: true },
     error: { state: true },
     roles: { state: true },
-    statusFilter: { state: true },
-    sourceFilter: { state: true },
-    minFit: { state: true },
-    sectorQuery: { state: true },
+    filters: { state: true },
     selectedRow: { state: true },
   };
 
@@ -39,10 +46,7 @@ export class JobPipeline extends LitElement {
     this.state = 'idle';
     this.error = '';
     this.roles = [];
-    this.statusFilter = new Set();
-    this.sourceFilter = new Set();
-    this.minFit = 0;
-    this.sectorQuery = '';
+    this.filters = EMPTY_FILTERS();
     this.selectedRow = null;
   }
 
@@ -80,75 +84,55 @@ export class JobPipeline extends LitElement {
     }
   }
 
-  async _onSync() {
-    await this._load(true);
-  }
+  async _onSync() { await this._load(true); }
 
-  _toggleSet(set, value, prop) {
-    const next = new Set(set);
-    if (next.has(value)) next.delete(value); else next.add(value);
-    this[prop] = next;
-    this.requestUpdate();
+  _setFilter(key, value) {
+    this.filters = { ...this.filters, [key]: value };
+  }
+  _clearFilters() { this.filters = EMPTY_FILTERS(); }
+  _activeFilterCount() {
+    const f = this.filters;
+    let n = 0;
+    if (f.minFit) n++;
+    if (f.status) n++;
+    if (f.company) n++;
+    if (f.title) n++;
+    if (f.source) n++;
+    if (f.sector) n++;
+    if (f.salary) n++;
+    if (f.hasResume !== 'any') n++;
+    if (f.hasCover !== 'any') n++;
+    return n;
   }
 
   _filtered() {
+    const f = this.filters;
+    const lc = (s) => (s || '').toLowerCase();
+    const has = (haystack, needle) => !needle || lc(haystack).includes(lc(needle));
     return this.roles.filter(r => {
-      if (this.statusFilter.size && !this.statusFilter.has(r.status || '(blank)')) return false;
-      if (this.sourceFilter.size && !this.sourceFilter.has(r.source || '(blank)')) return false;
-      if (this.minFit && r.score < this.minFit) return false;
-      if (this.sectorQuery && !(r.sector || '').toLowerCase().includes(this.sectorQuery.toLowerCase())) return false;
+      if (f.minFit && (r.score == null || r.score < f.minFit)) return false;
+      if (f.status && (r.status || '') !== f.status) return false;
+      if (f.source && (r.source || '') !== f.source) return false;
+      if (!has(r.company, f.company)) return false;
+      if (!has(r.title, f.title)) return false;
+      if (!has(r.sector, f.sector)) return false;
+      if (!has(r.salary, f.salary)) return false;
+      if (f.hasResume === 'has' && !r.hasResume) return false;
+      if (f.hasResume === 'missing' && r.hasResume) return false;
+      if (f.hasCover === 'has' && !r.hasCoverLetter) return false;
+      if (f.hasCover === 'missing' && r.hasCoverLetter) return false;
       return true;
     });
   }
 
-  _statuses() {
-    const s = new Set();
-    this.roles.forEach(r => s.add(r.status || '(blank)'));
-    return Array.from(s).sort();
-  }
-  _sources() {
-    const s = new Set();
-    this.roles.forEach(r => s.add(r.source || '(blank)'));
-    return Array.from(s).sort();
-  }
-
-  _renderFilters() {
-    return html`
-      <div class="pipeline-filters">
-        <div class="pipeline-filters__group">
-          <label>Status</label>
-          <div class="chip-row">
-            ${this._statuses().map(s => html`
-              <button class="chip ${this.statusFilter.has(s) ? 'chip--on' : ''}"
-                @click=${() => this._toggleSet(this.statusFilter, s, 'statusFilter')}>${s}</button>
-            `)}
-          </div>
-        </div>
-        <div class="pipeline-filters__group">
-          <label>Source</label>
-          <div class="chip-row">
-            ${this._sources().map(s => html`
-              <button class="chip ${this.sourceFilter.has(s) ? 'chip--on' : ''}"
-                @click=${() => this._toggleSet(this.sourceFilter, s, 'sourceFilter')}>${s}</button>
-            `)}
-          </div>
-        </div>
-        <div class="pipeline-filters__group">
-          <label>Min fit ${this.minFit}</label>
-          <input type="range" min="0" max="100" .value=${String(this.minFit)}
-            @input=${(e) => { this.minFit = parseInt(e.target.value, 10); }}>
-        </div>
-        <div class="pipeline-filters__group">
-          <label>Sector</label>
-          <input type="text" placeholder="e.g. health, fintech"
-            .value=${this.sectorQuery}
-            @input=${(e) => { this.sectorQuery = e.target.value; }}>
-        </div>
-      </div>
-    `;
+  _uniques(field) {
+    const set = new Set();
+    this.roles.forEach(r => set.add(r[field] || ''));
+    return Array.from(set).filter(Boolean).sort();
   }
 
   _scoreClass(s) {
+    if (s == null) return 'fit-pill fit-pill--poor';
     if (s >= 70) return 'fit-pill fit-pill--strong';
     if (s >= 50) return 'fit-pill fit-pill--ok';
     if (s >= 30) return 'fit-pill fit-pill--weak';
@@ -177,7 +161,6 @@ export class JobPipeline extends LitElement {
   }
 
   async _onApplyClick(r) {
-    // Open the posting in a new tab even if status update fails.
     if (r.url) window.open(r.url, '_blank', 'noopener,noreferrer');
     if (!APPLIED_STATUSES.has(r.status) && !TERMINAL_STATUSES.has(r.status)) {
       await this._changeStatus(r, 'Applied');
@@ -201,12 +184,8 @@ export class JobPipeline extends LitElement {
     }
   }
 
-  _detailHref(r, tab) {
-    return `/job/jobs/${r.slug}/?tab=${tab}`;
-  }
-  _onBackdropClick(e) {
-    if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal();
-  }
+  _detailHref(r, tab) { return `/job/jobs/${r.slug}/?tab=${tab}`; }
+  _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
   _renderApplyCell(r) {
     if (TERMINAL_STATUSES.has(r.status)) {
@@ -223,11 +202,7 @@ export class JobPipeline extends LitElement {
       `;
     }
     if (!r.url) return html`<span class="muted">—</span>`;
-    return html`
-      <button class="btn btn--sm btn--accent" @click=${() => this._onApplyClick(r)}>
-        Apply ↗
-      </button>
-    `;
+    return html`<button class="btn btn--sm btn--accent" @click=${() => this._onApplyClick(r)}>Apply ↗</button>`;
   }
 
   _renderAssetCell(r, kind) {
@@ -235,9 +210,7 @@ export class JobPipeline extends LitElement {
     const generating = kind === 'resume' ? r._genResume : r._genCover;
     if (has) {
       return html`
-        <a class="link-subtle" href=${this._detailHref(r, kind)} target="_blank" rel="noopener">
-          View / Edit
-        </a>
+        <a class="link-subtle" href=${this._detailHref(r, kind)} target="_blank" rel="noopener">View / Edit</a>
       `;
     }
     return html`
@@ -247,26 +220,65 @@ export class JobPipeline extends LitElement {
     `;
   }
 
+  _renderFilterRow() {
+    const f = this.filters;
+    const set = (k) => (e) => this._setFilter(k, e.target.value);
+    return html`
+      <tr class="pipeline-table__filters">
+        <th>
+          <input type="number" min="0" max="100" placeholder="min"
+            class="col-filter col-filter--num"
+            .value=${f.minFit ? String(f.minFit) : ''}
+            @input=${(e) => this._setFilter('minFit', parseInt(e.target.value, 10) || 0)}>
+        </th>
+        <th>
+          <select class="col-filter" .value=${f.status} @change=${set('status')}>
+            <option value="">Any</option>
+            ${this._uniques('status').map(s => html`<option value=${s} ?selected=${f.status===s}>${s}</option>`)}
+          </select>
+        </th>
+        <th><input type="text" placeholder="filter…" class="col-filter" .value=${f.company} @input=${set('company')}></th>
+        <th><input type="text" placeholder="filter…" class="col-filter" .value=${f.title} @input=${set('title')}></th>
+        <th></th>
+        <th>
+          <select class="col-filter" .value=${f.hasResume} @change=${set('hasResume')}>
+            <option value="any">Any</option>
+            <option value="has" ?selected=${f.hasResume==='has'}>Has</option>
+            <option value="missing" ?selected=${f.hasResume==='missing'}>Missing</option>
+          </select>
+        </th>
+        <th>
+          <select class="col-filter" .value=${f.hasCover} @change=${set('hasCover')}>
+            <option value="any">Any</option>
+            <option value="has" ?selected=${f.hasCover==='has'}>Has</option>
+            <option value="missing" ?selected=${f.hasCover==='missing'}>Missing</option>
+          </select>
+        </th>
+        <th><input type="text" placeholder="filter…" class="col-filter" .value=${f.sector} @input=${set('sector')}></th>
+        <th><input type="text" placeholder="filter…" class="col-filter" .value=${f.salary} @input=${set('salary')}></th>
+        <th>
+          <select class="col-filter" .value=${f.source} @change=${set('source')}>
+            <option value="">Any</option>
+            ${this._uniques('source').map(s => html`<option value=${s} ?selected=${f.source===s}>${s}</option>`)}
+          </select>
+        </th>
+      </tr>
+    `;
+  }
+
   _renderRow(r) {
     return html`
       <tr>
         <td>
-          <button
-            class=${this._scoreClass(r.score) + ' fit-pill--button'}
-            title="Tap to see the breakdown"
-            @click=${() => this._openFitModal(r)}>
-            ${r.score}
+          <button class=${this._scoreClass(r.score) + ' fit-pill--button'}
+            title="Tap to see the breakdown" @click=${() => this._openFitModal(r)}>
+            ${r.score == null ? '—' : r.score}
           </button>
         </td>
         <td class="status-cell">
-          <select
-            class="status-select ${r._saving ? 'is-saving' : ''}"
-            ?disabled=${r._saving}
-            .value=${r.status || ''}
-            @change=${(e) => this._changeStatus(r, e.target.value)}>
-            ${STATUS_OPTIONS.map(s => html`
-              <option value=${s} ?selected=${(r.status || '') === s}>${s || '—'}</option>
-            `)}
+          <select class="status-select ${r._saving ? 'is-saving' : ''}" ?disabled=${r._saving}
+            .value=${r.status || ''} @change=${(e) => this._changeStatus(r, e.target.value)}>
+            ${STATUS_OPTIONS.map(s => html`<option value=${s} ?selected=${(r.status || '') === s}>${s || '—'}</option>`)}
           </select>
           ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
         </td>
@@ -294,24 +306,21 @@ export class JobPipeline extends LitElement {
               <p class="fit-modal__eyebrow">${r.company}</p>
               <h2>${r.title || 'Untitled role'}</h2>
             </div>
-            <button class="fit-modal__close" @click=${this._closeFitModal} aria-label="Close">×</button>
+            <button class="fit-modal__close" @click=${() => this._closeFitModal()} aria-label="Close">×</button>
           </header>
-
           <div class="fit-modal__score">
-            <span class=${this._scoreClass(r.score)}>${r.score}</span>
+            <span class=${this._scoreClass(r.score)}>${r.score == null ? '—' : r.score}</span>
             <div>
               <p class="fit-modal__score-label">Fit score</p>
               <p class="fit-modal__score-sub">Out of 100. Sum of seven weighted dimensions; hard fails cap at 30.</p>
             </div>
           </div>
-
           ${r.hardFails && r.hardFails.length ? html`
             <div class="fit-modal__fails">
               <strong>Hard fail${r.hardFails.length > 1 ? 's' : ''}:</strong>
               ${r.hardFails.join(', ')}. Score capped at 30.
             </div>
           ` : nothing}
-
           <ul class="fit-breakdown">
             ${dims.map(k => {
               const meta = DIM_LABELS[k];
@@ -323,15 +332,12 @@ export class JobPipeline extends LitElement {
                     <span class="fit-breakdown__label">${meta.label}</span>
                     <span class="fit-breakdown__value">${v} / ${meta.max}</span>
                   </div>
-                  <div class="fit-breakdown__bar">
-                    <span style=${`width:${pct}%`}></span>
-                  </div>
+                  <div class="fit-breakdown__bar"><span style=${`width:${pct}%`}></span></div>
                   <p class="fit-breakdown__hint">${meta.hint}</p>
                 </li>
               `;
             })}
           </ul>
-
           <footer class="fit-modal__foot">
             <p class="muted">Weights are fixed in v1. Tunable in v2 once Vision integration lands.</p>
           </footer>
@@ -351,10 +357,15 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._filtered();
+    const nFilters = this._activeFilterCount();
     return html`
-      ${this._renderFilters()}
       <div class="pipeline-meta">
         Showing <strong>${rows.length}</strong> of ${this.roles.length} roles, sorted by fit score.
+        ${nFilters > 0 ? html`
+          <button class="btn btn--sm" style="margin-left:var(--space-3);" @click=${() => this._clearFilters()}>
+            Clear ${nFilters} filter${nFilters > 1 ? 's' : ''}
+          </button>
+        ` : nothing}
         <button class="btn btn--sm" style="margin-left:var(--space-3);" @click=${() => this._onSync()}>
           Sync from sheet
         </button>
@@ -374,6 +385,7 @@ export class JobPipeline extends LitElement {
               <th>Salary</th>
               <th>Source</th>
             </tr>
+            ${this._renderFilterRow()}
           </thead>
           <tbody>${rows.map(r => this._renderRow(r))}</tbody>
         </table>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.13.0">
-  <script src="/job/js/theme.js?v=0.13.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
+  <script src="/job/js/theme.js?v=0.14.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.13.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Bugs

1. View / Edit links produced URLs like
\`\`\`
/job/jobs/_drill/?slug=_drill&slug=_drill&...&slug=code-for-america-lead-product-manager&row=46&tab=resume
\`\`\`
(13 stacked \`slug=_drill\`).

2. Resume / cover-letter Create appeared broken because the resulting View/Edit link was unreachable.

## Root cause

**Jekyll silently excludes any directory whose name starts with \`_\`** from the GitHub Pages build. \`/job/jobs/_drill/\` wasn't being served, so the SPA-router \`404.html\` matched the \`_drill\` path against \`[a-z0-9_-]+\` and redirected back to itself with \`slug=_drill\` prepended, looping until the browser hit the redirect cap.

Backend was fine — verified \`gen-asset\` POST returns a 2.4KB cover letter in ~10s and writes it to \`job.role_assets\`. The "Create isn't working" symptom was the destination URL.

## Fix

- \`_config.yml\` — explicitly include \`job/jobs/_drill\` and \`job/history/_drill\` so Jekyll serves them.
- \`404.html\` — tighten the slug regex to \`[a-z0-9-]+\` (no underscore). \`roleSlug()\` never produces underscores, so this is loss-free and closes the recursion even if Jekyll's behaviour shifts.

## Per-column filters

- Drops the separate \`.pipeline-filters\` panel.
- Filter row sits inside \`<thead>\`. Each column gets the right input:
  - **Fit** — min number
  - **Status / Source** — select with unique values
  - **Company / Role / Sector / Salary** — text-contains
  - **Resume / Cover** — any / has / missing
- "Clear N filters" button next to the count when any are active.

App bumped to 0.14.0.

## Test plan
- [ ] After Pages deploy, hard-refresh /job/jobs/. Filter row visible in header.
- [ ] Click Create on a row → cell flips to View / Edit (~10s).
- [ ] Click View / Edit → /job/jobs/{slug}/?tab=resume opens cleanly, no _drill in URL.
- [ ] Type "abridge" in Company filter → only Abridge rows visible.
- [ ] Set min fit 70 → only top-quartile rows visible. "Clear 1 filter" button appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)