### PR TITLE
Fix /job drill 404 + tolerate column-shifted sheet rows

### DIFF
--- a/404.html
+++ b/404.html
@@ -43,24 +43,23 @@ permalink: /404.html
         return;
       }
 
-      // /job/history/{kind}/{slug}/ — drilldown route handled by /job/history/_drill/
-      var jobMatch = path.match(/^\/job\/history\/(companies|projects|skills|wins|roles)\/([a-z0-9-]+)\/?$/);
+      // /job/history/{kind}/{slug}/ — drilldown handled by /job/history/drill/.
+      // Negative lookahead skips the literal /drill/ target so the router
+      // never matches its own destination.
+      var jobMatch = path.match(/^\/job\/history\/(companies|projects|skills|wins|roles)\/(?!drill\/?$)([a-z0-9-]+)\/?$/);
       if (jobMatch) {
         sessionStorage.setItem('job:prettyPath', path);
-        window.location.replace('/job/history/_drill/?kind=' + jobMatch[1] + '&slug=' + jobMatch[2]);
+        window.location.replace('/job/history/drill/?kind=' + jobMatch[1] + '&slug=' + jobMatch[2]);
         return;
       }
 
-      // /job/jobs/{slug}/ — per-role detail handled by /job/jobs/_drill/.
-      // Slugs are produced by slugify() which never includes underscores;
-      // requiring [a-z0-9-]+ (no underscore) prevents the router from
-      // matching `_drill` itself and entering a redirect loop.
-      var roleMatch = path.match(/^\/job\/jobs\/([a-z0-9-]+)\/?$/);
+      // /job/jobs/{slug}/ — per-role detail handled by /job/jobs/drill/.
+      var roleMatch = path.match(/^\/job\/jobs\/(?!drill\/?$)([a-z0-9-]+)\/?$/);
       if (roleMatch) {
         sessionStorage.setItem('job:prettyPath', path);
         var qs = window.location.search.replace(/^\?/, '');
         var sep = qs ? '&' : '';
-        window.location.replace('/job/jobs/_drill/?slug=' + roleMatch[1] + sep + qs);
+        window.location.replace('/job/jobs/drill/?slug=' + roleMatch[1] + sep + qs);
         return;
       }
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,2 @@
 theme: jekyll-theme-minimal
-# Jekyll excludes any directory starting with `_` by default. The /job
-# product uses _drill subdirectories as SPA-routed targets, so they must
-# be explicitly included for GitHub Pages to serve them.
-include:
-  - .well-known
-  - "job/jobs/_drill"
-  - "job/history/_drill"
+include: [".well-known"]

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Role — /job</title>
+  <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -25,10 +25,10 @@
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
-      <job-role-detail></job-role-detail>
+      <job-detail></job-detail>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.15.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.15.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>History — /job</title>
+  <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -25,10 +25,10 @@
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
-      <job-detail></job-detail>
+      <job-role-detail></job-role-detail>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.15.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.15.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.14.0';
-console.log(`[job] v${VERSION} - jekyll _drill fix + column filters`);
+const VERSION = '0.15.0';
+console.log(`[job] v${VERSION} - drill rename + column-shift tolerance`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -14,12 +14,12 @@ const ALLOWED_EMAIL = 'fike101@gmail.com';
 import('./components/job-rail.js' + V);
 import('./kb.js' + V);
 // Route-specific components.
-if (location.pathname.startsWith('/job/history/_drill')) {
+if (location.pathname.startsWith('/job/history/drill')) {
   import('./components/job-detail.js' + V);
 } else if (location.pathname.startsWith('/job/history')) {
   import('./components/job-history-resume.js' + V);
 }
-if (location.pathname.startsWith('/job/jobs/_drill')) {
+if (location.pathname.startsWith('/job/jobs/drill')) {
   import('./components/job-role-detail.js' + V);
 } else if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.14.0">
-  <script src="/job/js/theme.js?v=0.14.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.15.0">
+  <script src="/job/js/theme.js?v=0.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.14.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.15.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,16 @@ const STATUS_ENUM = new Set([
   '', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network',
 ]);
 
+// Heuristics for the column-shift workaround below.
+const SALARY_RE = /^\$?\s*\d[\d.,kK]*\s*[-–]\s*\$?\s*\d/;        // "$140k - $200k", "$128,945 - $157,850"
+const URL_RE    = /^https?:\/\//i;
+const SOURCE_VOCAB = new Set([
+  'Manual', 'Network', 'LinkedIn Saved', 'LinkedIn Recommended',
+  'From Company Pages', 'Imported',
+]);
+
 function rowToRole(row: string[]): RoleRow {
-  return {
+  const role: RoleRow = {
     status: (row[2] || '').trim(),
     rank: (row[1] || '').trim(),
     company: (row[3] || '').trim(),
@@ -34,6 +42,35 @@ function rowToRole(row: string[]): RoleRow {
     website: (row[11] || '').trim(),
     crunchbase: (row[12] || '').trim(),
   };
+
+  // Tolerance for sheet rows where values were pasted into the wrong columns.
+  // Observed in the live sheet: ~5 rows have col F (URL) empty and the URL
+  // sitting in col L (Website). Those same rows have shifted-by-one data:
+  //   col G (Source)  → actually salary or empty
+  //   col H (Contact) → actually sector
+  // Detect the shift via the URL signature, then re-map.
+  const looksShifted = !role.url && URL_RE.test(role.website || '');
+  if (looksShifted) {
+    role.url = role.website;
+    role.website = '';
+    if (role.source && !role.salary && !SOURCE_VOCAB.has(role.source)) {
+      role.salary = role.source;
+      role.source = '';
+    }
+    if (role.contact && !role.sector) {
+      role.sector = role.contact;
+      role.contact = '';
+    }
+  }
+
+  // Belt-and-braces: even if the row didn't pass the URL signature, salary
+  // text in the Source column is always a misplacement.
+  if (role.source && SALARY_RE.test(role.source) && !role.salary) {
+    role.salary = role.source;
+    role.source = '';
+  }
+
+  return role;
 }
 
 function parseSalary(s: string | undefined): { low: number | null; high: number | null } {


### PR DESCRIPTION
## Bugs

1. **\`/job/jobs/_drill/\` still 404'd** on Pages even after adding it to \`_config.yml\` include list. GitHub Pages apparently doesn't honor nested-path entries.
2. **5 sheet rows have salary in the Source column** (Develop Health, Nooks, NexHealth, Rec Technologies, Crossing Hurdles, Code for America, etc.) — the sheet itself was pasted shifted. UI faithfully showed the wrong data.

## Fixes

### Drill rename
- \`_drill\` → \`drill\` in both \`job/jobs/\` and \`job/history/\`. No leading underscore = Jekyll serves it.
- \`404.html\` SPA router uses negative lookahead \`(?!drill\\/?$)\` so the regex never matches its own redirect target.
- Reverted the \`include:\` config since it wasn't doing the work anyway.

### Sheet column-shift tolerance
- \`rowToRole()\` now detects the shift via the URL signature: if the canonical URL column (F) is empty AND the website column (L) looks like \`http(s)://\`, the row is shifted; re-map url + salary + sector.
- Belt-and-braces: any \`$\`-formatted value in the Source column always moves to Salary.

App bumped to 0.15.0.

## Verification (after smoke test on staging)
- /job/jobs/{slug}/ resolves cleanly, no _drill in the URL bar
- /job/jobs/drill/?slug=ambience-product-lead-platform&tab=resume renders the imported resume
- Re-sync repaired the 5 shifted rows: Salary column shows \`$140k - $200k\`, Sector shows \`Unknown (verify stage)\`, URL is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)