### PR TITLE
Jobs page: color-coded status, View column, filter Strava + no-url rows

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -352,13 +352,16 @@
 .fit-pill--weak   { background: rgba(237,200,67,0.20); color: #6E5400; }
 .fit-pill--poor   { background: rgba(168,32,13,0.12); color: var(--error); }
 
-/* --- Status select + apply cell --- */
+/* --- Status select (color-coded by current value) --- */
 .status-cell { display: flex; align-items: center; gap: var(--space-2); }
 .status-select {
-  /* Wise small-component size: 32px height, body-small typography. */
   font: inherit;
   font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
   height: 32px;
+  width: auto;
+  min-width: 110px;
+  max-width: 160px;
   padding: 0 var(--space-5) 0 var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
@@ -367,8 +370,6 @@
   cursor: pointer;
   appearance: none;
   -webkit-appearance: none;
-  /* Chevron uses a CSS mask so it picks up the current text colour and
-     stays correct across light + dark themes. */
   background-image: linear-gradient(45deg, transparent 50%, currentColor 50%),
                     linear-gradient(-45deg, transparent 50%, currentColor 50%);
   background-position: calc(100% - 14px) calc(50% + 2px),
@@ -377,8 +378,23 @@
   background-repeat: no-repeat;
 }
 .status-select:hover { border-color: var(--border-strong); }
-.status-select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.status-select:focus { outline: none; box-shadow: 0 0 0 3px var(--accent-muted); }
 .status-select.is-saving { opacity: 0.6; }
+
+/* Color variants by current status. Soft tinted backgrounds + matching
+   text. Each pairs with a specific lifecycle stage. */
+.status-select[data-status="New"]              { background-color: var(--accent-muted); color: var(--accent); border-color: transparent; }
+.status-select[data-status="Apply"]            { background-color: rgba(237,200,67,0.22); color: #6E5400; border-color: transparent; }
+.status-select[data-status="Talking"]          { background-color: var(--accent-strong); color: var(--accent-strong-fg); border-color: transparent; }
+.status-select[data-status="Applied"]          { background-color: rgba(47,87,17,0.16); color: var(--success); border-color: transparent; }
+.status-select[data-status="Pass"]             { background-color: var(--bg-surface); color: var(--fg-subtle); border-color: var(--border); }
+.status-select[data-status="Rejected"]         { background-color: rgba(168,32,13,0.12); color: var(--error); border-color: transparent; }
+.status-select[data-status="Closed"]           { background-color: var(--bg-surface); color: var(--fg-subtle); border-color: var(--border); }
+.status-select[data-status="Not Listed"]       { background-color: var(--bg-surface); color: var(--fg-subtle); border-color: var(--border); }
+.status-select[data-status="Nudge / Network"]  { background-color: rgba(159,232,112,0.18); color: var(--success); border-color: transparent; }
+/* Dark theme adjustments where needed */
+[data-theme="generic-dark"] .status-select[data-status="Apply"] { color: var(--warning); }
+[data-theme="generic-dark"] .status-select[data-status="Applied"] { color: var(--accent-strong); }
 .status-cell__err {
   display: inline-grid;
   place-items: center;
@@ -396,8 +412,6 @@
   padding: 0 var(--space-3);
   font-size: var(--font-size-small);
 }
-.apply-cell { display: flex; flex-direction: column; gap: 2px; line-height: 1.2; }
-.apply-cell .link-subtle { font-size: var(--font-size-caption); }
 
 .link-subtle { color: var(--fg-muted); }
 .link-subtle:hover { color: var(--fg); text-decoration: underline; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.16.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.16.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.16.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.16.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.16.0';
-console.log(`[job] v${VERSION} - sortable column headers`);
+const VERSION = '0.17.0';
+console.log(`[job] v${VERSION} - status colors + view column + filter no-url`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -25,13 +25,22 @@ const COLUMNS = [
   { id: 'status',  label: 'Status',  sortKey: 'status',         type: 'text' },
   { id: 'company', label: 'Company', sortKey: 'company',        type: 'text' },
   { id: 'role',    label: 'Role',    sortKey: 'title',          type: 'text' },
-  { id: 'apply',   label: 'Apply',   sortKey: null },
   { id: 'resume',  label: 'Resume',  sortKey: 'hasResume',      type: 'bool', defaultDir: 'desc' },
   { id: 'cover',   label: 'Cover',   sortKey: 'hasCoverLetter', type: 'bool', defaultDir: 'desc' },
   { id: 'sector',  label: 'Sector',  sortKey: 'sector',         type: 'text' },
   { id: 'salary',  label: 'Salary',  sortKey: 'salary_high',    type: 'num',  defaultDir: 'desc' },
   { id: 'source',  label: 'Source',  sortKey: 'source',         type: 'text' },
+  { id: 'view',    label: '',        sortKey: null },
 ];
+
+// Drop rows without an apply link, and any Strava postings (out of scope).
+function isVisibleRole(r) {
+  if (!r.url) return false;
+  const company = (r.company || '').toLowerCase();
+  if (company === 'strava') return false;
+  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
+  return true;
+}
 
 export class JobPipeline extends LitElement {
   createRenderRoot() { return this; }
@@ -110,7 +119,7 @@ export class JobPipeline extends LitElement {
   _sorted() {
     const key = this.sortKey;
     const dir = this.sortDir === 'desc' ? -1 : 1;
-    const arr = this.roles.slice();
+    const arr = this.roles.filter(isVisibleRole);
     arr.sort((a, b) => {
       const av = a[key];
       const bv = b[key];
@@ -154,13 +163,6 @@ export class JobPipeline extends LitElement {
     this.requestUpdate();
   }
 
-  async _onApplyClick(r) {
-    if (r.url) window.open(r.url, '_blank', 'noopener,noreferrer');
-    if (!APPLIED_STATUSES.has(r.status) && !TERMINAL_STATUSES.has(r.status)) {
-      await this._changeStatus(r, 'Applied');
-    }
-  }
-
   async _onGenerate(r, kind) {
     const flag = kind === 'resume' ? '_genResume' : '_genCover';
     if (r[flag]) return;
@@ -178,25 +180,15 @@ export class JobPipeline extends LitElement {
     }
   }
 
-  _detailHref(r, tab) { return `/job/jobs/${r.slug}/?tab=${tab}`; }
+  _detailHref(r, tab) { return tab ? `/job/jobs/${r.slug}/?tab=${tab}` : `/job/jobs/${r.slug}/`; }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
-  _renderApplyCell(r) {
-    if (TERMINAL_STATUSES.has(r.status)) {
-      return r.url
-        ? html`<a class="link-subtle" href=${r.url} target="_blank" rel="noopener noreferrer">Posting ↗</a>`
-        : html`<span class="muted">—</span>`;
-    }
-    if (APPLIED_STATUSES.has(r.status)) {
-      return html`
-        <div class="apply-cell apply-cell--applied">
-          <span class="muted">Applied</span>
-          ${r.url ? html`<a class="link-subtle" href=${r.url} target="_blank" rel="noopener noreferrer">Posting ↗</a>` : nothing}
-        </div>
-      `;
-    }
-    if (!r.url) return html`<span class="muted">—</span>`;
-    return html`<button class="btn btn--sm btn--accent" @click=${() => this._onApplyClick(r)}>Apply ↗</button>`;
+  _renderViewCell(r) {
+    return html`
+      <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener">
+        View
+      </a>
+    `;
   }
 
   _renderAssetCell(r, kind) {
@@ -242,7 +234,9 @@ export class JobPipeline extends LitElement {
           </button>
         </td>
         <td class="status-cell">
-          <select class="status-select ${r._saving ? 'is-saving' : ''}" ?disabled=${r._saving}
+          <select class="status-select ${r._saving ? 'is-saving' : ''}"
+            data-status=${r.status || 'New'}
+            ?disabled=${r._saving}
             .value=${r.status || ''} @change=${(e) => this._changeStatus(r, e.target.value)}>
             ${STATUS_OPTIONS.map(s => html`<option value=${s} ?selected=${(r.status || '') === s}>${s || '—'}</option>`)}
           </select>
@@ -250,12 +244,12 @@ export class JobPipeline extends LitElement {
         </td>
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
-        <td>${this._renderApplyCell(r)}</td>
         <td>${this._renderAssetCell(r, 'resume')}</td>
         <td>${this._renderAssetCell(r, 'cover-letter')}</td>
         <td><span class="muted">${r.sector || ''}</span></td>
         <td><span class="muted">${r.salary || ''}</span></td>
         <td><span class="muted">${r.source || ''}</span></td>
+        <td>${this._renderViewCell(r)}</td>
       </tr>
     `;
   }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.16.0">
-  <script src="/job/js/theme.js?v=0.16.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
+  <script src="/job/js/theme.js?v=0.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.16.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Status select is now tinted by the current value (Applied=forest, Rejected=red, Talking=bright green, etc.). Apply column moved to the right edge as a 'View' button that opens /job/jobs/{slug}/ in a new tab. Rows without a posting URL and Strava postings are hidden.

App bumped to 0.17.0. The Apply-to-posting flow moves to the detail page in PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)