### PR TITLE
Role detail redesign: Details tab + Apply button + auto-generate

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -687,3 +687,97 @@
 .asset-editor:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
 
 .asset-doc { max-width: 720px; }
+
+/* --- Role detail (drill page) --- */
+.role-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
+}
+.role-header__title h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-1);
+  letter-spacing: -0.02em;
+  line-height: var(--lh-title);
+}
+.role-header__sub {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-body-lg);
+  color: var(--fg-muted);
+}
+.role-header__actions { flex-shrink: 0; padding-top: var(--space-2); }
+
+.role-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  margin-bottom: var(--space-5);
+}
+.role-meta__item dt {
+  margin: 0 0 4px;
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+  text-transform: none;
+  font-weight: var(--fw-medium);
+}
+.role-meta__item dd {
+  margin: 0;
+  font-size: var(--font-size-body);
+  color: var(--fg);
+  font-weight: var(--fw-medium);
+}
+
+.role-summary {
+  margin-bottom: var(--space-5);
+  font-size: var(--font-size-body-lg);
+  color: var(--fg);
+}
+.role-summary .kb-doc { font-size: var(--font-size-body-lg); }
+
+.role-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.role-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  padding: var(--space-5);
+}
+.role-card__head h3 {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.01em;
+}
+.role-card__body .kb-doc {
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+}
+.role-card__body .kb-doc p:last-child,
+.role-card__body .kb-doc ul:last-child { margin-bottom: 0; }
+
+.role-callout {
+  border-left: 3px solid var(--accent-strong);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  margin-bottom: var(--space-5);
+}
+.role-callout h4 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-muted);
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.17.0';
-console.log(`[job] v${VERSION} - status colors + view column + filter no-url`);
+const VERSION = '0.18.0';
+console.log(`[job] v${VERSION} - role detail: Details tab + Apply + auto-gen`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -1,19 +1,44 @@
-// job-role-detail — per-role detail page with Resume / Cover Letter tabs.
-// Reads /job/jobs/{slug}/?tab= and renders/edits assets from job.role_assets
-// via the role-asset endpoint.
+// job-role-detail — per-role detail page with Details / Resume / Cover Letter
+// tabs. The Details tab is the default landing and shows AI-generated cards
+// (Why it fits / Risks / Candidate strength) plus role metadata. Apply button
+// in the top-right opens the posting in a new tab.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
 ]);
 
 const TABS = [
-  { id: 'resume', label: 'Resume' },
+  { id: 'details',      label: 'Details' },
+  { id: 'resume',       label: 'Resume' },
   { id: 'cover-letter', label: 'Cover letter' },
 ];
+
+const KIND_BY_TAB = {
+  details: 'analysis',
+  resume: 'resume',
+  'cover-letter': 'cover-letter',
+};
+
+function fmtDate(s) {
+  if (!s) return '—';
+  try {
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return '—';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  } catch { return '—'; }
+}
+
+function fitClass(s) {
+  if (s == null) return 'fit-pill fit-pill--poor';
+  if (s >= 70) return 'fit-pill fit-pill--strong';
+  if (s >= 50) return 'fit-pill fit-pill--ok';
+  if (s >= 30) return 'fit-pill fit-pill--weak';
+  return 'fit-pill fit-pill--poor';
+}
 
 export class JobRoleDetail extends LitElement {
   createRenderRoot() { return this; }
@@ -22,10 +47,9 @@ export class JobRoleDetail extends LitElement {
     state: { state: true },
     error: { state: true },
     slug: { state: true },
-    rowNumber: { state: true },
     activeTab: { state: true },
-    assets: { state: true },        // { 'resume': { content, sha, draft, mode, saving, dirty } }
     role: { state: true },
+    assets: { state: true },         // { resume, cover-letter, analysis } each: {content, draft, mode, saving, dirty, error}
   };
 
   constructor() {
@@ -34,18 +58,19 @@ export class JobRoleDetail extends LitElement {
     this.error = '';
     const params = new URLSearchParams(location.search);
     this.slug = (params.get('slug') || '').toLowerCase();
-    this.rowNumber = Number(params.get('row')) || null;
     const tab = params.get('tab');
-    this.activeTab = TABS.find(t => t.id === tab)?.id || 'resume';
-    this.assets = { 'resume': null, 'cover-letter': null };
+    this.activeTab = TABS.find(t => t.id === tab)?.id || 'details';
     this.role = null;
+    this.assets = { 'resume': null, 'cover-letter': null, 'analysis': null };
 
     const pretty = sessionStorage.getItem('job:prettyPath');
-    if (pretty && /^\/job\/jobs\/[a-z0-9_-]+\/?$/.test(pretty)) {
+    if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
       sessionStorage.removeItem('job:prettyPath');
-      history.replaceState(null, '', pretty + (this.activeTab !== 'resume' ? `?tab=${this.activeTab}` : ''));
+      const qs = this.activeTab !== 'details' ? `?tab=${this.activeTab}` : '';
+      history.replaceState(null, '', pretty.replace(/\/?$/, '/') + qs);
     } else if (this.slug) {
-      history.replaceState(null, '', `/job/jobs/${this.slug}/${this.activeTab !== 'resume' ? `?tab=${this.activeTab}` : ''}`);
+      const qs = this.activeTab !== 'details' ? `?tab=${this.activeTab}` : '';
+      history.replaceState(null, '', `/job/jobs/${this.slug}/${qs}`);
     }
   }
 
@@ -65,21 +90,24 @@ export class JobRoleDetail extends LitElement {
   async _maybeLoad() {
     if (document.body.dataset.authState !== 'in') return;
     if (this.state === 'loading' || this.state === 'loaded') return;
-    if (!this.slug) {
-      this.state = 'error';
-      this.error = 'Missing slug';
-      return;
-    }
+    if (!this.slug) { this.state = 'error'; this.error = 'Missing slug'; return; }
     this.state = 'loading';
     try {
-      // Load both assets in parallel; tolerate 404 (asset not yet generated).
-      const [resume, cover] = await Promise.all([
+      // Load the role row + all three asset rows in parallel.
+      const [pipeline, resume, cover, analysis] = await Promise.all([
+        fetchPipeline(),
         this._loadAsset('resume'),
         this._loadAsset('cover-letter'),
+        this._loadAsset('analysis'),
       ]);
-      this.assets = { 'resume': resume, 'cover-letter': cover };
+      this.role = (pipeline.roles || []).find(r => r.slug === this.slug) || null;
+      this.assets = { 'resume': resume, 'cover-letter': cover, 'analysis': analysis };
       this.state = 'loaded';
-      document.title = `${this.slug} — /job`;
+      document.title = this.role
+        ? `${this.role.company} — ${this.role.title} — /job`
+        : `${this.slug} — /job`;
+      // Auto-generate any missing asset.
+      this._autoGenerateMissing();
     } catch (e) {
       this.state = 'error';
       this.error = String(e);
@@ -87,86 +115,192 @@ export class JobRoleDetail extends LitElement {
   }
 
   async _loadAsset(kind) {
-    const r = await readRoleAsset(this.slug, kind);
-    if (!r) {
-      return { content: '', draft: '', mode: 'empty', saving: false, dirty: false, error: '' };
+    try {
+      const r = await readRoleAsset(this.slug, kind);
+      if (!r) return { kind, content: '', draft: '', mode: 'empty', saving: false, dirty: false, error: '' };
+      return { kind, content: r.content_md, draft: r.content_md, mode: 'view', saving: false, dirty: false, error: '' };
+    } catch (e) {
+      return { kind, content: '', draft: '', mode: 'empty', saving: false, dirty: false, error: String(e) };
     }
-    return { content: r.content_md, draft: r.content_md, mode: 'view', saving: false, dirty: false, error: '' };
+  }
+
+  _autoGenerateMissing() {
+    for (const kind of ['analysis', 'resume', 'cover-letter']) {
+      const a = this.assets[kind];
+      if (a && a.mode === 'empty' && !a.saving) this._onGenerate(kind);
+    }
   }
 
   _switchTab(id) {
     this.activeTab = id;
-    history.replaceState(null, '', `/job/jobs/${this.slug}/${id !== 'resume' ? `?tab=${id}` : ''}`);
+    const qs = id !== 'details' ? `?tab=${id}` : '';
+    history.replaceState(null, '', `/job/jobs/${this.slug}/${qs}`);
   }
 
   async _onGenerate(kind) {
-    const a = this.assets[kind] || {};
-    a.saving = true;
-    a.error = '';
-    this.assets = { ...this.assets, [kind]: { ...a } };
+    const a = this.assets[kind] || { kind };
+    this.assets = { ...this.assets, [kind]: { ...a, saving: true, error: '' } };
     try {
       const res = await generateAsset(this.slug, kind);
       this.assets = {
         ...this.assets,
-        [kind]: {
-          content: res.content,
-          draft: res.content,
-          mode: 'view',
-          saving: false,
-          dirty: false,
-          error: '',
-        },
+        [kind]: { kind, content: res.content, draft: res.content, mode: 'view', saving: false, dirty: false, error: '' },
       };
     } catch (e) {
-      this._setAssetError(kind, String(e));
+      this.assets = { ...this.assets, [kind]: { ...this.assets[kind], saving: false, error: String(e) } };
     }
-  }
-
-  _setAssetError(kind, msg) {
-    const a = this.assets[kind] || {};
-    this.assets = { ...this.assets, [kind]: { ...a, saving: false, error: msg } };
   }
 
   _enterEdit(kind) {
     const a = this.assets[kind];
     this.assets = { ...this.assets, [kind]: { ...a, mode: 'edit', draft: a.content } };
   }
-
   _cancelEdit(kind) {
     const a = this.assets[kind];
     this.assets = { ...this.assets, [kind]: { ...a, mode: 'view', draft: a.content, dirty: false, error: '' } };
   }
-
   _onDraftInput(kind, e) {
     const a = this.assets[kind];
     this.assets = { ...this.assets, [kind]: { ...a, draft: e.target.value, dirty: e.target.value !== a.content } };
   }
-
   async _saveEdit(kind) {
     const a = this.assets[kind];
     if (!a.dirty) return;
     this.assets = { ...this.assets, [kind]: { ...a, saving: true, error: '' } };
     try {
       await writeRoleAsset(this.slug, kind, a.draft);
-      this.assets = {
-        ...this.assets,
-        [kind]: { ...a, content: a.draft, mode: 'view', saving: false, dirty: false },
-      };
+      this.assets = { ...this.assets, [kind]: { ...a, content: a.draft, mode: 'view', saving: false, dirty: false } };
     } catch (e) {
-      this._setAssetError(kind, String(e));
+      this.assets = { ...this.assets, [kind]: { ...a, saving: false, error: String(e) } };
     }
   }
 
-  _renderTabBody(kind) {
+  // --- Details tab ---------------------------------------------------------
+
+  _parseAnalysis(content) {
+    if (!content) return null;
+    // Tolerate: bare JSON, JSON inside ```json fences, or markdown with ## sections.
+    const stripped = content.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+    try {
+      const obj = JSON.parse(stripped);
+      if (obj && typeof obj === 'object') return obj;
+    } catch { /* fall through to section parse */ }
+
+    const sections = {};
+    const lines = content.split(/\r?\n/);
+    let cur = null;
+    let buf = [];
+    const flush = () => { if (cur) sections[cur] = buf.join('\n').trim(); buf = []; };
+    for (const line of lines) {
+      const m = line.match(/^##\s+(.+)$/);
+      if (m) {
+        flush();
+        cur = m[1].toLowerCase().replace(/\s+/g, '');
+      } else {
+        buf.push(line);
+      }
+    }
+    flush();
+    return {
+      description: sections['briefdescription'] || sections['description'] || content,
+      whyFits: sections['whyitfits'] || sections['whyfits'] || '',
+      risks: sections['risks'] || '',
+      candidateStrength: sections['candidatestrength'] || sections['strength'] || '',
+      suggestedAngle: sections['suggestedangle'] || sections['angle'] || '',
+    };
+  }
+
+  _renderMetaRow() {
+    const r = this.role;
+    if (!r) return nothing;
+    const items = [
+      ['Fit', html`<span class=${fitClass(r.score)} style="padding:2px var(--space-2);font-size:var(--font-size-small);">${r.score == null ? '—' : r.score}</span>`],
+      ['Status', r.status || '—'],
+      ['Sector', r.sector || '—'],
+      ['Compensation', r.salary || '—'],
+      ['Source', r.source || '—'],
+      ['Added', fmtDate(r.first_seen || r.applied_at)],
+      ['Last seen', fmtDate(r.last_seen || r.status_changed_at)],
+    ];
+    return html`
+      <dl class="role-meta">
+        ${items.map(([k, v]) => html`
+          <div class="role-meta__item">
+            <dt>${k}</dt>
+            <dd>${v}</dd>
+          </div>
+        `)}
+      </dl>
+    `;
+  }
+
+  _renderCard(title, body, status) {
+    return html`
+      <article class="role-card">
+        <header class="role-card__head">
+          <h3>${title}</h3>
+        </header>
+        <div class="role-card__body">
+          ${status === 'loading' ? html`<p class="muted">Generating…</p>`
+            : status === 'error'  ? html`<p class="muted" style="color:var(--error);">Couldn't load</p>`
+            : !body                ? html`<p class="muted">—</p>`
+            : html`<div class="kb-doc">${unsafeHTML(renderMarkdown(body))}</div>`}
+        </div>
+      </article>
+    `;
+  }
+
+  _renderDetails() {
+    const a = this.assets['analysis'];
+    const status = !a ? 'loading' : a.saving ? 'loading' : a.error ? 'error' : a.mode === 'empty' ? 'loading' : 'ok';
+    const parsed = a && a.mode === 'view' ? this._parseAnalysis(a.content) : null;
+    return html`
+      ${this._renderMetaRow()}
+      ${parsed?.description ? html`
+        <section class="role-summary">
+          <div class="kb-doc">${unsafeHTML(renderMarkdown(parsed.description))}</div>
+        </section>
+      ` : status === 'loading' ? html`<p class="muted">Drafting summary…</p>` : nothing}
+
+      <div class="role-cards">
+        ${this._renderCard('Why it fits',         parsed?.whyFits, status)}
+        ${this._renderCard('Risks',               parsed?.risks, status)}
+        ${this._renderCard('Candidate strength',  parsed?.candidateStrength, status)}
+      </div>
+
+      ${parsed?.suggestedAngle ? html`
+        <aside class="role-callout">
+          <h4>Suggested angle for the cover letter</h4>
+          <div class="kb-doc">${unsafeHTML(renderMarkdown(parsed.suggestedAngle))}</div>
+        </aside>
+      ` : nothing}
+
+      ${a?.error ? html`<p class="muted" style="color:var(--error);">${a.error}</p>` : nothing}
+      <div class="asset-toolbar" style="margin-top:var(--space-5);">
+        <button class="btn btn--sm" ?disabled=${a?.saving} @click=${() => this._onGenerate('analysis')}>
+          ${a?.saving ? 'Regenerating…' : 'Regenerate analysis'}
+        </button>
+      </div>
+    `;
+  }
+
+  // --- Resume / Cover-letter tab body -------------------------------------
+
+  _renderAssetTab(kind) {
     const a = this.assets[kind];
     if (!a) return html`<div class="placeholder"><h2>Loading…</h2></div>`;
-
+    if (a.saving && !a.content) {
+      return html`<div class="placeholder">
+        <h2>Generating ${kind === 'resume' ? 'resume' : 'cover letter'}…</h2>
+        <p>Pulling Ian's KB + voice rules. ~10–20s.</p>
+      </div>`;
+    }
     if (a.mode === 'empty') {
       return html`
         <div class="placeholder">
           <h2>No ${kind === 'resume' ? 'resume' : 'cover letter'} yet</h2>
-          <p>Generate one tailored to this role using your career KB and voice rules.</p>
-          <div style="margin-top:var(--space-4);display:flex;justify-content:center;gap:var(--space-3);">
+          <p>Generate one tailored to this role using the career KB and voice rules.</p>
+          <div style="margin-top:var(--space-4);display:flex;justify-content:center;">
             <button class="btn btn--primary" ?disabled=${a.saving} @click=${() => this._onGenerate(kind)}>
               ${a.saving ? 'Generating…' : `Generate ${kind === 'resume' ? 'resume' : 'cover letter'}`}
             </button>
@@ -175,7 +309,6 @@ export class JobRoleDetail extends LitElement {
         </div>
       `;
     }
-
     return html`
       <div class="asset-toolbar">
         ${a.mode === 'view' ? html`
@@ -191,11 +324,9 @@ export class JobRoleDetail extends LitElement {
         `}
         ${a.error ? html`<span class="muted" style="color:var(--error);">${a.error}</span>` : nothing}
       </div>
-
       ${a.mode === 'edit'
         ? html`<textarea class="asset-editor" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)}></textarea>`
-        : html`<article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(a.content))}</article>`
-      }
+        : html`<article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(a.content))}</article>`}
     `;
   }
 
@@ -209,17 +340,26 @@ export class JobRoleDetail extends LitElement {
         <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
       </div>`;
     }
-
+    const r = this.role;
     return html`
       <nav class="breadcrumb">
         <a href="/job/jobs/">Jobs</a>
         <span>›</span>
-        <span>${this.slug}</span>
+        <span>${r?.company || this.slug}</span>
       </nav>
 
-      <header class="page-header">
-        <h1>${this.slug}</h1>
-        <p>Resume and cover letter for this role. Each draft is committed to fikei/job/03-jobs/${this.slug}/.</p>
+      <header class="role-header">
+        <div class="role-header__title">
+          <h1>${r?.title || this.slug}</h1>
+          <p class="role-header__sub">${r?.company || ''}${r?.sector ? ` · ${r.sector}` : ''}</p>
+        </div>
+        <div class="role-header__actions">
+          ${r?.url ? html`
+            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer">
+              Apply ↗
+            </a>
+          ` : nothing}
+        </div>
       </header>
 
       <div class="asset-tabs">
@@ -232,7 +372,7 @@ export class JobRoleDetail extends LitElement {
       </div>
 
       <section class="asset-panel">
-        ${this._renderTabBody(this.activeTab)}
+        ${this.activeTab === 'details' ? this._renderDetails() : this._renderAssetTab(this.activeTab)}
       </section>
     `;
   }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.17.0">
-  <script src="/job/js/theme.js?v=0.17.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
+  <script src="/job/js/theme.js?v=0.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.17.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -98,9 +98,14 @@ serve(async (req) => {
     const body = await req.json().catch(() => ({}));
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
-    const kind = body.kind === 'cover-letter' ? 'cover-letter' : (body.kind === 'resume' ? 'resume' : null);
+    const kindIn = body.kind;
+    const kind: 'resume' | 'cover-letter' | 'analysis' | null =
+      kindIn === 'cover-letter' ? 'cover-letter'
+      : kindIn === 'resume'     ? 'resume'
+      : kindIn === 'analysis'   ? 'analysis'
+      : null;
     if (!slugIn && !rowIn) return err('slug or rowNumber required', 400);
-    if (!kind) return err('kind must be "resume" or "cover-letter"', 400);
+    if (!kind) return err('kind must be "resume", "cover-letter", or "analysis"', 400);
 
     const role = await loadRole(slugIn, rowIn);
     if (!role) return err('role not found', 404);

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -60,16 +60,40 @@ VOICE RULES (same as cover letter):
 
 Output ONLY the markdown. No preamble. No "Here is your resume." Start with "# Ian Fike".`;
 
-export function buildSystemPrompt(kind: 'resume' | 'cover-letter'): string {
-  const voice = kind === 'cover-letter' ? COVER_LETTER_VOICE : RESUME_VOICE;
-  return `You are drafting a ${kind === 'cover-letter' ? 'cover letter' : 'resume'} for Ian Fike, a senior PM. Your job: produce final-quality markdown that Ian could submit without further editing.
+export const ANALYSIS_VOICE = `You are advising Ian on a specific role. Output ONLY a JSON object with these keys, each value a markdown string:
+
+{
+  "description":         "2-3 sentence plain summary of the role and what the team is trying to ship.",
+  "whyFits":             "3-5 bullets in markdown explaining why this role plays to Ian's strengths. Reference specific past projects/skills by name. Don't editorialize.",
+  "risks":               "2-4 bullets in markdown calling out the real concerns: ICP/seniority mismatch, sector adjacency, comp gap, geo, gaps in evidence. Be honest, not encouraging.",
+  "candidateStrength":   "1-2 sentences in markdown rating Ian's relative strength as a candidate (strong / mid / stretch) with the single strongest piece of evidence.",
+  "suggestedAngle":      "1-2 sentences in markdown suggesting the framing he should lead with in the cover letter."
+}
+
+Rules:
+- Output ONLY the JSON object. No prose before or after. No code fence. No commentary.
+- Markdown values are short. Bullets use "- " prefix.
+- No em dashes. No "passionate about" / "excited to". No try-hard cleverness.
+- Reference real projects/skills/wins by their slug-like name when relevant (livongo-platform-scaling, eligibility-engine, growth-experimentation, etc).`;
+
+export function buildSystemPrompt(kind: 'resume' | 'cover-letter' | 'analysis'): string {
+  const voice =
+    kind === 'cover-letter' ? COVER_LETTER_VOICE :
+    kind === 'analysis'     ? ANALYSIS_VOICE :
+                              RESUME_VOICE;
+  const intro =
+    kind === 'analysis'
+      ? `You are reviewing a job posting for Ian Fike (senior PM) and producing a structured assessment.`
+      : `You are drafting a ${kind === 'cover-letter' ? 'cover letter' : 'resume'} for Ian Fike, a senior PM. Your job: produce final-quality markdown that Ian could submit without further editing.`;
+
+  return `${intro}
 
 ${voice}
 
 Below is Ian's career knowledge base — companies, projects, skills, wins, and goals/intents. Use it as the source of truth for facts. Do not invent.`;
 }
 
-export function buildUserMessage(kind: 'resume' | 'cover-letter', kbContext: string, role: { company: string; title: string; sector?: string; salary?: string; url?: string }): string {
+export function buildUserMessage(kind: 'resume' | 'cover-letter' | 'analysis', kbContext: string, role: { company: string; title: string; sector?: string; salary?: string; url?: string }): string {
   const meta = [
     `Company: ${role.company}`,
     `Title: ${role.title}`,
@@ -78,9 +102,10 @@ export function buildUserMessage(kind: 'resume' | 'cover-letter', kbContext: str
     role.url ? `Posting: ${role.url}` : '',
   ].filter(Boolean).join('\n');
 
-  const ask = kind === 'cover-letter'
-    ? 'Draft the cover letter as markdown. ~350 words, one page. Address it to the company by name.'
-    : 'Draft the resume as markdown. One page. Tailored emphasis for this role.';
+  const ask =
+    kind === 'cover-letter' ? 'Draft the cover letter as markdown. ~350 words, one page. Address it to the company by name.'
+    : kind === 'analysis'   ? 'Produce the JSON object now. JSON only.'
+    :                         'Draft the resume as markdown. One page. Tailored emphasis for this role.';
 
   return `# Career knowledge base
 

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,6 +1,5 @@
-// Auto-generated mirror of supabase/migrations/047_job_product_schema.sql.
-// Bundled as a TS export because the Supabase CLI doesn't ship .sql files
-// to the function runtime.
+// Bundled schema for migrate-job. Mirrors 047 + 048 from supabase/migrations.
+// Backticks stripped from inline SQL since this is a template literal.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -199,4 +198,11 @@ begin
     execute format('alter table job.%I enable row level security;', t);
   end loop;
 end $$;
+
+-- 048 ----------------------------------------------------------------
+-- Allow analysis as a role_assets kind. The detail page stores Claude's
+-- structured analysis (brief, why-fits, risks, candidate-strength) here.
+alter table job.role_assets drop constraint if exists role_assets_kind_check;
+alter table job.role_assets add constraint role_assets_kind_check
+  check (kind in ('resume', 'cover-letter', 'notes', 'analysis'));
 `;

--- a/supabase/functions/role-asset/index.ts
+++ b/supabase/functions/role-asset/index.ts
@@ -12,7 +12,7 @@ import { db } from '../_shared/job-db.ts';
 const VERSION = '0.1.0';
 console.log(`[role-asset] v${VERSION}`);
 
-const KIND_RE = /^(resume|cover-letter|notes)$/;
+const KIND_RE = /^(resume|cover-letter|notes|analysis)$/;
 const SLUG_RE = /^[a-z0-9_-]+$/;
 const MAX_BYTES = 64 * 1024;
 

--- a/supabase/migrations/048_job_role_assets_analysis.sql
+++ b/supabase/migrations/048_job_role_assets_analysis.sql
@@ -1,0 +1,5 @@
+-- Allow `analysis` as a role_assets kind. The detail page stores Claude's
+-- structured analysis (brief, why-fits, risks, candidate-strength) here.
+alter table job.role_assets drop constraint if exists role_assets_kind_check;
+alter table job.role_assets add constraint role_assets_kind_check
+  check (kind in ('resume', 'cover-letter', 'notes', 'analysis'));


### PR DESCRIPTION
## Summary

\`/job/jobs/{slug}/\` lands on a new **Details** tab. Resume and Cover letter tabs sit beside it. An **Apply ↗** button in the top-right opens the posting.

### Backend
- Migration 048 (bundled into \`migrate-job\`'s schema): allow \`'analysis'\` in \`job.role_assets.kind\`.
- \`gen-asset\` accepts \`kind: 'analysis'\`. New \`ANALYSIS_VOICE\` prompt asks Claude for a JSON object with \`description\`, \`whyFits\`, \`risks\`, \`candidateStrength\`, \`suggestedAngle\`. Voice rules baked in: no em dashes, no "passionate about", references real KB slugs.
- \`role-asset\` allows the new kind.

### Frontend (app v0.18.0)
- **Header**: role title + company subline. **Apply ↗** Bright Green button on the right opens the posting in a new tab.
- **Meta strip**: Fit pill, Status, Sector, Compensation, Source, Added, Last seen.
- **Three cards**: "Why it fits", "Risks", "Candidate strength" rendered from the analysis JSON.
- **Suggested angle** callout below the cards (single-paragraph cover-letter framing).
- **Auto-generate**: on first load, any of the three assets that don't exist gets kicked off; existing assets render immediately. Tabs show their own "Generating…" state.

\`_parseAnalysis\` tolerates raw JSON, fenced JSON, or \`## Section\` markdown fallback.

## Verified
\`\`\`
gen-asset POST { kind: 'analysis' } → 200 in 12.5s
content begins with: ```json\n{ "description": "Abridge is building..."
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)