### PR TITLE
Dark greyscale + CTRL theme + status alignment

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,7 +1,10 @@
 @import url("./tokens-generic-light.css");
 @import url("./tokens-generic-dark.css");
+@import url("./tokens-ctrl-light.css");
+@import url("./tokens-ctrl-dark.css");
 @import url("./components.css");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 
 * { box-sizing: border-box; }
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -352,12 +352,24 @@
 .fit-pill--weak   { background: rgba(237,200,67,0.20); color: #6E5400; }
 .fit-pill--poor   { background: rgba(168,32,13,0.12); color: var(--error); }
 
-/* --- Status select (color-coded by current value) --- */
-.status-cell { display: flex; align-items: center; gap: var(--space-2); }
+/* --- Status select (color-coded by current value) ---
+   Note: <td> retains its native vertical-align: middle. Avoid flex on the cell —
+   it created an extra-tall row + visible gap below the pill. */
+.status-cell {
+  white-space: nowrap;
+  line-height: 1;
+}
+.status-cell__err {
+  margin-left: var(--space-2);
+  vertical-align: middle;
+}
 .status-select {
+  display: inline-block;
+  vertical-align: middle;
   font: inherit;
   font-size: var(--font-size-small);
   font-weight: var(--fw-semibold);
+  line-height: 30px;
   height: 32px;
   width: auto;
   min-width: 110px;
@@ -378,7 +390,7 @@
   background-repeat: no-repeat;
 }
 .status-select:hover { border-color: var(--border-strong); }
-.status-select:focus { outline: none; box-shadow: 0 0 0 3px var(--accent-muted); }
+.status-select:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--accent-muted); }
 .status-select.is-saving { opacity: 0.6; }
 
 /* Color variants by current status. Soft tinted backgrounds + matching

--- a/job/css/tokens-ctrl-dark.css
+++ b/job/css/tokens-ctrl-dark.css
@@ -1,0 +1,79 @@
+/* CTRL design system — dark theme.
+   Voice: terminal, monospace, terminal-cyan accent on near-black surfaces. */
+[data-theme="ctrl-dark"] {
+  /* Backgrounds — neutral dark from CTRL DS */
+  --bg: #111110;
+  --bg-surface: #1a1a18;
+  --bg-elevated: #22221f;
+  --bg-overlay: rgba(255, 255, 255, 0.04);
+
+  /* Content */
+  --fg: #e8e6e3;
+  --fg-muted: #a8a6a3;
+  --fg-subtle: #666560;
+  --fg-link: #00fff7;
+
+  /* Interactive — terminal cyan accent */
+  --accent: #e8e6e3;
+  --accent-fg: #111110;
+  --accent-muted: rgba(0, 255, 247, 0.20);
+  --accent-strong: #00fff7;
+  --accent-strong-fg: #111110;
+
+  /* Borders */
+  --border: #33332f;
+  --border-strong: #5a5852;
+
+  /* Sentiment */
+  --success: #4ade80;
+  --error: #f87171;
+  --warning: #fbbf24;
+
+  /* Typography */
+  --font-body: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+
+  --font-size-display: 48px;
+  --font-size-title-1: 32px;
+  --font-size-title-2: 24px;
+  --font-size-title-3: 18px;
+  --font-size-title-4: 16px;
+  --font-size-body-lg: 16px;
+  --font-size-body: 14px;
+  --font-size-small: 12px;
+  --font-size-caption: 11px;
+
+  --lh-display: 1.1;
+  --lh-title: 1.2;
+  --lh-body: 1.6;
+  --lh-tight: 1.3;
+
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  /* Radius */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 4px;
+  --radius-xl: 8px;
+  --radius-2xl: 8px;
+  --radius-pill: 4px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 0 rgba(0,0,0,0.4);
+  --shadow-md: 0 2px 8px rgba(0,0,0,0.5);
+  --shadow-lg: 0 4px 16px rgba(0,0,0,0.6);
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 48px;
+  --space-9: 64px;
+  --space-10: 80px;
+}

--- a/job/css/tokens-ctrl-light.css
+++ b/job/css/tokens-ctrl-light.css
@@ -1,0 +1,80 @@
+/* CTRL design system — light theme.
+   Maps the existing /design-system/ tokens onto the /job abstract contract.
+   Voice: monospace, terminal, hard-edged. Tighter radii than Wise. */
+[data-theme="ctrl-light"] {
+  /* Backgrounds — warm off-white from the CTRL DS light palette */
+  --bg: #faf9f7;
+  --bg-surface: #f1efea;
+  --bg-elevated: #ffffff;
+  --bg-overlay: rgba(0, 0, 0, 0.04);
+
+  /* Content */
+  --fg: #1a1a18;
+  --fg-muted: #4a4a47;
+  --fg-subtle: #8a8885;
+  --fg-link: #0055aa;
+
+  /* Interactive — solid black + terminal-cyan highlight */
+  --accent: #1a1a18;
+  --accent-fg: #faf9f7;
+  --accent-muted: rgba(0, 255, 247, 0.18);
+  --accent-strong: #00a8a0;
+  --accent-strong-fg: #ffffff;
+
+  /* Borders — high contrast (CTRL convention is 1px solid black) */
+  --border: #1a1a18;
+  --border-strong: #1a1a18;
+
+  /* Sentiment — DS palette */
+  --success: #166534;
+  --error: #991b1b;
+  --warning: #92400e;
+
+  /* Typography */
+  --font-body: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  --font-display: "Space Grotesk", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+
+  --font-size-display: 48px;
+  --font-size-title-1: 32px;
+  --font-size-title-2: 24px;
+  --font-size-title-3: 18px;
+  --font-size-title-4: 16px;
+  --font-size-body-lg: 16px;
+  --font-size-body: 14px;
+  --font-size-small: 12px;
+  --font-size-caption: 11px;
+
+  --lh-display: 1.1;
+  --lh-title: 1.2;
+  --lh-body: 1.6;
+  --lh-tight: 1.3;
+
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  /* Radius — CTRL is hard-edged (no pill buttons, no 30px cards) */
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 4px;
+  --radius-xl: 8px;
+  --radius-2xl: 8px;
+  --radius-pill: 4px;
+
+  /* Shadows — minimal in CTRL */
+  --shadow-sm: 0 1px 0 rgba(0,0,0,0.06);
+  --shadow-md: 0 2px 4px rgba(0,0,0,0.08);
+  --shadow-lg: 0 4px 12px rgba(0,0,0,0.12);
+
+  /* Spacing — same scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 48px;
+  --space-9: 64px;
+  --space-10: 80px;
+}

--- a/job/css/tokens-generic-dark.css
+++ b/job/css/tokens-generic-dark.css
@@ -1,35 +1,36 @@
 /* Wise design system — dark theme tokens.
-   Forest Green base with Bright Green as the active accent. */
+   Backgrounds and surfaces are greyscale; the brand keeps its green only on
+   active accents (status pills, View button, fit-score "strong" pill). */
 [data-theme="generic-dark"] {
-  /* Backgrounds — Forest Green family */
-  --bg: #102600;
-  --bg-surface: #163300;                            /* Forest Green */
-  --bg-elevated: #1F4400;
-  --bg-overlay: rgba(159, 232, 112, 0.08);
+  /* Backgrounds — neutral greyscale */
+  --bg: #0d1117;
+  --bg-surface: #161b22;
+  --bg-elevated: #1f2630;
+  --bg-overlay: rgba(255, 255, 255, 0.06);
 
   /* Content */
-  --fg: #FFFFFF;                                    /* Base Light */
-  --fg-muted: rgba(255, 255, 255, 0.72);
-  --fg-subtle: rgba(255, 255, 255, 0.50);
+  --fg: #f0f6fc;
+  --fg-muted: rgba(240, 246, 252, 0.72);
+  --fg-subtle: rgba(240, 246, 252, 0.50);
   --fg-link: #9FE870;
 
-  /* Interactive — Bright Green leads in dark */
-  --accent: #9FE870;                                /* Bright Green */
-  --accent-fg: #163300;                             /* Forest Green for text on accent */
+  /* Interactive — Bright Green still leads as the active accent */
+  --accent: #9FE870;
+  --accent-fg: #0d1117;
   --accent-muted: rgba(159, 232, 112, 0.16);
   --accent-strong: #9FE870;
-  --accent-strong-fg: #163300;
+  --accent-strong-fg: #0d1117;
 
   /* Borders */
-  --border: rgba(255, 255, 255, 0.12);
-  --border-strong: rgba(255, 255, 255, 0.24);
+  --border: rgba(240, 246, 252, 0.12);
+  --border-strong: rgba(240, 246, 252, 0.24);
 
   /* Sentiment */
   --success: #9FE870;
   --error: #FF7A6E;
   --warning: #FFEB69;
 
-  /* Typography (same scale; weights match light) */
+  /* Typography */
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-display: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -60,7 +61,7 @@
   --radius-2xl: 60px;
   --radius-pill: 999px;
 
-  /* Shadows — softer in dark */
+  /* Shadows */
   --shadow-sm: 0 2px 6px rgba(0,0,0,0.30);
   --shadow-md: 0 8px 24px rgba(0,0,0,0.40);
   --shadow-lg: 0 16px 48px rgba(0,0,0,0.55);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.18.0';
-console.log(`[job] v${VERSION} - role detail: Details tab + Apply + auto-gen`);
+const VERSION = '0.19.0';
+console.log(`[job] v${VERSION} - dark greyscale + CTRL theme + status alignment`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -11,8 +11,8 @@ const ROUTES = [
 const THEMES = [
   { value: 'generic-light', label: 'Generic · Light' },
   { value: 'generic-dark',  label: 'Generic · Dark' },
-  { value: 'ctrl-light',    label: 'CTRL · Light (soon)', disabled: true },
-  { value: 'ctrl-dark',     label: 'CTRL · Dark (soon)',  disabled: true }
+  { value: 'ctrl-light',    label: 'CTRL · Light' },
+  { value: 'ctrl-dark',     label: 'CTRL · Dark' }
 ];
 
 export class JobRail extends LitElement {

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.18.0">
-  <script src="/job/js/theme.js?v=0.18.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
+  <script src="/job/js/theme.js?v=0.19.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.18.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Three things in one PR.

1. **Status row alignment** — status <td> was display:flex, forcing tall rows + a visible gap below the pill. Switched to default table-cell + inline-block select + line-height. Replaced :focus with :focus-visible so mouse clicks don't leave a stuck ring.

2. **Dark theme greyscale** — forest-green backgrounds out, GitHub-dark neutrals in. Bright-green stays as the active accent (View button, fit pill strong, status pills, links). Borders use white-alpha now.

3. **CTRL design system** — new tokens-ctrl-{light,dark}.css mapped to the abstract /job contract. JetBrains Mono body / Space Grotesk display / hard-edged 2–4px radii / terminal-cyan strong accent. Both ctrl themes enabled in the rail picker.

App bumped to 0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)