### PR TITLE
Fix md.replace TypeError on analysis tab + harden prompt

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.19.0';
-console.log(`[job] v${VERSION} - dark greyscale + CTRL theme + status alignment`);
+const VERSION = '0.19.1';
+console.log(`[job] v${VERSION} - markdown string coerce + analysis prompt hardening`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/markdown.js
+++ b/job/js/markdown.js
@@ -21,9 +21,19 @@ export function resolveSlug(slug) {
   return `/job/history/companies/${s}/`;
 }
 
+// Coerce non-string inputs to a markdown string. Claude sometimes returns
+// arrays of bullets where we asked for a single markdown string.
+function toMd(input) {
+  if (input == null) return '';
+  if (typeof input === 'string') return input;
+  if (Array.isArray(input)) return input.map(toMd).map(s => s.startsWith('-') ? s : '- ' + s).join('\n');
+  if (typeof input === 'object') return JSON.stringify(input, null, 2);
+  return String(input);
+}
+
 // Pre-process [[slug]] and [[slug|label]] before marked sees the text.
 function expandWikiLinks(md) {
-  return md.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, slug, label) => {
+  return toMd(md).replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_match, slug, label) => {
     const href = resolveSlug(slug);
     const text = (label || slug).trim();
     return `[${text}](${href})`;

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.0">
-  <script src="/job/js/theme.js?v=0.19.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
+  <script src="/job/js/theme.js?v=0.19.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -60,19 +60,19 @@ VOICE RULES (same as cover letter):
 
 Output ONLY the markdown. No preamble. No "Here is your resume." Start with "# Ian Fike".`;
 
-export const ANALYSIS_VOICE = `You are advising Ian on a specific role. Output ONLY a JSON object with these keys, each value a markdown string:
+export const ANALYSIS_VOICE = `You are advising Ian on a specific role. Output ONLY a JSON object. Every value MUST be a STRING (markdown). Never an array, never a nested object.
 
 {
   "description":         "2-3 sentence plain summary of the role and what the team is trying to ship.",
-  "whyFits":             "3-5 bullets in markdown explaining why this role plays to Ian's strengths. Reference specific past projects/skills by name. Don't editorialize.",
-  "risks":               "2-4 bullets in markdown calling out the real concerns: ICP/seniority mismatch, sector adjacency, comp gap, geo, gaps in evidence. Be honest, not encouraging.",
-  "candidateStrength":   "1-2 sentences in markdown rating Ian's relative strength as a candidate (strong / mid / stretch) with the single strongest piece of evidence.",
-  "suggestedAngle":      "1-2 sentences in markdown suggesting the framing he should lead with in the cover letter."
+  "whyFits":             "3-5 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Reference specific past projects/skills by name. Don't editorialize.",
+  "risks":               "2-4 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Real concerns: ICP/seniority mismatch, sector adjacency, comp gap, geo, gaps in evidence. Honest, not encouraging.",
+  "candidateStrength":   "1-2 sentences in a single markdown string rating Ian's relative strength (strong / mid / stretch) with the single strongest piece of evidence.",
+  "suggestedAngle":      "1-2 sentences in a single markdown string suggesting the framing he should lead with in the cover letter."
 }
 
-Rules:
+Format rules:
 - Output ONLY the JSON object. No prose before or after. No code fence. No commentary.
-- Markdown values are short. Bullets use "- " prefix.
+- EVERY value is a string. If the content is bullets, the value is one string with embedded newlines and "- " prefixes.
 - No em dashes. No "passionate about" / "excited to". No try-hard cleverness.
 - Reference real projects/skills/wins by their slug-like name when relevant (livongo-platform-scaling, eligibility-engine, growth-experimentation, etc).`;
 


### PR DESCRIPTION
Bug: `Uncaught TypeError: md.replace is not a function at expandWikiLinks`. Claude sometimes returned analysis JSON with array values for whyFits/risks despite the prompt asking for markdown strings, and the component passed arrays straight into renderMarkdown.

Fix:
- markdown.js: `toMd()` coerces null/array/object inputs into a markdown string. Arrays become one bullet per line.
- gen-asset prompt repeatedly states 'every value is a STRING' and rules out arrays.

App bumped to 0.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)