### PR TITLE
Drop Resume + Cover columns from pipeline table

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.19.1';
-console.log(`[job] v${VERSION} - markdown string coerce + analysis prompt hardening`);
+const VERSION = '0.20.0';
+console.log(`[job] v${VERSION} - drop resume/cover columns; assets live in detail`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,7 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, setStatus, generateAsset } = await import('../pipeline.js' + V);
+const { fetchPipeline, setStatus } = await import('../pipeline.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -20,16 +20,15 @@ const DIM_LABELS = {
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
+// Resume + Cover assets live on the detail page now, not the main table.
 const COLUMNS = [
-  { id: 'fit',     label: 'Fit',     sortKey: 'score',          type: 'num',  defaultDir: 'desc' },
-  { id: 'status',  label: 'Status',  sortKey: 'status',         type: 'text' },
-  { id: 'company', label: 'Company', sortKey: 'company',        type: 'text' },
-  { id: 'role',    label: 'Role',    sortKey: 'title',          type: 'text' },
-  { id: 'resume',  label: 'Resume',  sortKey: 'hasResume',      type: 'bool', defaultDir: 'desc' },
-  { id: 'cover',   label: 'Cover',   sortKey: 'hasCoverLetter', type: 'bool', defaultDir: 'desc' },
-  { id: 'sector',  label: 'Sector',  sortKey: 'sector',         type: 'text' },
-  { id: 'salary',  label: 'Salary',  sortKey: 'salary_high',    type: 'num',  defaultDir: 'desc' },
-  { id: 'source',  label: 'Source',  sortKey: 'source',         type: 'text' },
+  { id: 'fit',     label: 'Fit',     sortKey: 'score',       type: 'num',  defaultDir: 'desc' },
+  { id: 'status',  label: 'Status',  sortKey: 'status',      type: 'text' },
+  { id: 'company', label: 'Company', sortKey: 'company',     type: 'text' },
+  { id: 'role',    label: 'Role',    sortKey: 'title',       type: 'text' },
+  { id: 'sector',  label: 'Sector',  sortKey: 'sector',      type: 'text' },
+  { id: 'salary',  label: 'Salary',  sortKey: 'salary_high', type: 'num',  defaultDir: 'desc' },
+  { id: 'source',  label: 'Source',  sortKey: 'source',      type: 'text' },
   { id: 'view',    label: '',        sortKey: null },
 ];
 
@@ -163,24 +162,7 @@ export class JobPipeline extends LitElement {
     this.requestUpdate();
   }
 
-  async _onGenerate(r, kind) {
-    const flag = kind === 'resume' ? '_genResume' : '_genCover';
-    if (r[flag]) return;
-    r[flag] = true;
-    this.requestUpdate();
-    try {
-      await generateAsset(r.slug, kind);
-      if (kind === 'resume') r.hasResume = true;
-      else r.hasCoverLetter = true;
-    } catch (e) {
-      r._error = String(e);
-    } finally {
-      r[flag] = false;
-      this.requestUpdate();
-    }
-  }
-
-  _detailHref(r, tab) { return tab ? `/job/jobs/${r.slug}/?tab=${tab}` : `/job/jobs/${r.slug}/`; }
+  _detailHref(r) { return `/job/jobs/${r.slug}/`; }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
   _renderViewCell(r) {
@@ -188,19 +170,6 @@ export class JobPipeline extends LitElement {
       <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener">
         View
       </a>
-    `;
-  }
-
-  _renderAssetCell(r, kind) {
-    const has = kind === 'resume' ? r.hasResume : r.hasCoverLetter;
-    const generating = kind === 'resume' ? r._genResume : r._genCover;
-    if (has) {
-      return html`<a class="link-subtle" href=${this._detailHref(r, kind)} target="_blank" rel="noopener">View / Edit</a>`;
-    }
-    return html`
-      <button class="btn btn--sm" ?disabled=${generating} @click=${() => this._onGenerate(r, kind)}>
-        ${generating ? 'Generating…' : 'Create'}
-      </button>
     `;
   }
 
@@ -244,8 +213,6 @@ export class JobPipeline extends LitElement {
         </td>
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
-        <td>${this._renderAssetCell(r, 'resume')}</td>
-        <td>${this._renderAssetCell(r, 'cover-letter')}</td>
         <td><span class="muted">${r.sector || ''}</span></td>
         <td><span class="muted">${r.salary || ''}</span></td>
         <td><span class="muted">${r.source || ''}</span></td>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.19.1">
-  <script src="/job/js/theme.js?v=0.19.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
+  <script src="/job/js/theme.js?v=0.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.19.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Assets live on the per-role detail page now. Pipeline shrinks to Fit / Status / Company / Role / Sector / Salary / Source / View.

App bumped to 0.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)