### PR TITLE
Merge Details cards + drop Source/Salary cols + shimmer skeleton

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -793,3 +793,87 @@
   font-weight: var(--fw-semibold);
   color: var(--fg-muted);
 }
+
+/* --- Stoplight pill (role-fit / candidate-strength scores) --- */
+.stoplight {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 4px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+}
+.stoplight::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+.stoplight--strong { background: rgba(47,87,17,0.16); color: var(--success); }
+.stoplight--mid    { background: rgba(237,200,67,0.20); color: #6E5400; }
+.stoplight--weak   { background: rgba(168,32,13,0.12); color: var(--error); }
+[data-theme="generic-dark"] .stoplight--strong { color: var(--accent-strong); }
+[data-theme="generic-dark"] .stoplight--mid    { color: var(--warning); }
+[data-theme="ctrl-light"]   .stoplight--strong { color: var(--success); }
+[data-theme="ctrl-dark"]    .stoplight--strong { color: var(--success); }
+
+/* --- Two-section role card --- */
+.role-card__head--with-extra {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+}
+.role-card__head--with-extra h3 { margin-bottom: 0; }
+.role-card__split {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-5);
+}
+@media (min-width: 720px) {
+  .role-card__split { grid-template-columns: 1fr 1fr; }
+}
+.role-card__section h4 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-muted);
+}
+
+/* --- Shimmer skeleton (loading state) --- */
+.skeleton {
+  display: inline-block;
+  background: var(--bg-surface);
+  border-radius: var(--radius-sm);
+  position: relative;
+  overflow: hidden;
+  vertical-align: middle;
+}
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--bg-elevated) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+}
+.skeleton--pill { border-radius: var(--radius-pill); }
+.skeleton-row td { padding-top: var(--space-3); padding-bottom: var(--space-3); }
+.skeleton-row:hover td { background: transparent !important; }
+
+@keyframes shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after { animation: none; opacity: 0.5; }
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.20.0';
-console.log(`[job] v${VERSION} - drop resume/cover columns; assets live in detail`);
+const VERSION = '0.21.0';
+console.log(`[job] v${VERSION} - merged cards + skeleton + drop salary/source cols`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -20,15 +20,13 @@ const DIM_LABELS = {
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
-// Resume + Cover assets live on the detail page now, not the main table.
+// Resume + Cover, Source + Salary all live on the detail page now.
 const COLUMNS = [
-  { id: 'fit',     label: 'Fit',     sortKey: 'score',       type: 'num',  defaultDir: 'desc' },
-  { id: 'status',  label: 'Status',  sortKey: 'status',      type: 'text' },
-  { id: 'company', label: 'Company', sortKey: 'company',     type: 'text' },
-  { id: 'role',    label: 'Role',    sortKey: 'title',       type: 'text' },
-  { id: 'sector',  label: 'Sector',  sortKey: 'sector',      type: 'text' },
-  { id: 'salary',  label: 'Salary',  sortKey: 'salary_high', type: 'num',  defaultDir: 'desc' },
-  { id: 'source',  label: 'Source',  sortKey: 'source',      type: 'text' },
+  { id: 'fit',     label: 'Fit',     sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
+  { id: 'status',  label: 'Status',  sortKey: 'status',  type: 'text' },
+  { id: 'company', label: 'Company', sortKey: 'company', type: 'text' },
+  { id: 'role',    label: 'Role',    sortKey: 'title',   type: 'text' },
+  { id: 'sector',  label: 'Sector',  sortKey: 'sector',  type: 'text' },
   { id: 'view',    label: '',        sortKey: null },
 ];
 
@@ -214,9 +212,20 @@ export class JobPipeline extends LitElement {
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
         <td><span class="muted">${r.sector || ''}</span></td>
-        <td><span class="muted">${r.salary || ''}</span></td>
-        <td><span class="muted">${r.source || ''}</span></td>
         <td>${this._renderViewCell(r)}</td>
+      </tr>
+    `;
+  }
+
+  _renderSkeletonRow() {
+    return html`
+      <tr class="skeleton-row">
+        <td><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
+        <td><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>
+        <td><span class="skeleton" style="width:100px;height:16px;"></span></td>
+        <td><span class="skeleton" style="width:60%;height:16px;"></span></td>
+        <td><span class="skeleton" style="width:80px;height:16px;"></span></td>
+        <td><span class="skeleton skeleton--pill" style="width:64px;height:32px;"></span></td>
       </tr>
     `;
   }
@@ -275,7 +284,20 @@ export class JobPipeline extends LitElement {
 
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
-      return html`<div class="placeholder"><h2>Loading pipeline…</h2><p>Reading the Job Search sheet.</p></div>`;
+      // Render the same shell that the loaded view will use, with skeleton
+      // rows in place of real content so the table doesn't visually jolt
+      // into existence on load.
+      return html`
+        <div class="pipeline-meta">
+          <span class="skeleton" style="width:160px;height:14px;display:inline-block;"></span>
+        </div>
+        <div class="pipeline-table-wrap">
+          <table class="pipeline-table">
+            <thead>${this._renderHeader()}</thead>
+            <tbody>${Array.from({ length: 8 }).map(() => this._renderSkeletonRow())}</tbody>
+          </table>
+        </div>
+      `;
     }
     if (this.state === 'error') {
       return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -179,35 +179,52 @@ export class JobRoleDetail extends LitElement {
 
   _parseAnalysis(content) {
     if (!content) return null;
-    // Tolerate: bare JSON, JSON inside ```json fences, or markdown with ## sections.
+    // Tolerate bare JSON or JSON inside ```json fences. Backwards-compatible
+    // with the v0.18 shape (no roleFitScore/candidateScore/strengths/gaps).
     const stripped = content.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+    let obj = null;
     try {
-      const obj = JSON.parse(stripped);
-      if (obj && typeof obj === 'object') return obj;
-    } catch { /* fall through to section parse */ }
+      const parsed = JSON.parse(stripped);
+      if (parsed && typeof parsed === 'object') obj = parsed;
+    } catch { /* fall back below */ }
 
-    const sections = {};
-    const lines = content.split(/\r?\n/);
-    let cur = null;
-    let buf = [];
-    const flush = () => { if (cur) sections[cur] = buf.join('\n').trim(); buf = []; };
-    for (const line of lines) {
-      const m = line.match(/^##\s+(.+)$/);
-      if (m) {
-        flush();
-        cur = m[1].toLowerCase().replace(/\s+/g, '');
-      } else {
-        buf.push(line);
+    if (!obj) {
+      // Old "## Section" markdown fallback.
+      const sections = {};
+      const lines = content.split(/\r?\n/);
+      let cur = null;
+      let buf = [];
+      const flush = () => { if (cur) sections[cur] = buf.join('\n').trim(); buf = []; };
+      for (const line of lines) {
+        const m = line.match(/^##\s+(.+)$/);
+        if (m) { flush(); cur = m[1].toLowerCase().replace(/\s+/g, ''); }
+        else buf.push(line);
       }
+      flush();
+      obj = {
+        description: sections['briefdescription'] || sections['description'] || content,
+        whyFits: sections['whyitfits'] || sections['whyfits'] || '',
+        risks: sections['risks'] || '',
+        strengths: sections['strengths'] || sections['candidatestrength'] || '',
+        gaps: sections['gaps'] || '',
+        suggestedAngle: sections['suggestedangle'] || sections['angle'] || '',
+      };
     }
-    flush();
-    return {
-      description: sections['briefdescription'] || sections['description'] || content,
-      whyFits: sections['whyitfits'] || sections['whyfits'] || '',
-      risks: sections['risks'] || '',
-      candidateStrength: sections['candidatestrength'] || sections['strength'] || '',
-      suggestedAngle: sections['suggestedangle'] || sections['angle'] || '',
-    };
+
+    // Normalize: in the previous shape, `candidateStrength` carried strengths
+    // text. Promote it into `strengths` if `strengths` is empty.
+    if (!obj.strengths && obj.candidateStrength) obj.strengths = obj.candidateStrength;
+
+    return obj;
+  }
+
+  _scoreFromAnalysis(parsed, key) {
+    const v = (parsed && parsed[key] || '').toString().toLowerCase().trim();
+    if (!v) return null;
+    if (/^(strong|strong fit|high)/.test(v)) return 'strong';
+    if (/^(mid|mixed|medium|moderate|ok)/.test(v)) return 'mid';
+    if (/^(weak|stretch|low|poor)/.test(v)) return 'weak';
+    return v.includes('strong') ? 'strong' : v.includes('weak') || v.includes('stretch') ? 'weak' : 'mid';
   }
 
   _renderMetaRow() {
@@ -234,17 +251,39 @@ export class JobRoleDetail extends LitElement {
     `;
   }
 
-  _renderCard(title, body, status) {
+  _renderStoplight(score) {
+    if (!score) return nothing;
+    const labels = { strong: 'Strong fit', mid: 'Mixed fit', weak: 'Weak fit' };
+    return html`<span class="stoplight stoplight--${score}">${labels[score] || score}</span>`;
+  }
+  _renderCandidateStoplight(score) {
+    if (!score) return nothing;
+    const labels = { strong: 'Strong candidate', mid: 'Mid candidate', weak: 'Stretch candidate' };
+    return html`<span class="stoplight stoplight--${score}">${labels[score] || score}</span>`;
+  }
+
+  _renderTwoColCard({ title, headerExtra, sections, status }) {
     return html`
       <article class="role-card">
-        <header class="role-card__head">
+        <header class="role-card__head role-card__head--with-extra">
           <h3>${title}</h3>
+          ${headerExtra || nothing}
         </header>
         <div class="role-card__body">
           ${status === 'loading' ? html`<p class="muted">Generating…</p>`
             : status === 'error'  ? html`<p class="muted" style="color:var(--error);">Couldn't load</p>`
-            : !body                ? html`<p class="muted">—</p>`
-            : html`<div class="kb-doc">${unsafeHTML(renderMarkdown(body))}</div>`}
+            : html`
+              <div class="role-card__split">
+                ${sections.map(([heading, body]) => html`
+                  <section class="role-card__section">
+                    <h4>${heading}</h4>
+                    ${body
+                      ? html`<div class="kb-doc">${unsafeHTML(renderMarkdown(body))}</div>`
+                      : html`<p class="muted">—</p>`}
+                  </section>
+                `)}
+              </div>
+            `}
         </div>
       </article>
     `;
@@ -254,6 +293,8 @@ export class JobRoleDetail extends LitElement {
     const a = this.assets['analysis'];
     const status = !a ? 'loading' : a.saving ? 'loading' : a.error ? 'error' : a.mode === 'empty' ? 'loading' : 'ok';
     const parsed = a && a.mode === 'view' ? this._parseAnalysis(a.content) : null;
+    const roleFit = this._scoreFromAnalysis(parsed, 'roleFitScore');
+    const candidate = this._scoreFromAnalysis(parsed, 'candidateScore');
     return html`
       ${this._renderMetaRow()}
       ${parsed?.description ? html`
@@ -263,9 +304,24 @@ export class JobRoleDetail extends LitElement {
       ` : status === 'loading' ? html`<p class="muted">Drafting summary…</p>` : nothing}
 
       <div class="role-cards">
-        ${this._renderCard('Why it fits',         parsed?.whyFits, status)}
-        ${this._renderCard('Risks',               parsed?.risks, status)}
-        ${this._renderCard('Candidate strength',  parsed?.candidateStrength, status)}
+        ${this._renderTwoColCard({
+          title: 'Role fit',
+          headerExtra: this._renderStoplight(roleFit),
+          sections: [
+            ['Why it fits', parsed?.whyFits],
+            ['Risks',       parsed?.risks],
+          ],
+          status,
+        })}
+        ${this._renderTwoColCard({
+          title: 'Candidate strength',
+          headerExtra: this._renderCandidateStoplight(candidate),
+          sections: [
+            ['Strengths', parsed?.strengths],
+            ['Gaps',      parsed?.gaps],
+          ],
+          status,
+        })}
       </div>
 
       ${parsed?.suggestedAngle ? html`

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.20.0">
-  <script src="/job/js/theme.js?v=0.20.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
+  <script src="/job/js/theme.js?v=0.21.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.20.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -60,21 +60,25 @@ VOICE RULES (same as cover letter):
 
 Output ONLY the markdown. No preamble. No "Here is your resume." Start with "# Ian Fike".`;
 
-export const ANALYSIS_VOICE = `You are advising Ian on a specific role. Output ONLY a JSON object. Every value MUST be a STRING (markdown). Never an array, never a nested object.
+export const ANALYSIS_VOICE = `You are advising Ian on a specific role. Output ONLY a JSON object. Every value MUST be a STRING. Never an array, never a nested object.
 
 {
-  "description":         "2-3 sentence plain summary of the role and what the team is trying to ship.",
-  "whyFits":             "3-5 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Reference specific past projects/skills by name. Don't editorialize.",
-  "risks":               "2-4 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Real concerns: ICP/seniority mismatch, sector adjacency, comp gap, geo, gaps in evidence. Honest, not encouraging.",
-  "candidateStrength":   "1-2 sentences in a single markdown string rating Ian's relative strength (strong / mid / stretch) with the single strongest piece of evidence.",
-  "suggestedAngle":      "1-2 sentences in a single markdown string suggesting the framing he should lead with in the cover letter."
+  "description":      "2-3 sentence plain summary of the role and what the team is trying to ship.",
+  "roleFitScore":     "EXACTLY one of: strong | mixed | weak. Pick honestly. 'strong' = high alignment on title/sector/stage; 'mixed' = real fit but with concerns; 'weak' = adjacent or stretch with hard fails.",
+  "whyFits":          "3-5 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Reference specific past projects/skills by name (livongo-platform-scaling, eligibility-engine, growth-experimentation, etc). Don't editorialize.",
+  "risks":            "2-4 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Real concerns: ICP/seniority mismatch, sector adjacency, comp gap, geo, gaps in evidence. Honest, not encouraging.",
+  "candidateScore":   "EXACTLY one of: strong | mid | stretch. 'strong' = top 30% of likely applicants; 'mid' = solid contender; 'stretch' = on-paper-weak, will need a strong cover-letter angle.",
+  "strengths":        "3-5 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Specific, evidence-backed strengths Ian brings to THIS role. Reference projects/wins by name.",
+  "gaps":             "2-4 bullets in a SINGLE markdown string (each bullet on its own line, prefixed with - ). Honest gaps where his evidence is thin or his background diverges from the JD.",
+  "suggestedAngle":   "1-2 sentences in a single markdown string suggesting the framing he should lead with in the cover letter."
 }
 
 Format rules:
 - Output ONLY the JSON object. No prose before or after. No code fence. No commentary.
-- EVERY value is a string. If the content is bullets, the value is one string with embedded newlines and "- " prefixes.
+- EVERY value is a string. Bullets are one string with embedded newlines and "- " prefixes.
+- roleFitScore + candidateScore are exactly one lowercase token from their allowed set.
 - No em dashes. No "passionate about" / "excited to". No try-hard cleverness.
-- Reference real projects/skills/wins by their slug-like name when relevant (livongo-platform-scaling, eligibility-engine, growth-experimentation, etc).`;
+- Reference real projects/skills/wins by their slug-like name when relevant.`;
 
 export function buildSystemPrompt(kind: 'resume' | 'cover-letter' | 'analysis'): string {
   const voice =


### PR DESCRIPTION
Three requests, in order.

### 1. Merge Details-tab cards (3 → 2)
- **Role fit** — stoplight in header (Strong / Mixed / Weak), body splits 'Why it fits' and 'Risks'.
- **Candidate strength** — stoplight (Strong / Mid / Stretch), body splits 'Strengths' and 'Gaps'.
- gen-asset prompt now asks for 8-field JSON: description, roleFitScore, whyFits, risks, candidateScore, strengths, gaps, suggestedAngle. Still strict 'every value is a string' per v0.19.1 hardening.
- Old v0.18.x analyses render gracefully via backwards-compat parser.

### 2. Pipeline columns trimmed
Dropped Salary and Source. Both stay in the role-detail meta strip. Pipeline columns: Fit / Status / Company / Role / Sector / View.

### 3. Shimmer skeleton on Jobs load
Same table shell as the loaded state, skeleton pills/lines for each cell, 1.4s gradient sweep. Respects `prefers-reduced-motion`.

App bumped to 0.21.0; gen-asset redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)