### PR TITLE
Archive job rows + view filter + injected footer

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -877,3 +877,94 @@
 @media (prefers-reduced-motion: reduce) {
   .skeleton::after { animation: none; opacity: 0.5; }
 }
+
+/* --- Pipeline meta line + bottom strip --- */
+.pipeline-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+.pipeline-meta__filter {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-small);
+}
+.pipeline-foot {
+  display: flex;
+  justify-content: center;
+  margin: var(--space-5) 0 var(--space-6);
+}
+
+/* --- Row actions: View button + triple-dot menu --- */
+.row-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.row-menu { position: relative; }
+.row-menu__trigger {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-muted);
+  font-size: 18px;
+  line-height: 1;
+  font-weight: var(--fw-semibold);
+  cursor: pointer;
+  padding: 0;
+}
+.row-menu__trigger:hover { color: var(--fg); border-color: var(--border-strong); }
+.row-menu__panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 50;
+  min-width: 160px;
+  padding: var(--space-1);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+}
+.row-menu__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+  font-size: var(--font-size-small);
+  color: var(--fg);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.row-menu__item:hover { background: var(--bg-surface); }
+
+/* --- Archived row treatment --- */
+.pipeline-table tr.is-archived td { opacity: 0.55; }
+.pipeline-table tr.is-archived:hover td { opacity: 0.85; }
+
+/* --- App footer (injected once per page) --- */
+.app__foot {
+  margin-top: var(--space-8);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+}
+.app__foot__inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-4);
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+}
+.app__foot__inner .link-subtle { color: var(--fg-subtle); }
+.app__foot__inner .link-subtle:hover { color: var(--fg-muted); }
+@media (max-width: 640px) {
+  .app__foot__inner { flex-direction: column; align-items: flex-start; gap: var(--space-2); }
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.21.0';
-console.log(`[job] v${VERSION} - merged cards + skeleton + drop salary/source cols`);
+const VERSION = '0.22.0';
+console.log(`[job] v${VERSION} - archive: triple-dot menu + view filter + footer`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -33,6 +33,28 @@ function applySignedInState(email) {
   document.body.dataset.authState = 'in';
   // Notify components that may have mounted before the event arrived.
   document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
+  injectFooter();
+}
+
+// Add a single shared footer to every /job page on first signed-in render.
+// Stays out of the route HTML so we don't have to edit five files for copy.
+function injectFooter() {
+  if (document.querySelector('.app__foot')) return;
+  const main = document.querySelector('.app__main');
+  if (!main) return;
+  const foot = document.createElement('footer');
+  foot.className = 'app__foot';
+  foot.innerHTML = `
+    <div class="app__foot__inner">
+      <span class="muted">/job · v${VERSION} · ctrl.rodeo</span>
+      <span class="muted">
+        <a href="/" class="link-subtle">ctrl.rodeo</a>
+        <span aria-hidden="true"> · </span>
+        <a href="https://github.com/fikei/job" target="_blank" rel="noopener" class="link-subtle">fikei/job</a>
+      </span>
+    </div>
+  `;
+  main.appendChild(foot);
 }
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,7 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, setStatus } = await import('../pipeline.js' + V);
+const { fetchPipeline, setStatus, setArchived } = await import('../pipeline.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -39,6 +39,13 @@ function isVisibleRole(r) {
   return true;
 }
 
+function isArchived(r) { return !!r.archivedAt; }
+function archiveFilter(r, view) {
+  if (view === 'archived') return isArchived(r);
+  if (view === 'all')      return true;
+  return !isArchived(r); // 'active' default
+}
+
 export class JobPipeline extends LitElement {
   createRenderRoot() { return this; }
 
@@ -49,6 +56,8 @@ export class JobPipeline extends LitElement {
     sortKey: { state: true },
     sortDir: { state: true },
     selectedRow: { state: true },
+    archivedView: { state: true },   // 'active' | 'all' | 'archived'
+    openMenuSlug: { state: true },
   };
 
   constructor() {
@@ -59,6 +68,8 @@ export class JobPipeline extends LitElement {
     this.sortKey = 'score';
     this.sortDir = 'desc';
     this.selectedRow = null;
+    this.archivedView = 'active';
+    this.openMenuSlug = null;
   }
 
   connectedCallback() {
@@ -67,13 +78,22 @@ export class JobPipeline extends LitElement {
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
     document.addEventListener('job:auth:ready', this._onAuth);
-    this._onKey = (e) => { if (e.key === 'Escape') this._closeFitModal(); };
+    this._onKey = (e) => {
+      if (e.key === 'Escape') { this._closeFitModal(); this.openMenuSlug = null; }
+    };
     document.addEventListener('keydown', this._onKey);
+    this._onDocClick = (e) => {
+      if (!this.openMenuSlug) return;
+      // Close menu when clicking outside any row-menu element.
+      if (!e.target.closest('.row-menu')) this.openMenuSlug = null;
+    };
+    document.addEventListener('click', this._onDocClick);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('keydown', this._onKey);
+    document.removeEventListener('click', this._onDocClick);
     super.disconnectedCallback();
   }
 
@@ -116,7 +136,7 @@ export class JobPipeline extends LitElement {
   _sorted() {
     const key = this.sortKey;
     const dir = this.sortDir === 'desc' ? -1 : 1;
-    const arr = this.roles.filter(isVisibleRole);
+    const arr = this.roles.filter(r => isVisibleRole(r) && archiveFilter(r, this.archivedView));
     arr.sort((a, b) => {
       const av = a[key];
       const bv = b[key];
@@ -161,13 +181,48 @@ export class JobPipeline extends LitElement {
   }
 
   _detailHref(r) { return `/job/jobs/${r.slug}/`; }
+
+  _toggleMenu(slug, e) {
+    e.stopPropagation();
+    this.openMenuSlug = this.openMenuSlug === slug ? null : slug;
+  }
+
+  async _onArchive(r, archived) {
+    this.openMenuSlug = null;
+    const prev = r.archivedAt;
+    r.archivedAt = archived ? new Date().toISOString() : null;
+    this.requestUpdate();
+    try {
+      await setArchived(r.slug, archived);
+    } catch (e) {
+      r.archivedAt = prev;
+      r._error = String(e);
+      this.requestUpdate();
+    }
+  }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
   _renderViewCell(r) {
+    const archived = isArchived(r);
+    const menuOpen = this.openMenuSlug === r.slug;
     return html`
-      <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener">
-        View
-      </a>
+      <div class="row-actions">
+        <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener">
+          View
+        </a>
+        <div class="row-menu">
+          <button class="row-menu__trigger" aria-label="Row actions"
+                  aria-expanded=${menuOpen ? 'true' : 'false'}
+                  @click=${(e) => this._toggleMenu(r.slug, e)}>⋮</button>
+          ${menuOpen ? html`
+            <div class="row-menu__panel" role="menu">
+              <button role="menuitem" class="row-menu__item" @click=${() => this._onArchive(r, !archived)}>
+                ${archived ? 'Unarchive' : 'Archive'}
+              </button>
+            </div>
+          ` : nothing}
+        </div>
+      </div>
     `;
   }
 
@@ -193,7 +248,7 @@ export class JobPipeline extends LitElement {
 
   _renderRow(r) {
     return html`
-      <tr>
+      <tr class=${isArchived(r) ? 'is-archived' : ''}>
         <td>
           <button class=${this._scoreClass(r.score) + ' fit-pill--button'}
             title="Tap to see the breakdown" @click=${() => this._openFitModal(r)}>
@@ -306,10 +361,21 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._sorted();
+    const archivedCount = this.roles.filter(r => isVisibleRole(r) && isArchived(r)).length;
     return html`
       <div class="pipeline-meta">
         <strong>${rows.length}</strong> roles, sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.
-        <button class="btn btn--sm" style="margin-left:var(--space-3);" @click=${() => this._onSync()}>
+        <label class="pipeline-meta__filter">
+          <span class="muted">View:</span>
+          <select class="status-select" style="min-width:120px;"
+                  .value=${this.archivedView}
+                  @change=${(e) => { this.archivedView = e.target.value; }}>
+            <option value="active"   ?selected=${this.archivedView==='active'}>Active</option>
+            <option value="all"      ?selected=${this.archivedView==='all'}>All (incl. archived)</option>
+            <option value="archived" ?selected=${this.archivedView==='archived'}>Archived only</option>
+          </select>
+        </label>
+        <button class="btn btn--sm" @click=${() => this._onSync()}>
           Sync from sheet
         </button>
       </div>
@@ -319,6 +385,19 @@ export class JobPipeline extends LitElement {
           <tbody>${rows.map(r => this._renderRow(r))}</tbody>
         </table>
       </div>
+
+      <div class="pipeline-foot">
+        ${archivedCount > 0 ? html`
+          <button class="btn btn--sm" @click=${() => {
+            this.archivedView = this.archivedView === 'active' ? 'all' : 'active';
+          }}>
+            ${this.archivedView === 'active'
+              ? `Show archived (${archivedCount})`
+              : 'Hide archived'}
+          </button>
+        ` : html`<span class="muted">No archived roles yet.</span>`}
+      </div>
+
       ${this._renderFitModal()}
     `;
   }

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -31,6 +31,17 @@ export async function setStatus(role, status) {
   return res.json();
 }
 
+export async function setArchived(slug, archived) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, archived }),
+  });
+  if (!res.ok) throw new Error(`set-archived ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
 const GEN_ASSET_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gen-asset';
 
 export async function generateAsset(slug, kind) {

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.21.0">
-  <script src="/job/js/theme.js?v=0.21.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
+  <script src="/job/js/theme.js?v=0.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.21.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -11,8 +11,8 @@ import { computeFit, RoleRow } from './fit.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.4.0';
-console.log(`[jobs-pipe] v${VERSION} - Postgres cutover + sheet sync`);
+const VERSION = '0.5.0';
+console.log(`[jobs-pipe] v${VERSION} - archive support`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const STATUS_ENUM = new Set([
@@ -136,6 +136,8 @@ async function listRoles() {
       r.contact, r.salary_range as salary, r.salary_low, r.salary_high,
       r.sector, r.investors, r.fit_score as score, r.fit_breakdown as breakdown,
       r.hard_fails as "hardFails", r.applied_at, r.status_changed_at,
+      r.first_seen, r.last_seen,
+      r.archived_at as "archivedAt",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
       coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter"
     from job.pipeline_roles r
@@ -164,10 +166,6 @@ serve(async (req) => {
 
     if (req.method === 'POST') {
       const body = await req.json().catch(() => ({}));
-      const status = String(body.status ?? '');
-      if (!STATUS_ENUM.has(status)) {
-        return err(`status must be one of: ${Array.from(STATUS_ENUM).filter(Boolean).join(', ')}`, 400);
-      }
       let slug = body.slug ? String(body.slug) : '';
       let rowNumber = Number(body.rowNumber);
       const sql = db();
@@ -181,7 +179,22 @@ serve(async (req) => {
       }
       if (!slug) return err('role not found (provide slug or rowNumber)', 404);
 
-      // Update Postgres first.
+      // Archive / unarchive — independent from status changes.
+      if ('archived' in body) {
+        const archived = !!body.archived;
+        await sql`
+          update job.pipeline_roles
+          set archived_at = ${archived ? sql`now()` : null}
+          where slug = ${slug};
+        `;
+        return jsonResp({ ok: true, slug, archived });
+      }
+
+      // Status writeback.
+      const status = String(body.status ?? '');
+      if (!STATUS_ENUM.has(status)) {
+        return err(`status must be one of: ${Array.from(STATUS_ENUM).filter(Boolean).join(', ')}`, 400);
+      }
       await sql`
         update job.pipeline_roles
         set status = ${status},
@@ -190,7 +203,6 @@ serve(async (req) => {
             status_history = coalesce(status_history, '[]'::jsonb) || ${sql.json([{ status, at: new Date().toISOString() }])}
         where slug = ${slug};
       `;
-      // Mirror to the sheet so the /jobs skill stays in sync. Best-effort.
       if (Number.isInteger(rowNumber) && rowNumber >= 2) {
         try { await writeSheetCell(SHEET_ID, `Roles!C${rowNumber}`, status); } catch (e) {
           console.warn('[jobs-pipe] sheet writeback failed', e);

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,5 +1,4 @@
-// Bundled schema for migrate-job. Mirrors 047 + 048 from supabase/migrations.
-// Backticks stripped from inline SQL since this is a template literal.
+// Bundled schema for migrate-job. Mirrors 047 + 048 + 049 from supabase/migrations.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -205,4 +204,15 @@ end $$;
 alter table job.role_assets drop constraint if exists role_assets_kind_check;
 alter table job.role_assets add constraint role_assets_kind_check
   check (kind in ('resume', 'cover-letter', 'notes', 'analysis'));
+
+-- 049 ----------------------------------------------------------------
+-- Soft-archive flag for pipeline_roles. archived_at IS NULL means active;
+-- a non-null timestamp means the row is archived (hidden from the default
+-- pipeline view).
+alter table job.pipeline_roles
+  add column if not exists archived_at timestamptz;
+
+create index if not exists pipeline_roles_archived_idx
+  on job.pipeline_roles (archived_at)
+  where archived_at is not null;
 `;

--- a/supabase/migrations/049_job_pipeline_archived.sql
+++ b/supabase/migrations/049_job_pipeline_archived.sql
@@ -1,0 +1,9 @@
+-- Soft-archive flag for pipeline_roles. archived_at IS NULL means active;
+-- a non-null timestamp means the row is archived (hidden from the default
+-- pipeline view).
+alter table job.pipeline_roles
+  add column if not exists archived_at timestamptz;
+
+create index if not exists pipeline_roles_archived_idx
+  on job.pipeline_roles (archived_at)
+  where archived_at is not null;


### PR DESCRIPTION
Adds an archive concept to /job/jobs/, plus a footer.

### Backend
- Migration 049: `pipeline_roles.archived_at` nullable timestamptz + partial index. Bundled into migrate-job.
- jobs-pipe v0.5.0: GET returns `archivedAt`. POST `{ slug, archived }` sets archived_at to now() or null.

### Frontend (app v0.22.0)
- Per-row triple-dot menu with Archive / Unarchive. Optimistic; reverts on failure; closes on Esc or outside click.
- Pipeline meta has a 'View:' select: Active (default) / All (incl. archived) / Archived only.
- Bottom 'Show archived (N)' toggle + view-status indicator.
- Archived rows dim to 0.55 opacity (0.85 on hover).

### Footer
- `app.js` injects a single `<footer class="app__foot">` into `.app__main` on signed-in render. Shows version + ctrl.rodeo / fikei/job links. No per-route HTML edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)