### PR TITLE
Tappable rows + full breadcrumb + drop /jobs subheader

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -968,3 +968,8 @@
 @media (max-width: 640px) {
   .app__foot__inner { flex-direction: column; align-items: flex-start; gap: var(--space-2); }
 }
+
+/* --- Clickable pipeline rows --- */
+.pipeline-row { cursor: pointer; }
+.pipeline-row:hover td { background: var(--bg-surface); }
+.pipeline-row.is-archived { cursor: pointer; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -27,12 +27,11 @@
     <main class="app__main">
       <header class="page-header">
         <h1>Jobs</h1>
-        <p>Pipeline, fit-scored. Reads from Job Search sheet.</p>
       </header>
       <job-pipeline></job-pipeline>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.22.0';
-console.log(`[job] v${VERSION} - archive: triple-dot menu + view filter + footer`);
+const VERSION = '0.23.0';
+console.log(`[job] v${VERSION} - tappable rows + full breadcrumb + drop subheader`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -246,16 +246,24 @@ export class JobPipeline extends LitElement {
     `;
   }
 
+  _onRowClick(r, e) {
+    // Don't navigate when the click landed on an interactive child
+    // (status select, fit pill, View button, triple-dot menu).
+    if (e.target.closest('button, select, a, .row-menu, .fit-pill--button')) return;
+    window.open(this._detailHref(r), '_blank', 'noopener');
+  }
+
   _renderRow(r) {
     return html`
-      <tr class=${isArchived(r) ? 'is-archived' : ''}>
+      <tr class=${'pipeline-row' + (isArchived(r) ? ' is-archived' : '')}
+          @click=${(e) => this._onRowClick(r, e)}>
         <td>
           <button class=${this._scoreClass(r.score) + ' fit-pill--button'}
-            title="Tap to see the breakdown" @click=${() => this._openFitModal(r)}>
+            title="Tap to see the breakdown" @click=${(e) => { e.stopPropagation(); this._openFitModal(r); }}>
             ${r.score == null ? '—' : r.score}
           </button>
         </td>
-        <td class="status-cell">
+        <td class="status-cell" @click=${(e) => e.stopPropagation()}>
           <select class="status-select ${r._saving ? 'is-saving' : ''}"
             data-status=${r.status || 'New'}
             ?disabled=${r._saving}

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -398,10 +398,11 @@ export class JobRoleDetail extends LitElement {
     }
     const r = this.role;
     return html`
-      <nav class="breadcrumb">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
         <a href="/job/jobs/">Jobs</a>
+        ${r?.company ? html`<span>›</span><span>${r.company}</span>` : nothing}
         <span>›</span>
-        <span>${r?.company || this.slug}</span>
+        <span>${r?.title || this.slug}</span>
       </nav>
 
       <header class="role-header">

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.22.0">
-  <script src="/job/js/theme.js?v=0.22.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
+  <script src="/job/js/theme.js?v=0.23.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.22.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Three small UX changes:

- Pipeline rows are click-through to the role detail page (opens a new tab). Clicks on interactive children (status select, fit pill, View button, triple-dot menu) are blocked from bubbling so existing controls keep working.
- Detail page breadcrumb expands from 'Jobs › Company' to 'Jobs › Company › Title'.
- Dropped the '/job/jobs' subheader text. Meta line + view selector cover the affordance.

App bumped to 0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)