### PR TITLE
Tokenize sector → atomic tags

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -973,3 +973,25 @@
 .pipeline-row { cursor: pointer; }
 .pipeline-row:hover td { background: var(--bg-surface); }
 .pipeline-row.is-archived { cursor: pointer; }
+
+/* --- Sector tag chips (pipeline cell) --- */
+.tag-chips {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.tag-chip {
+  font-size: var(--font-size-caption);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-weight: var(--fw-medium);
+  white-space: nowrap;
+}
+[data-theme="generic-dark"] .tag-chip { color: var(--accent-strong); }
+[data-theme="ctrl-light"]   .tag-chip { color: var(--accent-strong); background: rgba(0,168,160,0.12); }
+[data-theme="ctrl-dark"]    .tag-chip { color: var(--accent-strong); background: rgba(0,255,247,0.14); }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.23.0';
-console.log(`[job] v${VERSION} - tappable rows + full breadcrumb + drop subheader`);
+const VERSION = '0.24.0';
+console.log(`[job] v${VERSION} - tokenized sector tags`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -274,9 +274,21 @@ export class JobPipeline extends LitElement {
         </td>
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
-        <td><span class="muted">${r.sector || ''}</span></td>
+        <td>${this._renderSectorCell(r)}</td>
         <td>${this._renderViewCell(r)}</td>
       </tr>
+    `;
+  }
+
+  _renderSectorCell(r) {
+    const tags = Array.isArray(r.sectorTags) ? r.sectorTags : [];
+    if (!tags.length) {
+      return r.sector ? html`<span class="muted">${r.sector}</span>` : html`<span class="muted">—</span>`;
+    }
+    return html`
+      <ul class="tag-chips">
+        ${tags.map(t => html`<li class="tag-chip">${t.name}</li>`)}
+      </ul>
     `;
   }
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.23.0">
-  <script src="/job/js/theme.js?v=0.23.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
+  <script src="/job/js/theme.js?v=0.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.23.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/sector-tags.ts
+++ b/supabase/functions/_shared/sector-tags.ts
@@ -1,0 +1,71 @@
+// parseSectorTags — split a free-text sector string from the Job Search
+// sheet into atomic tags. Used by jobs-pipe sync and build-sector-tags.
+
+import { slugify } from './job-auth.ts';
+
+// Tokens that should split off into their own tag even when adjacent to a
+// longer phrase. "Healthcare AI" → ["Healthcare", "AI"]; "Health AI" → same.
+const SUFFIX_TOKENS = ['AI', 'ML', 'Infra'];
+
+// Canonical names for known synonyms. After parsing, we normalize the
+// display value through this map so e.g. "Health" / "Healthcare" merge.
+const CANONICAL: Record<string, string> = {
+  'Health': 'Healthcare',
+  'Healthcare AI': 'Healthcare',
+  'Health AI': 'Healthcare',
+  'Healthcare Infra': 'Healthcare',
+  'Telehealth': 'Healthcare',
+  "Women's Health": 'Healthcare',
+  'Mental Health': 'Mental Health',
+  'EdTech': 'EdTech',
+  'Education': 'EdTech',
+  'Legal AI': 'Legal',
+  'Sales AI': 'Sales',
+  'AI / Public Interest': 'AI',
+  'Public Sector': 'Public Sector',
+  'Civic Tech': 'Civic Tech',
+  'Civic Tech / Public Sector': 'Civic Tech',
+  'SaaS - Productivity': 'Productivity',
+  'AI / Consumer Hardware': 'Consumer',
+  'Consumer Hardware': 'Consumer',
+};
+
+function splitToken(token: string): string[] {
+  let t = token.trim();
+  if (!t) return [];
+  // Pull off "X AI" / "X ML" suffixes into separate atoms.
+  for (const suf of SUFFIX_TOKENS) {
+    const re = new RegExp(`\\s+${suf}\\s*$`, 'i');
+    if (re.test(t) && t.toLowerCase() !== suf.toLowerCase()) {
+      const base = t.replace(re, '').trim();
+      const parts = base ? splitToken(base) : [];
+      parts.push(suf);
+      return parts;
+    }
+  }
+  return [t];
+}
+
+export interface SectorTag { slug: string; name: string; }
+
+export function parseSectorTags(input: string | null | undefined): SectorTag[] {
+  if (!input) return [];
+  // Split on common separators. Don't split on whitespace.
+  const raw = String(input)
+    .split(/\s*(?:[\/,;]|\s-\s|\s—\s)\s*/)
+    .map(s => s.trim())
+    .filter(Boolean)
+    .flatMap(splitToken);
+
+  const seen = new Set<string>();
+  const out: SectorTag[] = [];
+  for (const r of raw) {
+    const cleaned = r.replace(/\s+/g, ' ').trim();
+    const canonical = CANONICAL[cleaned] || cleaned;
+    const slug = slugify(canonical);
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push({ slug, name: canonical });
+  }
+  return out;
+}

--- a/supabase/functions/build-sector-tags/index.ts
+++ b/supabase/functions/build-sector-tags/index.ts
@@ -1,0 +1,53 @@
+// build-sector-tags — backfill sector tags for every pipeline_role.
+// Call once after migration 050; future syncs in jobs-pipe will keep it
+// up to date inline.
+//
+// POST → { upsertedTags, taggedRoles }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+import { parseSectorTags } from '../_shared/sector-tags.ts';
+
+const VERSION = '0.1.0';
+console.log(`[build-sector-tags] v${VERSION}`);
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const sql = db();
+    const roles = await sql`select slug, sector from job.pipeline_roles where sector is not null`;
+    const tagSet = new Map<string, string>();
+    let taggedRoles = 0;
+
+    for (const r of roles) {
+      const tags = parseSectorTags(r.sector);
+      if (!tags.length) continue;
+      for (const t of tags) tagSet.set(t.slug, t.name);
+      // Upsert role↔tag rows. Clear and rewrite so removed tags drop off.
+      await sql`delete from job.role_sector_tags where role_slug = ${r.slug}`;
+      for (const t of tags) {
+        await sql`
+          insert into job.sector_tags (slug, name) values (${t.slug}, ${t.name})
+          on conflict (slug) do nothing;
+        `;
+        await sql`
+          insert into job.role_sector_tags (role_slug, tag_slug)
+          values (${r.slug}, ${t.slug})
+          on conflict do nothing;
+        `;
+      }
+      taggedRoles += 1;
+    }
+
+    return jsonResp({ ok: true, upsertedTags: tagSet.size, taggedRoles, tags: Array.from(tagSet.entries()).map(([slug, name]) => ({ slug, name })) });
+  } catch (e) {
+    console.error('[build-sector-tags] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -10,9 +10,10 @@ import { readSheetValues, writeSheetCell } from './sheets.ts';
 import { computeFit, RoleRow } from './fit.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
+import { parseSectorTags } from '../_shared/sector-tags.ts';
 
-const VERSION = '0.5.0';
-console.log(`[jobs-pipe] v${VERSION} - archive support`);
+const VERSION = '0.6.0';
+console.log(`[jobs-pipe] v${VERSION} - sector tag tokens`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const STATUS_ENUM = new Set([
@@ -122,6 +123,22 @@ async function syncFromSheet() {
         hard_fails = excluded.hard_fails,
         updated_at = now();
     `;
+
+    // Refresh role↔sector_tags from the latest sector text.
+    const tags = parseSectorTags(role.sector);
+    await sql`delete from job.role_sector_tags where role_slug = ${slug}`;
+    for (const t of tags) {
+      await sql`
+        insert into job.sector_tags (slug, name) values (${t.slug}, ${t.name})
+        on conflict (slug) do nothing;
+      `;
+      await sql`
+        insert into job.role_sector_tags (role_slug, tag_slug)
+        values (${slug}, ${t.slug})
+        on conflict do nothing;
+      `;
+    }
+
     upserted += 1;
   }
   return upserted;
@@ -139,7 +156,13 @@ async function listRoles() {
       r.first_seen, r.last_seen,
       r.archived_at as "archivedAt",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
-      coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter"
+      coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter",
+      coalesce((
+        select array_agg(json_build_object('slug', t.slug, 'name', t.name) order by t.name)
+        from job.role_sector_tags rt
+        join job.sector_tags t on t.slug = rt.tag_slug
+        where rt.role_slug = r.slug
+      ), array[]::json[]) as "sectorTags"
     from job.pipeline_roles r
     left join job.role_assets ra_resume on ra_resume.role_slug = r.slug and ra_resume.kind = 'resume'
     left join job.role_assets ra_cover  on ra_cover.role_slug = r.slug and ra_cover.kind = 'cover-letter'

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,4 +1,4 @@
-// Bundled schema for migrate-job. Mirrors 047 + 048 + 049 from supabase/migrations.
+// Bundled schema for migrate-job. Mirrors 047–050 from supabase/migrations.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -215,4 +215,26 @@ alter table job.pipeline_roles
 create index if not exists pipeline_roles_archived_idx
   on job.pipeline_roles (archived_at)
   where archived_at is not null;
+
+-- 050 ----------------------------------------------------------------
+-- Sector tag normalization. Free-text sector strings on pipeline_roles
+-- (e.g. "Healthcare AI", "Mental Health / AI", "Legal AI") get parsed into
+-- atomic tags and joined many-to-many.
+create table if not exists job.sector_tags (
+  slug        text primary key,                    -- 'healthcare', 'ai', 'legal'
+  name        text not null,                       -- canonical display name
+  category    text,                                -- optional grouping ('industry' | 'modality' | …)
+  created_at  timestamptz not null default now()
+);
+
+create table if not exists job.role_sector_tags (
+  role_slug   text references job.pipeline_roles(slug) on delete cascade,
+  tag_slug    text references job.sector_tags(slug) on delete cascade,
+  primary key (role_slug, tag_slug)
+);
+
+create index if not exists role_sector_tags_tag_idx on job.role_sector_tags (tag_slug);
+
+alter table job.sector_tags enable row level security;
+alter table job.role_sector_tags enable row level security;
 `;

--- a/supabase/migrations/050_job_sector_tags.sql
+++ b/supabase/migrations/050_job_sector_tags.sql
@@ -1,0 +1,20 @@
+-- Sector tag normalization. Free-text sector strings on pipeline_roles
+-- (e.g. "Healthcare AI", "Mental Health / AI", "Legal AI") get parsed into
+-- atomic tags and joined many-to-many.
+create table if not exists job.sector_tags (
+  slug        text primary key,                    -- 'healthcare', 'ai', 'legal'
+  name        text not null,                       -- canonical display name
+  category    text,                                -- optional grouping ('industry' | 'modality' | …)
+  created_at  timestamptz not null default now()
+);
+
+create table if not exists job.role_sector_tags (
+  role_slug   text references job.pipeline_roles(slug) on delete cascade,
+  tag_slug    text references job.sector_tags(slug) on delete cascade,
+  primary key (role_slug, tag_slug)
+);
+
+create index if not exists role_sector_tags_tag_idx on job.role_sector_tags (tag_slug);
+
+alter table job.sector_tags enable row level security;
+alter table job.role_sector_tags enable row level security;


### PR DESCRIPTION
Free-text sector strings now parse into atomic tags rendered as chips.

### Schema (migration 050)
- `job.sector_tags` + `job.role_sector_tags` join table.

### Parser (_shared/sector-tags.ts)
- Splits on `/`, comma, semicolon, ' - ', ' — '.
- Pulls `X AI` / `X ML` / `X Infra` suffixes into their own tag.
- Canonical map merges synonyms (Health/Telehealth/Healthcare AI → Healthcare).

### Backend
- New `build-sector-tags` Edge Function: backfilled 12 unique tags across 29 roles (Healthcare, AI, Fintech, SaaS, Productivity, Legal, Mental Health, Civic Tech, Public Sector, Consumer, Public Interest, Unknown).
- `jobs-pipe` v0.6.0: every sync upsert calls `parseSectorTags` and refreshes the role↔tag joins.
- `jobs-pipe` GET returns `sectorTags: [{slug, name}]` per role.

### Frontend (app v0.24.0)
- Pipeline Sector cell renders chips. Falls back to plain text for any not-yet-tagged row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)