### PR TITLE
Delete in row menu + detail page shimmer + instant prefill

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -995,3 +995,8 @@
 [data-theme="generic-dark"] .tag-chip { color: var(--accent-strong); }
 [data-theme="ctrl-light"]   .tag-chip { color: var(--accent-strong); background: rgba(0,168,160,0.12); }
 [data-theme="ctrl-dark"]    .tag-chip { color: var(--accent-strong); background: rgba(0,255,247,0.14); }
+
+/* Danger menu item (Delete) */
+.row-menu__item--danger { color: var(--error); }
+.row-menu__item--danger:hover { background: rgba(168,32,13,0.08); }
+[data-theme="generic-dark"] .row-menu__item--danger:hover { background: rgba(255,122,110,0.12); }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.24.0';
-console.log(`[job] v${VERSION} - tokenized sector tags`);
+const VERSION = '0.25.0';
+console.log(`[job] v${VERSION} - delete + detail shimmer + prefill`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,7 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, setStatus, setArchived } = await import('../pipeline.js' + V);
+const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill } = await import('../pipeline.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -200,6 +200,27 @@ export class JobPipeline extends LitElement {
       this.requestUpdate();
     }
   }
+
+  async _onDelete(r) {
+    this.openMenuSlug = null;
+    const ok = window.confirm(
+      `Delete "${r.title}" at ${r.company}?\n\n` +
+      `The row disappears from the pipeline. We keep a record in the backend for continuity, but it won't show up in any view.`
+    );
+    if (!ok) return;
+    // Optimistic: drop from local list.
+    const idx = this.roles.findIndex(x => x.slug === r.slug);
+    const removed = idx >= 0 ? this.roles.splice(idx, 1)[0] : null;
+    this.requestUpdate();
+    try {
+      await deleteRole(r.slug);
+    } catch (e) {
+      // restore on failure
+      if (removed) this.roles.splice(idx, 0, removed);
+      r._error = String(e);
+      this.requestUpdate();
+    }
+  }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
   _renderViewCell(r) {
@@ -207,7 +228,8 @@ export class JobPipeline extends LitElement {
     const menuOpen = this.openMenuSlug === r.slug;
     return html`
       <div class="row-actions">
-        <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener">
+        <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener"
+           @click=${() => stashRolePrefill(r)}>
           View
         </a>
         <div class="row-menu">
@@ -218,6 +240,9 @@ export class JobPipeline extends LitElement {
             <div class="row-menu__panel" role="menu">
               <button role="menuitem" class="row-menu__item" @click=${() => this._onArchive(r, !archived)}>
                 ${archived ? 'Unarchive' : 'Archive'}
+              </button>
+              <button role="menuitem" class="row-menu__item row-menu__item--danger" @click=${() => this._onDelete(r)}>
+                Delete…
               </button>
             </div>
           ` : nothing}
@@ -250,6 +275,7 @@ export class JobPipeline extends LitElement {
     // Don't navigate when the click landed on an interactive child
     // (status select, fit pill, View button, triple-dot menu).
     if (e.target.closest('button, select, a, .row-menu, .fit-pill--button')) return;
+    stashRolePrefill(r);
     window.open(this._detailHref(r), '_blank', 'noopener');
   }
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -5,7 +5,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -60,7 +60,10 @@ export class JobRoleDetail extends LitElement {
     this.slug = (params.get('slug') || '').toLowerCase();
     const tab = params.get('tab');
     this.activeTab = TABS.find(t => t.id === tab)?.id || 'details';
-    this.role = null;
+    // Pre-populate from sessionStorage if the user came from /job/jobs/.
+    // Title/company/tags paint instantly; the network refresh fills in
+    // analysis + resume + cover.
+    this.role = this.slug ? readRolePrefill(this.slug) : null;
     this.assets = { 'resume': null, 'cover-letter': null, 'analysis': null };
 
     const pretty = sessionStorage.getItem('job:prettyPath');
@@ -386,9 +389,92 @@ export class JobRoleDetail extends LitElement {
     `;
   }
 
+  _renderChromeFromPrefill() {
+    const r = this.role;
+    if (!r) return null;
+    return html`
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <a href="/job/jobs/">Jobs</a>
+        ${r.company ? html`<span>›</span><span>${r.company}</span>` : nothing}
+        <span>›</span>
+        <span>${r.title || this.slug}</span>
+      </nav>
+      <header class="role-header">
+        <div class="role-header__title">
+          <h1>${r.title || this.slug}</h1>
+          <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+        </div>
+        <div class="role-header__actions">
+          ${r.url ? html`
+            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer">Apply ↗</a>
+          ` : nothing}
+        </div>
+      </header>
+      ${Array.isArray(r.sectorTags) && r.sectorTags.length ? html`
+        <ul class="tag-chips" style="margin: 0 0 var(--space-5);">
+          ${r.sectorTags.map(t => html`<li class="tag-chip">${t.name}</li>`)}
+        </ul>
+      ` : nothing}
+    `;
+  }
+
+  _renderShimmerBody() {
+    return html`
+      <dl class="role-meta">
+        ${Array.from({ length: 6 }).map(() => html`
+          <div class="role-meta__item">
+            <dt><span class="skeleton" style="width:48px;height:11px;display:inline-block;"></span></dt>
+            <dd><span class="skeleton" style="width:80%;height:14px;display:inline-block;"></span></dd>
+          </div>
+        `)}
+      </dl>
+      <div class="skeleton" style="width:100%;height:48px;border-radius:var(--radius-md);margin-bottom:var(--space-5);"></div>
+      <div class="role-cards">
+        ${Array.from({ length: 2 }).map(() => html`
+          <div class="role-card">
+            <div class="skeleton" style="width:140px;height:18px;display:inline-block;"></div>
+            <div class="role-card__split" style="margin-top:var(--space-3);">
+              ${Array.from({ length: 2 }).map(() => html`
+                <section>
+                  <div class="skeleton" style="width:80px;height:11px;display:block;margin-bottom:var(--space-2);"></div>
+                  <div class="skeleton" style="width:100%;height:12px;display:block;margin-bottom:6px;"></div>
+                  <div class="skeleton" style="width:90%;height:12px;display:block;margin-bottom:6px;"></div>
+                  <div class="skeleton" style="width:70%;height:12px;display:block;"></div>
+                </section>
+              `)}
+            </div>
+          </div>
+        `)}
+      </div>
+    `;
+  }
+
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
-      return html`<div class="placeholder"><h2>Loading…</h2></div>`;
+      // If the user came from the pipeline we already have title/company/tags
+      // in sessionStorage — paint that instantly with a shimmer body below.
+      if (this.role) {
+        return html`
+          ${this._renderChromeFromPrefill()}
+          <div class="asset-tabs">
+            ${TABS.map(t => html`
+              <button class="asset-tabs__tab ${this.activeTab === t.id ? 'is-active' : ''}"
+                      @click=${() => this._switchTab(t.id)}>
+                ${t.label}
+              </button>
+            `)}
+          </div>
+          <section class="asset-panel">
+            ${this._renderShimmerBody()}
+          </section>
+        `;
+      }
+      return html`
+        <div class="skeleton" style="width:140px;height:14px;margin-bottom:var(--space-3);display:block;"></div>
+        <div class="skeleton" style="width:60%;height:36px;margin-bottom:var(--space-2);display:block;"></div>
+        <div class="skeleton" style="width:40%;height:18px;margin-bottom:var(--space-5);display:block;"></div>
+        ${this._renderShimmerBody()}
+      `;
     }
     if (this.state === 'error') {
       return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -42,6 +42,48 @@ export async function setArchived(slug, archived) {
   return res.json();
 }
 
+export async function deleteRole(slug) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, action: 'delete' }),
+  });
+  if (!res.ok) throw new Error(`delete-role ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// Stash a role row in sessionStorage so the detail page can paint title/
+// company/tags instantly on next load. Read with readRolePrefill(slug).
+export function stashRolePrefill(role) {
+  if (!role?.slug) return;
+  try {
+    sessionStorage.setItem(`job:rolePrefill:${role.slug}`, JSON.stringify({
+      slug: role.slug,
+      company: role.company,
+      title: role.title,
+      sector: role.sector,
+      sectorTags: role.sectorTags || [],
+      score: role.score,
+      status: role.status,
+      url: role.url,
+      salary: role.salary,
+      source: role.source,
+      first_seen: role.first_seen,
+      last_seen: role.last_seen,
+      archivedAt: role.archivedAt,
+      hasResume: role.hasResume,
+      hasCoverLetter: role.hasCoverLetter,
+    }));
+  } catch { /* sessionStorage unavailable — silently skip */ }
+}
+export function readRolePrefill(slug) {
+  try {
+    const raw = sessionStorage.getItem(`job:rolePrefill:${slug}`);
+    return raw ? JSON.parse(raw) : null;
+  } catch { return null; }
+}
+
 const GEN_ASSET_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gen-asset';
 
 export async function generateAsset(slug, kind) {

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.24.0">
-  <script src="/job/js/theme.js?v=0.24.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
+  <script src="/job/js/theme.js?v=0.25.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.24.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -12,8 +12,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '..
 import { db } from '../_shared/job-db.ts';
 import { parseSectorTags } from '../_shared/sector-tags.ts';
 
-const VERSION = '0.6.0';
-console.log(`[jobs-pipe] v${VERSION} - sector tag tokens`);
+const VERSION = '0.7.0';
+console.log(`[jobs-pipe] v${VERSION} - soft delete`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const STATUS_ENUM = new Set([
@@ -166,6 +166,7 @@ async function listRoles() {
     from job.pipeline_roles r
     left join job.role_assets ra_resume on ra_resume.role_slug = r.slug and ra_resume.kind = 'resume'
     left join job.role_assets ra_cover  on ra_cover.role_slug = r.slug and ra_cover.kind = 'cover-letter'
+    where r.deleted_at is null
     order by r.fit_score desc nulls last, r.title asc;
   `;
   return rows;
@@ -211,6 +212,16 @@ serve(async (req) => {
           where slug = ${slug};
         `;
         return jsonResp({ ok: true, slug, archived });
+      }
+
+      // Soft delete — row stays in DB but disappears from every list.
+      if (body.action === 'delete') {
+        await sql`
+          update job.pipeline_roles
+          set deleted_at = now()
+          where slug = ${slug};
+        `;
+        return jsonResp({ ok: true, slug, deleted: true });
       }
 
       // Status writeback.

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,4 +1,4 @@
-// Bundled schema for migrate-job. Mirrors 047–050 from supabase/migrations.
+// Bundled schema for migrate-job. Mirrors 047–051 from supabase/migrations.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -237,4 +237,14 @@ create index if not exists role_sector_tags_tag_idx on job.role_sector_tags (tag
 
 alter table job.sector_tags enable row level security;
 alter table job.role_sector_tags enable row level security;
+
+-- 051 ----------------------------------------------------------------
+-- Soft-delete column for pipeline_roles. Hidden from every UI surface
+-- (no filter exposes it), kept in DB for continuity / undo.
+alter table job.pipeline_roles
+  add column if not exists deleted_at timestamptz;
+
+create index if not exists pipeline_roles_deleted_idx
+  on job.pipeline_roles (deleted_at)
+  where deleted_at is null;
 `;

--- a/supabase/migrations/051_job_pipeline_deleted.sql
+++ b/supabase/migrations/051_job_pipeline_deleted.sql
@@ -1,0 +1,8 @@
+-- Soft-delete column for pipeline_roles. Hidden from every UI surface
+-- (no filter exposes it), kept in DB for continuity / undo.
+alter table job.pipeline_roles
+  add column if not exists deleted_at timestamptz;
+
+create index if not exists pipeline_roles_deleted_idx
+  on job.pipeline_roles (deleted_at)
+  where deleted_at is null;


### PR DESCRIPTION
Three changes around the pipeline → detail flow.

### Soft delete
- Migration 051: `pipeline_roles.deleted_at` + partial index.
- jobs-pipe v0.7.0: GET filters `deleted_at IS NULL`. POST `{ slug, action: 'delete' }` stamps `deleted_at = now()`.
- Sync from sheet leaves `deleted_at` untouched, so a deleted row stays gone even if the scrape skill re-saves it.
- Triple-dot menu gets a 'Delete…' item (red). Click → `window.confirm` → optimistic drop + POST; restored on failure.

### Detail page shimmer + prefill
- `pipeline.js` exports `stashRolePrefill` / `readRolePrefill` (sessionStorage).
- Pipeline row clicks + View link both stash the row before navigation.
- Detail page reads prefill before the network call, so breadcrumb / title / company / sector chips / Apply button paint instantly. Shimmer skeleton replaces the placeholder for meta + cards until the network finishes.
- Slug-only fallback shimmer covers the deep-link-no-prefill case.

App bumped to 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)