### PR TITLE
Your Career: rename + Work history / Narratives tabs + shimmer

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1000,3 +1000,43 @@
 .row-menu__item--danger { color: var(--error); }
 .row-menu__item--danger:hover { background: rgba(168,32,13,0.08); }
 [data-theme="generic-dark"] .row-menu__item--danger:hover { background: rgba(255,122,110,0.12); }
+
+/* --- Your Career: narrative blocks + prompt carousel --- */
+.narrative-block { margin-bottom: var(--space-7); }
+.narrative-block h2 {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-2);
+  letter-spacing: -0.018em;
+}
+
+.prompt-carousel {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(280px, 320px);
+  gap: var(--space-4);
+  overflow-x: auto;
+  padding: var(--space-1) var(--space-1) var(--space-3);
+  margin: 0 calc(-1 * var(--space-1));
+  scroll-snap-type: x mandatory;
+}
+.prompt-carousel::-webkit-scrollbar { height: 8px; }
+.prompt-carousel::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-pill); }
+.prompt-card {
+  scroll-snap-align: start;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.prompt-card p {
+  margin: 0;
+  flex: 1;
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+}
+.prompt-card .btn { align-self: flex-start; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>History — /job</title>
+  <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -26,13 +26,12 @@
     <job-rail></job-rail>
     <main class="app__main">
       <header class="page-header">
-        <h1>History</h1>
-        <p>LinkedIn-style resume. Drilldown: Company → Project → Skill.</p>
+        <h1>Your career</h1>
       </header>
-      <job-history-resume></job-history-resume>
+      <job-career></job-career>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.25.0';
-console.log(`[job] v${VERSION} - delete + detail shimmer + prefill`);
+const VERSION = '0.26.0';
+console.log(`[job] v${VERSION} - Your Career: tabs + narratives + shimmer`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -17,7 +17,7 @@ import('./kb.js' + V);
 if (location.pathname.startsWith('/job/history/drill')) {
   import('./components/job-detail.js' + V);
 } else if (location.pathname.startsWith('/job/history')) {
-  import('./components/job-history-resume.js' + V);
+  import('./components/job-career.js' + V);
 }
 if (location.pathname.startsWith('/job/jobs/drill')) {
   import('./components/job-role-detail.js' + V);

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -1,0 +1,166 @@
+// job-career — tabbed shell for the Your Career page.
+//   Work History — full-width company cards (the previous History view).
+//   Narratives  — narrative-arc + voice-rules pulled from job.vision,
+//                 plus a horizontal carousel of skill-prompts derived from
+//                 patterns in the live pipeline JDs.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { fetchPipeline }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../pipeline.js' + V),
+]);
+
+// Lazy-load the resume sub-component so the Work History tab doesn't
+// pull markdown deps when only the Narratives tab is active.
+import('./job-history-resume.js' + V);
+
+const TABS = [
+  { id: 'work',       label: 'Work history' },
+  { id: 'narratives', label: 'Narratives' },
+];
+
+// Minimal seed of skill prompts. Real version derives prompts from JD
+// patterns in pipeline_roles.title + sector tags. v1: hand-curated.
+const FALLBACK_PROMPTS = [
+  { tag: 'Platform thinking', prompt: 'Tell me about a time you protected shared infrastructure from a product team that wanted to fork.' },
+  { tag: 'Healthcare',        prompt: 'Walk me through one decision in a regulated environment where the right product call clashed with compliance.' },
+  { tag: 'Growth',            prompt: 'Describe an experiment that changed your gut about how the funnel actually worked.' },
+  { tag: 'Zero-to-one',       prompt: 'Pick a feature you killed before launch. What signal told you to stop?' },
+  { tag: 'Founding PM',       prompt: 'How do you decide what NOT to build when the company is pre-PMF?' },
+  { tag: 'AI',                prompt: 'When does an AI feature need a hard guarantee, and when is "best effort" honest?' },
+];
+
+export class JobCareer extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    error: { state: true },
+    activeTab: { state: true },
+    vision: { state: true },
+    promptTags: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    this.activeTab = (new URLSearchParams(location.search).get('tab') === 'narratives') ? 'narratives' : 'work';
+    this.vision = null;
+    this.promptTags = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      // Pull the live pipeline so we can derive prompts from real JD tags.
+      const data = await fetchPipeline();
+      const tagCounts = new Map();
+      for (const r of (data.roles || [])) {
+        for (const t of (r.sectorTags || [])) {
+          tagCounts.set(t.name, (tagCounts.get(t.name) || 0) + 1);
+        }
+      }
+      // Top 8 tags by frequency become the carousel filter chips.
+      this.promptTags = Array.from(tagCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([name, count]) => ({ name, count }));
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e);
+      this.state = 'error';
+    }
+  }
+
+  _switchTab(id) {
+    this.activeTab = id;
+    const qs = id === 'narratives' ? '?tab=narratives' : '';
+    history.replaceState(null, '', `/job/history/${qs}`);
+  }
+
+  _renderTabs() {
+    return html`
+      <div class="asset-tabs">
+        ${TABS.map(t => html`
+          <button class="asset-tabs__tab ${this.activeTab === t.id ? 'is-active' : ''}"
+                  @click=${() => this._switchTab(t.id)}>
+            ${t.label}
+          </button>
+        `)}
+      </div>
+    `;
+  }
+
+  _renderWork() {
+    return html`<job-history-resume></job-history-resume>`;
+  }
+
+  _renderNarratives() {
+    if (this.state === 'loading') {
+      return html`
+        <section style="margin-bottom: var(--space-6);">
+          <div class="skeleton" style="width:200px;height:18px;display:block;margin-bottom:var(--space-3);"></div>
+          <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:96%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+        </section>
+      `;
+    }
+    return html`
+      <section class="narrative-block">
+        <h2>Narrative arc</h2>
+        <p class="muted">The one-paragraph version Ian tells. Sourced from <code>02-goals-intents/narrative-arc.md</code>.</p>
+        <div class="kb-doc">
+          <p><em>Open the Vision tab to read or edit the live narrative. (Direct fetch lands with the Vision page rebuild.)</em></p>
+        </div>
+      </section>
+
+      <section class="narrative-block">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);">
+          <div>
+            <h2 style="margin:0;">Skill prompts</h2>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);">Quick-fire prompts for filling in evidence. Tagged by themes that show up most in your live pipeline.</p>
+          </div>
+          ${this.promptTags.length ? html`
+            <span class="muted" style="font-size:var(--font-size-caption);">Top tags: ${this.promptTags.slice(0, 5).map(t => t.name).join(' · ')}</span>
+          ` : nothing}
+        </header>
+        <div class="prompt-carousel" role="list">
+          ${FALLBACK_PROMPTS.map(p => html`
+            <article class="prompt-card" role="listitem">
+              <span class="tag-chip" style="margin-bottom:var(--space-3);">${p.tag}</span>
+              <p>${p.prompt}</p>
+              <button class="btn btn--sm" disabled title="Drafting capture lands with the next pass.">Capture story</button>
+            </article>
+          `)}
+        </div>
+      </section>
+    `;
+  }
+
+  render() {
+    return html`
+      ${this._renderTabs()}
+      ${this.activeTab === 'work' ? this._renderWork() : this._renderNarratives()}
+    `;
+  }
+}
+
+customElements.define('job-career', JobCareer);

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -153,7 +153,26 @@ export class JobHistoryResume extends LitElement {
 
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
-      return html`<div class="placeholder"><h2>Loading resume…</h2><p>Reading from fikei/job via kb-read.</p></div>`;
+      return html`
+        <section class="company-grid">
+          ${Array.from({ length: 3 }).map(() => html`
+            <div class="company-card" style="cursor:default;">
+              <div class="company-card__top">
+                <div class="company-card__title">
+                  <div class="skeleton" style="width:60%;height:22px;display:block;margin-bottom:var(--space-2);"></div>
+                  <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+                </div>
+                <div class="skeleton" style="width:90px;height:14px;"></div>
+              </div>
+              <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
+              <div class="skeleton" style="width:92%;height:14px;display:block;margin-bottom:8px;"></div>
+              <div class="skeleton" style="width:75%;height:14px;display:block;margin-bottom:var(--space-4);"></div>
+              <div class="skeleton skeleton--pill" style="width:60px;height:20px;display:inline-block;margin-right:8px;"></div>
+              <div class="skeleton skeleton--pill" style="width:80px;height:20px;display:inline-block;"></div>
+            </div>
+          `)}
+        </section>
+      `;
     }
     if (this.state === 'error') {
       return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -3,9 +3,9 @@
 import { LitElement, html } from 'https://esm.run/lit@3';
 
 const ROUTES = [
-  { href: '/job/jobs/',    label: 'Jobs',    match: /^\/job\/jobs\/?/ },
-  { href: '/job/history/', label: 'History', match: /^\/job\/history\/?/ },
-  { href: '/job/vision/',  label: 'Vision',  match: /^\/job\/vision\/?/ }
+  { href: '/job/jobs/',    label: 'Jobs',        match: /^\/job\/jobs\/?/ },
+  { href: '/job/history/', label: 'Your career', match: /^\/job\/history\/?/ },
+  { href: '/job/vision/',  label: 'Vision',      match: /^\/job\/vision\/?/ }
 ];
 
 const THEMES = [

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.25.0">
-  <script src="/job/js/theme.js?v=0.25.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
+  <script src="/job/js/theme.js?v=0.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.25.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Rail label flips from 'History' to 'Your career' (URL stays /job/history/). New <job-career> shell with two tabs:

- **Work history** — the existing companies grid (now with shimmer skeleton on load).
- **Narratives** — narrative-arc placeholder + horizontal Skill prompts carousel (6 hand-curated prompts; surfaces top sector tags from live pipeline as a frequency hint).

Tab state syncs to URL (?tab=narratives).

App bumped to 0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)