### PR TITLE
Drop Sheet sync + drop View button

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.26.0';
-console.log(`[job] v${VERSION} - Your Career: tabs + narratives + shimmer`);
+const VERSION = '0.27.0';
+console.log(`[job] v${VERSION} - drop sheet sync + drop View button`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -20,14 +20,15 @@ const DIM_LABELS = {
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
-// Resume + Cover, Source + Salary all live on the detail page now.
+// Rows are tappable so the View button is gone; the rightmost cell now
+// holds only the triple-dot menu.
 const COLUMNS = [
   { id: 'fit',     label: 'Fit',     sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
   { id: 'status',  label: 'Status',  sortKey: 'status',  type: 'text' },
   { id: 'company', label: 'Company', sortKey: 'company', type: 'text' },
   { id: 'role',    label: 'Role',    sortKey: 'title',   type: 'text' },
   { id: 'sector',  label: 'Sector',  sortKey: 'sector',  type: 'text' },
-  { id: 'view',    label: '',        sortKey: null },
+  { id: 'menu',    label: '',        sortKey: null },
 ];
 
 // Drop rows without an apply link, and any Strava postings (out of scope).
@@ -100,13 +101,9 @@ export class JobPipeline extends LitElement {
   async _maybeLoad() {
     if (document.body.dataset.authState !== 'in') return;
     if (this.state === 'loading' || this.state === 'loaded') return;
-    await this._load(false);
-  }
-
-  async _load(sync) {
     this.state = 'loading';
     try {
-      const data = await fetchPipeline({ sync });
+      const data = await fetchPipeline();
       this.roles = (data.roles || []).slice();
       this.state = 'loaded';
     } catch (e) {
@@ -114,8 +111,6 @@ export class JobPipeline extends LitElement {
       this.state = 'error';
     }
   }
-
-  async _onSync() { await this._load(true); }
 
   _onSortClick(col) {
     if (!col.sortKey) return;
@@ -223,30 +218,24 @@ export class JobPipeline extends LitElement {
   }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
-  _renderViewCell(r) {
+  _renderMenuCell(r) {
     const archived = isArchived(r);
     const menuOpen = this.openMenuSlug === r.slug;
     return html`
-      <div class="row-actions">
-        <a class="btn btn--sm btn--accent" href=${this._detailHref(r)} target="_blank" rel="noopener"
-           @click=${() => stashRolePrefill(r)}>
-          View
-        </a>
-        <div class="row-menu">
-          <button class="row-menu__trigger" aria-label="Row actions"
-                  aria-expanded=${menuOpen ? 'true' : 'false'}
-                  @click=${(e) => this._toggleMenu(r.slug, e)}>⋮</button>
-          ${menuOpen ? html`
-            <div class="row-menu__panel" role="menu">
-              <button role="menuitem" class="row-menu__item" @click=${() => this._onArchive(r, !archived)}>
-                ${archived ? 'Unarchive' : 'Archive'}
-              </button>
-              <button role="menuitem" class="row-menu__item row-menu__item--danger" @click=${() => this._onDelete(r)}>
-                Delete…
-              </button>
-            </div>
-          ` : nothing}
-        </div>
+      <div class="row-menu">
+        <button class="row-menu__trigger" aria-label="Row actions"
+                aria-expanded=${menuOpen ? 'true' : 'false'}
+                @click=${(e) => this._toggleMenu(r.slug, e)}>⋮</button>
+        ${menuOpen ? html`
+          <div class="row-menu__panel" role="menu">
+            <button role="menuitem" class="row-menu__item" @click=${() => this._onArchive(r, !archived)}>
+              ${archived ? 'Unarchive' : 'Archive'}
+            </button>
+            <button role="menuitem" class="row-menu__item row-menu__item--danger" @click=${() => this._onDelete(r)}>
+              Delete…
+            </button>
+          </div>
+        ` : nothing}
       </div>
     `;
   }
@@ -301,7 +290,7 @@ export class JobPipeline extends LitElement {
         <td><strong>${r.company}</strong></td>
         <td>${r.title}</td>
         <td>${this._renderSectorCell(r)}</td>
-        <td>${this._renderViewCell(r)}</td>
+        <td>${this._renderMenuCell(r)}</td>
       </tr>
     `;
   }
@@ -421,9 +410,6 @@ export class JobPipeline extends LitElement {
             <option value="archived" ?selected=${this.archivedView==='archived'}>Archived only</option>
           </select>
         </label>
-        <button class="btn btn--sm" @click=${() => this._onSync()}>
-          Sync from sheet
-        </button>
       </div>
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -10,22 +10,20 @@ async function authHeader() {
   return { Authorization: `Bearer ${token}` };
 }
 
-export async function fetchPipeline({ sync = false } = {}) {
+export async function fetchPipeline() {
   const headers = await authHeader();
-  const url = sync ? `${FN_URL}?sync=1` : FN_URL;
-  const res = await fetch(url, { headers });
+  const res = await fetch(FN_URL, { headers });
   if (!res.ok) throw new Error(`jobs-pipe ${res.status}: ${await res.text()}`);
   return res.json();
 }
 
 export async function setStatus(role, status) {
-  // role can be { slug, rowNumber } or just a slug string for backward compat.
-  const body = typeof role === 'string' ? { slug: role, status } : { slug: role.slug, rowNumber: role.rowNumber, status };
+  const slug = typeof role === 'string' ? role : role.slug;
   const headers = await authHeader();
   const res = await fetch(FN_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ slug, status }),
   });
   if (!res.ok) throw new Error(`set-status ${res.status}: ${await res.text()}`);
   return res.json();

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.26.0">
-  <script src="/job/js/theme.js?v=0.26.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
+  <script src="/job/js/theme.js?v=0.27.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.26.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -1,148 +1,23 @@
-// jobs-pipe — read pipeline from Postgres, sync from Sheet on demand,
-// write status changes back to both.
+// jobs-pipe — read pipeline from Postgres, write status changes there.
+// Google Sheet integration was removed in v0.8.0 (the sheet was a
+// migration-era input feed; ongoing changes flow through Postgres only).
+// migrate-job retains the sheet helpers for one-shot backfill if needed.
 //
 //   GET                          → list pipeline_roles (Postgres)
-//   GET ?sync=1                  → sheet → Postgres upsert, then list
-//   POST { rowNumber|slug, status } → updates Postgres + sheet (dual-write)
+//   POST { slug, status }        → status writeback (Postgres only)
+//   POST { slug, archived }      → archive / unarchive
+//   POST { slug, action: 'delete' } → soft delete
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { readSheetValues, writeSheetCell } from './sheets.ts';
-import { computeFit, RoleRow } from './fit.ts';
-import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '../_shared/job-auth.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
-import { parseSectorTags } from '../_shared/sector-tags.ts';
 
-const VERSION = '0.7.0';
-console.log(`[jobs-pipe] v${VERSION} - soft delete`);
+const VERSION = '0.8.0';
+console.log(`[jobs-pipe] v${VERSION} - sheet removed`);
 
-const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 const STATUS_ENUM = new Set([
   '', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network',
 ]);
-
-// Heuristics for the column-shift workaround below.
-const SALARY_RE = /^\$?\s*\d[\d.,kK]*\s*[-–]\s*\$?\s*\d/;        // "$140k - $200k", "$128,945 - $157,850"
-const URL_RE    = /^https?:\/\//i;
-const SOURCE_VOCAB = new Set([
-  'Manual', 'Network', 'LinkedIn Saved', 'LinkedIn Recommended',
-  'From Company Pages', 'Imported',
-]);
-
-function rowToRole(row: string[]): RoleRow {
-  const role: RoleRow = {
-    status: (row[2] || '').trim(),
-    rank: (row[1] || '').trim(),
-    company: (row[3] || '').trim(),
-    title: (row[4] || '').trim(),
-    url: (row[5] || '').trim(),
-    source: (row[6] || '').trim(),
-    contact: (row[7] || '').trim(),
-    salary: (row[8] || '').trim(),
-    sector: (row[9] || '').trim(),
-    investors: (row[10] || '').trim(),
-    website: (row[11] || '').trim(),
-    crunchbase: (row[12] || '').trim(),
-  };
-
-  // Tolerance for sheet rows where values were pasted into the wrong columns.
-  // Observed in the live sheet: ~5 rows have col F (URL) empty and the URL
-  // sitting in col L (Website). Those same rows have shifted-by-one data:
-  //   col G (Source)  → actually salary or empty
-  //   col H (Contact) → actually sector
-  // Detect the shift via the URL signature, then re-map.
-  const looksShifted = !role.url && URL_RE.test(role.website || '');
-  if (looksShifted) {
-    role.url = role.website;
-    role.website = '';
-    if (role.source && !role.salary && !SOURCE_VOCAB.has(role.source)) {
-      role.salary = role.source;
-      role.source = '';
-    }
-    if (role.contact && !role.sector) {
-      role.sector = role.contact;
-      role.contact = '';
-    }
-  }
-
-  // Belt-and-braces: even if the row didn't pass the URL signature, salary
-  // text in the Source column is always a misplacement.
-  if (role.source && SALARY_RE.test(role.source) && !role.salary) {
-    role.salary = role.source;
-    role.source = '';
-  }
-
-  return role;
-}
-
-function parseSalary(s: string | undefined): { low: number | null; high: number | null } {
-  if (!s) return { low: null, high: null };
-  const norm = s.toLowerCase().replace(/[,$]/g, '').replace(/\s+/g, '');
-  const nums = Array.from(norm.matchAll(/(\d+(?:\.\d+)?)(k)?/g)).map(m => {
-    const n = parseFloat(m[1]);
-    return m[2] === 'k' ? Math.round(n * 1000) : Math.round(n);
-  }).filter(n => n >= 1000);
-  if (!nums.length) return { low: null, high: null };
-  if (nums.length === 1) return { low: nums[0], high: nums[0] };
-  return { low: Math.min(...nums), high: Math.max(...nums) };
-}
-
-async function syncFromSheet() {
-  const sql = db();
-  const rows = await readSheetValues(SHEET_ID, 'Roles!A2:M1000');
-  let upserted = 0;
-  for (let idx = 0; idx < rows.length; idx++) {
-    const r = rows[idx];
-    const role = rowToRole(r);
-    if (!role.company && !role.title) continue;
-    const slug = roleSlug(role.company, role.title);
-    if (!slug) continue;
-    const fit = computeFit(role);
-    const { low, high } = parseSalary(role.salary);
-    const investors = role.investors ? role.investors.split(/,|;/).map(s => s.trim()).filter(Boolean) : [];
-
-    await sql`
-      insert into job.pipeline_roles (
-        slug, source_row, company_slug, company_name, title, url, source, status,
-        contact, salary_range, salary_low, salary_high, sector, investors,
-        fit_score, fit_breakdown, hard_fails
-      ) values (
-        ${slug}, ${idx + 2}, ${slugify(role.company)}, ${role.company}, ${role.title},
-        ${role.url || null}, ${role.source || null}, ${role.status || 'New'},
-        ${role.contact || null}, ${role.salary || null}, ${low}, ${high},
-        ${role.sector || null}, ${investors},
-        ${fit.score}, ${sql.json(fit.breakdown)}, ${fit.hardFails}
-      )
-      on conflict (slug) do update set
-        source_row = excluded.source_row,
-        company_name = excluded.company_name, title = excluded.title,
-        url = excluded.url, source = excluded.source, status = excluded.status,
-        contact = excluded.contact, salary_range = excluded.salary_range,
-        salary_low = excluded.salary_low, salary_high = excluded.salary_high,
-        sector = excluded.sector, investors = excluded.investors,
-        fit_score = excluded.fit_score, fit_breakdown = excluded.fit_breakdown,
-        hard_fails = excluded.hard_fails,
-        updated_at = now();
-    `;
-
-    // Refresh role↔sector_tags from the latest sector text.
-    const tags = parseSectorTags(role.sector);
-    await sql`delete from job.role_sector_tags where role_slug = ${slug}`;
-    for (const t of tags) {
-      await sql`
-        insert into job.sector_tags (slug, name) values (${t.slug}, ${t.name})
-        on conflict (slug) do nothing;
-      `;
-      await sql`
-        insert into job.role_sector_tags (role_slug, tag_slug)
-        values (${slug}, ${t.slug})
-        on conflict do nothing;
-      `;
-    }
-
-    upserted += 1;
-  }
-  return upserted;
-}
 
 async function listRoles() {
   const sql = db();
@@ -180,28 +55,15 @@ serve(async (req) => {
     if (!email) return err('unauthorized', 401);
 
     if (req.method === 'GET') {
-      const url = new URL(req.url);
-      const sync = url.searchParams.get('sync') === '1';
-      let synced = 0;
-      if (sync) synced = await syncFromSheet();
       const roles = await listRoles();
-      return jsonResp({ version: VERSION, count: roles.length, synced, roles });
+      return jsonResp({ version: VERSION, count: roles.length, roles });
     }
 
     if (req.method === 'POST') {
       const body = await req.json().catch(() => ({}));
-      let slug = body.slug ? String(body.slug) : '';
-      let rowNumber = Number(body.rowNumber);
+      const slug = body.slug ? String(body.slug) : '';
       const sql = db();
-
-      if (!slug && Number.isInteger(rowNumber)) {
-        const r = await sql`select slug from job.pipeline_roles where source_row = ${rowNumber} limit 1`;
-        slug = r[0]?.slug || '';
-      } else if (slug && !rowNumber) {
-        const r = await sql`select source_row from job.pipeline_roles where slug = ${slug} limit 1`;
-        rowNumber = r[0]?.source_row || 0;
-      }
-      if (!slug) return err('role not found (provide slug or rowNumber)', 404);
+      if (!slug) return err('role not found (provide slug)', 404);
 
       // Archive / unarchive — independent from status changes.
       if ('archived' in body) {
@@ -237,12 +99,7 @@ serve(async (req) => {
             status_history = coalesce(status_history, '[]'::jsonb) || ${sql.json([{ status, at: new Date().toISOString() }])}
         where slug = ${slug};
       `;
-      if (Number.isInteger(rowNumber) && rowNumber >= 2) {
-        try { await writeSheetCell(SHEET_ID, `Roles!C${rowNumber}`, status); } catch (e) {
-          console.warn('[jobs-pipe] sheet writeback failed', e);
-        }
-      }
-      return jsonResp({ ok: true, slug, rowNumber, status });
+      return jsonResp({ ok: true, slug, status });
     }
 
     return err('GET or POST only', 405);


### PR DESCRIPTION
Two cleanups in one PR.

- **Sheet integration removed.** jobs-pipe v0.8.0: no `?sync=1`, no sheet writeback, no SHEET_ID. fit.ts / sheets.ts files retained on disk for migrate-job's one-shot backfill but no longer imported by jobs-pipe. Status writeback is Postgres-only.
- **View button removed.** Rows are tappable (#660), so the explicit View button was redundant. Right-most cell now holds only the triple-dot menu.
- Sync button gone from the pipeline meta line.

App bumped to 0.27.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)