### PR TITLE
Liveness check + 'closed since last visit' banner

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1040,3 +1040,21 @@
   line-height: var(--lh-body);
 }
 .prompt-card .btn { align-self: flex-start; }
+
+/* --- Closed-since-last-visit banner --- */
+.closed-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: rgba(168,32,13,0.08);
+  border: 1px solid rgba(168,32,13,0.18);
+  border-radius: var(--radius-md);
+  color: var(--fg);
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-small);
+}
+.closed-banner strong { display: block; margin-bottom: 2px; color: var(--error); }
+.closed-banner .muted { display: block; margin-top: var(--space-1); }
+[data-theme="generic-dark"] .closed-banner { background: rgba(255,122,110,0.10); border-color: rgba(255,122,110,0.28); }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.27.0';
-console.log(`[job] v${VERSION} - drop sheet sync + drop View button`);
+const VERSION = '0.28.0';
+console.log(`[job] v${VERSION} - liveness check + closed banner`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,7 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill } = await import('../pipeline.js' + V);
+const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill, checkLiveness } = await import('../pipeline.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -59,6 +59,9 @@ export class JobPipeline extends LitElement {
     selectedRow: { state: true },
     archivedView: { state: true },   // 'active' | 'all' | 'archived'
     openMenuSlug: { state: true },
+    livenessChecking: { state: true },
+    closedSinceLastVisit: { state: true },
+    bannerDismissed: { state: true },
   };
 
   constructor() {
@@ -71,6 +74,12 @@ export class JobPipeline extends LitElement {
     this.selectedRow = null;
     this.archivedView = 'active';
     this.openMenuSlug = null;
+    this.livenessChecking = false;
+    this.closedSinceLastVisit = [];
+    this.bannerDismissed = false;
+    this._lastVisitAt = (() => {
+      try { return localStorage.getItem('job:jobs:lastVisitAt') || null; } catch { return null; }
+    })();
   }
 
   connectedCallback() {
@@ -105,10 +114,42 @@ export class JobPipeline extends LitElement {
     try {
       const data = await fetchPipeline();
       this.roles = (data.roles || []).slice();
+      this._computeClosedSinceLastVisit();
+      // Stamp the visit AFTER reading lastVisit so the banner sticks for
+      // this session.
+      try { localStorage.setItem('job:jobs:lastVisitAt', new Date().toISOString()); } catch {}
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
       this.state = 'error';
+    }
+  }
+
+  _computeClosedSinceLastVisit() {
+    const cutoff = this._lastVisitAt ? Date.parse(this._lastVisitAt) : 0;
+    this.closedSinceLastVisit = this.roles.filter(r =>
+      r.closedDetectedAt && Date.parse(r.closedDetectedAt) > cutoff
+    );
+  }
+
+  async _onCheckLiveness() {
+    if (this.livenessChecking) return;
+    this.livenessChecking = true;
+    this.requestUpdate();
+    try {
+      const res = await checkLiveness();
+      // Refresh the pipeline so newly-closed rows appear with archive/closed flags.
+      const data = await fetchPipeline();
+      this.roles = (data.roles || []).slice();
+      this._computeClosedSinceLastVisit();
+      if (res.closed?.length) {
+        this.bannerDismissed = false;
+      }
+    } catch (e) {
+      this.error = String(e);
+    } finally {
+      this.livenessChecking = false;
+      this.requestUpdate();
     }
   }
 
@@ -398,6 +439,19 @@ export class JobPipeline extends LitElement {
     const rows = this._sorted();
     const archivedCount = this.roles.filter(r => isVisibleRole(r) && isArchived(r)).length;
     return html`
+      ${!this.bannerDismissed && this.closedSinceLastVisit.length ? html`
+        <div class="closed-banner" role="status">
+          <div>
+            <strong>${this.closedSinceLastVisit.length}
+            ${this.closedSinceLastVisit.length === 1 ? 'role was' : 'roles were'} closed since your last visit.</strong>
+            They've been moved to Closed and archived.
+            <span class="muted">${this.closedSinceLastVisit.slice(0, 4).map(r => r.company).join(', ')}${this.closedSinceLastVisit.length > 4 ? '…' : ''}</span>
+          </div>
+          <button class="row-menu__trigger" aria-label="Dismiss"
+                  @click=${() => { this.bannerDismissed = true; }}>×</button>
+        </div>
+      ` : nothing}
+
       <div class="pipeline-meta">
         <strong>${rows.length}</strong> roles, sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.
         <label class="pipeline-meta__filter">
@@ -410,6 +464,10 @@ export class JobPipeline extends LitElement {
             <option value="archived" ?selected=${this.archivedView==='archived'}>Archived only</option>
           </select>
         </label>
+        <button class="btn btn--sm" ?disabled=${this.livenessChecking}
+                @click=${() => this._onCheckLiveness()}>
+          ${this.livenessChecking ? 'Checking…' : 'Check liveness'}
+        </button>
       </div>
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -1,5 +1,6 @@
 // pipeline.js — thin client for the jobs-pipe Edge Function.
 const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/jobs-pipe';
+const LIVENESS_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/check-liveness';
 
 async function authHeader() {
   const supabase = window.CtrlAuth?.getSupabaseClient?.();
@@ -48,6 +49,17 @@ export async function deleteRole(slug) {
     body: JSON.stringify({ slug, action: 'delete' }),
   });
   if (!res.ok) throw new Error(`delete-role ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function checkLiveness({ slug } = {}) {
+  const headers = await authHeader();
+  const res = await fetch(LIVENESS_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(slug ? { slug } : {}),
+  });
+  if (!res.ok) throw new Error(`check-liveness ${res.status}: ${await res.text()}`);
   return res.json();
 }
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.27.0">
-  <script src="/job/js/theme.js?v=0.27.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
+  <script src="/job/js/theme.js?v=0.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.27.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
 </body>
 </html>

--- a/supabase/functions/check-liveness/index.ts
+++ b/supabase/functions/check-liveness/index.ts
@@ -1,0 +1,131 @@
+// check-liveness — probe job posting URLs and auto-archive 404'd / dead rows.
+//
+//   POST                 → batch (up to 10 oldest-checked rows). Allowlist
+//                          auth required.
+//   POST { slug }        → single role, force-recheck.
+//   POST cron mode       → pass header 'x-cron-secret: <CRON_SECRET>' to bypass
+//                          user auth. Used by pg_cron.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[check-liveness] v${VERSION}`);
+
+const BATCH = 10;
+const TIMEOUT_MS = 8000;
+const CLOSE_STATUSES = new Set([404, 410, 451]);
+
+// Some sites return HTML 200 with a "this job is no longer available"
+// banner. Detecting that requires per-site parsing — out of scope for v1.
+// We only auto-close on 4xx/5xx where the URL is genuinely unreachable.
+
+interface CheckResult {
+  slug: string;
+  url: string;
+  status: number | null;
+  isLive: boolean | null;
+  willClose: boolean;
+  error?: string;
+}
+
+async function probe(url: string): Promise<{ status: number | null; error?: string }> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    // Many ATS pages don't honour HEAD — fall back to GET.
+    let res = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal });
+    if (res.status === 405 || res.status === 501) {
+      res = await fetch(url, { method: 'GET', redirect: 'follow', signal: controller.signal });
+    }
+    return { status: res.status };
+  } catch (e) {
+    return { status: null, error: (e as Error).message };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function checkRoles(filter: { slug?: string }): Promise<CheckResult[]> {
+  const sql = db();
+  const rows = filter.slug
+    ? await sql`
+        select slug, url from job.pipeline_roles
+        where slug = ${filter.slug} and url is not null;
+      `
+    : await sql`
+        select slug, url from job.pipeline_roles
+        where url is not null
+          and deleted_at is null
+          and archived_at is null
+          and (status is null or status not in ('Closed','Rejected','Pass'))
+        order by liveness_checked_at nulls first
+        limit ${BATCH};
+      `;
+
+  const results: CheckResult[] = [];
+  for (const r of rows) {
+    const probed = await probe(r.url);
+    const status = probed.status;
+    const willClose = status != null && CLOSE_STATUSES.has(status);
+    const isLive = status == null ? null : (status >= 200 && status < 400);
+
+    if (willClose) {
+      await sql`
+        update job.pipeline_roles set
+          liveness_checked_at = now(),
+          liveness_status_code = ${status},
+          is_live = false,
+          closed_detected_at = coalesce(closed_detected_at, now()),
+          status = 'Closed',
+          status_changed_at = now(),
+          archived_at = coalesce(archived_at, now()),
+          status_history = coalesce(status_history, '[]'::jsonb) || ${sql.json([{ status: 'Closed', at: new Date().toISOString(), by: 'liveness' }])}
+        where slug = ${r.slug};
+      `;
+    } else {
+      await sql`
+        update job.pipeline_roles set
+          liveness_checked_at = now(),
+          liveness_status_code = ${status ?? null},
+          is_live = ${isLive}
+        where slug = ${r.slug};
+      `;
+    }
+
+    results.push({ slug: r.slug, url: r.url, status, isLive, willClose, error: probed.error });
+  }
+  return results;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  // Cron mode: shared secret in header bypasses user auth.
+  const cronSecret = req.headers.get('x-cron-secret');
+  const expected = Deno.env.get('CRON_SECRET');
+  const cronAuthed = expected && cronSecret && cronSecret === expected;
+
+  if (!cronAuthed) {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+  }
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const slug = body.slug ? String(body.slug).toLowerCase() : undefined;
+    const results = await checkRoles({ slug });
+    return jsonResp({
+      ok: true,
+      version: VERSION,
+      checked: results.length,
+      closed: results.filter(r => r.willClose).map(r => r.slug),
+      results,
+    });
+  } catch (e) {
+    console.error('[check-liveness] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -30,6 +30,9 @@ async function listRoles() {
       r.hard_fails as "hardFails", r.applied_at, r.status_changed_at,
       r.first_seen, r.last_seen,
       r.archived_at as "archivedAt",
+      r.closed_detected_at as "closedDetectedAt",
+      r.is_live as "isLive",
+      r.liveness_checked_at as "livenessCheckedAt",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
       coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter",
       coalesce((

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,4 +1,4 @@
-// Bundled schema for migrate-job. Mirrors 047–051 from supabase/migrations.
+// Bundled schema for migrate-job. Mirrors 047–052 from supabase/migrations.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -246,5 +246,19 @@ alter table job.pipeline_roles
 
 create index if not exists pipeline_roles_deleted_idx
   on job.pipeline_roles (deleted_at)
+  where deleted_at is null;
+
+-- 052 ----------------------------------------------------------------
+-- Liveness tracking for pipeline_roles. A background job HEADs each URL
+-- on a cadence; rows that 404 (or otherwise become unreachable) get
+-- closed_detected_at stamped, status flipped to 'Closed', and archived.
+alter table job.pipeline_roles
+  add column if not exists liveness_checked_at timestamptz,
+  add column if not exists is_live boolean,
+  add column if not exists liveness_status_code int,
+  add column if not exists closed_detected_at timestamptz;
+
+create index if not exists pipeline_roles_liveness_idx
+  on job.pipeline_roles (liveness_checked_at nulls first)
   where deleted_at is null;
 `;

--- a/supabase/migrations/052_job_liveness.sql
+++ b/supabase/migrations/052_job_liveness.sql
@@ -1,0 +1,12 @@
+-- Liveness tracking for pipeline_roles. A background job HEADs each URL
+-- on a cadence; rows that 404 (or otherwise become unreachable) get
+-- closed_detected_at stamped, status flipped to 'Closed', and archived.
+alter table job.pipeline_roles
+  add column if not exists liveness_checked_at timestamptz,
+  add column if not exists is_live boolean,
+  add column if not exists liveness_status_code int,
+  add column if not exists closed_detected_at timestamptz;
+
+create index if not exists pipeline_roles_liveness_idx
+  on job.pipeline_roles (liveness_checked_at nulls first)
+  where deleted_at is null;


### PR DESCRIPTION
Background process that probes every `pipeline_roles.url` and auto-archives 404'd postings.

### Schema (migration 052)
- `pipeline_roles.{liveness_checked_at, is_live, liveness_status_code, closed_detected_at}`.

### Edge Function `check-liveness` v0.1.0
- POST → batches 10 oldest-checked rows, HEADs each URL (GET fallback on 405/501), 8s timeout.
- POST `{ slug }` → force a recheck.
- Auto-archive on 404/410/451: status='Closed', archived_at stamped, status_history appended with `by: 'liveness'`.
- Cron mode: `x-cron-secret` header bypasses user auth. Schedule via pg_cron once `CRON_SECRET` is set in Supabase secrets.

### Frontend (app v0.28.0)
- **Closed-since-last-visit banner** above the meta line: counts roles with `closedDetectedAt > localStorage 'job:jobs:lastVisitAt'`, lists first 4 companies, dismiss with ×. lastVisit is stamped after each load.
- **Check liveness** button in the meta line. Refreshes the pipeline on success.

### One-time setup (you)
```bash
supabase secrets set CRON_SECRET=<random> --project-ref yfhudwakpgzswiylhfbh
```
Then in Supabase SQL editor:
```sql
select cron.schedule(
  'job-liveness',  '0 */6 * * *',
  $$ select net.http_post(
    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/check-liveness',
    headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_secret'))
  ); $$
);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)