### PR TITLE
Paste-a-link + recommendations widget

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1058,3 +1058,159 @@
 .closed-banner strong { display: block; margin-bottom: 2px; color: var(--error); }
 .closed-banner .muted { display: block; margin-top: var(--space-1); }
 [data-theme="generic-dark"] .closed-banner { background: rgba(255,122,110,0.10); border-color: rgba(255,122,110,0.28); }
+
+/* --- Paste-a-link form --- */
+.paste-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  margin: var(--space-3) 0 var(--space-4);
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.paste-row input[type="url"] {
+  flex: 1;
+  height: 36px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+.paste-row input[type="url"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+/* --- Recommendations widget --- */
+.rec-shell {
+  margin-bottom: var(--space-6);
+}
+.rec-shell__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.rec-shell__head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.01em;
+}
+.rec-row {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(360px, 420px);
+  gap: var(--space-4);
+  overflow-x: auto;
+  padding-bottom: var(--space-3);
+  scroll-snap-type: x proximity;
+}
+.rec-row::-webkit-scrollbar { height: 8px; }
+.rec-row::-webkit-scrollbar-thumb { background: var(--border); border-radius: var(--radius-pill); }
+
+.rec-card {
+  scroll-snap-align: start;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.rec-card__head {
+  display: flex;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+.rec-card__logo {
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  object-fit: cover;
+}
+.rec-card__logo--placeholder {
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  color: var(--fg-muted);
+}
+.rec-card__title-block { min-width: 0; flex: 1; }
+.rec-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.rec-card__meta {
+  margin: 4px 0 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.rec-card__source {
+  margin: 6px 0 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.rec-card__source-icon { font-size: 13px; opacity: 0.8; }
+
+.rec-card__bullets {
+  list-style: disc;
+  margin: 0 0 0 var(--space-4);
+  padding: 0;
+  font-size: var(--font-size-body);
+  line-height: 1.55;
+  color: var(--fg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.rec-card__bullets li > * { display: inline; }
+.rec-card__bullets p { display: inline; margin: 0; }
+.rec-card__desc { margin: 0; font-size: var(--font-size-body); color: var(--fg-muted); }
+
+.rec-card__foot {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.rec-card__foot .link-subtle {
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: var(--font-size-small);
+  cursor: pointer;
+  padding: 0;
+}
+
+.rec-empty {
+  padding: var(--space-5);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: var(--font-size-small);
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.28.0';
-console.log(`[job] v${VERSION} - liveness check + closed banner`);
+const VERSION = '0.29.0';
+console.log(`[job] v${VERSION} - paste-a-link + recommendations widget`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,9 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill, checkLiveness } = await import('../pipeline.js' + V);
+const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
+// Mount the recommendations widget. It self-loads when the user is signed in.
+import('./job-recommendations.js' + V);
 
 const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network'];
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
@@ -62,6 +64,10 @@ export class JobPipeline extends LitElement {
     livenessChecking: { state: true },
     closedSinceLastVisit: { state: true },
     bannerDismissed: { state: true },
+    pasteOpen: { state: true },
+    pasteUrl: { state: true },
+    pasteSaving: { state: true },
+    pasteError: { state: true },
   };
 
   constructor() {
@@ -77,6 +83,10 @@ export class JobPipeline extends LitElement {
     this.livenessChecking = false;
     this.closedSinceLastVisit = [];
     this.bannerDismissed = false;
+    this.pasteOpen = false;
+    this.pasteUrl = '';
+    this.pasteSaving = false;
+    this.pasteError = '';
     this._lastVisitAt = (() => {
       try { return localStorage.getItem('job:jobs:lastVisitAt') || null; } catch { return null; }
     })();
@@ -94,17 +104,45 @@ export class JobPipeline extends LitElement {
     document.addEventListener('keydown', this._onKey);
     this._onDocClick = (e) => {
       if (!this.openMenuSlug) return;
-      // Close menu when clicking outside any row-menu element.
       if (!e.target.closest('.row-menu')) this.openMenuSlug = null;
     };
     document.addEventListener('click', this._onDocClick);
+    this._onRefresh = async () => {
+      try {
+        const data = await fetchPipeline();
+        this.roles = (data.roles || []).slice();
+      } catch {}
+    };
+    document.addEventListener('job:pipeline:refresh', this._onRefresh);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('keydown', this._onKey);
     document.removeEventListener('click', this._onDocClick);
+    document.removeEventListener('job:pipeline:refresh', this._onRefresh);
     super.disconnectedCallback();
+  }
+
+  async _onPasteSubmit(e) {
+    e.preventDefault();
+    if (!this.pasteUrl || this.pasteSaving) return;
+    this.pasteSaving = true;
+    this.pasteError = '';
+    try {
+      const r = await addRole({ url: this.pasteUrl });
+      // refresh & close
+      const data = await fetchPipeline();
+      this.roles = (data.roles || []).slice();
+      this.pasteOpen = false;
+      this.pasteUrl = '';
+      // Open the new role's detail page in a new tab so the user can flesh it out.
+      window.open(`/job/jobs/${r.slug}/`, '_blank', 'noopener');
+    } catch (err) {
+      this.pasteError = String(err);
+    } finally {
+      this.pasteSaving = false;
+    }
   }
 
   async _maybeLoad() {
@@ -439,6 +477,8 @@ export class JobPipeline extends LitElement {
     const rows = this._sorted();
     const archivedCount = this.roles.filter(r => isVisibleRole(r) && isArchived(r)).length;
     return html`
+      <job-recommendations></job-recommendations>
+
       ${!this.bannerDismissed && this.closedSinceLastVisit.length ? html`
         <div class="closed-banner" role="status">
           <div>
@@ -468,7 +508,23 @@ export class JobPipeline extends LitElement {
                 @click=${() => this._onCheckLiveness()}>
           ${this.livenessChecking ? 'Checking…' : 'Check liveness'}
         </button>
+        <button class="btn btn--sm btn--accent"
+                @click=${() => { this.pasteOpen = !this.pasteOpen; this.pasteError = ''; }}>
+          ${this.pasteOpen ? 'Cancel' : '＋ Add a role'}
+        </button>
       </div>
+
+      ${this.pasteOpen ? html`
+        <form class="paste-row" @submit=${(e) => this._onPasteSubmit(e)}>
+          <input type="url" required placeholder="Paste a job posting URL"
+                 .value=${this.pasteUrl}
+                 @input=${(e) => { this.pasteUrl = e.target.value; }}>
+          <button type="submit" class="btn btn--sm btn--primary" ?disabled=${this.pasteSaving || !this.pasteUrl}>
+            ${this.pasteSaving ? 'Adding…' : 'Add'}
+          </button>
+          ${this.pasteError ? html`<span class="muted" style="color:var(--error);font-size:var(--font-size-small);">${this.pasteError}</span>` : nothing}
+        </form>
+      ` : nothing}
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">
           <thead>${this._renderHeader()}</thead>

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -1,0 +1,188 @@
+// job-recommendations — horizontal carousel of recommended roles above
+// the Jobs table. Each card matches the ratecard mockup: logo, title,
+// company · location · salary, posted, source, and 3 markdown bullets
+// explaining why it matches. "Add to pipeline" sends to add-role.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../pipeline.js' + V),
+]);
+
+function relTime(iso) {
+  if (!iso) return '';
+  const ms = Date.now() - Date.parse(iso);
+  const s = Math.max(1, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24); if (d < 7)  return `${d}d ago`;
+  const w = Math.floor(d / 7);  if (w < 5)  return `${w}w ago`;
+  const mo = Math.floor(d / 30); return mo < 12 ? `${mo}mo ago` : `${Math.floor(mo / 12)}y ago`;
+}
+
+export class JobRecommendations extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    items: { state: true },
+    error: { state: true },
+    addingId: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.items = [];
+    this.error = '';
+    this.addingId = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      const data = await fetchRecommendations();
+      this.items = data.recommendations || [];
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e);
+      this.state = 'error';
+    }
+  }
+
+  async _onDismiss(id) {
+    this.items = this.items.filter(r => r.id !== id);
+    try { await dismissRecommendation(id); } catch {}
+  }
+
+  async _onAdd(rec) {
+    if (this.addingId) return;
+    this.addingId = rec.id;
+    try {
+      const r = await addRole({
+        url: rec.url,
+        title: rec.title,
+        company: rec.company,
+        sector: rec.sourceLabel === 'Web-sourced' ? '' : '',
+        source: 'Network',
+        fromRecommendationId: rec.id,
+      });
+      // Optimistic: pop from the carousel.
+      this.items = this.items.filter(x => x.id !== rec.id);
+      // Invite the pipeline to refresh.
+      document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
+    } catch (e) {
+      console.warn('[recommendations] add failed', e);
+    } finally {
+      this.addingId = null;
+    }
+  }
+
+  _renderCard(rec) {
+    const meta = [rec.company, rec.location, rec.salary].filter(Boolean).join('  •  ');
+    const bullets = Array.isArray(rec.matchBullets) ? rec.matchBullets : [];
+    return html`
+      <article class="rec-card" role="listitem">
+        <header class="rec-card__head">
+          ${rec.logoUrl
+            ? html`<img class="rec-card__logo" src=${rec.logoUrl} alt="${rec.company || ''} logo" />`
+            : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${(rec.company || '?').slice(0, 1)}</div>`}
+          <div class="rec-card__title-block">
+            <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
+            ${meta ? html`<p class="rec-card__meta">${meta}</p>` : nothing}
+            <p class="rec-card__source">
+              ${rec.postedAt ? html`Posted ${relTime(rec.postedAt)}` : nothing}
+              ${rec.postedAt && rec.sourceLabel ? html` <span aria-hidden="true"> · </span> ` : nothing}
+              ${rec.sourceLabel ? html`
+                <span class="rec-card__source-icon" aria-hidden="true">🌐</span>
+                <a href=${rec.url} target="_blank" rel="noopener" class="link-subtle">${rec.sourceLabel}</a>
+              ` : nothing}
+            </p>
+          </div>
+        </header>
+
+        ${bullets.length ? html`
+          <ul class="rec-card__bullets">
+            ${bullets.slice(0, 4).map(b => html`<li>${unsafeHTML(renderMarkdown(b))}</li>`)}
+          </ul>
+        ` : rec.description ? html`<p class="rec-card__desc">${rec.description}</p>` : nothing}
+
+        <footer class="rec-card__foot">
+          <button class="btn btn--sm btn--accent" ?disabled=${this.addingId === rec.id}
+                  @click=${() => this._onAdd(rec)}>
+            ${this.addingId === rec.id ? 'Adding…' : 'Add to pipeline'}
+          </button>
+          <button class="link-subtle" @click=${() => this._onDismiss(rec.id)}>Dismiss</button>
+        </footer>
+      </article>
+    `;
+  }
+
+  _renderEmpty() {
+    return html`
+      <div class="rec-empty">
+        <strong>No recommendations yet.</strong>
+        <span class="muted">Once the LinkedIn pull worker runs, fresh roles tagged with why they match will surface here.</span>
+      </div>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`
+        <div class="rec-shell">
+          <div class="rec-row">
+            ${Array.from({ length: 3 }).map(() => html`
+              <div class="rec-card">
+                <div class="rec-card__head">
+                  <div class="skeleton" style="width:48px;height:48px;border-radius:var(--radius-md);"></div>
+                  <div style="flex:1;">
+                    <div class="skeleton" style="width:80%;height:18px;display:block;margin-bottom:8px;"></div>
+                    <div class="skeleton" style="width:60%;height:13px;display:block;margin-bottom:6px;"></div>
+                    <div class="skeleton" style="width:40%;height:13px;display:block;"></div>
+                  </div>
+                </div>
+                <div class="skeleton" style="width:100%;height:12px;display:block;margin-top:16px;margin-bottom:6px;"></div>
+                <div class="skeleton" style="width:90%;height:12px;display:block;margin-bottom:6px;"></div>
+                <div class="skeleton" style="width:80%;height:12px;display:block;"></div>
+              </div>
+            `)}
+          </div>
+        </div>
+      `;
+    }
+    if (this.state === 'error' || !this.items.length) {
+      return html`<div class="rec-shell">${this._renderEmpty()}</div>`;
+    }
+    return html`
+      <section class="rec-shell" aria-label="Recommendations">
+        <header class="rec-shell__head">
+          <h2>Recommended for you</h2>
+          <span class="muted">${this.items.length} fresh ${this.items.length === 1 ? 'role' : 'roles'}</span>
+        </header>
+        <div class="rec-row" role="list">
+          ${this.items.map(r => this._renderCard(r))}
+        </div>
+      </section>
+    `;
+  }
+}
+
+customElements.define('job-recommendations', JobRecommendations);

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -1,6 +1,8 @@
 // pipeline.js — thin client for the jobs-pipe Edge Function.
 const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/jobs-pipe';
 const LIVENESS_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/check-liveness';
+const ADD_ROLE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/add-role';
+const REC_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recommendations';
 
 async function authHeader() {
   const supabase = window.CtrlAuth?.getSupabaseClient?.();
@@ -49,6 +51,34 @@ export async function deleteRole(slug) {
     body: JSON.stringify({ slug, action: 'delete' }),
   });
   if (!res.ok) throw new Error(`delete-role ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function addRole({ url, title, company, sector, source, fromRecommendationId } = {}) {
+  const headers = await authHeader();
+  const res = await fetch(ADD_ROLE_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url, title, company, sector, source, fromRecommendationId }),
+  });
+  if (!res.ok) throw new Error(`add-role ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function fetchRecommendations() {
+  const headers = await authHeader();
+  const res = await fetch(REC_URL, { headers });
+  if (!res.ok) throw new Error(`recommendations ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+export async function dismissRecommendation(id) {
+  const headers = await authHeader();
+  const res = await fetch(REC_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, dismiss: true }),
+  });
+  if (!res.ok) throw new Error(`dismiss-rec ${res.status}: ${await res.text()}`);
   return res.json();
 }
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.28.0">
-  <script src="/job/js/theme.js?v=0.28.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
+  <script src="/job/js/theme.js?v=0.29.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.28.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
 </body>
 </html>

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -1,0 +1,135 @@
+// add-role — accept a pasted URL (and optional title/company) and insert
+// a new pipeline_role. Best-effort enrichment via the page's <title>; the
+// user can refine via the detail page.
+//
+// POST { url, title?, company?, source?, fromRecommendationId? }
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders, slugify, roleSlug } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+import { parseSectorTags } from '../_shared/sector-tags.ts';
+
+const VERSION = '0.1.0';
+console.log(`[add-role] v${VERSION}`);
+
+const URL_RE = /^https?:\/\//i;
+const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
+// LinkedIn job pages /jobs/view/{id}/ — try to coerce to the original
+// posting if the page reveals it. Best-effort; many LinkedIn URLs are
+// kept as-is.
+function detectSource(url: string): { source: string; sourceLabel: string } {
+  if (/(^|\.)linkedin\.com\b/i.test(url)) return { source: 'LinkedIn Saved', sourceLabel: 'LinkedIn Saved' };
+  if (/ashby(hq)?\.com|greenhouse|lever\.co|workday|smartrecruiters/i.test(url)) {
+    return { source: 'From Company Pages', sourceLabel: 'From Company Pages' };
+  }
+  return { source: 'Manual', sourceLabel: 'Manual' };
+}
+
+async function fetchTitle(url: string): Promise<string | null> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 8000);
+    const res = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ctrl-rodeo-job/1.0)' },
+      redirect: 'follow',
+      signal: ctrl.signal,
+    });
+    clearTimeout(t);
+    if (!res.ok) return null;
+    const html = await res.text();
+    const m = html.match(TITLE_RE);
+    if (!m) return null;
+    return m[1].replace(/&amp;/g, '&').replace(/&[a-z]+;/g, ' ').replace(/\s+/g, ' ').trim() || null;
+  } catch { return null; }
+}
+
+// "Senior PM, Foundations | Stripe" → { title: "Senior PM, Foundations", company: "Stripe" }
+function splitTitleCompany(pageTitle: string | null): { title?: string; company?: string } {
+  if (!pageTitle) return {};
+  const seps = [' | ', ' - ', ' – ', ' — ', ' at '];
+  for (const s of seps) {
+    const idx = pageTitle.indexOf(s);
+    if (idx > 0) return { title: pageTitle.slice(0, idx).trim(), company: pageTitle.slice(idx + s.length).trim() };
+  }
+  return { title: pageTitle };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+
+    const body = await req.json().catch(() => ({}));
+    const url = String(body.url || '').trim();
+    if (!url || !URL_RE.test(url)) return err('valid http(s) url required', 400);
+
+    let title = String(body.title || '').trim();
+    let company = String(body.company || '').trim();
+
+    if (!title || !company) {
+      const pageTitle = await fetchTitle(url);
+      const guess = splitTitleCompany(pageTitle);
+      if (!title && guess.title) title = guess.title;
+      if (!company && guess.company) company = guess.company;
+    }
+    if (!title) title = '(untitled role)';
+    if (!company) company = '(unknown company)';
+
+    const slug = roleSlug(company, title);
+    if (!slug) return err('could not derive slug from title/company', 400);
+
+    const { source, sourceLabel } = detectSource(url);
+    const finalSource = body.source ? String(body.source) : source;
+
+    const sql = db();
+    // Insert / restore — if a deleted row exists for this slug, un-delete it.
+    await sql`
+      insert into job.pipeline_roles (
+        slug, company_slug, company_name, title, url, source, status
+      ) values (
+        ${slug}, ${slugify(company)}, ${company}, ${title},
+        ${url}, ${finalSource}, 'New'
+      )
+      on conflict (slug) do update set
+        url = excluded.url,
+        title = excluded.title,
+        company_name = excluded.company_name,
+        company_slug = excluded.company_slug,
+        source = coalesce(job.pipeline_roles.source, excluded.source),
+        deleted_at = null,
+        archived_at = null,
+        updated_at = now();
+    `;
+
+    // Tag the row using whatever sector blob the user / recommendation passed.
+    const sector = String(body.sector || '').trim();
+    if (sector) {
+      await sql`update job.pipeline_roles set sector = ${sector} where slug = ${slug}`;
+      const tags = parseSectorTags(sector);
+      await sql`delete from job.role_sector_tags where role_slug = ${slug}`;
+      for (const t of tags) {
+        await sql`insert into job.sector_tags (slug, name) values (${t.slug}, ${t.name}) on conflict do nothing`;
+        await sql`insert into job.role_sector_tags (role_slug, tag_slug) values (${slug}, ${t.slug}) on conflict do nothing`;
+      }
+    }
+
+    // Wire the recommendation → pipeline link, if any.
+    if (body.fromRecommendationId) {
+      try {
+        await sql`
+          update job.recommended_roles
+          set added_to_pipeline_slug = ${slug}
+          where id = ${body.fromRecommendationId};
+        `;
+      } catch (e) { console.warn('[add-role] rec link failed', e); }
+    }
+
+    return jsonResp({ ok: true, slug, title, company, source: finalSource, sourceLabel });
+  } catch (e) {
+    console.error('[add-role] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -1,4 +1,4 @@
-// Bundled schema for migrate-job. Mirrors 047–052 from supabase/migrations.
+// Bundled schema for migrate-job. Mirrors 047–053 from supabase/migrations.
 export const SCHEMA_SQL = String.raw`
 -- /job product schema (Phase 2 migration foundation).
 -- Tables live in their own schema to avoid colliding with Boards.
@@ -197,14 +197,12 @@ begin
     execute format('alter table job.%I enable row level security;', t);
   end loop;
 end $$;
-
 -- 048 ----------------------------------------------------------------
 -- Allow analysis as a role_assets kind. The detail page stores Claude's
 -- structured analysis (brief, why-fits, risks, candidate-strength) here.
 alter table job.role_assets drop constraint if exists role_assets_kind_check;
 alter table job.role_assets add constraint role_assets_kind_check
   check (kind in ('resume', 'cover-letter', 'notes', 'analysis'));
-
 -- 049 ----------------------------------------------------------------
 -- Soft-archive flag for pipeline_roles. archived_at IS NULL means active;
 -- a non-null timestamp means the row is archived (hidden from the default
@@ -215,7 +213,6 @@ alter table job.pipeline_roles
 create index if not exists pipeline_roles_archived_idx
   on job.pipeline_roles (archived_at)
   where archived_at is not null;
-
 -- 050 ----------------------------------------------------------------
 -- Sector tag normalization. Free-text sector strings on pipeline_roles
 -- (e.g. "Healthcare AI", "Mental Health / AI", "Legal AI") get parsed into
@@ -237,7 +234,6 @@ create index if not exists role_sector_tags_tag_idx on job.role_sector_tags (tag
 
 alter table job.sector_tags enable row level security;
 alter table job.role_sector_tags enable row level security;
-
 -- 051 ----------------------------------------------------------------
 -- Soft-delete column for pipeline_roles. Hidden from every UI surface
 -- (no filter exposes it), kept in DB for continuity / undo.
@@ -247,7 +243,6 @@ alter table job.pipeline_roles
 create index if not exists pipeline_roles_deleted_idx
   on job.pipeline_roles (deleted_at)
   where deleted_at is null;
-
 -- 052 ----------------------------------------------------------------
 -- Liveness tracking for pipeline_roles. A background job HEADs each URL
 -- on a cadence; rows that 404 (or otherwise become unreachable) get
@@ -261,4 +256,35 @@ alter table job.pipeline_roles
 create index if not exists pipeline_roles_liveness_idx
   on job.pipeline_roles (liveness_checked_at nulls first)
   where deleted_at is null;
+-- 053 ----------------------------------------------------------------
+-- Recommendations staging. The /jobs skill (or future LinkedIn pull
+-- worker) inserts here; the recommendations Edge Function reads.
+-- Card layout in /job/jobs/ expects: logo, title, company · location ·
+-- salary, posted date, source, 3 bullets explaining the match.
+create table if not exists job.recommended_roles (
+  id              uuid primary key default gen_random_uuid(),
+  source          text not null,                 -- 'linkedin' | 'web' | 'manual'
+  source_id       text,                          -- per-source dedup key
+  source_label    text,                          -- "Web-sourced", "LinkedIn Recommended"
+  url             text not null,
+  company         text,
+  title           text,
+  location        text,                          -- "San Francisco (Hybrid)"
+  salary          text,                          -- "$320,000 – $375,000"
+  logo_url        text,
+  posted_at       timestamptz,                   -- "Posted 1w ago" derived
+  description     text,                          -- 1 sentence headline
+  match_bullets   jsonb,                         -- array of markdown strings (3 by convention)
+  suggested_at    timestamptz not null default now(),
+  dismissed_at    timestamptz,
+  added_to_pipeline_slug text references job.pipeline_roles(slug) on delete set null,
+  payload         jsonb,
+  unique (source, source_id)
+);
+
+create index if not exists recommended_roles_active_idx
+  on job.recommended_roles (suggested_at desc)
+  where dismissed_at is null and added_to_pipeline_slug is null;
+
+alter table job.recommended_roles enable row level security;
 `;

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -1,0 +1,49 @@
+// recommendations — list active recommendations for /job/jobs/.
+//
+//   GET                    → list active (not dismissed, not added)
+//   POST { id, dismiss:true }  → dismiss a recommendation
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[recommendations] v${VERSION}`);
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const rows = await sql`
+        select id, source, source_label as "sourceLabel", url, company, title, location,
+               salary, logo_url as "logoUrl", posted_at as "postedAt",
+               description, match_bullets as "matchBullets", suggested_at as "suggestedAt"
+        from job.recommended_roles
+        where dismissed_at is null and added_to_pipeline_slug is null
+        order by suggested_at desc
+        limit 24;
+      `;
+      return jsonResp({ ok: true, version: VERSION, count: rows.length, recommendations: rows });
+    }
+
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const id = body.id ? String(body.id) : '';
+      if (!id) return err('id required', 400);
+      if (body.dismiss) {
+        await sql`update job.recommended_roles set dismissed_at = now() where id = ${id}`;
+        return jsonResp({ ok: true, id, dismissed: true });
+      }
+      return err('unknown POST action', 400);
+    }
+
+    return err('GET or POST only', 405);
+  } catch (e) {
+    console.error('[recommendations] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/053_job_recommendations.sql
+++ b/supabase/migrations/053_job_recommendations.sql
@@ -1,0 +1,30 @@
+-- Recommendations staging. The /jobs skill (or future LinkedIn pull
+-- worker) inserts here; the recommendations Edge Function reads.
+-- Card layout in /job/jobs/ expects: logo, title, company · location ·
+-- salary, posted date, source, 3 bullets explaining the match.
+create table if not exists job.recommended_roles (
+  id              uuid primary key default gen_random_uuid(),
+  source          text not null,                 -- 'linkedin' | 'web' | 'manual'
+  source_id       text,                          -- per-source dedup key
+  source_label    text,                          -- "Web-sourced", "LinkedIn Recommended"
+  url             text not null,
+  company         text,
+  title           text,
+  location        text,                          -- "San Francisco (Hybrid)"
+  salary          text,                          -- "$320,000 – $375,000"
+  logo_url        text,
+  posted_at       timestamptz,                   -- "Posted 1w ago" derived
+  description     text,                          -- 1 sentence headline
+  match_bullets   jsonb,                         -- array of markdown strings (3 by convention)
+  suggested_at    timestamptz not null default now(),
+  dismissed_at    timestamptz,
+  added_to_pipeline_slug text references job.pipeline_roles(slug) on delete set null,
+  payload         jsonb,
+  unique (source, source_id)
+);
+
+create index if not exists recommended_roles_active_idx
+  on job.recommended_roles (suggested_at desc)
+  where dismissed_at is null and added_to_pipeline_slug is null;
+
+alter table job.recommended_roles enable row level security;


### PR DESCRIPTION
Two role-ingestion surfaces above the pipeline.

### Backend
- Migration 053: `job.recommended_roles` table with logo_url, posted_at, match_bullets jsonb, etc.
- `add-role` v0.1.0: paste a URL, server fetches `<title>`, derives source from domain, inserts (or un-deletes) a pipeline_roles row, refreshes sector tags, links any originating recommendation.
- `recommendations` v0.1.0: GET active recs, POST dismiss.

### Frontend (app v0.29.0)
- `<job-recommendations>` carousel above the Jobs table. Card matches the screenshot: square logo, big title, Company · Location · Salary, 'Posted Xw ago · 🌐 Web-sourced' source line, 3-4 markdown bullets explaining the match (**bold** for emphasis), Add-to-pipeline button + Dismiss link. Empty state + 3-card shimmer.
- '＋ Add a role' accent button in the meta line. Toggles a paste form; submit calls add-role, refreshes pipeline, opens the new role's detail page.

### Note
Recommendations table is empty for now — population comes from the LinkedIn pull worker (a separate task — currently the /jobs Claude skill writes to the sheet; we'd retarget it at this table). The card UI is ready and shows an empty state until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)