### PR TITLE
Stack Role+Company; liveness completion banner; animated Generating dots

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1214,3 +1214,51 @@
   gap: 4px;
   font-size: var(--font-size-small);
 }
+
+/* --- Role cell (title row 1, company row 2) --- */
+.role-cell { line-height: 1.3; }
+.role-cell__title {
+  font-weight: var(--fw-medium);
+  color: var(--fg);
+}
+.role-cell__company {
+  margin-top: 2px;
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+}
+
+/* --- Liveness completion banner --- */
+.liveness-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-md);
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-small);
+}
+.liveness-banner strong { color: var(--fg); }
+.liveness-banner--clean { background: rgba(47,87,17,0.10); border: 1px solid rgba(47,87,17,0.20); }
+.liveness-banner--closed { background: rgba(168,32,13,0.06); border: 1px solid rgba(168,32,13,0.18); }
+[data-theme="generic-dark"] .liveness-banner--clean  { background: rgba(159,232,112,0.08); border-color: rgba(159,232,112,0.22); }
+[data-theme="generic-dark"] .liveness-banner--closed { background: rgba(255,122,110,0.08); border-color: rgba(255,122,110,0.24); }
+
+/* --- Animated 'Generating' dots --- */
+.dots-anim::after {
+  content: '';
+  display: inline-block;
+  width: 1.2em;
+  text-align: left;
+  animation: dots-cycle 1.4s steps(4, end) infinite;
+}
+@keyframes dots-cycle {
+  0%   { content: ''; }
+  25%  { content: '.'; }
+  50%  { content: '..'; }
+  75%  { content: '...'; }
+  100% { content: ''; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dots-anim::after { content: '…'; animation: none; }
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.29.0';
-console.log(`[job] v${VERSION} - paste-a-link + recommendations widget`);
+const VERSION = '0.30.0';
+console.log(`[job] v${VERSION} - role+company stack, liveness banner, generating dots`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -22,15 +22,14 @@ const DIM_LABELS = {
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
-// Rows are tappable so the View button is gone; the rightmost cell now
-// holds only the triple-dot menu.
+// Role + Company collapsed into a single stacked cell: title row 1,
+// company row 2. Header sort defaults to title (alphabetical).
 const COLUMNS = [
-  { id: 'fit',     label: 'Fit',     sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
-  { id: 'status',  label: 'Status',  sortKey: 'status',  type: 'text' },
-  { id: 'company', label: 'Company', sortKey: 'company', type: 'text' },
-  { id: 'role',    label: 'Role',    sortKey: 'title',   type: 'text' },
-  { id: 'sector',  label: 'Sector',  sortKey: 'sector',  type: 'text' },
-  { id: 'menu',    label: '',        sortKey: null },
+  { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
+  { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
+  { id: 'role',   label: 'Role',   sortKey: 'title',   type: 'text' },
+  { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
+  { id: 'menu',   label: '',       sortKey: null },
 ];
 
 // Drop rows without an apply link, and any Strava postings (out of scope).
@@ -62,6 +61,8 @@ export class JobPipeline extends LitElement {
     archivedView: { state: true },   // 'active' | 'all' | 'archived'
     openMenuSlug: { state: true },
     livenessChecking: { state: true },
+    livenessResult: { state: true },
+    livenessResultDismissed: { state: true },
     closedSinceLastVisit: { state: true },
     bannerDismissed: { state: true },
     pasteOpen: { state: true },
@@ -81,6 +82,8 @@ export class JobPipeline extends LitElement {
     this.archivedView = 'active';
     this.openMenuSlug = null;
     this.livenessChecking = false;
+    this.livenessResult = null;            // { checked, closed: [slug…] }
+    this.livenessResultDismissed = false;
     this.closedSinceLastVisit = [];
     this.bannerDismissed = false;
     this.pasteOpen = false;
@@ -173,16 +176,19 @@ export class JobPipeline extends LitElement {
   async _onCheckLiveness() {
     if (this.livenessChecking) return;
     this.livenessChecking = true;
+    this.livenessResult = null;
+    this.livenessResultDismissed = false;
     this.requestUpdate();
     try {
       const res = await checkLiveness();
-      // Refresh the pipeline so newly-closed rows appear with archive/closed flags.
       const data = await fetchPipeline();
       this.roles = (data.roles || []).slice();
       this._computeClosedSinceLastVisit();
-      if (res.closed?.length) {
-        this.bannerDismissed = false;
-      }
+      this.livenessResult = {
+        checked: res.checked || 0,
+        closed: Array.isArray(res.closed) ? res.closed : [],
+      };
+      if (this.livenessResult.closed.length) this.bannerDismissed = false;
     } catch (e) {
       this.error = String(e);
     } finally {
@@ -366,8 +372,10 @@ export class JobPipeline extends LitElement {
           </select>
           ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
         </td>
-        <td><strong>${r.company}</strong></td>
-        <td>${r.title}</td>
+        <td class="role-cell">
+          <div class="role-cell__title">${r.title || '(untitled)'}</div>
+          <div class="role-cell__company">${r.company || ''}</div>
+        </td>
         <td>${this._renderSectorCell(r)}</td>
         <td>${this._renderMenuCell(r)}</td>
       </tr>
@@ -391,10 +399,12 @@ export class JobPipeline extends LitElement {
       <tr class="skeleton-row">
         <td><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
         <td><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>
-        <td><span class="skeleton" style="width:100px;height:16px;"></span></td>
-        <td><span class="skeleton" style="width:60%;height:16px;"></span></td>
+        <td>
+          <span class="skeleton" style="width:80%;height:14px;display:block;margin-bottom:6px;"></span>
+          <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
+        </td>
         <td><span class="skeleton" style="width:80px;height:16px;"></span></td>
-        <td><span class="skeleton skeleton--pill" style="width:64px;height:32px;"></span></td>
+        <td><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
       </tr>
     `;
   }
@@ -478,6 +488,24 @@ export class JobPipeline extends LitElement {
     const archivedCount = this.roles.filter(r => isVisibleRole(r) && isArchived(r)).length;
     return html`
       <job-recommendations></job-recommendations>
+
+      ${this.livenessResult && !this.livenessResultDismissed ? html`
+        <div class="liveness-banner ${this.livenessResult.closed.length ? 'liveness-banner--closed' : 'liveness-banner--clean'}" role="status">
+          <div>
+            ${this.livenessResult.closed.length
+              ? html`
+                <strong>${this.livenessResult.closed.length} of ${this.livenessResult.checked} ${this.livenessResult.checked === 1 ? 'role was' : 'roles were'} closed.</strong>
+                Archived and moved to Closed. <span class="muted">Pipeline updated.</span>
+              `
+              : html`
+                <strong>✓ All ${this.livenessResult.checked} ${this.livenessResult.checked === 1 ? 'role is' : 'roles are'} still live.</strong>
+                <span class="muted">Last checked just now.</span>
+              `}
+          </div>
+          <button class="row-menu__trigger" aria-label="Dismiss"
+                  @click=${() => { this.livenessResultDismissed = true; }}>×</button>
+        </div>
+      ` : nothing}
 
       ${!this.bannerDismissed && this.closedSinceLastVisit.length ? html`
         <div class="closed-banner" role="status">

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -273,7 +273,7 @@ export class JobRoleDetail extends LitElement {
           ${headerExtra || nothing}
         </header>
         <div class="role-card__body">
-          ${status === 'loading' ? html`<p class="muted">Generating…</p>`
+          ${status === 'loading' ? html`<p class="muted"><span class="dots-anim">Generating</span></p>`
             : status === 'error'  ? html`<p class="muted" style="color:var(--error);">Couldn't load</p>`
             : html`
               <div class="role-card__split">
@@ -350,7 +350,7 @@ export class JobRoleDetail extends LitElement {
     if (!a) return html`<div class="placeholder"><h2>Loading…</h2></div>`;
     if (a.saving && !a.content) {
       return html`<div class="placeholder">
-        <h2>Generating ${kind === 'resume' ? 'resume' : 'cover letter'}…</h2>
+        <h2><span class="dots-anim">Generating ${kind === 'resume' ? 'resume' : 'cover letter'}</span></h2>
         <p>Pulling Ian's KB + voice rules. ~10–20s.</p>
       </div>`;
     }
@@ -361,7 +361,7 @@ export class JobRoleDetail extends LitElement {
           <p>Generate one tailored to this role using the career KB and voice rules.</p>
           <div style="margin-top:var(--space-4);display:flex;justify-content:center;">
             <button class="btn btn--primary" ?disabled=${a.saving} @click=${() => this._onGenerate(kind)}>
-              ${a.saving ? 'Generating…' : `Generate ${kind === 'resume' ? 'resume' : 'cover letter'}`}
+              ${a.saving ? html`<span class="dots-anim">Generating</span>` : `Generate ${kind === 'resume' ? 'resume' : 'cover letter'}`}
             </button>
           </div>
           ${a.error ? html`<p class="muted" style="color:var(--error);margin-top:var(--space-3);">${a.error}</p>` : nothing}

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.29.0">
-  <script src="/job/js/theme.js?v=0.29.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
+  <script src="/job/js/theme.js?v=0.30.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.29.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Three batched UX changes.

1. **Role + Company stacked.** One cell, title on row 1, company on row 2. Header sort defaults to title alphabetical. Skeleton matches the new shape.
2. **Liveness completion banner.** After Check-liveness: '✓ All N roles still live' or 'M of N closed and archived'. × to dismiss.
3. **Animated 'Generating' dots** on detail-page asset loaders. CSS keyframes cycle . / .. / …; respects prefers-reduced-motion.

App bumped to 0.30.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)