### PR TITLE
Square company logos on Jobs list, recommendations, detail

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1262,3 +1262,41 @@
 @media (prefers-reduced-motion: reduce) {
   .dots-anim::after { content: '…'; animation: none; }
 }
+
+/* --- Square company logo (table rows, detail header) --- */
+.company-logo {
+  display: inline-block;
+  flex-shrink: 0;
+  background: var(--bg-surface);
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  vertical-align: middle;
+}
+.company-logo--sm { width: 28px; height: 28px; border-radius: var(--radius-sm); }
+.company-logo--md { width: 40px; height: 40px; }
+.company-logo--lg { width: 56px; height: 56px; border-radius: var(--radius-md); }
+
+.company-logo--placeholder {
+  display: inline-grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+}
+.company-logo--placeholder.company-logo--sm { font-size: 14px; }
+.company-logo--placeholder.company-logo--md { font-size: 18px; }
+.company-logo--placeholder.company-logo--lg { font-size: 24px; }
+
+.role-cell__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.role-header__lead {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  min-width: 0;
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.31.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.31.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.31.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.31.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.30.0';
-console.log(`[job] v${VERSION} - role+company stack, liveness banner, generating dots`);
+const VERSION = '0.31.0';
+console.log(`[job] v${VERSION} - company logos`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -3,6 +3,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
 const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
+const { logoSrc, logoInitial } = await import('../logo.js' + V);
 // Mount the recommendations widget. It self-loads when the user is signed in.
 import('./job-recommendations.js' + V);
 
@@ -373,12 +374,37 @@ export class JobPipeline extends LitElement {
           ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
         </td>
         <td class="role-cell">
-          <div class="role-cell__title">${r.title || '(untitled)'}</div>
-          <div class="role-cell__company">${r.company || ''}</div>
+          <div class="role-cell__inner">
+            ${this._renderLogo(r, 'sm')}
+            <div>
+              <div class="role-cell__title">${r.title || '(untitled)'}</div>
+              <div class="role-cell__company">${r.company || ''}</div>
+            </div>
+          </div>
         </td>
         <td>${this._renderSectorCell(r)}</td>
         <td>${this._renderMenuCell(r)}</td>
       </tr>
+    `;
+  }
+
+  _renderLogo(r, size = 'sm') {
+    const src = logoSrc(r);
+    const cls = `company-logo company-logo--${size}`;
+    if (!src) {
+      return html`<span class=${cls + ' company-logo--placeholder'} aria-hidden="true">${logoInitial(r.company)}</span>`;
+    }
+    return html`
+      <img class=${cls} src=${src} alt=""
+           loading="lazy" decoding="async"
+           @error=${(e) => {
+             // Swap to placeholder when Clearbit returns 404.
+             const span = document.createElement('span');
+             span.className = cls + ' company-logo--placeholder';
+             span.setAttribute('aria-hidden', 'true');
+             span.textContent = logoInitial(r.company);
+             e.target.replaceWith(span);
+           }}/>
     `;
   }
 

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -5,9 +5,10 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }, { logoSrc, logoInitial }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
+  import('../logo.js' + V),
 ]);
 
 function relTime(iso) {
@@ -101,9 +102,19 @@ export class JobRecommendations extends LitElement {
     return html`
       <article class="rec-card" role="listitem">
         <header class="rec-card__head">
-          ${rec.logoUrl
-            ? html`<img class="rec-card__logo" src=${rec.logoUrl} alt="${rec.company || ''} logo" />`
-            : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${(rec.company || '?').slice(0, 1)}</div>`}
+          ${(() => {
+            const src = rec.logoUrl || logoSrc(rec);
+            return src
+              ? html`<img class="rec-card__logo" src=${src} alt="" loading="lazy" decoding="async"
+                          @error=${(e) => {
+                            const div = document.createElement('div');
+                            div.className = 'rec-card__logo rec-card__logo--placeholder';
+                            div.setAttribute('aria-hidden', 'true');
+                            div.textContent = logoInitial(rec.company);
+                            e.target.replaceWith(div);
+                          }}/>`
+              : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${logoInitial(rec.company)}</div>`;
+          })()}
           <div class="rec-card__title-block">
             <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
             ${meta ? html`<p class="rec-card__meta">${meta}</p>` : nothing}

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -5,10 +5,11 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
+  import('../logo.js' + V),
 ]);
 
 const TABS = [
@@ -400,9 +401,25 @@ export class JobRoleDetail extends LitElement {
         <span>${r.title || this.slug}</span>
       </nav>
       <header class="role-header">
-        <div class="role-header__title">
-          <h1>${r.title || this.slug}</h1>
-          <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+        <div class="role-header__lead">
+          ${(() => {
+            const src = logoSrc(r);
+            return src
+              ? html`<img class="company-logo company-logo--lg" src=${src} alt=""
+                          loading="lazy" decoding="async"
+                          @error=${(e) => {
+                            const span = document.createElement('span');
+                            span.className = 'company-logo company-logo--lg company-logo--placeholder';
+                            span.setAttribute('aria-hidden', 'true');
+                            span.textContent = logoInitial(r.company);
+                            e.target.replaceWith(span);
+                          }}/>`
+              : html`<span class="company-logo company-logo--lg company-logo--placeholder" aria-hidden="true">${logoInitial(r.company)}</span>`;
+          })()}
+          <div class="role-header__title">
+            <h1>${r.title || this.slug}</h1>
+            <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+          </div>
         </div>
         <div class="role-header__actions">
           ${r.url ? html`

--- a/job/js/logo.js
+++ b/job/js/logo.js
@@ -1,0 +1,56 @@
+// logo.js — derive a company logo URL from a role's posting URL or
+// company name. Best-effort. Pure client-side; no DB column needed.
+//
+//   logoSrc(role) → a Clearbit logo URL, or null if we can't guess.
+//   logoInitial(company) → first letter for the placeholder fallback.
+
+const ATS_HOSTS = /(ashbyhq|greenhouse(?:\.io)?|lever\.co|workday(?:jobs)?|smartrecruiters|linkedin|indeed)\.(com|co|io)$/i;
+const COMPANY_DOMAIN_OVERRIDES = {
+  // Hand-curated where domain-from-name doesn't work. Add as needed.
+  'abridge': 'abridge.com',
+  'ambience': 'ambiencehealthcare.com',
+  'ambience healthcare': 'ambiencehealthcare.com',
+  'general medicine': 'generalmedicine.com',
+  'maven clinic': 'mavenclinic.com',
+  'verily health': 'verily.com',
+  'sully.ai': 'sully.ai',
+  'evenup': 'evenuplaw.com',
+  'plaud': 'plaud.ai',
+  'crossing hurdles': 'crossinghurdles.com',
+  'rec technologies': 'rec.io',
+  'develop health': 'develophealth.io',
+  'spring health': 'springhealth.com',
+};
+
+function looksLikeAts(host) { return ATS_HOSTS.test(host); }
+
+export function logoSrc(role) {
+  if (!role) return null;
+  if (role.logoUrl) return role.logoUrl;
+
+  // Try the explicit posting URL first.
+  let domain = null;
+  try {
+    if (role.url) {
+      const host = new URL(role.url).hostname.replace(/^www\./, '');
+      if (!looksLikeAts(host)) domain = host;
+    }
+  } catch { /* ignore */ }
+
+  // Fall back to a guess from the company name.
+  if (!domain && role.company) {
+    const key = role.company.trim().toLowerCase();
+    if (COMPANY_DOMAIN_OVERRIDES[key]) {
+      domain = COMPANY_DOMAIN_OVERRIDES[key];
+    } else {
+      const slug = role.company.toLowerCase().replace(/[^a-z0-9]/g, '');
+      if (slug.length >= 2) domain = `${slug}.com`;
+    }
+  }
+  if (!domain) return null;
+  return `https://logo.clearbit.com/${domain}`;
+}
+
+export function logoInitial(company) {
+  return (company || '?').trim().charAt(0).toUpperCase() || '?';
+}

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.30.0">
-  <script src="/job/js/theme.js?v=0.30.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
+  <script src="/job/js/theme.js?v=0.31.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.30.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.31.0"></script>
 </body>
 </html>


### PR DESCRIPTION
New `job/js/logo.js`. Logos via Clearbit (no key required). Tries role.url hostname; skips ATS subdomains; falls back to a hand-curated map then a `{slug}.com` guess. Placeholder square with the company initial when the image 404s.

- **Pipeline row**: 28×28 logo before the title.
- **Detail header**: 56×56 logo to the left of the title.
- **Recommendations card**: server-supplied logoUrl wins, otherwise logoSrc fallback.

App bumped to 0.31.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)