### PR TITLE
Company logos in pipeline, role detail, and recommendations

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1217,6 +1217,13 @@
 
 /* --- Role cell (title row 1, company row 2) --- */
 .role-cell { line-height: 1.3; }
+.role-cell__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+.role-cell__text { min-width: 0; }
 .role-cell__title {
   font-weight: var(--fw-medium);
   color: var(--fg);
@@ -1225,6 +1232,32 @@
   margin-top: 2px;
   font-size: var(--font-size-small);
   color: var(--fg-subtle);
+}
+
+/* --- Company logo (shared across pipeline + detail) --- */
+.company-logo {
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  object-fit: contain;
+}
+.company-logo--lg { border-radius: var(--radius-md); }
+.company-logo--placeholder {
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.company-logo--lg.company-logo--placeholder { font-size: var(--font-size-title-3); }
+
+.role-header__lead {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+  min-width: 0;
 }
 
 /* --- Liveness completion banner --- */

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.30.0';
-console.log(`[job] v${VERSION} - role+company stack, liveness banner, generating dots`);
+const VERSION = '0.31.0';
+console.log(`[job] v${VERSION} - company logos in pipeline, detail header, recommendations`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/companyLogo.js
+++ b/job/js/companyLogo.js
@@ -1,0 +1,85 @@
+// companyLogo — derive a favicon URL for a job posting. Prefers the
+// company's own domain; falls back through common ATS host patterns
+// (greenhouse, lever, ashby, etc.) so the logo is the company's, not
+// the ATS provider's. Returns null when we can't derive a useful host.
+
+// ATS / aggregator hosts whose favicon would be the platform, not the
+// employer. When we land on one of these, derive the company slug from
+// the URL path and use `<slug>.com` as a guess for the favicon source.
+const ATS_HOSTS = [
+  /(^|\.)greenhouse\.io$/i,
+  /(^|\.)lever\.co$/i,
+  /(^|\.)ashbyhq\.com$/i,
+  /(^|\.)workable\.com$/i,
+  /(^|\.)smartrecruiters\.com$/i,
+  /(^|\.)recruitee\.com$/i,
+  /(^|\.)bamboohr\.com$/i,
+  /(^|\.)jobvite\.com$/i,
+  /(^|\.)workday(jobs)?\.com$/i,
+  /(^|\.)icims\.com$/i,
+  /(^|\.)taleo\.net$/i,
+  /(^|\.)breezy\.hr$/i,
+  /(^|\.)rippling\.com$/i,
+  /(^|\.)pinpointhq\.com$/i,
+  /(^|\.)teamtailor\.com$/i,
+  /(^|\.)wellfound\.com$/i,
+  /(^|\.)angel\.co$/i,
+  /(^|\.)builtin\.com$/i,
+  /(^|\.)linkedin\.com$/i,
+  /(^|\.)indeed\.com$/i,
+  /(^|\.)glassdoor\.com$/i,
+];
+
+function isAts(host) {
+  return ATS_HOSTS.some(re => re.test(host));
+}
+
+function slugifyCompany(name) {
+  return String(name || '')
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, '')
+    .slice(0, 40);
+}
+
+// Pull a likely company slug out of an ATS URL path.
+//   boards.greenhouse.io/<slug>/jobs/...     → slug
+//   jobs.lever.co/<slug>/...                 → slug
+//   jobs.ashbyhq.com/<slug>/...              → slug
+//   <slug>.workable.com / .recruitee.com     → already a subdomain
+function atsSlugFromUrl(u) {
+  const host = u.hostname;
+  const seg = u.pathname.split('/').filter(Boolean);
+  if (/greenhouse\.io$/i.test(host) || /lever\.co$/i.test(host) || /ashbyhq\.com$/i.test(host) ||
+      /smartrecruiters\.com$/i.test(host) || /jobvite\.com$/i.test(host) ||
+      /pinpointhq\.com$/i.test(host) || /teamtailor\.com$/i.test(host)) {
+    return seg[0] || '';
+  }
+  // <slug>.workable.com etc.
+  const parts = host.split('.');
+  if (parts.length >= 3) return parts[0];
+  return '';
+}
+
+// Returns a favicon URL or null. Prefers the role's URL host; if it's an
+// ATS, derives a guess from the path/subdomain or the company name.
+export function companyLogoUrl({ url, company } = {}) {
+  let domain = '';
+  if (url) {
+    try {
+      const u = new URL(url);
+      if (isAts(u.hostname)) {
+        const slug = atsSlugFromUrl(u) || slugifyCompany(company);
+        if (slug) domain = `${slug}.com`;
+      } else {
+        domain = u.hostname.replace(/^www\./i, '');
+      }
+    } catch { /* fall through */ }
+  }
+  if (!domain && company) {
+    const slug = slugifyCompany(company);
+    if (slug) domain = `${slug}.com`;
+  }
+  if (!domain) return null;
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=64`;
+}

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -3,6 +3,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
 const { fetchPipeline, setStatus, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
+const { companyLogoUrl } = await import('../companyLogo.js' + V);
 // Mount the recommendations widget. It self-loads when the user is signed in.
 import('./job-recommendations.js' + V);
 
@@ -303,6 +304,28 @@ export class JobPipeline extends LitElement {
   }
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
+  _renderCompanyLogo(r, size = 28) {
+    const src = companyLogoUrl({ url: r.url, company: r.company });
+    const initial = (r.company || '?').slice(0, 1).toUpperCase();
+    const sizePx = `${size}px`;
+    if (!src) {
+      return html`<div class="company-logo company-logo--placeholder"
+                       style="width:${sizePx};height:${sizePx};" aria-hidden="true">${initial}</div>`;
+    }
+    return html`<img class="company-logo" style="width:${sizePx};height:${sizePx};"
+                     src=${src} alt="${r.company || ''} logo"
+                     loading="lazy" referrerpolicy="no-referrer"
+                     @error=${(e) => {
+                       const ph = document.createElement('div');
+                       ph.className = 'company-logo company-logo--placeholder';
+                       ph.style.width = sizePx;
+                       ph.style.height = sizePx;
+                       ph.setAttribute('aria-hidden', 'true');
+                       ph.textContent = initial;
+                       e.target.replaceWith(ph);
+                     }} />`;
+  }
+
   _renderMenuCell(r) {
     const archived = isArchived(r);
     const menuOpen = this.openMenuSlug === r.slug;
@@ -373,8 +396,13 @@ export class JobPipeline extends LitElement {
           ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
         </td>
         <td class="role-cell">
-          <div class="role-cell__title">${r.title || '(untitled)'}</div>
-          <div class="role-cell__company">${r.company || ''}</div>
+          <div class="role-cell__inner">
+            ${this._renderCompanyLogo(r, 28)}
+            <div class="role-cell__text">
+              <div class="role-cell__title">${r.title || '(untitled)'}</div>
+              <div class="role-cell__company">${r.company || ''}</div>
+            </div>
+          </div>
         </td>
         <td>${this._renderSectorCell(r)}</td>
         <td>${this._renderMenuCell(r)}</td>

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -5,9 +5,10 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }, { companyLogoUrl }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
+  import('../companyLogo.js' + V),
 ]);
 
 function relTime(iso) {
@@ -101,9 +102,21 @@ export class JobRecommendations extends LitElement {
     return html`
       <article class="rec-card" role="listitem">
         <header class="rec-card__head">
-          ${rec.logoUrl
-            ? html`<img class="rec-card__logo" src=${rec.logoUrl} alt="${rec.company || ''} logo" />`
-            : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${(rec.company || '?').slice(0, 1)}</div>`}
+          ${(() => {
+            const src = rec.logoUrl || companyLogoUrl({ url: rec.url, company: rec.company });
+            const initial = (rec.company || '?').slice(0, 1);
+            return src
+              ? html`<img class="rec-card__logo" src=${src} alt="${rec.company || ''} logo"
+                          loading="lazy" referrerpolicy="no-referrer"
+                          @error=${(e) => {
+                            const ph = document.createElement('div');
+                            ph.className = 'rec-card__logo rec-card__logo--placeholder';
+                            ph.setAttribute('aria-hidden', 'true');
+                            ph.textContent = initial;
+                            e.target.replaceWith(ph);
+                          }} />`
+              : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${initial}</div>`;
+          })()}
           <div class="rec-card__title-block">
             <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
             ${meta ? html`<p class="rec-card__meta">${meta}</p>` : nothing}

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -5,11 +5,35 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }, { companyLogoUrl }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
+  import('../companyLogo.js' + V),
 ]);
+
+function renderCompanyLogo(role, size = 44) {
+  const src = companyLogoUrl({ url: role?.url, company: role?.company });
+  const initial = (role?.company || '?').slice(0, 1).toUpperCase();
+  const sizePx = `${size}px`;
+  if (!src) {
+    return html`<div class="company-logo company-logo--placeholder company-logo--lg"
+                     style="width:${sizePx};height:${sizePx};" aria-hidden="true">${initial}</div>`;
+  }
+  return html`<img class="company-logo company-logo--lg"
+                   style="width:${sizePx};height:${sizePx};"
+                   src=${src} alt="${role?.company || ''} logo"
+                   loading="lazy" referrerpolicy="no-referrer"
+                   @error=${(e) => {
+                     const ph = document.createElement('div');
+                     ph.className = 'company-logo company-logo--placeholder company-logo--lg';
+                     ph.style.width = sizePx;
+                     ph.style.height = sizePx;
+                     ph.setAttribute('aria-hidden', 'true');
+                     ph.textContent = initial;
+                     e.target.replaceWith(ph);
+                   }} />`;
+}
 
 const TABS = [
   { id: 'details',      label: 'Details' },
@@ -400,9 +424,12 @@ export class JobRoleDetail extends LitElement {
         <span>${r.title || this.slug}</span>
       </nav>
       <header class="role-header">
-        <div class="role-header__title">
-          <h1>${r.title || this.slug}</h1>
-          <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+        <div class="role-header__lead">
+          ${renderCompanyLogo(r, 44)}
+          <div class="role-header__title">
+            <h1>${r.title || this.slug}</h1>
+            <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+          </div>
         </div>
         <div class="role-header__actions">
           ${r.url ? html`
@@ -492,9 +519,12 @@ export class JobRoleDetail extends LitElement {
       </nav>
 
       <header class="role-header">
-        <div class="role-header__title">
-          <h1>${r?.title || this.slug}</h1>
-          <p class="role-header__sub">${r?.company || ''}${r?.sector ? ` · ${r.sector}` : ''}</p>
+        <div class="role-header__lead">
+          ${renderCompanyLogo(r, 44)}
+          <div class="role-header__title">
+            <h1>${r?.title || this.slug}</h1>
+            <p class="role-header__sub">${r?.company || ''}${r?.sector ? ` · ${r.sector}` : ''}</p>
+          </div>
         </div>
         <div class="role-header__actions">
           ${r?.url ? html`


### PR DESCRIPTION
## Summary
- New `job/js/companyLogo.js` helper derives a favicon URL from the posting URL (or company name fallback). Detects ATS hosts (greenhouse, lever, ashby, workable, etc.) and reroutes to the employer's domain rather than showing the platform's logo.
- Added logos to the pipeline Role cell, the role detail header, and the recommendations card (as a fallback when the recommended_roles row has no `logo_url`).
- Shared `.company-logo` CSS with placeholder fallback (initial letter) on image error.
- Bumped `[job]` to v0.31.0.

## Recommendations bug — root cause
The "No recommendations yet" empty state is correct: nothing currently writes to `job.recommended_roles`. The widget reads from that table (via `recommendations` Edge Function), and the migration (053) was added in anticipation of a LinkedIn pull worker that doesn't exist yet. The /jobs skill writes to a Google Sheet, not Postgres. To get recommendations to surface, we need either a worker that inserts rows or to extend /jobs to POST into recommended_roles.

## Test plan
- [ ] /job/jobs/ — logos render next to each row
- [ ] /job/jobs/{slug}/ — logo renders in detail header
- [ ] Recommendations card shows logo when `logoUrl` is null
- [ ] Placeholder (initial letter) appears when favicon 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)