### PR TITLE
Recommendations pull worker (phase 1) + tracked-companies ATS source

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1149,6 +1149,13 @@
   color: var(--fg-muted);
 }
 .rec-card__title-block { min-width: 0; flex: 1; }
+.rec-card__title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.rec-card__title-row .fit-pill { flex-shrink: 0; }
 .rec-card__title {
   margin: 0;
   font-family: var(--font-display);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.31.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.31.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.31.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.31.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.31.2';
-console.log(`[job] v${VERSION} - logo on role detail post-load render too`);
+const VERSION = '0.32.0';
+console.log(`[job] v${VERSION} - fit pill on recommendation cards`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -96,6 +96,14 @@ export class JobRecommendations extends LitElement {
     }
   }
 
+  _fitClass(s) {
+    if (s == null) return 'fit-pill fit-pill--poor';
+    if (s >= 70) return 'fit-pill fit-pill--strong';
+    if (s >= 50) return 'fit-pill fit-pill--ok';
+    if (s >= 30) return 'fit-pill fit-pill--weak';
+    return 'fit-pill fit-pill--poor';
+  }
+
   _renderCard(rec) {
     const meta = [rec.company, rec.location, rec.salary].filter(Boolean).join('  •  ');
     const bullets = Array.isArray(rec.matchBullets) ? rec.matchBullets : [];
@@ -116,7 +124,12 @@ export class JobRecommendations extends LitElement {
               : html`<div class="rec-card__logo rec-card__logo--placeholder" aria-hidden="true">${logoInitial(rec.company)}</div>`;
           })()}
           <div class="rec-card__title-block">
-            <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
+            <div class="rec-card__title-row">
+              <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
+              ${rec.fitScore != null
+                ? html`<span class=${this._fitClass(rec.fitScore)} title="Fit score">${rec.fitScore}</span>`
+                : nothing}
+            </div>
             ${meta ? html`<p class="rec-card__meta">${meta}</p>` : nothing}
             <p class="rec-card__source">
               ${rec.postedAt ? html`Posted ${relTime(rec.postedAt)}` : nothing}

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.31.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/sources/fixture.ts
+++ b/supabase/functions/_shared/sources/fixture.ts
@@ -1,0 +1,33 @@
+// fixture — synthetic source for end-to-end testing of the worker
+// pipeline before any real plugin is wired up. Returns N hardcoded
+// postings tagged with the current run timestamp so dedup is easy to
+// reason about during smoke tests.
+import type { Source, RecommendedRoleInput } from './types.ts';
+
+interface FixtureConfig {
+  count?: number;     // how many synthetic rows to emit
+}
+
+export const fixtureSource: Source<FixtureConfig> = {
+  type: 'fixture',
+  async pull(cfg) {
+    const count = Math.max(1, Math.min(10, cfg.count ?? 3));
+    const stamp = new Date().toISOString().slice(0, 16);
+    const rows: RecommendedRoleInput[] = [];
+    for (let i = 0; i < count; i++) {
+      rows.push({
+        source:      'fixture',
+        sourceId:    `fixture-${stamp}-${i}`,
+        sourceLabel: 'Fixture',
+        url:         `https://example.com/jobs/${stamp}-${i}`,
+        company:     'Acme Co',
+        title:       `Synthetic Role ${i + 1}`,
+        location:    'Remote',
+        salary:      '$200k – $250k',
+        postedAt:    new Date().toISOString(),
+        description: 'This is a fixture posting used to validate the worker pipeline.',
+      });
+    }
+    return rows;
+  },
+};

--- a/supabase/functions/_shared/sources/registry.ts
+++ b/supabase/functions/_shared/sources/registry.ts
@@ -1,0 +1,10 @@
+// Source registry — the worker looks plugins up by `type` here.
+// Adding a source = import the plugin and add it to this map.
+import type { Source } from './types.ts';
+import { fixtureSource } from './fixture.ts';
+import { trackedAtsSource } from './tracked-ats.ts';
+
+export const SOURCES: Record<string, Source> = {
+  [fixtureSource.type]:     fixtureSource,
+  [trackedAtsSource.type]:  trackedAtsSource,
+};

--- a/supabase/functions/_shared/sources/tracked-ats.ts
+++ b/supabase/functions/_shared/sources/tracked-ats.ts
@@ -1,0 +1,117 @@
+// tracked-ats — pulls open postings from every row in
+// job.tracked_companies that has an `ats` + `ats_slug`. One plugin
+// covers Greenhouse, Lever, and Ashby because their public job-board
+// APIs don't require auth and return roughly the same shape.
+//
+// Config is empty: the company list comes from the DB, not from the
+// user_sources row. That keeps "tracked companies" a single concept —
+// you add a company once, it shows up everywhere.
+
+import type { Source, RecommendedRoleInput } from './types.ts';
+import { db } from '../job-db.ts';
+
+interface TrackedCompany {
+  slug: string;
+  name: string;
+  ats: string | null;
+  ats_slug: string | null;
+  sector: string | null;
+}
+
+// ---------- Per-ATS adapters ----------
+// Each returns the same RecommendedRoleInput shape so the worker
+// downstream is ATS-agnostic.
+
+async function pullGreenhouse(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
+  const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(c.ats_slug!)}/jobs`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`greenhouse ${c.ats_slug} → ${res.status}`);
+  const data = await res.json() as { jobs: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string } }> };
+  return (data.jobs || []).map(j => ({
+    source:      'tracked-ats',
+    sourceId:    `gh:${c.ats_slug}:${j.id}`,
+    sourceLabel: `Greenhouse · ${c.name}`,
+    url:         j.absolute_url,
+    company:     c.name,
+    title:       j.title,
+    location:    j.location?.name,
+    postedAt:    j.updated_at,
+    payload:     { ats: 'Greenhouse', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
+  }));
+}
+
+async function pullLever(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
+  const url = `https://api.lever.co/v0/postings/${encodeURIComponent(c.ats_slug!)}?mode=json`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`lever ${c.ats_slug} → ${res.status}`);
+  const data = await res.json() as Array<{ id: string; text: string; hostedUrl: string; createdAt: number; categories?: { location?: string } }>;
+  return (data || []).map(j => ({
+    source:      'tracked-ats',
+    sourceId:    `lever:${c.ats_slug}:${j.id}`,
+    sourceLabel: `Lever · ${c.name}`,
+    url:         j.hostedUrl,
+    company:     c.name,
+    title:       j.text,
+    location:    j.categories?.location,
+    postedAt:    j.createdAt ? new Date(j.createdAt).toISOString() : undefined,
+    payload:     { ats: 'Lever', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
+  }));
+}
+
+async function pullAshby(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
+  const url = `https://api.ashbyhq.com/posting-api/job-board/${encodeURIComponent(c.ats_slug!)}?includeCompensation=true`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`ashby ${c.ats_slug} → ${res.status}`);
+  const data = await res.json() as { jobs?: Array<{ id: string; title: string; jobUrl: string; publishedAt?: string; locationName?: string; compensationTierSummary?: string }> };
+  return (data.jobs || []).map(j => ({
+    source:      'tracked-ats',
+    sourceId:    `ashby:${c.ats_slug}:${j.id}`,
+    sourceLabel: `Ashby · ${c.name}`,
+    url:         j.jobUrl,
+    company:     c.name,
+    title:       j.title,
+    location:    j.locationName,
+    salary:      j.compensationTierSummary,
+    postedAt:    j.publishedAt,
+    payload:     { ats: 'Ashby', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
+  }));
+}
+
+const ADAPTERS: Record<string, (c: TrackedCompany) => Promise<RecommendedRoleInput[]>> = {
+  greenhouse: pullGreenhouse,
+  lever:      pullLever,
+  ashby:      pullAshby,
+};
+
+export const trackedAtsSource: Source = {
+  type: 'tracked-ats',
+  async pull(_cfg, ctx) {
+    const sql = db();
+    const companies = await sql<TrackedCompany[]>`
+      select slug, name, ats, ats_slug, sector
+      from job.tracked_companies
+      where ats is not null and ats_slug is not null
+    `;
+    const out: RecommendedRoleInput[] = [];
+    for (const c of companies) {
+      const adapter = ADAPTERS[(c.ats || '').toLowerCase()];
+      if (!adapter) continue;
+      try {
+        const rawRows = await adapter(c);
+        // Stamp the company's sector onto every posting so the worker's
+        // fit step has signal beyond just the title.
+        const rows = rawRows.map(r => ({ ...r, sector: r.sector ?? c.sector ?? undefined }));
+        // Optional `since` filter — postedAt is sometimes missing, in
+        // which case we keep the row (better to overshoot than to lose
+        // a posting that lacks a timestamp).
+        const filtered = ctx.since
+          ? rows.filter(r => !r.postedAt || new Date(r.postedAt) >= ctx.since!)
+          : rows;
+        out.push(...filtered);
+      } catch (e) {
+        console.warn(`[tracked-ats] ${c.ats}/${c.ats_slug}: ${(e as Error).message}`);
+      }
+    }
+    return out;
+  },
+};

--- a/supabase/functions/_shared/sources/types.ts
+++ b/supabase/functions/_shared/sources/types.ts
@@ -1,0 +1,44 @@
+// Shape every Source plugin returns. Maps 1:1 onto the columns the
+// pull-recommendations worker writes into job.recommended_roles.
+//
+// `source` and `sourceId` together must be unique across all rows the
+// plugin ever emits — the worker relies on the unique(source, source_id)
+// constraint to dedupe across runs.
+export interface RecommendedRoleInput {
+  source:        string;            // 'tracked-ats' | 'linkedin-rss' | …
+  sourceId:      string;            // stable per posting (e.g. ATS posting ID)
+  sourceLabel?:  string;            // user-facing, e.g. "Greenhouse · Abridge"
+  url:           string;
+  company?:      string;
+  title?:        string;
+  location?:     string;
+  salary?:       string;
+  logoUrl?:      string;
+  postedAt?:     string;            // ISO8601
+  description?:  string;
+  // Scoring hints — plugins fill these from whatever metadata they can
+  // grab so the fit-score step has signal to work with. Optional;
+  // missing fields fall back to neutral defaults inside computeFit.
+  sector?:       string;
+  investors?:    string[];
+  // matchBullets are produced post-pull by the worker; plugins leave
+  // this empty and let the worker generate them once per new row.
+  payload?:      Record<string, unknown>;
+}
+
+// A Source<Cfg> is a pure function from config → array of postings. No
+// DB access, no env vars beyond what the plugin needs for the upstream
+// API. Throwing is fine — the worker captures errors per source.
+export interface Source<Cfg = Record<string, unknown>> {
+  type:        string;
+  pull(cfg: Cfg, ctx: SourceContext): Promise<RecommendedRoleInput[]>;
+}
+
+// What the worker passes to every plugin. Kept tiny on purpose —
+// expand only when a plugin actually needs it.
+export interface SourceContext {
+  userEmail: string;
+  // `since` lets a plugin skip postings older than the last successful
+  // run. May be null on first run.
+  since: Date | null;
+}

--- a/supabase/functions/migrate-job/schema.ts
+++ b/supabase/functions/migrate-job/schema.ts
@@ -282,9 +282,39 @@ create table if not exists job.recommended_roles (
   unique (source, source_id)
 );
 
+alter table job.recommended_roles
+  add column if not exists fit_score      int,
+  add column if not exists fit_breakdown  jsonb,
+  add column if not exists hard_fails     text[] default '{}',
+  add column if not exists sector         text,
+  add column if not exists investors      text[] default '{}',
+  add column if not exists user_email     text,
+  add column if not exists user_source_id uuid;
+
 create index if not exists recommended_roles_active_idx
   on job.recommended_roles (suggested_at desc)
-  where dismissed_at is null and added_to_pipeline_slug is null;
+  where dismissed_at is null
+    and added_to_pipeline_slug is null
+    and (fit_score is null or fit_score >= 50);
 
 alter table job.recommended_roles enable row level security;
+
+-- User-configured recommendation sources (see migration 054).
+create table if not exists job.user_sources (
+  id              uuid primary key default gen_random_uuid(),
+  user_email      text not null,
+  type            text not null,
+  label           text,
+  config          jsonb not null default '{}'::jsonb,
+  enabled         boolean not null default true,
+  schedule_cron   text not null default '0 */6 * * *',
+  min_score       int not null default 50,
+  last_run_at     timestamptz,
+  last_run_count  int,
+  last_dropped    int,
+  last_error      text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+alter table job.user_sources enable row level security;
 `;

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -1,0 +1,273 @@
+// pull-recommendations — single tick of the recommendations worker.
+//
+// On every invocation:
+//   1. Find user_sources rows that are enabled and due per schedule_cron.
+//   2. For each one, look up the plugin in SOURCES[type] and call pull().
+//   3. Score every returned posting with the same fit logic as the pipeline.
+//   4. Drop hard-failed roles AND roles below user_sources.min_score.
+//   5. Insert survivors into job.recommended_roles using ON CONFLICT
+//      DO NOTHING RETURNING * to learn which rows are actually new.
+//   6. For new rows only, ask Claude Haiku for 3 personalized match
+//      bullets grounded in the user's resume / skills / wins / vision.
+//   7. Stamp last_run_at, last_run_count, last_dropped, last_error.
+//
+// Auth: header X-Cron-Secret must match env CRON_SECRET. The pg_cron
+// schedule sets this header.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { db } from '../_shared/job-db.ts';
+import { computeFit, type RoleRow } from '../jobs-pipe/fit.ts';
+import { SOURCES } from '../_shared/sources/registry.ts';
+import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
+
+const VERSION = '0.1.0';
+console.log(`[pull-recommendations] v${VERSION}`);
+
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
+
+interface UserSourceRow {
+  id:            string;
+  user_email:    string;
+  type:          string;
+  config:        Record<string, unknown>;
+  schedule_cron: string;
+  min_score:     number;
+  last_run_at:   string | null;
+}
+
+interface UserContext {
+  resume:   string;
+  skills:   string;
+  wins:     string;
+  vision:   string;
+}
+
+serve(async (req) => {
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return new Response('POST only', { status: 405 });
+  }
+  const secret = Deno.env.get('CRON_SECRET');
+  if (secret && req.headers.get('x-cron-secret') !== secret) {
+    return new Response('forbidden', { status: 403 });
+  }
+
+  const sql = db();
+  const sources = await sql<UserSourceRow[]>`
+    select id, user_email, type, config, schedule_cron, min_score, last_run_at
+    from job.user_sources
+    where enabled = true
+  `;
+
+  const summary: Array<Record<string, unknown>> = [];
+  for (const src of sources) {
+    if (!isDue(src)) { summary.push({ id: src.id, skipped: 'not-due' }); continue; }
+    const plugin = SOURCES[src.type];
+    if (!plugin) {
+      await markRun(sql, src.id, { count: 0, dropped: 0, error: `unknown source type: ${src.type}` });
+      summary.push({ id: src.id, skipped: 'unknown-type' });
+      continue;
+    }
+    try {
+      const since = src.last_run_at ? new Date(src.last_run_at) : null;
+      const pulled = await plugin.pull(src.config, { userEmail: src.user_email, since });
+      const { kept, dropped } = scoreAndFilter(pulled, src.min_score);
+      const inserted = await insertNew(sql, src, kept);
+      if (inserted.length) {
+        const ctx = await loadUserContext(sql);
+        await Promise.all(inserted.map(row => generateBullets(sql, row, ctx)));
+      }
+      await markRun(sql, src.id, { count: inserted.length, dropped, error: null });
+      summary.push({ id: src.id, type: src.type, pulled: pulled.length, kept: kept.length, dropped, inserted: inserted.length });
+    } catch (e) {
+      await markRun(sql, src.id, { count: 0, dropped: 0, error: (e as Error).message });
+      summary.push({ id: src.id, type: src.type, error: (e as Error).message });
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true, version: VERSION, ranAt: new Date().toISOString(), sources: summary }, null, 2), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+});
+
+// ---------- Scoring + filtering ----------
+
+interface ScoredRow {
+  input:     RecommendedRoleInput;
+  fitScore:  number;
+  breakdown: Record<string, number>;
+  hardFails: string[];
+}
+
+function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number): { kept: ScoredRow[]; dropped: number } {
+  const kept: ScoredRow[] = [];
+  let dropped = 0;
+  for (const r of rows) {
+    const fit = computeFit(toRoleRow(r));
+    if (fit.hardFails.length || fit.score < minScore) { dropped++; continue; }
+    kept.push({ input: r, fitScore: fit.score, breakdown: fit.breakdown as unknown as Record<string, number>, hardFails: fit.hardFails });
+  }
+  return { kept, dropped };
+}
+
+// Map a RecommendedRoleInput → the RoleRow shape computeFit expects.
+// computeFit was written against the spreadsheet row, so this is mostly
+// a field-renaming pass with a few "we don't have it yet" defaults.
+function toRoleRow(r: RecommendedRoleInput): RoleRow {
+  return {
+    status:     '',
+    rank:      '',
+    company:    r.company || '',
+    title:      r.title || '',
+    url:        r.url,
+    source:     r.sourceLabel || r.source,
+    contact:    '',
+    salary:     r.salary || '',
+    sector:     r.sector || '',
+    investors:  (r.investors || []).join(', '),
+    website:    '',
+    crunchbase: '',
+  };
+}
+
+// ---------- Insert ----------
+
+async function insertNew(
+  sql: ReturnType<typeof db>,
+  src: UserSourceRow,
+  rows: ScoredRow[],
+): Promise<Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null }>> {
+  if (!rows.length) return [];
+  const values = rows.map(r => ({
+    user_email:     src.user_email,
+    user_source_id: src.id,
+    source:         r.input.source,
+    source_id:      r.input.sourceId,
+    source_label:   r.input.sourceLabel ?? null,
+    url:            r.input.url,
+    company:        r.input.company ?? null,
+    title:          r.input.title ?? null,
+    location:       r.input.location ?? null,
+    salary:         r.input.salary ?? null,
+    logo_url:       r.input.logoUrl ?? null,
+    posted_at:      r.input.postedAt ?? null,
+    description:    r.input.description ?? null,
+    fit_score:      r.fitScore,
+    fit_breakdown:  r.breakdown,
+    hard_fails:     r.hardFails,
+    sector:         r.input.sector ?? null,
+    investors:      r.input.investors ?? [],
+    payload:        r.input.payload ?? null,
+  }));
+  const inserted = await sql`
+    insert into job.recommended_roles ${sql(values)}
+    on conflict (source, source_id) do nothing
+    returning id, company, title, url, fit_score as "fitScore", fit_breakdown as "breakdown", payload
+  `;
+  return inserted as unknown as Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null }>;
+}
+
+// ---------- Bullet generation ----------
+//
+// Bullets answer two halves at once:
+//   - Why does the user fit this role? (cite their skills/wins/vision)
+//   - Why does the role fit the user? (cite the breakdown — e.g. "+22 title")
+
+async function loadUserContext(sql: ReturnType<typeof db>): Promise<UserContext> {
+  const [skills, wins, vision] = await Promise.all([
+    sql`select name, type, level, body_md from job.skills order by name`,
+    sql`select headline, metric_value, body_md from job.wins order by created_at desc limit 30`,
+    sql`select body_md from job.vision order by created_at desc limit 1`,
+  ]);
+  return {
+    resume: '', // hook for a future "primary resume" lookup
+    skills: (skills as Array<Record<string, unknown>>).map(s => `- ${s.name} (${s.type}/${s.level}): ${(s.body_md || '').toString().slice(0, 200)}`).join('\n'),
+    wins:   (wins as Array<Record<string, unknown>>).map(w => `- ${w.headline} (${w.metric_value || 'n/a'}): ${(w.body_md || '').toString().slice(0, 200)}`).join('\n'),
+    vision: (vision as Array<Record<string, unknown>>)[0]?.body_md as string || '',
+  };
+}
+
+async function generateBullets(
+  sql: ReturnType<typeof db>,
+  row: { id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null },
+  user: UserContext,
+): Promise<void> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) return;       // no key → leave bullets null, widget falls back to description
+  const system = `You write 3 short markdown bullets explaining why a candidate fits a job.
+Each bullet cites a CONCRETE detail from the candidate's skills/wins/vision OR from the role's fit breakdown — never vague platitudes.
+Keep each bullet under 22 words. Return only the markdown bullets, nothing else.`;
+  const userPrompt = [
+    `# Role`,
+    `${row.title} at ${row.company} (fit score ${row.fitScore}).`,
+    `Score breakdown: ${Object.entries(row.breakdown).map(([k, v]) => `${k}=${v}`).join(', ')}.`,
+    `URL: ${row.url}`,
+    `\n# Candidate skills\n${user.skills || '(none)'}`,
+    `\n# Recent wins\n${user.wins || '(none)'}`,
+    `\n# Vision\n${user.vision || '(none)'}`,
+  ].join('\n');
+  try {
+    const res = await fetch(ANTHROPIC_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 400,
+        system,
+        messages: [{ role: 'user', content: userPrompt }],
+      }),
+    });
+    if (!res.ok) throw new Error(`anthropic ${res.status}`);
+    const data = await res.json() as { content: Array<{ type: string; text: string }> };
+    const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('\n').trim();
+    const bullets = text.split('\n').map(l => l.replace(/^[-*]\s*/, '').trim()).filter(Boolean).slice(0, 3);
+    if (bullets.length) {
+      await sql`update job.recommended_roles set match_bullets = ${sql.json(bullets)} where id = ${row.id}`;
+    }
+  } catch (e) {
+    console.warn(`[pull-recommendations] bullet gen failed for ${row.id}: ${(e as Error).message}`);
+  }
+}
+
+// ---------- Schedule ----------
+// Tiny cron predicate. Supports the cases we actually use: '0 */6 * * *',
+// '*/30 * * * *', '0 9 * * *'. Falls back to "due if last_run_at older
+// than 6h" for anything fancier.
+function isDue(src: UserSourceRow): boolean {
+  if (!src.last_run_at) return true;
+  const lastMs = Date.parse(src.last_run_at);
+  if (!isFinite(lastMs)) return true;
+  const ageMin = (Date.now() - lastMs) / 60_000;
+  const cron = src.schedule_cron.trim();
+  // hourly modulus
+  const m = cron.match(/^(\S+)\s+\*\/(\d+)\s+\*\s+\*\s+\*$/);
+  if (m) return ageMin >= Number(m[2]) * 60 - 5;
+  // every-N-minutes
+  const m2 = cron.match(/^\*\/(\d+)\s+\*\s+\*\s+\*\s+\*$/);
+  if (m2) return ageMin >= Number(m2[1]) - 1;
+  // daily at HH
+  const m3 = cron.match(/^0\s+(\d+)\s+\*\s+\*\s+\*$/);
+  if (m3) return ageMin >= 24 * 60 - 30;
+  return ageMin >= 6 * 60;
+}
+
+async function markRun(
+  sql: ReturnType<typeof db>,
+  id: string,
+  { count, dropped, error }: { count: number; dropped: number; error: string | null },
+) {
+  await sql`
+    update job.user_sources
+       set last_run_at    = now(),
+           last_run_count = ${count},
+           last_dropped   = ${dropped},
+           last_error     = ${error},
+           updated_at     = now()
+     where id = ${id}
+  `;
+}

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.1.0';
-console.log(`[recommendations] v${VERSION}`);
+const VERSION = '0.2.0';
+console.log(`[recommendations] v${VERSION} - score-filtered + fitScore in response`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -21,10 +21,15 @@ serve(async (req) => {
       const rows = await sql`
         select id, source, source_label as "sourceLabel", url, company, title, location,
                salary, logo_url as "logoUrl", posted_at as "postedAt",
-               description, match_bullets as "matchBullets", suggested_at as "suggestedAt"
+               description, match_bullets as "matchBullets", suggested_at as "suggestedAt",
+               fit_score as "fitScore", fit_breakdown as "breakdown",
+               hard_fails as "hardFails", sector
         from job.recommended_roles
-        where dismissed_at is null and added_to_pipeline_slug is null
-        order by suggested_at desc
+        where dismissed_at is null
+          and added_to_pipeline_slug is null
+          and (fit_score is null or fit_score >= 50)
+          and coalesce(array_length(hard_fails, 1), 0) = 0
+        order by fit_score desc nulls last, suggested_at desc
         limit 24;
       `;
       return jsonResp({ ok: true, version: VERSION, count: rows.length, recommendations: rows });

--- a/supabase/functions/user-sources/index.ts
+++ b/supabase/functions/user-sources/index.ts
@@ -1,0 +1,94 @@
+// user-sources — CRUD for the recommendations source registry.
+//   GET                          → list
+//   POST { type, label?, config?, schedule_cron?, min_score? } → create
+//   POST { id, ... }             → update (any subset of fields)
+//   POST { id, action: 'delete' } → delete
+//   POST { id, action: 'run' }    → trigger a one-off pull (returns the worker's response)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+import { SOURCES } from '../_shared/sources/registry.ts';
+
+const VERSION = '0.1.0';
+console.log(`[user-sources] v${VERSION}`);
+
+const PULL_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const rows = await sql`
+        select id, type, label, config, enabled, schedule_cron, min_score,
+               last_run_at as "lastRunAt", last_run_count as "lastRunCount",
+               last_dropped as "lastDropped", last_error as "lastError"
+        from job.user_sources
+        where user_email = ${email}
+        order by created_at desc
+      `;
+      return jsonResp({ ok: true, version: VERSION, sources: rows, knownTypes: Object.keys(SOURCES) });
+    }
+
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const id = body.id ? String(body.id) : '';
+
+      if (id && body.action === 'delete') {
+        await sql`delete from job.user_sources where id = ${id} and user_email = ${email}`;
+        return jsonResp({ ok: true, id, deleted: true });
+      }
+      if (id && body.action === 'run') {
+        const cronSecret = Deno.env.get('CRON_SECRET') || '';
+        const r = await fetch(PULL_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Cron-Secret': cronSecret },
+          body: '{}',
+        });
+        const text = await r.text();
+        return jsonResp({ ok: r.ok, id, runStatus: r.status, runBody: safeJson(text) });
+      }
+
+      if (id) {
+        // Patch — accept any subset of fields.
+        const patch: Record<string, unknown> = {};
+        if (body.label !== undefined)        patch.label = body.label;
+        if (body.config !== undefined)       patch.config = body.config;
+        if (body.enabled !== undefined)      patch.enabled = !!body.enabled;
+        if (body.schedule_cron !== undefined) patch.schedule_cron = body.schedule_cron;
+        if (body.min_score !== undefined)    patch.min_score = Number(body.min_score) | 0;
+        if (!Object.keys(patch).length) return err('no fields to update', 400);
+        patch.updated_at = new Date().toISOString();
+        await sql`update job.user_sources set ${sql(patch)} where id = ${id} and user_email = ${email}`;
+        return jsonResp({ ok: true, id, updated: Object.keys(patch) });
+      }
+
+      const type = String(body.type || '').trim();
+      if (!type || !SOURCES[type]) return err(`unknown type "${type}"`, 400);
+      const row = {
+        user_email:    email,
+        type,
+        label:         body.label ?? null,
+        config:        body.config ?? {},
+        enabled:       body.enabled ?? true,
+        schedule_cron: body.schedule_cron ?? '0 */6 * * *',
+        min_score:     Number(body.min_score ?? 50) | 0,
+      };
+      const [inserted] = await sql`insert into job.user_sources ${sql(row)} returning id`;
+      return jsonResp({ ok: true, id: inserted.id });
+    }
+
+    return err('GET or POST only', 405);
+  } catch (e) {
+    console.error('[user-sources] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});
+
+function safeJson(s: string) {
+  try { return JSON.parse(s); } catch { return s; }
+}

--- a/supabase/migrations/054_job_user_sources.sql
+++ b/supabase/migrations/054_job_user_sources.sql
@@ -1,0 +1,116 @@
+-- User-configured recommendation sources. The pull-recommendations
+-- worker iterates rows where enabled=true and the schedule is due,
+-- looks up the plugin in the in-code registry by `type`, calls
+-- pull(config), and writes results into job.recommended_roles.
+--
+-- Each plugin owns the shape of `config`. Validation lives in the
+-- plugin (TS), not here, so we keep this table dumb.
+
+create table if not exists job.user_sources (
+  id              uuid primary key default gen_random_uuid(),
+  user_email      text not null,
+  type            text not null,                   -- 'fixture' | 'tracked-ats' | 'linkedin-rss' | …
+  label           text,                            -- human-readable, e.g. "PM jobs in NYC"
+  config          jsonb not null default '{}'::jsonb,
+  enabled         boolean not null default true,
+  schedule_cron   text not null default '0 */6 * * *',
+  -- Roles below min_score (or with any hard-fail) are scored and then
+  -- dropped before insert. Default mirrors the pipeline UX: 50+ shows
+  -- as "ok" or better. Set to 0 to keep everything.
+  min_score       int not null default 50,
+  last_run_at     timestamptz,
+  last_run_count  int,                             -- # of new rows the last run inserted
+  last_dropped    int,                             -- # filtered out by score / hard-fails
+  last_error      text,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+-- Score columns on the recommendations themselves so the widget can
+-- show fit pills and the breakdown modal, exactly like the pipeline.
+alter table job.recommended_roles
+  add column if not exists fit_score      int,
+  add column if not exists fit_breakdown  jsonb,
+  add column if not exists hard_fails     text[] default '{}',
+  add column if not exists sector         text,
+  add column if not exists investors      text[] default '{}',
+  add column if not exists user_email     text,
+  add column if not exists user_source_id uuid references job.user_sources(id) on delete set null;
+
+-- Active-list query becomes "active AND scored well." Replace the
+-- prior partial index so the recommendations endpoint can rely on it.
+drop index if exists job.recommended_roles_active_idx;
+create index if not exists recommended_roles_active_idx
+  on job.recommended_roles (suggested_at desc)
+  where dismissed_at is null
+    and added_to_pipeline_slug is null
+    and (fit_score is null or fit_score >= 50);
+
+create index if not exists user_sources_enabled_idx
+  on job.user_sources (enabled, type)
+  where enabled = true;
+
+alter table job.user_sources enable row level security;
+
+-- Backfill ats / ats_slug on tracked_companies from any pipeline_roles
+-- URL we already have. Matches Greenhouse, Lever, and Ashby URLs;
+-- leaves anything else alone (so Workday / iCIMS / careers pages stay
+-- empty until you fill them in by hand).
+with derived as (
+  select distinct on (pr.company_slug)
+    pr.company_slug,
+    case
+      when pr.url ~* 'boards\.greenhouse\.io/[^/]+'                  then 'Greenhouse'
+      when pr.url ~* 'jobs\.lever\.co/[^/]+'                         then 'Lever'
+      when pr.url ~* 'jobs\.ashbyhq\.com/[^/]+'                      then 'Ashby'
+    end as ats,
+    case
+      when pr.url ~* 'boards\.greenhouse\.io/([^/?#]+)'
+        then substring(pr.url from 'boards\.greenhouse\.io/([^/?#]+)')
+      when pr.url ~* 'jobs\.lever\.co/([^/?#]+)'
+        then substring(pr.url from 'jobs\.lever\.co/([^/?#]+)')
+      when pr.url ~* 'jobs\.ashbyhq\.com/([^/?#]+)'
+        then substring(pr.url from 'jobs\.ashbyhq\.com/([^/?#]+)')
+    end as ats_slug
+  from job.pipeline_roles pr
+  where pr.company_slug is not null
+    and pr.url is not null
+    and pr.url ~* '(boards\.greenhouse\.io|jobs\.lever\.co|jobs\.ashbyhq\.com)/'
+)
+update job.tracked_companies tc
+   set ats      = coalesce(tc.ats, d.ats),
+       ats_slug = coalesce(tc.ats_slug, d.ats_slug),
+       updated_at = now()
+  from derived d
+ where d.company_slug = tc.slug
+   and (tc.ats is null or tc.ats_slug is null);
+
+-- pg_cron + pg_net: tick the worker every 30 minutes. The function
+-- itself decides which user_sources are due based on schedule_cron.
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+-- Idempotent re-schedule: drop any prior tick first, then create.
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'job_pull_recommendations_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end$$;
+
+select cron.schedule(
+  'job_pull_recommendations_tick',
+  '*/30 * * * *',
+  $$
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'X-Cron-Secret', current_setting('app.cron_secret', true)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+  $$
+);


### PR DESCRIPTION
## Summary
Wires up the long-promised LinkedIn-style pull worker as a pluggable system. Adding a future source = drop a new file in \`supabase/functions/_shared/sources/\` and register it.

**What ships:**
- \`job.user_sources\` table + \`recommended_roles\` score columns (migration 054)
- \`Source<Cfg>\` interface, plugin registry
- Two plugins: \`fixture\` (smoke-test) and \`tracked-ats\` (Greenhouse + Lever + Ashby for every \`job.tracked_companies\` row with an ATS slug)
- \`pull-recommendations\` Edge Function: pull → score with the pipeline's \`computeFit\` → drop hard-fails + sub-threshold → upsert → personalized match bullets (Claude Haiku, grounded in your skills/wins/vision)
- \`user-sources\` Edge Function: CRUD + "run now"
- pg_cron tick every 30 minutes
- Recommendations endpoint + widget show the fit pill and filter by score
- Migration 054 backfills \`tracked_companies.ats\` / \`ats_slug\` from existing \`pipeline_roles\` URLs

**Relevance guarantee.** Same \`computeFit\` the pipeline uses. Anything below \`min_score\` (per-source, default 50) or with a hard-fail (intern-level title, mega-cap company, etc.) never reaches the widget.

## Manual steps after merge (require human approval per CLAUDE.md)
1. **Set \`CRON_SECRET\` env on Supabase** for both \`pull-recommendations\` and \`user-sources\`. Set the same value as a Postgres GUC: \`alter database postgres set app.cron_secret = '…'\` so pg_cron can pass it through.
2. After deploy, hit \`POST /functions/v1/user-sources\` with \`{type: 'tracked-ats', label: 'Tracked companies'}\` to create the first source.
3. Then \`POST /functions/v1/user-sources {id, action: 'run'}\` to trigger an immediate pull.

## Test plan
- [ ] Migration 054 applies cleanly; \`tracked_companies.ats_slug\` populated for known Greenhouse/Lever/Ashby companies
- [ ] Manual run of \`tracked-ats\` source returns rows; sub-50 / hard-fail dropped before insert
- [ ] Match bullets generated for inserted rows
- [ ] Widget shows cards with fit pill on /job/jobs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)