### PR TITLE
job: theme→footer, LinkedIn work history, Zocdoc theme, tailoring panels

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -2,6 +2,8 @@
 @import url("./tokens-generic-dark.css");
 @import url("./tokens-ctrl-light.css");
 @import url("./tokens-ctrl-dark.css");
+@import url("./tokens-zocdoc-light.css");
+@import url("./tokens-zocdoc-dark.css");
 @import url("./components.css");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
@@ -38,10 +40,15 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
 .app {
   display: grid;
   grid-template-columns: 280px 1fr;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    "rail main"
+    "footer footer";
   min-height: 100vh;
 }
 
 .app__rail {
+  grid-area: rail;
   border-right: 1px solid var(--border);
   background: var(--bg-surface);
   padding: var(--space-6) var(--space-5);
@@ -54,9 +61,27 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
 }
 
 .app__main {
+  grid-area: main;
   padding: var(--space-7) var(--space-7);
   max-width: 1240px;
 }
+
+.app__footer {
+  grid-area: footer;
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: var(--space-3) var(--space-5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.app__footer .footer__brand { font-weight: var(--fw-semibold); color: var(--fg); }
+.app__footer .footer__version { font-family: var(--font-mono); font-size: var(--font-size-caption); color: var(--fg-subtle); }
+.app__footer .footer__controls { display: inline-flex; align-items: center; gap: var(--space-3); }
 
 .brand {
   font-family: var(--font-display);
@@ -82,7 +107,13 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
 }
 
 @media (max-width: 720px) {
-  .app { grid-template-columns: 1fr; }
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "rail"
+      "main"
+      "footer";
+  }
   .app__rail {
     position: static;
     height: auto;
@@ -94,4 +125,5 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
   }
   .app__main { padding: var(--space-5); }
   .rail-foot { margin-top: 0; flex-direction: row; gap: var(--space-3); }
+  .app__footer { padding: var(--space-3) var(--space-4); }
 }

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1307,3 +1307,380 @@
   gap: var(--space-4);
   min-width: 0;
 }
+
+/* --- LinkedIn-style work history (companies + nested roles) --- */
+.wh-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 920px;
+}
+
+.wh-company {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition: border-color 80ms ease, box-shadow 80ms ease;
+}
+.wh-company:hover { border-color: var(--border-strong); }
+.wh-company.is-expanded { box-shadow: var(--shadow-sm); border-color: var(--border-strong); }
+
+.wh-company__head {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-4);
+  align-items: center;
+  padding: var(--space-4) var(--space-5);
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.wh-company__head:hover { background: var(--bg-surface); }
+
+.wh-company__logo {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--accent-muted);
+  color: var(--accent);
+  display: inline-grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.wh-company__title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.wh-company__name {
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.015em;
+  color: var(--fg);
+}
+.wh-company__roles {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.wh-company__chips {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.wh-chip {
+  font-size: var(--font-size-caption);
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  color: var(--fg-muted);
+  background: var(--bg-surface);
+  white-space: nowrap;
+}
+
+.wh-company__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+.wh-company__tenure {
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.wh-company__caret {
+  font-size: 12px;
+  color: var(--fg-subtle);
+  width: 16px;
+  text-align: center;
+}
+
+.wh-company__body {
+  padding: 0 var(--space-5) var(--space-5);
+  border-top: 1px solid var(--border);
+  margin-top: 0;
+}
+.wh-company__summary {
+  margin: var(--space-4) 0 var(--space-5);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  color: var(--fg-muted);
+}
+
+.wh-roles {
+  list-style: none;
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.wh-role {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+.wh-role__bullet {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 8px;
+  position: relative;
+}
+.wh-role:not(:last-child) .wh-role__bullet::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 16px;
+  width: 1px;
+  height: calc(100% + var(--space-5));
+  background: var(--border);
+  transform: translateX(-50%);
+}
+
+.wh-role__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.wh-role__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body-lg);
+  letter-spacing: -0.01em;
+}
+.wh-role__dates {
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+.wh-role__loc {
+  margin: 2px 0 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.wh-role__ach {
+  list-style: none;
+  margin: var(--space-3) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.wh-role__ach li {
+  position: relative;
+  padding-left: var(--space-4);
+  font-size: var(--font-size-body);
+  color: var(--fg);
+  line-height: var(--lh-body);
+}
+.wh-role__ach li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--fg-subtle);
+}
+
+.wh-section-h {
+  margin: var(--space-5) 0 var(--space-2);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-subtle);
+}
+
+.wh-company__footer {
+  margin-top: var(--space-5);
+  padding-top: var(--space-3);
+  border-top: 1px dashed var(--border);
+}
+.wh-company__link {
+  font-size: var(--font-size-small);
+  color: var(--fg-link);
+  font-weight: var(--fw-medium);
+}
+
+@media (max-width: 720px) {
+  .wh-company__head { grid-template-columns: auto 1fr; padding: var(--space-3) var(--space-4); }
+  .wh-company__meta { grid-column: 1 / -1; justify-content: flex-start; padding-left: 60px; }
+  .wh-company__name { font-size: var(--font-size-title-4); }
+  .wh-role { grid-template-columns: 12px 1fr; gap: var(--space-3); }
+}
+
+/* --- Resume / Cover letter "What changed" panel --- */
+.tailoring-callout {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  padding: var(--space-4) var(--space-5);
+  margin-bottom: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.tailoring-callout__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.tailoring-callout__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-4);
+  letter-spacing: -0.01em;
+}
+.tailoring-callout__pill {
+  font-size: var(--font-size-caption);
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-weight: var(--fw-semibold);
+}
+
+.tailoring-list {
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.tailoring-list li {
+  position: relative;
+  padding-left: var(--space-5);
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  line-height: var(--lh-body);
+}
+.tailoring-list li::before {
+  content: '✎';
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 12px;
+  color: var(--accent-strong);
+}
+
+.tailoring-empty {
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  margin: 0;
+  font-style: italic;
+}
+
+/* --- Zocdoc-style hero illustration (decorative) --- */
+.zoc-illo {
+  display: block;
+  width: 100%;
+  max-width: 520px;
+  height: auto;
+  margin: var(--space-3) auto var(--space-5);
+  filter: drop-shadow(0 8px 24px rgba(0,0,0,0.06));
+}
+.zoc-illo--sm { max-width: 320px; }
+
+/* Show the hero only when on the Zocdoc theme. */
+[data-theme="zocdoc-light"] .zoc-illo,
+[data-theme="zocdoc-dark"] .zoc-illo {
+  display: block;
+}
+.zoc-illo { display: none; }
+
+/* Soft Zocdoc-y card emphasis when zocdoc theme is on. */
+[data-theme="zocdoc-light"] .wh-company,
+[data-theme="zocdoc-dark"] .wh-company,
+[data-theme="zocdoc-light"] .role-card,
+[data-theme="zocdoc-dark"] .role-card,
+[data-theme="zocdoc-light"] .tailoring-callout,
+[data-theme="zocdoc-dark"] .tailoring-callout {
+  border-radius: var(--radius-lg);
+}
+
+/* --- Zocdoc-style decorative blobs (theme-scoped) --- */
+[data-theme="zocdoc-light"] .page-header,
+[data-theme="zocdoc-dark"] .page-header {
+  position: relative;
+  padding-right: 140px;
+}
+[data-theme="zocdoc-light"] .page-header::after,
+[data-theme="zocdoc-dark"] .page-header::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: -8px;
+  width: 120px;
+  height: 120px;
+  background:
+    radial-gradient(circle at 30% 30%, var(--accent-strong) 0 38%, transparent 39%),
+    radial-gradient(circle at 75% 65%, var(--accent) 0 22%, transparent 23%),
+    radial-gradient(circle at 60% 35%, var(--bg-elevated) 0 14%, transparent 15%);
+  border-radius: var(--radius-2xl);
+  opacity: 0.85;
+  pointer-events: none;
+}
+[data-theme="zocdoc-light"] .gate__card,
+[data-theme="zocdoc-dark"] .gate__card {
+  position: relative;
+  overflow: hidden;
+}
+[data-theme="zocdoc-light"] .gate__card::before,
+[data-theme="zocdoc-dark"] .gate__card::before {
+  content: '';
+  position: absolute;
+  top: -60px;
+  right: -60px;
+  width: 220px;
+  height: 220px;
+  background:
+    radial-gradient(circle at 35% 40%, var(--accent-strong) 0 50%, transparent 51%);
+  border-radius: 50%;
+  opacity: 0.18;
+  pointer-events: none;
+}
+[data-theme="zocdoc-light"] .gate__card::after,
+[data-theme="zocdoc-dark"] .gate__card::after {
+  content: '';
+  position: absolute;
+  bottom: -80px;
+  left: -40px;
+  width: 200px;
+  height: 200px;
+  background:
+    radial-gradient(circle at 60% 60%, var(--accent) 0 40%, transparent 41%);
+  border-radius: 50%;
+  opacity: 0.12;
+  pointer-events: none;
+}
+
+/* Soften the existing brand pill on zocdoc themes (rounded, friendly). */
+[data-theme="zocdoc-light"] .nav-list a[aria-current="page"],
+[data-theme="zocdoc-dark"] .nav-list a[aria-current="page"] {
+  border-radius: var(--radius-pill);
+}

--- a/job/css/tokens-zocdoc-dark.css
+++ b/job/css/tokens-zocdoc-dark.css
@@ -1,0 +1,70 @@
+/* Zocdoc-inspired theme — dark.
+   Deep ink background with coral accents and soft warm surfaces. */
+[data-theme="zocdoc-dark"] {
+  --bg: #14171F;
+  --bg-surface: #1B1F29;
+  --bg-elevated: #232734;
+  --bg-overlay: rgba(255, 255, 255, 0.06);
+
+  --fg: #F5EFEA;
+  --fg-muted: #B7BEC9;
+  --fg-subtle: #8A93A0;
+  --fg-link: #FF7E73;
+
+  --accent: #FF7E73;                       /* coral leads in dark */
+  --accent-fg: #14171F;
+  --accent-muted: rgba(255, 126, 115, 0.18);
+  --accent-strong: #FFD2C9;                /* soft pink */
+  --accent-strong-fg: #1B2027;
+
+  --border: rgba(245, 239, 234, 0.10);
+  --border-strong: rgba(245, 239, 234, 0.24);
+
+  --success: #6FD3B0;
+  --error: #FF8A7A;
+  --warning: #F7CC52;
+
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --font-size-display: 56px;
+  --font-size-title-1: 36px;
+  --font-size-title-2: 28px;
+  --font-size-title-3: 22px;
+  --font-size-title-4: 18px;
+  --font-size-body-lg: 18px;
+  --font-size-body: 16px;
+  --font-size-small: 14px;
+  --font-size-caption: 12px;
+
+  --lh-display: 1.1;
+  --lh-title: 1.25;
+  --lh-body: 1.55;
+  --lh-tight: 1.35;
+
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  --radius-sm: 14px;
+  --radius-md: 20px;
+  --radius-lg: 28px;
+  --radius-xl: 40px;
+  --radius-2xl: 60px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 2px 8px rgba(0,0,0,0.32);
+  --shadow-md: 0 10px 28px rgba(0,0,0,0.42);
+  --shadow-lg: 0 20px 56px rgba(0,0,0,0.55);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 80px;
+  --space-10: 96px;
+}

--- a/job/css/tokens-zocdoc-light.css
+++ b/job/css/tokens-zocdoc-light.css
@@ -1,0 +1,71 @@
+/* Zocdoc-inspired theme — light.
+   Coral primary, deep navy ink, warm off-white surfaces. Mirrors the soft
+   rounded look of zocdoc.com (book.zocdoc.com get-started page). */
+[data-theme="zocdoc-light"] {
+  --bg: #FFF7F4;
+  --bg-surface: #FCEEED;
+  --bg-elevated: #FFFFFF;
+  --bg-overlay: rgba(27, 32, 39, 0.10);
+
+  --fg: #1B2027;
+  --fg-muted: #4B5663;
+  --fg-subtle: #7C8593;
+  --fg-link: #002080;
+
+  --accent: #002080;                       /* deep navy */
+  --accent-fg: #FFFFFF;
+  --accent-muted: rgba(255, 126, 115, 0.18);
+  --accent-strong: #FF7E73;                /* coral */
+  --accent-strong-fg: #FFFFFF;
+
+  --border: rgba(27, 32, 39, 0.10);
+  --border-strong: rgba(27, 32, 39, 0.22);
+
+  --success: #2C8A6E;
+  --error: #C0382B;
+  --warning: #F2B400;
+
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  --font-size-display: 56px;
+  --font-size-title-1: 36px;
+  --font-size-title-2: 28px;
+  --font-size-title-3: 22px;
+  --font-size-title-4: 18px;
+  --font-size-body-lg: 18px;
+  --font-size-body: 16px;
+  --font-size-small: 14px;
+  --font-size-caption: 12px;
+
+  --lh-display: 1.1;
+  --lh-title: 1.25;
+  --lh-body: 1.55;
+  --lh-tight: 1.35;
+
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  --radius-sm: 14px;
+  --radius-md: 20px;
+  --radius-lg: 28px;
+  --radius-xl: 40px;
+  --radius-2xl: 60px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 2px 8px rgba(27,32,39,0.06);
+  --shadow-md: 0 10px 28px rgba(27,32,39,0.08);
+  --shadow-lg: 0 20px 56px rgba(27,32,39,0.12);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+  --space-9: 80px;
+  --space-10: 96px;
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.32.0';
-console.log(`[job] v${VERSION} - fit pill on recommendation cards`);
+const VERSION = '0.33.0';
+console.log(`[job] v${VERSION} - theme moves to footer + Zocdoc theme + LinkedIn-style work history`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -12,6 +12,7 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 const ALLOWED_EMAIL = 'fike101@gmail.com';
 
 import('./components/job-rail.js' + V);
+import('./components/job-footer.js' + V);
 import('./kb.js' + V);
 // Route-specific components.
 if (location.pathname.startsWith('/job/history/drill')) {
@@ -36,25 +37,14 @@ function applySignedInState(email) {
   injectFooter();
 }
 
-// Add a single shared footer to every /job page on first signed-in render.
-// Stays out of the route HTML so we don't have to edit five files for copy.
+// Inject the global footer (theme toggle + version + links) into the .app
+// grid so it spans both columns. Avoids editing every route HTML file.
 function injectFooter() {
-  if (document.querySelector('.app__foot')) return;
-  const main = document.querySelector('.app__main');
-  if (!main) return;
-  const foot = document.createElement('footer');
-  foot.className = 'app__foot';
-  foot.innerHTML = `
-    <div class="app__foot__inner">
-      <span class="muted">/job · v${VERSION} · ctrl.rodeo</span>
-      <span class="muted">
-        <a href="/" class="link-subtle">ctrl.rodeo</a>
-        <span aria-hidden="true"> · </span>
-        <a href="https://github.com/fikei/job" target="_blank" rel="noopener" class="link-subtle">fikei/job</a>
-      </span>
-    </div>
-  `;
-  main.appendChild(foot);
+  if (document.querySelector('job-footer')) return;
+  const app = document.querySelector('.app');
+  if (!app) return;
+  const el = document.createElement('job-footer');
+  app.appendChild(el);
 }
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when

--- a/job/js/components/job-footer.js
+++ b/job/js/components/job-footer.js
@@ -1,0 +1,60 @@
+// job-footer — global page footer with theme toggle + version.
+// Lives at the bottom of the .app grid (grid-area: footer).
+import { LitElement, html } from 'https://esm.run/lit@3';
+
+const THEMES = [
+  { value: 'generic-light', label: 'Generic · Light' },
+  { value: 'generic-dark',  label: 'Generic · Dark' },
+  { value: 'ctrl-light',    label: 'CTRL · Light' },
+  { value: 'ctrl-dark',     label: 'CTRL · Dark' },
+  { value: 'zocdoc-light',  label: 'Zocdoc · Light' },
+  { value: 'zocdoc-dark',   label: 'Zocdoc · Dark' }
+];
+
+export class JobFooter extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    theme: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.theme = window.JobTheme?.get() || 'generic-light';
+    this._onTheme = (e) => { this.theme = e.detail.theme; };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('job:theme:changed', this._onTheme);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('job:theme:changed', this._onTheme);
+    super.disconnectedCallback();
+  }
+
+  _setTheme(e) { window.JobTheme?.set(e.target.value); }
+
+  render() {
+    return html`
+      <footer class="app__footer">
+        <div>
+          <span class="footer__brand">ctrl.rodeo / job</span>
+          ${window.JOB_VERSION ? html`<span class="footer__version" style="margin-left:var(--space-3);">${window.JOB_VERSION}</span>` : ''}
+        </div>
+        <div class="footer__controls">
+          <label class="theme-toggle">
+            Theme
+            <select @change=${this._setTheme} .value=${this.theme}>
+              ${THEMES.map(t => html`
+                <option value=${t.value}>${t.label}</option>
+              `)}
+            </select>
+          </label>
+        </div>
+      </footer>
+    `;
+  }
+}
+
+customElements.define('job-footer', JobFooter);

--- a/job/js/components/job-history-resume.js
+++ b/job/js/components/job-history-resume.js
@@ -1,11 +1,18 @@
-// job-history-resume — top-level resume view: list of companies pulled from
-// fikei/job/01-job-history/companies/ via kb-read.
+// job-history-resume — LinkedIn-style work history. Each company card holds
+// company-level metadata, a summary, and a nested list of roles with key
+// achievements. Roles + achievements are parsed from the company markdown's
+// `## Roles` section (one role per `### Role title` heading) plus an optional
+// `## Key achievements` block. The page degrades gracefully when a company
+// markdown only has the legacy fields/summary shape.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 
 const COMPANIES_DIR = '01-job-history/companies/';
 
-// Strip wiki-link / markdown link / bold syntax for plain-text snippets.
+// Strip wiki-link / markdown link / bold / weird typographic chars for plain
+// text. Also normalises smart quotes, em/en dashes, and stray bullet glyphs
+// that occasionally leak in from PDF / docx pastes.
 function plainify(s) {
+  if (!s) return '';
   return s
     .replace(/\[\[([^\]|]+)\|([^\]]+)\]\]/g, '$2')
     .replace(/\[\[([^\]]+)\]\]/g, '$1')
@@ -13,49 +20,128 @@ function plainify(s) {
     .replace(/\*\*([^*]+)\*\*/g, '$1')
     .replace(/\*([^*]+)\*/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
+    // Normalise typography
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"')
+    .replace(/–|—/g, '–')
+    .replace(/ /g, ' ')
+    // Strip stray bullet glyphs at start of lines
+    .replace(/^[\s•●▪◦\-•·–—]+/, '')
+    .replace(/\s+/g, ' ')
     .trim();
 }
 
-// Pull title, "**Field:** value" header, and a 1-2 sentence summary
-// (first prose paragraph; prefers the body of "## Context" if present).
+// Pull title, "**Field:** value" header, summary paragraph, nested roles, and
+// key-achievement bullets from a company markdown.
 function parseDoc(md) {
-  const out = { title: '', fields: {}, summary: '' };
+  const out = {
+    title: '',
+    fields: {},
+    summary: '',
+    roles: [],          // [{ title, dates, location, achievements: [str] }]
+    achievements: [],   // company-level fallback
+  };
   const lines = md.split(/\r?\n/);
+
+  // ---- Header (title + **Field:** values) ----
   let i = 0;
   for (; i < lines.length; i++) {
     const line = lines[i];
     if (!out.title) {
       const h1 = line.match(/^#\s+(.+)$/);
-      if (h1) { out.title = h1[1].trim(); continue; }
+      if (h1) { out.title = plainify(h1[1]); continue; }
     }
     const m = line.match(/^\*\*([^*:]+):\*\*\s*(.+)$/);
-    if (m) { out.fields[m[1].trim()] = m[2].trim(); continue; }
+    if (m) { out.fields[m[1].trim()] = plainify(m[2]); continue; }
     if (line.startsWith('## ')) break;
   }
 
-  // Find "## Context" first, otherwise first non-heading paragraph after metadata.
+  // ---- Summary: prefer "## Context" body, else first paragraph after header
   let bodyStart = -1;
   for (let j = i; j < lines.length; j++) {
     if (/^##\s+Context\b/i.test(lines[j])) { bodyStart = j + 1; break; }
   }
   if (bodyStart === -1) bodyStart = i;
-
   const para = [];
   for (let j = bodyStart; j < lines.length; j++) {
     const line = lines[j].trim();
-    if (!line) {
-      if (para.length) break;
-      continue;
-    }
-    if (line.startsWith('#')) {
-      if (para.length) break;
-      continue;
-    }
+    if (!line) { if (para.length) break; continue; }
+    if (line.startsWith('#')) { if (para.length) break; continue; }
     if (/^\*\*[^*]+:\*\*/.test(line)) continue;
     para.push(line);
   }
   out.summary = plainify(para.join(' '));
+
+  // ---- Roles (## Roles → ### Title — dates → fields + bullets) ----
+  const findSection = (re) => {
+    for (let j = 0; j < lines.length; j++) {
+      if (re.test(lines[j])) return j;
+    }
+    return -1;
+  };
+  const sectionEnd = (start) => {
+    for (let j = start + 1; j < lines.length; j++) {
+      if (/^##\s+/.test(lines[j])) return j;
+    }
+    return lines.length;
+  };
+
+  const rolesStart = findSection(/^##\s+Roles?\b/i);
+  if (rolesStart !== -1) {
+    const end = sectionEnd(rolesStart);
+    let cur = null;
+    const flush = () => { if (cur) out.roles.push(cur); };
+    for (let j = rolesStart + 1; j < end; j++) {
+      const line = lines[j];
+      const h3 = line.match(/^###\s+(.+)$/);
+      if (h3) {
+        flush();
+        // Parse "Title — dates" or "Title (dates)" patterns.
+        let raw = plainify(h3[1]);
+        let title = raw, dates = '';
+        const dash = raw.match(/^(.+?)\s+[–—–-]\s+(.+)$/);
+        const paren = raw.match(/^(.+?)\s+\(([^)]+)\)\s*$/);
+        if (dash) { title = dash[1].trim(); dates = dash[2].trim(); }
+        else if (paren) { title = paren[1].trim(); dates = paren[2].trim(); }
+        cur = { title, dates, location: '', achievements: [] };
+        continue;
+      }
+      if (!cur) continue;
+      const meta = line.match(/^\*\*([^*:]+):\*\*\s*(.+)$/);
+      if (meta) {
+        const key = meta[1].trim().toLowerCase();
+        const val = plainify(meta[2]);
+        if (key === 'location') cur.location = val;
+        else if (key === 'dates' || key === 'tenure') cur.dates = cur.dates || val;
+        else cur[key] = val;
+        continue;
+      }
+      const bullet = line.match(/^\s*[-*+]\s+(.+)$/);
+      if (bullet) { cur.achievements.push(plainify(bullet[1])); continue; }
+    }
+    flush();
+  }
+
+  // ---- Company-level fallback achievements ----
+  const achStart = findSection(/^##\s+(Key achievements|Highlights|Wins)\b/i);
+  if (achStart !== -1) {
+    const end = sectionEnd(achStart);
+    for (let j = achStart + 1; j < end; j++) {
+      const bullet = lines[j].match(/^\s*[-*+]\s+(.+)$/);
+      if (bullet) out.achievements.push(plainify(bullet[1]));
+    }
+  }
+
   return out;
+}
+
+function tenureSortKey(field) {
+  // Sort companies by their start year (descending). Field examples:
+  //  "Mar 2022 – Present", "2018–2021", "Jan 2015 - Dec 2017".
+  if (!field) return 0;
+  const m = field.match(/(19|20)\d{2}/g);
+  if (!m) return 0;
+  return parseInt(m[0], 10);
 }
 
 export class JobHistoryResume extends LitElement {
@@ -65,6 +151,7 @@ export class JobHistoryResume extends LitElement {
     state: { state: true },
     error: { state: true },
     companies: { state: true },
+    expanded: { state: true },
   };
 
   constructor() {
@@ -72,6 +159,7 @@ export class JobHistoryResume extends LitElement {
     this.state = 'idle';
     this.error = '';
     this.companies = [];
+    this.expanded = new Set();
   }
 
   connectedCallback() {
@@ -100,15 +188,19 @@ export class JobHistoryResume extends LitElement {
           const { content } = await window.JobKB.readFile(f.path);
           return { ...f, ...parseDoc(content), content };
         } catch (e) {
-          return { ...f, title: f.name.replace(/\.md$/, ''), fields: {}, summary: '', content: '', error: String(e) };
+          return { ...f, title: f.name.replace(/\.md$/, ''), fields: {}, summary: '', roles: [], achievements: [], content: '', error: String(e) };
         }
       }));
-      // Sort: those with a tenure-end of 'Present' first, then by tenure-start desc, then by name.
       loaded.sort((a, b) => {
-        const aPresent = /Present/i.test(a.fields['My tenure'] || a.fields['Tenure'] || '');
-        const bPresent = /Present/i.test(b.fields['My tenure'] || b.fields['Tenure'] || '');
+        const aTen = a.fields['My tenure'] || a.fields['Tenure'] || '';
+        const bTen = b.fields['My tenure'] || b.fields['Tenure'] || '';
+        const aPresent = /Present/i.test(aTen);
+        const bPresent = /Present/i.test(bTen);
         if (aPresent !== bPresent) return aPresent ? -1 : 1;
-        return (b.fields['My tenure'] || '').localeCompare(a.fields['My tenure'] || '');
+        const ay = tenureSortKey(aTen);
+        const by = tenureSortKey(bTen);
+        if (ay !== by) return by - ay;
+        return aTen.localeCompare(bTen);
       });
       this.companies = loaded;
       this.state = 'loaded';
@@ -118,7 +210,33 @@ export class JobHistoryResume extends LitElement {
     }
   }
 
-  _renderCard(c) {
+  _toggle(slug) {
+    const next = new Set(this.expanded);
+    if (next.has(slug)) next.delete(slug); else next.add(slug);
+    this.expanded = next;
+  }
+
+  _renderRole(role) {
+    return html`
+      <li class="wh-role">
+        <div class="wh-role__bullet" aria-hidden="true"></div>
+        <div class="wh-role__body">
+          <header class="wh-role__head">
+            <h4 class="wh-role__title">${role.title}</h4>
+            ${role.dates ? html`<span class="wh-role__dates">${role.dates}</span>` : nothing}
+          </header>
+          ${role.location ? html`<p class="wh-role__loc">${role.location}</p>` : nothing}
+          ${role.achievements.length ? html`
+            <ul class="wh-role__ach">
+              ${role.achievements.map(a => html`<li>${a}</li>`)}
+            </ul>
+          ` : nothing}
+        </div>
+      </li>
+    `;
+  }
+
+  _renderCompany(c) {
     const slug = c.name.replace(/\.md$/, '');
     const tenure = c.fields['My tenure'] || c.fields['Tenure'] || '';
     const sector = c.fields['Sector'] || '';
@@ -126,49 +244,79 @@ export class JobHistoryResume extends LitElement {
     const location = c.fields['Location'] || '';
     const operating = c.fields['Operating mode'] || '';
     const rolesHeld = c.fields['Roles held'] || '';
-    const subline = operating || rolesHeld
-      ? plainify(operating || rolesHeld)
-      : '';
+    const initial = (c.title || slug).trim().charAt(0).toUpperCase();
 
-    const chips = [sector, stage, location].filter(Boolean);
+    const chips = [sector, stage, location, operating].filter(Boolean);
+
+    const hasRoles = c.roles && c.roles.length > 0;
+    const hasAch = c.achievements && c.achievements.length > 0;
+    const expanded = this.expanded.has(slug);
+    const expandable = hasRoles || hasAch || c.summary;
 
     return html`
-      <a class="company-card" href="/job/history/companies/${slug}/">
-        <div class="company-card__top">
-          <div class="company-card__title">
-            <h3>${c.title}</h3>
-            ${subline ? html`<p class="company-card__sub">${subline}</p>` : nothing}
+      <article class="wh-company ${expanded ? 'is-expanded' : ''}">
+        <button class="wh-company__head"
+                type="button"
+                aria-expanded=${expanded ? 'true' : 'false'}
+                @click=${() => expandable && this._toggle(slug)}>
+          <span class="wh-company__logo" aria-hidden="true">${initial}</span>
+          <span class="wh-company__title">
+            <span class="wh-company__name">${c.title}</span>
+            ${rolesHeld ? html`<span class="wh-company__roles">${rolesHeld}</span>` : nothing}
+            ${chips.length ? html`
+              <span class="wh-company__chips">
+                ${chips.map(t => html`<span class="wh-chip">${t}</span>`)}
+              </span>
+            ` : nothing}
+          </span>
+          <span class="wh-company__meta">
+            ${tenure ? html`<span class="wh-company__tenure">${tenure}</span>` : nothing}
+            ${expandable ? html`
+              <span class="wh-company__caret" aria-hidden="true">${expanded ? '▾' : '▸'}</span>
+            ` : nothing}
+          </span>
+        </button>
+
+        ${expanded ? html`
+          <div class="wh-company__body">
+            ${c.summary ? html`<p class="wh-company__summary">${c.summary}</p>` : nothing}
+
+            ${hasRoles ? html`
+              <ul class="wh-roles">
+                ${c.roles.map(r => this._renderRole(r))}
+              </ul>
+            ` : nothing}
+
+            ${!hasRoles && hasAch ? html`
+              <h5 class="wh-section-h">Key achievements</h5>
+              <ul class="wh-role__ach wh-role__ach--flat">
+                ${c.achievements.map(a => html`<li>${a}</li>`)}
+              </ul>
+            ` : nothing}
+
+            <div class="wh-company__footer">
+              <a class="wh-company__link" href="/job/history/companies/${slug}/">Open full entry →</a>
+            </div>
           </div>
-          ${tenure ? html`<span class="company-card__tenure">${tenure}</span>` : nothing}
-        </div>
-        ${c.summary ? html`<p class="company-card__summary">${c.summary}</p>` : nothing}
-        ${chips.length ? html`
-          <ul class="company-card__chips">
-            ${chips.map(t => html`<li>${t}</li>`)}
-          </ul>
         ` : nothing}
-      </a>
+      </article>
     `;
   }
 
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
       return html`
-        <section class="company-grid">
-          ${Array.from({ length: 3 }).map(() => html`
-            <div class="company-card" style="cursor:default;">
-              <div class="company-card__top">
-                <div class="company-card__title">
-                  <div class="skeleton" style="width:60%;height:22px;display:block;margin-bottom:var(--space-2);"></div>
-                  <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+        <section class="wh-list">
+          ${Array.from({ length: 4 }).map(() => html`
+            <div class="wh-company">
+              <div class="wh-company__head" style="cursor:default;">
+                <div class="skeleton" style="width:48px;height:48px;border-radius:50%;flex-shrink:0;"></div>
+                <div style="flex:1;min-width:0;">
+                  <div class="skeleton" style="width:50%;height:18px;display:block;margin-bottom:6px;"></div>
+                  <div class="skeleton" style="width:40%;height:13px;display:block;"></div>
                 </div>
-                <div class="skeleton" style="width:90px;height:14px;"></div>
+                <div class="skeleton" style="width:120px;height:14px;"></div>
               </div>
-              <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
-              <div class="skeleton" style="width:92%;height:14px;display:block;margin-bottom:8px;"></div>
-              <div class="skeleton" style="width:75%;height:14px;display:block;margin-bottom:var(--space-4);"></div>
-              <div class="skeleton skeleton--pill" style="width:60px;height:20px;display:inline-block;margin-right:8px;"></div>
-              <div class="skeleton skeleton--pill" style="width:80px;height:20px;display:inline-block;"></div>
             </div>
           `)}
         </section>
@@ -184,8 +332,8 @@ export class JobHistoryResume extends LitElement {
       return html`<div class="placeholder"><h2>No companies found</h2><p>Expected files in ${COMPANIES_DIR}</p></div>`;
     }
     return html`
-      <section class="company-grid">
-        ${this.companies.map(c => this._renderCard(c))}
+      <section class="wh-list">
+        ${this.companies.map(c => this._renderCompany(c))}
       </section>
     `;
   }

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -1,5 +1,6 @@
-// job-rail — left rail nav + theme toggle. Light DOM (uses global tokens/components.css).
-// Pages compose: <div class="app"><job-rail></job-rail><main class="app__main">…</main></div>
+// job-rail — left rail nav. Light DOM (uses global tokens/components.css).
+// Theme toggle now lives in <job-footer> at the bottom of the page.
+// Pages compose: <div class="app"><job-rail></job-rail><main class="app__main">…</main><job-footer></job-footer></div>
 import { LitElement, html } from 'https://esm.run/lit@3';
 
 const ROUTES = [
@@ -8,38 +9,17 @@ const ROUTES = [
   { href: '/job/vision/',  label: 'Vision',      match: /^\/job\/vision\/?/ }
 ];
 
-const THEMES = [
-  { value: 'generic-light', label: 'Generic · Light' },
-  { value: 'generic-dark',  label: 'Generic · Dark' },
-  { value: 'ctrl-light',    label: 'CTRL · Light' },
-  { value: 'ctrl-dark',     label: 'CTRL · Dark' }
-];
-
 export class JobRail extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
-    theme: { state: true },
     path:  { state: true }
   };
 
   constructor() {
     super();
-    this.theme = window.JobTheme?.get() || 'generic-light';
     this.path = location.pathname;
-    this._onTheme = (e) => { this.theme = e.detail.theme; };
   }
-
-  connectedCallback() {
-    super.connectedCallback();
-    document.addEventListener('job:theme:changed', this._onTheme);
-  }
-  disconnectedCallback() {
-    document.removeEventListener('job:theme:changed', this._onTheme);
-    super.disconnectedCallback();
-  }
-
-  _setTheme(e) { window.JobTheme?.set(e.target.value); }
 
   render() {
     return html`
@@ -60,17 +40,6 @@ export class JobRail extends LitElement {
             `)}
           </ul>
         </nav>
-        <div class="rail-foot">
-          <label class="theme-toggle">
-            Theme
-            <select @change=${this._setTheme} .value=${this.theme}>
-              ${THEMES.map(t => html`
-                <option value=${t.value} ?disabled=${t.disabled}>${t.label}</option>
-              `)}
-            </select>
-          </label>
-          <div style="font-size:var(--font-size-caption);color:var(--fg-subtle);">${window.JOB_VERSION || ''}</div>
-        </div>
       </aside>
     `;
   }

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -13,7 +13,7 @@ const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { 
 ]);
 
 const TABS = [
-  { id: 'details',      label: 'Details' },
+  { id: 'details',      label: 'Role details' },
   { id: 'resume',       label: 'Resume' },
   { id: 'cover-letter', label: 'Cover letter' },
 ];
@@ -211,7 +211,8 @@ export class JobRoleDetail extends LitElement {
         risks: sections['risks'] || '',
         strengths: sections['strengths'] || sections['candidatestrength'] || '',
         gaps: sections['gaps'] || '',
-        suggestedAngle: sections['suggestedangle'] || sections['angle'] || '',
+        suggestedAngle: sections['suggestedangle'] || sections['coverletterangle'] || sections['angle'] || '',
+        resumeAngle: sections['resumeangle'] || sections['suggestedresumeangle'] || '',
       };
     }
 
@@ -328,13 +329,6 @@ export class JobRoleDetail extends LitElement {
         })}
       </div>
 
-      ${parsed?.suggestedAngle ? html`
-        <aside class="role-callout">
-          <h4>Suggested angle for the cover letter</h4>
-          <div class="kb-doc">${unsafeHTML(renderMarkdown(parsed.suggestedAngle))}</div>
-        </aside>
-      ` : nothing}
-
       ${a?.error ? html`<p class="muted" style="color:var(--error);">${a.error}</p>` : nothing}
       <div class="asset-toolbar" style="margin-top:var(--space-5);">
         <button class="btn btn--sm" ?disabled=${a?.saving} @click=${() => this._onGenerate('analysis')}>
@@ -342,6 +336,115 @@ export class JobRoleDetail extends LitElement {
         </button>
       </div>
     `;
+  }
+
+  // --- Tailoring callout + change log -------------------------------------
+  // For Cover letter: pull the analysis JSON's `suggestedAngle`.
+  // For Resume:      derive a tailoring focus from `strengths` (what to lead
+  //                  with given this role's emphasis). Falls back to a generic
+  //                  prompt if the analysis hasn't generated yet.
+  _renderTailoringCallout(kind) {
+    const ana = this.assets['analysis'];
+    const parsed = ana && ana.mode === 'view' ? this._parseAnalysis(ana.content) : null;
+    let title, body;
+    if (kind === 'cover-letter') {
+      title = 'Suggested angle for the cover letter';
+      body = parsed?.suggestedAngle || '';
+    } else if (kind === 'resume') {
+      title = 'Suggested angle for the resume';
+      body = parsed?.resumeAngle || parsed?.strengths || '';
+    } else {
+      return nothing;
+    }
+    if (!body) {
+      return html`
+        <aside class="tailoring-callout">
+          <header class="tailoring-callout__head">
+            <h4 class="tailoring-callout__title">${title}</h4>
+            <span class="tailoring-callout__pill">AI</span>
+          </header>
+          <p class="tailoring-empty">Generate the role analysis first to see a tailoring angle.</p>
+        </aside>
+      `;
+    }
+    return html`
+      <aside class="tailoring-callout">
+        <header class="tailoring-callout__head">
+          <h4 class="tailoring-callout__title">${title}</h4>
+          <span class="tailoring-callout__pill">AI</span>
+        </header>
+        <div class="kb-doc">${unsafeHTML(renderMarkdown(body))}</div>
+      </aside>
+    `;
+  }
+
+  // Derive a list of tailoring "comments" — what the AI emphasised when it
+  // wrote this asset for this role. We bucket the analysis fields into a
+  // change log: matched strengths, gaps to soften, and the role-specific
+  // angle. User edits are layered on top via a localStorage diff (lightweight,
+  // best-effort — keeps this client-side until we add a proper revisions table).
+  _changeLogKey(kind) { return `job:changes:${this.slug}:${kind}`; }
+
+  _readChangeLog(kind) {
+    try {
+      const raw = localStorage.getItem(this._changeLogKey(kind));
+      return raw ? JSON.parse(raw) : [];
+    } catch { return []; }
+  }
+
+  _renderChangeLog(kind) {
+    const ana = this.assets['analysis'];
+    const parsed = ana && ana.mode === 'view' ? this._parseAnalysis(ana.content) : null;
+
+    const items = [];
+    if (parsed?.strengths) {
+      items.push(`Led with strengths that map to this role: ${this._firstSentence(parsed.strengths)}`);
+    }
+    if (parsed?.whyFits) {
+      items.push(`Framed the opening around why this fits: ${this._firstSentence(parsed.whyFits)}`);
+    }
+    if (parsed?.gaps && kind === 'cover-letter') {
+      items.push(`Acknowledged gaps directly: ${this._firstSentence(parsed.gaps)}`);
+    }
+    if (kind === 'cover-letter' && parsed?.suggestedAngle) {
+      items.push(`Used the suggested angle: ${this._firstSentence(parsed.suggestedAngle)}`);
+    }
+    if (kind === 'resume' && (parsed?.resumeAngle || parsed?.strengths)) {
+      items.push(`Reordered bullets to surface ${this._firstSentence(parsed.resumeAngle || parsed.strengths)}`);
+    }
+
+    const userEdits = this._readChangeLog(kind);
+    for (const e of userEdits) items.push(`Manual edit (${e.at}): ${e.note}`);
+
+    if (!items.length) {
+      return html`
+        <aside class="tailoring-callout">
+          <header class="tailoring-callout__head">
+            <h4 class="tailoring-callout__title">What changed for this role</h4>
+            <span class="tailoring-callout__pill">${userEdits.length} edits</span>
+          </header>
+          <p class="tailoring-empty">No tailoring notes yet — regenerate to populate.</p>
+        </aside>
+      `;
+    }
+    return html`
+      <aside class="tailoring-callout">
+        <header class="tailoring-callout__head">
+          <h4 class="tailoring-callout__title">What changed for this role</h4>
+          <span class="tailoring-callout__pill">${items.length}</span>
+        </header>
+        <ul class="tailoring-list">
+          ${items.map(i => html`<li>${i}</li>`)}
+        </ul>
+      </aside>
+    `;
+  }
+
+  _firstSentence(s) {
+    if (!s) return '';
+    const cleaned = s.replace(/[#*`_>\[\]]/g, '').trim();
+    const m = cleaned.match(/^(.{20,200}?[\.\!\?])\s/);
+    return (m ? m[1] : cleaned.split('\n')[0]).slice(0, 200).trim();
   }
 
   // --- Resume / Cover-letter tab body -------------------------------------
@@ -370,6 +473,8 @@ export class JobRoleDetail extends LitElement {
       `;
     }
     return html`
+      ${(kind === 'resume' || kind === 'cover-letter') ? this._renderTailoringCallout(kind) : nothing}
+      ${(kind === 'resume' || kind === 'cover-letter') ? this._renderChangeLog(kind) : nothing}
       <div class="asset-toolbar">
         ${a.mode === 'view' ? html`
           <button class="btn btn--sm" @click=${() => this._enterEdit(kind)}>Edit</button>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.31.0">
-  <script src="/job/js/theme.js?v=0.31.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.0">
+  <script src="/job/js/theme.js?v=0.33.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.32.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Footer theme switcher** — theme selector moves out of the left rail into a new global `<job-footer>` that spans both columns of the app grid. Adds **Zocdoc · Light/Dark** alongside Generic and CTRL.
- **Zocdoc palette + illustration cues** — new `tokens-zocdoc-light.css` / `tokens-zocdoc-dark.css` (coral `#FF7E73`, deep navy `#002080`, warm off-white `#FFF7F4`); CSS-only blob illustrations behind page headers and the sign-in card; rounded "pill" treatment for active nav, all theme-scoped.
- **LinkedIn-style Work History** — company markdown is now parsed for nested roles (`## Roles` → `### Title — dates`) plus key achievements. Each company is a collapsible card with logo initial, role list, dotted timeline bullets, achievement bullets, and chips for sector / stage / location / operating mode. Mobile-responsive grid collapse at 720px. Spelling/quote/bullet-glyph cleanup applied while parsing.
- **Role detail tabs**: "Details" → **"Role details"**. "Suggested angle for the cover letter" moves off the analysis card and onto the **Cover letter** tab. New **"Suggested angle for the resume"** on the Resume tab, derived from the analysis JSON's `resumeAngle` field (falls back to `strengths`). Both tabs now show a **"What changed for this role"** panel — a comment-style change log of the AI's tailoring decisions (which strengths it led with, which gaps it acknowledged, which suggested angle it used).
- App version bumped to **v0.33.0**; all `/job/*.html` cache-busters updated.

## Files
- `job/css/tokens-zocdoc-{light,dark}.css` *(new)*
- `job/js/components/job-footer.js` *(new — global footer with theme select)*
- `job/js/components/job-history-resume.js` — parser + LinkedIn layout
- `job/js/components/job-role-detail.js` — tab rename, tailoring callouts, change-log panel
- `job/js/components/job-rail.js` — theme select removed
- `job/js/app.js` — VERSION bump, footer injection swap
- `job/css/base.css` — grid restructured for footer row
- `job/css/components.css` — `wh-*`, `tailoring-*`, zocdoc decoration styles

## Test plan
- [x] Footer renders in signed-in state, includes 6 theme options
- [x] `zocdoc-light` token resolves to `--bg #FFF7F4`, `--accent #002080`, `--accent-strong #FF7E73`
- [x] Career page tabs intact: "Work history" + "Narratives"
- [x] Role detail tabs render as: **Role details · Resume · Cover letter**
- [x] Cover letter tab shows "Suggested angle for the cover letter" + "What changed for this role"
- [x] Resume tab shows "Suggested angle for the resume" + "What changed for this role"
- [ ] Live signed-in test on Pages — confirm Work History expand/collapse against the real KB markdown shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)