### PR TITLE
job: zocdoc = generic + yellow pill buttons only

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1595,3 +1595,26 @@
   font-style: italic;
 }
 
+
+/* --- Zocdoc theme: yellow buttons only, fully rounded ---
+   Tokens otherwise mirror the generic system. */
+[data-theme="zocdoc-light"] .btn,
+[data-theme="zocdoc-dark"] .btn {
+  border-radius: var(--radius-pill);
+}
+[data-theme="zocdoc-light"] .btn--primary,
+[data-theme="zocdoc-dark"] .btn--primary,
+[data-theme="zocdoc-light"] .btn--accent,
+[data-theme="zocdoc-dark"] .btn--accent {
+  background: #FFCD3F;
+  color: #0E0F0C;
+  border-color: #FFCD3F;
+}
+[data-theme="zocdoc-light"] .btn--primary:hover,
+[data-theme="zocdoc-dark"] .btn--primary:hover,
+[data-theme="zocdoc-light"] .btn--accent:hover,
+[data-theme="zocdoc-dark"] .btn--accent:hover {
+  background: #F2BD2A;
+  border-color: #F2BD2A;
+  filter: none;
+}

--- a/job/css/tokens-zocdoc-dark.css
+++ b/job/css/tokens-zocdoc-dark.css
@@ -1,35 +1,30 @@
-/* Zocdoc theme — dark. Mirrors generic-dark with green swapped for yellow
-   and a tighter corner-radius scale. */
+/* Zocdoc theme — dark. Literal clone of the generic dark tokens. The yellow
+   accent and pill-rounded buttons are applied via component-level overrides
+   in components.css, scoped to [data-theme="zocdoc-*"] .btn. */
 [data-theme="zocdoc-dark"] {
-  /* Backgrounds — neutral greyscale */
   --bg: #0d1117;
   --bg-surface: #161b22;
   --bg-elevated: #1f2630;
   --bg-overlay: rgba(255, 255, 255, 0.06);
 
-  /* Content */
   --fg: #f0f6fc;
   --fg-muted: rgba(240, 246, 252, 0.72);
   --fg-subtle: rgba(240, 246, 252, 0.50);
-  --fg-link: #FFCD3F;
+  --fg-link: #9FE870;
 
-  /* Interactive — Zocdoc yellow leads as the active accent */
-  --accent: #FFCD3F;
+  --accent: #9FE870;
   --accent-fg: #0d1117;
-  --accent-muted: rgba(255, 205, 63, 0.16);
-  --accent-strong: #FFCD3F;
+  --accent-muted: rgba(159, 232, 112, 0.16);
+  --accent-strong: #9FE870;
   --accent-strong-fg: #0d1117;
 
-  /* Borders */
   --border: rgba(240, 246, 252, 0.12);
   --border-strong: rgba(240, 246, 252, 0.24);
 
-  /* Sentiment */
   --success: #9FE870;
   --error: #FF7A6E;
   --warning: #FFEB69;
 
-  /* Typography */
   --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-display: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
@@ -52,20 +47,17 @@
   --fw-medium: 500;
   --fw-semibold: 600;
 
-  /* Radius — Zocdoc scale (tighter than Wise) */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 20px;
-  --radius-xl: 28px;
-  --radius-2xl: 40px;
+  --radius-sm: 16px;
+  --radius-md: 20px;
+  --radius-lg: 30px;
+  --radius-xl: 40px;
+  --radius-2xl: 60px;
   --radius-pill: 999px;
 
-  /* Shadows */
   --shadow-sm: 0 2px 6px rgba(0,0,0,0.30);
   --shadow-md: 0 8px 24px rgba(0,0,0,0.40);
   --shadow-lg: 0 16px 48px rgba(0,0,0,0.55);
 
-  /* Spacing */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;

--- a/job/css/tokens-zocdoc-light.css
+++ b/job/css/tokens-zocdoc-light.css
@@ -1,25 +1,25 @@
-/* Zocdoc theme — light. Identical to the generic (Wise) design system,
-   with green swapped for yellow and a slightly tighter corner-radius scale.
-   Everything else (typography, spacing, sentiment, neutrals) stays generic. */
+/* Zocdoc theme — light. Literal clone of the generic (Wise) light tokens.
+   The yellow accent and pill-rounded buttons are applied via component-level
+   overrides in components.css, scoped to [data-theme="zocdoc-*"] .btn. */
 [data-theme="zocdoc-light"] {
   /* Backgrounds */
   --bg: #FFFFFF;
-  --bg-surface: #FBF6E8;                           /* tinted neutral lift, yellow cast */
+  --bg-surface: #F5F7F4;
   --bg-elevated: #FFFFFF;
-  --bg-overlay: rgba(122, 88, 0, 0.08);
+  --bg-overlay: rgba(22, 51, 0, 0.08);
 
   /* Content */
   --fg: #0E0F0C;
   --fg-muted: #454745;
   --fg-subtle: #6A6C6A;
-  --fg-link: #7A5800;                              /* deep yellow/ochre (was forest green) */
+  --fg-link: #163300;
 
-  /* Interactive — green replaced with yellow */
-  --accent: #7A5800;                               /* dark yellow / ochre — primary text & button bg */
+  /* Interactive — generic forest/bright green; buttons get yellow via overrides */
+  --accent: #163300;
   --accent-fg: #FFFFFF;
-  --accent-muted: rgba(255, 205, 63, 0.20);        /* tinted Zocdoc yellow */
-  --accent-strong: #FFCD3F;                        /* Zocdoc yellow — accent highlight */
-  --accent-strong-fg: #0E0F0C;                     /* dark text on yellow */
+  --accent-muted: rgba(159, 232, 112, 0.20);
+  --accent-strong: #9FE870;
+  --accent-strong-fg: #163300;
 
   /* Borders */
   --border: rgba(14, 15, 12, 0.12);
@@ -53,12 +53,12 @@
   --fw-medium: 500;
   --fw-semibold: 600;
 
-  /* Radius — Zocdoc scale (tighter than Wise) */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 20px;
-  --radius-xl: 28px;
-  --radius-2xl: 40px;
+  /* Radius — generic Wise scale */
+  --radius-sm: 16px;
+  --radius-md: 20px;
+  --radius-lg: 30px;
+  --radius-xl: 40px;
+  --radius-2xl: 60px;
   --radius-pill: 999px;
 
   /* Shadows */

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.2"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.2"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.2"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.2"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.33.1';
-console.log(`[job] v${VERSION} - Zocdoc theme reduced to yellow + radius (no other overrides)`);
+const VERSION = '0.33.2';
+console.log(`[job] v${VERSION} - Zocdoc theme = generic + yellow pill buttons only`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.1">
-  <script src="/job/js/theme.js?v=0.33.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.2">
+  <script src="/job/js/theme.js?v=0.33.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.2"></script>
 </body>
 </html>


### PR DESCRIPTION
Zocdoc tokens revert to a literal clone of generic. Yellow now lives only on .btn variants, with all buttons fully pill-rounded. Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)