### PR TITLE
job(footer): theme select reflects active theme on first paint

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.3"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.3"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.3"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.3"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.33.3';
-console.log(`[job] v${VERSION} - Zocdoc theme removed`);
+const VERSION = '0.33.4';
+console.log(`[job] v${VERSION} - footer theme select reflects current theme on first paint`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-footer.js
+++ b/job/js/components/job-footer.js
@@ -43,9 +43,9 @@ export class JobFooter extends LitElement {
         <div class="footer__controls">
           <label class="theme-toggle">
             Theme
-            <select @change=${this._setTheme} .value=${this.theme}>
+            <select @change=${this._setTheme}>
               ${THEMES.map(t => html`
-                <option value=${t.value}>${t.label}</option>
+                <option value=${t.value} ?selected=${t.value === this.theme}>${t.label}</option>
               `)}
             </select>
           </label>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.3">
-  <script src="/job/js/theme.js?v=0.33.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
+  <script src="/job/js/theme.js?v=0.33.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.3"></script>
+  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes the theme dropdown always showing 'Generic · Light' regardless of what was applied. Lit's .value=${this.theme} on a <select> sets the property before its <option> children mount, so the visual selection silently fell back to the first option. Switch to per-option ?selected binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)