### PR TITLE
job(jobs): Leads/Active/Archive subtabs + status in row menu

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1594,3 +1594,118 @@
   margin: 0;
   font-style: italic;
 }
+
+/* --- Sub-nav under an active rail item (e.g. Jobs > Leads/Active/Archive) --- */
+.nav-sublist {
+  list-style: none;
+  margin: var(--space-1) 0 var(--space-2) var(--space-4);
+  padding: 0 0 0 var(--space-3);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nav-sublist a {
+  display: block;
+  padding: 6px var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-medium);
+}
+.nav-sublist a:hover { background: var(--bg-elevated); color: var(--fg); text-decoration: none; }
+.nav-sublist a[aria-current="page"] {
+  background: var(--accent-muted);
+  color: var(--accent);
+}
+
+/* --- Bucket tabs (in-page Leads / Active / Archive) --- */
+.bucket-tabs {
+  display: inline-flex;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  margin-bottom: var(--space-4);
+}
+.bucket-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 6px var(--space-4);
+  border-radius: var(--radius-pill);
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  text-decoration: none;
+}
+.bucket-tab:hover { background: var(--bg-elevated); color: var(--fg); text-decoration: none; }
+.bucket-tab.is-active {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.bucket-tab__count {
+  font-size: var(--font-size-caption);
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-overlay);
+  font-variant-numeric: tabular-nums;
+  min-width: 18px;
+  text-align: center;
+}
+.bucket-tab.is-active .bucket-tab__count { background: rgba(255,255,255,0.18); color: inherit; }
+
+/* --- Status pill (read-only label in the row) --- */
+.status-pill {
+  display: inline-block;
+  padding: 4px var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.status-pill.is-saving { opacity: 0.6; }
+.status-pill--new          { background: var(--accent-muted); color: var(--accent); border-color: transparent; }
+.status-pill--apply        { background: rgba(159, 232, 112, 0.30); color: var(--accent); border-color: transparent; }
+.status-pill--applied,
+.status-pill--talking      { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+.status-pill--pass,
+.status-pill--rejected,
+.status-pill--closed,
+.status-pill--not-listed   { background: rgba(168,32,13,0.10); color: var(--error); border-color: transparent; }
+.status-pill--nudge-network { background: rgba(237,200,67,0.20); color: #6E5400; border-color: transparent; }
+
+/* --- Triple-dot menu: wider panel with a status submenu --- */
+.row-menu__panel--wide { min-width: 220px; }
+.row-menu__group-label {
+  padding: 8px var(--space-4) 4px;
+  font-size: var(--font-size-caption);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-subtle);
+  font-weight: var(--fw-semibold);
+}
+.row-menu__item--status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-small);
+}
+.row-menu__item--status.is-current { background: var(--bg-surface); }
+.row-menu__check {
+  display: inline-block;
+  width: 14px;
+  text-align: center;
+  color: var(--accent);
+  font-weight: var(--fw-semibold);
+}
+.row-menu__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.33.4';
-console.log(`[job] v${VERSION} - footer theme select reflects current theme on first paint`);
+const VERSION = '0.34.0';
+console.log(`[job] v${VERSION} - Jobs split into Leads/Active/Archive subtabs; status moves into triple-dot menu`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -11,6 +11,19 @@ const STATUS_OPTIONS = ['', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejec
 const TERMINAL_STATUSES = new Set(['Pass', 'Rejected', 'Closed']);
 const APPLIED_STATUSES = new Set(['Applied', 'Talking']);
 
+// Bucket assignment — drives the Leads / Active / Archive subtabs.
+//   archive: archived OR status in {Pass, Rejected, Closed, Not Listed}
+//   leads:   not archive AND status in {'', 'New', 'Nudge / Network'}
+//   active:  everything else not archive (Apply, Applied, Talking, …)
+const ARCHIVE_STATUSES = new Set(['Pass', 'Rejected', 'Closed', 'Not Listed']);
+const LEADS_STATUSES   = new Set(['', 'New', 'Nudge / Network']);
+function bucketFor(r) {
+  if (r.archivedAt) return 'archive';
+  if (ARCHIVE_STATUSES.has(r.status || '')) return 'archive';
+  if (LEADS_STATUSES.has(r.status || '')) return 'leads';
+  return 'active';
+}
+
 const DIM_LABELS = {
   title:   { label: 'Title match',   max: 25, hint: 'Founding/Senior/Staff PM scores higher; below seniority hard-fails.' },
   stage:   { label: 'Stage',         max: 20, hint: 'Inferred from investors. Pre-seed → C scores high; public/mega-cap hard-fails.' },
@@ -23,8 +36,6 @@ const DIM_LABELS = {
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
-// Role + Company collapsed into a single stacked cell: title row 1,
-// company row 2. Header sort defaults to title (alphabetical).
 const COLUMNS = [
   { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
   { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
@@ -43,10 +54,8 @@ function isVisibleRole(r) {
 }
 
 function isArchived(r) { return !!r.archivedAt; }
-function archiveFilter(r, view) {
-  if (view === 'archived') return isArchived(r);
-  if (view === 'all')      return true;
-  return !isArchived(r); // 'active' default
+function bucketFilter(r, bucket) {
+  return bucketFor(r) === bucket;
 }
 
 export class JobPipeline extends LitElement {
@@ -59,7 +68,7 @@ export class JobPipeline extends LitElement {
     sortKey: { state: true },
     sortDir: { state: true },
     selectedRow: { state: true },
-    archivedView: { state: true },   // 'active' | 'all' | 'archived'
+    bucket: { state: true },         // 'leads' | 'active' | 'archive'
     openMenuSlug: { state: true },
     livenessChecking: { state: true },
     livenessResult: { state: true },
@@ -80,7 +89,16 @@ export class JobPipeline extends LitElement {
     this.sortKey = 'score';
     this.sortDir = 'desc';
     this.selectedRow = null;
-    this.archivedView = 'active';
+    const params = new URLSearchParams(location.search);
+    const b = params.get('bucket');
+    this.bucket = (b === 'leads' || b === 'active' || b === 'archive') ? b : 'leads';
+    if (b !== this.bucket) {
+      // Normalise URL so subnav highlight matches.
+      const qs = new URLSearchParams(location.search);
+      qs.set('bucket', this.bucket);
+      history.replaceState(null, '', `${location.pathname}?${qs}`);
+    }
+    document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: this.bucket } }));
     this.openMenuSlug = null;
     this.livenessChecking = false;
     this.livenessResult = null;            // { checked, closed: [slug…] }
@@ -118,6 +136,14 @@ export class JobPipeline extends LitElement {
       } catch {}
     };
     document.addEventListener('job:pipeline:refresh', this._onRefresh);
+    this._onPopState = () => {
+      const b = new URLSearchParams(location.search).get('bucket') || 'leads';
+      if (b !== this.bucket) {
+        this.bucket = b;
+        document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: b } }));
+      }
+    };
+    window.addEventListener('popstate', this._onPopState);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
@@ -125,6 +151,7 @@ export class JobPipeline extends LitElement {
     document.removeEventListener('keydown', this._onKey);
     document.removeEventListener('click', this._onDocClick);
     document.removeEventListener('job:pipeline:refresh', this._onRefresh);
+    window.removeEventListener('popstate', this._onPopState);
     super.disconnectedCallback();
   }
 
@@ -217,7 +244,7 @@ export class JobPipeline extends LitElement {
   _sorted() {
     const key = this.sortKey;
     const dir = this.sortDir === 'desc' ? -1 : 1;
-    const arr = this.roles.filter(r => isVisibleRole(r) && archiveFilter(r, this.archivedView));
+    const arr = this.roles.filter(r => isVisibleRole(r) && bucketFilter(r, this.bucket));
     arr.sort((a, b) => {
       const av = a[key];
       const bv = b[key];
@@ -268,6 +295,16 @@ export class JobPipeline extends LitElement {
     this.openMenuSlug = this.openMenuSlug === slug ? null : slug;
   }
 
+  _switchBucket(bucket, e) {
+    e.preventDefault();
+    if (bucket === this.bucket) return;
+    this.bucket = bucket;
+    const qs = new URLSearchParams(location.search);
+    qs.set('bucket', bucket);
+    history.pushState(null, '', `${location.pathname}?${qs}`);
+    document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket } }));
+  }
+
   async _onArchive(r, archived) {
     this.openMenuSlug = null;
     const prev = r.archivedAt;
@@ -307,13 +344,24 @@ export class JobPipeline extends LitElement {
   _renderMenuCell(r) {
     const archived = isArchived(r);
     const menuOpen = this.openMenuSlug === r.slug;
+    const cur = r.status || '';
     return html`
       <div class="row-menu">
         <button class="row-menu__trigger" aria-label="Row actions"
                 aria-expanded=${menuOpen ? 'true' : 'false'}
                 @click=${(e) => this._toggleMenu(r.slug, e)}>⋮</button>
         ${menuOpen ? html`
-          <div class="row-menu__panel" role="menu">
+          <div class="row-menu__panel row-menu__panel--wide" role="menu" @click=${(e) => e.stopPropagation()}>
+            <div class="row-menu__group-label">Set status</div>
+            ${STATUS_OPTIONS.map(s => html`
+              <button role="menuitem"
+                      class=${'row-menu__item row-menu__item--status' + (cur === s ? ' is-current' : '')}
+                      @click=${() => this._changeStatusFromMenu(r, s)}>
+                <span class="row-menu__check" aria-hidden="true">${cur === s ? '✓' : ''}</span>
+                <span>${s || '— (clear)'}</span>
+              </button>
+            `)}
+            <div class="row-menu__divider" role="separator"></div>
             <button role="menuitem" class="row-menu__item" @click=${() => this._onArchive(r, !archived)}>
               ${archived ? 'Unarchive' : 'Archive'}
             </button>
@@ -323,6 +371,20 @@ export class JobPipeline extends LitElement {
           </div>
         ` : nothing}
       </div>
+    `;
+  }
+
+  async _changeStatusFromMenu(r, status) {
+    this.openMenuSlug = null;
+    await this._changeStatus(r, status);
+  }
+
+  _renderStatusCell(r) {
+    const s = r.status || '';
+    const cls = 'status-pill status-pill--' + (s ? s.toLowerCase().replace(/[^a-z]+/g, '-') : 'none');
+    return html`
+      <span class=${cls + (r._saving ? ' is-saving' : '')}>${s || '—'}</span>
+      ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
     `;
   }
 
@@ -364,15 +426,7 @@ export class JobPipeline extends LitElement {
             ${r.score == null ? '—' : r.score}
           </button>
         </td>
-        <td class="status-cell" @click=${(e) => e.stopPropagation()}>
-          <select class="status-select ${r._saving ? 'is-saving' : ''}"
-            data-status=${r.status || 'New'}
-            ?disabled=${r._saving}
-            .value=${r.status || ''} @change=${(e) => this._changeStatus(r, e.target.value)}>
-            ${STATUS_OPTIONS.map(s => html`<option value=${s} ?selected=${(r.status || '') === s}>${s || '—'}</option>`)}
-          </select>
-          ${r._error ? html`<span class="status-cell__err" title=${r._error}>!</span>` : nothing}
-        </td>
+        <td class="status-cell">${this._renderStatusCell(r)}</td>
         <td class="role-cell">
           <div class="role-cell__inner">
             ${this._renderLogo(r, 'sm')}
@@ -511,7 +565,12 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._sorted();
-    const archivedCount = this.roles.filter(r => isVisibleRole(r) && isArchived(r)).length;
+    const counts = this.roles.reduce((acc, r) => {
+      if (!isVisibleRole(r)) return acc;
+      acc[bucketFor(r)] = (acc[bucketFor(r)] || 0) + 1;
+      return acc;
+    }, { leads: 0, active: 0, archive: 0 });
+    const bucketLabel = { leads: 'Leads', active: 'Active', archive: 'Archive' }[this.bucket];
     return html`
       <job-recommendations></job-recommendations>
 
@@ -546,18 +605,20 @@ export class JobPipeline extends LitElement {
         </div>
       ` : nothing}
 
+      <div class="bucket-tabs" role="tablist" aria-label="Jobs view">
+        ${['leads','active','archive'].map(b => html`
+          <a class=${'bucket-tab' + (this.bucket === b ? ' is-active' : '')}
+             role="tab"
+             aria-selected=${this.bucket === b ? 'true' : 'false'}
+             href=${`/job/jobs/?bucket=${b}`}
+             @click=${(e) => this._switchBucket(b, e)}>
+            ${{leads:'Leads',active:'Active',archive:'Archive'}[b]}
+            <span class="bucket-tab__count">${counts[b]}</span>
+          </a>
+        `)}
+      </div>
       <div class="pipeline-meta">
-        <strong>${rows.length}</strong> roles, sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.
-        <label class="pipeline-meta__filter">
-          <span class="muted">View:</span>
-          <select class="status-select" style="min-width:120px;"
-                  .value=${this.archivedView}
-                  @change=${(e) => { this.archivedView = e.target.value; }}>
-            <option value="active"   ?selected=${this.archivedView==='active'}>Active</option>
-            <option value="all"      ?selected=${this.archivedView==='all'}>All (incl. archived)</option>
-            <option value="archived" ?selected=${this.archivedView==='archived'}>Archived only</option>
-          </select>
-        </label>
+        <strong>${rows.length}</strong> ${bucketLabel.toLowerCase()} ${rows.length === 1 ? 'role' : 'roles'}, sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.
         <button class="btn btn--sm" ?disabled=${this.livenessChecking}
                 @click=${() => this._onCheckLiveness()}>
           ${this.livenessChecking ? 'Checking…' : 'Check liveness'}
@@ -586,17 +647,14 @@ export class JobPipeline extends LitElement {
         </table>
       </div>
 
-      <div class="pipeline-foot">
-        ${archivedCount > 0 ? html`
-          <button class="btn btn--sm" @click=${() => {
-            this.archivedView = this.archivedView === 'active' ? 'all' : 'active';
-          }}>
-            ${this.archivedView === 'active'
-              ? `Show archived (${archivedCount})`
-              : 'Hide archived'}
-          </button>
-        ` : html`<span class="muted">No archived roles yet.</span>`}
-      </div>
+      ${rows.length === 0 ? html`
+        <div class="placeholder" style="margin-top:var(--space-4);">
+          <h2>No ${bucketLabel.toLowerCase()} ${rows.length === 1 ? 'role' : 'roles'} yet</h2>
+          <p>${this.bucket === 'leads' ? 'Add a posting or wait for the crawler to find a fit.'
+              : this.bucket === 'active' ? 'Move a lead to Apply / Applied / Talking via the row menu.'
+              : 'Closed, passed, rejected, and archived roles land here.'}</p>
+        </div>
+      ` : nothing}
 
       ${this._renderFitModal()}
     `;

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -4,7 +4,16 @@
 import { LitElement, html } from 'https://esm.run/lit@3';
 
 const ROUTES = [
-  { href: '/job/jobs/',    label: 'Jobs',        match: /^\/job\/jobs\/?/ },
+  {
+    href: '/job/jobs/',
+    label: 'Jobs',
+    match: /^\/job\/jobs\/?/,
+    sub: [
+      { href: '/job/jobs/?bucket=leads',   label: 'Leads',   bucket: 'leads' },
+      { href: '/job/jobs/?bucket=active',  label: 'Active',  bucket: 'active' },
+      { href: '/job/jobs/?bucket=archive', label: 'Archive', bucket: 'archive' },
+    ],
+  },
   { href: '/job/history/', label: 'Your career', match: /^\/job\/history\/?/ },
   { href: '/job/vision/',  label: 'Vision',      match: /^\/job\/vision\/?/ }
 ];
@@ -13,12 +22,24 @@ export class JobRail extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
-    path:  { state: true }
+    path:  { state: true },
+    bucket: { state: true },
   };
 
   constructor() {
     super();
     this.path = location.pathname;
+    this.bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
+    this._onBucket = (e) => { this.bucket = e.detail.bucket; };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('job:jobs:bucket', this._onBucket);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('job:jobs:bucket', this._onBucket);
+    super.disconnectedCallback();
   }
 
   render() {
@@ -30,14 +51,29 @@ export class JobRail extends LitElement {
         </div>
         <nav>
           <ul class="nav-list">
-            ${ROUTES.map(r => html`
-              <li>
-                <a href=${r.href}
-                   aria-current=${r.match.test(this.path) ? 'page' : 'false'}>
-                  ${r.label}
-                </a>
-              </li>
-            `)}
+            ${ROUTES.map(r => {
+              const active = r.match.test(this.path);
+              return html`
+                <li>
+                  <a href=${r.href}
+                     aria-current=${active ? 'page' : 'false'}>
+                    ${r.label}
+                  </a>
+                  ${active && r.sub ? html`
+                    <ul class="nav-sublist">
+                      ${r.sub.map(s => html`
+                        <li>
+                          <a href=${s.href}
+                             aria-current=${this.bucket === s.bucket ? 'page' : 'false'}>
+                            ${s.label}
+                          </a>
+                        </li>
+                      `)}
+                    </ul>
+                  ` : ''}
+                </li>
+              `;
+            })}
           </ul>
         </nav>
       </aside>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.33.4">
-  <script src="/job/js/theme.js?v=0.33.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
+  <script src="/job/js/theme.js?v=0.34.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.33.4"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Restructures the Jobs table per request:

- Subtabs under Jobs in the left rail: Leads, Active, Archive (also rendered as in-page bucket tabs).
- Bucket logic:
  - Archive: archived OR status in {Pass, Rejected, Closed, Not Listed}
  - Leads: not archive AND status in {'', 'New', 'Nudge / Network'}
  - Active: everything else not archive (Apply, Applied, Talking, …)
- The in-row status dropdown is gone — status renders as a read-only colour pill, and the triple-dot menu now leads with a 'Set status' list (✓ marks current). Set Closed/Pass/Rejected from the menu and the row moves to Archive.
- URL-driven (?bucket=...) with popstate sync; sub-nav highlight matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)