### PR TITLE
job(jobs): leads-only recs, drop status column on leads, drop in-page bucket tabs

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = '0.34.0';
-console.log(`[job] v${VERSION} - Jobs split into Leads/Active/Archive subtabs; status moves into triple-dot menu`);
+const VERSION = '0.34.1';
+console.log(`[job] v${VERSION} - Leads view: drop Status column + bucket-tabs strip; recommendations only on Leads`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -388,10 +388,15 @@ export class JobPipeline extends LitElement {
     `;
   }
 
+  _visibleColumns() {
+    // Status column is meaningless on Leads (it's always New/empty there).
+    return COLUMNS.filter(c => !(c.id === 'status' && this.bucket === 'leads'));
+  }
+
   _renderHeader() {
     return html`
       <tr>
-        ${COLUMNS.map(c => {
+        ${this._visibleColumns().map(c => {
           if (!c.sortKey) return html`<th>${c.label}</th>`;
           const active = this.sortKey === c.sortKey;
           const arrow = active ? (this.sortDir === 'asc' ? '↑' : '↓') : '↕';
@@ -417,6 +422,7 @@ export class JobPipeline extends LitElement {
   }
 
   _renderRow(r) {
+    const showStatus = this.bucket !== 'leads';
     return html`
       <tr class=${'pipeline-row' + (isArchived(r) ? ' is-archived' : '')}
           @click=${(e) => this._onRowClick(r, e)}>
@@ -426,7 +432,7 @@ export class JobPipeline extends LitElement {
             ${r.score == null ? '—' : r.score}
           </button>
         </td>
-        <td class="status-cell">${this._renderStatusCell(r)}</td>
+        ${showStatus ? html`<td class="status-cell">${this._renderStatusCell(r)}</td>` : nothing}
         <td class="role-cell">
           <div class="role-cell__inner">
             ${this._renderLogo(r, 'sm')}
@@ -475,10 +481,11 @@ export class JobPipeline extends LitElement {
   }
 
   _renderSkeletonRow() {
+    const showStatus = this.bucket !== 'leads';
     return html`
       <tr class="skeleton-row">
         <td><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
-        <td><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>
+        ${showStatus ? html`<td><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
         <td>
           <span class="skeleton" style="width:80%;height:14px;display:block;margin-bottom:6px;"></span>
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
@@ -565,14 +572,9 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._sorted();
-    const counts = this.roles.reduce((acc, r) => {
-      if (!isVisibleRole(r)) return acc;
-      acc[bucketFor(r)] = (acc[bucketFor(r)] || 0) + 1;
-      return acc;
-    }, { leads: 0, active: 0, archive: 0 });
     const bucketLabel = { leads: 'Leads', active: 'Active', archive: 'Archive' }[this.bucket];
     return html`
-      <job-recommendations></job-recommendations>
+      ${this.bucket === 'leads' ? html`<job-recommendations></job-recommendations>` : nothing}
 
       ${this.livenessResult && !this.livenessResultDismissed ? html`
         <div class="liveness-banner ${this.livenessResult.closed.length ? 'liveness-banner--closed' : 'liveness-banner--clean'}" role="status">
@@ -605,18 +607,6 @@ export class JobPipeline extends LitElement {
         </div>
       ` : nothing}
 
-      <div class="bucket-tabs" role="tablist" aria-label="Jobs view">
-        ${['leads','active','archive'].map(b => html`
-          <a class=${'bucket-tab' + (this.bucket === b ? ' is-active' : '')}
-             role="tab"
-             aria-selected=${this.bucket === b ? 'true' : 'false'}
-             href=${`/job/jobs/?bucket=${b}`}
-             @click=${(e) => this._switchBucket(b, e)}>
-            ${{leads:'Leads',active:'Active',archive:'Archive'}[b]}
-            <span class="bucket-tab__count">${counts[b]}</span>
-          </a>
-        `)}
-      </div>
       <div class="pipeline-meta">
         <strong>${rows.length}</strong> ${bucketLabel.toLowerCase()} ${rows.length === 1 ? 'role' : 'roles'}, sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.
         <button class="btn btn--sm" ?disabled=${this.livenessChecking}

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.0">
-  <script src="/job/js/theme.js?v=0.34.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
+  <script src="/job/js/theme.js?v=0.34.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.34.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Per follow-up:
- Recommendations widget shows only on the Leads bucket.
- Leads view drops the Status column (always empty/new there); Active and Archive keep it.
- In-page pill strip of bucket tabs removed; left-rail subnav under Jobs is now the only switcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)