### PR TITLE
Resume diff vs base + cover-letter JD highlights + clean PDF download

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -700,6 +700,30 @@
 
 .asset-doc { max-width: 720px; }
 
+/* --- Diff highlighting (resume + cover letter "Show changes") --- */
+.asset-doc ins.d-add {
+  background: rgba(76, 175, 80, 0.18);
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: rgba(76, 175, 80, 0.6);
+  text-underline-offset: 2px;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+.asset-doc del.d-del {
+  background: rgba(244, 67, 54, 0.12);
+  color: rgba(244, 67, 54, 0.85);
+  text-decoration: line-through;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+.asset-doc mark.d-jd {
+  background: rgba(255, 213, 79, 0.35);
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
 /* --- Role detail (drill page) --- */
 .role-header {
   display: flex;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.35.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.35.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.35.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.35.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.34.2";
-console.log(`[job] v${VERSION} - Leads view: drop Status column + bucket-tabs strip; recommendations only on Leads`);
+const VERSION = "0.35.0";
+console.log(`[job] v${VERSION} - Resume diff vs base + cover-letter JD highlights + clean PDF download + Career → Base resume tab`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -6,10 +6,13 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchPipeline }] = await Promise.all([
+const [{ renderMarkdown }, { fetchPipeline, generateAsset }, { readRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
+  import('../roleAsset.js' + V),
 ]);
+
+const BASE_RESUME_SLUG = '__base__';
 
 // Lazy-load the resume sub-component so the Work History tab doesn't
 // pull markdown deps when only the Narratives tab is active.
@@ -18,6 +21,7 @@ import('./job-history-resume.js' + V);
 const TABS = [
   { id: 'work',       label: 'Work history' },
   { id: 'narratives', label: 'Narratives' },
+  { id: 'base',       label: 'Base resume' },
 ];
 
 // Minimal seed of skill prompts. Real version derives prompts from JD
@@ -40,15 +44,18 @@ export class JobCareer extends LitElement {
     activeTab: { state: true },
     vision: { state: true },
     promptTags: { state: true },
+    baseResume: { state: true },     // { content, missing, generating, error }
   };
 
   constructor() {
     super();
     this.state = 'idle';
     this.error = '';
-    this.activeTab = (new URLSearchParams(location.search).get('tab') === 'narratives') ? 'narratives' : 'work';
+    const tabParam = new URLSearchParams(location.search).get('tab');
+    this.activeTab = TABS.find(t => t.id === tabParam)?.id || 'work';
     this.vision = null;
     this.promptTags = [];
+    this.baseResume = { content: '', missing: true, generating: false, error: '' };
   }
 
   connectedCallback() {
@@ -82,6 +89,11 @@ export class JobCareer extends LitElement {
         .sort((a, b) => b[1] - a[1])
         .slice(0, 8)
         .map(([name, count]) => ({ name, count }));
+      // Best-effort load of the base resume — fine if absent.
+      try {
+        const r = await readRoleAsset(BASE_RESUME_SLUG, 'resume');
+        if (r?.content_md) this.baseResume = { content: r.content_md, missing: false, generating: false, error: '' };
+      } catch { /* leave missing=true */ }
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
@@ -91,8 +103,48 @@ export class JobCareer extends LitElement {
 
   _switchTab(id) {
     this.activeTab = id;
-    const qs = id === 'narratives' ? '?tab=narratives' : '';
+    const qs = id === 'work' ? '' : `?tab=${id}`;
     history.replaceState(null, '', `/job/history/${qs}`);
+  }
+
+  async _generateBaseResume() {
+    this.baseResume = { ...this.baseResume, generating: true, error: '' };
+    try {
+      const res = await generateAsset(null, 'base-resume');
+      this.baseResume = { content: res.content, missing: false, generating: false, error: '' };
+    } catch (e) {
+      this.baseResume = { ...this.baseResume, generating: false, error: String(e) };
+    }
+  }
+
+  _renderBase() {
+    const b = this.baseResume;
+    if (this.state === 'loading') {
+      return html`
+        <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
+        <div class="skeleton" style="width:96%;height:14px;display:block;margin-bottom:8px;"></div>
+        <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+      `;
+    }
+    return html`
+      <section class="narrative-block">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);">
+          <div>
+            <h2 style="margin:0;">Base resume</h2>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);">
+              The canonical, untargeted resume — generated from your KB. Each per-role tailoring diffs against this.
+            </p>
+          </div>
+          <button class="btn btn--sm ${b.missing ? 'btn--primary' : ''}" ?disabled=${b.generating} @click=${() => this._generateBaseResume()}>
+            ${b.generating ? 'Generating…' : (b.missing ? 'Generate from KB' : 'Regenerate from KB')}
+          </button>
+        </header>
+        ${b.error ? html`<p class="muted" style="color:var(--error);">${b.error}</p>` : nothing}
+        ${b.content
+          ? html`<article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(b.content))}</article>`
+          : html`<p class="muted">No base resume yet. Generate one to enable diff highlighting on per-role resumes.</p>`}
+      </section>
+    `;
   }
 
   _renderTabs() {
@@ -158,7 +210,9 @@ export class JobCareer extends LitElement {
   render() {
     return html`
       ${this._renderTabs()}
-      ${this.activeTab === 'work' ? this._renderWork() : this._renderNarratives()}
+      ${this.activeTab === 'work' ? this._renderWork()
+        : this.activeTab === 'narratives' ? this._renderNarratives()
+        : this._renderBase()}
     `;
   }
 }

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -5,12 +5,15 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
   import('../logo.js' + V),
+  import('../diff.js' + V),
 ]);
+
+const BASE_RESUME_SLUG = '__base__';
 
 const TABS = [
   { id: 'details',      label: 'Role details' },
@@ -51,6 +54,8 @@ export class JobRoleDetail extends LitElement {
     activeTab: { state: true },
     role: { state: true },
     assets: { state: true },         // { resume, cover-letter, analysis } each: {content, draft, mode, saving, dirty, error}
+    baseResume: { state: true },     // { content } | null — canonical untargeted resume, source of truth for diff
+    showChanges: { state: true },    // bool — toggle the diff/highlight overlay on resume + cover tabs
   };
 
   constructor() {
@@ -66,6 +71,8 @@ export class JobRoleDetail extends LitElement {
     // analysis + resume + cover.
     this.role = this.slug ? readRolePrefill(this.slug) : null;
     this.assets = { 'resume': null, 'cover-letter': null, 'analysis': null };
+    this.baseResume = null;
+    this.showChanges = true;
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -97,15 +104,17 @@ export class JobRoleDetail extends LitElement {
     if (!this.slug) { this.state = 'error'; this.error = 'Missing slug'; return; }
     this.state = 'loading';
     try {
-      // Load the role row + all three asset rows in parallel.
-      const [pipeline, resume, cover, analysis] = await Promise.all([
+      // Load the role row + all three asset rows + the base resume in parallel.
+      const [pipeline, resume, cover, analysis, baseResume] = await Promise.all([
         fetchPipeline(),
         this._loadAsset('resume'),
         this._loadAsset('cover-letter'),
         this._loadAsset('analysis'),
+        this._loadBaseResume(),
       ]);
       this.role = (pipeline.roles || []).find(r => r.slug === this.slug) || null;
       this.assets = { 'resume': resume, 'cover-letter': cover, 'analysis': analysis };
+      this.baseResume = baseResume;
       this.state = 'loaded';
       document.title = this.role
         ? `${this.role.company} — ${this.role.title} — /job`
@@ -126,6 +135,64 @@ export class JobRoleDetail extends LitElement {
     } catch (e) {
       return { kind, content: '', draft: '', mode: 'empty', saving: false, dirty: false, error: String(e) };
     }
+  }
+
+  async _loadBaseResume() {
+    try {
+      const r = await readRoleAsset(BASE_RESUME_SLUG, 'resume');
+      if (!r) return { content: '', missing: true };
+      return { content: r.content_md, missing: false };
+    } catch {
+      return { content: '', missing: true };
+    }
+  }
+
+  // Open a stripped-down print window with just one asset rendered, then
+  // call window.print(). Print CSS strips the diff/highlight markup so the
+  // saved PDF is clean. User picks "Save as PDF" in the print dialog.
+  _downloadAssetPdf(kind) {
+    const a = this.assets[kind];
+    if (!a || !a.content) return;
+    const r = this.role || {};
+    const docTitle = `IanFike_${kind === 'resume' ? 'Resume' : 'CoverLetter'}_${(r.company || 'role').replace(/\s+/g, '_')}`;
+    const html = renderMarkdown(a.content); // clean — no diff markers
+    const w = window.open('', '_blank', 'noopener');
+    if (!w) return;
+    w.document.write(`<!doctype html>
+<html><head><meta charset="utf-8"><title>${docTitle}</title>
+<style>
+  body { font: 12pt/1.5 -apple-system, BlinkMacSystemFont, "Inter", "Helvetica Neue", Arial, sans-serif; color: #111; max-width: 740px; margin: 48px auto; padding: 0 32px; }
+  h1 { font-size: 22pt; margin: 0 0 4pt; letter-spacing: -0.01em; }
+  h2 { font-size: 11pt; text-transform: uppercase; letter-spacing: 0.08em; margin: 18pt 0 6pt; border-bottom: 1px solid #ddd; padding-bottom: 2pt; }
+  h3 { font-size: 12pt; margin: 12pt 0 2pt; }
+  p, li { font-size: 10.5pt; line-height: 1.5; }
+  ul { padding-left: 18pt; margin: 4pt 0 8pt; }
+  em { color: #555; }
+  a { color: inherit; text-decoration: none; }
+  /* Strip any diff markers that snuck through */
+  ins, mark, del { all: unset; }
+  del { display: none !important; }
+  @page { size: letter; margin: 0.6in; }
+  @media print { body { margin: 0; padding: 0; } }
+</style></head>
+<body>${html}
+<script>
+  window.addEventListener('load', () => { setTimeout(() => window.print(), 50); });
+</script>
+</body></html>`);
+    w.document.close();
+  }
+
+  _toggleChanges() { this.showChanges = !this.showChanges; }
+
+  // For the cover-letter tab, pull source phrases out of the analysis JSON
+  // for "what was tailored from the JD" highlighting.
+  _coverHighlightSources() {
+    const ana = this.assets['analysis'];
+    if (!ana || ana.mode !== 'view') return [];
+    const parsed = this._parseAnalysis(ana.content);
+    if (!parsed) return [];
+    return [parsed.suggestedAngle, parsed.whyFits, parsed.strengths, parsed.gaps].filter(Boolean);
   }
 
   _autoGenerateMissing() {
@@ -472,6 +539,20 @@ export class JobRoleDetail extends LitElement {
         </div>
       `;
     }
+    const canDiff = (kind === 'resume' || kind === 'cover-letter') && a.mode === 'view';
+    const showingChanges = canDiff && this.showChanges;
+
+    let bodyHtml = '';
+    if (a.mode === 'view') {
+      if (kind === 'resume' && showingChanges && this.baseResume?.content) {
+        bodyHtml = renderMarkdown(diffMarkdown(this.baseResume.content, a.content));
+      } else if (kind === 'cover-letter' && showingChanges) {
+        bodyHtml = renderMarkdown(highlightPhrases(a.content, this._coverHighlightSources()));
+      } else {
+        bodyHtml = renderMarkdown(a.content);
+      }
+    }
+
     return html`
       ${(kind === 'resume' || kind === 'cover-letter') ? this._renderTailoringCallout(kind) : nothing}
       ${(kind === 'resume' || kind === 'cover-letter') ? this._renderChangeLog(kind) : nothing}
@@ -481,6 +562,19 @@ export class JobRoleDetail extends LitElement {
           <button class="btn btn--sm" ?disabled=${a.saving} @click=${() => this._onGenerate(kind)}>
             ${a.saving ? 'Regenerating…' : 'Regenerate'}
           </button>
+          ${canDiff ? html`
+            <button class="btn btn--sm ${this.showChanges ? 'btn--primary' : ''}" @click=${() => this._toggleChanges()}>
+              ${this.showChanges ? 'Hide changes' : 'Show changes'}
+            </button>
+          ` : nothing}
+          <button class="btn btn--sm btn--accent" @click=${() => this._downloadAssetPdf(kind)}>
+            Download clean PDF
+          </button>
+          ${kind === 'resume' && this.baseResume?.missing ? html`
+            <span class="muted" style="font-size: var(--font-size-small);">
+              No base resume yet — generate one in <a href="/job/history/?tab=base">Career → Base resume</a>.
+            </span>
+          ` : nothing}
         ` : html`
           <button class="btn btn--sm btn--primary" ?disabled=${!a.dirty || a.saving} @click=${() => this._saveEdit(kind)}>
             ${a.saving ? 'Saving…' : 'Save'}
@@ -491,7 +585,7 @@ export class JobRoleDetail extends LitElement {
       </div>
       ${a.mode === 'edit'
         ? html`<textarea class="asset-editor" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)}></textarea>`
-        : html`<article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(a.content))}</article>`}
+        : html`<article class="kb-doc asset-doc">${unsafeHTML(bodyHtml)}</article>`}
     `;
   }
 

--- a/job/js/diff.js
+++ b/job/js/diff.js
@@ -1,0 +1,121 @@
+// diff.js — produce a marked-up markdown string showing changes between a
+// "base" and a "tailored" version. The output is markdown with inline
+// <ins class="d-add"> / <del class="d-del"> tags, which renderMarkdown passes
+// through to DOMPurify (both tags are allowed by default).
+//
+// Word-level granularity. Whitespace and punctuation are treated as token
+// boundaries by diffWords, so small edits (a swapped verb, a re-ordered
+// keyword) show up as compact add/del pairs rather than whole-line rewrites.
+
+import { diffWords } from 'https://esm.run/diff@5';
+
+export function diffMarkdown(baseMd, tailoredMd) {
+  const base = String(baseMd || '');
+  const tailored = String(tailoredMd || '');
+  if (!base) return tailored;
+  const parts = diffWords(base, tailored);
+  let out = '';
+  for (const p of parts) {
+    if (p.added)        out += wrapInline('ins', 'd-add', p.value);
+    else if (p.removed) out += wrapInline('del', 'd-del', p.value);
+    else                out += p.value;
+  }
+  return out;
+}
+
+// Don't let inline diff tags span newlines — markdown block parsers need
+// structural \n's untouched, otherwise bullets and headings stop rendering.
+function wrapInline(tag, cls, value) {
+  return value.split(/(\n)/).map(seg => {
+    if (seg === '\n') return '\n';
+    if (!seg) return '';
+    return `<${tag} class="${cls}">${seg}</${tag}>`;
+  }).join('');
+}
+
+// Highlight phrases in `text` (markdown) that appear in any of the
+// `sourcePhrases` strings. Used for cover-letter "from JD" highlighting:
+// pull bullets from analysis.suggestedAngle / whyFits / strengths / gaps and
+// mark substrings of the cover letter that echo them.
+//
+// Heuristic: tokenise each source into 3-6 word "chunks" (skipping bullets,
+// headings, common stopwords-only chunks). For each chunk, do a literal
+// case-insensitive match in the cover letter and wrap with <mark>.
+//
+// We deliberately keep this conservative — false positives are noisy.
+const STOPWORDS = new Set([
+  'the','a','an','and','or','of','to','in','on','for','with','at','by','from',
+  'is','are','was','were','be','been','being','as','that','this','it','its',
+  'his','her','their','they','he','she','we','i','you','your','our','my','me',
+  'but','if','then','than','so','not','no','do','does','did','have','has','had',
+  'will','would','can','could','should','may','might','one','two','three',
+]);
+
+function chunkPhrase(s) {
+  const cleaned = String(s || '')
+    .replace(/[#*`_>\[\]]/g, ' ')
+    .replace(/^\s*[-•·]\s*/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return [];
+  const words = cleaned.split(' ');
+  const chunks = [];
+  // Sliding 4-word windows; drop windows that are all stopwords or under
+  // 12 chars total.
+  for (let i = 0; i + 3 < words.length; i++) {
+    const win = words.slice(i, i + 4);
+    const meaningful = win.filter(w => !STOPWORDS.has(w.toLowerCase().replace(/[^a-z0-9-]/g, '')));
+    if (meaningful.length < 2) continue;
+    const phrase = win.join(' ');
+    if (phrase.length < 12) continue;
+    chunks.push(phrase);
+  }
+  return chunks;
+}
+
+function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+export function highlightPhrases(text, sources) {
+  let body = String(text || '');
+  if (!body) return body;
+  const seen = new Set();
+  const phrases = [];
+  for (const src of (sources || [])) {
+    for (const c of chunkPhrase(src)) {
+      const k = c.toLowerCase();
+      if (seen.has(k)) continue;
+      seen.add(k);
+      phrases.push(c);
+    }
+  }
+  // Sort longest-first so longer phrases match before their substrings.
+  phrases.sort((a, b) => b.length - a.length);
+
+  // Track ranges already wrapped to avoid nested <mark>.
+  const wrapped = []; // [startIdx, endIdx)
+  const hits = [];   // [{start, end, phrase}]
+  const lower = body.toLowerCase();
+  for (const p of phrases) {
+    const re = new RegExp(escapeRegex(p), 'gi');
+    let m;
+    while ((m = re.exec(lower)) !== null) {
+      const start = m.index;
+      const end = start + m[0].length;
+      const overlaps = wrapped.some(([s, e]) => start < e && end > s);
+      if (overlaps) continue;
+      wrapped.push([start, end]);
+      hits.push({ start, end });
+    }
+  }
+  if (!hits.length) return body;
+  hits.sort((a, b) => a.start - b.start);
+  let out = '';
+  let cursor = 0;
+  for (const h of hits) {
+    out += body.slice(cursor, h.start);
+    out += `<mark class="d-jd">${body.slice(h.start, h.end)}</mark>`;
+    cursor = h.end;
+  }
+  out += body.slice(cursor);
+  return out;
+}

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -128,10 +128,11 @@ const GEN_ASSET_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gen
 
 export async function generateAsset(slug, kind) {
   const headers = await authHeader();
+  const body = kind === 'base-resume' ? { kind } : { slug, kind };
   const res = await fetch(GEN_ASSET_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ slug, kind }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
   return res.json(); // { slug, kind, content }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.34.1">
-  <script src="/job/js/theme.js?v=0.34.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
+  <script src="/job/js/theme.js?v=0.35.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.34.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.35.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,10 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.2.0';
-console.log(`[gen-asset] v${VERSION} - Postgres cutover`);
+const VERSION = '0.3.0';
+console.log(`[gen-asset] v${VERSION} - base-resume kind for diff baseline`);
+
+const BASE_RESUME_SLUG = '__base__';
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -99,13 +101,34 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
+      : kindIn === 'base-resume' ? 'base-resume'
       : null;
+    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", or "base-resume"', 400);
+
+    // base-resume is global — no role required, persisted in job.global_assets.
+    if (kind === 'base-resume') {
+      const kb = await loadKb();
+      const system = buildSystemPrompt(kind);
+      const user = buildUserMessage(kind, kb, null);
+      const content = await callClaude(system, user);
+      const sql = db();
+      await sql`
+        insert into job.global_assets (kind, content_md, generated_by, generated_at)
+        values ('base-resume', ${content}, ${ANTHROPIC_MODEL}, now())
+        on conflict (kind) do update set
+          content_md = excluded.content_md,
+          generated_by = excluded.generated_by,
+          generated_at = excluded.generated_at,
+          updated_at = now();
+      `;
+      return jsonResp({ ok: true, slug: BASE_RESUME_SLUG, kind, content });
+    }
+
     if (!slugIn && !rowIn) return err('slug or rowNumber required', 400);
-    if (!kind) return err('kind must be "resume", "cover-letter", or "analysis"', 400);
 
     const role = await loadRole(slugIn, rowIn);
     if (!role) return err('role not found', 404);

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -80,7 +80,9 @@ Format rules:
 - No em dashes. No "passionate about" / "excited to". No try-hard cleverness.
 - Reference real projects/skills/wins by their slug-like name when relevant.`;
 
-export function buildSystemPrompt(kind: 'resume' | 'cover-letter' | 'analysis'): string {
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume';
+
+export function buildSystemPrompt(kind: GenKind): string {
   const voice =
     kind === 'cover-letter' ? COVER_LETTER_VOICE :
     kind === 'analysis'     ? ANALYSIS_VOICE :
@@ -88,6 +90,8 @@ export function buildSystemPrompt(kind: 'resume' | 'cover-letter' | 'analysis'):
   const intro =
     kind === 'analysis'
       ? `You are reviewing a job posting for Ian Fike (senior PM) and producing a structured assessment.`
+      : kind === 'base-resume'
+      ? `You are drafting Ian Fike's canonical, untargeted base resume. This is the "before" version that future per-role tailoring will diff against. Write the strongest single-resume he could send to a generalist senior-PM role. Do not target any specific company or sector. Produce final-quality markdown.`
       : `You are drafting a ${kind === 'cover-letter' ? 'cover letter' : 'resume'} for Ian Fike, a senior PM. Your job: produce final-quality markdown that Ian could submit without further editing.`;
 
   return `${intro}
@@ -97,13 +101,24 @@ ${voice}
 Below is Ian's career knowledge base — companies, projects, skills, wins, and goals/intents. Use it as the source of truth for facts. Do not invent.`;
 }
 
-export function buildUserMessage(kind: 'resume' | 'cover-letter' | 'analysis', kbContext: string, role: { company: string; title: string; sector?: string; salary?: string; url?: string }): string {
+export function buildUserMessage(kind: GenKind, kbContext: string, role: { company: string; title: string; sector?: string; salary?: string; url?: string } | null): string {
+  if (kind === 'base-resume') {
+    return `# Career knowledge base
+
+${kbContext}
+
+# Ask
+
+Draft Ian's canonical base resume as markdown. One page. No company-specific tailoring — write the strongest generalist senior-PM resume the KB supports.`;
+  }
+
+  const r = role!;
   const meta = [
-    `Company: ${role.company}`,
-    `Title: ${role.title}`,
-    role.sector ? `Sector: ${role.sector}` : '',
-    role.salary ? `Salary: ${role.salary}` : '',
-    role.url ? `Posting: ${role.url}` : '',
+    `Company: ${r.company}`,
+    `Title: ${r.title}`,
+    r.sector ? `Sector: ${r.sector}` : '',
+    r.salary ? `Salary: ${r.salary}` : '',
+    r.url ? `Posting: ${r.url}` : '',
   ].filter(Boolean).join('\n');
 
   const ask =

--- a/supabase/functions/role-asset/index.ts
+++ b/supabase/functions/role-asset/index.ts
@@ -9,12 +9,17 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.1.0';
-console.log(`[role-asset] v${VERSION}`);
+const VERSION = '0.2.0';
+console.log(`[role-asset] v${VERSION} - route __base__ slug to job.global_assets`);
 
 const KIND_RE = /^(resume|cover-letter|notes|analysis)$/;
 const SLUG_RE = /^[a-z0-9_-]+$/;
 const MAX_BYTES = 64 * 1024;
+
+// Sentinel slug used by the frontend to address the global, untargeted base
+// resume. Persisted in job.global_assets (no FK to pipeline_roles).
+const BASE_SLUG = '__base__';
+const BASE_GLOBAL_KIND = 'base-resume';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -31,6 +36,20 @@ serve(async (req) => {
       const kind = (url.searchParams.get('kind') || '').toLowerCase();
       if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
       if (!KIND_RE.test(kind)) return err('invalid kind', 400);
+
+      if (slug === BASE_SLUG) {
+        // Only resume is supported as a global asset today.
+        if (kind !== 'resume') return err('not found', 404);
+        const rows = await sql`
+          select 'resume' as kind, content_md, generated_by, generated_at, edited_at, updated_at
+          from job.global_assets
+          where kind = ${BASE_GLOBAL_KIND}
+          limit 1;
+        `;
+        if (rows.length === 0) return err('not found', 404);
+        return jsonResp({ slug: BASE_SLUG, ...rows[0] });
+      }
+
       const rows = await sql`
         select role_slug as slug, kind, content_md, source_path, generated_by,
                generated_at, edited_at, updated_at
@@ -51,6 +70,20 @@ serve(async (req) => {
       if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
       if (!KIND_RE.test(kind)) return err('invalid kind', 400);
       if (content_md.length > MAX_BYTES) return err(`content exceeds ${MAX_BYTES} bytes`, 413);
+
+      if (slug === BASE_SLUG) {
+        if (kind !== 'resume') return err('only resume kind is supported for __base__', 400);
+        const result = await sql`
+          insert into job.global_assets (kind, content_md, generated_by, edited_at)
+          values (${BASE_GLOBAL_KIND}, ${content_md}, 'manual', now())
+          on conflict (kind) do update set
+            content_md = excluded.content_md,
+            edited_at = now(),
+            updated_at = now()
+          returning kind, updated_at, edited_at;
+        `;
+        return jsonResp({ ok: true, ...result[0] });
+      }
 
       // Confirm the role exists; we don't auto-create here.
       const role = await sql`select 1 from job.pipeline_roles where slug = ${slug} limit 1`;

--- a/supabase/migrations/056_job_global_assets.sql
+++ b/supabase/migrations/056_job_global_assets.sql
@@ -1,0 +1,30 @@
+-- 056_job_global_assets — global (non-role-scoped) generated assets.
+--
+-- Currently used for the canonical base resume that per-role tailored
+-- resumes diff against. Kept separate from job.role_assets because that
+-- table has a FK to job.pipeline_roles(slug) and we don't want a phantom
+-- role row to host this content.
+
+create table if not exists job.global_assets (
+  kind         text primary key,
+  content_md   text not null,
+  generated_by text,
+  generated_at timestamptz default now(),
+  edited_at    timestamptz,
+  updated_at   timestamptz default now()
+);
+
+create or replace function job.touch_global_assets_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_global_assets_updated_at on job.global_assets;
+create trigger trg_global_assets_updated_at
+before update on job.global_assets
+for each row execute function job.touch_global_assets_updated_at();


### PR DESCRIPTION
## Summary
- New \`job.global_assets\` table (migration 056) holds the canonical untargeted **base resume**. \`gen-asset\` now accepts \`kind='base-resume'\` and writes there. Career page → **Base resume** tab generates/regenerates it from the KB.
- Role detail's **Resume** tab renders a word-level diff against the base resume (\`<ins>\` / \`<del>\` markup, esm.run \`diff@5\`). Per-role tailoring is now visible inline rather than implied.
- Role detail's **Cover letter** tab highlights phrases pulled from the analysis JSON (\`suggestedAngle\`, \`whyFits\`, \`strengths\`, \`gaps\`) — signals which lines came from the JD framing rather than boilerplate.
- New **Show changes** toggle + **Download clean PDF** button on each asset. PDF opens a stripped print window with diff markers removed and triggers \`window.print()\` — user saves via the dialog. No server roundtrip, no Typst dependency.
- Bumps: \`gen-asset\` 0.3.0, \`role-asset\` 0.2.0, \`/job\` 0.35.0.

Future-direction note saved to memory: for new (non-Ian) users, the base resume should be generated from **Narratives + Job History** the first time they hit the Career page.

## Test plan
- [ ] Migration 056 applies cleanly (\`job.global_assets\` exists, trigger present).
- [ ] Edge functions deploy: \`supabase functions deploy gen-asset role-asset\`.
- [ ] Career page → Base resume tab: "Generate from KB" produces a one-page resume; reload preserves it.
- [ ] Role detail → Resume tab: with base present, "Show changes" highlights inserts/deletes; toggle hides them.
- [ ] Role detail → Cover letter tab: phrases echoing the analysis are highlighted yellow.
- [ ] Download clean PDF button opens print dialog with markup stripped.
- [ ] No regression on existing Edit/Save/Regenerate flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)