### PR TITLE
Fix pdfjs workerSrc for base-resume PDF upload

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.37.0";
-console.log(`[job] v${VERSION} - Base resume: upload (md/txt/pdf) or paste replaces generate-from-KB`);
+const VERSION = "0.37.1";
+console.log(`[job] v${VERSION} - pdfjs worker fix for base-resume PDF upload`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -28,10 +28,12 @@ async function readFileAsText(file) {
 let _pdfLib = null;
 async function getPdfLib() {
   if (_pdfLib) return _pdfLib;
-  // pdfjs-dist v4 — legacy build runs without a worker for small docs.
-  const mod = await import('https://esm.run/pdfjs-dist@4.7.76/legacy/build/pdf.mjs');
-  // Disable the worker so we don't have to host a worker file.
-  mod.GlobalWorkerOptions.workerSrc = '';
+  // pdfjs-dist v4 requires a worker. Pin both main + worker to the same
+  // version on jsdelivr so they stay in sync.
+  const PDFJS_VERSION = '4.7.76';
+  const mod = await import(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.mjs`);
+  mod.GlobalWorkerOptions.workerSrc =
+    `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.worker.min.mjs`;
   _pdfLib = mod;
   return mod;
 }
@@ -39,7 +41,7 @@ async function getPdfLib() {
 async function readPdfAsText(file) {
   const lib = await getPdfLib();
   const buf = await file.arrayBuffer();
-  const doc = await lib.getDocument({ data: buf, useWorker: false, isEvalSupported: false }).promise;
+  const doc = await lib.getDocument({ data: buf, isEvalSupported: false }).promise;
   const pages = [];
   for (let i = 1; i <= doc.numPages; i++) {
     const page = await doc.getPage(i);

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Set `GlobalWorkerOptions.workerSrc` to the jsdelivr-hosted worker build, version-pinned to match the main pdfjs import. Resolves "No GlobalWorkerOptions.workerSrc specified" error when uploading a PDF on Career → Base resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)