### PR TITLE
role-asset 0.2.1: redeploy w/ Docker bundle

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.37.0";
-console.log(`[job] v${VERSION} - Base resume: upload (md/txt/pdf) or paste replaces generate-from-KB`);
+const VERSION = "0.37.1";
+console.log(`[job] v${VERSION} - pdfjs worker fix for base-resume PDF upload`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -28,10 +28,12 @@ async function readFileAsText(file) {
 let _pdfLib = null;
 async function getPdfLib() {
   if (_pdfLib) return _pdfLib;
-  // pdfjs-dist v4 — legacy build runs without a worker for small docs.
-  const mod = await import('https://esm.run/pdfjs-dist@4.7.76/legacy/build/pdf.mjs');
-  // Disable the worker so we don't have to host a worker file.
-  mod.GlobalWorkerOptions.workerSrc = '';
+  // pdfjs-dist v4 requires a worker. Pin both main + worker to the same
+  // version on jsdelivr so they stay in sync.
+  const PDFJS_VERSION = '4.7.76';
+  const mod = await import(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.mjs`);
+  mod.GlobalWorkerOptions.workerSrc =
+    `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.worker.min.mjs`;
   _pdfLib = mod;
   return mod;
 }
@@ -39,7 +41,7 @@ async function getPdfLib() {
 async function readPdfAsText(file) {
   const lib = await getPdfLib();
   const buf = await file.arrayBuffer();
-  const doc = await lib.getDocument({ data: buf, useWorker: false, isEvalSupported: false }).promise;
+  const doc = await lib.getDocument({ data: buf, isEvalSupported: false }).promise;
   const pages = [];
   for (let i = 1; i <= doc.numPages; i++) {
     const page = await doc.getPage(i);

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
 </body>
 </html>

--- a/supabase/functions/role-asset/index.ts
+++ b/supabase/functions/role-asset/index.ts
@@ -9,8 +9,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.2.0';
-console.log(`[role-asset] v${VERSION} - route __base__ slug to job.global_assets`);
+const VERSION = '0.2.1';
+console.log(`[role-asset] v${VERSION} - route __base__ slug to job.global_assets (redeploy)`);
 
 const KIND_RE = /^(resume|cover-letter|notes|analysis)$/;
 const SLUG_RE = /^[a-z0-9_-]+$/;


### PR DESCRIPTION
Previous role-asset deploys ran without Docker, so the bundle step was skipped and only function metadata was updated. The deployed code stayed at 0.1.0 and kept rejecting `__base__` writes with "role not found". Bumped to 0.2.1 and redeployed with Docker running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)