### PR TITLE
job(jobs): responsive table + mobile drawer nav

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1755,3 +1755,155 @@
   background: var(--border);
   margin: 4px 0;
 }
+
+/* --- Pipeline table column sizing + cell shape --- */
+.pipeline-table { table-layout: fixed; }
+
+.col-fit    { width: 72px;  min-width: 72px; }
+.col-status { width: 140px; min-width: 120px; }
+.col-role   { width: auto;  max-width: 360px; }
+.col-sector { width: 280px; min-width: 180px; }
+.col-menu   { width: 56px;  min-width: 56px; text-align: right; }
+
+.pipeline-table .col-role .role-cell__inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+}
+.pipeline-table .col-role .role-cell__text { min-width: 0; flex: 1; }
+.pipeline-table .col-role .role-cell__title,
+.pipeline-table .col-role .role-cell__company {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.pipeline-table .col-sector .tag-chips {
+  flex-wrap: wrap;
+  max-height: 56px;
+  overflow: hidden;
+}
+
+/* --- Mobile (< 720px): stack each row as a card --- */
+@media (max-width: 720px) {
+  .pipeline-table-wrap {
+    border: 0;
+    background: transparent;
+    overflow: visible;
+  }
+  .pipeline-table {
+    display: block;
+    table-layout: auto;
+  }
+  .pipeline-table thead { display: none; }
+  .pipeline-table tbody {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .pipeline-table tr {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "fit role menu"
+      "status sector sector";
+    gap: var(--space-2) var(--space-3);
+    align-items: center;
+    padding: var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--bg-elevated);
+  }
+  .pipeline-table tr:hover td { background: transparent; }
+  .pipeline-table td {
+    border-bottom: 0;
+    padding: 0;
+  }
+  .pipeline-table .col-fit    { grid-area: fit;    width: auto; }
+  .pipeline-table .col-status { grid-area: status; width: auto; }
+  .pipeline-table .col-role   { grid-area: role;   max-width: none; min-width: 0; }
+  .pipeline-table .col-sector { grid-area: sector; width: auto; }
+  .pipeline-table .col-menu   { grid-area: menu;   width: auto; text-align: right; }
+  .pipeline-table .col-sector .tag-chips { max-height: none; }
+}
+
+/* --- Mobile top app bar (hamburger → drawer) --- */
+.mobile-bar {
+  display: none;
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  padding: var(--space-3) var(--space-4);
+  align-items: center;
+  gap: var(--space-3);
+}
+.mobile-bar__menu {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  font-size: 18px;
+  cursor: pointer;
+}
+.mobile-bar__menu:hover { background: var(--bg-surface); }
+.mobile-bar__brand {
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body-lg);
+  letter-spacing: -0.015em;
+}
+.mobile-bar__sub {
+  margin-left: var(--space-2);
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  font-weight: var(--fw-medium);
+}
+
+/* Drawer scrim + sliding panel for rail nav. */
+.rail-scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(14,15,12,0.45);
+  z-index: 40;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+body.rail-open .rail-scrim { display: block; opacity: 1; }
+[data-theme$="-dark"] .rail-scrim { background: rgba(0,0,0,0.55); }
+
+@media (max-width: 720px) {
+  .mobile-bar { display: flex; }
+  .app__rail {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(280px, 86vw);
+    height: 100dvh;
+    transform: translateX(-100%);
+    transition: transform 220ms cubic-bezier(0.2, 0.0, 0.0, 1.0);
+    z-index: 50;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    box-shadow: var(--shadow-lg);
+    padding: var(--space-5) var(--space-4);
+    gap: var(--space-5);
+  }
+  body.rail-open .app__rail { transform: translateX(0); }
+  .rail-foot { margin-top: auto; flex-direction: column; align-items: flex-start; }
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "rail"
+      "main"
+      "footer";
+  }
+  /* Rail no longer occupies layout flow on mobile — reclaim the column. */
+  .app > .app__rail { grid-area: rail; }
+  .app__main { padding: var(--space-4); }
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.37.1";
-console.log(`[job] v${VERSION} - pdfjs worker fix for base-resume PDF upload`);
+const VERSION = "0.38.0";
+console.log(`[job] v${VERSION} - responsive jobs table + mobile drawer nav`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -35,6 +35,7 @@ function applySignedInState(email) {
   // Notify components that may have mounted before the event arrived.
   document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
   injectFooter();
+  injectMobileBar();
 }
 
 // Inject the global footer (theme toggle + version + links) into the .app
@@ -45,6 +46,56 @@ function injectFooter() {
   if (!app) return;
   const el = document.createElement('job-footer');
   app.appendChild(el);
+}
+
+// Inject a mobile top app bar (hamburger + brand) at the start of every
+// page's <main>. CSS hides it on >720px screens. Tapping the menu button
+// flips body.rail-open which slides the rail in as a drawer.
+function injectMobileBar() {
+  if (document.querySelector('.mobile-bar')) return;
+  const main = document.querySelector('.app__main');
+  const app = document.querySelector('.app');
+  if (!main || !app) return;
+
+  const bar = document.createElement('header');
+  bar.className = 'mobile-bar';
+  bar.innerHTML = `
+    <button type="button" class="mobile-bar__menu" aria-label="Open navigation"
+            aria-controls="job-rail" aria-expanded="false">☰</button>
+    <span class="mobile-bar__brand">ctrl.rodeo<span class="mobile-bar__sub">/ job</span></span>
+  `;
+  main.prepend(bar);
+
+  // Scrim sits between rail and the rest of the page; tapping it closes.
+  let scrim = document.querySelector('.rail-scrim');
+  if (!scrim) {
+    scrim = document.createElement('div');
+    scrim.className = 'rail-scrim';
+    scrim.setAttribute('aria-hidden', 'true');
+    document.body.appendChild(scrim);
+  }
+
+  const close = () => {
+    document.body.classList.remove('rail-open');
+    bar.querySelector('.mobile-bar__menu').setAttribute('aria-expanded', 'false');
+  };
+  const open = () => {
+    document.body.classList.add('rail-open');
+    bar.querySelector('.mobile-bar__menu').setAttribute('aria-expanded', 'true');
+  };
+
+  bar.querySelector('.mobile-bar__menu').addEventListener('click', () => {
+    document.body.classList.contains('rail-open') ? close() : open();
+  });
+  scrim.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+  // Tapping a nav link inside the rail should close the drawer.
+  document.querySelector('.app__rail')?.addEventListener('click', (e) => {
+    if (e.target.closest('a[href]')) close();
+  });
+  // If the viewport grows past the breakpoint, drop the open state.
+  const mq = window.matchMedia('(min-width: 721px)');
+  mq.addEventListener?.('change', (e) => { if (e.matches) close(); });
 }
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -397,11 +397,12 @@ export class JobPipeline extends LitElement {
     return html`
       <tr>
         ${this._visibleColumns().map(c => {
-          if (!c.sortKey) return html`<th>${c.label}</th>`;
+          const cls = `col col-${c.id}`;
+          if (!c.sortKey) return html`<th class=${cls}>${c.label}</th>`;
           const active = this.sortKey === c.sortKey;
           const arrow = active ? (this.sortDir === 'asc' ? '↑' : '↓') : '↕';
           return html`
-            <th>
+            <th class=${cls}>
               <button class="th-sort ${active ? 'is-active' : ''}" @click=${() => this._onSortClick(c)}>
                 <span>${c.label}</span>
                 <span class="th-sort__arrow">${arrow}</span>
@@ -426,24 +427,24 @@ export class JobPipeline extends LitElement {
     return html`
       <tr class=${'pipeline-row' + (isArchived(r) ? ' is-archived' : '')}
           @click=${(e) => this._onRowClick(r, e)}>
-        <td>
+        <td class="col col-fit" data-label="Fit">
           <button class=${this._scoreClass(r.score) + ' fit-pill--button'}
             title="Tap to see the breakdown" @click=${(e) => { e.stopPropagation(); this._openFitModal(r); }}>
             ${r.score == null ? '—' : r.score}
           </button>
         </td>
-        ${showStatus ? html`<td class="status-cell">${this._renderStatusCell(r)}</td>` : nothing}
-        <td class="role-cell">
+        ${showStatus ? html`<td class="col col-status status-cell" data-label="Status">${this._renderStatusCell(r)}</td>` : nothing}
+        <td class="col col-role role-cell" data-label="Role">
           <div class="role-cell__inner">
             ${this._renderLogo(r, 'sm')}
-            <div>
+            <div class="role-cell__text">
               <div class="role-cell__title">${r.title || '(untitled)'}</div>
               <div class="role-cell__company">${r.company || ''}</div>
             </div>
           </div>
         </td>
-        <td>${this._renderSectorCell(r)}</td>
-        <td>${this._renderMenuCell(r)}</td>
+        <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
+        <td class="col col-menu">${this._renderMenuCell(r)}</td>
       </tr>
     `;
   }
@@ -484,14 +485,14 @@ export class JobPipeline extends LitElement {
     const showStatus = this.bucket !== 'leads';
     return html`
       <tr class="skeleton-row">
-        <td><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
-        ${showStatus ? html`<td><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
-        <td>
+        <td class="col col-fit"><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
+        ${showStatus ? html`<td class="col col-status"><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
+        <td class="col col-role">
           <span class="skeleton" style="width:80%;height:14px;display:block;margin-bottom:6px;"></span>
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
         </td>
-        <td><span class="skeleton" style="width:80px;height:16px;"></span></td>
-        <td><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
+        <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
+        <td class="col col-menu"><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
       </tr>
     `;
   }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.35.0">
-  <script src="/job/js/theme.js?v=0.35.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
+  <script src="/job/js/theme.js?v=0.38.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.37.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Spacing/sizing follow-up + mobile nav.

Desktop:
- Pipeline-table uses table-layout: fixed with per-column widths (Fit 72px, Status 140px, Role auto/max-360px, Sector 280px, Menu 56px). Title/company ellipsize.

Mobile (<720px):
- Each row becomes a card: fit + role + menu in row 1, status + sector in row 2. Table headers hidden, card-style borders.
- New .mobile-bar (hamburger + brand) injected by app.js into every signed-in page; tapping toggles body.rail-open which slides the existing rail in as a drawer with a scrim. Esc / scrim tap / nav-click closes. Resize past breakpoint auto-closes.

v0.38.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)