### PR TITLE
job(css): cache-bust @import children of base.css

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,8 +1,11 @@
-@import url("./tokens-generic-light.css");
-@import url("./tokens-generic-dark.css");
-@import url("./tokens-ctrl-light.css");
-@import url("./tokens-ctrl-dark.css");
-@import url("./components.css");
+/* @import querystrings are bumped alongside JOB_VERSION in app.js so a
+   release that only touches components.css/tokens busts the browser
+   disk cache. The HTML cache-buster only refreshes base.css itself. */
+@import url("./tokens-generic-light.css?v=0.38.1");
+@import url("./tokens-generic-dark.css?v=0.38.1");
+@import url("./tokens-ctrl-light.css?v=0.38.1");
+@import url("./tokens-ctrl-dark.css?v=0.38.1");
+@import url("./components.css?v=0.38.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.38.0";
-console.log(`[job] v${VERSION} - responsive jobs table + mobile drawer nav`);
+const VERSION = "0.38.1";
+console.log(`[job] v${VERSION} - cache-bust @import children of base.css`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.0">
-  <script src="/job/js/theme.js?v=0.38.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
+  <script src="/job/js/theme.js?v=0.38.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Followup to #711: base.css's @imports had no version querystring, so the new components.css rules (responsive table sizing + mobile drawer) loaded in network panel but the browser served the stale parsed copy. Appending ?v=<JOB_VERSION> to each @import.

v0.38.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)