### PR TITLE
job(vision): list, render, and edit 02-goals-intents

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.38.1");
-@import url("./tokens-generic-dark.css?v=0.38.1");
-@import url("./tokens-ctrl-light.css?v=0.38.1");
-@import url("./tokens-ctrl-dark.css?v=0.38.1");
-@import url("./components.css?v=0.38.1");
+@import url("./tokens-generic-light.css?v=0.39.0");
+@import url("./tokens-generic-dark.css?v=0.39.0");
+@import url("./tokens-ctrl-light.css?v=0.39.0");
+@import url("./tokens-ctrl-dark.css?v=0.39.0");
+@import url("./components.css?v=0.39.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.38.1";
-console.log(`[job] v${VERSION} - cache-bust @import children of base.css`);
+const VERSION = "0.39.0";
+console.log(`[job] v${VERSION} - vision page reads/edits 02-goals-intents`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -24,6 +24,9 @@ if (location.pathname.startsWith('/job/jobs/drill')) {
   import('./components/job-role-detail.js' + V);
 } else if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);
+}
+if (location.pathname.startsWith('/job/vision')) {
+  import('./components/job-vision.js' + V);
 }
 
 function applySignedInState(email) {

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -1,0 +1,189 @@
+// job-vision — render & edit the goals/intents corpus that the /jobs skill
+// reads for relevance scoring. Lists 02-goals-intents/ via kb-read, renders
+// each .md file, and commits edits back through kb-write (with baseSha
+// concurrency control).
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { writeFile }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../kbwrite.js' + V),
+]);
+
+const VISION_DIR = '02-goals-intents';
+
+function titleFromFile(name, content) {
+  const m = (content || '').match(/^#\s+(.+)$/m);
+  if (m) return m[1].trim();
+  return name.replace(/\.md$/, '').replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export class JobVision extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    error: { state: true },
+    files: { state: true }, // [{ path, name, content, sha, editing, draft, saving, saveError }]
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    this.files = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      const { entries = [] } = await window.JobKB.listDir(VISION_DIR);
+      const mdEntries = entries
+        .filter(e => e.type === 'file' && e.name.endsWith('.md'))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const files = await Promise.all(mdEntries.map(async (e) => {
+        try {
+          const { content, sha } = await window.JobKB.readFile(e.path);
+          return { path: e.path, name: e.name, content, sha,
+                   editing: false, draft: '', saving: false, saveError: '' };
+        } catch (err) {
+          return { path: e.path, name: e.name, content: '', sha: '',
+                   editing: false, draft: '', saving: false,
+                   saveError: String(err?.message || err) };
+        }
+      }));
+      this.files = files;
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e?.message || e);
+      this.state = 'error';
+    }
+  }
+
+  _updateFile(path, patch) {
+    this.files = this.files.map(f => f.path === path ? { ...f, ...patch } : f);
+  }
+
+  _startEdit(path) {
+    const f = this.files.find(x => x.path === path);
+    if (!f) return;
+    this._updateFile(path, { editing: true, draft: f.content, saveError: '' });
+  }
+
+  _cancelEdit(path) {
+    this._updateFile(path, { editing: false, draft: '', saveError: '' });
+  }
+
+  _onDraftInput(path, value) {
+    this._updateFile(path, { draft: value });
+  }
+
+  async _save(path) {
+    const f = this.files.find(x => x.path === path);
+    if (!f) return;
+    const next = (f.draft ?? '').trimEnd() + '\n';
+    if (next === (f.content ?? '')) {
+      this._updateFile(path, { editing: false, draft: '', saveError: '' });
+      return;
+    }
+    this._updateFile(path, { saving: true, saveError: '' });
+    try {
+      const res = await writeFile(path, next, f.sha);
+      this._updateFile(path, {
+        content: next,
+        sha: res?.sha || f.sha,
+        editing: false,
+        draft: '',
+        saving: false,
+        saveError: '',
+      });
+    } catch (e) {
+      this._updateFile(path, {
+        saving: false,
+        saveError: String(e?.message || e),
+      });
+    }
+  }
+
+  _renderFile(f) {
+    const title = titleFromFile(f.name, f.content);
+    const stripped = (f.content || '').replace(/^#\s+.+\n+/, '');
+    return html`
+      <section class="narrative-block">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
+          <div>
+            <h2 style="margin:0;">${title}</h2>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);font-family:var(--font-mono);">${f.path}</p>
+          </div>
+          ${f.editing ? html`
+            <div style="display:flex;gap:var(--space-2);">
+              <button class="btn btn--sm" ?disabled=${f.saving} @click=${() => this._cancelEdit(f.path)}>Cancel</button>
+              <button class="btn btn--sm btn--primary" ?disabled=${f.saving} @click=${() => this._save(f.path)}>
+                ${f.saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          ` : html`
+            <button class="btn btn--sm" @click=${() => this._startEdit(f.path)}>Edit</button>
+          `}
+        </header>
+
+        ${f.saveError ? html`
+          <p class="muted" style="color:var(--error);margin:0 0 var(--space-3);">${f.saveError}</p>
+        ` : nothing}
+
+        ${f.editing ? html`
+          <textarea class="asset-editor" style="min-height: 320px;"
+                    .value=${f.draft}
+                    @input=${(e) => this._onDraftInput(f.path, e.target.value)}></textarea>
+        ` : html`
+          <article class="kb-doc">${unsafeHTML(renderMarkdown(stripped || f.content || '_(empty)_'))}</article>
+        `}
+      </section>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`
+        <section class="narrative-block">
+          <div class="skeleton" style="width:240px;height:18px;display:block;margin-bottom:var(--space-3);"></div>
+          <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:96%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+        </section>
+      `;
+    }
+    if (this.state === 'error') {
+      return html`
+        <div class="placeholder" style="border-color:var(--error);color:var(--error);">
+          <h2>Couldn't load Vision</h2>
+          <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
+        </div>`;
+    }
+    if (!this.files.length) {
+      return html`
+        <div class="placeholder">
+          <h2>No vision files yet</h2>
+          <p>Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
+        </div>`;
+    }
+    return html`${this.files.map(f => this._renderFile(f))}`;
+  }
+}
+
+customElements.define('job-vision', JobVision);

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,13 +29,10 @@
         <h1>Vision</h1>
         <p>Goals and intents. The same source the /jobs skill reads for relevance.</p>
       </header>
-      <div class="placeholder">
-        <h2>Vision view ships after History</h2>
-        <p>Reads fikei/job/02-goals-intents/ via kb-read. Edits commit through kb-write.</p>
-      </div>
+      <job-vision></job-vision>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- New \`<job-vision>\` component: lists \`02-goals-intents/\` via kb-read, renders each .md, and supports inline edit → commit through kb-write (with baseSha concurrency control).
- Replaces the Vision placeholder page; same source the /jobs skill reads for relevance.
- /job bumped to v0.39.0 (cache-bust across all job HTML/CSS).

## Test plan
- [ ] Sign in to /job/vision/ as fike101@gmail.com — files under \`02-goals-intents/\` render in order with titles derived from H1 (or filename fallback).
- [ ] "Edit" reveals a textarea pre-filled with the file content; "Cancel" reverts; "Save" commits to fikei/job and updates the rendered view.
- [ ] Concurrent edit (stale baseSha) surfaces the kb-write error inline rather than silently overwriting.
- [ ] Other /job pages still load (cache-bust didn't break anything).

🤖 Generated with [Claude Code](https://claude.com/claude-code)