### PR TITLE
job(jobs): fix role column eating leftover width

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,19 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.39.0");
-@import url("./tokens-generic-dark.css?v=0.39.0");
-@import url("./tokens-ctrl-light.css?v=0.39.0");
-@import url("./tokens-ctrl-dark.css?v=0.39.0");
-@import url("./components.css?v=0.39.0");
+<<<<<<< HEAD
+@import url("./tokens-generic-light.css?v=0.39.1");
+@import url("./tokens-generic-dark.css?v=0.39.1");
+@import url("./tokens-ctrl-light.css?v=0.39.1");
+@import url("./tokens-ctrl-dark.css?v=0.39.1");
+@import url("./components.css?v=0.39.1");
+=======
+@import url("./tokens-generic-light.css?v=0.39.1");
+@import url("./tokens-generic-dark.css?v=0.39.1");
+@import url("./tokens-ctrl-light.css?v=0.39.1");
+@import url("./tokens-ctrl-dark.css?v=0.39.1");
+@import url("./components.css?v=0.39.1");
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1761,8 +1761,8 @@
 
 .col-fit    { width: 72px;  min-width: 72px; }
 .col-status { width: 140px; min-width: 120px; }
-.col-role   { width: auto;  max-width: 360px; }
-.col-sector { width: 280px; min-width: 180px; }
+.col-role   { width: 360px; min-width: 240px; max-width: 360px; }
+.col-sector { width: auto;  min-width: 200px; }     /* slack absorber; chips wrap */
 .col-menu   { width: 56px;  min-width: 56px; text-align: right; }
 
 .pipeline-table .col-role .role-cell__inner {

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,13 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +34,10 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+=======
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,13 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +37,10 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+=======
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,13 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +34,10 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+=======
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,13 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +37,10 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+=======
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.39.0";
-console.log(`[job] v${VERSION} - vision page reads/edits 02-goals-intents`);
+const VERSION = "0.39.1";
+console.log(`[job] v${VERSION} - role column fixed-width; sector absorbs slack`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,13 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+=======
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
+  <script src="/job/js/theme.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +38,10 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+<<<<<<< HEAD
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+=======
+  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+>>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>


### PR DESCRIPTION
Under table-layout:fixed, max-width on a th/td doesn't constrain the column — the auto column absorbs all leftover space. Role had width:auto + max-width:360px, so on wide screens it grew past 600px while sector stayed at 280px.

Make role explicitly 360px (min 240) and turn sector into the auto absorber. Sector chips wrap, so a wider sector column reads cleanly.

v0.39.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)