### PR TITLE
job(vision): tabbed card grid w/ inline detail + edit

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.39.0");
-@import url("./tokens-generic-dark.css?v=0.39.0");
-@import url("./tokens-ctrl-light.css?v=0.39.0");
-@import url("./tokens-ctrl-dark.css?v=0.39.0");
-@import url("./components.css?v=0.39.0");
+@import url("./tokens-generic-light.css?v=0.40.0");
+@import url("./tokens-generic-dark.css?v=0.40.0");
+@import url("./tokens-ctrl-light.css?v=0.40.0");
+@import url("./tokens-ctrl-dark.css?v=0.40.0");
+@import url("./components.css?v=0.40.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.38.1");
-@import url("./tokens-generic-dark.css?v=0.38.1");
-@import url("./tokens-ctrl-light.css?v=0.38.1");
-@import url("./tokens-ctrl-dark.css?v=0.38.1");
-@import url("./components.css?v=0.38.1");
+@import url("./tokens-generic-light.css?v=0.39.0");
+@import url("./tokens-generic-dark.css?v=0.39.0");
+@import url("./tokens-ctrl-light.css?v=0.39.0");
+@import url("./tokens-ctrl-dark.css?v=0.39.0");
+@import url("./components.css?v=0.39.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1086,6 +1086,122 @@
 }
 .prompt-card .btn { align-self: flex-start; }
 
+/* --- Vision: tabbed category browser w/ card grid + inline expand --- */
+.vision-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  flex-wrap: wrap;
+}
+.vision-meta .tag-chip { font-size: var(--font-size-caption); }
+
+.vision-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+  align-items: start;
+}
+
+.vision-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  cursor: pointer;
+  transition: border-color 120ms ease, transform 120ms ease, box-shadow 120ms ease;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  width: 100%;
+}
+.vision-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.04);
+}
+.vision-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.012em;
+  line-height: var(--lh-title);
+}
+.vision-card__meta {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  flex-wrap: wrap;
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+}
+.vision-card__preview {
+  margin: 0;
+  font-size: var(--font-size-small);
+  line-height: var(--lh-body);
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.vision-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: auto;
+  padding-top: var(--space-2);
+}
+.vision-card__cta {
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  color: var(--accent);
+}
+
+.vision-detail {
+  grid-column: 1 / -1;
+  background: var(--bg-elevated);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-6);
+}
+.vision-detail__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+.vision-detail__title {
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-2);
+  letter-spacing: -0.018em;
+  line-height: var(--lh-title);
+}
+.vision-detail__actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.vision-empty {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--fg-muted);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+}
+
 /* --- Closed-since-last-visit banner --- */
 .closed-banner {
   display: flex;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.39.0";
-console.log(`[job] v${VERSION} - vision page reads/edits 02-goals-intents`);
+const VERSION = "0.40.0";
+console.log(`[job] v${VERSION} - vision: tabs + card grid + inline detail`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.38.1";
-console.log(`[job] v${VERSION} - cache-bust @import children of base.css`);
+const VERSION = "0.39.0";
+console.log(`[job] v${VERSION} - vision page reads/edits 02-goals-intents`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -24,6 +24,9 @@ if (location.pathname.startsWith('/job/jobs/drill')) {
   import('./components/job-role-detail.js' + V);
 } else if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);
+}
+if (location.pathname.startsWith('/job/vision')) {
+  import('./components/job-vision.js' + V);
 }
 
 function applySignedInState(email) {

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -1,0 +1,189 @@
+// job-vision — render & edit the goals/intents corpus that the /jobs skill
+// reads for relevance scoring. Lists 02-goals-intents/ via kb-read, renders
+// each .md file, and commits edits back through kb-write (with baseSha
+// concurrency control).
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { writeFile }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../kbwrite.js' + V),
+]);
+
+const VISION_DIR = '02-goals-intents';
+
+function titleFromFile(name, content) {
+  const m = (content || '').match(/^#\s+(.+)$/m);
+  if (m) return m[1].trim();
+  return name.replace(/\.md$/, '').replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export class JobVision extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state: { state: true },
+    error: { state: true },
+    files: { state: true }, // [{ path, name, content, sha, editing, draft, saving, saveError }]
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    this.files = [];
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      const { entries = [] } = await window.JobKB.listDir(VISION_DIR);
+      const mdEntries = entries
+        .filter(e => e.type === 'file' && e.name.endsWith('.md'))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const files = await Promise.all(mdEntries.map(async (e) => {
+        try {
+          const { content, sha } = await window.JobKB.readFile(e.path);
+          return { path: e.path, name: e.name, content, sha,
+                   editing: false, draft: '', saving: false, saveError: '' };
+        } catch (err) {
+          return { path: e.path, name: e.name, content: '', sha: '',
+                   editing: false, draft: '', saving: false,
+                   saveError: String(err?.message || err) };
+        }
+      }));
+      this.files = files;
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e?.message || e);
+      this.state = 'error';
+    }
+  }
+
+  _updateFile(path, patch) {
+    this.files = this.files.map(f => f.path === path ? { ...f, ...patch } : f);
+  }
+
+  _startEdit(path) {
+    const f = this.files.find(x => x.path === path);
+    if (!f) return;
+    this._updateFile(path, { editing: true, draft: f.content, saveError: '' });
+  }
+
+  _cancelEdit(path) {
+    this._updateFile(path, { editing: false, draft: '', saveError: '' });
+  }
+
+  _onDraftInput(path, value) {
+    this._updateFile(path, { draft: value });
+  }
+
+  async _save(path) {
+    const f = this.files.find(x => x.path === path);
+    if (!f) return;
+    const next = (f.draft ?? '').trimEnd() + '\n';
+    if (next === (f.content ?? '')) {
+      this._updateFile(path, { editing: false, draft: '', saveError: '' });
+      return;
+    }
+    this._updateFile(path, { saving: true, saveError: '' });
+    try {
+      const res = await writeFile(path, next, f.sha);
+      this._updateFile(path, {
+        content: next,
+        sha: res?.sha || f.sha,
+        editing: false,
+        draft: '',
+        saving: false,
+        saveError: '',
+      });
+    } catch (e) {
+      this._updateFile(path, {
+        saving: false,
+        saveError: String(e?.message || e),
+      });
+    }
+  }
+
+  _renderFile(f) {
+    const title = titleFromFile(f.name, f.content);
+    const stripped = (f.content || '').replace(/^#\s+.+\n+/, '');
+    return html`
+      <section class="narrative-block">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
+          <div>
+            <h2 style="margin:0;">${title}</h2>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);font-family:var(--font-mono);">${f.path}</p>
+          </div>
+          ${f.editing ? html`
+            <div style="display:flex;gap:var(--space-2);">
+              <button class="btn btn--sm" ?disabled=${f.saving} @click=${() => this._cancelEdit(f.path)}>Cancel</button>
+              <button class="btn btn--sm btn--primary" ?disabled=${f.saving} @click=${() => this._save(f.path)}>
+                ${f.saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          ` : html`
+            <button class="btn btn--sm" @click=${() => this._startEdit(f.path)}>Edit</button>
+          `}
+        </header>
+
+        ${f.saveError ? html`
+          <p class="muted" style="color:var(--error);margin:0 0 var(--space-3);">${f.saveError}</p>
+        ` : nothing}
+
+        ${f.editing ? html`
+          <textarea class="asset-editor" style="min-height: 320px;"
+                    .value=${f.draft}
+                    @input=${(e) => this._onDraftInput(f.path, e.target.value)}></textarea>
+        ` : html`
+          <article class="kb-doc">${unsafeHTML(renderMarkdown(stripped || f.content || '_(empty)_'))}</article>
+        `}
+      </section>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`
+        <section class="narrative-block">
+          <div class="skeleton" style="width:240px;height:18px;display:block;margin-bottom:var(--space-3);"></div>
+          <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:96%;height:14px;display:block;margin-bottom:8px;"></div>
+          <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
+        </section>
+      `;
+    }
+    if (this.state === 'error') {
+      return html`
+        <div class="placeholder" style="border-color:var(--error);color:var(--error);">
+          <h2>Couldn't load Vision</h2>
+          <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
+        </div>`;
+    }
+    if (!this.files.length) {
+      return html`
+        <div class="placeholder">
+          <h2>No vision files yet</h2>
+          <p>Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
+        </div>`;
+    }
+    return html`${this.files.map(f => this._renderFile(f))}`;
+  }
+}
+
+customElements.define('job-vision', JobVision);

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -1,7 +1,15 @@
-// job-vision — render & edit the goals/intents corpus that the /jobs skill
-// reads for relevance scoring. Lists 02-goals-intents/ via kb-read, renders
-// each .md file, and commits edits back through kb-write (with baseSha
-// concurrency control).
+// job-vision — tabbed browser for fikei/job/02-goals-intents/.
+//
+// Layout:
+//   [Narrative | Goals | Intents | Filters | Other]   ← only non-empty tabs
+//   Grid of cards  (title · path · preview · word count · "Open")
+//   Click a card  → expands inline (full-row) to render the markdown and
+//                   expose Edit/Save/Cancel. Edits commit via kb-write with
+//                   baseSha concurrency control.
+//
+// Filename → tab classification is a tolerant prefix/keyword match; anything
+// unmatched lands in "Other". The /jobs skill reads the same files; nothing
+// here changes what it sees on disk.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
@@ -12,19 +20,62 @@ const [{ renderMarkdown }, { writeFile }] = await Promise.all([
 
 const VISION_DIR = '02-goals-intents';
 
+// Order matters — tabs render in this order; first match wins. The "All" tab
+// is prepended automatically. Each entry maps to (label, predicate).
+const CATEGORIES = [
+  { id: 'narrative', label: 'Narrative',
+    test: (n) => /^(narrative|voice|story|bio|about|arc)/.test(n) },
+  { id: 'goals',     label: 'Goals',
+    test: (n) => /^(goal|north|mission|vision|aim|ambition)/.test(n) },
+  { id: 'intents',   label: 'Intents',
+    test: (n) => /^(intent|target|seeking|looking|wants|preference)/.test(n) },
+  { id: 'filters',   label: 'Filters',
+    test: (n) => /^(criteria|filter|dealbreaker|anti|no-go|must|reject|exclud)/.test(n) },
+  { id: 'other',     label: 'Other', test: () => true },
+];
+
+function categoryFor(name) {
+  const base = name.replace(/\.md$/, '').toLowerCase();
+  for (const c of CATEGORIES) if (c.test(base)) return c.id;
+  return 'other';
+}
+
 function titleFromFile(name, content) {
   const m = (content || '').match(/^#\s+(.+)$/m);
   if (m) return m[1].trim();
   return name.replace(/\.md$/, '').replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
+// Plain-text preview: drop the H1, strip markdown syntax, collapse whitespace.
+function previewFor(content) {
+  const noH1 = (content || '').replace(/^#\s+.+\n+/, '');
+  const stripped = noH1
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_m, s, l) => (l || s))
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .replace(/^[#>*\-+\s]+/gm, '')
+    .replace(/\*\*?([^*]+)\*\*?/g, '$1')
+    .replace(/_+([^_]+)_+/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stripped;
+}
+
+function wordCount(content) {
+  return (content || '').trim().split(/\s+/).filter(Boolean).length;
+}
+
 export class JobVision extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
-    state: { state: true },
-    error: { state: true },
-    files: { state: true }, // [{ path, name, content, sha, editing, draft, saving, saveError }]
+    state:    { state: true },
+    error:    { state: true },
+    files:    { state: true }, // [{ path, name, content, sha, category, editing, draft, saving, saveError }]
+    activeTab:{ state: true }, // 'all' | category id
+    openPath: { state: true }, // currently expanded file
   };
 
   constructor() {
@@ -32,6 +83,9 @@ export class JobVision extends LitElement {
     this.state = 'idle';
     this.error = '';
     this.files = [];
+    const params = new URLSearchParams(location.search);
+    this.activeTab = params.get('tab') || 'all';
+    this.openPath = params.get('open') || '';
   }
 
   connectedCallback() {
@@ -59,12 +113,18 @@ export class JobVision extends LitElement {
       const files = await Promise.all(mdEntries.map(async (e) => {
         try {
           const { content, sha } = await window.JobKB.readFile(e.path);
-          return { path: e.path, name: e.name, content, sha,
-                   editing: false, draft: '', saving: false, saveError: '' };
+          return {
+            path: e.path, name: e.name, content, sha,
+            category: categoryFor(e.name),
+            editing: false, draft: '', saving: false, saveError: '',
+          };
         } catch (err) {
-          return { path: e.path, name: e.name, content: '', sha: '',
-                   editing: false, draft: '', saving: false,
-                   saveError: String(err?.message || err) };
+          return {
+            path: e.path, name: e.name, content: '', sha: '',
+            category: categoryFor(e.name),
+            editing: false, draft: '', saving: false,
+            saveError: String(err?.message || err),
+          };
         }
       }));
       this.files = files;
@@ -73,6 +133,32 @@ export class JobVision extends LitElement {
       this.error = String(e?.message || e);
       this.state = 'error';
     }
+  }
+
+  _writeUrl() {
+    const qs = new URLSearchParams();
+    if (this.activeTab && this.activeTab !== 'all') qs.set('tab', this.activeTab);
+    if (this.openPath) qs.set('open', this.openPath);
+    const search = qs.toString();
+    history.replaceState(null, '', '/job/vision/' + (search ? `?${search}` : ''));
+  }
+
+  _switchTab(id) {
+    this.activeTab = id;
+    if (this.openPath) {
+      const open = this.files.find(f => f.path === this.openPath);
+      if (open && id !== 'all' && open.category !== id) this.openPath = '';
+    }
+    this._writeUrl();
+  }
+
+  _openCard(path) {
+    this.openPath = this.openPath === path ? '' : path;
+    if (!this.openPath) {
+      // Close any in-progress edit when collapsing.
+      this._updateFile(path, { editing: false, draft: '', saveError: '' });
+    }
+    this._writeUrl();
   }
 
   _updateFile(path, patch) {
@@ -84,11 +170,9 @@ export class JobVision extends LitElement {
     if (!f) return;
     this._updateFile(path, { editing: true, draft: f.content, saveError: '' });
   }
-
   _cancelEdit(path) {
     this._updateFile(path, { editing: false, draft: '', saveError: '' });
   }
-
   _onDraftInput(path, value) {
     this._updateFile(path, { draft: value });
   }
@@ -120,26 +204,77 @@ export class JobVision extends LitElement {
     }
   }
 
-  _renderFile(f) {
+  _visibleTabs() {
+    const counts = new Map([['all', this.files.length]]);
+    for (const f of this.files) counts.set(f.category, (counts.get(f.category) || 0) + 1);
+    const tabs = [{ id: 'all', label: 'All', count: counts.get('all') || 0 }];
+    for (const c of CATEGORIES) {
+      const n = counts.get(c.id) || 0;
+      if (n > 0) tabs.push({ id: c.id, label: c.label, count: n });
+    }
+    return tabs;
+  }
+
+  _filteredFiles() {
+    if (this.activeTab === 'all') return this.files;
+    return this.files.filter(f => f.category === this.activeTab);
+  }
+
+  _renderTabs(tabs) {
+    return html`
+      <div class="asset-tabs">
+        ${tabs.map(t => html`
+          <button class="asset-tabs__tab ${this.activeTab === t.id ? 'is-active' : ''}"
+                  @click=${() => this._switchTab(t.id)}>
+            ${t.label} <span class="muted" style="font-weight:400;">${t.count}</span>
+          </button>
+        `)}
+      </div>
+    `;
+  }
+
+  _renderCard(f) {
     const title = titleFromFile(f.name, f.content);
+    const preview = previewFor(f.content);
+    const words = wordCount(f.content);
+    const isOpen = this.openPath === f.path;
+    if (isOpen) return this._renderDetail(f, title);
+    return html`
+      <button type="button" class="vision-card" @click=${() => this._openCard(f.path)}>
+        <h3 class="vision-card__title">${title}</h3>
+        <div class="vision-card__meta">
+          <span>${f.name}</span>
+          <span>·</span>
+          <span>${words} ${words === 1 ? 'word' : 'words'}</span>
+        </div>
+        <p class="vision-card__preview">${preview || '_(empty)_'}</p>
+        <div class="vision-card__footer">
+          <span class="vision-card__cta">Open →</span>
+        </div>
+      </button>
+    `;
+  }
+
+  _renderDetail(f, title) {
     const stripped = (f.content || '').replace(/^#\s+.+\n+/, '');
     return html`
-      <section class="narrative-block">
-        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
+      <section class="vision-detail">
+        <header class="vision-detail__head">
           <div>
-            <h2 style="margin:0;">${title}</h2>
+            <h2 class="vision-detail__title">${title}</h2>
             <p class="muted" style="margin:0;font-size:var(--font-size-small);font-family:var(--font-mono);">${f.path}</p>
           </div>
-          ${f.editing ? html`
-            <div style="display:flex;gap:var(--space-2);">
+          <div class="vision-detail__actions">
+            ${f.editing ? html`
               <button class="btn btn--sm" ?disabled=${f.saving} @click=${() => this._cancelEdit(f.path)}>Cancel</button>
               <button class="btn btn--sm btn--primary" ?disabled=${f.saving} @click=${() => this._save(f.path)}>
                 ${f.saving ? 'Saving…' : 'Save'}
               </button>
-            </div>
-          ` : html`
-            <button class="btn btn--sm" @click=${() => this._startEdit(f.path)}>Edit</button>
-          `}
+            ` : html`
+              <button class="btn btn--sm" @click=${() => this._startEdit(f.path)}>Edit</button>
+              <button class="btn btn--sm" @click=${() => this._openCard(f.path)}>Close</button>
+            `}
+          </div>
         </header>
 
         ${f.saveError ? html`
@@ -147,11 +282,11 @@ export class JobVision extends LitElement {
         ` : nothing}
 
         ${f.editing ? html`
-          <textarea class="asset-editor" style="min-height: 320px;"
+          <textarea class="asset-editor" style="min-height: 360px;"
                     .value=${f.draft}
                     @input=${(e) => this._onDraftInput(f.path, e.target.value)}></textarea>
         ` : html`
-          <article class="kb-doc">${unsafeHTML(renderMarkdown(stripped || f.content || '_(empty)_'))}</article>
+          <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(stripped || f.content || '_(empty)_'))}</article>
         `}
       </section>
     `;
@@ -160,12 +295,15 @@ export class JobVision extends LitElement {
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
       return html`
-        <section class="narrative-block">
-          <div class="skeleton" style="width:240px;height:18px;display:block;margin-bottom:var(--space-3);"></div>
-          <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
-          <div class="skeleton" style="width:96%;height:14px;display:block;margin-bottom:8px;"></div>
-          <div class="skeleton" style="width:80%;height:14px;display:block;"></div>
-        </section>
+        <div class="vision-grid">
+          ${[0,1,2,3].map(() => html`
+            <div class="vision-card" style="cursor:default;">
+              <div class="skeleton" style="width:60%;height:18px;display:block;margin-bottom:8px;"></div>
+              <div class="skeleton" style="width:90%;height:12px;display:block;margin-bottom:6px;"></div>
+              <div class="skeleton" style="width:80%;height:12px;display:block;"></div>
+            </div>
+          `)}
+        </div>
       `;
     }
     if (this.state === 'error') {
@@ -177,12 +315,27 @@ export class JobVision extends LitElement {
     }
     if (!this.files.length) {
       return html`
-        <div class="placeholder">
-          <h2>No vision files yet</h2>
-          <p>Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
+        <div class="vision-empty">
+          <h2 style="margin:0 0 var(--space-2);">No vision files yet</h2>
+          <p style="margin:0;">Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
         </div>`;
     }
-    return html`${this.files.map(f => this._renderFile(f))}`;
+    const tabs = this._visibleTabs();
+    const filtered = this._filteredFiles();
+    const totalWords = this.files.reduce((sum, f) => sum + wordCount(f.content), 0);
+    return html`
+      ${this._renderTabs(tabs)}
+      <div class="vision-meta">
+        <span>${filtered.length} ${filtered.length === 1 ? 'file' : 'files'}</span>
+        <span>·</span>
+        <span>${totalWords.toLocaleString()} words across all of Vision</span>
+      </div>
+      <div class="vision-grid">
+        ${filtered.length === 0
+          ? html`<div class="vision-empty" style="grid-column: 1 / -1;">Nothing in this category yet.</div>`
+          : filtered.map(f => this._renderCard(f))}
+      </div>
+    `;
   }
 }
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
-  <script src="/job/js/theme.js?v=0.39.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Vision — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.38.1">
-  <script src="/job/js/theme.js?v=0.38.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.39.0">
+  <script src="/job/js/theme.js?v=0.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,13 +29,10 @@
         <h1>Vision</h1>
         <p>Goals and intents. The same source the /jobs skill reads for relevance.</p>
       </header>
-      <div class="placeholder">
-        <h2>Vision view ships after History</h2>
-        <p>Reads fikei/job/02-goals-intents/ via kb-read. Edits commit through kb-write.</p>
-      </div>
+      <job-vision></job-vision>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.38.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.39.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces the flat Vision list with a tabbed card grid (Narrative / Goals / Intents / Filters / Other), classified from filename.
- Cards: title, filename, word count, 4-line preview. Click expands the row in-place to render full markdown with Edit / Save / Cancel.
- Active tab + open file mirror to \`?tab=\` and \`?open=\` for deep links.
- /job bumped to v0.40.0; kb-read / kb-write unchanged.

## Test plan
- [ ] /job/vision/ shows only tabs that have files; "All" always present with the correct counts.
- [ ] Click a card → expands to full row; "Close" collapses it; tab switch to a category that doesn't contain the open card auto-collapses.
- [ ] Edit → Save round-trips through kb-write; rendered view shows the new content immediately.
- [ ] Reload with \`?tab=goals&open=02-goals-intents/...md\` restores state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)