### PR TITLE
Base resume: AI cleanup pass before save

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -7,11 +7,11 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -35,9 +35,9 @@
   </div>
 
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -7,11 +7,11 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -38,9 +38,9 @@
   </div>
 
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,11 +7,11 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -35,9 +35,9 @@
   </div>
 
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -7,11 +7,11 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -38,9 +38,9 @@
   </div>
 
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.39.1";
-console.log(`[job] v${VERSION} - role column fixed-width; sector absorbs slack`);
+const VERSION = "0.40.0";
+console.log(`[job] v${VERSION} - Base resume: AI cleanup pass for uploaded text`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -6,7 +6,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchPipeline }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { fetchPipeline, formatResumeText }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -92,7 +92,8 @@ export class JobCareer extends LitElement {
     activeTab: { state: true },
     vision: { state: true },
     promptTags: { state: true },
-    baseResume: { state: true },     // { content, missing, generating, error }
+    baseResume: { state: true },     // saved row: { content, missing, generating, error }
+    baseDraft: { state: true },      // editing buffer: { text, status, error } — status in idle|reading|formatting|saving
   };
 
   constructor() {
@@ -104,6 +105,7 @@ export class JobCareer extends LitElement {
     this.vision = null;
     this.promptTags = [];
     this.baseResume = { content: '', missing: true, generating: false, error: '' };
+    this.baseDraft = { text: '', status: 'idle', error: '' };
   }
 
   connectedCallback() {
@@ -155,42 +157,67 @@ export class JobCareer extends LitElement {
     history.replaceState(null, '', `/job/history/${qs}`);
   }
 
+  // Upload: extract text and drop it into the draft textarea — does NOT
+  // save. User reviews, optionally runs AI cleanup, then saves.
   async _onBaseUpload(file) {
     if (!file) return;
-    this.baseResume = { ...this.baseResume, generating: true, error: '' };
+    this.baseDraft = { text: '', status: 'reading', error: '' };
     try {
       const text = await readFileAsText(file);
       if (!text || !text.trim()) throw new Error('Empty file');
-      await writeRoleAsset(BASE_RESUME_SLUG, 'resume', text);
-      this.baseResume = { content: text, missing: false, generating: false, error: '' };
+      this.baseDraft = { text, status: 'idle', error: '' };
     } catch (e) {
-      this.baseResume = { ...this.baseResume, generating: false, error: String(e?.message || e) };
+      this.baseDraft = { text: '', status: 'idle', error: String(e?.message || e) };
     }
   }
 
-  async _onBasePaste() {
-    const ta = this.querySelector('#base-paste');
-    const text = (ta?.value || '').trim();
+  _onDraftInput(e) {
+    this.baseDraft = { ...this.baseDraft, text: e.target.value };
+  }
+
+  // Send the draft text through Claude to reformat into clean markdown.
+  // Replaces the draft with the cleaned version on success.
+  async _onCleanupDraft() {
+    const text = (this.baseDraft.text || '').trim();
     if (!text) {
-      this.baseResume = { ...this.baseResume, error: 'Paste your resume first.' };
+      this.baseDraft = { ...this.baseDraft, error: 'Paste or upload resume text first.' };
       return;
     }
-    this.baseResume = { ...this.baseResume, generating: true, error: '' };
+    this.baseDraft = { ...this.baseDraft, status: 'formatting', error: '' };
+    try {
+      const cleaned = await formatResumeText(text);
+      this.baseDraft = { text: cleaned, status: 'idle', error: '' };
+    } catch (e) {
+      this.baseDraft = { ...this.baseDraft, status: 'idle', error: String(e?.message || e) };
+    }
+  }
+
+  async _onSaveDraft() {
+    const text = (this.baseDraft.text || '').trim();
+    if (!text) {
+      this.baseDraft = { ...this.baseDraft, error: 'Nothing to save.' };
+      return;
+    }
+    this.baseDraft = { ...this.baseDraft, status: 'saving', error: '' };
     try {
       await writeRoleAsset(BASE_RESUME_SLUG, 'resume', text);
       this.baseResume = { content: text, missing: false, generating: false, error: '' };
+      this.baseDraft = { text: '', status: 'idle', error: '' };
     } catch (e) {
-      this.baseResume = { ...this.baseResume, generating: false, error: String(e?.message || e) };
+      this.baseDraft = { ...this.baseDraft, status: 'idle', error: String(e?.message || e) };
     }
   }
 
   _onBaseClear() {
-    // Just reveal the upload zone — the next upload/paste overwrites the row.
+    // Reveal the upload/edit zone again, seeded with the saved content so
+    // the user can edit-in-place rather than starting from scratch.
+    this.baseDraft = { text: this.baseResume.content || '', status: 'idle', error: '' };
     this.baseResume = { content: '', missing: true, generating: false, error: '' };
   }
 
   _renderBase() {
     const b = this.baseResume;
+    const d = this.baseDraft;
     if (this.state === 'loading') {
       return html`
         <div class="skeleton" style="width:100%;height:14px;display:block;margin-bottom:8px;"></div>
@@ -199,17 +226,18 @@ export class JobCareer extends LitElement {
       `;
     }
     const hasContent = !!b.content;
+    const busy = d.status !== 'idle';
     return html`
       <section class="narrative-block">
         <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
           <div>
             <h2 style="margin:0;">Base resume</h2>
             <p class="muted" style="margin:0;font-size:var(--font-size-small);">
-              Upload or paste your canonical resume. Per-role tailoring will diff against this.
+              Upload or paste your canonical resume, then clean it up with AI before saving. Per-role tailoring diffs against this.
             </p>
           </div>
           ${hasContent ? html`
-            <button class="btn btn--sm" ?disabled=${b.generating} @click=${() => this._onBaseClear()}>Replace</button>
+            <button class="btn btn--sm" ?disabled=${busy} @click=${() => this._onBaseClear()}>Replace</button>
           ` : nothing}
         </header>
 
@@ -218,24 +246,34 @@ export class JobCareer extends LitElement {
             <label class="base-upload__drop">
               <input type="file" accept=".md,.markdown,.txt,.pdf,text/markdown,text/plain,application/pdf"
                      @change=${(e) => this._onBaseUpload(e.target.files?.[0])}
-                     ?disabled=${b.generating}>
+                     ?disabled=${busy}>
               <span class="base-upload__cta">
-                ${b.generating ? 'Reading file…' : 'Upload resume'}
+                ${d.status === 'reading' ? 'Reading file…' : 'Upload resume'}
               </span>
-              <span class="muted" style="font-size:var(--font-size-small);">.md, .txt, or .pdf</span>
+              <span class="muted" style="font-size:var(--font-size-small);">.md, .txt, or .pdf — or paste below</span>
             </label>
-            <details style="margin-top: var(--space-4);">
-              <summary class="muted" style="cursor:pointer;font-size:var(--font-size-small);">Or paste resume text</summary>
-              <textarea id="base-paste" class="asset-editor" style="margin-top: var(--space-3); min-height: 240px;"
-                        placeholder="# Ian Fike&#10;&#10;Paste markdown or plain text here…"></textarea>
-              <button class="btn btn--sm btn--primary" style="margin-top: var(--space-3);"
-                      ?disabled=${b.generating} @click=${() => this._onBasePaste()}>
-                ${b.generating ? 'Saving…' : 'Save pasted resume'}
+
+            <textarea class="asset-editor" style="margin-top: var(--space-4); min-height: 320px;"
+                      placeholder="# Your name&#10;&#10;Upload above, or paste markdown / plain text here. Then click Clean up with AI to fix structure, or Save to keep as-is."
+                      .value=${d.text}
+                      @input=${(e) => this._onDraftInput(e)}
+                      ?disabled=${busy}></textarea>
+
+            <div style="display:flex;gap:var(--space-3);margin-top:var(--space-3);align-items:center;flex-wrap:wrap;">
+              <button class="btn btn--sm" ?disabled=${busy || !d.text.trim()} @click=${() => this._onCleanupDraft()}>
+                ${d.status === 'formatting' ? 'Cleaning up…' : 'Clean up with AI'}
               </button>
-            </details>
+              <button class="btn btn--sm btn--primary" ?disabled=${busy || !d.text.trim()} @click=${() => this._onSaveDraft()}>
+                ${d.status === 'saving' ? 'Saving…' : 'Save'}
+              </button>
+              <span class="muted" style="font-size:var(--font-size-small);">
+                AI rewrites structure (headings, bullets) without changing facts. Review before saving.
+              </span>
+            </div>
           </div>
         ` : nothing}
 
+        ${d.error ? html`<p class="muted" style="color:var(--error);margin-top:var(--space-3);">${d.error}</p>` : nothing}
         ${b.error ? html`<p class="muted" style="color:var(--error);margin-top:var(--space-3);">${b.error}</p>` : nothing}
 
         ${hasContent

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -138,4 +138,18 @@ export async function generateAsset(slug, kind) {
   return res.json(); // { slug, kind, content }
 }
 
-window.JobPipeline = { fetchPipeline, setStatus, generateAsset };
+// Send raw resume text through Claude to get well-formatted markdown back.
+// Stateless on the server — caller is responsible for persisting the result.
+export async function formatResumeText(rawText) {
+  const headers = await authHeader();
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'format-resume', raw_text: rawText }),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.content;
+}
+
+window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -7,11 +7,11 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=0.39.1">
-  <script src="/job/js/theme.js?v=0.39.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.40.0">
+  <script src="/job/js/theme.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -39,9 +39,9 @@
   </div>
 
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=0.39.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.40.0"></script>
 >>>>>>> 3214eb3c (job(jobs): fix role column eating leftover width)
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.3.0';
-console.log(`[gen-asset] v${VERSION} - base-resume kind for diff baseline`);
+const VERSION = '0.4.0';
+console.log(`[gen-asset] v${VERSION} - format-resume kind: reformat raw text into clean markdown`);
 
 const BASE_RESUME_SLUG = '__base__';
 
@@ -101,13 +101,25 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
       : kindIn === 'base-resume' ? 'base-resume'
+      : kindIn === 'format-resume' ? 'format-resume'
       : null;
-    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", or "base-resume"', 400);
+    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", "base-resume", or "format-resume"', 400);
+
+    // format-resume is stateless: take raw text in, return clean markdown.
+    // Does not touch the DB. The frontend persists separately.
+    if (kind === 'format-resume') {
+      const rawText = String(body.raw_text || '').trim();
+      if (!rawText) return err('raw_text required', 400);
+      if (rawText.length > 32 * 1024) return err('raw_text exceeds 32KB', 413);
+      const system = buildSystemPrompt(kind);
+      const content = await callClaude(system, rawText);
+      return jsonResp({ ok: true, kind, content });
+    }
 
     // base-resume is global — no role required, persisted in job.global_assets.
     if (kind === 'base-resume') {

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -80,9 +80,34 @@ Format rules:
 - No em dashes. No "passionate about" / "excited to". No try-hard cleverness.
 - Reference real projects/skills/wins by their slug-like name when relevant.`;
 
-export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume';
+export const FORMAT_RESUME_VOICE = `You will receive raw text extracted from a resume PDF or pasted from another tool. The text has lost its structure: headings, bullets, and section breaks may be flattened into one stream.
+
+Your job: reconstruct it as clean, well-structured markdown. Preserve every fact verbatim — names, dates, companies, titles, metrics, locations. Do NOT paraphrase, embellish, summarize, or invent. If something is ambiguous, keep the source phrasing.
+
+OUTPUT STRUCTURE:
+- Start with a top-level "# Name" heading.
+- Italic line for current title/role if present.
+- Plain contact line (city · email · website/links).
+- Then "## Summary" (if there's a summary paragraph), "## Experience", "## Skills", "## Education", "## Projects", etc — only the sections actually present in the source.
+- Each role under Experience: "### Title, Company (start–end)", optional location line, then bullets prefixed "- ".
+- Lines that are clearly bullets in the source (start with •, ●, ▪, ◦, -, or are short imperatives starting with verbs like "Owned", "Shipped", "Led", "Scaled") become "- " bullets.
+- Lines that are clearly section headers (all-caps, large in source, isolated on their own line) become "## " or "### ".
+
+VOICE RULES:
+- No em dashes. Replace any — with periods, commas, or colons.
+- Smart quotes/dashes/bullet glyphs normalized to ASCII.
+- Drop runs of whitespace inside lines.
+- Don't add fluff. Don't add a summary if the source had none.
+- Don't reorder sections. Don't merge or split bullets.
+
+Output ONLY the markdown. No preamble. No "Here is your reformatted resume." Start with "# ".`;
+
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume';
 
 export function buildSystemPrompt(kind: GenKind): string {
+  if (kind === 'format-resume') {
+    return `You are a resume reformatter. ${FORMAT_RESUME_VOICE}`;
+  }
   const voice =
     kind === 'cover-letter' ? COVER_LETTER_VOICE :
     kind === 'analysis'     ? ANALYSIS_VOICE :


### PR DESCRIPTION
Upload extracts text into a draft textarea instead of saving immediately. Two buttons: **Clean up with AI** sends the draft through Claude Haiku (new `gen-asset` kind=`format-resume`, stateless) which reformats raw text into clean markdown without changing facts. **Save** persists.

Fixes the formatting problem where PDF text extraction lost structure and produced an unreadable wall of text.

Bumps: `gen-asset` 0.4.0, `/job` 0.40.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)