### PR TITLE
job(vision): structured fields + bullet preview on Search plan

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.40.1");
-@import url("./tokens-generic-dark.css?v=0.40.1");
-@import url("./tokens-ctrl-light.css?v=0.40.1");
-@import url("./tokens-ctrl-dark.css?v=0.40.1");
-@import url("./components.css?v=0.40.1");
+@import url("./tokens-generic-light.css?v=0.43.0");
+@import url("./tokens-generic-dark.css?v=0.43.0");
+@import url("./tokens-ctrl-light.css?v=0.43.0");
+@import url("./tokens-ctrl-dark.css?v=0.43.0");
+@import url("./components.css?v=0.43.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1165,7 +1165,59 @@
   font-size: var(--font-size-small);
   font-weight: var(--fw-semibold);
   color: var(--accent);
+  white-space: nowrap;
 }
+.vision-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+}
+
+/* Bullet preview inside a card (deal-breakers, voice rules, etc.) */
+.card-bullets {
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--font-size-small);
+  color: var(--fg);
+}
+.card-bullets li { line-height: var(--lh-body); }
+
+/* Structured fact strip — used in both card preview and detail panel */
+.facts {
+  display: grid;
+  grid-template-columns: minmax(140px, max-content) 1fr;
+  gap: var(--space-2) var(--space-4);
+  margin: 0 0 var(--space-4);
+}
+.facts--compact { margin-bottom: 0; gap: var(--space-1) var(--space-3); }
+.facts__row { display: contents; }
+.facts__label {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  font-weight: var(--fw-semibold);
+  letter-spacing: 0.02em;
+  color: var(--fg-muted);
+  text-transform: none;
+  align-self: baseline;
+  padding-top: 2px;
+}
+.facts__value {
+  margin: 0;
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  color: var(--fg);
+}
+.facts__value--money {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-small);
+  font-feature-settings: "tnum" 1;
+}
+.facts--compact .facts__value { font-size: var(--font-size-small); }
+.facts--compact .facts__label { padding-top: 0; }
 
 .vision-detail {
   grid-column: 1 / -1;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.42.0">
-  <script src="/job/js/theme.js?v=0.42.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.42.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.42.0">
-  <script src="/job/js/theme.js?v=0.42.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.42.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.42.0">
-  <script src="/job/js/theme.js?v=0.42.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.42.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.42.0">
-  <script src="/job/js/theme.js?v=0.42.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.42.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.42.0";
-console.log(`[job] v${VERSION} - Base resume: AI cleanup pass for uploaded text`);
+const VERSION = "0.43.0";
+console.log(`[job] v${VERSION} - search plan: structured fields + bullet preview`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -2,14 +2,16 @@
 //
 // Layout:
 //   [Narrative | Goals | Intents | Filters | Other]   ← only non-empty tabs
-//   Grid of cards  (title · path · preview · word count · "Open")
-//   Click a card  → expands inline (full-row) to render the markdown and
-//                   expose Edit/Save/Cancel. Edits commit via kb-write with
-//                   baseSha concurrency control.
+//   Single-column list of cards (title · facts/bullets preview · "Open")
+//   Click a card  → expands inline to render structured fields + markdown
+//                   body, plus Edit/Save/Cancel. Edits commit via kb-write
+//                   with baseSha concurrency control.
 //
-// Filename → tab classification is a tolerant prefix/keyword match; anything
-// unmatched lands in "Other". The /jobs skill reads the same files; nothing
-// here changes what it sees on disk.
+// Structure on disk: the same `**Label:** value` convention used elsewhere
+// in fikei/job (see migrate-job's parseDoc). Fields live between the H1 and
+// the first H2 / non-field line. We lift those into a "facts strip" so the
+// UI matches how /jobs already consumes the data, while editing stays raw
+// markdown — no schema lock-in.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
@@ -20,17 +22,15 @@ const [{ renderMarkdown }, { writeFile }] = await Promise.all([
 
 const VISION_DIR = '02-goals-intents';
 
-// Order matters — tabs render in this order; first match wins. The "All" tab
-// is prepended automatically. Each entry maps to (label, predicate).
 const CATEGORIES = [
   { id: 'narrative', label: 'Narrative',
     test: (n) => /^(narrative|voice|story|bio|about|arc)/.test(n) },
   { id: 'goals',     label: 'Goals',
     test: (n) => /^(goal|north|mission|vision|aim|ambition)/.test(n) },
   { id: 'intents',   label: 'Intents',
-    test: (n) => /^(intent|target|seeking|looking|wants|preference)/.test(n) },
+    test: (n) => /^(intent|target|seeking|looking|wants|preference|stage|sector|role|geo|comp|salary|location)/.test(n) },
   { id: 'filters',   label: 'Filters',
-    test: (n) => /^(criteria|filter|dealbreaker|anti|no-go|must|reject|exclud)/.test(n) },
+    test: (n) => /^(criteria|filter|dealbreaker|deal-breaker|anti|no-go|must|reject|exclud)/.test(n) },
   { id: 'other',     label: 'Other', test: () => true },
 ];
 
@@ -46,10 +46,69 @@ function titleFromFile(name, content) {
   return name.replace(/\.md$/, '').replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 }
 
-// Plain-text preview: drop the H1, strip markdown syntax, collapse whitespace.
-function previewFor(content) {
-  const noH1 = (content || '').replace(/^#\s+.+\n+/, '');
-  const stripped = noH1
+function wordCount(content) {
+  return (content || '').trim().split(/\s+/).filter(Boolean).length;
+}
+
+// Parse `**Label:** value` lines between the H1 and the first H2 / non-field
+// content. Mirrors migrate-job's parseDoc. Anything we couldn't pull out as a
+// field stays in the body for normal markdown rendering.
+function parseDoc(content) {
+  const out = { title: '', fields: [], body: '' };
+  const lines = (content || '').split(/\r?\n/);
+  let i = 0;
+  let inHeader = true;
+  const bodyStart = () => lines.slice(i).join('\n').trim();
+  for (; i < lines.length; i++) {
+    const line = lines[i];
+    if (!out.title) {
+      const h1 = line.match(/^#\s+(.+)$/);
+      if (h1) { out.title = h1[1].trim(); continue; }
+    }
+    if (inHeader) {
+      if (line.startsWith('## ')) { inHeader = false; break; }
+      const f = line.match(/^\*\*([^*:]+):\*\*\s*(.*)$/);
+      if (f) { out.fields.push({ label: f[1].trim(), value: f[2].trim() }); continue; }
+      if (!line.trim()) continue;
+      // First non-field, non-blank line ends the header section.
+      inHeader = false;
+      break;
+    }
+  }
+  out.body = bodyStart();
+  return out;
+}
+
+// A value is treated as a list if it has 2+ items separated by `,` or `;`
+// or ` / `. Returns null otherwise. We use this to pick chip vs. inline.
+function splitList(value) {
+  if (!value) return null;
+  const parts = value.split(/\s*(?:,|;| \/ )\s*/).map(s => s.trim()).filter(Boolean);
+  return parts.length >= 2 ? parts : null;
+}
+
+// Field labels that should render as money. Values are passed through —
+// we don't reformat (Ian might write "$180k base + 0.5% equity").
+const MONEY_LABELS = /^(base|base floor|salary|salary floor|cash|total comp|total comp target|fractional|fractional rate|day rate|hourly|equity|equity expectation|equity target|all-in|total)/i;
+
+function isMoney(label) { return MONEY_LABELS.test(label); }
+
+// First non-field, non-heading bullet line from the body — used as a card
+// preview when the file is bullet-heavy (deal-breakers, voice rules, etc.).
+function firstBullets(body, max = 3) {
+  if (!body) return [];
+  const out = [];
+  for (const line of body.split(/\r?\n/)) {
+    const m = line.match(/^\s*[-*+]\s+(.+?)\s*$/);
+    if (m) out.push(m[1]);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+// Plain-text fallback preview if the file has no fields and no bullets.
+function prosePreview(body) {
+  return (body || '')
     .replace(/```[\s\S]*?```/g, ' ')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_m, s, l) => (l || s))
@@ -60,11 +119,6 @@ function previewFor(content) {
     .replace(/_+([^_]+)_+/g, '$1')
     .replace(/\s+/g, ' ')
     .trim();
-  return stripped;
-}
-
-function wordCount(content) {
-  return (content || '').trim().split(/\s+/).filter(Boolean).length;
 }
 
 export class JobVision extends LitElement {
@@ -73,9 +127,9 @@ export class JobVision extends LitElement {
   static properties = {
     state:    { state: true },
     error:    { state: true },
-    files:    { state: true }, // [{ path, name, content, sha, category, editing, draft, saving, saveError }]
-    activeTab:{ state: true }, // 'all' | category id
-    openPath: { state: true }, // currently expanded file
+    files:    { state: true },
+    activeTab:{ state: true },
+    openPath: { state: true },
   };
 
   constructor() {
@@ -155,7 +209,6 @@ export class JobVision extends LitElement {
   _openCard(path) {
     this.openPath = this.openPath === path ? '' : path;
     if (!this.openPath) {
-      // Close any in-progress edit when collapsing.
       this._updateFile(path, { editing: false, draft: '', saveError: '' });
     }
     this._writeUrl();
@@ -233,30 +286,71 @@ export class JobVision extends LitElement {
     `;
   }
 
+  // Render one field row. Lists become chips; money labels render as the
+  // value emphasized; everything else is plain text.
+  _renderField(field) {
+    const items = splitList(field.value);
+    const money = isMoney(field.label);
+    return html`
+      <div class="facts__row">
+        <dt class="facts__label">${field.label}</dt>
+        <dd class="facts__value ${money ? 'facts__value--money' : ''}">
+          ${items
+            ? html`<div class="chip-row">${items.map(x => html`<span class="tag-chip">${x}</span>`)}</div>`
+            : (field.value || html`<span class="muted">—</span>`)}
+        </dd>
+      </div>
+    `;
+  }
+
+  _renderFacts(doc, { compact = false } = {}) {
+    if (!doc.fields.length) return nothing;
+    const fields = compact ? doc.fields.slice(0, 4) : doc.fields;
+    return html`
+      <dl class="facts ${compact ? 'facts--compact' : ''}">
+        ${fields.map(f => this._renderField(f))}
+      </dl>
+    `;
+  }
+
+  _renderCardPreview(doc) {
+    if (doc.fields.length) return this._renderFacts(doc, { compact: true });
+    const bullets = firstBullets(doc.body, 3);
+    if (bullets.length) {
+      return html`
+        <ul class="card-bullets">
+          ${bullets.map(b => html`<li>${b}</li>`)}
+        </ul>
+      `;
+    }
+    const prose = prosePreview(doc.body);
+    return html`<p class="vision-card__preview">${prose || html`<span class="muted">_(empty)_</span>`}</p>`;
+  }
+
   _renderCard(f) {
-    const title = titleFromFile(f.name, f.content);
-    const preview = previewFor(f.content);
+    const doc = parseDoc(f.content);
+    const title = doc.title || titleFromFile(f.name, f.content);
     const words = wordCount(f.content);
     const isOpen = this.openPath === f.path;
-    if (isOpen) return this._renderDetail(f, title);
+    if (isOpen) return this._renderDetail(f, doc, title);
     return html`
       <button type="button" class="vision-card" @click=${() => this._openCard(f.path)}>
-        <h3 class="vision-card__title">${title}</h3>
+        <header class="vision-card__head">
+          <h3 class="vision-card__title">${title}</h3>
+          <span class="vision-card__cta">Open →</span>
+        </header>
         <div class="vision-card__meta">
           <span>${f.name}</span>
           <span>·</span>
           <span>${words} ${words === 1 ? 'word' : 'words'}</span>
+          ${doc.fields.length ? html`<span>·</span><span>${doc.fields.length} field${doc.fields.length === 1 ? '' : 's'}</span>` : nothing}
         </div>
-        <p class="vision-card__preview">${preview || '_(empty)_'}</p>
-        <div class="vision-card__footer">
-          <span class="vision-card__cta">Open →</span>
-        </div>
+        ${this._renderCardPreview(doc)}
       </button>
     `;
   }
 
-  _renderDetail(f, title) {
-    const stripped = (f.content || '').replace(/^#\s+.+\n+/, '');
+  _renderDetail(f, doc, title) {
     return html`
       <section class="vision-detail">
         <header class="vision-detail__head">
@@ -285,8 +379,16 @@ export class JobVision extends LitElement {
           <textarea class="asset-editor" style="min-height: 360px;"
                     .value=${f.draft}
                     @input=${(e) => this._onDraftInput(f.path, e.target.value)}></textarea>
+          <p class="muted" style="font-size:var(--font-size-small);margin:var(--space-3) 0 0;">
+            Tip: header fields use <code>**Label:** value</code>. Commas in a value become chips
+            (e.g. <code>**Primary sectors:** healthtech, edtech</code>). The /jobs skill reads
+            the same fields.
+          </p>
         ` : html`
-          <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(stripped || f.content || '_(empty)_'))}</article>
+          ${this._renderFacts(doc)}
+          ${doc.body ? html`
+            <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(doc.body))}</article>
+          ` : (doc.fields.length ? nothing : html`<p class="muted">_(empty)_</p>`)}
         `}
       </section>
     `;
@@ -309,26 +411,26 @@ export class JobVision extends LitElement {
     if (this.state === 'error') {
       return html`
         <div class="placeholder" style="border-color:var(--error);color:var(--error);">
-          <h2>Couldn't load Vision</h2>
+          <h2>Couldn't load Search plan</h2>
           <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
         </div>`;
     }
     if (!this.files.length) {
       return html`
         <div class="vision-empty">
-          <h2 style="margin:0 0 var(--space-2);">No vision files yet</h2>
+          <h2 style="margin:0 0 var(--space-2);">No files yet</h2>
           <p style="margin:0;">Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
         </div>`;
     }
     const tabs = this._visibleTabs();
     const filtered = this._filteredFiles();
-    const totalWords = this.files.reduce((sum, f) => sum + wordCount(f.content), 0);
+    const totalFields = this.files.reduce((sum, f) => sum + parseDoc(f.content).fields.length, 0);
     return html`
       ${this._renderTabs(tabs)}
       <div class="vision-meta">
         <span>${filtered.length} ${filtered.length === 1 ? 'file' : 'files'}</span>
         <span>·</span>
-        <span>${totalWords.toLocaleString()} words across all of Vision</span>
+        <span>${totalFields} structured field${totalFields === 1 ? '' : 's'} across Search plan</span>
       </div>
       <div class="vision-grid">
         ${filtered.length === 0

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.40.1">
-  <script src="/job/js/theme.js?v=0.40.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.42.0">
-  <script src="/job/js/theme.js?v=0.42.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
+  <script src="/job/js/theme.js?v=0.43.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.42.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Parses \`**Label:** value\` fields out of each \`02-goals-intents/*.md\` file (same convention migrate-job already uses) and renders them as a structured "facts" strip in the card and detail view.
- Comma/semicolon/\`/\`-separated values render as chips. Money labels (Base, Equity, Fractional, Total comp, Day rate, etc.) render monospace, tabular-figures so dollar figures line up.
- Card previews lead with up to 4 facts when present; fall back to real \`<ul>\` bullets when the file is bullet-heavy (deal-breakers, voice rules); only fall back to prose previews as a last resort.
- Detail view shows the full facts list above the prose body. Edit mode is still raw markdown — single source of truth.

## Audit — fields worth structuring (UI side now lights up if you add them)
| File | Suggested fields |
|---|---|
| \`compensation.md\` | \`Base floor:\`, \`Equity expectation:\`, \`Fractional day rate:\`, \`Total comp target:\`, \`Currency:\` |
| \`geography.md\` | \`Primary:\`, \`Remote:\`, \`Travel:\` |
| \`stage-targets.md\` | \`Stage range:\`, \`Headcount range:\` |
| \`sector-targets.md\` | \`Primary:\`, \`Adjacent:\`, \`Avoid:\` (commas → chips) |
| \`role-titles.md\` | \`Primary:\`, \`Adjacent:\`, \`Avoid:\` (commas → chips) |
| \`deal-breakers.md\` | Bulleted list — renders as bullets in preview, full prose in detail |
| \`narrative-arc.md\` | No fields — prose only |
| \`voice-and-cover-letter-rules.md\` | Bulleted list |

Files don't need updating for this PR to be useful — once you start adding the fields, the UI surfaces them automatically.

## Test plan
- [ ] Files that already have \`**Label:** value\` lines render those as a facts strip.
- [ ] A list value (e.g. \`**Primary sectors:** healthtech, edtech\`) renders as chips, not a comma-joined string.
- [ ] A money-labeled field (\`**Base floor:** \$180k\`) renders monospace.
- [ ] Files like \`deal-breakers.md\` show real bullet list preview on the card.
- [ ] Edit → Save still round-trips through kb-write; switching back to read view re-parses the fields.
- [ ] Other /job pages still load (cache-bust to v0.43.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)