### PR TITLE
job(vision): dedupe leading bullet glyphs + start v2 schema

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.43.0");
-@import url("./tokens-generic-dark.css?v=0.43.0");
-@import url("./tokens-ctrl-light.css?v=0.43.0");
-@import url("./tokens-ctrl-dark.css?v=0.43.0");
-@import url("./components.css?v=0.43.0");
+@import url("./tokens-generic-light.css?v=0.43.1");
+@import url("./tokens-generic-dark.css?v=0.43.1");
+@import url("./tokens-ctrl-light.css?v=0.43.1");
+@import url("./tokens-ctrl-dark.css?v=0.43.1");
+@import url("./components.css?v=0.43.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.43.0";
-console.log(`[job] v${VERSION} - search plan: structured fields + bullet preview`);
+const VERSION = "0.43.1";
+console.log(`[job] v${VERSION} - search plan: dedupe leading bullet glyphs`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -93,6 +93,33 @@ const MONEY_LABELS = /^(base|base floor|salary|salary floor|cash|total comp|tota
 
 function isMoney(label) { return MONEY_LABELS.test(label); }
 
+// Some KB files have a literal bullet glyph after the markdown marker
+// (e.g. `- • foo` from copy/paste). Both the marker AND the glyph render,
+// giving the appearance of "double bullets". Strip the leading glyph
+// (and other common variants) from the captured text. Also collapse any
+// remaining nested markdown bullet markers at the very start.
+const LEADING_BULLET_RE = /^[\s ]*[•·●○◦▪▫–—-][\s ]*/;
+
+function cleanBulletText(text) {
+  let out = (text || '').trim();
+  // Repeat in case the line is `· · foo` etc.
+  for (let i = 0; i < 3 && LEADING_BULLET_RE.test(out); i++) {
+    out = out.replace(LEADING_BULLET_RE, '');
+  }
+  return out.trim();
+}
+
+// Normalize the raw markdown body before marked sees it: when a list line
+// starts with `- • foo` (or any equivalent), drop the glyph so marked
+// renders only one bullet from the list marker. Leaves real content alone.
+function normalizeBulletGlyphs(md) {
+  if (!md) return md;
+  return md.replace(
+    /^([ \t]*)([-*+])([ \t]+)([•·●○◦▪▫–—-])([ \t]+|)/gm,
+    (_m, indent, marker, sp, _glyph, _tail) => `${indent}${marker}${sp}`
+  );
+}
+
 // First non-field, non-heading bullet line from the body — used as a card
 // preview when the file is bullet-heavy (deal-breakers, voice rules, etc.).
 function firstBullets(body, max = 3) {
@@ -100,7 +127,7 @@ function firstBullets(body, max = 3) {
   const out = [];
   for (const line of body.split(/\r?\n/)) {
     const m = line.match(/^\s*[-*+]\s+(.+?)\s*$/);
-    if (m) out.push(m[1]);
+    if (m) out.push(cleanBulletText(m[1]));
     if (out.length >= max) break;
   }
   return out;
@@ -387,7 +414,7 @@ export class JobVision extends LitElement {
         ` : html`
           ${this._renderFacts(doc)}
           ${doc.body ? html`
-            <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(doc.body))}</article>
+            <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(normalizeBulletGlyphs(doc.body)))}</article>
           ` : (doc.fields.length ? nothing : html`<p class="muted">_(empty)_</p>`)}
         `}
       </section>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.43.0">
-  <script src="/job/js/theme.js?v=0.43.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.43.1">
+  <script src="/job/js/theme.js?v=0.43.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.43.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.43.1"></script>
 </body>
 </html>

--- a/supabase/functions/migrate-job/index.ts
+++ b/supabase/functions/migrate-job/index.ts
@@ -15,8 +15,8 @@ import { readSheetValues } from '../jobs-pipe/sheets.ts';
 import { SCHEMA_SQL } from './schema.ts';
 import { DESKTOP_ASSETS } from './desktop-bundle.ts';
 
-const VERSION = '0.1.0';
-console.log(`[migrate-job] v${VERSION}`);
+const VERSION = '0.2.0';
+console.log(`[migrate-job] v${VERSION} - search plan v2: sections + fields + summary`);
 
 const SHEET_ID = '1YtZp3vxlsVP8t_eWpcYzYEVjaSKu8rVYmVRPr4AGeAU';
 
@@ -201,9 +201,8 @@ async function seedKb(sql: ReturnType<typeof postgres>): Promise<Pick<Counts, 'c
     }
   }
 
-  // Vision: fold all 02-goals-intents/*.md into a single row.
+  // Vision (v1 — kept for backwards compat with the existing scorer).
   const visionMd = vision.map(v => `# ${v.slug}\n\n${v.content}`).join('\n\n---\n\n');
-  // Pull a couple of the lighter fields out for structured access.
   const narrative = vision.find(v => v.slug === 'narrative-arc')?.content || null;
   const dealBreakers = vision.find(v => v.slug === 'deal-breakers')?.content || null;
   const voiceRules = vision.find(v => v.slug === 'voice-and-cover-letter-rules')?.content || null;
@@ -215,6 +214,9 @@ async function seedKb(sql: ReturnType<typeof postgres>): Promise<Pick<Counts, 'c
       voice_rules_md = excluded.voice_rules_md, raw_md = excluded.raw_md, updated_at = now();
   `;
 
+  // Search Plan v2 — parsed sections + fields. See migration 057.
+  await populateSearchPlanV2(sql, vision);
+
   return {
     companies: companies.length,
     projects: projects.length,
@@ -224,6 +226,225 @@ async function seedKb(sql: ReturnType<typeof postgres>): Promise<Pick<Counts, 'c
     win_skills: 0,
     vision: 1,
   };
+}
+
+// --- Search Plan v2: populate sections + fields + summary -----------------
+//
+// Mirrors the UI parse: between H1 and first H2 / non-field line, every
+// `**Label:** value` line becomes a field. Lists are split on `,`, `;`, or
+// ` / `. Money labels parse into cents.
+//
+// Filename → category mirrors the UI's CATEGORIES list so the two stay
+// consistent. Anything unmatched lands in 'other'.
+
+const SP_CATEGORIES: { id: string; test: (n: string) => boolean }[] = [
+  { id: 'narrative', test: (n) => /^(narrative|voice|story|bio|about|arc)/.test(n) },
+  { id: 'goals',     test: (n) => /^(goal|north|mission|vision|aim|ambition)/.test(n) },
+  { id: 'intents',   test: (n) => /^(intent|target|seeking|looking|wants|preference|stage|sector|role|geo|comp|salary|location)/.test(n) },
+  { id: 'filters',   test: (n) => /^(criteria|filter|dealbreaker|deal-breaker|anti|no-go|must|reject|exclud)/.test(n) },
+];
+
+function spCategoryFor(slug: string): string {
+  const base = slug.toLowerCase();
+  for (const c of SP_CATEGORIES) if (c.test(base)) return c.id;
+  return 'other';
+}
+
+const SP_MONEY_LABEL_RE = /^(base|base floor|base target|salary|salary floor|cash|total comp|total comp target|all-in|all in|fractional|fractional rate|fractional day rate|day rate|hourly).*$/i;
+const SP_EQUITY_LABEL_RE = /^(equity|equity target|equity expectation|options).*$/i;
+
+function spNormalizeLabel(label: string): string {
+  return label.toLowerCase().normalize('NFKD').replace(/[̀-ͯ]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function spSplitList(value: string): string[] | null {
+  const parts = value.split(/\s*(?:,|;| \/ )\s*/).map(s => s.trim()).filter(Boolean);
+  return parts.length >= 2 ? parts : null;
+}
+
+// Parse one money/range value into cents bounds. Handles "$180k", "180,000",
+// "$180k–$220k", "180k-220k", "$2k/day". Returns null if no number found.
+function spParseMoneyCents(value: string): { low: number | null; high: number | null } | null {
+  if (!value) return null;
+  const norm = value.toLowerCase().replace(/[,_]/g, '');
+  const nums = Array.from(norm.matchAll(/\$?\s*(\d+(?:\.\d+)?)\s*(k|m)?/g)).map(m => {
+    const n = parseFloat(m[1]);
+    if (Number.isNaN(n)) return null;
+    const scale = m[2] === 'm' ? 1_000_000 : m[2] === 'k' ? 1_000 : 1;
+    return Math.round(n * scale * 100); // cents
+  }).filter((n): n is number => n !== null && n >= 100); // require ≥ $1
+  if (!nums.length) return null;
+  if (nums.length === 1) return { low: nums[0], high: nums[0] };
+  return { low: Math.min(...nums), high: Math.max(...nums) };
+}
+
+// Parse equity percentage range. Handles "0.5%", "0.5-1%", "0.5–1.0 %".
+function spParseEquityPct(value: string): { low: number | null; high: number | null } | null {
+  if (!value) return null;
+  const nums = Array.from(value.matchAll(/(\d+(?:\.\d+)?)/g)).map(m => parseFloat(m[1])).filter(n => !Number.isNaN(n));
+  if (!nums.length) return null;
+  if (nums.length === 1) return { low: nums[0], high: nums[0] };
+  return { low: Math.min(...nums), high: Math.max(...nums) };
+}
+
+interface ParsedField {
+  label: string;
+  value: string;
+  ord: number;
+  list: string[] | null;
+  money: { low: number | null; high: number | null } | null;
+  kind: 'money' | 'list' | 'range' | 'text';
+}
+
+function spClassifyField(label: string, value: string): ParsedField {
+  const ord = 0;
+  const list = spSplitList(value);
+  const isMoney = SP_MONEY_LABEL_RE.test(label) && !/^equity/i.test(label);
+  const money = isMoney ? spParseMoneyCents(value) : null;
+  const kind: ParsedField['kind'] = money ? 'money' : list ? 'list' : /[-–—]/.test(value) && /\d/.test(value) ? 'range' : 'text';
+  return { label, value, ord, list, money, kind };
+}
+
+async function populateSearchPlanV2(
+  sql: ReturnType<typeof postgres>,
+  vision: { path: string; slug: string; content: string }[],
+) {
+  // Wipe stale rows before re-upserting; sections cascade to fields.
+  await sql`delete from job.search_plan_sections;`;
+
+  const summary = {
+    base_floor_cents: null as number | null,
+    base_target_cents: null as number | null,
+    total_comp_target_cents: null as number | null,
+    equity_low: null as number | null,
+    equity_high: null as number | null,
+    fractional_day_rate_cents: null as number | null,
+    fractional_hourly_cents: null as number | null,
+    geo_primary: [] as string[],
+    geo_remote: null as string | null,
+    travel: null as string | null,
+    stage_min: null as string | null,
+    stage_max: null as string | null,
+    headcount_min: null as number | null,
+    headcount_max: null as number | null,
+    sector_primary: [] as string[],
+    sector_adjacent: [] as string[],
+    sector_avoid: [] as string[],
+    title_primary: [] as string[],
+    title_adjacent: [] as string[],
+    title_avoid: [] as string[],
+    deal_breakers: [] as string[],
+    narrative_arc_md: null as string | null,
+    voice_rules_md: null as string | null,
+  };
+
+  for (let idx = 0; idx < vision.length; idx++) {
+    const v = vision[idx];
+    const doc = parseDoc(v.content);
+    const title = doc.title || v.slug.replace(/[-_]+/g, ' ');
+    const category = spCategoryFor(v.slug);
+
+    await sql`
+      insert into job.search_plan_sections (slug, title, category, source_path, body_md, raw_md, ord)
+      values (${v.slug}, ${title}, ${category}, ${v.path}, ${doc.body || null}, ${v.content}, ${idx})
+      on conflict (slug) do update set
+        title = excluded.title, category = excluded.category, source_path = excluded.source_path,
+        body_md = excluded.body_md, raw_md = excluded.raw_md, ord = excluded.ord, updated_at = now();
+    `;
+
+    const entries = Object.entries(doc.fields);
+    for (let j = 0; j < entries.length; j++) {
+      const [label, value] = entries[j];
+      const pf = spClassifyField(label, value);
+      const labelNorm = spNormalizeLabel(label);
+      await sql`
+        insert into job.search_plan_fields (
+          section_slug, ord, label, label_norm, value, value_list,
+          value_min_cents, value_max_cents, kind
+        ) values (
+          ${v.slug}, ${j}, ${label}, ${labelNorm}, ${value},
+          ${pf.list}, ${pf.money?.low ?? null}, ${pf.money?.high ?? null}, ${pf.kind}
+        );
+      `;
+
+      // Route well-known fields to the summary row.
+      if (pf.money && /base floor/i.test(label)) summary.base_floor_cents = pf.money.low;
+      else if (pf.money && /base target/i.test(label)) summary.base_target_cents = pf.money.high ?? pf.money.low;
+      else if (pf.money && /total comp/i.test(label)) summary.total_comp_target_cents = pf.money.high ?? pf.money.low;
+      else if (pf.money && /day rate|fractional rate|fractional day/i.test(label)) summary.fractional_day_rate_cents = pf.money.low;
+      else if (pf.money && /hourly/i.test(label)) summary.fractional_hourly_cents = pf.money.low;
+
+      if (SP_EQUITY_LABEL_RE.test(label)) {
+        const eq = spParseEquityPct(value);
+        if (eq) { summary.equity_low = eq.low; summary.equity_high = eq.high; }
+      }
+
+      if (/^primary( sectors?)?$/i.test(label) && /sector/.test(v.slug)) summary.sector_primary = pf.list ?? [value];
+      else if (/^adjacent( sectors?)?$/i.test(label) && /sector/.test(v.slug)) summary.sector_adjacent = pf.list ?? [value];
+      else if (/^avoid( sectors?)?$/i.test(label) && /sector/.test(v.slug)) summary.sector_avoid = pf.list ?? [value];
+
+      if (/^primary( titles?)?$/i.test(label) && /role|title/.test(v.slug)) summary.title_primary = pf.list ?? [value];
+      else if (/^adjacent( titles?)?$/i.test(label) && /role|title/.test(v.slug)) summary.title_adjacent = pf.list ?? [value];
+      else if (/^avoid( titles?)?$/i.test(label) && /role|title/.test(v.slug)) summary.title_avoid = pf.list ?? [value];
+
+      if (/^primary$/i.test(label) && /geo|location/.test(v.slug)) summary.geo_primary = pf.list ?? [value];
+      else if (/^remote$/i.test(label) && /geo|location/.test(v.slug)) summary.geo_remote = value;
+      else if (/^travel/i.test(label)) summary.travel = value;
+
+      if (/^stage( range)?$/i.test(label)) {
+        const parts = pf.list ?? value.split(/\s*[–—-]\s*/).map(s => s.trim()).filter(Boolean);
+        if (parts.length >= 1) summary.stage_min = parts[0];
+        if (parts.length >= 2) summary.stage_max = parts[parts.length - 1];
+      }
+      if (/^headcount( range)?$/i.test(label)) {
+        const nums = Array.from(value.matchAll(/(\d+)/g)).map(m => parseInt(m[1], 10)).filter(n => !Number.isNaN(n));
+        if (nums.length >= 1) summary.headcount_min = nums[0];
+        if (nums.length >= 2) summary.headcount_max = nums[nums.length - 1];
+      }
+    }
+
+    // Body-derived summary fields.
+    if (v.slug === 'narrative-arc') summary.narrative_arc_md = v.content;
+    if (v.slug === 'voice-and-cover-letter-rules') summary.voice_rules_md = v.content;
+    if (/deal[-_]?breakers?/.test(v.slug)) {
+      // Pull top-level bullets as discrete deal-breakers.
+      const bullets = (doc.body || '').split(/\r?\n/)
+        .map(l => l.match(/^\s*[-*+]\s+(.+?)\s*$/))
+        .filter((m): m is RegExpMatchArray => !!m)
+        .map(m => m[1].replace(/^[•·●○◦▪▫–—-]\s*/, '').trim())
+        .filter(Boolean);
+      if (bullets.length) summary.deal_breakers = bullets;
+    }
+  }
+
+  await sql`
+    update job.search_plan_summary set
+      base_floor_cents          = ${summary.base_floor_cents},
+      base_target_cents         = ${summary.base_target_cents},
+      total_comp_target_cents   = ${summary.total_comp_target_cents},
+      equity_target_pct_low     = ${summary.equity_low},
+      equity_target_pct_high    = ${summary.equity_high},
+      fractional_day_rate_cents = ${summary.fractional_day_rate_cents},
+      fractional_hourly_cents   = ${summary.fractional_hourly_cents},
+      geo_primary               = ${summary.geo_primary},
+      geo_remote                = ${summary.geo_remote},
+      travel_willingness        = ${summary.travel},
+      stage_min                 = ${summary.stage_min},
+      stage_max                 = ${summary.stage_max},
+      headcount_min             = ${summary.headcount_min},
+      headcount_max             = ${summary.headcount_max},
+      sector_primary            = ${summary.sector_primary},
+      sector_adjacent           = ${summary.sector_adjacent},
+      sector_avoid              = ${summary.sector_avoid},
+      title_primary             = ${summary.title_primary},
+      title_adjacent            = ${summary.title_adjacent},
+      title_avoid               = ${summary.title_avoid},
+      deal_breakers             = ${summary.deal_breakers},
+      narrative_arc_md          = ${summary.narrative_arc_md},
+      voice_rules_md            = ${summary.voice_rules_md},
+      updated_at                = now()
+    where id = 1;
+  `;
 }
 
 // --- Sheet → pipeline_roles ------------------------------------------------

--- a/supabase/migrations/057_job_search_plan_v2.sql
+++ b/supabase/migrations/057_job_search_plan_v2.sql
@@ -1,0 +1,117 @@
+-- /job — Search Plan v2 schema.
+--
+-- v1 stored the entire 02-goals-intents corpus as a single `job.vision` row
+-- with a handful of typed columns plus a `raw_md` blob (see migration 047).
+-- Most fields were never populated and the /jobs scorer fell back to grep.
+--
+-- v2 moves to a sections + fields model that mirrors the on-disk convention
+-- (`**Label:** value` headers between H1 and first H2). Each markdown file
+-- under fikei/job/02-goals-intents/ becomes one row in
+-- `job.search_plan_sections`; every parsed field becomes one row in
+-- `job.search_plan_fields`. List values (comma/semicolon/slash-separated)
+-- are stored as text[] so the scorer can do set intersection against
+-- pipeline_roles.sector / sectorTags / title without re-parsing prose.
+--
+-- A singleton `job.search_plan_summary` denormalizes the most-used fields
+-- for the scorer's hot path (compensation floor, geo, stage, primary
+-- sectors/titles, deal-breakers). It's refreshed by migrate-job whenever the
+-- sections table is upserted.
+--
+-- Backwards-compat: `job.vision` stays in place for now — migrate-job keeps
+-- writing it. A later migration drops it once the scorer + UI are off it.
+
+-- ============================================================================
+-- Sections (one row per markdown file)
+-- ============================================================================
+create table if not exists job.search_plan_sections (
+  slug              text primary key,            -- e.g. 'compensation', 'narrative-arc'
+  title             text not null,               -- H1 of the file
+  category          text not null
+                     check (category in ('narrative','goals','intents','filters','other')),
+  source_path       text not null,               -- '02-goals-intents/compensation.md'
+  body_md           text,                        -- markdown after the fields block
+  raw_md            text,                        -- entire file content (audit trail)
+  ord               int not null default 0,      -- display order within category
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+create index if not exists search_plan_sections_category_idx
+  on job.search_plan_sections (category, ord);
+
+-- ============================================================================
+-- Fields (one row per **Label:** value line)
+-- ============================================================================
+create table if not exists job.search_plan_fields (
+  section_slug      text not null references job.search_plan_sections(slug) on delete cascade,
+  ord               int not null default 0,      -- preserves on-disk order
+  label             text not null,               -- exact label, e.g. 'Base floor'
+  label_norm        text not null,               -- lowercase, ascii, whitespace-collapsed
+  value             text not null,               -- raw string value as written
+  value_list        text[],                      -- non-null when value parsed as a list
+  -- For monetary fields, parsed cents bounds so the scorer can compare
+  -- numerically against pipeline_roles.salary_low/high. Either both null
+  -- (not a money field) or both set; if the value is a single point both
+  -- equal each other.
+  value_min_cents   bigint,
+  value_max_cents   bigint,
+  -- Free-form classifier so a later trigger can route a field to the
+  -- summary row without depending on label spelling alone.
+  kind              text check (kind in ('money','list','range','text','date') ),
+  updated_at        timestamptz not null default now(),
+  primary key (section_slug, ord)
+);
+
+create index if not exists search_plan_fields_label_idx
+  on job.search_plan_fields (label_norm);
+
+-- ============================================================================
+-- Summary (singleton — the scorer's hot path)
+-- ============================================================================
+-- Populated by migrate-job after sections/fields are upserted. Anything not
+-- yet provided by Ian's KB files is null; the scorer treats nulls as "no
+-- preference expressed" and falls back to neutral weights.
+create table if not exists job.search_plan_summary (
+  id                       smallint primary key default 1 check (id = 1),
+
+  -- Compensation (cents, USD assumed)
+  base_floor_cents         bigint,
+  base_target_cents        bigint,
+  total_comp_target_cents  bigint,
+  equity_target_pct_low    numeric(6,3),
+  equity_target_pct_high   numeric(6,3),
+  fractional_day_rate_cents bigint,
+  fractional_hourly_cents  bigint,
+
+  -- Geography
+  geo_primary              text[] default '{}',  -- ['SF','NYC']
+  geo_remote               text,                 -- 'US-only', 'Global', null
+  travel_willingness       text,                 -- '2 days/qtr', 'none', etc.
+
+  -- Stage / company shape
+  stage_min                text,                 -- 'pre-seed'
+  stage_max                text,                 -- 'Series C'
+  headcount_min            int,
+  headcount_max            int,
+
+  -- Sectors
+  sector_primary           text[] default '{}',
+  sector_adjacent          text[] default '{}',
+  sector_avoid             text[] default '{}',
+
+  -- Titles
+  title_primary            text[] default '{}',
+  title_adjacent           text[] default '{}',
+  title_avoid              text[] default '{}',
+
+  -- Hard filters + voice
+  deal_breakers            text[] default '{}',
+  narrative_arc_md         text,
+  voice_rules_md           text,
+
+  updated_at               timestamptz not null default now()
+);
+
+-- Seed the singleton row so callers can `update ... where id = 1` without a
+-- prior insert.
+insert into job.search_plan_summary (id) values (1) on conflict (id) do nothing;


### PR DESCRIPTION
## Summary

**UI fix — double bullets**
When a KB list line has a literal bullet glyph after the markdown marker (e.g. \`- · foo\`, \`- • foo\` from a paste), marked renders the markdown bullet AND the glyph. Now stripped from both card-preview bullets and the body before \`renderMarkdown\` sees it.

**Search Plan v2 schema (migration 057)**
- \`job.search_plan_sections\` — one row per \`02-goals-intents/*.md\`.
- \`job.search_plan_fields\` — one row per \`**Label:** value\` line, with denormalized \`value_list text[]\` and \`value_min_cents/value_max_cents\` so the scorer can compare against \`pipeline_roles\` numerically without re-parsing prose.
- Singleton \`job.search_plan_summary\` — hot-path columns (base floor, equity range, geo primary, stage range, sector primary/adjacent/avoid, title primary/adjacent/avoid, deal-breakers, narrative & voice md).
- \`job.vision\` (v1) untouched — separate migration drops it once the scorer + UI cut over.

**migrate-job** gets \`populateSearchPlanV2\`: parses every vision file with the existing \`parseDoc\`, classifies fields (money / list / range / text), upserts sections + fields, refreshes the summary. Routing uses label + source filename so \`**Primary:**\` in \`sector-targets.md\` lands in \`sector_primary\` rather than colliding with \`role-titles.md\`.

Bumps /job to v0.43.1 and migrate-job to v0.2.0.

## Test plan
- [ ] Files with \`- · foo\` style bullets now render with one bullet, not two, on both card preview and detail view.
- [ ] Apply migration 057 against the Boards Supabase project.
- [ ] Deploy \`migrate-job\` and run it; \`select count(*) from job.search_plan_sections\` matches the number of \`02-goals-intents/*.md\` files; \`select count(*) from job.search_plan_fields\` matches the number of header lines.
- [ ] \`select * from job.search_plan_summary\` shows populated fields (or null where the KB hasn't been updated yet — expected).
- [ ] /job/vision/ still loads and edits the KB files unchanged (UI continues reading from \`kb-read\`; nothing routes through the new tables yet).

## Follow-ups (not in this PR)
1. Point the /jobs scorer at \`job.search_plan_summary\` instead of regexing \`job.vision.raw_md\`.
2. Switch the Vision UI to read from the new tables once the scorer's off the v1 schema.
3. Drop \`job.vision\` in a later migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)