### PR TITLE
Cover letter: rationale comment rail + inline editing

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -722,6 +722,125 @@
   color: inherit;
   padding: 0 2px;
   border-radius: 2px;
+  cursor: help;
+  transition: background 80ms ease;
+}
+.asset-doc mark.d-jd.is-focused {
+  background: rgba(255, 167, 38, 0.65);
+  outline: 1px solid rgba(255, 152, 0, 0.6);
+}
+.asset-doc sup.d-fn {
+  font-size: 0.7em;
+  font-weight: var(--fw-semibold);
+  color: rgba(120, 80, 0, 0.85);
+  margin-left: 1px;
+  padding: 0 3px;
+  vertical-align: super;
+}
+
+/* --- Cover letter: body + comment rail (Google-Docs-style) --- */
+.cover-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: var(--space-6);
+  align-items: start;
+}
+.cover-layout__body { min-width: 0; }
+.cover-layout__rail {
+  position: sticky;
+  top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-height: calc(100vh - var(--space-6));
+  overflow-y: auto;
+  padding-right: var(--space-2);
+}
+.cover-rail__title {
+  margin: 0;
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+}
+.cover-rail__hint {
+  margin: 0 0 var(--space-2);
+  font-size: var(--font-size-caption);
+}
+.cover-comment {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  padding: var(--space-3) var(--space-4);
+  transition: border-color 80ms ease, box-shadow 80ms ease, transform 80ms ease;
+  cursor: default;
+}
+.cover-comment:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+.cover-comment__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+.cover-comment__num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: rgba(255, 213, 79, 0.5);
+  color: rgba(80, 50, 0, 0.95);
+  font-size: var(--font-size-caption);
+  font-weight: var(--fw-semibold);
+  font-variant-numeric: tabular-nums;
+}
+.cover-comment__label {
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  color: var(--fg);
+}
+.cover-comment__body {
+  font-size: var(--font-size-small);
+  line-height: var(--lh-body);
+  color: var(--fg-muted);
+}
+.cover-comment__body p { margin: 0 0 var(--space-2); }
+.cover-comment__body ul { margin: 0; padding-left: var(--space-4); }
+.cover-comment__body li { margin-bottom: var(--space-1); }
+
+@media (max-width: 960px) {
+  .cover-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cover-layout__rail {
+    position: static;
+    max-height: none;
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-4);
+    margin-top: var(--space-4);
+  }
+}
+
+/* Inline editor: feel less like a code editor, more like a doc edit. */
+.asset-editor.asset-editor--inline {
+  font-family: var(--font-body, "Inter", "Helvetica Neue", Arial, sans-serif);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  min-height: 60vh;
+  padding: var(--space-5) var(--space-6);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+.asset-editor.asset-editor--inline:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
 }
 
 /* --- Base resume upload zone --- */

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.44.0">
-  <script src="/job/js/theme.js?v=0.44.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
+  <script src="/job/js/theme.js?v=0.45.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.44.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.45.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.44.0">
-  <script src="/job/js/theme.js?v=0.44.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
+  <script src="/job/js/theme.js?v=0.45.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.44.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.45.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.44.0">
-  <script src="/job/js/theme.js?v=0.44.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
+  <script src="/job/js/theme.js?v=0.45.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.44.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.45.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.44.0">
-  <script src="/job/js/theme.js?v=0.44.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
+  <script src="/job/js/theme.js?v=0.45.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.44.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.45.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.44.0";
-console.log(`[job] v${VERSION} - Base resume: auto-format on upload + Clean up saved resume button`);
+const VERSION = "0.45.0";
+console.log(`[job] v${VERSION} - Cover letter: comment rail with rationale + inline editing`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -186,13 +186,20 @@ export class JobRoleDetail extends LitElement {
   _toggleChanges() { this.showChanges = !this.showChanges; }
 
   // For the cover-letter tab, pull source phrases out of the analysis JSON
-  // for "what was tailored from the JD" highlighting.
+  // for "what was tailored from the JD" highlighting. Returns labeled
+  // sources so the comment rail can show which analysis field each
+  // highlight came from.
   _coverHighlightSources() {
     const ana = this.assets['analysis'];
     if (!ana || ana.mode !== 'view') return [];
     const parsed = this._parseAnalysis(ana.content);
     if (!parsed) return [];
-    return [parsed.suggestedAngle, parsed.whyFits, parsed.strengths, parsed.gaps].filter(Boolean);
+    const out = [];
+    if (parsed.suggestedAngle) out.push({ label: 'Suggested angle', text: parsed.suggestedAngle });
+    if (parsed.whyFits)        out.push({ label: 'Why it fits',     text: parsed.whyFits });
+    if (parsed.strengths)      out.push({ label: 'Strengths',       text: parsed.strengths });
+    if (parsed.gaps)           out.push({ label: 'Gaps to address', text: parsed.gaps });
+    return out;
   }
 
   _autoGenerateMissing() {
@@ -543,15 +550,20 @@ export class JobRoleDetail extends LitElement {
     const showingChanges = canDiff && this.showChanges;
 
     let bodyHtml = '';
+    let coverComments = [];
     if (a.mode === 'view') {
       if (kind === 'resume' && showingChanges && this.baseResume?.content) {
         bodyHtml = renderMarkdown(diffMarkdown(this.baseResume.content, a.content));
       } else if (kind === 'cover-letter' && showingChanges) {
-        bodyHtml = renderMarkdown(highlightPhrases(a.content, this._coverHighlightSources()));
+        const { html: marked, comments } = highlightPhrases(a.content, this._coverHighlightSources());
+        bodyHtml = renderMarkdown(marked);
+        coverComments = comments;
       } else {
         bodyHtml = renderMarkdown(a.content);
       }
     }
+
+    const isCover = kind === 'cover-letter';
 
     return html`
       ${(kind === 'resume' || kind === 'cover-letter') ? this._renderTailoringCallout(kind) : nothing}
@@ -564,7 +576,7 @@ export class JobRoleDetail extends LitElement {
           </button>
           ${canDiff ? html`
             <button class="btn btn--sm ${this.showChanges ? 'btn--primary' : ''}" @click=${() => this._toggleChanges()}>
-              ${this.showChanges ? 'Hide changes' : 'Show changes'}
+              ${this.showChanges ? (isCover ? 'Hide comments' : 'Hide changes') : (isCover ? 'Show comments' : 'Show changes')}
             </button>
           ` : nothing}
           <button class="btn btn--sm btn--accent" @click=${() => this._downloadAssetPdf(kind)}>
@@ -572,7 +584,7 @@ export class JobRoleDetail extends LitElement {
           </button>
           ${kind === 'resume' && this.baseResume?.missing ? html`
             <span class="muted" style="font-size: var(--font-size-small);">
-              No base resume yet — generate one in <a href="/job/history/?tab=base">Career → Base resume</a>.
+              No base resume yet — set one in <a href="/job/history/?tab=base">Career → Base resume</a>.
             </span>
           ` : nothing}
         ` : html`
@@ -584,9 +596,41 @@ export class JobRoleDetail extends LitElement {
         ${a.error ? html`<span class="muted" style="color:var(--error);">${a.error}</span>` : nothing}
       </div>
       ${a.mode === 'edit'
-        ? html`<textarea class="asset-editor" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)}></textarea>`
-        : html`<article class="kb-doc asset-doc">${unsafeHTML(bodyHtml)}</article>`}
+        ? html`<textarea class="asset-editor asset-editor--inline" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)} @blur=${() => a.dirty && this._saveEdit(kind)}></textarea>`
+        : (isCover && coverComments.length
+          ? html`
+            <div class="cover-layout">
+              <article class="kb-doc asset-doc cover-layout__body">${unsafeHTML(bodyHtml)}</article>
+              <aside class="cover-layout__rail" aria-label="Rationale">
+                <h4 class="cover-rail__title">Rationale</h4>
+                <p class="muted cover-rail__hint">Why each highlighted phrase is here.</p>
+                ${coverComments.map(c => html`
+                  <article class="cover-comment" data-rationale-id=${c.id}
+                           @mouseenter=${() => this._highlightRationale(c.id, true)}
+                           @mouseleave=${() => this._highlightRationale(c.id, false)}>
+                    <header class="cover-comment__head">
+                      <span class="cover-comment__num">${c.id}</span>
+                      <span class="cover-comment__label">${c.label}</span>
+                    </header>
+                    <div class="cover-comment__body">${unsafeHTML(renderMarkdown(c.text))}</div>
+                  </article>
+                `)}
+              </aside>
+            </div>
+          `
+          : html`<article class="kb-doc asset-doc">${unsafeHTML(bodyHtml)}</article>`)}
     `;
+  }
+
+  // Visual link between a comment card and its highlights — toggle a class
+  // on every <mark> with the matching data-rationale id when the card is
+  // hovered, so the user can see which sentences a rationale anchors to.
+  _highlightRationale(id, on) {
+    const root = this.querySelector('.cover-layout__body');
+    if (!root) return;
+    root.querySelectorAll(`mark[data-rationale="${id}"]`).forEach(el => {
+      el.classList.toggle('is-focused', on);
+    });
   }
 
   _renderChromeFromPrefill() {

--- a/job/js/diff.js
+++ b/job/js/diff.js
@@ -75,47 +75,71 @@ function chunkPhrase(s) {
 
 function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
 
+// Highlight phrases AND collect rationale comments for each match.
+// `sources` is an array of `{ label, text }` — label shows in the comment
+// header (e.g. "Suggested angle"), text is the source bullet/sentence.
+//
+// Returns `{ html, comments }` where:
+//   html      — markdown with <mark class="d-jd" data-rationale="N">…</mark>
+//   comments  — [{ id, label, text }] in order of first appearance.
+//
+// The renderer can drop the body into the page and render the comments
+// list in a side rail, anchoring each card to its mark via the data-id.
 export function highlightPhrases(text, sources) {
-  let body = String(text || '');
-  if (!body) return body;
-  const seen = new Set();
-  const phrases = [];
+  const body = String(text || '');
+  if (!body) return { html: body, comments: [] };
+
+  // Build phrase → source map (longest-first; first source wins for ties).
+  const phraseToSource = new Map();
   for (const src of (sources || [])) {
-    for (const c of chunkPhrase(src)) {
+    if (!src) continue;
+    const label = (typeof src === 'string') ? '' : (src.label || '');
+    const stext = (typeof src === 'string') ? src : (src.text || '');
+    for (const c of chunkPhrase(stext)) {
       const k = c.toLowerCase();
-      if (seen.has(k)) continue;
-      seen.add(k);
-      phrases.push(c);
+      if (phraseToSource.has(k)) continue;
+      phraseToSource.set(k, { phrase: c, label, text: stext });
     }
   }
-  // Sort longest-first so longer phrases match before their substrings.
-  phrases.sort((a, b) => b.length - a.length);
+  const phrases = Array.from(phraseToSource.values()).sort((a, b) => b.phrase.length - a.phrase.length);
 
-  // Track ranges already wrapped to avoid nested <mark>.
-  const wrapped = []; // [startIdx, endIdx)
-  const hits = [];   // [{start, end, phrase}]
+  // Find non-overlapping matches in document order.
+  const wrapped = [];
+  const hits = [];
   const lower = body.toLowerCase();
   for (const p of phrases) {
-    const re = new RegExp(escapeRegex(p), 'gi');
+    const re = new RegExp(escapeRegex(p.phrase), 'gi');
     let m;
     while ((m = re.exec(lower)) !== null) {
       const start = m.index;
       const end = start + m[0].length;
-      const overlaps = wrapped.some(([s, e]) => start < e && end > s);
-      if (overlaps) continue;
+      if (wrapped.some(([s, e]) => start < e && end > s)) continue;
       wrapped.push([start, end]);
-      hits.push({ start, end });
+      hits.push({ start, end, label: p.label, text: p.text });
     }
   }
-  if (!hits.length) return body;
+  if (!hits.length) return { html: body, comments: [] };
   hits.sort((a, b) => a.start - b.start);
+
+  // De-duplicate comments by (label + text) so two highlights of the same
+  // bullet share one comment card.
+  const commentMap = new Map();
+  const comments = [];
+  let nextId = 1;
   let out = '';
   let cursor = 0;
   for (const h of hits) {
+    const key = `${h.label}\n${h.text}`;
+    let id = commentMap.get(key);
+    if (!id) {
+      id = nextId++;
+      commentMap.set(key, id);
+      comments.push({ id, label: h.label, text: h.text });
+    }
     out += body.slice(cursor, h.start);
-    out += `<mark class="d-jd">${body.slice(h.start, h.end)}</mark>`;
+    out += `<mark class="d-jd" data-rationale="${id}">${body.slice(h.start, h.end)}<sup class="d-fn">${id}</sup></mark>`;
     cursor = h.end;
   }
   out += body.slice(cursor);
-  return out;
+  return { html: out, comments };
 }

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.44.0">
-  <script src="/job/js/theme.js?v=0.44.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
+  <script src="/job/js/theme.js?v=0.45.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.44.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.45.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Two-column cover letter view: body on the left, sticky comment rail on the right showing the source label and bullet for each highlight. Numbered markers on each highlight match a numbered card. Hovering a card focuses its highlights so it's clear which sentences a rationale anchors to.

Edit textarea restyled as inline doc editing (body font, generous padding) with autosave on blur. "Show changes" → "Show comments" on the cover-letter tab.

Cover letter remains written from scratch — no base, no diff, just rationale per highlight as you requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)