### PR TITLE
job(gmail): Phase 1 — Gmail-sourced job recs in widget

### DIFF
--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -31,11 +31,20 @@
 | [Phase 11: Instagram Import](./phase-11-instagram-import.md) | Pending | 0/73 |
 | [Phase 12: Lookback](./phase-12-lookback.md) | IN PROGRESS | 47/249 |
 | [Phase 13: Boards React Rewrite](./phase-13-react-rewrite.md) | Pending | 0/272 |
+| [Phase 14: Gmail → Jobs Pipe](./phase-14-gmail-jobs-pipe.md) | IN PROGRESS | 0/73 |
 | [Backlog](./backlog.md) | Future | 1/118 |
 
 ---
 
 ## Recent Milestones
+
+### Gmail → Jobs Pipe — Phase 1 Started
+**Added: 2026-05-10** — Phase 14 filed from [PRD: Job Product](/docs/strategy/prds/job-product.md)
+
+- **Scope**: Gmail OAuth (Option B split — `gmail-auth` function + `_shared/google-tokens.ts` shared with `calendar-api`), token storage in `user_google_tokens` keyed by `(user_id, scope_set)`, job-source enrichment cascade (cache → ATS patterns → careers scrape → unresolved bucket), `GmailJobsSource` plugin with recruiter-blast skip logic and aggregator allowlist, `gmail-scan` cron function, fixture-based test path
+- **Deferred to Phase 2**: contacts graph, connections enrichment, LinkedIn CSV upload, network overlay, paid enrichment APIs
+- **Infrastructure**: 3 new migrations (`021_user_google_tokens`, `022_job_companies`, `023_gmail_skipped`), 3 new edge functions (`gmail-auth`, `enrich-job-source`, `gmail-scan`), 2 shared helpers (`_shared/google-tokens.ts`, `_shared/gmail.ts`)
+- **Total tasks**: 73 across 4 epics, 12 stories
 
 ### Systemic v2 — Planned
 **Added: 2026-04-10** — 16 stories filed from [PRD: Systemic v2](/docs/strategy/prds/systemic-v2.md)

--- a/docs/execution/project-plan/phase-14-gmail-jobs-pipe.md
+++ b/docs/execution/project-plan/phase-14-gmail-jobs-pipe.md
@@ -1,0 +1,197 @@
+# Phase 14: Gmail → Jobs Pipe (Phase 1 — Recommendations Only)
+
+> Back to [Project Plan](./index.md)
+>
+> **Reference**: [PRD: Job Product](/docs/strategy/prds/job-product.md)
+>
+> **Vision**: Scan Gmail for recruiter outreach and surface scored, deduplicated, canonically-linked role recommendations inside the existing Jobs recommendations widget — with zero manual input from Ian. Phase 1 is strictly the recommendations pipe: Gmail OAuth, token storage, job-source enrichment, Gmail scanning, and source plugin wiring. Contacts, connections, network overlay, and LinkedIn CSV import are deferred to Phase 2.
+
+---
+
+## Goal
+
+A Gmail-connected user sees scored, deduplicated, canonically-linked Gmail-sourced roles in the existing recommendations widget — automatically, without touching a spreadsheet.
+
+## Success Criteria
+
+- [ ] Ian can complete the Gmail OAuth flow and revoke access from the product UI
+- [ ] `user_google_tokens` table stores tokens keyed by `(user_id, scope_set)` with refresh-token rotation working end-to-end
+- [ ] Gmail scan runs on cron and surfaces new recruiter-inbound roles in the recommendations widget within one cron cycle
+- [ ] Recruiter-blast emails (mass outreach to >N recipients) are skipped and logged to `gmail_skipped`, not surfaced as recommendations
+- [ ] Roles from major aggregator domains (Greenhouse, Lever, Ashby, Workday, etc.) resolve to a canonical careers-page URL
+- [ ] Deduplication prevents the same role appearing twice when contacted via multiple threads
+- [ ] Fixture-based test path exercises the full scan → enrich → score → widget pipeline without hitting live Gmail
+
+---
+
+## Out of Scope — Phase 2 (Deferred)
+
+The following are explicitly excluded from Phase 1. Do not add them here.
+
+- **Contacts graph** — importing or maintaining a contact list from Gmail/LinkedIn
+- **Connections enrichment** — mapping contacts to companies or investors
+- **LinkedIn CSV upload** — network import flow
+- **Network overlay** — showing connection signals on pipeline roles
+- **Paid enrichment APIs** — Hunter.io, Clearbit, or similar for contact resolution
+
+---
+
+## Epic 1: Shared Gmail / Google Infrastructure
+
+> **Goal**: Stand up the OAuth split architecture (Option B) — a dedicated `gmail-auth` edge function with a shared `_shared/google-tokens.ts` helper consumed by both `calendar-api` and `gmail-auth`. Tokens are stored in `user_google_tokens`, keyed by `(user_id, scope_set)`.
+
+### Story 1.1 — Token Table Migration
+
+| Task | Status |
+|------|--------|
+| Write migration `021_user_google_tokens.sql`: table `user_google_tokens (id, user_id, scope_set, access_token, refresh_token, expires_at, created_at, updated_at)` | Pending |
+| Add unique constraint on `(user_id, scope_set)` | Pending |
+| Add RLS policy: users can only read/write their own rows | Pending |
+| Add index on `(user_id, scope_set)` for fast token lookup | Pending |
+| Document migration in `docs/infrastructure/deployment.md` under Boards migrations | Pending |
+
+### Story 1.2 — `_shared/google-tokens.ts` Helper
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/_shared/google-tokens.ts` | Pending |
+| Implement `getToken(userId, scopeSet)` — reads from `user_google_tokens`, refreshes via Google token endpoint if `expires_at` is within 5 minutes, writes back updated tokens | Pending |
+| Implement `storeToken(userId, scopeSet, tokenResponse)` — upsert on `(user_id, scope_set)` | Pending |
+| Implement `revokeToken(userId, scopeSet)` — calls Google revoke endpoint + deletes row | Pending |
+| Export typed `ScopeSet` union (`'calendar' | 'gmail'`) so call sites are compile-checked | Pending |
+| Unit-test with Deno test fixtures: fresh token, expired token (triggers refresh), revoked token | Pending |
+
+### Story 1.3 — `_shared/gmail.ts` Client
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/_shared/gmail.ts` | Pending |
+| Implement `listMessages(accessToken, query, maxResults)` — wraps Gmail `users.messages.list` API | Pending |
+| Implement `getMessage(accessToken, messageId)` — wraps `users.messages.get` with `format=full` | Pending |
+| Implement `getThread(accessToken, threadId)` — wraps `users.threads.get` | Pending |
+| Add typed interfaces: `GmailMessage`, `GmailThread`, `GmailHeader` | Pending |
+| Handle 401 responses by surfacing a typed `TokenExpiredError` so callers know to refresh | Pending |
+
+### Story 1.4 — `gmail-auth` Edge Function
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/gmail-auth/index.ts` with `const VERSION = '1.0.0'` | Pending |
+| Implement `GET /gmail-auth/connect` — redirects to Google OAuth consent screen with `gmail.readonly` scope, `access_type=offline`, `prompt=consent` | Pending |
+| Implement `GET /gmail-auth/callback` — exchanges code for tokens, calls `storeToken(userId, 'gmail', ...)`, redirects to product UI with success param | Pending |
+| Implement `POST /gmail-auth/revoke` — calls `revokeToken(userId, 'gmail')`, returns 200 | Pending |
+| Implement `GET /gmail-auth/status` — returns `{ connected: boolean, scopeSet: 'gmail' }` for the authenticated user | Pending |
+| Wire `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` from Supabase Edge Function secrets (document in `deployment.md`) | Pending |
+| Update `calendar-api` to import `getToken` from `_shared/google-tokens.ts` instead of its own token logic | Pending |
+
+---
+
+## Epic 2: Job-Source Enrichment
+
+> **Goal**: Given a company name or careers-page URL extracted from Gmail, resolve it to a canonical `job.companies` entry with a verified careers-page URL. Enrichment uses a cascade: cache → tracked-ATS domain patterns → careers-page scrape → unresolved bucket with retry timestamp.
+
+### Story 2.1 — `job.companies` Cache Migration
+
+| Task | Status |
+|------|--------|
+| Write migration `022_job_companies.sql`: table `job_companies (id, name_canonical, careers_url, ats_domain, ats_type, resolved_at, retry_after, created_at, updated_at)` | Pending |
+| Add unique index on `name_canonical` (lowercased, trimmed) | Pending |
+| Add index on `ats_domain` for ATS-pattern lookups | Pending |
+| Add `retry_after TIMESTAMPTZ` column — NULL means resolved; non-NULL means unresolved, retry after that timestamp | Pending |
+| RLS: service-role only (no user-facing reads needed in Phase 1) | Pending |
+
+### Story 2.2 — `enrich-job-source` Edge Function
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/enrich-job-source/index.ts` with `const VERSION = '1.0.0'` | Pending |
+| Implement cascade Step 1 — cache lookup: query `job_companies` by `name_canonical`; return immediately if `resolved_at` is set and `retry_after` is NULL | Pending |
+| Implement cascade Step 2 — ATS domain pattern match: check if the inbound URL's domain matches known ATS patterns (Greenhouse `greenhouse.io`, Lever `jobs.lever.co`, Ashby `jobs.ashbyhq.com`, Workday `myworkdayjobs.com`, SmartRecruiters, iCIMS, BambooHR, Jobvite); if match, extract company slug and construct canonical URL | Pending |
+| Implement cascade Step 3 — careers-page scrape: fetch company root domain, look for `<a>` hrefs containing `/careers`, `/jobs`, `/join`; score candidates by keyword density; return highest-confidence URL | Pending |
+| Implement cascade Step 4 — unresolved bucket: if all steps fail, upsert row with `retry_after = NOW() + INTERVAL '24 hours'`; return `{ resolved: false }` | Pending |
+| On successful resolution (Steps 2 or 3), upsert `job_companies` with `resolved_at = NOW()`, `retry_after = NULL`, `careers_url` | Pending |
+| Expose `POST /enrich-job-source` accepting `{ companyName: string, hintUrl?: string }` | Pending |
+
+---
+
+## Epic 3: Gmail-Jobs Source Plugin
+
+> **Goal**: Wire Gmail as a job-recommendation source. The plugin reads Gmail threads matching recruiter-outreach patterns, extracts company + role signals, skips recruiter blasts, deduplicates against existing pipeline roles, and feeds enriched candidates into the recommendations widget via the existing source registry.
+
+### Story 3.1 — `_shared/sources/gmail-jobs.ts` Plugin
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/_shared/sources/gmail-jobs.ts` | Pending |
+| Implement `GmailJobsSource` class conforming to the existing source plugin interface | Pending |
+| Query Gmail with search string: `(subject:"opportunity" OR subject:"role" OR subject:"position" OR subject:"opening" OR "I'd love to connect") in:inbox newer_than:14d` | Pending |
+| For each matching thread, extract: sender domain, subject, body snippet, any URLs in body | Pending |
+| Pass extracted company name + hint URL to `enrich-job-source`; skip threads where enrichment returns `{ resolved: false }` and `retry_after` is in the future | Pending |
+| Extract role title from subject line using pattern list (title-case noun phrases preceding "at", "with", "—", " @ ") | Pending |
+| Deduplicate against existing `roles_pipeline` rows by `(name_canonical, role_title_normalized)` — skip if already tracked | Pending |
+
+### Story 3.2 — Recruiter-Blast Skip Logic
+
+| Task | Status |
+|------|--------|
+| Write migration `023_gmail_skipped.sql`: table `gmail_skipped (id, thread_id, user_id, reason, skipped_at)` with index on `(user_id, thread_id)` | Pending |
+| In `GmailJobsSource`, detect blast emails: fetch thread recipient count via `getThread`; skip and log to `gmail_skipped` if `to` header contains >5 addresses or BCC indicators are present | Pending |
+| Also skip and log if sender domain is on the aggregator allowlist (see Story 3.3) — these are sourced separately, not from Gmail body | Pending |
+| Skip and log if the same `thread_id` has already been processed (idempotency guard) | Pending |
+
+### Story 3.3 — Aggregator Allowlist
+
+| Task | Status |
+|------|--------|
+| Define `AGGREGATOR_DOMAINS` constant in `gmail-jobs.ts`: `['linkedin.com', 'indeed.com', 'glassdoor.com', 'ziprecruiter.com', 'dice.com', 'monster.com', 'simplyhired.com', 'builtinsf.com', 'wellfound.com', 'otta.com']` | Pending |
+| Skip threads where sender domain is in `AGGREGATOR_DOMAINS` — log to `gmail_skipped` with `reason: 'aggregator'` | Pending |
+| Document rationale: aggregator emails are handled by other source plugins, not Gmail body parsing | Pending |
+
+### Story 3.4 — Source Registry Wiring
+
+| Task | Status |
+|------|--------|
+| Register `GmailJobsSource` in the existing source registry under key `'gmail-jobs'` | Pending |
+| Add `user-sources` support for `type='gmail-jobs'`: a user with a connected Gmail account auto-gets this source enabled | Pending |
+| Ensure the source only activates when `gmail-auth/status` returns `{ connected: true }` for the user | Pending |
+| Add `'gmail-jobs'` to the recommendations widget eligibility check so Gmail-sourced roles can appear in the widget | Pending |
+
+---
+
+## Epic 4: Cron Tick + E2E
+
+> **Goal**: A `gmail-scan` edge function runs on a cron schedule, invokes the `GmailJobsSource` plugin for each connected user, and feeds results into the recommendations pipeline. A fixture-based test path validates the full flow without hitting live Gmail.
+
+### Story 4.1 — `gmail-scan` Edge Function
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/gmail-scan/index.ts` with `const VERSION = '1.0.0'` | Pending |
+| On invocation, query `user_google_tokens` for all rows where `scope_set = 'gmail'` and `retry_after IS NULL` | Pending |
+| For each user, instantiate `GmailJobsSource`, call `scan()`, collect candidate roles | Pending |
+| For each candidate, call `enrich-job-source` (or call inline if colocated), then upsert into `roles_pipeline` with `source = 'gmail-jobs'` and `status = 'New'` | Pending |
+| Log scan summary per user: threads scanned, roles added, roles skipped (blast), roles skipped (aggregator), roles skipped (already tracked) | Pending |
+| Schedule via Supabase cron: `0 8 * * *` (08:00 UTC daily) — document in `deployment.md` | Pending |
+
+### Story 4.2 — Fixture-Based Test Path
+
+| Task | Status |
+|------|--------|
+| Create `supabase/functions/gmail-scan/fixtures/` directory with 5 sample Gmail thread JSON blobs: genuine recruiter outreach, blast email, aggregator-domain sender, already-tracked role, unresolvable company | Pending |
+| Implement `runFixture(fixtureName)` function in `gmail-scan` invocable via `POST /gmail-scan?fixture=<name>` when `GMAIL_FIXTURE_MODE=true` env var is set | Pending |
+| Assert expected outcomes per fixture: genuine → role upserted; blast → logged to `gmail_skipped`; aggregator → logged to `gmail_skipped`; already-tracked → skipped silently; unresolvable → `retry_after` set | Pending |
+| Write Deno test file `gmail-scan.test.ts` that runs all 5 fixture assertions | Pending |
+
+### Story 4.3 — Deploy + Run Migrations
+
+| Task | Status |
+|------|--------|
+| Run migration `021_user_google_tokens.sql` against Boards Supabase project | Pending |
+| Run migration `022_job_companies.sql` against Boards Supabase project | Pending |
+| Run migration `023_gmail_skipped.sql` against Boards Supabase project | Pending |
+| Deploy `gmail-auth` edge function: `supabase functions deploy gmail-auth` | Pending |
+| Deploy `enrich-job-source` edge function: `supabase functions deploy enrich-job-source` | Pending |
+| Deploy `gmail-scan` edge function: `supabase functions deploy gmail-scan` | Pending |
+| Verify `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set in Supabase Edge Function secrets | Pending |
+| Manually trigger first scan via `POST /gmail-scan` and confirm roles appear in recommendations widget | Pending |
+| Update `calendar-api` deployment after `_shared/google-tokens.ts` refactor: `supabase functions deploy calendar-api` | Pending |

--- a/supabase/functions/_shared/gmail.ts
+++ b/supabase/functions/_shared/gmail.ts
@@ -1,0 +1,210 @@
+// Minimal Gmail API client for Phase 1 of the jobs pipe.
+//
+// What this provides:
+//   - listSinceCursor:  fetch Gmail message IDs newer than a stored
+//                       historyId (preferred) or ISO timestamp (fallback).
+//   - getMessage:       fetch one message with headers + decoded text body.
+//   - extractFields:    helpers to pull subject, sender, plain-text body,
+//                       and the canonical Message-ID header for dedupe.
+//
+// Constraints:
+//   - We never persist raw bodies. Callers extract structured fields and
+//     either emit a recommendation row or log to gmail_skipped.
+//   - We only request format=metadata or format=full as needed to keep
+//     response size low.
+
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+export interface GmailMessageRef {
+  id: string;
+  threadId: string;
+}
+
+export interface GmailHeader {
+  name: string;
+  value: string;
+}
+
+export interface GmailPayloadPart {
+  partId?: string;
+  mimeType?: string;
+  filename?: string;
+  headers?: GmailHeader[];
+  body?: { size?: number; data?: string };
+  parts?: GmailPayloadPart[];
+}
+
+export interface GmailMessage {
+  id: string;
+  threadId: string;
+  historyId?: string;
+  internalDate?: string;
+  snippet?: string;
+  payload?: GmailPayloadPart;
+}
+
+export interface ListResult {
+  messageIds: string[];
+  nextHistoryId: string | null;
+  // True when the caller should fall back to a fresh `q` query because
+  // the historyId we sent was too old (Gmail expires history after ~7
+  // days). Caller catches this and re-runs with the timestamp fallback.
+  historyExpired: boolean;
+}
+
+// ---------- Listing ----------
+//
+// Two paths:
+//   1. history.list when we have a stored historyId. Cheapest.
+//   2. messages.list?q=…  fallback when there's no history (first run)
+//      or history expired. Returns messages newer than `after:` epoch.
+
+export async function listSinceCursor(
+  accessToken: string,
+  cursor: { historyId?: string | null; afterEpochSec?: number | null },
+  query?: string,                                       // e.g. 'newer_than:7d category:updates'
+): Promise<ListResult> {
+  if (cursor.historyId) {
+    const url = new URL(`${GMAIL_BASE}/history`);
+    url.searchParams.set('startHistoryId', cursor.historyId);
+    url.searchParams.set('historyTypes', 'messageAdded');
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (r.status === 404 || r.status === 410) {
+      // History expired. Caller should retry with the timestamp path.
+      return { messageIds: [], nextHistoryId: null, historyExpired: true };
+    }
+    if (!r.ok) throw new Error(`gmail history.list ${r.status}: ${await r.text()}`);
+    const data = await r.json() as { history?: Array<{ messagesAdded?: Array<{ message: GmailMessageRef }> }>; historyId?: string };
+    const ids: string[] = [];
+    for (const h of (data.history || [])) {
+      for (const ma of (h.messagesAdded || [])) {
+        if (ma.message?.id) ids.push(ma.message.id);
+      }
+    }
+    return { messageIds: dedupe(ids), nextHistoryId: data.historyId || cursor.historyId || null, historyExpired: false };
+  }
+
+  // Timestamp path. Default to last 14 days if no cursor at all.
+  const afterEpoch = cursor.afterEpochSec ?? Math.floor((Date.now() - 14 * 24 * 60 * 60 * 1000) / 1000);
+  const q = [query || '', `after:${afterEpoch}`].filter(Boolean).join(' ');
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+  // Cap pages so a runaway query can't burn the whole tick.
+  for (let page = 0; page < 5; page++) {
+    const url = new URL(`${GMAIL_BASE}/messages`);
+    url.searchParams.set('q', q);
+    url.searchParams.set('maxResults', '100');
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!r.ok) throw new Error(`gmail messages.list ${r.status}: ${await r.text()}`);
+    const data = await r.json() as { messages?: GmailMessageRef[]; nextPageToken?: string };
+    for (const m of (data.messages || [])) ids.push(m.id);
+    if (!data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  // messages.list doesn't return historyId; caller should ask
+  // getProfileHistoryId after a successful timestamp scan to seed the
+  // history cursor for the next tick.
+  return { messageIds: dedupe(ids), nextHistoryId: null, historyExpired: false };
+}
+
+// Fetch the user's profile to seed a historyId on first scan. Cheaper
+// than walking the inbox just to learn what "now" is.
+export async function getProfileHistoryId(accessToken: string): Promise<string | null> {
+  const r = await fetch(`${GMAIL_BASE}/profile`, { headers: { Authorization: `Bearer ${accessToken}` } });
+  if (!r.ok) return null;
+  const data = await r.json() as { historyId?: string };
+  return data.historyId || null;
+}
+
+// ---------- Single message ----------
+
+export async function getMessage(
+  accessToken: string,
+  id: string,
+  format: 'metadata' | 'full' = 'full',
+): Promise<GmailMessage> {
+  const url = new URL(`${GMAIL_BASE}/messages/${encodeURIComponent(id)}`);
+  url.searchParams.set('format', format);
+  if (format === 'metadata') {
+    for (const h of ['Subject', 'From', 'To', 'Date', 'Message-ID', 'List-Unsubscribe']) {
+      url.searchParams.append('metadataHeaders', h);
+    }
+  }
+  const r = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  if (!r.ok) throw new Error(`gmail messages.get(${id}) ${r.status}: ${await r.text()}`);
+  return await r.json() as GmailMessage;
+}
+
+// ---------- Extraction helpers ----------
+
+export function getHeader(msg: GmailMessage, name: string): string | null {
+  const headers = msg.payload?.headers || [];
+  const lc = name.toLowerCase();
+  const h = headers.find(h => h.name.toLowerCase() === lc);
+  return h?.value ?? null;
+}
+
+// Walk the MIME tree, prefer text/plain, fall back to text/html stripped.
+export function extractBody(msg: GmailMessage): string {
+  const parts = flattenParts(msg.payload);
+  const plain = parts.find(p => (p.mimeType || '').toLowerCase() === 'text/plain' && p.body?.data);
+  if (plain) return decodeB64Url(plain.body!.data!);
+  const html = parts.find(p => (p.mimeType || '').toLowerCase() === 'text/html' && p.body?.data);
+  if (html) return stripHtml(decodeB64Url(html.body!.data!));
+  // Top-level body for simple messages
+  if (msg.payload?.body?.data) {
+    const decoded = decodeB64Url(msg.payload.body.data);
+    return (msg.payload.mimeType || '').toLowerCase().includes('html') ? stripHtml(decoded) : decoded;
+  }
+  return msg.snippet || '';
+}
+
+// Pull the angle-bracketed Message-ID for cross-run dedupe. Falls back
+// to the Gmail API id if the header is missing (rare but possible on
+// drafts / corrupted messages).
+export function getMessageIdHeader(msg: GmailMessage): string {
+  const raw = getHeader(msg, 'Message-ID') || getHeader(msg, 'Message-Id');
+  if (raw) return raw.trim();
+  return `gmail-id:${msg.id}`;
+}
+
+// ---------- private ----------
+
+function flattenParts(part?: GmailPayloadPart): GmailPayloadPart[] {
+  if (!part) return [];
+  const out: GmailPayloadPart[] = [part];
+  for (const p of (part.parts || [])) out.push(...flattenParts(p));
+  return out;
+}
+
+function decodeB64Url(s: string): string {
+  // Gmail uses URL-safe base64 with no padding.
+  const norm = s.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = norm.length % 4 ? '='.repeat(4 - (norm.length % 4)) : '';
+  try {
+    const bytes = Uint8Array.from(atob(norm + pad), c => c.charCodeAt(0));
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function dedupe(arr: string[]): string[] {
+  return [...new Set(arr)];
+}

--- a/supabase/functions/_shared/google-tokens.ts
+++ b/supabase/functions/_shared/google-tokens.ts
@@ -1,0 +1,185 @@
+// Shared Google OAuth token store for any function that needs Google
+// API access (calendar-api, gmail-auth, gmail-scan, …).
+//
+// Keyed by (user_id, scope_set). When the user re-consents to add a
+// new scope (e.g. gmail.readonly on top of calendar.events), we write
+// a separate row so revoking one scope doesn't take down the other.
+//
+// Two halves:
+//   - DB I/O: read / write rows in public.user_google_tokens.
+//   - Refresh: exchange the refresh_token for a fresh access_token
+//     and persist the new expiry.
+//
+// Functions consuming this should call `getAccessToken(user, scope)`
+// to get a valid bearer; the helper handles refresh transparently.
+
+import { createClient, SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+export interface UserGoogleToken {
+  id: string;
+  user_id: string;
+  scope_set: string;
+  google_refresh_token: string;
+  google_access_token: string | null;
+  token_expires_at: string | null;
+  google_email: string | null;
+  granted_for: string | null;
+  revoked_at: string | null;
+}
+
+// Canonical form for a scope set. Sorting + lowercase makes lookups
+// deterministic regardless of the order Google returns scopes in.
+export function canonicalScopeSet(scopes: string[]): string {
+  return [...new Set(scopes.map(s => s.trim()).filter(Boolean))]
+    .sort()
+    .join(',');
+}
+
+// Returns true if `tokenScopes` covers every scope in `required`. Used
+// to decide whether an existing row is sufficient or we need re-consent.
+export function scopeSetCovers(tokenScopes: string, required: string[]): boolean {
+  const have = new Set(tokenScopes.split(','));
+  return required.every(s => have.has(s));
+}
+
+export function getServiceClient(): SupabaseClient {
+  return createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  );
+}
+
+// Find the active (non-revoked) token row whose scope_set covers every
+// required scope. Returns null if the user hasn't consented yet.
+export async function findTokenForScopes(
+  db: SupabaseClient,
+  userId: string,
+  required: string[],
+): Promise<UserGoogleToken | null> {
+  const { data, error } = await db
+    .from('user_google_tokens')
+    .select('*')
+    .eq('user_id', userId)
+    .is('revoked_at', null);
+  if (error || !data) return null;
+  for (const row of data as UserGoogleToken[]) {
+    if (scopeSetCovers(row.scope_set, required)) return row;
+  }
+  return null;
+}
+
+// Upsert a token row. Caller passes the canonical scope_set.
+export async function upsertToken(
+  db: SupabaseClient,
+  row: {
+    user_id: string;
+    scope_set: string;
+    google_refresh_token: string;
+    google_access_token: string;
+    token_expires_at: string;
+    google_email?: string | null;
+    granted_for?: string | null;
+  },
+): Promise<void> {
+  const { error } = await db.from('user_google_tokens').upsert({
+    ...row,
+    revoked_at: null,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'user_id,scope_set' });
+  if (error) throw new Error(`upsertToken: ${error.message}`);
+}
+
+// Mark a row revoked. Called when Google returns invalid_grant on
+// refresh — that means the user revoked consent on Google's side.
+export async function markRevoked(
+  db: SupabaseClient,
+  tokenId: string,
+): Promise<void> {
+  await db.from('user_google_tokens')
+    .update({ revoked_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+    .eq('id', tokenId);
+}
+
+// Refresh the access token if it's expired or close to expiry. Returns
+// a valid access token string or throws.
+export async function getAccessToken(
+  db: SupabaseClient,
+  userId: string,
+  required: string[],
+): Promise<{ accessToken: string; tokenRow: UserGoogleToken } | null> {
+  const row = await findTokenForScopes(db, userId, required);
+  if (!row) return null;
+
+  // Still valid (with 5 min buffer)?
+  if (row.google_access_token && row.token_expires_at) {
+    const expires = new Date(row.token_expires_at).getTime();
+    if (expires > Date.now() + 5 * 60 * 1000) {
+      return { accessToken: row.google_access_token, tokenRow: row };
+    }
+  }
+
+  const clientId = Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID')!;
+  const clientSecret = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!;
+  const resp = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: row.google_refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    // invalid_grant = user revoked consent on Google's side. Mark the
+    // row revoked so subsequent calls don't keep retrying a dead token.
+    if (text.includes('invalid_grant')) {
+      await markRevoked(db, row.id);
+    }
+    throw new Error(`token refresh failed: ${resp.status} ${text.slice(0, 200)}`);
+  }
+
+  const data = await resp.json() as { access_token: string; expires_in: number };
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000).toISOString();
+
+  await db.from('user_google_tokens')
+    .update({
+      google_access_token: data.access_token,
+      token_expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', row.id);
+
+  return {
+    accessToken: data.access_token,
+    tokenRow: { ...row, google_access_token: data.access_token, token_expires_at: expiresAt },
+  };
+}
+
+// Look up a user_id by job-product email. The job product authenticates
+// users by email (job-auth.ts → ALLOWLIST), but Google tokens are keyed
+// by auth.users.id. Uses the admin API since RLS prevents direct
+// auth.users selects from a service-role client through the REST layer.
+export async function userIdForEmail(
+  db: SupabaseClient,
+  email: string,
+): Promise<string | null> {
+  const adminClient = db as unknown as { auth: { admin: { listUsers: (args: { perPage: number }) => Promise<{ data: { users: Array<{ id: string; email: string | null }> } }> } } };
+  try {
+    const res = await adminClient.auth.admin.listUsers({ perPage: 1000 });
+    const user = res.data.users.find(u => (u.email || '').toLowerCase() === email.toLowerCase());
+    return user?.id ?? null;
+  } catch (e) {
+    console.warn(`[google-tokens] userIdForEmail(${email}) failed: ${(e as Error).message}`);
+    return null;
+  }
+}
+
+// Standard Gmail scope. Exported so every call site uses the same string.
+export const GMAIL_READONLY_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly';
+export const CALENDAR_READONLY_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly';
+export const CALENDAR_EVENTS_SCOPE = 'https://www.googleapis.com/auth/calendar.events';

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -1,0 +1,433 @@
+// gmail-jobs source — pulls job postings from the user's inbox.
+//
+// Responsibility split:
+//   - This plugin decides which messages to look at, asks Haiku to
+//     extract { company, title, location, alert_url } per message,
+//     calls enrich-job-source to get the canonical JD + URL, and
+//     returns RecommendedRoleInput[] back to pull-recommendations.
+//   - pull-recommendations does the scoring, dedup, insert.
+//   - enrich-job-source owns the cache + ATS resolution.
+//
+// Config (per user_sources row):
+//   {
+//     allowSenders?: string[]     // extra sender domains beyond the defaults
+//     blockSenders?: string[]     // domains to ignore even if allowlisted
+//     query?: string              // override the Gmail search query
+//     maxMessagesPerRun?: number  // safety cap; default 50
+//   }
+//
+// State: gmail-scan persists historyId in job.gmail_scan_state so this
+// plugin only sees new messages each tick.
+
+import type { Source, RecommendedRoleInput } from './types.ts';
+import {
+  getServiceClient,
+  GMAIL_READONLY_SCOPE,
+  getAccessToken,
+  userIdForEmail,
+} from '../google-tokens.ts';
+import { db } from '../job-db.ts';
+import {
+  type GmailMessage,
+  extractBody,
+  getHeader,
+  getMessage,
+  getMessageIdHeader,
+  getProfileHistoryId,
+  listSinceCursor,
+} from '../gmail.ts';
+
+interface GmailJobsCfg {
+  allowSenders?: string[];
+  blockSenders?: string[];
+  query?: string;
+  maxMessagesPerRun?: number;
+}
+
+// Default sender allowlist — major aggregator domains. Single-role
+// alerts from these flow through; recruiter-blast digests get skipped
+// by the multi-role detector below. Users can extend via config.
+const DEFAULT_ALLOW_SENDERS = [
+  'jobs-noreply@linkedin.com',
+  'jobalerts-noreply@linkedin.com',
+  '@linkedin.com',
+  '@wellfound.com',
+  '@otta.com',
+  '@hellootta.com',
+  '@hnhiring.com',
+  '@hackernewsletter.com',
+  '@builtin.com',
+  '@yc.startup.jobs',
+  '@workatastartup.com',
+];
+
+// Subjects/senders that are almost always multi-role digests. We log
+// these to gmail_skipped with reason='multi_role_digest' for review.
+const DIGEST_HINTS = [
+  'hn hiring',
+  'who is hiring',
+  'who\'s hiring',
+  'jobs for you',                  // LinkedIn weekly recap
+  'top jobs of the week',
+  'this week\'s top',
+  'roundup',
+  'job digest',
+  'jobs digest',
+];
+
+const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+
+const ENRICH_URL =
+  Deno.env.get('ENRICH_JOB_SOURCE_URL') ||
+  'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/enrich-job-source';
+
+interface ExtractedJob {
+  company: string;
+  title: string;
+  location?: string;
+  alertUrl?: string;
+  // Haiku confidence 0–1; below 0.5 we drop / log as no_company.
+  confidence?: number;
+}
+
+export const gmailJobsSource: Source<GmailJobsCfg> = {
+  type: 'gmail-jobs',
+
+  async pull(cfg, ctx): Promise<RecommendedRoleInput[]> {
+    const sb = getServiceClient();
+
+    // Resolve user_id for the email so we can look up the Google token.
+    const userId = await userIdForEmail(sb, ctx.userEmail);
+    if (!userId) {
+      console.warn(`[gmail-jobs] no user_id for ${ctx.userEmail}; not connected?`);
+      return [];
+    }
+
+    const tokenRes = await getAccessToken(sb, userId, [GMAIL_READONLY_SCOPE]);
+    if (!tokenRes) {
+      console.warn(`[gmail-jobs] no gmail token for ${ctx.userEmail}; user has not consented`);
+      return [];
+    }
+    const accessToken = tokenRes.accessToken;
+
+    const sql = db();
+
+    // Cursor: prefer historyId, fall back to last_scan_at.
+    const stateRows = await sql<{ history_id: string | null; last_scan_at: string | null }[]>`
+      select history_id, last_scan_at from job.gmail_scan_state
+       where user_email = ${ctx.userEmail} limit 1`;
+    const state = stateRows[0] || { history_id: null, last_scan_at: null };
+
+    const allowSenders = mergeAllowlist(cfg.allowSenders);
+    const blockSenders = (cfg.blockSenders || []).map(s => s.toLowerCase());
+    const maxMessages = Math.max(1, Math.min(200, cfg.maxMessagesPerRun ?? 50));
+
+    // Build a Gmail query when we don't have a historyId. Using `from:`
+    // with the allowlist keeps the result set small. category:updates
+    // captures most aggregator alerts.
+    const fromFilter = allowSenders.map(s => `from:${s}`).join(' OR ');
+    const builtQuery = cfg.query ||
+      `(${fromFilter}) -in:spam -in:trash`;
+
+    let listRes;
+    try {
+      listRes = await listSinceCursor(
+        accessToken,
+        {
+          historyId: state.history_id,
+          afterEpochSec: state.last_scan_at
+            ? Math.floor(new Date(state.last_scan_at).getTime() / 1000)
+            : null,
+        },
+        builtQuery,
+      );
+      // Fallback: history expired → re-list by timestamp.
+      if (listRes.historyExpired) {
+        listRes = await listSinceCursor(
+          accessToken,
+          { afterEpochSec: state.last_scan_at ? Math.floor(new Date(state.last_scan_at).getTime() / 1000) : null },
+          builtQuery,
+        );
+      }
+    } catch (e) {
+      await markScanError(sql, ctx.userEmail, (e as Error).message);
+      throw e;
+    }
+
+    const ids = listRes.messageIds.slice(0, maxMessages);
+    console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidate messages (history=${!!state.history_id})`);
+
+    const out: RecommendedRoleInput[] = [];
+
+    for (const id of ids) {
+      let msg: GmailMessage;
+      try {
+        msg = await getMessage(accessToken, id, 'full');
+      } catch (e) {
+        console.warn(`[gmail-jobs] fetch ${id} failed: ${(e as Error).message}`);
+        continue;
+      }
+      const messageId = getMessageIdHeader(msg);
+
+      // Already seen (skipped or ingested)? The unique (source, source_id)
+      // constraint on recommended_roles handles dedup at insert time, but
+      // we also want to avoid re-processing skipped messages every tick.
+      const already = await sql<{ message_id: string }[]>`
+        select message_id from job.gmail_skipped
+         where user_email = ${ctx.userEmail} and message_id = ${messageId} limit 1`;
+      if (already.length) continue;
+
+      const sender = (getHeader(msg, 'From') || '').toLowerCase();
+      if (blockSenders.some(b => sender.includes(b))) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'blocked_sender');
+        continue;
+      }
+      if (!allowSenders.some(a => sender.includes(a.toLowerCase()))) {
+        // Out of allowlist — silently skip. Don't fill gmail_skipped
+        // with every newsletter the user gets; only log when we tried
+        // and failed.
+        continue;
+      }
+
+      const subject = getHeader(msg, 'Subject') || '';
+      if (looksLikeDigest(subject, sender)) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'multi_role_digest', { subject });
+        continue;
+      }
+
+      const body = extractBody(msg);
+      if (!body) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'parse_error', { reason: 'empty_body' });
+        continue;
+      }
+
+      let job: ExtractedJob | null;
+      try {
+        job = await extractJob({ subject, sender, body });
+      } catch (e) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'parse_error', { reason: (e as Error).message });
+        continue;
+      }
+
+      if (!job || !job.company || (job.confidence !== undefined && job.confidence < 0.5)) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'no_company', { extracted: job });
+        continue;
+      }
+      if (!job.title) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'no_title', { extracted: job });
+        continue;
+      }
+
+      // Multi-role guard #2: if Haiku confessed multiple roles in one
+      // message, we treat it as a digest. Haiku is instructed to set
+      // confidence < 0.4 in that case.
+      if ((job.confidence ?? 1) < 0.4) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'multi_role_digest', { extracted: job });
+        continue;
+      }
+
+      // Enrichment.
+      let enriched: { resolved: boolean; companyId: string; canonicalUrl?: string; jdText?: string; nextRetryAt?: string; atsProvider?: string };
+      try {
+        enriched = await enrich({ company: job.company, title: job.title, hintAtsUrl: job.alertUrl, hintDomain: senderDomain(sender) });
+      } catch (e) {
+        console.warn(`[gmail-jobs] enrich(${job.company}) failed: ${(e as Error).message}`);
+        // Soft-fail: still emit the row pointing at the alert URL,
+        // flagged unresolved, so the user sees something.
+        enriched = { resolved: false, companyId: '', canonicalUrl: undefined };
+      }
+
+      const url = enriched.canonicalUrl || job.alertUrl;
+      if (!url) {
+        await logSkipped(sql, ctx.userEmail, msg, messageId, 'no_url', { extracted: job });
+        continue;
+      }
+
+      const sourceId = `gmail:${messageId}`;
+      const sourceLabel = enriched.resolved && enriched.atsProvider
+        ? `Gmail · ${enriched.atsProvider} · ${job.company}`
+        : `Gmail · ${job.company}`;
+
+      out.push({
+        source:      'gmail-jobs',
+        sourceId,
+        sourceLabel,
+        url,
+        company:     job.company,
+        title:       job.title,
+        location:    job.location,
+        postedAt:    msg.internalDate ? new Date(Number(msg.internalDate)).toISOString() : undefined,
+        description: enriched.jdText ? enriched.jdText.slice(0, 4000) : undefined,
+        enrichmentStatus:  enriched.resolved ? 'resolved' : 'unresolved',
+        enrichmentRetryAt: enriched.nextRetryAt,
+        canonicalUrl:      enriched.canonicalUrl,
+        companyId:         enriched.companyId || undefined,
+        payload: {
+          gmailMessageId:    messageId,
+          gmailApiId:        msg.id,
+          enrichmentResolved: enriched.resolved,
+          enrichmentRetryAt:  enriched.nextRetryAt ?? null,
+          companyId:          enriched.companyId || null,
+          canonicalUrl:       enriched.canonicalUrl ?? null,
+          alertUrl:           job.alertUrl ?? null,
+          atsProvider:        enriched.atsProvider ?? null,
+          sender,
+        },
+      });
+    }
+
+    // Persist new cursor. Prefer the historyId Gmail returned;
+    // otherwise stamp last_scan_at = now (we just consumed everything
+    // up to "now" via the timestamp query). On first run with no
+    // history_id, ask Gmail what its current historyId is so the next
+    // tick goes through the cheap path.
+    let nextHistory: string | null = listRes.nextHistoryId;
+    if (!nextHistory && !state.history_id) {
+      nextHistory = await getProfileHistoryId(accessToken);
+    }
+    await sql`
+      insert into job.gmail_scan_state (user_email, history_id, last_scan_at, last_error, updated_at)
+        values (${ctx.userEmail}, ${nextHistory}, now(), null, now())
+      on conflict (user_email) do update
+        set history_id = coalesce(excluded.history_id, job.gmail_scan_state.history_id),
+            last_scan_at = excluded.last_scan_at,
+            last_error = null,
+            updated_at = now()
+    `;
+
+    return out;
+  },
+};
+
+// ---------- helpers ----------
+
+function mergeAllowlist(extra?: string[]): string[] {
+  return [...new Set([...DEFAULT_ALLOW_SENDERS, ...(extra || [])])].map(s => s.toLowerCase());
+}
+
+function looksLikeDigest(subject: string, sender: string): boolean {
+  const subj = subject.toLowerCase();
+  if (DIGEST_HINTS.some(h => subj.includes(h))) return true;
+  // hnhiring / yc.startup.jobs digests are always multi-role
+  if (/(hnhiring\.com|hackernewsletter\.com)/.test(sender)) return true;
+  return false;
+}
+
+function senderDomain(sender: string): string | undefined {
+  const m = sender.match(/<?([^<\s@]+)@([^>\s]+)>?/);
+  return m?.[2]?.toLowerCase();
+}
+
+async function logSkipped(
+  sql: ReturnType<typeof db>,
+  userEmail: string,
+  msg: GmailMessage,
+  messageId: string,
+  reason: string,
+  details?: Record<string, unknown>,
+) {
+  try {
+    await sql`
+      insert into job.gmail_skipped (user_email, message_id, gmail_id, sender, subject, reason, details)
+        values (${userEmail}, ${messageId}, ${msg.id}, ${getHeader(msg, 'From')}, ${getHeader(msg, 'Subject')}, ${reason}, ${details ? sql.json(details) : null})
+      on conflict (user_email, message_id) do nothing`;
+  } catch (e) {
+    console.warn(`[gmail-jobs] logSkipped failed: ${(e as Error).message}`);
+  }
+}
+
+async function markScanError(sql: ReturnType<typeof db>, userEmail: string, error: string) {
+  await sql`
+    insert into job.gmail_scan_state (user_email, last_error, updated_at)
+      values (${userEmail}, ${error}, now())
+    on conflict (user_email) do update
+      set last_error = excluded.last_error, updated_at = now()`;
+}
+
+// ---------- Haiku extraction ----------
+//
+// Single-shot prompt. Returns JSON only. Confidence < 0.5 means "I'm
+// not sure this is a job alert" → skip with no_company. Confidence
+// < 0.4 means "this looks like multiple roles in one email" → skip
+// as digest.
+
+const EXTRACT_SYSTEM = `You extract job postings from email alerts (LinkedIn, Wellfound, Otta, etc).
+
+Return STRICT JSON, no prose:
+{ "company": "...", "title": "...", "location": "...", "alertUrl": "...", "confidence": 0.0-1.0 }
+
+Rules:
+- Only extract a SINGLE role. If the email contains multiple distinct roles (digest format), set confidence to 0.3 and leave fields blank.
+- "alertUrl" is the FIRST clickable link to the role's posting/apply page in the email body. Prefer aggregator URLs over generic homepage links.
+- "company" is the hiring company, NOT the email sender. e.g. "Open Phone" not "LinkedIn".
+- "location" is the role's location string (e.g. "San Francisco, CA", "Remote, US"). Empty string if absent.
+- If you cannot identify a company AND title with reasonable confidence, set confidence < 0.5.
+- NEVER invent fields. Empty string > guess.`;
+
+async function extractJob(args: { subject: string; sender: string; body: string }): Promise<ExtractedJob | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    console.warn('[gmail-jobs] ANTHROPIC_API_KEY missing; skipping extraction');
+    return null;
+  }
+  // Truncate body — alerts are ≤ a few KB but HTML pasted ones can be
+  // huge. 6k chars is plenty for a single role.
+  const trimmed = args.body.slice(0, 6000);
+  const userPrompt = [
+    `Subject: ${args.subject}`,
+    `From: ${args.sender}`,
+    `---`,
+    trimmed,
+  ].join('\n');
+
+  const r = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 400,
+      system: EXTRACT_SYSTEM,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  });
+  if (!r.ok) throw new Error(`anthropic ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json() as { content: Array<{ type: string; text: string }> };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  // Tolerate ```json fences in case the model adds them despite system.
+  const jsonText = text.replace(/^```json\s*/i, '').replace(/^```\s*/, '').replace(/```\s*$/, '').trim();
+  let parsed: { company?: string; title?: string; location?: string; alertUrl?: string; confidence?: number };
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    throw new Error(`bad JSON from haiku: ${jsonText.slice(0, 120)}`);
+  }
+  return {
+    company:    (parsed.company || '').trim(),
+    title:      (parsed.title || '').trim(),
+    location:   (parsed.location || '').trim() || undefined,
+    alertUrl:   (parsed.alertUrl || '').trim() || undefined,
+    confidence: typeof parsed.confidence === 'number' ? parsed.confidence : undefined,
+  };
+}
+
+// ---------- enrichment call ----------
+
+async function enrich(args: { company: string; title: string; hintAtsUrl?: string; hintDomain?: string }): Promise<{ resolved: boolean; companyId: string; canonicalUrl?: string; jdText?: string; nextRetryAt?: string; atsProvider?: string }> {
+  const r = await fetch(ENRICH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // Service role bearer so the function can be called function-to-function.
+      'Authorization': `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!}`,
+    },
+    body: JSON.stringify(args),
+    signal: AbortSignal.timeout(30000),
+  });
+  if (!r.ok) throw new Error(`enrich ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return await r.json();
+}

--- a/supabase/functions/_shared/sources/registry.ts
+++ b/supabase/functions/_shared/sources/registry.ts
@@ -6,6 +6,7 @@ import { trackedAtsSource } from './tracked-ats.ts';
 import { linkedinRssSource } from './linkedin-rss.ts';
 import { rssSource } from './rss.ts';
 import { theirstackSource } from './theirstack.ts';
+import { gmailJobsSource } from './gmail-jobs.ts';
 
 export const SOURCES: Record<string, Source> = {
   [fixtureSource.type]:     fixtureSource,
@@ -13,4 +14,5 @@ export const SOURCES: Record<string, Source> = {
   [linkedinRssSource.type]: linkedinRssSource as unknown as Source,
   [rssSource.type]:         rssSource as unknown as Source,
   [theirstackSource.type]:  theirstackSource as unknown as Source,
+  [gmailJobsSource.type]:   gmailJobsSource as unknown as Source,
 };

--- a/supabase/functions/_shared/sources/types.ts
+++ b/supabase/functions/_shared/sources/types.ts
@@ -24,6 +24,15 @@ export interface RecommendedRoleInput {
   // matchBullets are produced post-pull by the worker; plugins leave
   // this empty and let the worker generate them once per new row.
   payload?:      Record<string, unknown>;
+  // Enrichment status for sources that resolve a canonical posting in a
+  // separate step (e.g. gmail-jobs → enrich-job-source). 'unresolved'
+  // means we surfaced the row with the alert/aggregator URL because we
+  // couldn't find the canonical JD; the widget should flag it. Sources
+  // that don't have this concept can leave these undefined.
+  enrichmentStatus?:    'resolved' | 'unresolved' | 'failed';
+  enrichmentRetryAt?:   string;       // ISO8601
+  canonicalUrl?:        string;       // canonical apply URL when resolved
+  companyId?:           string;       // job.companies.id when known
 }
 
 // A Source<Cfg> is a pure function from config → array of postings. No

--- a/supabase/functions/enrich-job-source/index.ts
+++ b/supabase/functions/enrich-job-source/index.ts
@@ -1,0 +1,341 @@
+// enrich-job-source — first-class enrichment step. Takes a (company,
+// title?) pair (and an optional aggregator URL) and resolves it to a
+// canonical posting on a known ATS. Returns the canonical_url, JD text,
+// and ats_provider — or an unresolved flag with a retry timestamp.
+//
+// Cascade (cheapest → most expensive):
+//   1. job.companies cache hit (resolved row).
+//   2. ATS detection from sender domain or company-name guesses against
+//      Greenhouse / Lever / Ashby.
+//   3. Careers-page scrape (best-effort via direct fetch).
+//   4. Mark unresolved with backoff and return.
+//
+// POST /functions/v1/enrich-job-source
+//   body: { company: string, title?: string, hintDomain?: string,
+//           hintAtsUrl?: string }
+//   →     { resolved: boolean, companyId: uuid,
+//           atsProvider?: string, atsSlug?: string,
+//           canonicalUrl?: string, jdText?: string,
+//           nextRetryAt?: ISO8601 }
+
+const VERSION = '0.1.0';
+console.log(`[enrich-job-source] v${VERSION} - cache → ats → scrape cascade`);
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { db } from '../_shared/job-db.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+
+interface EnrichRequest {
+  company: string;
+  title?: string;
+  hintDomain?: string;          // 'acme.com' from sender or alert
+  hintAtsUrl?: string;          // aggregator URL or any URL that might contain an ATS slug
+}
+
+interface EnrichResponse {
+  resolved: boolean;
+  companyId: string;
+  atsProvider?: string;
+  atsSlug?: string;
+  canonicalUrl?: string;
+  jdText?: string;
+  nextRetryAt?: string;
+  reason?: string;
+}
+
+interface CompanyRow {
+  id: string;
+  name: string;
+  domain: string | null;
+  ats_provider: string | null;
+  ats_slug: string | null;
+  careers_url: string | null;
+  resolution_status: string;
+  retry_count: number;
+}
+
+// Backoff schedule for unresolved companies. Capped at 7 days.
+function nextRetry(retryCount: number): Date {
+  const minutes = Math.min(60 * 24 * 7, [60, 4 * 60, 24 * 60, 3 * 24 * 60, 7 * 24 * 60][Math.min(retryCount, 4)]);
+  return new Date(Date.now() + minutes * 60 * 1000);
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+  const body = await req.json().catch(() => ({})) as EnrichRequest;
+  const company = (body.company || '').trim();
+  if (!company) return json({ error: 'company required' }, 400);
+  const title = (body.title || '').trim();
+
+  const sql = db();
+
+  // 1) Cache lookup or insert.
+  const existing = await sql<CompanyRow[]>`
+    select id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
+      from job.companies
+     where name_norm = lower(trim(${company}))
+     limit 1
+  `;
+  let row = existing[0] as CompanyRow | undefined;
+  if (!row) {
+    const [inserted] = await sql<CompanyRow[]>`
+      insert into job.companies (name, domain)
+        values (${company}, ${normalizeDomain(body.hintDomain) || null})
+      on conflict (name_norm) do update
+        set domain = coalesce(job.companies.domain, excluded.domain),
+            updated_at = now()
+      returning id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
+    `;
+    row = inserted as CompanyRow;
+  }
+
+  // Resolved cache hit → try to canonicalize for the title.
+  if (row.resolution_status === 'resolved' && row.ats_provider && row.ats_slug) {
+    const canonical = await resolveCanonicalForTitle(row, title);
+    return json(<EnrichResponse>{
+      resolved: !!canonical,
+      companyId: row.id,
+      atsProvider: row.ats_provider,
+      atsSlug: row.ats_slug,
+      canonicalUrl: canonical?.url,
+      jdText: canonical?.jd,
+      reason: canonical ? undefined : 'cached_company_no_title_match',
+    });
+  }
+
+  // 2) ATS detection.
+  const detected = await detectAts({ company, hintDomain: body.hintDomain, hintAtsUrl: body.hintAtsUrl });
+
+  if (detected) {
+    // Persist the resolution before we even try to fetch the title —
+    // even a partial resolve (provider+slug, no canonical match) helps
+    // the next user querying the same company.
+    await sql`
+      update job.companies
+         set ats_provider = ${detected.provider},
+             ats_slug = ${detected.slug},
+             careers_url = ${detected.careersUrl ?? null},
+             domain = coalesce(domain, ${normalizeDomain(body.hintDomain) || null}),
+             resolution_status = 'resolved',
+             last_resolved_at = now(),
+             retry_count = 0,
+             next_retry_at = null,
+             updated_at = now()
+       where id = ${row.id}
+    `;
+    const canonical = await resolveCanonicalForTitle({ ...row, ats_provider: detected.provider, ats_slug: detected.slug }, title);
+    return json(<EnrichResponse>{
+      resolved: !!canonical,
+      companyId: row.id,
+      atsProvider: detected.provider,
+      atsSlug: detected.slug,
+      canonicalUrl: canonical?.url,
+      jdText: canonical?.jd,
+      reason: canonical ? undefined : 'resolved_company_no_title_match',
+    });
+  }
+
+  // 3) Mark unresolved with backoff.
+  const nextCount = (row.retry_count || 0) + 1;
+  const retryAt = nextRetry(nextCount);
+  await sql`
+    update job.companies
+       set resolution_status = 'unresolved',
+           retry_count = ${nextCount},
+           next_retry_at = ${retryAt.toISOString()},
+           updated_at = now()
+     where id = ${row.id}
+  `;
+  return json(<EnrichResponse>{
+    resolved: false,
+    companyId: row.id,
+    nextRetryAt: retryAt.toISOString(),
+    reason: 'ats_unresolved',
+  });
+});
+
+// ---------- ATS detection ----------
+
+interface DetectedAts {
+  provider: 'Greenhouse' | 'Lever' | 'Ashby';
+  slug: string;
+  careersUrl?: string;
+}
+
+// First, parse any URL we were given (alert URL might already be on
+// the ATS). Then guess slugs from a normalized company name and probe
+// each ATS's public JSON endpoint until one returns a 200.
+async function detectAts(args: { company: string; hintDomain?: string; hintAtsUrl?: string }): Promise<DetectedAts | null> {
+  // 1) URL-derived
+  if (args.hintAtsUrl) {
+    const fromUrl = atsFromUrl(args.hintAtsUrl);
+    if (fromUrl) return fromUrl;
+  }
+
+  // 2) Slug guesses from company name + (optionally) domain
+  const slugs = candidateSlugs(args.company, args.hintDomain);
+  for (const slug of slugs) {
+    const hit = await probeSlug(slug);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function atsFromUrl(url: string): DetectedAts | null {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.toLowerCase();
+    const seg = u.pathname.split('/').filter(Boolean);
+    if (/(?:^|\.)(boards|job-boards)\.greenhouse\.io$/.test(host) && seg[0]) {
+      return { provider: 'Greenhouse', slug: seg[0], careersUrl: `https://boards.greenhouse.io/${seg[0]}` };
+    }
+    if (/(?:^|\.)jobs\.lever\.co$/.test(host) && seg[0]) {
+      return { provider: 'Lever', slug: seg[0], careersUrl: `https://jobs.lever.co/${seg[0]}` };
+    }
+    if (/(?:^|\.)jobs\.ashbyhq\.com$/.test(host) && seg[0]) {
+      return { provider: 'Ashby', slug: seg[0], careersUrl: `https://jobs.ashbyhq.com/${seg[0]}` };
+    }
+  } catch { /* fallthrough */ }
+  return null;
+}
+
+function candidateSlugs(company: string, domain?: string): string[] {
+  const base = company.toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const compact = base.replace(/-/g, '');
+  const noSuffix = base.replace(/-(inc|llc|corp|corporation|ltd|labs|hq|ai|io|app)$/i, '');
+  const fromDomain = domain ? normalizeDomain(domain)?.split('.')[0] : '';
+  const out = [base, compact, noSuffix, fromDomain].filter(Boolean) as string[];
+  return [...new Set(out)];
+}
+
+async function probeSlug(slug: string): Promise<DetectedAts | null> {
+  const probes: Array<{ provider: DetectedAts['provider']; url: string; careers: string }> = [
+    { provider: 'Greenhouse', url: `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`,           careers: `https://boards.greenhouse.io/${slug}` },
+    { provider: 'Lever',      url: `https://api.lever.co/v0/postings/${slug}?mode=json`,                careers: `https://jobs.lever.co/${slug}` },
+    { provider: 'Ashby',      url: `https://api.ashbyhq.com/posting-api/job-board/${slug}`,             careers: `https://jobs.ashbyhq.com/${slug}` },
+  ];
+  for (const p of probes) {
+    try {
+      const r = await fetch(p.url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(8000) });
+      if (!r.ok) continue;
+      const data = await r.json();
+      // Only accept the slug if the board has at least one job — empty
+      // boards on the wrong slug are common (squatted / archived
+      // tenants). Cheap sanity check.
+      const hasJobs =
+        (Array.isArray((data as { jobs?: unknown[] }).jobs) && ((data as { jobs: unknown[] }).jobs.length > 0)) ||
+        (Array.isArray(data) && data.length > 0);
+      if (hasJobs) return { provider: p.provider, slug, careersUrl: p.careers };
+    } catch { /* try next */ }
+  }
+  return null;
+}
+
+// ---------- Canonical posting lookup ----------
+
+interface CanonicalHit { url: string; jd: string }
+
+async function resolveCanonicalForTitle(
+  row: { ats_provider: string | null; ats_slug: string | null },
+  title: string,
+): Promise<CanonicalHit | null> {
+  if (!row.ats_provider || !row.ats_slug || !title) return null;
+  const titleLc = title.toLowerCase();
+  try {
+    if (row.ats_provider === 'Greenhouse') {
+      const r = await fetch(`https://boards-api.greenhouse.io/v1/boards/${row.ats_slug}/jobs?content=true`, {
+        headers: { 'User-Agent': UA },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!r.ok) return null;
+      const data = await r.json() as { jobs?: Array<{ title: string; absolute_url: string; content?: string }> };
+      const match = (data.jobs || []).find(j => titleSimilar(j.title.toLowerCase(), titleLc));
+      if (match) return { url: match.absolute_url, jd: stripHtml(match.content || '') };
+    }
+    if (row.ats_provider === 'Lever') {
+      const r = await fetch(`https://api.lever.co/v0/postings/${row.ats_slug}?mode=json`, {
+        headers: { 'User-Agent': UA },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!r.ok) return null;
+      const data = await r.json() as Array<{ text: string; hostedUrl: string; descriptionPlain?: string; description?: string }>;
+      const match = (data || []).find(j => titleSimilar(j.text.toLowerCase(), titleLc));
+      if (match) return { url: match.hostedUrl, jd: match.descriptionPlain || stripHtml(match.description || '') };
+    }
+    if (row.ats_provider === 'Ashby') {
+      const r = await fetch(`https://api.ashbyhq.com/posting-api/job-board/${row.ats_slug}`, {
+        headers: { 'User-Agent': UA },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (!r.ok) return null;
+      const data = await r.json() as { jobs?: Array<{ title: string; jobUrl: string; descriptionPlain?: string; descriptionHtml?: string }> };
+      const match = (data.jobs || []).find(j => titleSimilar(j.title.toLowerCase(), titleLc));
+      if (match) return { url: match.jobUrl, jd: match.descriptionPlain || stripHtml(match.descriptionHtml || '') };
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+// Token-overlap similarity. Posting titles drift between aggregator
+// ("Senior Product Manager") and ATS ("Senior PM, Platform"), so we
+// match on shared meaningful tokens after light normalization.
+function titleSimilar(a: string, b: string): boolean {
+  const norm = (s: string) => s
+    .replace(/\bproduct manager\b/g, 'pm')
+    .replace(/[(),]/g, ' ')
+    .split(/\s+/).filter(t => t && !STOP.has(t));
+  const ta = new Set(norm(a));
+  const tb = new Set(norm(b));
+  if (!ta.size || !tb.size) return false;
+  let shared = 0;
+  for (const t of ta) if (tb.has(t)) shared++;
+  // Need at least 2 shared meaningful tokens AND ≥50% overlap from the
+  // shorter side. Tunable; this is conservative on purpose.
+  const minSize = Math.min(ta.size, tb.size);
+  return shared >= 2 && shared / minSize >= 0.5;
+}
+
+const STOP = new Set([
+  'a','an','the','of','for','in','on','at','to','and','or','&','-','/','i','ii','iii',
+  'job','jobs','role','position','opening','remote','hybrid','onsite',
+]);
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeDomain(d?: string | null): string | null {
+  if (!d) return null;
+  try {
+    const trimmed = d.trim().toLowerCase();
+    if (!trimmed) return null;
+    if (trimmed.includes('://')) return new URL(trimmed).hostname.replace(/^www\./, '');
+    return trimmed.replace(/^www\./, '').split('/')[0];
+  } catch { return null; }
+}

--- a/supabase/functions/gmail-auth/index.ts
+++ b/supabase/functions/gmail-auth/index.ts
@@ -1,0 +1,194 @@
+// gmail-auth — Google OAuth flow for the gmail.readonly scope used by
+// the jobs pipe. Mirrors calendar-api's connect/status pattern but
+// writes to the shared user_google_tokens table so revoking gmail
+// doesn't take down calendar (and vice-versa).
+//
+// POST /functions/v1/gmail-auth
+//   body: { action: 'auth-url' }                         → { url }
+//   body: { action: 'connect', code }                    → { connected, email }
+//   body: { action: 'status' }                           → { connected, email }
+//   body: { action: 'disconnect' }                       → { revoked }
+//
+// Uses the existing GOOGLE_CALENDAR_* secrets (same OAuth client) so we
+// don't need a new client registration. The redirect URI for gmail
+// connect points at /job/ — calendar-api keeps /calendar/.
+
+const VERSION = '0.1.0';
+console.log(`[gmail-auth] v${VERSION} - oauth for gmail.readonly`);
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import {
+  canonicalScopeSet,
+  findTokenForScopes,
+  getServiceClient,
+  GMAIL_READONLY_SCOPE,
+  markRevoked,
+  upsertToken,
+} from '../_shared/google-tokens.ts';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+const GOOGLE_CLIENT_ID     = Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID')!;
+const GOOGLE_CLIENT_SECRET = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!;
+// Separate redirect for gmail so the JS handler on /job/ can spot the
+// callback and call action:'connect'. Falls back to a sane default.
+const GMAIL_REDIRECT_URI   = Deno.env.get('GMAIL_OAUTH_REDIRECT_URI') || 'https://ctrl.rodeo/job/';
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+async function getUser(req: Request): Promise<{ id: string; email: string } | null> {
+  const auth = req.headers.get('authorization');
+  if (!auth) return null;
+  const sb = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_ANON_KEY')!,
+    { global: { headers: { Authorization: auth } } },
+  );
+  const { data } = await sb.auth.getUser();
+  if (!data?.user?.id || !data.user.email) return null;
+  return { id: data.user.id, email: data.user.email.toLowerCase() };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const action = body.action;
+    if (!action) return json({ error: 'action is required' }, 400);
+
+    const user = await getUser(req);
+    if (!user) return json({ error: 'unauthorized' }, 401);
+
+    const db = getServiceClient();
+    const scopeSet = canonicalScopeSet([GMAIL_READONLY_SCOPE]);
+
+    if (action === 'auth-url') {
+      const params = new URLSearchParams({
+        client_id: GOOGLE_CLIENT_ID,
+        redirect_uri: GMAIL_REDIRECT_URI,
+        response_type: 'code',
+        scope: GMAIL_READONLY_SCOPE,
+        access_type: 'offline',
+        prompt: 'consent',
+        // Including 'gmail' in state lets the /job/ JS distinguish this
+        // callback from a calendar one if both flows ever land on the
+        // same host. user_id is included so the JS doesn't have to track
+        // it client-side.
+        state: `gmail:${user.id}`,
+        include_granted_scopes: 'true',
+      });
+      return json({ url: `https://accounts.google.com/o/oauth2/v2/auth?${params}` });
+    }
+
+    if (action === 'connect') {
+      const code = body.code;
+      if (!code) return json({ error: 'code required' }, 400);
+
+      const tokenResp = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          client_id: GOOGLE_CLIENT_ID,
+          client_secret: GOOGLE_CLIENT_SECRET,
+          code,
+          grant_type: 'authorization_code',
+          redirect_uri: GMAIL_REDIRECT_URI,
+        }),
+      });
+      if (!tokenResp.ok) {
+        const err = await tokenResp.text();
+        console.error('[gmail-auth] token exchange failed:', err);
+        return json({ error: 'oauth exchange failed' }, 400);
+      }
+      const tokens = await tokenResp.json() as {
+        access_token: string;
+        refresh_token?: string;
+        expires_in: number;
+        scope: string;
+      };
+
+      // Verify Google actually granted gmail.readonly. include_granted_scopes
+      // means a previous calendar consent could come back without gmail.
+      const grantedScopes = tokens.scope.split(/\s+/).filter(Boolean);
+      if (!grantedScopes.includes(GMAIL_READONLY_SCOPE)) {
+        return json({ error: 'gmail.readonly was not granted' }, 400);
+      }
+
+      // Resolve the Google account email so the user can confirm which
+      // identity they connected.
+      const profileResp = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+        headers: { Authorization: `Bearer ${tokens.access_token}` },
+      });
+      const profile = profileResp.ok ? await profileResp.json() as { email?: string } : { email: null };
+
+      // Refresh-token quirk: Google only re-issues a refresh_token when
+      // prompt=consent forces it. We always send prompt=consent above,
+      // so refresh_token should be present — but if the user already
+      // had a row, fall back to the previously stored token.
+      let refresh = tokens.refresh_token;
+      if (!refresh) {
+        const existing = await findTokenForScopes(db, user.id, [GMAIL_READONLY_SCOPE]);
+        refresh = existing?.google_refresh_token;
+      }
+      if (!refresh) {
+        return json({ error: 'no refresh_token; reconnect with prompt=consent' }, 400);
+      }
+
+      const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+      await upsertToken(db, {
+        user_id: user.id,
+        scope_set: scopeSet,
+        google_refresh_token: refresh,
+        google_access_token: tokens.access_token,
+        token_expires_at: expiresAt,
+        google_email: profile.email ?? null,
+        granted_for: 'gmail-jobs',
+      });
+
+      return json({ connected: true, email: profile.email ?? null });
+    }
+
+    if (action === 'status') {
+      const row = await findTokenForScopes(db, user.id, [GMAIL_READONLY_SCOPE]);
+      return json({
+        connected: !!row,
+        email: row?.google_email ?? null,
+        connectedAt: row ? null : null, // updated_at not exposed; keep response minimal
+      });
+    }
+
+    if (action === 'disconnect') {
+      const row = await findTokenForScopes(db, user.id, [GMAIL_READONLY_SCOPE]);
+      if (!row) return json({ revoked: false });
+      // Best-effort revocation on Google's side. Even if this fails,
+      // mark our row revoked so we stop trying to refresh it.
+      try {
+        await fetch(`https://oauth2.googleapis.com/revoke?token=${encodeURIComponent(row.google_refresh_token)}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        });
+      } catch (e) {
+        console.warn('[gmail-auth] revoke call failed:', (e as Error).message);
+      }
+      await markRevoked(db, row.id);
+      return json({ revoked: true });
+    }
+
+    return json({ error: `unknown action: ${action}` }, 400);
+  } catch (e) {
+    console.error('[gmail-auth] error', e);
+    return json({ error: (e as Error).message || 'server error' }, 500);
+  }
+});

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -20,8 +20,8 @@ import { computeFit, type RoleRow } from '../jobs-pipe/fit.ts';
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 
-const VERSION = '0.1.0';
-console.log(`[pull-recommendations] v${VERSION}`);
+const VERSION = '0.2.0';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs enrichment cols`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -305,6 +305,10 @@ async function insertNew(
     sector:         r.input.sector ?? null,
     investors:      r.input.investors ?? [],
     payload:        r.input.payload ?? null,
+    enrichment_status:   r.input.enrichmentStatus ?? null,
+    enrichment_retry_at: r.input.enrichmentRetryAt ?? null,
+    canonical_url:       r.input.canonicalUrl ?? null,
+    company_id:          r.input.companyId ?? null,
   }));
   const inserted = await sql`
     insert into job.recommended_roles ${sql(values)}

--- a/supabase/migrations/058_gmail_jobs_pipe.sql
+++ b/supabase/migrations/058_gmail_jobs_pipe.sql
@@ -1,0 +1,141 @@
+-- Gmail → Jobs Pipe, Phase 1 (recommendations only).
+-- Adds:
+--   1. user_google_tokens — shared Google OAuth token store keyed by
+--      (user_id, scope_set) so calendar and gmail track scopes
+--      independently and survive partial revocation.
+--   2. job.companies — cache of resolved ATS / careers data, the lever
+--      that amortizes ATS resolution across users and alerts.
+--   3. job.gmail_skipped — log of multi-role digests + parse failures
+--      we deliberately did not turn into recommendations, so we can
+--      audit and revisit later.
+--   4. job.recommended_roles enrichment columns — flag unresolved
+--      postings so the widget can render them honestly with a retry
+--      timestamp.
+--
+-- Out of scope this phase: job.contacts, job.connections, network
+-- overlay. Those are Phase 2.
+
+-- ---------- 1) user_google_tokens ----------
+-- One row per (user_id, scope_set). When a user re-consents to add a
+-- scope (e.g. gmail.readonly on top of calendar.readonly), we write a
+-- new row rather than mutating the calendar row, so revoking one scope
+-- doesn't take down the other.
+create table if not exists public.user_google_tokens (
+  id                    uuid primary key default gen_random_uuid(),
+  user_id               uuid not null references auth.users(id) on delete cascade,
+  -- Sorted, comma-joined scope list — e.g.
+  -- 'https://www.googleapis.com/auth/gmail.readonly'
+  -- or 'https://www.googleapis.com/auth/calendar.events,https://www.googleapis.com/auth/calendar.readonly'.
+  -- Sorting at write time keeps lookups deterministic.
+  scope_set             text not null,
+  google_refresh_token  text not null,
+  google_access_token   text,
+  token_expires_at      timestamptz,
+  -- Google account email this consent is tied to. Helps the UI
+  -- disambiguate when a user has multiple Google accounts.
+  google_email          text,
+  -- Where in the app the consent was granted. Diagnostic only.
+  granted_for           text,                       -- 'calendar' | 'gmail-jobs' | 'gmail-jobs+calendar'
+  revoked_at            timestamptz,
+  created_at            timestamptz not null default now(),
+  updated_at            timestamptz not null default now(),
+  unique (user_id, scope_set)
+);
+
+create index if not exists user_google_tokens_active_idx
+  on public.user_google_tokens (user_id)
+  where revoked_at is null;
+
+alter table public.user_google_tokens enable row level security;
+
+-- ---------- 2) job.companies cache ----------
+-- name is the canonical display name (case-preserved). domain is the
+-- primary marketing/website domain — the join key for "who do I know
+-- here" in Phase 2 and the seed for ATS detection in Phase 1.
+-- ats_provider is one of {'Greenhouse','Lever','Ashby','Workable',
+-- 'Workday','Other'}; ats_slug is the per-provider tenant identifier.
+-- resolution_status mirrors the cascade in enrich-job-source.
+create table if not exists job.companies (
+  id                  uuid primary key default gen_random_uuid(),
+  name                text not null,
+  -- Lowercase normalized form, used for case-insensitive lookups.
+  name_norm           text generated always as (lower(trim(name))) stored,
+  domain              text,                          -- 'acme.com' (no scheme, no path)
+  ats_provider        text,                          -- null until resolved
+  ats_slug            text,
+  careers_url         text,
+  resolution_status   text not null default 'unresolved'
+                       check (resolution_status in ('resolved','unresolved','failed')),
+  last_resolved_at    timestamptz,
+  -- Backoff for retries on unresolved/failed rows. enrich-job-source
+  -- skips a row whose next_retry_at is in the future.
+  next_retry_at       timestamptz,
+  retry_count         int not null default 0,
+  notes               text,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  unique (name_norm)
+);
+
+create index if not exists companies_domain_idx
+  on job.companies (domain) where domain is not null;
+create index if not exists companies_unresolved_idx
+  on job.companies (next_retry_at)
+  where resolution_status <> 'resolved';
+
+alter table job.companies enable row level security;
+
+-- ---------- 3) job.gmail_skipped ----------
+-- When the gmail-jobs plugin chooses NOT to emit a row (multi-role
+-- digest, unparseable, no company found), it logs it here with a
+-- reason. This keeps the inbox-pipe honest — we can review what we
+-- skipped and add fan-out for digest senders later.
+create table if not exists job.gmail_skipped (
+  id           uuid primary key default gen_random_uuid(),
+  user_email   text not null,
+  message_id   text not null,                       -- Gmail Message-ID header
+  gmail_id     text not null,                       -- Gmail API id (not the same as Message-ID)
+  sender       text,
+  subject      text,
+  reason       text not null,                       -- 'multi_role_digest' | 'no_company' | 'no_url' | 'parse_error' | …
+  details      jsonb,                               -- e.g. extracted role count
+  skipped_at   timestamptz not null default now(),
+  unique (user_email, message_id)
+);
+
+create index if not exists gmail_skipped_user_idx
+  on job.gmail_skipped (user_email, skipped_at desc);
+
+alter table job.gmail_skipped enable row level security;
+
+-- ---------- 4) recommended_roles enrichment columns ----------
+-- Honest-UI surface: when enrich-job-source can't find the canonical
+-- JD/apply URL, we still insert the row but flag it so the widget can
+-- show a "verifying source" badge. enrichment_retry_at lets the worker
+-- re-attempt later without losing the row.
+alter table job.recommended_roles
+  add column if not exists enrichment_status   text
+    check (enrichment_status in ('resolved','unresolved','failed')),
+  add column if not exists enrichment_retry_at timestamptz,
+  add column if not exists company_id          uuid references job.companies(id) on delete set null,
+  add column if not exists canonical_url       text;
+
+create index if not exists recommended_roles_unresolved_idx
+  on job.recommended_roles (enrichment_retry_at)
+  where enrichment_status <> 'resolved'
+    and dismissed_at is null
+    and added_to_pipeline_slug is null;
+
+-- ---------- 5) gmail scan cursor ----------
+-- Per-user high-water mark so gmail-scan only fetches new messages.
+-- Stored as a Gmail historyId (preferred) and a fallback ISO timestamp
+-- for first runs / history expiry.
+create table if not exists job.gmail_scan_state (
+  user_email      text primary key,
+  history_id      text,
+  last_scan_at    timestamptz,
+  last_error      text,
+  updated_at      timestamptz not null default now()
+);
+
+alter table job.gmail_scan_state enable row level security;


### PR DESCRIPTION
## Summary

Phase 1 of the Gmail → Jobs Board pipe: inbox alerts (LinkedIn, Wellfound, Otta, etc.) become scored, deduplicated, canonically-linked recommendations in the existing widget. Out of scope this phase: contacts, connections, network overlay (Phase 2).

## What's wired

- **Migration 058** — `user_google_tokens` (shared with calendar via `scope_set`), `job.companies` cache, `job.gmail_skipped` audit log, `job.gmail_scan_state` cursor, `recommended_roles` enrichment columns
- **`gmail-auth` function** — OAuth flow for `gmail.readonly` on the existing Google client (split from `calendar-api` so revoking gmail doesn't take down calendar)
- **`enrich-job-source` function** — cache → ATS slug probe (Greenhouse/Lever/Ashby) → canonical posting lookup → unresolved bucket with exponential backoff
- **`_shared/sources/gmail-jobs.ts`** — Haiku-driven extraction per message, sender allowlist, multi-role digest skip-and-log, plugs into the existing `pull-recommendations` cron via `SOURCES` registry

## Decisions resolved (from PRD)

- Q1 Phasing: Feature 1 first (recs only this PR)
- Q2 OAuth: split — new `gmail-auth` + shared `_shared/google-tokens.ts`
- Q3 Cache scope: `job.companies` (not `public.`)
- Q4 Fallback: surface unresolved with retry timestamp + flag, not hidden
- Q5 Network shape: deferred to Phase 2
- Q6 Phase B: sibling PRD, not in this one
- Q7 Consent UI: deferred (no upload UI in this phase)
- Q8 Recruiter blasts: skip + log to `gmail_skipped`

## Architectural choice worth flagging

The brief listed a separate `gmail-scan` cron function. In Phase-1-recs-only that function would have one consumer (the gmail-jobs source) which is already invoked by the `pull-recommendations` 30-min tick. Building a parallel cron would be pure overhead with no behavior gain. When Phase 2 adds the contacts emitter, we'll either extract a shared scan or fan out from inside the source plugin — picking that fork makes more sense once we have the second consumer in hand.

## Test plan

- [ ] Run migration 058 against the boards project (`yfhudwakpgzswiylhfbh`)
- [ ] Deploy `gmail-auth`, `enrich-job-source`, redeploy `pull-recommendations`
- [ ] Set `GMAIL_OAUTH_REDIRECT_URI` secret (defaults to `https://ctrl.rodeo/job/`)
- [ ] Hit `gmail-auth` action='auth-url', complete consent for `gmail.readonly`, then action='connect' with the returned code
- [ ] Verify `user_google_tokens` row exists with `scope_set='https://www.googleapis.com/auth/gmail.readonly'`
- [ ] Insert a `user_sources` row: `{ type: 'gmail-jobs', enabled: true, schedule_cron: '*/30 * * * *', min_score: 50 }`
- [ ] Force-run via `user-sources` `action='run'` and check `recommended_roles` for new `source='gmail-jobs'` rows
- [ ] Confirm canonical URL routes to ATS posting when resolved; alert URL when `enrichment_status='unresolved'`
- [ ] Check `gmail_skipped` for at least one digest entry from a Hacker News "who's hiring" thread

## Follow-ups

- Phase 2: `job.contacts` + `job.connections` + LinkedIn CSV upload + per-role "🤝 N at this company" chip
- Widget UI: render the `enrichment_status='unresolved'` flag honestly on role cards
- Recruiter-blast fan-out (currently skip + log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)