### PR TITLE
Cover letter: AI semantic rationale match

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -813,6 +813,11 @@
 .cover-comment__body p { margin: 0 0 var(--space-2); }
 .cover-comment__body ul { margin: 0; padding-left: var(--space-4); }
 .cover-comment__body li { margin-bottom: var(--space-1); }
+.cover-rail__empty {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  padding: var(--space-3) 0;
+}
 
 @media (max-width: 960px) {
   .cover-layout {

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.46.0">
-  <script src="/job/js/theme.js?v=0.46.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.47.0">
+  <script src="/job/js/theme.js?v=0.47.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.46.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.47.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.46.0">
-  <script src="/job/js/theme.js?v=0.46.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.47.0">
+  <script src="/job/js/theme.js?v=0.47.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.46.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.47.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.46.0">
-  <script src="/job/js/theme.js?v=0.46.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.47.0">
+  <script src="/job/js/theme.js?v=0.47.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.46.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.47.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.46.0">
-  <script src="/job/js/theme.js?v=0.46.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.47.0">
+  <script src="/job/js/theme.js?v=0.47.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.46.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.47.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.46.0";
-console.log(`[job] v${VERSION} - Cover letter: comment rail with rationale + inline editing`);
+const VERSION = "0.47.0";
+console.log(`[job] v${VERSION} - Cover letter: AI semantic rationale match (verbatim phrase highlights)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -5,7 +5,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -56,6 +56,7 @@ export class JobRoleDetail extends LitElement {
     assets: { state: true },         // { resume, cover-letter, analysis } each: {content, draft, mode, saving, dirty, error}
     baseResume: { state: true },     // { content } | null — canonical untargeted resume, source of truth for diff
     showChanges: { state: true },    // bool — toggle the diff/highlight overlay on resume + cover tabs
+    coverRationale: { state: true }, // { sig, highlights, loading, error } — AI cover-letter rationale cache
   };
 
   constructor() {
@@ -73,6 +74,7 @@ export class JobRoleDetail extends LitElement {
     this.assets = { 'resume': null, 'cover-letter': null, 'analysis': null };
     this.baseResume = null;
     this.showChanges = true;
+    this.coverRationale = { sig: '', highlights: [], loading: false, error: '' };
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -551,11 +553,20 @@ export class JobRoleDetail extends LitElement {
 
     let bodyHtml = '';
     let coverComments = [];
+    let coverLoading = false;
     if (a.mode === 'view') {
       if (kind === 'resume' && showingChanges && this.baseResume?.content) {
         bodyHtml = renderMarkdown(diffMarkdown(this.baseResume.content, a.content));
       } else if (kind === 'cover-letter' && showingChanges) {
-        const { html: marked, comments } = highlightPhrases(a.content, this._coverHighlightSources());
+        // Kick a fetch if our cached rationale doesn't match the current
+        // cover+sources. Render with whatever's in cache right now.
+        const sig = this._coverSig();
+        if (this.coverRationale.sig !== sig && !this.coverRationale.loading) {
+          // Defer to avoid mutating state during render.
+          queueMicrotask(() => this._ensureCoverRationale());
+        }
+        coverLoading = this.coverRationale.loading;
+        const { html: marked, comments } = applyAIHighlights(a.content, this.coverRationale.highlights);
         bodyHtml = renderMarkdown(marked);
         coverComments = comments;
       } else {
@@ -597,13 +608,24 @@ export class JobRoleDetail extends LitElement {
       </div>
       ${a.mode === 'edit'
         ? html`<textarea class="asset-editor asset-editor--inline" .value=${a.draft} @input=${(e) => this._onDraftInput(kind, e)} @blur=${() => a.dirty && this._saveEdit(kind)}></textarea>`
-        : (isCover && coverComments.length
+        : (isCover && showingChanges
           ? html`
             <div class="cover-layout">
               <article class="kb-doc asset-doc cover-layout__body">${unsafeHTML(bodyHtml)}</article>
               <aside class="cover-layout__rail" aria-label="Rationale">
                 <h4 class="cover-rail__title">Rationale</h4>
-                <p class="muted cover-rail__hint">Why each highlighted phrase is here.</p>
+                <p class="muted cover-rail__hint">Why each highlighted phrase is doing work.</p>
+                ${coverLoading && !coverComments.length ? html`
+                  <div class="cover-rail__empty">
+                    <span class="dots-anim">Reading the cover letter</span>
+                  </div>
+                ` : nothing}
+                ${this.coverRationale.error ? html`
+                  <p class="muted" style="color:var(--error);">${this.coverRationale.error}</p>
+                ` : nothing}
+                ${!coverLoading && !coverComments.length && !this.coverRationale.error ? html`
+                  <p class="muted cover-rail__empty">No load-bearing phrases identified yet. Edit and save the cover letter, or click "Hide comments / Show comments" to retry.</p>
+                ` : nothing}
                 ${coverComments.map(c => html`
                   <article class="cover-comment" data-rationale-id=${c.id}
                            @mouseenter=${() => this._highlightRationale(c.id, true)}
@@ -620,6 +642,51 @@ export class JobRoleDetail extends LitElement {
           `
           : html`<article class="kb-doc asset-doc">${unsafeHTML(bodyHtml)}</article>`)}
     `;
+  }
+
+  // Build a stable signature for "this cover letter + these analysis sources"
+  // so we re-fetch the AI rationale only when content changes.
+  _coverSig() {
+    const cover = this.assets['cover-letter']?.content || '';
+    const sources = this._coverHighlightSources();
+    const srcKey = sources.map(s => `${s.label}\n${s.text}`).join('\n---\n');
+    return `${cover.length}|${this._fnv(cover)}|${this._fnv(srcKey)}`;
+  }
+
+  _fnv(s) {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i);
+      h = Math.imul(h, 0x01000193) >>> 0;
+    }
+    return h.toString(16);
+  }
+
+  // Lazy fetch — runs when the cover-letter tab is showing comments and
+  // the current cache signature doesn't match the live cover/sources.
+  async _ensureCoverRationale() {
+    const sig = this._coverSig();
+    if (this.coverRationale.sig === sig && !this.coverRationale.error) return;
+    if (this.coverRationale.loading && this.coverRationale.sig === sig) return;
+    const cover = this.assets['cover-letter']?.content || '';
+    const sources = this._coverHighlightSources();
+    if (!cover || sources.length === 0) {
+      this.coverRationale = { sig, highlights: [], loading: false, error: '' };
+      return;
+    }
+    this.coverRationale = { sig, highlights: [], loading: true, error: '' };
+    try {
+      const highlights = await fetchCoverRationale(cover, sources);
+      // Only commit if the signature is still current — guards against a
+      // racing edit + regenerate that finishes after newer state.
+      if (this._coverSig() === sig) {
+        this.coverRationale = { sig, highlights, loading: false, error: '' };
+      }
+    } catch (e) {
+      if (this._coverSig() === sig) {
+        this.coverRationale = { sig, highlights: [], loading: false, error: String(e?.message || e) };
+      }
+    }
   }
 
   // Visual link between a comment card and its highlights — toggle a class

--- a/job/js/diff.js
+++ b/job/js/diff.js
@@ -75,6 +75,45 @@ function chunkPhrase(s) {
 
 function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
 
+// Wrap AI-supplied highlights into the markdown source. `aiHighlights` is
+// an array of `{phrase, label, rationale}` returned by the cover-rationale
+// edge function. Each phrase is matched as a verbatim case-insensitive
+// substring; non-matches are silently skipped (the model occasionally
+// paraphrases). Returns `{html, comments}` shaped like highlightPhrases.
+export function applyAIHighlights(text, aiHighlights) {
+  const body = String(text || '');
+  if (!body || !Array.isArray(aiHighlights) || aiHighlights.length === 0) {
+    return { html: body, comments: [] };
+  }
+  const lower = body.toLowerCase();
+  const wrapped = [];
+  const hits = [];
+  for (const h of aiHighlights) {
+    const phrase = String(h?.phrase || '').trim();
+    if (!phrase) continue;
+    const start = lower.indexOf(phrase.toLowerCase());
+    if (start < 0) continue;
+    const end = start + phrase.length;
+    if (wrapped.some(([s, e]) => start < e && end > s)) continue;
+    wrapped.push([start, end]);
+    hits.push({ start, end, label: String(h.label || ''), rationale: String(h.rationale || '') });
+  }
+  if (!hits.length) return { html: body, comments: [] };
+  hits.sort((a, b) => a.start - b.start);
+  const comments = [];
+  let out = '';
+  let cursor = 0;
+  hits.forEach((h, i) => {
+    const id = i + 1;
+    comments.push({ id, label: h.label, text: h.rationale });
+    out += body.slice(cursor, h.start);
+    out += `<mark class="d-jd" data-rationale="${id}">${body.slice(h.start, h.end)}<sup class="d-fn">${id}</sup></mark>`;
+    cursor = h.end;
+  });
+  out += body.slice(cursor);
+  return { html: out, comments };
+}
+
 // Highlight phrases AND collect rationale comments for each match.
 // `sources` is an array of `{ label, text }` — label shows in the comment
 // header (e.g. "Suggested angle"), text is the source bullet/sentence.

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -152,4 +152,19 @@ export async function formatResumeText(rawText) {
   return j.content;
 }
 
-window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText };
+// Get AI rationale for a cover letter given role-analysis source bullets.
+// Returns [{ phrase, label, rationale }] in document order; empty array on
+// failure. Stateless on the server.
+export async function fetchCoverRationale(coverText, sources) {
+  const headers = await authHeader();
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'cover-rationale', cover_text: coverText, sources }),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return Array.isArray(j.highlights) ? j.highlights : [];
+}
+
+window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.46.0">
-  <script src="/job/js/theme.js?v=0.46.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.47.0">
+  <script src="/job/js/theme.js?v=0.47.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.46.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.47.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.4.0';
-console.log(`[gen-asset] v${VERSION} - format-resume kind: reformat raw text into clean markdown`);
+const VERSION = '0.5.0';
+console.log(`[gen-asset] v${VERSION} - cover-rationale kind: AI semantic-match cover letter phrases to analysis sources`);
 
 const BASE_RESUME_SLUG = '__base__';
 
@@ -101,14 +101,43 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
       : kindIn === 'base-resume' ? 'base-resume'
       : kindIn === 'format-resume' ? 'format-resume'
+      : kindIn === 'cover-rationale' ? 'cover-rationale'
       : null;
-    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", "base-resume", or "format-resume"', 400);
+    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", "base-resume", "format-resume", or "cover-rationale"', 400);
+
+    // cover-rationale is stateless: take cover letter + analysis sources,
+    // return a JSON list of {phrase, label, rationale}. No DB write.
+    if (kind === 'cover-rationale') {
+      const coverText = String(body.cover_text || '').trim();
+      const sources = Array.isArray(body.sources) ? body.sources : [];
+      if (!coverText) return err('cover_text required', 400);
+      if (!sources.length) return err('sources required', 400);
+      if (coverText.length > 16 * 1024) return err('cover_text exceeds 16KB', 413);
+      const system = buildSystemPrompt(kind);
+      const user = `# Cover letter
+
+${coverText}
+
+# Sources
+
+${sources.map((s: any) => `## ${s.label || ''}\n${s.text || ''}`).join('\n\n')}
+
+# Ask
+
+Produce the JSON object now. JSON only.`;
+      const raw = await callClaude(system, user);
+      const stripped = raw.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+      let parsed: any = null;
+      try { parsed = JSON.parse(stripped); } catch { /* ignore */ }
+      const highlights = Array.isArray(parsed?.highlights) ? parsed.highlights : [];
+      return jsonResp({ ok: true, kind, highlights });
+    }
 
     // format-resume is stateless: take raw text in, return clean markdown.
     // Does not touch the DB. The frontend persists separately.

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -102,11 +102,35 @@ VOICE RULES:
 
 Output ONLY the markdown. No preamble. No "Here is your reformatted resume." Start with "# ".`;
 
-export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume';
+export const COVER_RATIONALE_VOICE = `You are annotating a cover letter to explain why each load-bearing phrase is there.
+
+You will receive:
+- The full cover letter text.
+- A set of "source" bullets from a role analysis (Suggested angle, Why it fits, Strengths, Gaps to address). These describe what the cover letter SHOULD do for this role.
+
+Your job: identify 4–8 specific phrases or short sentences in the cover letter that map to one of the sources. For each, return:
+- "phrase":   an exact substring of the cover letter (verbatim, including any punctuation). Pick the shortest substring that captures the load-bearing claim — usually a clause, sometimes a sentence. Must appear EXACTLY in the cover letter.
+- "label":    one of "Suggested angle", "Why it fits", "Strengths", "Gaps to address" — the source field this phrase supports.
+- "rationale": one sentence (≤25 words) explaining what work the phrase does for the application — what point it makes, which JD/analysis bullet it addresses. NOT a paraphrase of the phrase itself.
+
+Output ONLY a JSON object: { "highlights": [ {phrase, label, rationale}, ... ] }. No prose, no code fence.
+
+Rules:
+- Each "phrase" MUST be a verbatim substring. If a sentence has been rewritten, find the closest exact substring.
+- Phrases must NOT overlap. Pick the most important one if two candidates collide.
+- Order them in document order (top to bottom).
+- 4–8 highlights total. Quality over quantity. If only 4 sentences are doing real work, pick those 4.
+- Skip pleasantries, sign-offs, the opener salutation, and generic transitions.
+- Don't reuse the same source label more than 3 times.`;
+
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale';
 
 export function buildSystemPrompt(kind: GenKind): string {
   if (kind === 'format-resume') {
     return `You are a resume reformatter. ${FORMAT_RESUME_VOICE}`;
+  }
+  if (kind === 'cover-rationale') {
+    return COVER_RATIONALE_VOICE;
   }
   const voice =
     kind === 'cover-letter' ? COVER_LETTER_VOICE :


### PR DESCRIPTION
Heuristic phrase matching couldn't surface rationale on from-scratch cover letters. Replaced with a Claude pass (`gen-asset` kind `cover-rationale`) that takes the cover letter + labeled analysis sources (Suggested angle / Why it fits / Strengths / Gaps to address) and returns 4-8 verbatim phrase highlights with rationale. Each phrase must be an exact substring of the letter; non-matches are dropped. Cached by content signature so it only re-fetches when cover or sources change.

Bumps: gen-asset 0.5.0, /job 0.47.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)