### PR TITLE
job(gmail): fix — rename hiring cache to job.hiring_companies

### DIFF
--- a/supabase/functions/_shared/sources/types.ts
+++ b/supabase/functions/_shared/sources/types.ts
@@ -32,7 +32,7 @@ export interface RecommendedRoleInput {
   enrichmentStatus?:    'resolved' | 'unresolved' | 'failed';
   enrichmentRetryAt?:   string;       // ISO8601
   canonicalUrl?:        string;       // canonical apply URL when resolved
-  companyId?:           string;       // job.companies.id when known
+  companyId?:           string;       // job.hiring_companies.id when known
 }
 
 // A Source<Cfg> is a pure function from config → array of postings. No

--- a/supabase/functions/enrich-job-source/index.ts
+++ b/supabase/functions/enrich-job-source/index.ts
@@ -4,7 +4,7 @@
 // and ats_provider — or an unresolved flag with a retry timestamp.
 //
 // Cascade (cheapest → most expensive):
-//   1. job.companies cache hit (resolved row).
+//   1. job.hiring_companies cache hit (resolved row).
 //   2. ATS detection from sender domain or company-name guesses against
 //      Greenhouse / Lever / Ashby.
 //   3. Careers-page scrape (best-effort via direct fetch).
@@ -18,8 +18,8 @@
 //           canonicalUrl?: string, jdText?: string,
 //           nextRetryAt?: ISO8601 }
 
-const VERSION = '0.1.0';
-console.log(`[enrich-job-source] v${VERSION} - cache → ats → scrape cascade`);
+const VERSION = '0.2.0';
+console.log(`[enrich-job-source] v${VERSION} - rename cache to job.hiring_companies (avoid collision with career history)`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
@@ -88,17 +88,17 @@ serve(async (req) => {
   // 1) Cache lookup or insert.
   const existing = await sql<CompanyRow[]>`
     select id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
-      from job.companies
+      from job.hiring_companies
      where name_norm = lower(trim(${company}))
      limit 1
   `;
   let row = existing[0] as CompanyRow | undefined;
   if (!row) {
     const [inserted] = await sql<CompanyRow[]>`
-      insert into job.companies (name, domain)
+      insert into job.hiring_companies (name, domain)
         values (${company}, ${normalizeDomain(body.hintDomain) || null})
       on conflict (name_norm) do update
-        set domain = coalesce(job.companies.domain, excluded.domain),
+        set domain = coalesce(job.hiring_companies.domain, excluded.domain),
             updated_at = now()
       returning id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
     `;
@@ -127,7 +127,7 @@ serve(async (req) => {
     // even a partial resolve (provider+slug, no canonical match) helps
     // the next user querying the same company.
     await sql`
-      update job.companies
+      update job.hiring_companies
          set ats_provider = ${detected.provider},
              ats_slug = ${detected.slug},
              careers_url = ${detected.careersUrl ?? null},
@@ -155,7 +155,7 @@ serve(async (req) => {
   const nextCount = (row.retry_count || 0) + 1;
   const retryAt = nextRetry(nextCount);
   await sql`
-    update job.companies
+    update job.hiring_companies
        set resolution_status = 'unresolved',
            retry_count = ${nextCount},
            next_retry_at = ${retryAt.toISOString()},

--- a/supabase/migrations/059_gmail_jobs_pipe_rename_cache.sql
+++ b/supabase/migrations/059_gmail_jobs_pipe_rename_cache.sql
@@ -1,0 +1,70 @@
+-- Fix migration 058: cache table collided with the existing
+-- job.companies table (which is your *career history* — companies
+-- you've worked at, keyed by slug). Move the hiring-side ATS cache
+-- into a new job.hiring_companies table so the two concepts don't
+-- share columns or rows.
+--
+-- Idempotent: safe whether or not 058 ran cleanly.
+
+-- 1) Revert the columns 058 added to job.companies (the career-history
+--    table). They were never populated and don't belong there.
+alter table job.companies drop column if exists domain;
+alter table job.companies drop column if exists ats_provider;
+alter table job.companies drop column if exists ats_slug;
+alter table job.companies drop column if exists careers_url;
+alter table job.companies drop column if exists resolution_status;
+alter table job.companies drop column if exists last_resolved_at;
+alter table job.companies drop column if exists next_retry_at;
+alter table job.companies drop column if exists retry_count;
+alter table job.companies drop column if exists notes;
+
+-- Drop the constraint we may have added in the cleanup pass.
+alter table job.companies drop constraint if exists companies_resolution_status_check;
+
+-- Drop indexes that referenced reverted columns.
+drop index if exists job.companies_domain_idx;
+drop index if exists job.companies_unresolved_idx;
+
+-- 2) Create the real cache table.
+create table if not exists job.hiring_companies (
+  id                  uuid primary key default gen_random_uuid(),
+  name                text not null,
+  name_norm           text generated always as (lower(trim(name))) stored,
+  domain              text,
+  ats_provider        text,
+  ats_slug            text,
+  careers_url         text,
+  resolution_status   text not null default 'unresolved'
+                       check (resolution_status in ('resolved','unresolved','failed')),
+  last_resolved_at    timestamptz,
+  next_retry_at       timestamptz,
+  retry_count         int not null default 0,
+  notes               text,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  unique (name_norm)
+);
+
+create index if not exists hiring_companies_domain_idx
+  on job.hiring_companies (domain) where domain is not null;
+create index if not exists hiring_companies_unresolved_idx
+  on job.hiring_companies (next_retry_at)
+  where resolution_status <> 'resolved';
+
+alter table job.hiring_companies enable row level security;
+
+-- 3) recommended_roles.company_id should reference the new table.
+--    The column was added by 058 (without the FK because the target
+--    didn't have an `id`). Add the FK now that the target exists.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'recommended_roles_company_id_fkey'
+       and conrelid = 'job.recommended_roles'::regclass
+  ) then
+    alter table job.recommended_roles
+      add constraint recommended_roles_company_id_fkey
+      foreign key (company_id) references job.hiring_companies(id) on delete set null;
+  end if;
+end$$;


### PR DESCRIPTION
## Summary

Migration 058 collided with the existing \`job.companies\` table (career history). Splits the cache into \`job.hiring_companies\` so the two concepts don't share columns or rows.

## Changes

- New migration 059: drops the columns 058 wrongly added to \`job.companies\`, creates \`job.hiring_companies\`, adds the FK from \`recommended_roles.company_id\` → \`hiring_companies.id\`
- \`enrich-job-source\` v0.2.0: points at the new table
- Type comment updated

## Test plan

- [ ] Run migration 059 in dashboard SQL editor
- [ ] Redeploy enrich-job-source
- [ ] \`select count(*) from job.hiring_companies\` → 0 rows (table exists)
- [ ] \`select column_name from information_schema.columns where table_schema='job' and table_name='companies' and column_name='ats_provider'\` → 0 rows (column reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)