### PR TITLE
Comment-anchored chat to edit cover letter (with Undo)

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -920,6 +920,111 @@
 .cover-comment__body p { margin: 0 0 var(--space-2); }
 .cover-comment__body ul { margin: 0; padding-left: var(--space-4); }
 .cover-comment__body li { margin-bottom: var(--space-1); }
+
+/* --- Comment chat thread --- */
+.cover-thread {
+  list-style: none;
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3) 0 0;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.cover-thread__msg {
+  font-size: var(--font-size-small);
+  line-height: 1.5;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--fg);
+  max-width: 92%;
+}
+.cover-thread__msg--user {
+  background: var(--accent-muted, rgba(0, 120, 255, 0.08));
+  color: var(--fg);
+  margin-left: auto;
+  border: 1px solid var(--border);
+}
+.cover-thread__msg--assistant {
+  background: transparent;
+  color: var(--fg-muted);
+  padding-left: 0;
+  padding-right: 0;
+}
+.cover-thread__msg--error {
+  background: rgba(179, 38, 30, 0.06);
+  color: #b3261e;
+  border: 1px solid rgba(179, 38, 30, 0.2);
+}
+.cover-thread__msg p { margin: 0 0 4px; }
+.cover-thread__msg p:last-child { margin: 0; }
+
+.cover-thread__form {
+  display: flex;
+  gap: var(--space-2);
+  align-items: flex-end;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+.cover-thread__input {
+  flex: 1;
+  resize: none;
+  min-height: 32px;
+  max-height: 160px;
+  padding: 6px var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+  line-height: 1.4;
+  outline: none;
+  transition: border-color 80ms ease, box-shadow 80ms ease;
+}
+.cover-thread__input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+.cover-thread__send {
+  appearance: none;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-fg);
+  cursor: pointer;
+  font-size: var(--font-size-body);
+  flex-shrink: 0;
+  transition: filter 80ms ease;
+}
+.cover-thread__send:hover { filter: brightness(1.06); }
+.cover-thread__send:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* --- Undo banner --- */
+.cover-undo {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  font-size: var(--font-size-small);
+  color: var(--fg);
+}
+
+/* --- Edit-just-applied flash on the cover body --- */
+@keyframes cover-flash-fade {
+  0%   { box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.4); }
+  100% { box-shadow: 0 0 0 3px rgba(46, 125, 50, 0); }
+}
+.cover-flash { animation: cover-flash-fade 1500ms ease-out; }
 .cover-rail__empty {
   font-size: var(--font-size-small);
   color: var(--fg-muted);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.49.0">
-  <script src="/job/js/theme.js?v=0.49.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
+  <script src="/job/js/theme.js?v=0.50.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.49.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.49.0">
-  <script src="/job/js/theme.js?v=0.49.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
+  <script src="/job/js/theme.js?v=0.50.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.49.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.49.0">
-  <script src="/job/js/theme.js?v=0.49.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
+  <script src="/job/js/theme.js?v=0.50.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.49.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.49.0">
-  <script src="/job/js/theme.js?v=0.49.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
+  <script src="/job/js/theme.js?v=0.50.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.49.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.49.0";
-console.log(`[job] v${VERSION} - Always-on inline editing, autosave w/ status, Wise-style comment cards`);
+const VERSION = "0.50.0";
+console.log(`[job] v${VERSION} - Comment-anchored chat to edit cover letter, with Undo`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -24,7 +24,7 @@ async function getTurndown() {
   return td;
 }
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -77,6 +77,8 @@ export class JobRoleDetail extends LitElement {
     showChanges: { state: true },    // bool — toggle the diff/highlight overlay on resume + cover tabs
     coverRationale: { state: true }, // { sig, highlights, loading, error } — AI cover-letter rationale cache
     activeRationale: { state: true }, // number | null — currently focused comment/highlight pair
+    threads: { state: true },         // { [commentId]: { messages: [...], sending, error } } — chat-to-edit per comment
+    coverUndo: { state: true },       // { content, label, expiresAt } | null — one-shot undo for last AI edit
   };
 
   constructor() {
@@ -96,6 +98,8 @@ export class JobRoleDetail extends LitElement {
     this.showChanges = true;
     this.coverRationale = { sig: '', highlights: [], loading: false, error: '' };
     this.activeRationale = null;
+    this.threads = {};
+    this.coverUndo = null;
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -651,6 +655,13 @@ export class JobRoleDetail extends LitElement {
         ${a.error ? html`<span class="muted" style="color:var(--error);">${a.error}</span>` : nothing}
       </div>
 
+      ${isCover && this.coverUndo ? html`
+        <div class="cover-undo">
+          <span>AI edit applied (${this.coverUndo.label}).</span>
+          <button class="btn btn--sm" @click=${() => this._undoCoverEdit()}>Undo</button>
+        </div>
+      ` : nothing}
+
       ${isCover && showingChanges
         ? html`
           <div class="cover-layout">
@@ -682,19 +693,64 @@ export class JobRoleDetail extends LitElement {
                 <p class="cover-rail__empty">No load-bearing phrases yet — try regenerating the cover letter.</p>
               ` : nothing}
               <div class="cover-rail__list" data-active=${this.activeRationale ?? ''}>
-                ${coverComments.map(c => html`
-                  <article class="cover-comment ${this.activeRationale === c.id ? 'is-active' : ''}"
-                           data-rationale-id=${c.id}
-                           @click=${() => this._scrollToHighlight(c.id)}
-                           @mouseenter=${() => this._highlightRationale(c.id, true)}
-                           @mouseleave=${() => this._highlightRationale(c.id, false)}>
-                    <header class="cover-comment__head">
-                      <span class="cover-comment__num">${c.id}</span>
-                      <span class="cover-comment__label">${c.label}</span>
-                    </header>
-                    <div class="cover-comment__body">${unsafeHTML(renderMarkdown(c.text))}</div>
-                  </article>
-                `)}
+                ${coverComments.map(c => {
+                  const thread = this._getThread(c.id);
+                  const isActive = this.activeRationale === c.id;
+                  return html`
+                    <article class="cover-comment ${isActive ? 'is-active' : ''}"
+                             data-rationale-id=${c.id}
+                             @mouseenter=${() => this._highlightRationale(c.id, true)}
+                             @mouseleave=${() => this._highlightRationale(c.id, false)}>
+                      <header class="cover-comment__head" @click=${() => { this._scrollToHighlight(c.id); }}>
+                        <span class="cover-comment__num">${c.id}</span>
+                        <span class="cover-comment__label">${c.label}</span>
+                      </header>
+                      <div class="cover-comment__body">${unsafeHTML(renderMarkdown(c.text))}</div>
+
+                      ${thread.messages.length ? html`
+                        <ul class="cover-thread">
+                          ${thread.messages.map(m => html`
+                            <li class="cover-thread__msg cover-thread__msg--${m.role}">
+                              ${unsafeHTML(renderMarkdown(m.text))}
+                            </li>
+                          `)}
+                          ${thread.sending ? html`
+                            <li class="cover-thread__msg cover-thread__msg--assistant">
+                              <span class="dots-anim">Editing</span>
+                            </li>
+                          ` : nothing}
+                          ${thread.error ? html`
+                            <li class="cover-thread__msg cover-thread__msg--error">${thread.error}</li>
+                          ` : nothing}
+                        </ul>
+                      ` : nothing}
+
+                      <form class="cover-thread__form" @submit=${(e) => {
+                        e.preventDefault();
+                        const input = e.currentTarget.querySelector('textarea');
+                        const v = input.value;
+                        input.value = '';
+                        this._sendCommentChat(c.id, v);
+                      }}>
+                        <textarea class="cover-thread__input"
+                                  rows="1"
+                                  placeholder=${isActive ? 'How should this change?' : 'Chat to edit…'}
+                                  ?disabled=${thread.sending}
+                                  @keydown=${(e) => {
+                                    if (e.key === 'Enter' && !e.shiftKey) {
+                                      e.preventDefault();
+                                      e.currentTarget.form.requestSubmit();
+                                    }
+                                  }}
+                                  @input=${(e) => {
+                                    e.target.style.height = 'auto';
+                                    e.target.style.height = e.target.scrollHeight + 'px';
+                                  }}></textarea>
+                        <button class="cover-thread__send" type="submit" ?disabled=${thread.sending} aria-label="Send">↵</button>
+                      </form>
+                    </article>
+                  `;
+                })}
               </div>
             </aside>
           </div>
@@ -790,6 +846,119 @@ export class JobRoleDetail extends LitElement {
       if (this._coverSig() === sig) {
         this.coverRationale = { sig, highlights: [], loading: false, error: String(e?.message || e) };
       }
+    }
+  }
+
+  // ----- Chat-to-edit on cover-letter comments -----------------------------
+
+  _threadKey(commentId) { return `cover:${commentId}`; }
+
+  _getThread(commentId) {
+    return this.threads[this._threadKey(commentId)] || { messages: [], sending: false, error: '' };
+  }
+
+  _setThread(commentId, t) {
+    this.threads = { ...this.threads, [this._threadKey(commentId)]: t };
+  }
+
+  // Send a chat message anchored to a comment. Pushes user msg into the
+  // thread, calls cover-edit, applies the new content, snapshots an undo.
+  async _sendCommentChat(commentId, instruction) {
+    const a = this.assets['cover-letter'];
+    if (!a || !a.content) return;
+    const trimmed = String(instruction || '').trim();
+    if (!trimmed) return;
+
+    const comment = (this.coverRationale.highlights || []).find((_h, i) => i + 1 === commentId);
+    if (!comment) return;
+
+    const prev = this._getThread(commentId);
+    const next = {
+      messages: [...prev.messages, { role: 'user', text: trimmed }],
+      sending: true,
+      error: '',
+    };
+    this._setThread(commentId, next);
+
+    try {
+      const newContent = await applyCoverEdit({
+        coverText: a.content,
+        instruction: trimmed,
+        comment: { label: comment.label, anchor_phrase: comment.phrase, rationale: comment.rationale },
+      });
+      // Snapshot for one-shot undo. Expire after 30s.
+      this.coverUndo = {
+        content: a.content,
+        label: `comment ${commentId}`,
+        expiresAt: Date.now() + 30_000,
+      };
+      // Persist immediately and refresh editHtml so the user sees the
+      // change. Rationale will refetch automatically (signature changed).
+      await writeRoleAsset(this.slug, 'cover-letter', newContent);
+      this.assets = {
+        ...this.assets,
+        'cover-letter': {
+          ...this.assets['cover-letter'],
+          content: newContent,
+          saveStatus: 'saved',
+          savedAt: Date.now(),
+        },
+      };
+      this._refreshEditHtml('cover-letter');
+      this._setThread(commentId, {
+        messages: [...next.messages, { role: 'assistant', text: 'Applied. Edit highlighted briefly. Undo available for 30s.' }],
+        sending: false,
+        error: '',
+      });
+      this._flashCoverEdit();
+      // Schedule undo expiry → state clear.
+      setTimeout(() => {
+        if (this.coverUndo && this.coverUndo.expiresAt <= Date.now()) this.coverUndo = null;
+      }, 30_000 + 200);
+    } catch (e) {
+      this._setThread(commentId, {
+        messages: next.messages,
+        sending: false,
+        error: String(e?.message || e),
+      });
+    }
+  }
+
+  // Briefly flash the cover-letter body to show that a chat edit just
+  // landed. Pure visual cue — no diff overlay (the rationale rail will
+  // refresh on its own and surface what's now load-bearing).
+  _flashCoverEdit() {
+    const body = this.querySelector('.cover-layout__body');
+    if (!body) return;
+    body.classList.remove('cover-flash');
+    // Force reflow so the animation restarts if it was already applied.
+    void body.offsetWidth;
+    body.classList.add('cover-flash');
+    setTimeout(() => body.classList.remove('cover-flash'), 1600);
+  }
+
+  async _undoCoverEdit() {
+    if (!this.coverUndo) return;
+    const { content } = this.coverUndo;
+    this.coverUndo = null;
+    try {
+      await writeRoleAsset(this.slug, 'cover-letter', content);
+      this.assets = {
+        ...this.assets,
+        'cover-letter': {
+          ...this.assets['cover-letter'],
+          content,
+          saveStatus: 'saved',
+          savedAt: Date.now(),
+        },
+      };
+      this._refreshEditHtml('cover-letter');
+    } catch (e) {
+      // Surface the error inline; user can retry or hand-edit.
+      this.assets = {
+        ...this.assets,
+        'cover-letter': { ...this.assets['cover-letter'], error: `undo failed: ${String(e?.message || e)}` },
+      };
     }
   }
 

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -167,4 +167,21 @@ export async function fetchCoverRationale(coverText, sources) {
   return Array.isArray(j.highlights) ? j.highlights : [];
 }
 
-window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale };
+// Apply a chat-driven edit to the cover letter. `comment` is optional
+// {label, anchor_phrase, rationale} for surgical, comment-anchored edits;
+// without it the AI treats `instruction` as a doc-wide directive.
+export async function applyCoverEdit({ coverText, instruction, comment }) {
+  const headers = await authHeader();
+  const body = { kind: 'cover-edit', cover_text: coverText, instruction };
+  if (comment) body.comment = comment;
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.content;
+}
+
+window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.49.0">
-  <script src="/job/js/theme.js?v=0.49.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
+  <script src="/job/js/theme.js?v=0.50.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.49.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.5.0';
-console.log(`[gen-asset] v${VERSION} - cover-rationale kind: AI semantic-match cover letter phrases to analysis sources`);
+const VERSION = '0.6.0';
+console.log(`[gen-asset] v${VERSION} - cover-edit kind: comment-anchored chat edits to the cover letter`);
 
 const BASE_RESUME_SLUG = '__base__';
 
@@ -101,15 +101,46 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
       : kindIn === 'base-resume' ? 'base-resume'
       : kindIn === 'format-resume' ? 'format-resume'
       : kindIn === 'cover-rationale' ? 'cover-rationale'
+      : kindIn === 'cover-edit' ? 'cover-edit'
       : null;
-    if (!kind) return err('kind must be "resume", "cover-letter", "analysis", "base-resume", "format-resume", or "cover-rationale"', 400);
+    if (!kind) return err('kind must be a known value', 400);
+
+    // cover-edit is stateless: take cover letter + comment context +
+    // user instruction, return the full revised markdown. No DB write —
+    // the frontend persists via writeRoleAsset.
+    if (kind === 'cover-edit') {
+      const coverText = String(body.cover_text || '').trim();
+      const instruction = String(body.instruction || '').trim();
+      const comment = body.comment && typeof body.comment === 'object' ? body.comment : null;
+      if (!coverText) return err('cover_text required', 400);
+      if (!instruction) return err('instruction required', 400);
+      if (coverText.length > 16 * 1024) return err('cover_text exceeds 16KB', 413);
+      if (instruction.length > 2 * 1024) return err('instruction exceeds 2KB', 413);
+      const system = buildSystemPrompt(kind);
+      const commentBlock = comment
+        ? `# Anchored comment\n\nLabel: ${String(comment.label || '')}\nAnchor phrase: ${String(comment.anchor_phrase || '')}\nRationale: ${String(comment.rationale || '')}\n\n`
+        : '';
+      const user = `# Cover letter
+
+${coverText}
+
+${commentBlock}# Instruction
+
+${instruction}
+
+# Ask
+
+Return the full revised cover letter markdown. Markdown only, no preamble.`;
+      const content = await callClaude(system, user);
+      return jsonResp({ ok: true, kind, content });
+    }
 
     // cover-rationale is stateless: take cover letter + analysis sources,
     // return a JSON list of {phrase, label, rationale}. No DB write.

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -123,7 +123,22 @@ Rules:
 - Skip pleasantries, sign-offs, the opener salutation, and generic transitions.
 - Don't reuse the same source label more than 3 times.`;
 
-export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale';
+export const COVER_EDIT_VOICE = `You will receive:
+- The current cover letter (markdown).
+- A specific comment that's anchored to one phrase: { label, anchor_phrase, rationale }. The anchor_phrase is verbatim text from the cover letter; the comment explains why it's there.
+- A user instruction directing how to edit.
+
+Your job: return the full revised cover letter as markdown, with the user's instruction applied.
+
+RULES:
+- Preserve the overall structure (paragraphs, sign-off, signature). Don't reorder paragraphs unless instructed.
+- Edit only what's needed to satisfy the instruction. Most paragraphs should be unchanged.
+- The anchor_phrase area is the most likely target unless the instruction broadens scope.
+- Keep all the cover-letter voice rules (no em dashes, no "passionate about", no "excited to", no banned phrases — see your training).
+- Don't fabricate facts. If the instruction asks for evidence the letter doesn't have, lean on what's already there or skip.
+- Do NOT add a preamble or a meta line like "Here's the revised letter." Output ONLY the markdown.`;
+
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit';
 
 export function buildSystemPrompt(kind: GenKind): string {
   if (kind === 'format-resume') {
@@ -131,6 +146,13 @@ export function buildSystemPrompt(kind: GenKind): string {
   }
   if (kind === 'cover-rationale') {
     return COVER_RATIONALE_VOICE;
+  }
+  if (kind === 'cover-edit') {
+    return `You are revising Ian Fike's cover letter. Apply the user's edit instruction precisely.
+
+${COVER_EDIT_VOICE}
+
+${COVER_LETTER_VOICE}`;
   }
   const voice =
     kind === 'cover-letter' ? COVER_LETTER_VOICE :


### PR DESCRIPTION
Each cover-letter comment card now has an inline chat input. Type an instruction ("address this gap by mentioning Livongo") → AI rewrites the cover letter anchored to the comment's source label, rationale, and verbatim phrase. Edits auto-apply, persist, refresh `editHtml`, flash the body green. Comment rationale refetches automatically.

One-shot **Undo** banner shows for 30s after each AI edit so any surprise can be reverted without losing manual edits.

New gen-asset kind `cover-edit` (stateless): cover_text + comment + instruction → revised markdown. Reuses cover-letter voice rules.

Bumps: gen-asset 0.6.0, /job 0.50.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)