### PR TITLE
job: top-5 recs widget + "Recommended for you" full-list page

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1826,6 +1826,78 @@
   .dots-anim::after { content: '…'; animation: none; }
 }
 
+/* --- Recommendations widget: "See all" footer link --- */
+.rec-shell__foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--space-2);
+}
+
+/* --- Recommended-for-you full list (sortable table) --- */
+.recs-page__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+.recs-page__head h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+}
+.recs-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+}
+.recs-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-body-sm);
+}
+.recs-table th,
+.recs-table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.recs-table thead th {
+  background: var(--bg-surface);
+  font-weight: var(--fw-semibold);
+  color: var(--text-muted);
+  font-size: var(--font-size-caption);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  user-select: none;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.recs-table th[data-sortable] { cursor: pointer; }
+.recs-table th[data-sortable]:hover { color: var(--text); }
+.recs-table th[aria-sort]::after {
+  margin-left: 4px;
+  opacity: 0.7;
+}
+.recs-table th[aria-sort="ascending"]::after  { content: ' ↑'; }
+.recs-table th[aria-sort="descending"]::after { content: ' ↓'; }
+.recs-table tbody tr:last-child td { border-bottom: 0; }
+.recs-table tbody tr:hover { background: var(--bg-surface); }
+.recs-table td.recs-table__title a {
+  color: var(--text);
+  text-decoration: none;
+}
+.recs-table td.recs-table__title a:hover { text-decoration: underline; }
+.recs-table td.recs-table__source { color: var(--text-muted); }
+.recs-table__empty {
+  padding: var(--space-6);
+  text-align: center;
+  color: var(--text-muted);
+}
+
 /* --- Square company logo (table rows, detail header) --- */
 .company-logo {
   display: inline-block;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
-  <script src="/job/js/theme.js?v=0.50.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
+  <script src="/job/js/theme.js?v=0.51.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
-  <script src="/job/js/theme.js?v=0.50.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
+  <script src="/job/js/theme.js?v=0.51.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
-  <script src="/job/js/theme.js?v=0.50.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
+  <script src="/job/js/theme.js?v=0.51.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Your career — /job</title>
+  <title>Recommended for you — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
@@ -25,10 +25,7 @@
   <div class="app">
     <job-rail></job-rail>
     <main class="app__main">
-      <header class="page-header">
-        <h1>Your career</h1>
-      </header>
-      <job-career></job-career>
+      <job-recommendations-table></job-recommendations-table>
     </main>
   </div>
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.50.0";
-console.log(`[job] v${VERSION} - Comment-anchored chat to edit cover letter, with Undo`);
+const VERSION = "0.51.0";
+console.log(`[job] v${VERSION} - Top-5 recs widget + /job/jobs/recommended/ sortable full list`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -22,6 +22,8 @@ if (location.pathname.startsWith('/job/history/drill')) {
 }
 if (location.pathname.startsWith('/job/jobs/drill')) {
   import('./components/job-role-detail.js' + V);
+} else if (location.pathname.startsWith('/job/jobs/recommended')) {
+  import('./components/job-recommendations-table.js' + V);
 } else if (location.pathname.startsWith('/job/jobs')) {
   import('./components/job-pipeline.js' + V);
 }

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -3,15 +3,21 @@
 // Pages compose: <div class="app"><job-rail></job-rail><main class="app__main">…</main><job-footer></job-footer></div>
 import { LitElement, html } from 'https://esm.run/lit@3';
 
+// Each Jobs sub-item is either a bucket-filter on /job/jobs/ (matched
+// by `bucket`) or a real sub-page (matched by `path` prefix). The
+// renderer below uses `path ? prefix-match : bucket-equality` to decide
+// aria-current — so when we're on a sub-page like /job/jobs/recommended/,
+// none of the bucket items light up.
 const ROUTES = [
   {
     href: '/job/jobs/',
     label: 'Jobs',
     match: /^\/job\/jobs\/?/,
     sub: [
-      { href: '/job/jobs/?bucket=leads',   label: 'Leads',   bucket: 'leads' },
-      { href: '/job/jobs/?bucket=active',  label: 'Active',  bucket: 'active' },
-      { href: '/job/jobs/?bucket=archive', label: 'Archive', bucket: 'archive' },
+      { href: '/job/jobs/?bucket=leads',     label: 'Leads',                bucket: 'leads' },
+      { href: '/job/jobs/?bucket=active',    label: 'Active',               bucket: 'active' },
+      { href: '/job/jobs/?bucket=archive',   label: 'Archive',              bucket: 'archive' },
+      { href: '/job/jobs/recommended/',      label: 'Recommended for you',  path: '/job/jobs/recommended/' },
     ],
   },
   { href: '/job/history/', label: 'Your career', match: /^\/job\/history\/?/ },
@@ -61,14 +67,23 @@ export class JobRail extends LitElement {
                   </a>
                   ${active && r.sub ? html`
                     <ul class="nav-sublist">
-                      ${r.sub.map(s => html`
-                        <li>
-                          <a href=${s.href}
-                             aria-current=${this.bucket === s.bucket ? 'page' : 'false'}>
-                            ${s.label}
-                          </a>
-                        </li>
-                      `)}
+                      ${r.sub.map(s => {
+                        // Path-based sub-items (real sub-pages) win out
+                        // over bucket-based ones — when we're on
+                        // /job/jobs/recommended/, no bucket should look
+                        // active.
+                        const onSubPath = r.sub.some(x => x.path && this.path.startsWith(x.path));
+                        const subActive = s.path
+                          ? this.path.startsWith(s.path)
+                          : (!onSubPath && this.bucket === s.bucket);
+                        return html`
+                          <li>
+                            <a href=${s.href} aria-current=${subActive ? 'page' : 'false'}>
+                              ${s.label}
+                            </a>
+                          </li>
+                        `;
+                      })}
                     </ul>
                   ` : ''}
                 </li>

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -1,0 +1,223 @@
+// job-recommendations-table — full sortable list for /job/jobs/recommended/.
+// Pulls the ?view=all variant so it includes recs below the carousel's
+// fit-score floor. Records persist in the DB regardless of what shows;
+// this view is the audit trail.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+const V = (new URL(import.meta.url)).search;
+const [{ fetchRecommendations, dismissRecommendation, addRole }] = await Promise.all([
+  import('../pipeline.js' + V),
+]);
+
+const COLUMNS = [
+  { key: 'fitScore',    label: 'Fit',      align: 'right', sortable: true, numeric: true },
+  { key: 'title',       label: 'Title',    align: 'left',  sortable: true },
+  { key: 'company',     label: 'Company',  align: 'left',  sortable: true },
+  { key: 'location',    label: 'Location', align: 'left',  sortable: true },
+  { key: 'source',      label: 'Source',   align: 'left',  sortable: true },
+  { key: 'sourceLabel', label: 'Detail',   align: 'left',  sortable: true },
+  { key: 'suggestedAt', label: 'Added',    align: 'left',  sortable: true, date: true },
+  { key: 'actions',     label: '',         align: 'right', sortable: false },
+];
+
+function relTime(iso) {
+  if (!iso) return '';
+  const ms = Date.now() - Date.parse(iso);
+  const s = Math.max(1, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24); if (d < 7)  return `${d}d ago`;
+  const w = Math.floor(d / 7);  if (w < 5)  return `${w}w ago`;
+  const mo = Math.floor(d / 30); return mo < 12 ? `${mo}mo ago` : `${Math.floor(mo / 12)}y ago`;
+}
+
+function fitClass(s) {
+  if (s == null) return 'fit-pill fit-pill--poor';
+  if (s >= 70) return 'fit-pill fit-pill--strong';
+  if (s >= 50) return 'fit-pill fit-pill--ok';
+  if (s >= 30) return 'fit-pill fit-pill--weak';
+  return 'fit-pill fit-pill--poor';
+}
+
+export class JobRecommendationsTable extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state:   { state: true },
+    items:   { state: true },
+    error:   { state: true },
+    sortKey: { state: true },
+    sortDir: { state: true },         // 'asc' | 'desc'
+    addingId: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.items = [];
+    this.error = '';
+    // Default sort: fit score desc — same order as the widget.
+    this.sortKey = 'fitScore';
+    this.sortDir = 'desc';
+    this.addingId = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this.state = 'loading';
+    try {
+      const data = await fetchRecommendations({ view: 'all' });
+      this.items = data.recommendations || [];
+      this.state = 'loaded';
+    } catch (e) {
+      this.error = String(e);
+      this.state = 'error';
+    }
+  }
+
+  _onSort(col) {
+    if (!col.sortable) return;
+    if (this.sortKey === col.key) {
+      this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortKey = col.key;
+      // Numeric and date columns default to desc (highest/newest first);
+      // text columns default to asc (A→Z).
+      this.sortDir = (col.numeric || col.date) ? 'desc' : 'asc';
+    }
+  }
+
+  _sorted() {
+    const col = COLUMNS.find(c => c.key === this.sortKey);
+    if (!col) return this.items;
+    const dir = this.sortDir === 'asc' ? 1 : -1;
+    const get = (r) => {
+      const v = r[col.key];
+      if (v == null) return col.numeric ? -Infinity : '';
+      if (col.numeric) return Number(v);
+      if (col.date) return Date.parse(v) || 0;
+      return String(v).toLowerCase();
+    };
+    return [...this.items].sort((a, b) => {
+      const va = get(a), vb = get(b);
+      if (va < vb) return -1 * dir;
+      if (va > vb) return  1 * dir;
+      return 0;
+    });
+  }
+
+  async _onDismiss(rec) {
+    this.items = this.items.filter(r => r.id !== rec.id);
+    try { await dismissRecommendation(rec.id); } catch {}
+  }
+
+  async _onAdd(rec) {
+    if (this.addingId) return;
+    this.addingId = rec.id;
+    try {
+      const r = await addRole({
+        url: rec.url,
+        title: rec.title,
+        company: rec.company,
+        source: 'Network',
+        fromRecommendationId: rec.id,
+      });
+      this.items = this.items.filter(x => x.id !== rec.id);
+      document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
+    } catch (e) {
+      console.warn('[recs-table] add failed', e);
+    } finally {
+      this.addingId = null;
+    }
+  }
+
+  _renderHeader() {
+    return html`
+      <tr>
+        ${COLUMNS.map(c => {
+          const sorted = this.sortKey === c.key;
+          const ariaSort = sorted ? (this.sortDir === 'asc' ? 'ascending' : 'descending') : 'none';
+          return html`
+            <th
+              style=${`text-align:${c.align}`}
+              ?data-sortable=${c.sortable}
+              aria-sort=${ariaSort}
+              @click=${() => this._onSort(c)}>
+              ${c.label}
+            </th>
+          `;
+        })}
+      </tr>
+    `;
+  }
+
+  _renderRow(r) {
+    return html`
+      <tr>
+        <td style="text-align:right">
+          ${r.fitScore != null
+            ? html`<span class=${fitClass(r.fitScore)} title="Fit score">${r.fitScore}</span>`
+            : html`<span class="muted">—</span>`}
+        </td>
+        <td class="recs-table__title">
+          <a href=${r.url} target="_blank" rel="noopener">${r.title || '(untitled)'}</a>
+        </td>
+        <td>${r.company || ''}</td>
+        <td>${r.location || ''}</td>
+        <td class="recs-table__source">${r.source || ''}</td>
+        <td class="recs-table__source">${r.sourceLabel || ''}</td>
+        <td>${r.suggestedAt ? relTime(r.suggestedAt) : ''}</td>
+        <td style="text-align:right; white-space:nowrap;">
+          <button class="btn btn--sm btn--accent"
+                  ?disabled=${this.addingId === r.id}
+                  @click=${() => this._onAdd(r)}>
+            ${this.addingId === r.id ? 'Saving…' : 'Save'}
+          </button>
+          <button class="link-subtle" @click=${() => this._onDismiss(r)}>Dismiss</button>
+        </td>
+      </tr>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`<p class="muted">Loading recommendations…</p>`;
+    }
+    if (this.state === 'error') {
+      return html`<p class="muted">Couldn't load recommendations: ${this.error}</p>`;
+    }
+    const rows = this._sorted();
+    return html`
+      <header class="recs-page__head">
+        <h1>Recommended for you</h1>
+        <span class="muted">${rows.length} ${rows.length === 1 ? 'role' : 'roles'}</span>
+      </header>
+      ${rows.length === 0
+        ? html`<div class="recs-table__empty">No recommendations yet. New ones land here as soon as the workers pull fresh roles.</div>`
+        : html`
+            <div class="recs-table-wrap">
+              <table class="recs-table">
+                <thead>${this._renderHeader()}</thead>
+                <tbody>${rows.map(r => this._renderRow(r))}</tbody>
+              </table>
+            </div>
+          `}
+    `;
+  }
+}
+
+customElements.define('job-recommendations-table', JobRecommendationsTable);

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -185,15 +185,27 @@ export class JobRecommendations extends LitElement {
     if (this.state === 'error' || !this.items.length) {
       return html`<div class="rec-shell">${this._renderEmpty()}</div>`;
     }
+    // Show only the top 5 by fit score on the widget; full list lives
+    // on /job/jobs/recommended/. Items already arrive sorted by
+    // fit_score desc from the recommendations function.
+    const top = this.items.slice(0, 5);
+    const total = this.items.length;
     return html`
       <section class="rec-shell" aria-label="Recommendations">
         <header class="rec-shell__head">
           <h2>Recommended for you</h2>
-          <span class="muted">${this.items.length} fresh ${this.items.length === 1 ? 'role' : 'roles'}</span>
+          <span class="muted">
+            Top ${top.length} of ${total} ${total === 1 ? 'role' : 'roles'}
+          </span>
         </header>
         <div class="rec-row" role="list">
-          ${this.items.map(r => this._renderCard(r))}
+          ${top.map(r => this._renderCard(r))}
         </div>
+        <footer class="rec-shell__foot">
+          <a class="link-subtle" href="/job/jobs/recommended/">
+            See all recommendations →
+          </a>
+        </footer>
       </section>
     `;
   }

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -65,9 +65,12 @@ export async function addRole({ url, title, company, sector, source, fromRecomme
   return res.json();
 }
 
-export async function fetchRecommendations() {
+export async function fetchRecommendations(opts = {}) {
   const headers = await authHeader();
-  const res = await fetch(REC_URL, { headers });
+  // opts.view === 'all' → full list (no fit-score floor) for the
+  // "Recommended for you" page. Default is the carousel/widget view.
+  const url = opts.view === 'all' ? `${REC_URL}?view=all` : REC_URL;
+  const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`recommendations ${res.status}: ${await res.text()}`);
   return res.json();
 }

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.50.0">
-  <script src="/job/js/theme.js?v=0.50.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
+  <script src="/job/js/theme.js?v=0.51.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.50.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.3.0';
-console.log(`[recommendations] v${VERSION} - dedupe against pipeline by company+title`);
+const VERSION = '0.4.0';
+console.log(`[recommendations] v${VERSION} - ?view=all lifts score floor for "Recommended for you" page`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -18,6 +18,14 @@ serve(async (req) => {
     const sql = db();
 
     if (req.method === 'GET') {
+      // ?view=all   → all active recs regardless of fit score (for the
+      //               "Recommended for you" full-list page). Still excludes
+      //               dismissed + already-in-pipeline; those are signal of
+      //               user intent, not just score thresholds.
+      // (default)   → score floor 50, max 60 rows (drives the carousel).
+      const url = new URL(req.url);
+      const view = url.searchParams.get('view') || 'default';
+      const isAll = view === 'all';
       const rows = await sql`
         select r.id, r.source, r.source_label as "sourceLabel", r.url, r.company, r.title, r.location,
                r.salary, r.logo_url as "logoUrl", r.posted_at as "postedAt",
@@ -27,8 +35,8 @@ serve(async (req) => {
         from job.recommended_roles r
         where r.dismissed_at is null
           and r.added_to_pipeline_slug is null
-          and (r.fit_score is null or r.fit_score >= 50)
-          and coalesce(array_length(r.hard_fails, 1), 0) = 0
+          and (${isAll} or r.fit_score is null or r.fit_score >= 50)
+          and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
           and not exists (
             select 1
               from job.pipeline_roles p
@@ -36,9 +44,9 @@ serve(async (req) => {
                and lower(p.title) = lower(r.title)
           )
         order by r.fit_score desc nulls last, r.suggested_at desc
-        limit 60;
+        limit ${isAll ? 500 : 60};
       `;
-      return jsonResp({ ok: true, version: VERSION, count: rows.length, recommendations: rows });
+      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows });
     }
 
     if (req.method === 'POST') {


### PR DESCRIPTION
## Summary

Widget on \`/job/jobs/\` shows top 5 highest-ranked recs with a "See all recommendations →" link. Full list lives at new sub-nav "Recommended for you" → \`/job/jobs/recommended/\` — sortable table including a Source column. All records persist in the DB regardless of what's surfaced.

## Changes

- \`recommendations\` function v0.4.0: \`?view=all\` lifts the fit-score floor for the full-list page (still excludes dismissed + in-pipeline — those are user intent, not score)
- \`job-rail\`: new path-based sub-item; active-state logic updated so bucket items don't light up on sub-pages
- \`job-recommendations\`: slice to top 5 + footer link
- \`job-recommendations-table\`: new sortable table component
- New page \`job/jobs/recommended/index.html\`
- \`app.js\` v0.51.0; cache-bust strings bumped on all /job HTML

## Test plan

- [ ] Deploy \`recommendations\` function
- [ ] Hard-refresh \`/job/jobs/\` — widget shows max 5 cards + "See all" link
- [ ] Click → lands on \`/job/jobs/recommended/\` with sortable table
- [ ] Click each column header to sort; "Source" sort works
- [ ] Save / Dismiss actions in the table refresh state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)