### PR TITLE
Cover letter: shimmer-on-edit + selection-to-edit + history rail

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1045,6 +1045,167 @@
   100% { box-shadow: 0 0 0 3px rgba(46, 125, 50, 0); }
 }
 .cover-flash { animation: cover-flash-fade 1500ms ease-out; }
+
+/* --- Shimmer + AI icon on the area currently being edited --- */
+@keyframes ai-shimmer-move {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+.ai-shimmer {
+  position: relative;
+  background-image: linear-gradient(
+    100deg,
+    rgba(0, 120, 255, 0.08) 0%,
+    rgba(0, 120, 255, 0.28) 50%,
+    rgba(0, 120, 255, 0.08) 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: ai-shimmer-move 1200ms ease-in-out infinite;
+  border-radius: 3px;
+  padding: 0 2px;
+}
+.ai-shimmer::after {
+  content: '✨';
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 0.9em;
+  vertical-align: 1px;
+  animation: ai-shimmer-pulse 900ms ease-in-out infinite;
+}
+@keyframes ai-shimmer-pulse {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50%      { opacity: 1;   transform: scale(1.15); }
+}
+
+/* --- Sidebar wraps comments + history side by side with the body --- */
+.cover-layout__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+/* --- Selection popover ("Edit selection with AI") --- */
+.sel-popover {
+  position: absolute;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  min-width: 320px;
+  max-width: 420px;
+}
+.sel-popover__form {
+  flex: 1;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-md);
+}
+.sel-popover__close {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+  margin-right: var(--space-2);
+}
+.sel-popover__close:hover { background: var(--bg-surface); color: var(--fg); }
+
+/* --- Edit history rail --- */
+.cover-history {
+  display: flex;
+  flex-direction: column;
+}
+.cover-history__list {
+  list-style: none;
+  margin: 0;
+  padding: 0 var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.cover-history__item { margin: 0; }
+.cover-history__btn {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  appearance: none;
+  text-align: left;
+  padding: var(--space-3);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 100ms ease, border-color 100ms ease;
+}
+.cover-history__btn:hover:not(:disabled) {
+  background: var(--bg-surface);
+  border-color: var(--border);
+}
+.cover-history__btn:disabled {
+  opacity: 0.85;
+  cursor: default;
+}
+.cover-history__icon {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.cover-history__icon[data-source^="ai"]   { background: rgba(0, 120, 255, 0.1); color: #1e88e5; }
+.cover-history__icon[data-source="manual"] { background: rgba(255, 213, 79, 0.18); color: #b26a00; }
+.cover-history__icon[data-source="restore"],
+.cover-history__icon[data-source="pre-restore"] { background: var(--bg-surface); color: var(--fg-muted); }
+.cover-history__meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.cover-history__label {
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+  color: var(--fg);
+  letter-spacing: -0.005em;
+}
+.cover-history__inst {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cover-history__ts {
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+.cover-history__item--current .cover-history__btn {
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+}
+.cover-history__item--current .cover-history__icon {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .cover-rail__empty {
   font-size: var(--font-size-small);
   color: var(--fg-muted);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
-  <script src="/job/js/theme.js?v=0.51.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.52.0">
+  <script src="/job/js/theme.js?v=0.52.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.52.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
-  <script src="/job/js/theme.js?v=0.51.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.52.0">
+  <script src="/job/js/theme.js?v=0.52.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.52.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
-  <script src="/job/js/theme.js?v=0.51.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.52.0">
+  <script src="/job/js/theme.js?v=0.52.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.52.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
-  <script src="/job/js/theme.js?v=0.51.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.52.0">
+  <script src="/job/js/theme.js?v=0.52.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.52.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.51.0";
-console.log(`[job] v${VERSION} - Wise-style chat input on comment threads`);
+const VERSION = "0.52.0";
+console.log(`[job] v${VERSION} - Cover letter: shimmer-on-edit, selection-to-edit, click-through history`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -79,6 +79,9 @@ export class JobRoleDetail extends LitElement {
     activeRationale: { state: true }, // number | null — currently focused comment/highlight pair
     threads: { state: true },         // { [commentId]: { messages: [...], sending, error } } — chat-to-edit per comment
     coverUndo: { state: true },       // { content, label, expiresAt } | null — one-shot undo for last AI edit
+    editingAnchor: { state: true },   // { kind: 'comment'|'selection', commentId?, phrase, instruction? } | null
+    selectionPopover: { state: true },// { visible, x, y, text, savedRange } | null — floating "edit selection" UI
+    coverHistory: { state: true },    // [{ id, ts, source, content, label, instruction? }] reverse-chrono
   };
 
   constructor() {
@@ -100,6 +103,9 @@ export class JobRoleDetail extends LitElement {
     this.activeRationale = null;
     this.threads = {};
     this.coverUndo = null;
+    this.editingAnchor = null;
+    this.selectionPopover = null;
+    this.coverHistory = [];
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -118,10 +124,13 @@ export class JobRoleDetail extends LitElement {
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
     document.addEventListener('job:auth:ready', this._onAuth);
+    this._onSelectionChange = () => this._handleSelectionChange();
+    document.addEventListener('selectionchange', this._onSelectionChange);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
+    document.removeEventListener('selectionchange', this._onSelectionChange);
     // Flush pending autosaves on unmount.
     for (const k of ['resume', 'cover-letter']) {
       if (this._autosaveTimers?.[k]) {
@@ -150,6 +159,17 @@ export class JobRoleDetail extends LitElement {
       this.assets = { 'resume': resume, 'cover-letter': cover, 'analysis': analysis };
       this.baseResume = baseResume;
       this.state = 'loaded';
+      // Seed history with the loaded cover letter so the user has a
+      // baseline to revert to even before they make any edits.
+      if (cover?.content) {
+        this.coverHistory = [{
+          id: this._newId(),
+          ts: Date.now(),
+          source: 'initial',
+          content: cover.content,
+          label: 'Loaded version',
+        }];
+      }
       document.title = this.role
         ? `${this.role.company} — ${this.role.title} — /job`
         : `${this.slug} — /job`;
@@ -662,6 +682,8 @@ export class JobRoleDetail extends LitElement {
         </div>
       ` : nothing}
 
+      ${isCover && this.selectionPopover?.visible ? this._renderSelectionPopover() : nothing}
+
       ${isCover && showingChanges
         ? html`
           <div class="cover-layout">
@@ -681,6 +703,7 @@ export class JobRoleDetail extends LitElement {
                          this._flushSave(kind);
                        }
                      }}>${unsafeHTML(a.editHtml || '')}</article>
+            <aside class="cover-layout__sidebar">
             <aside class="cover-layout__rail" aria-label="Comments">
               <header class="cover-rail__head">
                 <h4 class="cover-rail__title">Comments</h4>
@@ -757,6 +780,8 @@ export class JobRoleDetail extends LitElement {
                 })}
               </div>
             </aside>
+            ${this._renderHistory()}
+            </aside>
           </div>
         `
         : html`
@@ -773,6 +798,85 @@ export class JobRoleDetail extends LitElement {
                    }}>${unsafeHTML(a.editHtml || '')}</article>
         `}
     `;
+  }
+
+  // Floating popover that appears next to a non-empty selection inside
+  // the cover body. Lets the user direct an edit on just that range.
+  _renderSelectionPopover() {
+    const p = this.selectionPopover;
+    if (!p) return nothing;
+    const style = `position:absolute; left:${p.x}px; top:${p.y}px; transform: translateX(-50%);`;
+    return html`
+      <div class="sel-popover" style=${style} @mousedown=${(e) => e.preventDefault()}>
+        <form class="cover-thread__form sel-popover__form" @submit=${(e) => {
+          e.preventDefault();
+          const input = e.currentTarget.querySelector('textarea');
+          this._sendSelectionChat(input.value);
+        }}>
+          <textarea class="cover-thread__input"
+                    rows="1"
+                    autofocus
+                    placeholder="Direct an edit to selection…"
+                    @keydown=${(e) => {
+                      if (e.key === 'Escape') { this._closeSelectionPopover(); }
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        e.currentTarget.form.requestSubmit();
+                      }
+                    }}></textarea>
+          <button class="cover-thread__send" type="submit" aria-label="Send">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M8 13V3"/><path d="M3 8l5-5 5 5"/>
+            </svg>
+          </button>
+        </form>
+        <button class="sel-popover__close" type="button" @click=${() => this._closeSelectionPopover()} aria-label="Close">×</button>
+      </div>
+    `;
+  }
+
+  _renderHistory() {
+    const items = this.coverHistory || [];
+    if (items.length === 0) return nothing;
+    return html`
+      <aside class="cover-history" aria-label="Edit history">
+        <header class="cover-rail__head">
+          <h4 class="cover-rail__title">History</h4>
+          <span class="cover-rail__spin">${items.length} version${items.length === 1 ? '' : 's'}</span>
+        </header>
+        <ol class="cover-history__list">
+          ${items.map((h, i) => html`
+            <li class="cover-history__item ${i === 0 ? 'cover-history__item--current' : ''}">
+              <button class="cover-history__btn" ?disabled=${i === 0} @click=${() => this._restoreHistory(h.id)} title=${h.instruction || ''}>
+                <span class="cover-history__icon" data-source=${h.source}>${this._historyIcon(h.source)}</span>
+                <span class="cover-history__meta">
+                  <span class="cover-history__label">${h.label || this._historyDefaultLabel(h.source)}</span>
+                  ${h.instruction ? html`<span class="cover-history__inst">${this._truncate(h.instruction, 80)}</span>` : nothing}
+                </span>
+                <span class="cover-history__ts">${this._timeAgo(h.ts)}</span>
+              </button>
+            </li>
+          `)}
+        </ol>
+      </aside>
+    `;
+  }
+
+  _historyIcon(source) {
+    if (source === 'ai-comment' || source === 'ai-selection' || source === 'pre-ai') return '✨';
+    if (source === 'manual') return '✎';
+    if (source === 'restore' || source === 'pre-restore') return '↻';
+    return '·';
+  }
+  _historyDefaultLabel(source) {
+    if (source === 'manual') return 'Manual edit';
+    if (source === 'ai-comment') return 'AI edit (comment)';
+    if (source === 'ai-selection') return 'AI edit (selection)';
+    if (source === 'initial') return 'Loaded version';
+    if (source === 'pre-ai') return 'Pre-AI snapshot';
+    if (source === 'pre-restore') return 'Pre-restore snapshot';
+    if (source === 'restore') return 'Restored version';
+    return source;
   }
 
   // Save-status pill in the toolbar — green dot for "Saved", amber for
@@ -853,6 +957,157 @@ export class JobRoleDetail extends LitElement {
     }
   }
 
+  // ----- Edit history (cover letter) ----------------------------------------
+
+  _newId() { return Math.random().toString(36).slice(2, 10); }
+
+  _pushHistory(entry) {
+    // Skip if content didn't actually change from the most recent entry.
+    const last = this.coverHistory[0];
+    if (last && last.content === entry.content) return;
+    this.coverHistory = [{ id: this._newId(), ts: Date.now(), ...entry }, ...this.coverHistory].slice(0, 50);
+  }
+
+  async _restoreHistory(id) {
+    const entry = this.coverHistory.find(h => h.id === id);
+    if (!entry) return;
+    const a = this.assets['cover-letter'];
+    if (!a) return;
+    // Snapshot the current state into history as a "before restore" entry
+    // so we can come back to it via the same UI.
+    this._pushHistory({ source: 'pre-restore', content: a.content, label: 'Before restore' });
+    try {
+      await writeRoleAsset(this.slug, 'cover-letter', entry.content);
+      this.assets = {
+        ...this.assets,
+        'cover-letter': { ...a, content: entry.content, saveStatus: 'saved', savedAt: Date.now() },
+      };
+      this._refreshEditHtml('cover-letter');
+      this._pushHistory({ source: 'restore', content: entry.content, label: `Restored: ${entry.label || this._truncate(entry.instruction, 60) || 'version'}` });
+      this._flashCoverEdit();
+    } catch (e) {
+      this.assets = { ...this.assets, 'cover-letter': { ...a, error: `restore failed: ${String(e?.message || e)}` } };
+    }
+  }
+
+  _truncate(s, n) {
+    if (!s) return '';
+    s = String(s);
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  }
+
+  // ----- Selection-based edit ----------------------------------------------
+
+  // Watch document selection; if the user has selected non-empty text
+  // inside the cover body, show a floating "Edit with AI" popover near
+  // the selection end. Selection inside the chat composer / comment rail
+  // doesn't trigger.
+  _handleSelectionChange() {
+    if (this.activeTab !== 'cover-letter' || !this.showChanges) {
+      if (this.selectionPopover) this.selectionPopover = null;
+      return;
+    }
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+      // Keep the popover up if the user moved focus into the popover
+      // input (selection then becomes collapsed there).
+      const inPopover = document.activeElement?.closest?.('.sel-popover');
+      if (!inPopover && this.selectionPopover) this.selectionPopover = null;
+      return;
+    }
+    const range = sel.getRangeAt(0);
+    const body = this.querySelector('.cover-layout__body');
+    if (!body || !body.contains(range.commonAncestorContainer)) {
+      if (this.selectionPopover) this.selectionPopover = null;
+      return;
+    }
+    const text = sel.toString().trim();
+    if (text.length < 3) return;
+    const rect = range.getBoundingClientRect();
+    const scrollY = window.scrollY;
+    this.selectionPopover = {
+      visible: true,
+      x: rect.left + rect.width / 2,
+      y: rect.bottom + scrollY + 8,
+      text,
+      savedRange: range.cloneRange(),
+    };
+  }
+
+  _closeSelectionPopover() { this.selectionPopover = null; }
+
+  async _sendSelectionChat(instruction) {
+    const sp = this.selectionPopover;
+    if (!sp || !instruction.trim()) return;
+    const phrase = sp.text;
+    this.selectionPopover = null;
+    await this._applyCoverEdit({
+      anchorPhrase: phrase,
+      instruction: instruction.trim(),
+      source: 'ai-selection',
+      label: this._truncate(phrase, 40),
+      thread: null,
+    });
+  }
+
+  // ----- Shared apply pipeline for AI edits ---------------------------------
+
+  // One method drives every AI edit (comment-anchored or selection-based)
+  // so shimmer, history, undo, and post-apply refresh stay consistent.
+  async _applyCoverEdit({ anchorPhrase, anchorCommentLabel = '', anchorRationale = '', instruction, source, label, commentIdForThread = null }) {
+    const a = this.assets['cover-letter'];
+    if (!a || !a.content) return;
+
+    this.editingAnchor = { kind: source === 'ai-comment' ? 'comment' : 'selection', commentId: commentIdForThread, phrase: anchorPhrase };
+    if (commentIdForThread != null) {
+      const prev = this._getThread(commentIdForThread);
+      this._setThread(commentIdForThread, {
+        messages: [...prev.messages, { role: 'user', text: instruction }],
+        sending: true, error: '',
+      });
+    }
+    try {
+      const newContent = await applyCoverEdit({
+        coverText: a.content,
+        instruction,
+        comment: { label: anchorCommentLabel || 'User selection', anchor_phrase: anchorPhrase, rationale: anchorRationale },
+      });
+
+      // History entry for the version we're replacing (before-state).
+      this._pushHistory({ source: 'pre-ai', content: a.content, label: 'Before AI edit', instruction });
+      // Undo snapshot pointing to the pre-AI content.
+      this.coverUndo = { content: a.content, label, expiresAt: Date.now() + 30_000 };
+
+      await writeRoleAsset(this.slug, 'cover-letter', newContent);
+      this.assets = {
+        ...this.assets,
+        'cover-letter': { ...this.assets['cover-letter'], content: newContent, saveStatus: 'saved', savedAt: Date.now() },
+      };
+      this._refreshEditHtml('cover-letter');
+      this._pushHistory({ source, content: newContent, label, instruction });
+      this._flashCoverEdit();
+
+      if (commentIdForThread != null) {
+        const cur = this._getThread(commentIdForThread);
+        this._setThread(commentIdForThread, {
+          messages: [...cur.messages, { role: 'assistant', text: 'Edit applied. Undo available for 30s.' }],
+          sending: false, error: '',
+        });
+      }
+
+      setTimeout(() => { if (this.coverUndo && this.coverUndo.expiresAt <= Date.now()) this.coverUndo = null; }, 30_200);
+    } catch (e) {
+      if (commentIdForThread != null) {
+        const cur = this._getThread(commentIdForThread);
+        this._setThread(commentIdForThread, { messages: cur.messages, sending: false, error: String(e?.message || e) });
+      } else {
+        this.assets = { ...this.assets, 'cover-letter': { ...this.assets['cover-letter'], error: String(e?.message || e) } };
+      }
+    } finally {
+      this.editingAnchor = null;
+    }
+  }
+
   // ----- Chat-to-edit on cover-letter comments -----------------------------
 
   _threadKey(commentId) { return `cover:${commentId}`; }
@@ -865,67 +1120,23 @@ export class JobRoleDetail extends LitElement {
     this.threads = { ...this.threads, [this._threadKey(commentId)]: t };
   }
 
-  // Send a chat message anchored to a comment. Pushes user msg into the
-  // thread, calls cover-edit, applies the new content, snapshots an undo.
+  // Send a chat message anchored to a comment. Thin wrapper around the
+  // shared _applyCoverEdit pipeline so shimmer, history, and undo behave
+  // identically regardless of where the edit was triggered from.
   async _sendCommentChat(commentId, instruction) {
-    const a = this.assets['cover-letter'];
-    if (!a || !a.content) return;
     const trimmed = String(instruction || '').trim();
     if (!trimmed) return;
-
     const comment = (this.coverRationale.highlights || []).find((_h, i) => i + 1 === commentId);
     if (!comment) return;
-
-    const prev = this._getThread(commentId);
-    const next = {
-      messages: [...prev.messages, { role: 'user', text: trimmed }],
-      sending: true,
-      error: '',
-    };
-    this._setThread(commentId, next);
-
-    try {
-      const newContent = await applyCoverEdit({
-        coverText: a.content,
-        instruction: trimmed,
-        comment: { label: comment.label, anchor_phrase: comment.phrase, rationale: comment.rationale },
-      });
-      // Snapshot for one-shot undo. Expire after 30s.
-      this.coverUndo = {
-        content: a.content,
-        label: `comment ${commentId}`,
-        expiresAt: Date.now() + 30_000,
-      };
-      // Persist immediately and refresh editHtml so the user sees the
-      // change. Rationale will refetch automatically (signature changed).
-      await writeRoleAsset(this.slug, 'cover-letter', newContent);
-      this.assets = {
-        ...this.assets,
-        'cover-letter': {
-          ...this.assets['cover-letter'],
-          content: newContent,
-          saveStatus: 'saved',
-          savedAt: Date.now(),
-        },
-      };
-      this._refreshEditHtml('cover-letter');
-      this._setThread(commentId, {
-        messages: [...next.messages, { role: 'assistant', text: 'Applied. Edit highlighted briefly. Undo available for 30s.' }],
-        sending: false,
-        error: '',
-      });
-      this._flashCoverEdit();
-      // Schedule undo expiry → state clear.
-      setTimeout(() => {
-        if (this.coverUndo && this.coverUndo.expiresAt <= Date.now()) this.coverUndo = null;
-      }, 30_000 + 200);
-    } catch (e) {
-      this._setThread(commentId, {
-        messages: next.messages,
-        sending: false,
-        error: String(e?.message || e),
-      });
-    }
+    return this._applyCoverEdit({
+      anchorPhrase: comment.phrase,
+      anchorCommentLabel: comment.label,
+      anchorRationale: comment.rationale,
+      instruction: trimmed,
+      source: 'ai-comment',
+      label: `${comment.label}: ${this._truncate(trimmed, 50)}`,
+      commentIdForThread: commentId,
+    });
   }
 
   // Briefly flash the cover-letter body to show that a chat edit just
@@ -1027,10 +1238,41 @@ export class JobRoleDetail extends LitElement {
 
   updated(changed) {
     super.updated?.(changed);
-    // Re-anchor cover-letter comment cards after any render that could
-    // have changed their layout (cover content, rationale set, tab swap,
-    // active state, etc).
     this._alignComments();
+    this._applyEditingShimmer();
+  }
+
+  // Paint a shimmer + sparkle overlay on whichever <mark> (or first text
+  // substring) matches editingAnchor.phrase while an AI edit is in flight.
+  _applyEditingShimmer() {
+    const body = this.querySelector('.cover-layout__body');
+    if (!body) return;
+    body.querySelectorAll('.ai-shimmer').forEach(el => el.classList.remove('ai-shimmer'));
+    const anchor = this.editingAnchor;
+    if (!anchor || !anchor.phrase) return;
+    // Comment-anchored: target the mark by data-rationale id when we
+    // can map phrase → id.
+    if (anchor.kind === 'comment' && anchor.commentId != null) {
+      const m = body.querySelector(`mark[data-rationale="${anchor.commentId}"]`);
+      if (m) { m.classList.add('ai-shimmer'); return; }
+    }
+    // Otherwise: best-effort first-substring match across text nodes.
+    const phrase = anchor.phrase.toLowerCase();
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      const idx = node.nodeValue.toLowerCase().indexOf(phrase);
+      if (idx < 0) continue;
+      try {
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + phrase.length);
+        const span = document.createElement('span');
+        span.className = 'ai-shimmer ai-shimmer--inline';
+        range.surroundContents(span);
+      } catch { /* range may cross element boundaries — skip silently */ }
+      return;
+    }
   }
 
   // ----- Always-on inline editing + autosave --------------------------------
@@ -1076,6 +1318,11 @@ export class JobRoleDetail extends LitElement {
         this.assets = { ...this.assets, [kind]: { ...cur, content: md, saveStatus: 'saved', savedAt: Date.now() } };
       } else {
         this.assets = { ...this.assets, [kind]: { ...cur, content: md } };
+      }
+      // Track manual edits in cover-letter history so the user can flip
+      // back to any prior version (theirs or the AI's).
+      if (kind === 'cover-letter') {
+        this._pushHistory({ source: 'manual', content: md, label: 'Manual edit' });
       }
     } catch (e) {
       this.assets = { ...this.assets, [kind]: { ...this.assets[kind], saveStatus: 'error', error: String(e?.message || e) } };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.51.0">
-  <script src="/job/js/theme.js?v=0.51.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.52.0">
+  <script src="/job/js/theme.js?v=0.52.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.51.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.52.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Three additions:

1. **Shimmer + sparkle icon** overlays whichever phrase the AI is currently editing. For comment-anchored edits we class the matching `<mark>`; for selection-based edits we wrap the first match in a temporary span. Both clear automatically on apply.

2. **Selection-to-edit.** Selecting text inside the cover body shows a floating Wise-style composer right below the selection — type an instruction and the AI rewrites just that range. Shares the same apply pipeline as comment-anchored edits (persistence, shimmer, undo, history all consistent).

3. **Edit history rail.** Every version is preserved — loaded baseline, manual autosaves, AI edits with the instruction surfaced, and pre-restore snapshots so you can flip back anywhere. Click any prior entry to restore; current version pinned at top with an accent outline.

/job 0.52.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)