### PR TITLE
Cover opportunities: gap-flagging comments → narrative-additions

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -861,6 +861,37 @@
   background: var(--accent);
   border-radius: var(--radius-md) 0 0 var(--radius-md);
 }
+
+/* Opportunity card: amber accent + sigil + "ask" subtitle. */
+.cover-comment--op { background: rgba(255, 213, 79, 0.06); }
+.cover-comment--op .cover-comment__num {
+  background: rgba(255, 213, 79, 0.25);
+  color: #8a5a00;
+  border-color: rgba(255, 213, 79, 0.45);
+}
+.cover-comment--op.is-active::before { background: #c98a00; }
+.cover-comment--op.is-active .cover-comment__num {
+  background: #c98a00;
+  color: #fff;
+  border-color: #c98a00;
+}
+.cover-comment__ask {
+  margin: var(--space-2) 0 0;
+  font-size: var(--font-size-small);
+  font-style: italic;
+  color: var(--fg);
+}
+
+/* Opportunity marks in the body: dotted amber underline, no fill. */
+.asset-doc mark.d-op {
+  background: transparent;
+  color: inherit;
+  border-bottom: 2px dotted #c98a00;
+  padding: 0 1px;
+  cursor: help;
+}
+.asset-doc mark.d-op sup.d-fn { color: #8a5a00; }
+
 .cover-rail__list[data-active]:not([data-active=""]) .cover-comment:not(.is-active) {
   opacity: 0.55;
 }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.55.0">
-  <script src="/job/js/theme.js?v=0.55.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.56.0">
+  <script src="/job/js/theme.js?v=0.56.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.55.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.56.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.55.0">
-  <script src="/job/js/theme.js?v=0.55.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.56.0">
+  <script src="/job/js/theme.js?v=0.56.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.55.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.56.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.55.0">
-  <script src="/job/js/theme.js?v=0.55.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.56.0">
+  <script src="/job/js/theme.js?v=0.56.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.55.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.56.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.55.0">
-  <script src="/job/js/theme.js?v=0.55.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.56.0">
+  <script src="/job/js/theme.js?v=0.56.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.55.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.56.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.55.0";
-console.log(`[job] v${VERSION} - Selection popover: fixed positioning + sticky-until-close + autofocus`);
+const VERSION = "0.56.0";
+console.log(`[job] v${VERSION} - Cover opportunities: gap-flagging comments → narrative-additions`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -94,6 +94,7 @@ export class JobCareer extends LitElement {
     promptTags: { state: true },
     baseResume: { state: true },     // saved row: { content, missing, generating, error }
     baseDraft: { state: true },      // editing buffer: { text, status, error } — status in idle|reading|formatting|saving
+    narrativeAdditions: { state: true }, // markdown blob — additions captured via opportunity threads
   };
 
   constructor() {
@@ -106,6 +107,7 @@ export class JobCareer extends LitElement {
     this.promptTags = [];
     this.baseResume = { content: '', missing: true, generating: false, error: '' };
     this.baseDraft = { text: '', status: 'idle', error: '' };
+    this.narrativeAdditions = '';
   }
 
   connectedCallback() {
@@ -144,6 +146,11 @@ export class JobCareer extends LitElement {
         const r = await readRoleAsset(BASE_RESUME_SLUG, 'resume');
         if (r?.content_md) this.baseResume = { content: r.content_md, missing: false, generating: false, error: '' };
       } catch { /* leave missing=true */ }
+      // Best-effort load of narrative-additions for the Narratives tab.
+      try {
+        const n = await readRoleAsset('__narratives__', 'notes');
+        if (n?.content_md) this.narrativeAdditions = n.content_md;
+      } catch { /* leave empty */ }
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
@@ -354,6 +361,20 @@ export class JobCareer extends LitElement {
         <div class="kb-doc">
           <p><em>Open the Vision tab to read or edit the live narrative. (Direct fetch lands with the Vision page rebuild.)</em></p>
         </div>
+      </section>
+
+      <section class="narrative-block">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);">
+          <div>
+            <h2 style="margin:0;">Additions</h2>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);">
+              New context you've added via cover-letter opportunity threads. Drawn from <code>job.global_assets</code>.
+            </p>
+          </div>
+        </header>
+        ${this.narrativeAdditions
+          ? html`<article class="kb-doc">${unsafeHTML(renderMarkdown(this.narrativeAdditions))}</article>`
+          : html`<p class="muted" style="font-size:var(--font-size-small);">Nothing yet. When you respond to an "Opportunity" comment on a cover letter, the info you provide lands here.</p>`}
       </section>
 
       <section class="narrative-block">

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -24,7 +24,7 @@ async function getTurndown() {
   return td;
 }
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -75,7 +75,7 @@ export class JobRoleDetail extends LitElement {
     assets: { state: true },         // { resume, cover-letter, analysis } each: {content, draft, mode, saving, dirty, error}
     baseResume: { state: true },     // { content } | null — canonical untargeted resume, source of truth for diff
     showChanges: { state: true },    // bool — toggle the diff/highlight overlay on resume + cover tabs
-    coverRationale: { state: true }, // { sig, highlights, loading, error } — AI cover-letter rationale cache
+    coverRationale: { state: true }, // { sig, highlights, opportunities, loading, error } — AI cover-letter rationale cache
     activeRationale: { state: true }, // number | null — currently focused comment/highlight pair
     threads: { state: true },         // { [commentId]: { messages: [...], sending, error } } — chat-to-edit per comment
     coverUndo: { state: true },       // { content, label, expiresAt } | null — one-shot undo for last AI edit
@@ -99,7 +99,7 @@ export class JobRoleDetail extends LitElement {
     this.assets = { 'resume': null, 'cover-letter': null, 'analysis': null };
     this.baseResume = null;
     this.showChanges = true;
-    this.coverRationale = { sig: '', highlights: [], loading: false, error: '' };
+    this.coverRationale = { sig: '', highlights: [], opportunities: [], loading: false, error: '' };
     this.activeRationale = null;
     this.threads = {};
     this.coverUndo = null;
@@ -326,7 +326,7 @@ export class JobRoleDetail extends LitElement {
       html = renderMarkdown(diffMarkdown(this.baseResume.content, a.content));
       key = `diff:${this._fnv(this.baseResume.content)}:${this._fnv(a.content)}`;
     } else if (kind === 'cover-letter' && this.showChanges) {
-      const { html: marked } = applyAIHighlights(a.content, this.coverRationale.highlights);
+      const { html: marked } = applyAIHighlights(a.content, this.coverRationale.highlights, this.coverRationale.opportunities);
       html = renderMarkdown(marked);
       key = `cover:${this._fnv(a.content)}:${this._fnv(JSON.stringify(this.coverRationale.highlights))}`;
     } else {
@@ -648,7 +648,7 @@ export class JobRoleDetail extends LitElement {
         queueMicrotask(() => this._ensureCoverRationale());
       }
       coverLoading = this.coverRationale.loading;
-      ({ comments: coverComments } = applyAIHighlights(a.content, this.coverRationale.highlights));
+      ({ comments: coverComments } = applyAIHighlights(a.content, this.coverRationale.highlights, this.coverRationale.opportunities));
     }
 
     return html`
@@ -720,16 +720,21 @@ export class JobRoleDetail extends LitElement {
                 ${coverComments.map(c => {
                   const thread = this._getThread(c.id);
                   const isActive = this.activeRationale === c.id;
+                  const isOp = c.kind === 'opportunity';
+                  const ph = isOp
+                    ? (c.ask || 'Add the missing information…')
+                    : (isActive ? 'How should this change?' : 'Direct an edit…');
                   return html`
-                    <article class="cover-comment ${isActive ? 'is-active' : ''}"
+                    <article class="cover-comment ${isOp ? 'cover-comment--op' : ''} ${isActive ? 'is-active' : ''}"
                              data-rationale-id=${c.id}
                              @mouseenter=${() => this._highlightRationale(c.id, true)}
                              @mouseleave=${() => this._highlightRationale(c.id, false)}>
                       <header class="cover-comment__head" @click=${() => { this._scrollToHighlight(c.id); }}>
-                        <span class="cover-comment__num">${c.id}</span>
+                        <span class="cover-comment__num">${isOp ? '✦' : c.id}</span>
                         <span class="cover-comment__label">${c.label}</span>
                       </header>
                       <div class="cover-comment__body">${unsafeHTML(renderMarkdown(c.text))}</div>
+                      ${isOp && c.ask ? html`<p class="cover-comment__ask">${c.ask}</p>` : nothing}
 
                       ${thread.messages.length ? html`
                         <ul class="cover-thread">
@@ -740,7 +745,7 @@ export class JobRoleDetail extends LitElement {
                           `)}
                           ${thread.sending ? html`
                             <li class="cover-thread__msg cover-thread__msg--assistant">
-                              <span class="dots-anim">Editing</span>
+                              <span class="dots-anim">${isOp ? 'Saving & weaving in' : 'Editing'}</span>
                             </li>
                           ` : nothing}
                           ${thread.error ? html`
@@ -754,11 +759,12 @@ export class JobRoleDetail extends LitElement {
                         const input = e.currentTarget.querySelector('textarea');
                         const v = input.value;
                         input.value = '';
-                        this._sendCommentChat(c.id, v);
+                        if (isOp) this._sendOpportunity(c, v);
+                        else      this._sendCommentChat(c.id, v);
                       }}>
                         <textarea class="cover-thread__input"
                                   rows="1"
-                                  placeholder=${isActive ? 'How should this change?' : 'Direct an edit…'}
+                                  placeholder=${ph}
                                   ?disabled=${thread.sending}
                                   @keydown=${(e) => {
                                     if (e.key === 'Enter' && !e.shiftKey) {
@@ -941,24 +947,19 @@ export class JobRoleDetail extends LitElement {
     const cover = this.assets['cover-letter']?.content || '';
     const sources = this._coverHighlightSources();
     if (!cover || sources.length === 0) {
-      this.coverRationale = { sig, highlights: [], loading: false, error: '' };
+      this.coverRationale = { sig, highlights: [], opportunities: [], loading: false, error: '' };
       return;
     }
-    this.coverRationale = { sig, highlights: [], loading: true, error: '' };
+    this.coverRationale = { sig, highlights: [], opportunities: [], loading: true, error: '' };
     try {
-      const highlights = await fetchCoverRationale(cover, sources);
-      // Only commit if the signature is still current — guards against a
-      // racing edit + regenerate that finishes after newer state.
+      const { highlights, opportunities } = await fetchCoverRationale(cover, sources);
       if (this._coverSig() === sig) {
-        this.coverRationale = { sig, highlights, loading: false, error: '' };
-        // Fold the new highlights into the editable HTML so they show
-        // inline. The user pauses while we fetch (~3s), so the cursor
-        // jump from re-rendering is acceptable here.
+        this.coverRationale = { sig, highlights, opportunities, loading: false, error: '' };
         this._refreshEditHtml('cover-letter');
       }
     } catch (e) {
       if (this._coverSig() === sig) {
-        this.coverRationale = { sig, highlights: [], loading: false, error: String(e?.message || e) };
+        this.coverRationale = { sig, highlights: [], opportunities: [], loading: false, error: String(e?.message || e) };
       }
     }
   }
@@ -1128,6 +1129,46 @@ export class JobRoleDetail extends LitElement {
 
   _setThread(commentId, t) {
     this.threads = { ...this.threads, [this._threadKey(commentId)]: t };
+  }
+
+  // Opportunity threads do double duty: persist the user's new info to
+  // job.global_assets (narrative-additions) AND weave it into the cover
+  // letter via the cover-edit pipeline. Both happen in parallel; the
+  // user sees the edit immediately and the narrative addition syncs to
+  // the Career → Narratives tab.
+  async _sendOpportunity(comment, userText) {
+    const text = String(userText || '').trim();
+    if (!text) return;
+    const prev = this._getThread(comment.id);
+    this._setThread(comment.id, {
+      messages: [...prev.messages, { role: 'user', text }],
+      sending: true, error: '',
+    });
+    const sourceRole = this.role ? `${this.role.company} — ${this.role.title}` : this.slug;
+    // Fire the narrative-add in the background; persist failure shouldn't
+    // block the cover edit.
+    addNarrative({ snippet: text, sourceRole, ask: comment.ask || '' }).catch(() => {});
+    try {
+      await this._applyCoverEdit({
+        anchorPhrase: comment.phrase,
+        anchorCommentLabel: 'Opportunity',
+        anchorRationale: comment.ask || comment.text || '',
+        instruction: `Weave in this new information from the candidate, naturally and concisely: ${text}`,
+        source: 'ai-comment',
+        label: `Opportunity: ${this._truncate(text, 50)}`,
+        commentIdForThread: comment.id,
+      });
+      // _applyCoverEdit replaces thread messages on success — append a
+      // small "saved to narratives" note so the user knows it persisted.
+      const cur = this._getThread(comment.id);
+      this._setThread(comment.id, {
+        messages: [...cur.messages, { role: 'assistant', text: 'Also saved to your narratives.' }],
+        sending: false, error: '',
+      });
+    } catch (e) {
+      // _applyCoverEdit already set thread error if commentIdForThread
+      // was passed — leave it.
+    }
   }
 
   // Send a chat message anchored to a comment. Thin wrapper around the

--- a/job/js/diff.js
+++ b/job/js/diff.js
@@ -75,20 +75,24 @@ function chunkPhrase(s) {
 
 function escapeRegex(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
 
-// Wrap AI-supplied highlights into the markdown source. `aiHighlights` is
-// an array of `{phrase, label, rationale}` returned by the cover-rationale
-// edge function. Each phrase is matched as a verbatim case-insensitive
-// substring; non-matches are silently skipped (the model occasionally
-// paraphrases). Returns `{html, comments}` shaped like highlightPhrases.
-export function applyAIHighlights(text, aiHighlights) {
+// Wrap AI-supplied highlights AND opportunities into the markdown source.
+// Both are returned by the cover-rationale edge function:
+//   highlights:    [{ phrase, label, rationale }]
+//   opportunities: [{ phrase, gap, ask }]
+// Each phrase is matched as a verbatim case-insensitive substring;
+// non-matches are silently skipped. Returns `{ html, comments }` where
+// each comment carries `kind: 'rationale' | 'opportunity'` so the rail
+// can style them differently.
+export function applyAIHighlights(text, highlights, opportunities) {
   const body = String(text || '');
-  if (!body || !Array.isArray(aiHighlights) || aiHighlights.length === 0) {
-    return { html: body, comments: [] };
-  }
+  const hl = Array.isArray(highlights) ? highlights : [];
+  const ops = Array.isArray(opportunities) ? opportunities : [];
+  if (!body || (!hl.length && !ops.length)) return { html: body, comments: [] };
   const lower = body.toLowerCase();
   const wrapped = [];
   const hits = [];
-  for (const h of aiHighlights) {
+
+  for (const h of hl) {
     const phrase = String(h?.phrase || '').trim();
     if (!phrase) continue;
     const start = lower.indexOf(phrase.toLowerCase());
@@ -96,8 +100,19 @@ export function applyAIHighlights(text, aiHighlights) {
     const end = start + phrase.length;
     if (wrapped.some(([s, e]) => start < e && end > s)) continue;
     wrapped.push([start, end]);
-    hits.push({ start, end, label: String(h.label || ''), rationale: String(h.rationale || '') });
+    hits.push({ start, end, kind: 'rationale', label: String(h.label || ''), body: String(h.rationale || '') });
   }
+  for (const o of ops) {
+    const phrase = String(o?.phrase || '').trim();
+    if (!phrase) continue;
+    const start = lower.indexOf(phrase.toLowerCase());
+    if (start < 0) continue;
+    const end = start + phrase.length;
+    if (wrapped.some(([s, e]) => start < e && end > s)) continue;
+    wrapped.push([start, end]);
+    hits.push({ start, end, kind: 'opportunity', label: 'Opportunity', gap: String(o.gap || ''), ask: String(o.ask || ''), body: String(o.gap || '') });
+  }
+
   if (!hits.length) return { html: body, comments: [] };
   hits.sort((a, b) => a.start - b.start);
   const comments = [];
@@ -105,9 +120,17 @@ export function applyAIHighlights(text, aiHighlights) {
   let cursor = 0;
   hits.forEach((h, i) => {
     const id = i + 1;
-    comments.push({ id, label: h.label, text: h.rationale });
+    comments.push({
+      id,
+      kind: h.kind,
+      label: h.label,
+      text: h.body,
+      ask: h.ask || '',
+      phrase: body.slice(h.start, h.end),
+    });
     out += body.slice(cursor, h.start);
-    out += `<mark class="d-jd" data-rationale="${id}">${body.slice(h.start, h.end)}<sup class="d-fn">${id}</sup></mark>`;
+    const cls = h.kind === 'opportunity' ? 'd-op' : 'd-jd';
+    out += `<mark class="${cls}" data-rationale="${id}">${body.slice(h.start, h.end)}<sup class="d-fn">${id}</sup></mark>`;
     cursor = h.end;
   });
   out += body.slice(cursor);

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -155,8 +155,8 @@ export async function formatResumeText(rawText) {
   return j.content;
 }
 
-// Get AI rationale for a cover letter given role-analysis source bullets.
-// Returns [{ phrase, label, rationale }] in document order; empty array on
+// Get AI rationale + opportunities for a cover letter given the role-analysis
+// source bullets. Returns { highlights, opportunities }; empty arrays on
 // failure. Stateless on the server.
 export async function fetchCoverRationale(coverText, sources) {
   const headers = await authHeader();
@@ -167,7 +167,23 @@ export async function fetchCoverRationale(coverText, sources) {
   });
   if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
   const j = await res.json();
-  return Array.isArray(j.highlights) ? j.highlights : [];
+  return {
+    highlights:    Array.isArray(j.highlights)    ? j.highlights    : [],
+    opportunities: Array.isArray(j.opportunities) ? j.opportunities : [],
+  };
+}
+
+// Append a markdown snippet to job.global_assets kind='narrative-additions'.
+// Used to capture missing info volunteered through opportunity threads.
+export async function addNarrative({ snippet, sourceRole, ask }) {
+  const headers = await authHeader();
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'narrative-add', snippet, source_role: sourceRole, ask }),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  return res.json();
 }
 
 // Apply a chat-driven edit to the cover letter. `comment` is optional
@@ -187,4 +203,4 @@ export async function applyCoverEdit({ coverText, instruction, comment }) {
   return j.content;
 }
 
-window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit };
+window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit, addNarrative };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.55.0">
-  <script src="/job/js/theme.js?v=0.55.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.56.0">
+  <script src="/job/js/theme.js?v=0.56.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.55.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.56.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.6.0';
-console.log(`[gen-asset] v${VERSION} - cover-edit kind: comment-anchored chat edits to the cover letter`);
+const VERSION = '0.7.0';
+console.log(`[gen-asset] v${VERSION} - cover opportunities + narrative-add to job.global_assets`);
 
 const BASE_RESUME_SLUG = '__base__';
 
@@ -101,7 +101,7 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
@@ -109,8 +109,34 @@ serve(async (req) => {
       : kindIn === 'format-resume' ? 'format-resume'
       : kindIn === 'cover-rationale' ? 'cover-rationale'
       : kindIn === 'cover-edit' ? 'cover-edit'
+      : kindIn === 'narrative-add' ? 'narrative-add'
       : null;
     if (!kind) return err('kind must be a known value', 400);
+
+    // narrative-add: append a markdown snippet to job.global_assets with
+    // kind='narrative-additions'. No AI call — pure persistence. The
+    // frontend uses this from opportunity threads to capture missing
+    // info the candidate volunteers.
+    if (kind === 'narrative-add') {
+      const snippet = String(body.snippet || '').trim();
+      const sourceRole = String(body.source_role || '').trim();
+      const ask = String(body.ask || '').trim();
+      if (!snippet) return err('snippet required', 400);
+      if (snippet.length > 8 * 1024) return err('snippet exceeds 8KB', 413);
+      const ts = new Date().toISOString();
+      const header = `\n\n### ${ts.slice(0, 10)}${sourceRole ? ` — from ${sourceRole}` : ''}${ask ? `\n_${ask}_` : ''}\n\n`;
+      const blob = header + snippet + '\n';
+      const sql = db();
+      await sql`
+        insert into job.global_assets (kind, content_md, generated_by, edited_at)
+        values ('narrative-additions', ${blob}, 'manual', now())
+        on conflict (kind) do update set
+          content_md = job.global_assets.content_md || ${blob},
+          edited_at = now(),
+          updated_at = now();
+      `;
+      return jsonResp({ ok: true, kind });
+    }
 
     // cover-edit is stateless: take cover letter + comment context +
     // user instruction, return the full revised markdown. No DB write —
@@ -167,7 +193,8 @@ Produce the JSON object now. JSON only.`;
       let parsed: any = null;
       try { parsed = JSON.parse(stripped); } catch { /* ignore */ }
       const highlights = Array.isArray(parsed?.highlights) ? parsed.highlights : [];
-      return jsonResp({ ok: true, kind, highlights });
+      const opportunities = Array.isArray(parsed?.opportunities) ? parsed.opportunities : [];
+      return jsonResp({ ok: true, kind, highlights, opportunities });
     }
 
     // format-resume is stateless: take raw text in, return clean markdown.

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -102,26 +102,33 @@ VOICE RULES:
 
 Output ONLY the markdown. No preamble. No "Here is your reformatted resume." Start with "# ".`;
 
-export const COVER_RATIONALE_VOICE = `You are annotating a cover letter to explain why each load-bearing phrase is there.
+export const COVER_RATIONALE_VOICE = `You are annotating a cover letter for the candidate. Two jobs:
+
+A) Explain why each load-bearing phrase is there ("highlights").
+B) Surface places where new information would strengthen the letter ("opportunities") — concrete data, projects, anecdotes, or narratives that aren't in the sources you were given but would obviously sharpen the application if the candidate added them.
 
 You will receive:
 - The full cover letter text.
 - A set of "source" bullets from a role analysis (Suggested angle, Why it fits, Strengths, Gaps to address). These describe what the cover letter SHOULD do for this role.
 
-Your job: identify 4–8 specific phrases or short sentences in the cover letter that map to one of the sources. For each, return:
-- "phrase":   an exact substring of the cover letter (verbatim, including any punctuation). Pick the shortest substring that captures the load-bearing claim — usually a clause, sometimes a sentence. Must appear EXACTLY in the cover letter.
-- "label":    one of "Suggested angle", "Why it fits", "Strengths", "Gaps to address" — the source field this phrase supports.
-- "rationale": one sentence (≤25 words) explaining what work the phrase does for the application — what point it makes, which JD/analysis bullet it addresses. NOT a paraphrase of the phrase itself.
+For HIGHLIGHTS, identify 4–8 specific phrases or short sentences that map to one of the sources. For each:
+- "phrase":    exact substring of the cover letter (verbatim, including punctuation). Pick the shortest substring that captures the load-bearing claim.
+- "label":     one of "Suggested angle", "Why it fits", "Strengths", "Gaps to address".
+- "rationale": one sentence (≤25 words) explaining what work the phrase does — NOT a paraphrase of itself.
 
-Output ONLY a JSON object: { "highlights": [ {phrase, label, rationale}, ... ] }. No prose, no code fence.
+For OPPORTUNITIES, identify 2–5 places where missing information would make the letter materially stronger. For each:
+- "phrase":     exact substring of the cover letter (verbatim) where the missing info would live. Usually a sentence the candidate has hedged or generalized. Must appear EXACTLY in the letter.
+- "gap":        one sentence (≤25 words) naming what's missing — e.g. "No specific metric for the platform scaling outcome," or "Vague on which compliance frameworks Ian has shipped against."
+- "ask":        one short question (≤20 words) the candidate could answer to fill the gap, written to them in second person ("What specific…", "Which framework…", "How long did…").
+
+Output ONLY a JSON object: { "highlights": [...], "opportunities": [...] }. No prose, no code fence.
 
 Rules:
-- Each "phrase" MUST be a verbatim substring. If a sentence has been rewritten, find the closest exact substring.
-- Phrases must NOT overlap. Pick the most important one if two candidates collide.
-- Order them in document order (top to bottom).
-- 4–8 highlights total. Quality over quantity. If only 4 sentences are doing real work, pick those 4.
-- Skip pleasantries, sign-offs, the opener salutation, and generic transitions.
-- Don't reuse the same source label more than 3 times.`;
+- Each phrase MUST be a verbatim substring. Highlights and opportunities can overlap with different rationales (rare, but allowed if both are genuinely there).
+- Order each list in document order.
+- Skip pleasantries, sign-offs, the opener salutation.
+- Highlights: don't reuse the same source label more than 3 times.
+- Opportunities: prefer specific asks that would unlock a concrete next sentence — avoid generic asks like "What else can you share?"`;
 
 export const COVER_EDIT_VOICE = `You will receive:
 - The current cover letter (markdown).
@@ -138,7 +145,7 @@ RULES:
 - Don't fabricate facts. If the instruction asks for evidence the letter doesn't have, lean on what's already there or skip.
 - Do NOT add a preamble or a meta line like "Here's the revised letter." Output ONLY the markdown.`;
 
-export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit';
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add';
 
 export function buildSystemPrompt(kind: GenKind): string {
   if (kind === 'format-resume') {

--- a/supabase/functions/role-asset/index.ts
+++ b/supabase/functions/role-asset/index.ts
@@ -9,17 +9,18 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.2.1';
-console.log(`[role-asset] v${VERSION} - route __base__ slug to job.global_assets (redeploy)`);
+const VERSION = '0.3.0';
+console.log(`[role-asset] v${VERSION} - __base__ + __narratives__ routes to job.global_assets`);
 
 const KIND_RE = /^(resume|cover-letter|notes|analysis)$/;
 const SLUG_RE = /^[a-z0-9_-]+$/;
 const MAX_BYTES = 64 * 1024;
 
-// Sentinel slug used by the frontend to address the global, untargeted base
-// resume. Persisted in job.global_assets (no FK to pipeline_roles).
+// Sentinel slugs that route to job.global_assets instead of role_assets.
 const BASE_SLUG = '__base__';
 const BASE_GLOBAL_KIND = 'base-resume';
+const NARRATIVES_SLUG = '__narratives__';
+const NARRATIVES_GLOBAL_KIND = 'narrative-additions';
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -38,7 +39,6 @@ serve(async (req) => {
       if (!KIND_RE.test(kind)) return err('invalid kind', 400);
 
       if (slug === BASE_SLUG) {
-        // Only resume is supported as a global asset today.
         if (kind !== 'resume') return err('not found', 404);
         const rows = await sql`
           select 'resume' as kind, content_md, generated_by, generated_at, edited_at, updated_at
@@ -48,6 +48,17 @@ serve(async (req) => {
         `;
         if (rows.length === 0) return err('not found', 404);
         return jsonResp({ slug: BASE_SLUG, ...rows[0] });
+      }
+
+      if (slug === NARRATIVES_SLUG) {
+        const rows = await sql`
+          select ${kind}::text as kind, content_md, generated_by, generated_at, edited_at, updated_at
+          from job.global_assets
+          where kind = ${NARRATIVES_GLOBAL_KIND}
+          limit 1;
+        `;
+        if (rows.length === 0) return err('not found', 404);
+        return jsonResp({ slug: NARRATIVES_SLUG, ...rows[0] });
       }
 
       const rows = await sql`


### PR DESCRIPTION
**`cover-rationale`** now returns both highlights and **opportunities** — places where new info/data/narratives would strengthen the letter. Opportunity comments render in the same rail with distinct amber styling, ✦ sigil, and the AI-generated ask as the subtitle. Inline marks use a dotted amber underline (rationale stays solid amber fill) so the two types are visually distinguishable.

When you answer an opportunity prompt in its thread, the info:
1. Appends to `job.global_assets` (kind='narrative-additions') via a new `narrative-add` gen-asset path.
2. Triggers a `cover-edit` that weaves the info into the letter at the anchor phrase.

Career → Narratives tab gets an **Additions** section pulling from the same row.

Bumps: gen-asset 0.7.0, role-asset 0.3.0, /job 0.56.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)