### PR TITLE
job: "In progress" pill on Saved rows

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2463,6 +2463,25 @@
 }
 .nav-sublist .nav-sub__label { min-width: 0; }
 
+/* "In progress" pill — appears on Saved rows that have engagement
+   signal (drill page opened, Apply tapped, or a resume generated). */
+.in-progress-pill {
+  display: inline-flex;
+  align-items: center;
+  margin-left: var(--space-2);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 /* Tiny count chip next to sub-nav labels (Saved · Active · Recommended). */
 .nav-count {
   display: inline-flex;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Recommended for you — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.58.0";
-console.log(`[job] v${VERSION} - Recommended for you on top of sub-nav + count chips; cover-opportunities from master`);
+const VERSION = "0.59.0";
+console.log(`[job] v${VERSION} - "In progress" pill on Saved rows once a role's been viewed or applied`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -570,7 +570,12 @@ export class JobPipeline extends LitElement {
           <div class="role-cell__inner">
             ${this._renderLogo(r, 'sm')}
             <div class="role-cell__text">
-              <div class="role-cell__title">${r.title || '(untitled)'}</div>
+              <div class="role-cell__title">
+                ${r.title || '(untitled)'}
+                ${this.bucket === 'leads' && r.engagedAt
+                  ? html`<span class="in-progress-pill" title="You've viewed or applied to this role">In progress</span>`
+                  : nothing}
+              </div>
               <div class="role-cell__company">${r.company || ''}</div>
             </div>
           </div>

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -24,7 +24,7 @@ async function getTurndown() {
   return td;
 }
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative, engageRole }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -160,6 +160,10 @@ export class JobRoleDetail extends LitElement {
       this.assets = { 'resume': resume, 'cover-letter': cover, 'analysis': analysis };
       this.baseResume = baseResume;
       this.state = 'loaded';
+      // Passive engagement signal — opening the drill page counts as
+      // "in progress." Fire-and-forget; the helper is idempotent so
+      // re-opens are no-ops on the server.
+      if (this.role) engageRole(this.slug);
       // Seed history with the loaded cover letter so the user has a
       // baseline to revert to even before they make any edits.
       if (cover?.content) {
@@ -1453,7 +1457,8 @@ export class JobRoleDetail extends LitElement {
         </div>
         <div class="role-header__actions">
           ${r.url ? html`
-            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer">Apply ↗</a>
+            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
+               @click=${() => engageRole(this.slug)}>Apply ↗</a>
           ` : nothing}
         </div>
       </header>
@@ -1561,7 +1566,8 @@ export class JobRoleDetail extends LitElement {
         </div>
         <div class="role-header__actions">
           ${r?.url ? html`
-            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer">
+            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
+               @click=${() => engageRole(this.slug)}>
               Apply ↗
             </a>
           ` : nothing}

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -32,6 +32,24 @@ export async function setStatus(role, status) {
   return res.json();
 }
 
+// Stamp engaged_at on a pipeline row. Called from the drill page on
+// open and from Apply-button clicks — a passive signal that drives
+// the "In progress" pill on Saved rows. Idempotent (server only
+// writes on first call) and keepalive:true so it survives the
+// navigation that follows an Apply tap.
+export async function engageRole(slug) {
+  if (!slug) return;
+  try {
+    const headers = await authHeader();
+    await fetch(FN_URL, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, action: 'engage' }),
+      keepalive: true,
+    });
+  } catch { /* engagement is fire-and-forget */ }
+}
+
 export async function setArchived(slug, archived) {
   const headers = await authHeader();
   const res = await fetch(FN_URL, {

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.58.0">
-  <script src="/job/js/theme.js?v=0.58.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.59.0">
+  <script src="/job/js/theme.js?v=0.59.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.58.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.59.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -12,8 +12,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.8.0';
-console.log(`[jobs-pipe] v${VERSION} - sheet removed`);
+const VERSION = '0.9.0';
+console.log(`[jobs-pipe] v${VERSION} - engaged_at: record drill-page opens + apply clicks`);
 
 const STATUS_ENUM = new Set([
   '', 'New', 'Apply', 'Talking', 'Applied', 'Pass', 'Rejected', 'Closed', 'Not Listed', 'Nudge / Network',
@@ -33,6 +33,7 @@ async function listRoles() {
       r.closed_detected_at as "closedDetectedAt",
       r.is_live as "isLive",
       r.liveness_checked_at as "livenessCheckedAt",
+      r.engaged_at as "engagedAt",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
       coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter",
       coalesce((
@@ -77,6 +78,19 @@ serve(async (req) => {
           where slug = ${slug};
         `;
         return jsonResp({ ok: true, slug, archived });
+      }
+
+      // Engagement signal — drill page open or Apply tap. Stamps
+      // engaged_at so the Saved-bucket row can show an "In progress"
+      // pill. Doesn't alter status; this is a passive signal.
+      if (body.action === 'engage') {
+        await sql`
+          update job.pipeline_roles
+             set engaged_at = coalesce(engaged_at, now()),
+                 updated_at = now()
+           where slug = ${slug};
+        `;
+        return jsonResp({ ok: true, slug, engaged: true });
       }
 
       // Soft delete — row stays in DB but disappears from every list.

--- a/supabase/migrations/061_pipeline_engaged_at.sql
+++ b/supabase/migrations/061_pipeline_engaged_at.sql
@@ -1,0 +1,18 @@
+-- pipeline_roles.engaged_at — set when the user shows engagement on a
+-- role *before* moving its status forward (e.g. opens the drill page,
+-- taps Apply). Drives the "In progress" pill on the Saved bucket so
+-- saved-but-touched rows surface above saved-but-untouched ones.
+--
+-- Also backfilled from hasResume: if a resume exists for the role, the
+-- user clearly engaged with it at some point.
+
+alter table job.pipeline_roles
+  add column if not exists engaged_at timestamptz;
+
+-- Backfill: any role with a generated resume counts as engaged.
+update job.pipeline_roles r
+   set engaged_at = coalesce(r.engaged_at, ra.updated_at, now())
+  from job.role_assets ra
+ where ra.role_slug = r.slug
+   and ra.kind = 'resume'
+   and r.engaged_at is null;


### PR DESCRIPTION
Stamps pipeline_roles.engaged_at on drill-open or Apply-tap. Renders 'In progress' pill on Saved-bucket rows where engaged_at is set. Backfills from role_assets so existing roles with resumes earn the pill retroactively. v0.59.0.