### PR TITLE
job: hotfix DB pool — max 4→1 to stop slot exhaustion

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"25fddd1f-3db8-4bad-84b9-2d8752453e3d","pid":89083,"procStart":"Mon May 11 17:14:36 2026","acquiredAt":1778520137892}

--- a/supabase/functions/_shared/job-db.ts
+++ b/supabase/functions/_shared/job-db.ts
@@ -1,5 +1,17 @@
 // Shared Postgres helper for /job Edge Functions.
 // Lazy-init a single connection per function instance.
+//
+// CRITICAL on Supabase Edge: every cold-started function instance opens
+// its own pool. Hundreds of instances × multiple connections each
+// quickly exhausts the project's connection budget (we hit "remaining
+// connection slots are reserved for roles with the SUPERUSER attribute"
+// at ~50 idle pgjs connections).
+//
+// max: 1               → one connection per instance is enough; edge
+//                        functions handle requests serially.
+// idle_timeout: 20     → release connections fast on warm instances.
+// connect_timeout: 10  → fail fast if the pool is exhausted instead of
+//                        holding the request open.
 import postgres from 'https://deno.land/x/postgresjs@v3.4.4/mod.js';
 
 let _sql: ReturnType<typeof postgres> | null = null;
@@ -8,6 +20,11 @@ export function db() {
   if (_sql) return _sql;
   const url = Deno.env.get('SUPABASE_DB_URL');
   if (!url) throw new Error('SUPABASE_DB_URL not configured');
-  _sql = postgres(url, { prepare: false, max: 4 });
+  _sql = postgres(url, {
+    prepare: false,
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
   return _sql;
 }


### PR DESCRIPTION
Pool max 4 × many cold instances = exhausted budget → 'remaining connection slots are reserved' errors. Drop to max:1 with fast idle timeout.