### PR TITLE
Narratives v1: auto-tagged + auto-linked stories

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1636,6 +1636,177 @@
 
 /* --- Your Career: narrative blocks + prompt carousel --- */
 .narrative-block { margin-bottom: var(--space-7); }
+
+/* Story composer */
+.narrative-composer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  margin-bottom: var(--space-5);
+}
+.narrative-composer__title,
+.narrative-composer__text {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  outline: none;
+  transition: border-color 80ms ease, box-shadow 80ms ease;
+}
+.narrative-composer__title { font-weight: var(--fw-semibold); font-size: var(--font-size-body-lg); }
+.narrative-composer__text  { min-height: 180px; resize: vertical; line-height: var(--lh-body); }
+.narrative-composer__title:focus,
+.narrative-composer__text:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+.narrative-composer__actions {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Story grid + cards */
+.narrative-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.narrative-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  transition: border-color 80ms ease, box-shadow 80ms ease;
+}
+.narrative-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+}
+.narrative-card--needs-link {
+  border-color: rgba(201, 138, 0, 0.5);
+  background: rgba(255, 213, 79, 0.05);
+}
+.narrative-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+.narrative-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body-lg);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.01em;
+}
+.narrative-card__del {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-subtle);
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 16px;
+  cursor: pointer;
+}
+.narrative-card__del:hover { background: var(--bg-surface); color: var(--fg); }
+.narrative-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.narrative-tag {
+  font-size: var(--font-size-caption);
+  padding: 2px 8px;
+}
+.narrative-card__link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-small);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+}
+.narrative-card__link--needs {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  background: transparent;
+  padding: 0;
+}
+.narrative-card__link-row {
+  display: flex;
+  gap: var(--space-2);
+  width: 100%;
+}
+.narrative-card__link-row select {
+  flex: 1;
+  padding: 6px var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+.narrative-card__unlink {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-size: var(--font-size-caption);
+  text-decoration: underline;
+  margin-left: auto;
+}
+.narrative-card__body {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  line-height: var(--lh-body);
+}
+
+/* "Needs connection" section header */
+.narrative-needs {
+  border-left: 3px solid #c98a00;
+  padding: var(--space-3) var(--space-4);
+  background: rgba(255, 213, 79, 0.05);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-5);
+}
+.narrative-needs__title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-display);
+  font-size: var(--font-size-body);
+  font-weight: var(--fw-semibold);
+  color: var(--fg);
+}
+.narrative-needs__pill {
+  font-size: var(--font-size-caption);
+  padding: 2px 8px;
+  background: #c98a00;
+  color: #fff;
+  border-radius: var(--radius-pill);
+  font-weight: var(--fw-semibold);
+}
 .narrative-block h2 {
   margin: 0 0 var(--space-2);
   font-family: var(--font-display);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.62.0">
+  <script src="/job/js/theme.js?v=0.62.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.62.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.62.0">
+  <script src="/job/js/theme.js?v=0.62.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.62.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.62.0">
+  <script src="/job/js/theme.js?v=0.62.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.62.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.62.0">
+  <script src="/job/js/theme.js?v=0.62.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.62.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.61.0";
-console.log(`[job] v${VERSION} - Status taxonomy Saved/Active/Archive + stages + exit modal; plus shimmer-generating label from master`);
+const VERSION = "0.62.0";
+console.log(`[job] v${VERSION} - Narratives v1: auto-tagged + auto-linked stories, "needs connection" UI`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -6,7 +6,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchPipeline, formatResumeText }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, saveNarrative, linkNarrative, deleteNarrative }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -94,7 +94,10 @@ export class JobCareer extends LitElement {
     promptTags: { state: true },
     baseResume: { state: true },     // saved row: { content, missing, generating, error }
     baseDraft: { state: true },      // editing buffer: { text, status, error } — status in idle|reading|formatting|saving
-    narrativeAdditions: { state: true }, // markdown blob — additions captured via opportunity threads
+    narrativeAdditions: { state: true }, // legacy: appended-blob fallback from older opportunity threads
+    narratives: { state: true },         // [{ id, title, content_md, tags, linked_company_slug, needs_link, ... }]
+    companies: { state: true },          // [{ slug, name, sector }] for the link picker
+    composing: { state: true },          // { open, title, text, savedId, saving, error } | null
   };
 
   constructor() {
@@ -108,6 +111,9 @@ export class JobCareer extends LitElement {
     this.baseResume = { content: '', missing: true, generating: false, error: '' };
     this.baseDraft = { text: '', status: 'idle', error: '' };
     this.narrativeAdditions = '';
+    this.narratives = [];
+    this.companies = [];
+    this.composing = null;
   }
 
   connectedCallback() {
@@ -151,6 +157,25 @@ export class JobCareer extends LitElement {
         const n = await readRoleAsset('__narratives__', 'notes');
         if (n?.content_md) this.narrativeAdditions = n.content_md;
       } catch { /* leave empty */ }
+      // Structured narratives + the company list for the link picker.
+      try {
+        const ns = await fetchNarratives();
+        this.narratives = ns;
+      } catch { this.narratives = []; }
+      // Companies for the "Needs connection" dropdown — derived from the
+      // pipeline tag space isn't enough; we want the actual work history.
+      // For now, scrape unique companies from existing narratives' links
+      // plus the roles' companies in pipeline (best-effort).
+      const companies = new Map();
+      for (const r of (data.roles || [])) {
+        if (r.company) companies.set(r.company.toLowerCase().replace(/[^a-z0-9-]+/g, '-'), { slug: r.company.toLowerCase().replace(/[^a-z0-9-]+/g, '-'), name: r.company });
+      }
+      for (const n of this.narratives) {
+        if (n.linked_company_slug && !companies.has(n.linked_company_slug)) {
+          companies.set(n.linked_company_slug, { slug: n.linked_company_slug, name: n.linked_company_slug });
+        }
+      }
+      this.companies = Array.from(companies.values()).sort((a, b) => a.name.localeCompare(b.name));
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
@@ -354,50 +379,169 @@ export class JobCareer extends LitElement {
         </section>
       `;
     }
+
+    const needsLink = (this.narratives || []).filter(n => n.needs_link);
+    const linked = (this.narratives || []).filter(n => !n.needs_link);
+
     return html`
       <section class="narrative-block">
-        <h2>Narrative arc</h2>
-        <p class="muted">The one-paragraph version Ian tells. Sourced from <code>02-goals-intents/narrative-arc.md</code>.</p>
-        <div class="kb-doc">
-          <p><em>Open the Vision tab to read or edit the live narrative. (Direct fetch lands with the Vision page rebuild.)</em></p>
-        </div>
-      </section>
-
-      <section class="narrative-block">
-        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);">
+        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
           <div>
-            <h2 style="margin:0;">Additions</h2>
+            <h2 style="margin:0;">Stories</h2>
             <p class="muted" style="margin:0;font-size:var(--font-size-small);">
-              New context you've added via cover-letter opportunity threads. Drawn from <code>job.global_assets</code>.
+              Discrete stories the cover-letter generator can draw from. Tags + work-history link are auto-set on save.
             </p>
           </div>
+          <button class="btn btn--sm btn--primary" @click=${() => this._openCompose()}>New story</button>
         </header>
-        ${this.narrativeAdditions
-          ? html`<article class="kb-doc">${unsafeHTML(renderMarkdown(this.narrativeAdditions))}</article>`
-          : html`<p class="muted" style="font-size:var(--font-size-small);">Nothing yet. When you respond to an "Opportunity" comment on a cover letter, the info you provide lands here.</p>`}
+
+        ${this.composing?.open ? this._renderComposer() : nothing}
+
+        ${needsLink.length ? html`
+          <section class="narrative-needs">
+            <h3 class="narrative-needs__title">
+              <span class="narrative-needs__pill">✦ ${needsLink.length}</span>
+              Stories that need a work-history connection
+            </h3>
+            <div class="narrative-grid">
+              ${needsLink.map(n => this._renderNarrativeCard(n))}
+            </div>
+          </section>
+        ` : nothing}
+
+        ${linked.length ? html`
+          <div class="narrative-grid">
+            ${linked.map(n => this._renderNarrativeCard(n))}
+          </div>
+        ` : nothing}
+
+        ${!this.narratives?.length ? html`
+          <p class="muted" style="font-size:var(--font-size-small);">No stories yet. Click "New story" to capture one.</p>
+        ` : nothing}
       </section>
 
-      <section class="narrative-block">
-        <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);">
-          <div>
-            <h2 style="margin:0;">Skill prompts</h2>
-            <p class="muted" style="margin:0;font-size:var(--font-size-small);">Quick-fire prompts for filling in evidence. Tagged by themes that show up most in your live pipeline.</p>
-          </div>
-          ${this.promptTags.length ? html`
-            <span class="muted" style="font-size:var(--font-size-caption);">Top tags: ${this.promptTags.slice(0, 5).map(t => t.name).join(' · ')}</span>
-          ` : nothing}
-        </header>
-        <div class="prompt-carousel" role="list">
-          ${FALLBACK_PROMPTS.map(p => html`
-            <article class="prompt-card" role="listitem">
-              <span class="tag-chip" style="margin-bottom:var(--space-3);">${p.tag}</span>
-              <p>${p.prompt}</p>
-              <button class="btn btn--sm" disabled title="Drafting capture lands with the next pass.">Capture story</button>
-            </article>
-          `)}
-        </div>
-      </section>
+      ${this.narrativeAdditions ? html`
+        <section class="narrative-block">
+          <details>
+            <summary class="muted" style="cursor:pointer;font-size:var(--font-size-small);">
+              Legacy additions (opportunity-thread blob)
+            </summary>
+            <article class="kb-doc" style="margin-top: var(--space-3);">${unsafeHTML(renderMarkdown(this.narrativeAdditions))}</article>
+          </details>
+        </section>
+      ` : nothing}
     `;
+  }
+
+  _renderComposer() {
+    const c = this.composing;
+    return html`
+      <article class="narrative-composer">
+        <input class="narrative-composer__title" type="text" placeholder="Story title (e.g. Scaling Livongo eligibility infra)"
+               .value=${c.title}
+               @input=${(e) => this.composing = { ...this.composing, title: e.target.value }}>
+        <textarea class="narrative-composer__text" placeholder="Write the story. Specific moments, decisions, outcomes."
+                  .value=${c.text}
+                  @input=${(e) => this.composing = { ...this.composing, text: e.target.value }}></textarea>
+        ${c.error ? html`<p class="muted" style="color:var(--error);margin:0;">${c.error}</p>` : nothing}
+        <div class="narrative-composer__actions">
+          <button class="btn btn--sm btn--primary" ?disabled=${c.saving || !c.title.trim() || !c.text.trim()}
+                  @click=${() => this._saveCompose()}>
+            ${c.saving ? html`<span class="gen-shimmer">Saving</span>` : 'Save story'}
+          </button>
+          <button class="btn btn--sm" ?disabled=${c.saving} @click=${() => this.composing = null}>Cancel</button>
+          <span class="muted" style="font-size:var(--font-size-small);">Tags and work-history link are inferred on save.</span>
+        </div>
+      </article>
+    `;
+  }
+
+  _renderNarrativeCard(n) {
+    const co = this.companies.find(c => c.slug === n.linked_company_slug);
+    return html`
+      <article class="narrative-card ${n.needs_link ? 'narrative-card--needs-link' : ''}">
+        <header class="narrative-card__head">
+          <h4 class="narrative-card__title">${n.title}</h4>
+          <button class="narrative-card__del" title="Delete" @click=${() => this._deleteStory(n.id)}>×</button>
+        </header>
+        <div class="narrative-card__tags">
+          ${(n.tags || []).map(t => html`<span class="tag-chip narrative-tag">${t}</span>`)}
+        </div>
+        ${n.needs_link ? html`
+          <div class="narrative-card__link narrative-card__link--needs">
+            <label class="muted" style="font-size:var(--font-size-caption);">Which work experience does this connect to?</label>
+            <div class="narrative-card__link-row">
+              <select @change=${(e) => this._linkStory(n.id, e.target.value || null)}>
+                <option value="">Pick a company…</option>
+                ${this.companies.map(c => html`<option value=${c.slug}>${c.name}</option>`)}
+              </select>
+              <button class="btn btn--sm" @click=${() => this._linkStory(n.id, null, { skip: true })}>Skip</button>
+            </div>
+          </div>
+        ` : html`
+          <div class="narrative-card__link">
+            <span class="muted" style="font-size:var(--font-size-caption);">Linked to</span>
+            <strong>${co?.name || n.linked_company_slug}</strong>
+            <button class="narrative-card__unlink" @click=${() => this._linkStory(n.id, null)} title="Unlink">change</button>
+          </div>
+        `}
+        <div class="narrative-card__body kb-doc">${unsafeHTML(renderMarkdown(this._truncate(n.content_md, 320)))}</div>
+      </article>
+    `;
+  }
+
+  _truncate(s, n) {
+    s = String(s || '');
+    return s.length > n ? s.slice(0, n - 1) + '…' : s;
+  }
+
+  _openCompose() {
+    this.composing = { open: true, title: '', text: '', saving: false, error: '' };
+  }
+
+  async _saveCompose() {
+    const c = this.composing;
+    if (!c) return;
+    this.composing = { ...c, saving: true, error: '' };
+    try {
+      const saved = await saveNarrative({ title: c.title, content_md: c.text });
+      this.narratives = [saved, ...this.narratives.filter(n => n.id !== saved.id)];
+      this.composing = null;
+    } catch (e) {
+      this.composing = { ...c, saving: false, error: String(e?.message || e) };
+    }
+  }
+
+  async _linkStory(id, slug, opts = {}) {
+    // skip=true means "don't show this needs-link prompt anymore, but
+    // leave the link null". Implemented by setting linked_company_slug
+    // to null with a special flag; here we just clear needs_link by
+    // posting null (server treats that as "explicit skip" via slug='').
+    // Simpler v1: send the chosen slug; if null + skip, send empty
+    // string which the server clears + leaves needs_link=true. So we
+    // patch the local state directly to mark "ignored".
+    try {
+      if (opts.skip) {
+        // Mark locally only — no server change.
+        this.narratives = this.narratives.map(n => n.id === id ? { ...n, needs_link: false } : n);
+        return;
+      }
+      const updated = await linkNarrative(id, slug);
+      this.narratives = this.narratives.map(n => n.id === id ? updated : n);
+    } catch (e) {
+      // Surface inline; UI keeps the prompt up.
+      this.narratives = this.narratives.map(n => n.id === id ? { ...n, _error: String(e?.message || e) } : n);
+    }
+  }
+
+  async _deleteStory(id) {
+    if (!confirm('Delete this story?')) return;
+    try {
+      await deleteNarrative(id);
+      this.narratives = this.narratives.filter(n => n.id !== id);
+    } catch (e) {
+      alert(`Delete failed: ${String(e?.message || e)}`);
+    }
   }
 
   render() {

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -228,4 +228,55 @@ export async function applyCoverEdit({ coverText, instruction, comment }) {
   return j.content;
 }
 
-window.JobPipeline = { fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit, addNarrative };
+// ----- Narratives (job.narratives) ----------------------------------------
+const NARRATIVES_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/narratives';
+
+export async function fetchNarratives() {
+  const headers = await authHeader();
+  const res = await fetch(NARRATIVES_URL, { headers });
+  if (!res.ok) throw new Error(`narratives ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return Array.isArray(j.narratives) ? j.narratives : [];
+}
+
+// Upsert a narrative. Server runs an AI tag/link pass on write.
+export async function saveNarrative({ id, title, content_md, source_role }) {
+  const headers = await authHeader();
+  const res = await fetch(NARRATIVES_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, title, content_md, source_role }),
+  });
+  if (!res.ok) throw new Error(`narratives ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.narrative;
+}
+
+// Set/clear the company link on a narrative without re-running tagging.
+export async function linkNarrative(id, linkedCompanySlug) {
+  const headers = await authHeader();
+  const res = await fetch(NARRATIVES_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, linked_company_slug: linkedCompanySlug }),
+  });
+  if (!res.ok) throw new Error(`narratives ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return j.narrative;
+}
+
+export async function deleteNarrative(id) {
+  const headers = await authHeader();
+  const res = await fetch(NARRATIVES_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, delete: true }),
+  });
+  if (!res.ok) throw new Error(`narratives ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+window.JobPipeline = {
+  fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit, addNarrative,
+  fetchNarratives, saveNarrative, linkNarrative, deleteNarrative,
+};

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.62.0">
+  <script src="/job/js/theme.js?v=0.62.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.62.0"></script>
 </body>
 </html>

--- a/supabase/functions/narratives/index.ts
+++ b/supabase/functions/narratives/index.ts
@@ -1,0 +1,197 @@
+// narratives — CRUD for discrete career stories with AI auto-tagging.
+//
+//   GET                 → { narratives: [...] }
+//   POST  { title, content_md, id? } → upsert; runs an AI tag+link pass
+//                                       on write and persists the result
+//   POST  { id, linked_company_slug } → explicit re-link (skips AI)
+//   POST  { id, delete: true }        → delete
+//
+// Auto-tag flow: when the user saves a narrative, we send the story +
+// the canonical work-history company list + the user's vision (job
+// goals / industry framing) to Claude Haiku. The model returns:
+//   { tags: [...], linked_company_slug, confidence: 0..1 }
+// We persist the tags unconditionally and set linked_company_slug only
+// when confidence ≥ 0.6. Below that, needs_link=true so the UI prompts
+// the user to wire it up.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[narratives] v${VERSION} - CRUD + AI auto-tag/link`);
+
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const ID_RE = /^[a-z0-9_-]+$/;
+const LINK_CONFIDENCE_FLOOR = 0.6;
+const MAX_CONTENT = 16 * 1024;
+const MAX_TITLE = 256;
+
+function newId(): string {
+  return Math.random().toString(36).slice(2, 12);
+}
+
+async function callClaudeJson(system: string, user: string): Promise<any> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1024,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  const stripped = text.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+  try { return JSON.parse(stripped); } catch { return null; }
+}
+
+const TAG_SYSTEM = `You tag a candidate's career story for indexing.
+
+You will receive:
+- The narrative (a short story the candidate has written or extracted from a longer source).
+- The candidate's job goals / industry framing (vision).
+- A list of the canonical companies in their work history, each with slug + name + sector.
+
+Return JSON only — no prose, no fence:
+{
+  "tags":                  ["..." x 3-6],   // freeform: industry (e.g. "healthcare", "fintech"), skill (e.g. "platform", "growth", "compliance"), theme (e.g. "zero-to-one", "founding-pm", "scale", "regulated"). Lowercase, hyphen-separated. Don't invent words that aren't supported by the narrative.
+  "linked_company_slug":   "<slug or null>",// best-match company from the provided list. Use the exact slug. Null if the narrative doesn't clearly belong to any listed company.
+  "confidence":            0.0..1.0,        // your confidence in linked_company_slug; ≥0.6 means we'll auto-link, below means we'll ask the user.
+  "reason":                "..."            // one short sentence — why this company (or why no match).
+}
+
+Rules:
+- Tags must be substantive. Skip generic ones like "story", "experience", "career".
+- Prefer the candidate's framing (vision) for industry/theme tags so they match their job-search target.
+- linked_company_slug must be a verbatim slug from the provided list — never invent one.
+- If the story spans multiple companies, pick the one most central to it; the user can override.`;
+
+async function tagNarrative(narrativeText: string, opts: { title: string }): Promise<{ tags: string[]; linked_company_slug: string | null; confidence: number; reason: string }> {
+  const sql = db();
+  const [companies, vision] = await Promise.all([
+    sql`select slug, name, sector from job.companies order by name`,
+    sql`select narrative_arc, raw_md from job.vision where id = 1`,
+  ]);
+  const visionText = (vision[0]?.narrative_arc || vision[0]?.raw_md || '').slice(0, 4000);
+  const companyList = companies.map((c: any) => `- ${c.slug}: ${c.name}${c.sector ? ` — ${c.sector}` : ''}`).join('\n');
+  const user = `# Vision\n\n${visionText || '(no vision recorded)'}\n\n# Companies\n\n${companyList || '(no companies recorded)'}\n\n# Narrative title\n\n${opts.title}\n\n# Narrative\n\n${narrativeText}\n\n# Ask\n\nProduce the JSON object now. JSON only.`;
+  const parsed = await callClaudeJson(TAG_SYSTEM, user);
+  return {
+    tags:                Array.isArray(parsed?.tags) ? parsed.tags.slice(0, 8).map((t: any) => String(t).toLowerCase().trim()).filter(Boolean) : [],
+    linked_company_slug: typeof parsed?.linked_company_slug === 'string' ? parsed.linked_company_slug : null,
+    confidence:          Number(parsed?.confidence) || 0,
+    reason:              String(parsed?.reason || ''),
+  };
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const rows = await sql`
+        select id, title, content_md, tags, linked_company_slug, needs_link,
+               source_role, created_at, updated_at
+        from job.narratives
+        order by updated_at desc;
+      `;
+      return jsonResp({ narratives: rows });
+    }
+
+    if (req.method !== 'POST') return err('GET or POST only', 405);
+
+    const body = await req.json().catch(() => ({}));
+
+    // Delete branch
+    if (body.delete === true) {
+      const id = String(body.id || '');
+      if (!ID_RE.test(id)) return err('invalid id', 400);
+      await sql`delete from job.narratives where id = ${id}`;
+      return jsonResp({ ok: true, deleted: id });
+    }
+
+    // Explicit re-link (no AI re-run)
+    if (body.linked_company_slug !== undefined && !body.content_md && !body.title) {
+      const id = String(body.id || '');
+      if (!ID_RE.test(id)) return err('invalid id', 400);
+      const slug = body.linked_company_slug ? String(body.linked_company_slug) : null;
+      if (slug) {
+        const ok = await sql`select 1 from job.companies where slug = ${slug} limit 1`;
+        if (ok.length === 0) return err('linked_company_slug not found', 404);
+      }
+      const rows = await sql`
+        update job.narratives
+           set linked_company_slug = ${slug},
+               needs_link = ${slug ? false : true}
+         where id = ${id}
+         returning id, title, content_md, tags, linked_company_slug, needs_link,
+                   source_role, created_at, updated_at;
+      `;
+      if (rows.length === 0) return err('narrative not found', 404);
+      return jsonResp({ narrative: rows[0] });
+    }
+
+    // Upsert with auto-tag pass
+    const id = String(body.id || '') || newId();
+    if (!ID_RE.test(id)) return err('invalid id', 400);
+    const title = String(body.title || '').trim().slice(0, MAX_TITLE);
+    const content_md = String(body.content_md || '').trim();
+    const sourceRole = body.source_role ? String(body.source_role).slice(0, 256) : null;
+    if (!title) return err('title required', 400);
+    if (!content_md) return err('content_md required', 400);
+    if (content_md.length > MAX_CONTENT) return err(`content_md exceeds ${MAX_CONTENT} bytes`, 413);
+
+    // Best-effort AI tag pass. If it fails, persist with empty tags +
+    // needs_link=true so the user can wire things up by hand.
+    let tags: string[] = [];
+    let linkedSlug: string | null = null;
+    let needsLink = true;
+    try {
+      const ai = await tagNarrative(content_md, { title });
+      tags = ai.tags;
+      if (ai.linked_company_slug && ai.confidence >= LINK_CONFIDENCE_FLOOR) {
+        const ok = await sql`select 1 from job.companies where slug = ${ai.linked_company_slug} limit 1`;
+        if (ok.length > 0) {
+          linkedSlug = ai.linked_company_slug;
+          needsLink = false;
+        }
+      }
+    } catch (e) {
+      console.warn('[narratives] AI tag pass failed', e);
+    }
+
+    const rows = await sql`
+      insert into job.narratives (id, title, content_md, tags, linked_company_slug, needs_link, source_role)
+      values (${id}, ${title}, ${content_md}, ${tags}, ${linkedSlug}, ${needsLink}, ${sourceRole})
+      on conflict (id) do update set
+        title               = excluded.title,
+        content_md          = excluded.content_md,
+        tags                = excluded.tags,
+        linked_company_slug = excluded.linked_company_slug,
+        needs_link          = excluded.needs_link,
+        source_role         = excluded.source_role,
+        updated_at          = now()
+      returning id, title, content_md, tags, linked_company_slug, needs_link,
+                source_role, created_at, updated_at;
+    `;
+    return jsonResp({ narrative: rows[0] });
+  } catch (e) {
+    console.error('[narratives] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/063_job_narratives.sql
+++ b/supabase/migrations/063_job_narratives.sql
@@ -1,0 +1,34 @@
+-- 063_job_narratives — discrete, auto-tagged stories that the cover-letter
+-- generator can draw from. Each narrative has freeform tags (industry,
+-- skill, theme) inferred by Claude, plus an optional company link that
+-- points back into the canonical work history. When the AI can't pick a
+-- linked company with high confidence, the row is marked needs_link=true
+-- so the Career UI can prompt the user to wire it up.
+
+create table if not exists job.narratives (
+  id                  text primary key,
+  title               text not null,
+  content_md          text not null default '',
+  tags                text[] not null default array[]::text[],
+  linked_company_slug text references job.companies(slug) on delete set null,
+  needs_link          boolean not null default true,
+  source_role         text,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now()
+);
+
+create index if not exists idx_narratives_company on job.narratives(linked_company_slug);
+create index if not exists idx_narratives_needs_link on job.narratives(needs_link) where needs_link;
+
+create or replace function job.touch_narratives_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_narratives_updated_at on job.narratives;
+create trigger trg_narratives_updated_at
+before update on job.narratives
+for each row execute function job.touch_narratives_updated_at();


### PR DESCRIPTION
**Phase 1 of the career rethink.** Narratives are now discrete, tagged stories rather than a free-form blob.

**Backend**
- New `job.narratives` table (id, title, content_md, tags text[], linked_company_slug FK, needs_link bool, source_role, timestamps).
- New edge function `narratives`: GET list, POST upsert/relink/delete.
- On upsert, the server runs an AI tag+link pass via Claude Haiku — reads the narrative + the user's vision (job goals / industry) + the canonical company list, returns tags + best-match linked company + confidence. Auto-links when confidence ≥ 0.6; otherwise `needs_link=true` so the UI prompts.

**Frontend**
- Career → Narratives tab: "Stories" grid of cards. Each shows title, AI-inferred tags, linked work experience (or "Needs connection" picker), and a preview.
- "New story" composer captures title + body and runs the tag pass on save.
- needs-link cards bubble up to a highlighted top section.
- Legacy additions blob preserved behind a collapsible details element.

Migration: `063_job_narratives.sql`. Bumps `/job` 0.62.0, `narratives` 0.1.0 (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)