### PR TITLE
job(gmail): source-email link on cards + role detail + status default fix

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2277,6 +2277,15 @@
   font-size: var(--font-size-body-sm);
   color: var(--text-muted);
 }
+.rec-source-email {
+  display: inline-block;
+  margin-left: 6px;
+  text-decoration: none;
+  opacity: 0.6;
+  font-size: 14px;
+  vertical-align: middle;
+}
+.rec-source-email:hover { opacity: 1; }
 
 .rec-actions {
   display: inline-flex;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.63.0";
-console.log(`[job] v${VERSION} - Work history Phase 2: projects + clients under each role`);
+const VERSION = "0.64.0";
+console.log(`[job] v${VERSION} - Source-email link on Gmail recs + role detail header`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -217,6 +217,10 @@ export class JobRecommendationsTable extends LitElement {
         </td>
         <td class="col col-sector" data-label="Source">
           <span class="rec-source">${r.sourceLabel || r.source || ''}</span>
+          ${r.sourceEmailUrl ? html`
+            <a class="rec-source-email" href=${r.sourceEmailUrl} target="_blank" rel="noopener"
+               title="Open the originating email in Gmail" @click=${(e) => e.stopPropagation()}>📧</a>
+          ` : nothing}
         </td>
         <td class="col col-added" data-label="Added">
           <span class="muted">${r.suggestedAt ? relTime(r.suggestedAt) : ''}</span>

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -138,6 +138,10 @@ export class JobRecommendations extends LitElement {
                 <span class="rec-card__source-icon" aria-hidden="true">🌐</span>
                 <a href=${rec.url} target="_blank" rel="noopener" class="link-subtle">${rec.sourceLabel}</a>
               ` : nothing}
+              ${rec.sourceEmailUrl ? html`
+                <span aria-hidden="true"> · </span>
+                <a href=${rec.sourceEmailUrl} target="_blank" rel="noopener" class="link-subtle" title="Open the originating email in Gmail">📧 source email</a>
+              ` : nothing}
             </p>
           </div>
         </header>

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -1498,6 +1498,10 @@ export class JobRoleDetail extends LitElement {
           </div>
         </div>
         <div class="role-header__actions">
+          ${r.sourceEmailUrl ? html`
+            <a class="btn btn--sm" href=${r.sourceEmailUrl} target="_blank" rel="noopener noreferrer"
+               title="Open the originating email in Gmail">📧 Source email</a>
+          ` : nothing}
           ${r.url ? html`
             <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
                @click=${() => engageRole(this.slug)}>Apply ↗</a>
@@ -1607,6 +1611,10 @@ export class JobRoleDetail extends LitElement {
           </div>
         </div>
         <div class="role-header__actions">
+          ${r?.sourceEmailUrl ? html`
+            <a class="btn btn--sm" href=${r.sourceEmailUrl} target="_blank" rel="noopener noreferrer"
+               title="Open the originating email in Gmail">📧 Source email</a>
+          ` : nothing}
           ${r?.url ? html`
             <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
                @click=${() => engageRole(this.slug)}>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -10,7 +10,10 @@ import { db } from '../_shared/job-db.ts';
 import { parseSectorTags } from '../_shared/sector-tags.ts';
 import { computeFit } from '../jobs-pipe/fit.ts';
 
-const VERSION = '0.1.6';
+const VERSION = '0.2.0';
+// Status default: 'Saved' (post-taxonomy collapse).
+// Source-email-link: stash payload.gmailApiId as a Gmail web URL when
+// the rec came from Gmail.
 console.log(`[add-role] v${VERSION} - JSON-LD JobPosting + careerspage.io + URL clean + company case + cleanTitle 'job in X'`);
 
 const URL_RE = /^https?:\/\//i;
@@ -380,7 +383,7 @@ serve(async (req) => {
           slug, company_slug, company_name, title, url, source, status
         ) values (
           ${slug}, ${companySlug}, ${company}, ${title},
-          ${url}, ${finalSource}, 'New'
+          ${url}, ${finalSource}, 'Saved'
         )
         on conflict (slug) do update set
           url = excluded.url,
@@ -399,7 +402,7 @@ serve(async (req) => {
           slug, company_slug, company_name, title, url, source, status
         ) values (
           ${slug}, null, ${company}, ${title},
-          ${url}, ${finalSource}, 'New'
+          ${url}, ${finalSource}, 'Saved'
         )
         on conflict (slug) do update set
           url = excluded.url,
@@ -519,14 +522,30 @@ serve(async (req) => {
       `;
     } catch (e) { console.warn('[add-role] fit calc failed', e); }
 
-    // Wire the recommendation → pipeline link, if any.
+    // Wire the recommendation → pipeline link, if any. Also stash a
+    // back-link to the source email when the rec came from Gmail so the
+    // user can re-open the originating thread from the role detail.
     if (body.fromRecommendationId) {
       try {
+        const recRows = await sql<{ source: string; payload: Record<string, unknown> | null }[]>`
+          select source, payload from job.recommended_roles
+           where id = ${body.fromRecommendationId} limit 1`;
         await sql`
           update job.recommended_roles
           set added_to_pipeline_slug = ${slug}
           where id = ${body.fromRecommendationId};
         `;
+        const rec = recRows[0];
+        const gmailApiId = rec?.source === 'gmail-jobs'
+          ? (rec.payload as Record<string, unknown> | null)?.gmailApiId
+          : null;
+        if (gmailApiId) {
+          await sql`
+            update job.pipeline_roles
+               set source_email_url = ${'https://mail.google.com/mail/u/0/#inbox/' + String(gmailApiId)}
+             where slug = ${slug} and source_email_url is null;
+          `;
+        }
       } catch (e) { console.warn('[add-role] rec link failed', e); }
     }
 

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.10.0';
-console.log(`[jobs-pipe] v${VERSION} - Saved/Active/Archive taxonomy + stage + exit_reason`);
+const VERSION = '0.10.1';
+console.log(`[jobs-pipe] v${VERSION} - return sourceEmailUrl for Gmail-sourced rows`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -53,6 +53,7 @@ async function listRoles() {
       r.is_live as "isLive",
       r.liveness_checked_at as "livenessCheckedAt",
       r.engaged_at as "engagedAt",
+      r.source_email_url as "sourceEmailUrl",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
       coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter",
       coalesce((

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.4.0';
-console.log(`[recommendations] v${VERSION} - ?view=all lifts score floor for "Recommended for you" page`);
+const VERSION = '0.5.0';
+console.log(`[recommendations] v${VERSION} - return sourceEmailUrl for Gmail-sourced rows`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -31,7 +31,13 @@ serve(async (req) => {
                r.salary, r.logo_url as "logoUrl", r.posted_at as "postedAt",
                r.description, r.match_bullets as "matchBullets", r.suggested_at as "suggestedAt",
                r.fit_score as "fitScore", r.fit_breakdown as "breakdown",
-               r.hard_fails as "hardFails", r.sector
+               r.hard_fails as "hardFails", r.sector,
+               -- Source-email URL — derived from payload.gmailApiId for
+               -- Gmail-sourced recs so the UI can render a "view source"
+               -- link without parsing the JSON client-side.
+               case when r.source = 'gmail-jobs' and r.payload ? 'gmailApiId'
+                    then 'https://mail.google.com/mail/u/0/#inbox/' || (r.payload->>'gmailApiId')
+                    else null end as "sourceEmailUrl"
         from job.recommended_roles r
         where r.dismissed_at is null
           and r.added_to_pipeline_slug is null

--- a/supabase/migrations/063_pipeline_source_email.sql
+++ b/supabase/migrations/063_pipeline_source_email.sql
@@ -1,0 +1,18 @@
+-- Source-email-link: when a role is added from a Gmail-sourced rec, we
+-- stash the Gmail web URL so the user can jump back to the originating
+-- email from the role detail page (and rec cards before they're added).
+--
+-- The URL is constructed from recommended_roles.payload->>'gmailApiId'
+-- at add-role time. Format: https://mail.google.com/mail/u/0/#inbox/{id}
+
+alter table job.pipeline_roles
+  add column if not exists source_email_url text;
+
+-- Backfill: any pipeline_role that's linked to a Gmail-sourced rec.
+update job.pipeline_roles p
+   set source_email_url = 'https://mail.google.com/mail/u/0/#inbox/' || (r.payload->>'gmailApiId')
+  from job.recommended_roles r
+ where r.added_to_pipeline_slug = p.slug
+   and r.source = 'gmail-jobs'
+   and r.payload ? 'gmailApiId'
+   and p.source_email_url is null;


### PR DESCRIPTION
Adds a Gmail link back to the originating email on every surface a Gmail-sourced role appears. Migration 063, add-role v0.2.0 (status default Saved), recommendations v0.5.0, jobs-pipe v0.10.1, app v0.64.0.