### PR TITLE
Phase 3: career-opportunities audit + answer-to-narrative threads

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1781,6 +1781,73 @@
   line-height: var(--lh-body);
 }
 
+/* Career opportunities banner */
+.career-ops {
+  margin-bottom: var(--space-6);
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-lg);
+  background: rgba(0, 120, 255, 0.04);
+  border: 1px solid rgba(0, 120, 255, 0.18);
+}
+.career-ops__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+.career-ops__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body-lg);
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.career-ops__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-3);
+}
+.career-op {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+}
+.career-op__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.career-op__scope {
+  font-size: var(--font-size-caption);
+  padding: 1px 8px;
+  border-radius: var(--radius-pill);
+  background: rgba(0, 120, 255, 0.1);
+  color: #1e88e5;
+  text-transform: capitalize;
+}
+.career-op__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body);
+  letter-spacing: -0.005em;
+}
+.career-op__gap { margin: 0; font-size: var(--font-size-small); color: var(--fg-muted); line-height: 1.5; }
+.career-op__ask {
+  margin: 0;
+  font-size: var(--font-size-small);
+  font-style: italic;
+  color: var(--fg);
+}
+
 /* "Needs connection" section header */
 .narrative-needs {
   border-left: 3px solid #c98a00;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.63.0";
-console.log(`[job] v${VERSION} - Work history Phase 2: projects + clients under each role`);
+const VERSION = "0.64.0";
+console.log(`[job] v${VERSION} - Phase 3: career-opportunities AI audit + answer-to-narrative threads`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -6,7 +6,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, saveNarrative, linkNarrative, deleteNarrative }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, saveNarrative, linkNarrative, deleteNarrative, fetchCareerOpportunities }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -98,6 +98,8 @@ export class JobCareer extends LitElement {
     narratives: { state: true },         // [{ id, title, content_md, tags, linked_company_slug, needs_link, ... }]
     companies: { state: true },          // [{ slug, name, sector }] for the link picker
     composing: { state: true },          // { open, title, text, savedId, saving, error } | null
+    opportunities: { state: true },      // { items, loading, error } — AI-flagged career gaps
+    opportunityThreads: { state: true }, // { [idx]: { messages, sending, error } }
   };
 
   constructor() {
@@ -114,6 +116,8 @@ export class JobCareer extends LitElement {
     this.narratives = [];
     this.companies = [];
     this.composing = null;
+    this.opportunities = { items: [], loading: false, error: '' };
+    this.opportunityThreads = {};
   }
 
   connectedCallback() {
@@ -384,6 +388,8 @@ export class JobCareer extends LitElement {
     const linked = (this.narratives || []).filter(n => !n.needs_link);
 
     return html`
+      ${this._renderOpportunities()}
+
       <section class="narrative-block">
         <header style="display:flex;justify-content:space-between;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-3);flex-wrap:wrap;">
           <div>
@@ -542,6 +548,146 @@ export class JobCareer extends LitElement {
     } catch (e) {
       alert(`Delete failed: ${String(e?.message || e)}`);
     }
+  }
+
+  // ----- Career opportunities ---------------------------------------------
+
+  async _loadOpportunities() {
+    if (this.opportunities.loading) return;
+    this.opportunities = { items: [], loading: true, error: '' };
+    try {
+      const items = await fetchCareerOpportunities();
+      this.opportunities = { items, loading: false, error: '' };
+    } catch (e) {
+      this.opportunities = { items: [], loading: false, error: String(e?.message || e) };
+    }
+  }
+
+  _getOpThread(idx) {
+    return this.opportunityThreads[idx] || { messages: [], sending: false, error: '' };
+  }
+
+  _setOpThread(idx, t) {
+    this.opportunityThreads = { ...this.opportunityThreads, [idx]: t };
+  }
+
+  // Answering an opportunity creates a new narrative anchored to the
+  // company the opportunity was flagged against. The server's tag pass
+  // will reaffirm the link + assign tags consistent with the vision.
+  async _sendOpportunityAnswer(idx, userText) {
+    const op = this.opportunities.items[idx];
+    if (!op) return;
+    const text = String(userText || '').trim();
+    if (!text) return;
+    const prev = this._getOpThread(idx);
+    this._setOpThread(idx, {
+      messages: [...prev.messages, { role: 'user', text }],
+      sending: true, error: '',
+    });
+    try {
+      const title = op.title || `Captured from opportunity #${idx + 1}`;
+      const body = `> ${op.ask || op.gap || ''}\n\n${text}`;
+      const saved = await saveNarrative({ title, content_md: body, source_role: op.anchor_company_slug || '' });
+      this.narratives = [saved, ...this.narratives.filter(n => n.id !== saved.id)];
+      const cur = this._getOpThread(idx);
+      this._setOpThread(idx, {
+        messages: [...cur.messages, { role: 'assistant', text: 'Saved as a new story. Tags and link inferred.' }],
+        sending: false, error: '',
+      });
+    } catch (e) {
+      const cur = this._getOpThread(idx);
+      this._setOpThread(idx, { messages: cur.messages, sending: false, error: String(e?.message || e) });
+    }
+  }
+
+  _renderOpportunities() {
+    const o = this.opportunities;
+    return html`
+      <section class="career-ops">
+        <header class="career-ops__head">
+          <div>
+            <h3 class="career-ops__title">✦ Opportunities to strengthen your career KB</h3>
+            <p class="muted" style="margin:0;font-size:var(--font-size-small);">
+              AI-flagged gaps. Answer in a thread and the response saves as a new story.
+            </p>
+          </div>
+          <button class="btn btn--sm" ?disabled=${o.loading} @click=${() => this._loadOpportunities()}>
+            ${o.loading ? html`<span class="gen-shimmer">Auditing</span>` : (o.items.length ? 'Re-audit' : 'Find opportunities')}
+          </button>
+        </header>
+        ${o.error ? html`<p class="muted" style="color:var(--error);">${o.error}</p>` : nothing}
+        ${o.items.length ? html`
+          <div class="career-ops__grid">
+            ${o.items.map((op, idx) => this._renderOpportunityCard(op, idx))}
+          </div>
+        ` : !o.loading && !o.error ? html`
+          <p class="muted" style="font-size:var(--font-size-small);">Click "Find opportunities" to audit your career KB.</p>
+        ` : nothing}
+      </section>
+    `;
+  }
+
+  _renderOpportunityCard(op, idx) {
+    const thread = this._getOpThread(idx);
+    return html`
+      <article class="career-op">
+        <header class="career-op__head">
+          <span class="career-op__scope" data-scope=${op.scope || 'narrative'}>${op.scope || 'narrative'}</span>
+          <h4 class="career-op__title">${op.title}</h4>
+        </header>
+        ${op.gap ? html`<p class="career-op__gap">${op.gap}</p>` : nothing}
+        ${op.ask ? html`<p class="career-op__ask">${op.ask}</p>` : nothing}
+        ${op.anchor_company_slug ? html`
+          <p class="muted" style="font-size:var(--font-size-caption);margin:0;">Anchored to <strong>${op.anchor_company_slug}</strong></p>
+        ` : nothing}
+
+        ${thread.messages.length ? html`
+          <ul class="cover-thread">
+            ${thread.messages.map(m => html`
+              <li class="cover-thread__msg cover-thread__msg--${m.role}">
+                ${unsafeHTML(renderMarkdown(m.text))}
+              </li>
+            `)}
+            ${thread.sending ? html`
+              <li class="cover-thread__msg cover-thread__msg--assistant">
+                <span class="gen-shimmer">Saving</span>
+              </li>
+            ` : nothing}
+            ${thread.error ? html`
+              <li class="cover-thread__msg cover-thread__msg--error">${thread.error}</li>
+            ` : nothing}
+          </ul>
+        ` : nothing}
+
+        <form class="cover-thread__form" @submit=${(e) => {
+          e.preventDefault();
+          const input = e.currentTarget.querySelector('textarea');
+          const v = input.value;
+          input.value = '';
+          this._sendOpportunityAnswer(idx, v);
+        }}>
+          <textarea class="cover-thread__input"
+                    rows="1"
+                    placeholder="Answer to fill this gap…"
+                    ?disabled=${thread.sending}
+                    @keydown=${(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        e.currentTarget.form.requestSubmit();
+                      }
+                    }}
+                    @input=${(e) => {
+                      e.target.style.height = 'auto';
+                      e.target.style.height = e.target.scrollHeight + 'px';
+                    }}></textarea>
+          <button class="cover-thread__send" type="submit" ?disabled=${thread.sending} aria-label="Send">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M8 13V3"/><path d="M3 8l5-5 5 5"/>
+            </svg>
+          </button>
+        </form>
+      </article>
+    `;
   }
 
   render() {

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -228,6 +228,20 @@ export async function applyCoverEdit({ coverText, instruction, comment }) {
   return j.content;
 }
 
+// Audit the career KB (companies/projects/clients + narratives + vision)
+// and return highest-leverage gaps to fill. Stateless on the server.
+export async function fetchCareerOpportunities() {
+  const headers = await authHeader();
+  const res = await fetch(GEN_ASSET_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ kind: 'career-opportunities' }),
+  });
+  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return Array.isArray(j.opportunities) ? j.opportunities : [];
+}
+
 // ----- Narratives (job.narratives) ----------------------------------------
 const NARRATIVES_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/narratives';
 
@@ -339,4 +353,5 @@ window.JobPipeline = {
   fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit, addNarrative,
   fetchNarratives, saveNarrative, linkNarrative, deleteNarrative,
   fetchRoleProjects, saveRoleProject, deleteRoleProject, saveProjectClient, deleteProjectClient,
+  fetchCareerOpportunities,
 };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.63.0">
-  <script src="/job/js/theme.js?v=0.63.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.64.0">
+  <script src="/job/js/theme.js?v=0.64.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.63.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.64.0"></script>
 </body>
 </html>

--- a/supabase/functions/gen-asset/index.ts
+++ b/supabase/functions/gen-asset/index.ts
@@ -10,8 +10,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { buildSystemPrompt, buildUserMessage } from './prompts.ts';
 
-const VERSION = '0.7.0';
-console.log(`[gen-asset] v${VERSION} - cover opportunities + narrative-add to job.global_assets`);
+const VERSION = '0.8.0';
+console.log(`[gen-asset] v${VERSION} - career-opportunities kind: AI audit of work history + narratives`);
 
 const BASE_RESUME_SLUG = '__base__';
 
@@ -101,7 +101,7 @@ serve(async (req) => {
     const slugIn = body.slug ? String(body.slug).toLowerCase() : null;
     const rowIn = Number.isInteger(Number(body.rowNumber)) ? Number(body.rowNumber) : null;
     const kindIn = body.kind;
-    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add' | null =
+    const kind: 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add' | 'career-opportunities' | null =
       kindIn === 'cover-letter' ? 'cover-letter'
       : kindIn === 'resume'     ? 'resume'
       : kindIn === 'analysis'   ? 'analysis'
@@ -110,6 +110,7 @@ serve(async (req) => {
       : kindIn === 'cover-rationale' ? 'cover-rationale'
       : kindIn === 'cover-edit' ? 'cover-edit'
       : kindIn === 'narrative-add' ? 'narrative-add'
+      : kindIn === 'career-opportunities' ? 'career-opportunities'
       : null;
     if (!kind) return err('kind must be a known value', 400);
 
@@ -195,6 +196,50 @@ Produce the JSON object now. JSON only.`;
       const highlights = Array.isArray(parsed?.highlights) ? parsed.highlights : [];
       const opportunities = Array.isArray(parsed?.opportunities) ? parsed.opportunities : [];
       return jsonResp({ ok: true, kind, highlights, opportunities });
+    }
+
+    // career-opportunities: audit work history + narratives + KB and
+    // return the highest-leverage gaps to fill. Stateless — frontend
+    // shows them as callouts and persists the answers via narrative-add
+    // or project upserts as appropriate.
+    if (kind === 'career-opportunities') {
+      const sql = db();
+      const [vision, companies, projects, clients, narratives] = await Promise.all([
+        sql`select narrative_arc, raw_md from job.vision where id = 1`,
+        sql`select slug, name, sector, body_md from job.companies`,
+        sql`select id, company_slug, role_title, name, description, outcome, metric from job.role_projects`,
+        sql`select project_id, name, kind, description from job.project_clients`,
+        sql`select id, title, tags, linked_company_slug, content_md from job.narratives`,
+      ]);
+      const visionText = (vision[0]?.narrative_arc || vision[0]?.raw_md || '').slice(0, 6000);
+      const clientsByProject = new Map<string, any[]>();
+      for (const c of clients) {
+        if (!clientsByProject.has(c.project_id)) clientsByProject.set(c.project_id, []);
+        clientsByProject.get(c.project_id)!.push(c);
+      }
+      const projectsByCompany = new Map<string, any[]>();
+      for (const p of projects) {
+        if (!projectsByCompany.has(p.company_slug)) projectsByCompany.set(p.company_slug, []);
+        projectsByCompany.get(p.company_slug)!.push({ ...p, clients: clientsByProject.get(p.id) || [] });
+      }
+      const companyBlocks = companies.map((c: any) => {
+        const ps = (projectsByCompany.get(c.slug) || []).map((p: any) =>
+          `  - Project ${p.id}: ${p.name}${p.metric ? ` (metric: ${p.metric})` : ''}${p.outcome ? ` — outcome: ${p.outcome.slice(0, 160)}` : ''}${p.clients.length ? ` — clients: ${p.clients.map((c: any) => `${c.name} [${c.kind}]`).join(', ')}` : ''}`
+        ).join('\n');
+        return `## ${c.slug}: ${c.name}${c.sector ? ` — ${c.sector}` : ''}\n${ps || '  (no projects captured)'}`;
+      }).join('\n\n');
+      const narrativeBlocks = narratives.map((n: any) =>
+        `- ${n.id}: "${n.title}" — tags: ${(n.tags || []).join(', ') || '(none)'} — linked: ${n.linked_company_slug || '(unlinked)'}`
+      ).join('\n');
+
+      const system = buildSystemPrompt(kind);
+      const user = `# Vision\n\n${visionText || '(no vision recorded)'}\n\n# Work history\n\n${companyBlocks || '(no companies)'}\n\n# Existing narratives\n\n${narrativeBlocks || '(no narratives yet)'}\n\n# Ask\n\nProduce the JSON object now. JSON only.`;
+      const raw = await callClaude(system, user);
+      const stripped = raw.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+      let parsedOps: any = null;
+      try { parsedOps = JSON.parse(stripped); } catch { /* ignore */ }
+      const opportunities = Array.isArray(parsedOps?.opportunities) ? parsedOps.opportunities : [];
+      return jsonResp({ ok: true, kind, opportunities });
     }
 
     // format-resume is stateless: take raw text in, return clean markdown.

--- a/supabase/functions/gen-asset/prompts.ts
+++ b/supabase/functions/gen-asset/prompts.ts
@@ -145,7 +145,29 @@ RULES:
 - Don't fabricate facts. If the instruction asks for evidence the letter doesn't have, lean on what's already there or skip.
 - Do NOT add a preamble or a meta line like "Here's the revised letter." Output ONLY the markdown.`;
 
-export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add';
+export const CAREER_OPPORTUNITIES_VOICE = `You audit a candidate's career KB and surface the highest-leverage gaps to fill — places where adding a story, a project detail, a metric, or a client name would materially improve every future cover letter, resume, or pitch.
+
+You will receive:
+- The candidate's vision (job goals / industry framing).
+- The list of companies in their work history (slug + name + sector + roles + role-projects + clients).
+- The list of existing narratives (title + tags + linked company) — what the candidate has already captured as a story.
+
+Return 4–8 opportunities, prioritized by leverage. Each:
+- "title":      short, action-oriented (≤8 words). e.g. "Capture the Livongo eligibility win as a story", "Add a metric to the Spruce platform project".
+- "gap":        one sentence (≤25 words) — what's missing and why it matters for the candidate's job-search target. Reference specific company/role/project slugs when relevant.
+- "ask":        one short question (≤20 words), second person, the candidate can answer to fill the gap. Concrete enough to unlock a sentence or two of new content.
+- "scope":      one of "narrative" | "project" | "client" | "metric" — what kind of artifact this fills.
+- "anchor_company_slug": exact slug from the work history if the gap is anchored to a company; null if it's a cross-cutting / theme gap.
+
+Output ONLY a JSON object: { "opportunities": [...] }. No prose, no code fence.
+
+Rules:
+- Don't suggest filling things that are already captured.
+- Don't generate generic asks ("share more about your background"). Be specific.
+- Lean toward the candidate's stated job-search target when picking which gaps to prioritize.
+- Prefer fillable gaps (metric, client name, single story) over open-ended ones.`;
+
+export type GenKind = 'resume' | 'cover-letter' | 'analysis' | 'base-resume' | 'format-resume' | 'cover-rationale' | 'cover-edit' | 'narrative-add' | 'career-opportunities';
 
 export function buildSystemPrompt(kind: GenKind): string {
   if (kind === 'format-resume') {
@@ -153,6 +175,9 @@ export function buildSystemPrompt(kind: GenKind): string {
   }
   if (kind === 'cover-rationale') {
     return COVER_RATIONALE_VOICE;
+  }
+  if (kind === 'career-opportunities') {
+    return CAREER_OPPORTUNITIES_VOICE;
   }
   if (kind === 'cover-edit') {
     return `You are revising Ian Fike's cover letter. Apply the user's edit instruction precisely.


### PR DESCRIPTION
New `career-opportunities` gen-asset kind pulls work history + projects/clients + narratives + vision and asks Claude Haiku to surface 4-8 highest-leverage gaps with title / gap / ask / scope / anchor_company_slug.

Career → Narratives tab gets an **Opportunities** banner above Stories. Each card has the gap, the ask, and an inline Wise-style thread. Answering submits a new narrative anchored to the company slug; the server's tag pass infers tags + reaffirms the link.

Bumps: gen-asset 0.8.0, /job 0.64.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)