### PR TITLE
job: fit score v2 — mission + domain + skills + arc

### DIFF
--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -45,13 +45,16 @@ function bucketFor(r) {
 }
 
 const DIM_LABELS = {
-  title:   { label: 'Title match',   max: 25, hint: 'Founding/Senior/Staff PM scores higher; below seniority hard-fails.' },
-  stage:   { label: 'Stage',         max: 20, hint: 'Inferred from investors. Pre-seed → C scores high; public/mega-cap hard-fails.' },
-  sector:  { label: 'Sector',        max: 20, hint: 'Health and EdTech are top; AI-native / SaaS / Fintech middle.' },
-  geo:     { label: 'Geography',     max: 15, hint: 'Sheet has no geo column — neutral default for now.' },
-  comp:    { label: 'Compensation',  max: 10, hint: 'Top of range ≥ $200k = full marks.' },
-  source:  { label: 'Source',        max: 5,  hint: 'Network > LinkedIn Saved > LinkedIn Recommended > Company Pages > Manual.' },
-  network: { label: 'Network',       max: 5,  hint: 'A named contact in the row gets +5.' },
+  mission: { label: 'Mission & impact', max: 20, hint: 'Posting text matches your impact themes (health outcomes, cost reduction, education access, AI ethics). Anti-themes zero this out.' },
+  domain:  { label: 'Domain experience', max: 15, hint: 'Posting sector overlaps with companies you have worked at — healthtech, edtech, consumer SaaS surface automatically.' },
+  skills:  { label: 'Skills match',     max: 15, hint: 'Posting mentions skills from your profile (UX, platform thinking, zero-to-one, growth experimentation). Years-weighted.' },
+  title:   { label: 'Title match',      max: 15, hint: 'Founding / Senior / Staff PM scores higher; below seniority hard-fails.' },
+  arc:     { label: 'Career arc',       max: 10, hint: 'Stage + scope coherence: founding at seed/A, scale-up at B+, IPO/acquisition language.' },
+  stage:   { label: 'Stage',            max: 10, hint: 'Inferred from investors. Pre-seed → C scores high; public / mega-cap hard-fails.' },
+  geo:     { label: 'Geography',        max: 5,  hint: 'Most geo filtering happens upstream — this is a small bonus.' },
+  comp:    { label: 'Compensation',     max: 5,  hint: 'Top of range ≥ $200k = full marks.' },
+  source:  { label: 'Source',           max: 3,  hint: 'Network > LinkedIn Saved > LinkedIn Recommended > Company Pages.' },
+  network: { label: 'Network',          max: 2,  hint: 'A named contact in the row gets +2.' },
 };
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.

--- a/supabase/functions/jobs-pipe/fit.ts
+++ b/supabase/functions/jobs-pipe/fit.ts
@@ -1,5 +1,15 @@
-// Fit score — deterministic, fixed weights for v1 per PRD.
-// Pure function. No I/O. Inputs come from a single sheet row.
+// Fit score v2 — deterministic, weighted across role-fit, mission alignment,
+// domain experience, skills, and career-arc signals. Pure function. No I/O.
+//
+// Inputs:
+//   - RoleRow: one posting (sheet row OR pulled rec, normalized).
+//   - UserContext (optional): vision mission keywords + skills + companies
+//     pulled from job.* tables. When absent, those buckets score neutral
+//     so legacy callers (add-role) still work without crashes.
+//
+// Weights (total 100, ordered by importance):
+//   mission 20 | domain 15 | skills 15 | title 15 | arc 10
+//   stage 10 | geo 5 | comp 5 | source 3 | network 2
 
 export interface RoleRow {
   status: string;
@@ -14,125 +24,263 @@ export interface RoleRow {
   investors: string;
   website: string;
   crunchbase: string;
+  // v2: full posting description, used by mission/skills/arc/domain.
+  description?: string;
+}
+
+export interface UserContext {
+  // From job.vision — keyword pools the scorer matches posting text against.
+  missionKeywords:   string[];   // health, education, cost-reduction terms
+  antiMissionTerms:  string[];   // gambling, crypto, payday → mission = 0
+  impactThemes:      string[];   // (kept for telemetry; not directly scored)
+  missionRequired:   boolean;    // when true, zero-mission roles hard-fail
+  // From job.skills — skill names + level/years.
+  skills:            Array<{ name: string; years?: number | null }>;
+  // From job.companies — sectors the user has actually worked in.
+  pastSectors:       string[];   // free-text sector descriptions, lowercased
+  // From job.vision.narrative_arc — career arc tags (ipo, acquisition,
+  // zero-to-one, scale-up, platform, fractional, founding).
+  arcTags:           string[];
 }
 
 export interface FitBreakdown {
-  title: number;
-  stage: number;
-  sector: number;
-  geo: number;
-  comp: number;
-  source: number;
+  mission: number;
+  domain:  number;
+  skills:  number;
+  title:   number;
+  arc:     number;
+  stage:   number;
+  geo:     number;
+  comp:    number;
+  source:  number;
   network: number;
 }
 
 export interface FitResult {
-  score: number;
+  score:     number;
   breakdown: FitBreakdown;
   hardFails: string[];
 }
 
 const HARD_FAIL_CAP = 30;
 
-// --- Title scoring (max 25) ---
+// ---------- Helpers ----------
+
+function postingText(r: RoleRow): string {
+  return [r.title, r.company, r.sector, r.description || '']
+    .filter(Boolean).join(' ').toLowerCase();
+}
+
+function countMatches(haystack: string, needles: string[]): number {
+  let n = 0;
+  for (const t of needles) {
+    const k = t.trim().toLowerCase();
+    if (!k) continue;
+    if (haystack.includes(k)) n++;
+  }
+  return n;
+}
+
+// ---------- Title (max 15) ----------
 function scoreTitle(t: string): { v: number; fail?: string } {
   const s = t.toLowerCase();
   if (!s) return { v: 0 };
   if (/intern|coordinator|associate|assistant\b/.test(s)) return { v: 0, fail: 'below seniority floor' };
-  if (/founding (pm|product)/.test(s)) return { v: 25 };
-  if (/(?:^|\s)(product lead|head of product)\b/.test(s)) return { v: 22 };
-  if (/principal pm|principal product manager|staff pm|staff product manager/.test(s)) return { v: 20 };
-  if (/group product manager|group pm/.test(s)) return { v: 18 };
-  if (/senior pm|senior product manager|sr\.? pm/.test(s)) return { v: 18 };
-  if (/director, product|director of product/.test(s)) return { v: 15 };
-  if (/(^|\W)(pm|product manager)(\W|$)/.test(s)) return { v: 10 };
-  return { v: 5 };
+  if (/founding (pm|product)/.test(s)) return { v: 15 };
+  if (/(?:^|\s)(product lead|head of product)\b/.test(s)) return { v: 13 };
+  if (/principal pm|principal product manager|staff pm|staff product manager/.test(s)) return { v: 12 };
+  if (/group product manager|group pm/.test(s)) return { v: 11 };
+  if (/senior pm|senior product manager|sr\.? pm/.test(s)) return { v: 11 };
+  if (/director, product|director of product/.test(s)) return { v: 9 };
+  if (/(^|\W)(pm|product manager)(\W|$)/.test(s)) return { v: 6 };
+  return { v: 3 };
 }
 
-// --- Stage signal (max 20). We have no stage column; infer from investor names. ---
+// ---------- Mission (max 20) ----------
+// Match posting text against the user's mission_keywords pool. Anti-mission
+// hits zero out the bucket. When mission_required and zero matches → hard fail.
+function scoreMission(r: RoleRow, ctx?: UserContext): { v: number; fail?: string } {
+  if (!ctx) return { v: 10 }; // neutral when no context loaded
+  const text = postingText(r);
+  if (ctx.antiMissionTerms.length && countMatches(text, ctx.antiMissionTerms) > 0) {
+    return { v: 0, fail: 'mission-conflict (anti-theme)' };
+  }
+  if (!ctx.missionKeywords.length) return { v: 10 };
+  const hits = countMatches(text, ctx.missionKeywords);
+  if (hits === 0) {
+    if (ctx.missionRequired) return { v: 0, fail: 'no mission alignment' };
+    return { v: 4 };
+  }
+  if (hits === 1) return { v: 10 };
+  if (hits === 2) return { v: 14 };
+  if (hits === 3) return { v: 17 };
+  return { v: 20 };
+}
+
+// ---------- Domain (max 15) ----------
+// Has the user worked in a sector adjacent to this posting? Compare
+// posting text vs the words inside each pastSectors entry. Catches the
+// healthtech/edtech/consumer-saas overlap automatically without a hard
+// list.
+function scoreDomain(r: RoleRow, ctx?: UserContext): number {
+  if (!ctx || !ctx.pastSectors.length) {
+    // Fall back to the legacy sector keyword bucket so we don't regress
+    // pre-context callers (add-role) too hard.
+    return legacySector(r.sector);
+  }
+  const text = postingText(r);
+  // Tokenize each past-sector blob into useful keywords.
+  const stop = new Set(['the','a','and','of','for','in','to','with','on','at','via','then','from','an','or']);
+  const tokens = new Set<string>();
+  for (const blob of ctx.pastSectors) {
+    for (const raw of blob.toLowerCase().split(/[^a-z0-9+]+/)) {
+      if (raw.length >= 4 && !stop.has(raw)) tokens.add(raw);
+    }
+  }
+  // Add compound keywords that matter beyond single tokens.
+  const compounds = ['health tech','healthtech','health care','healthcare','edtech','education','chronic','consumer','platform','marketplace','telehealth'];
+  for (const c of compounds) if (ctx.pastSectors.some(s => s.toLowerCase().includes(c))) tokens.add(c);
+
+  const hits = countMatches(text, [...tokens]);
+  if (hits >= 4) return 15;
+  if (hits === 3) return 12;
+  if (hits === 2) return 9;
+  if (hits === 1) return 6;
+  return 3;
+}
+
+function legacySector(s: string): number {
+  const x = s.toLowerCase();
+  if (!x) return 6;
+  if (/health|medical|clinical|telehealth/.test(x)) return 15;
+  if (/edtech|education/.test(x)) return 15;
+  if (/ai-native|legal ai|productivity|saas|fintech/.test(x)) return 10;
+  if (/consumer|hardware|retail|marketplace/.test(x)) return 7;
+  if (/ad-?tech|crypto|gambling/.test(x)) return 0;
+  return 6;
+}
+
+// ---------- Skills (max 15) ----------
+// Count user-skill names that appear in posting text. Years-weighted: a
+// 9-year skill hit is worth more than a 3-year skill hit, capped at 15.
+function scoreSkills(r: RoleRow, ctx?: UserContext): number {
+  if (!ctx || !ctx.skills.length) return 7; // neutral
+  const text = postingText(r);
+  let pts = 0;
+  for (const s of ctx.skills) {
+    const name = s.name.toLowerCase();
+    if (!name) continue;
+    // Also match common variants by stripping "foundation"/"thinking".
+    const variants = [name, name.replace(/\s+(foundation|thinking|product)$/,'').trim()];
+    if (variants.some(v => v && text.includes(v))) {
+      const years = s.years || 3;
+      pts += years >= 8 ? 4 : years >= 4 ? 3 : 2;
+    }
+  }
+  return Math.min(15, pts || 4);
+}
+
+// ---------- Career arc (max 10) ----------
+// Reward postings whose stage/scope/scale signals match a journey the
+// user has actually walked. Founding PM at seed/A, scale-up at B+, IPO
+// or acquisition language in the posting.
+function scoreArc(r: RoleRow, ctx?: UserContext): number {
+  const text = postingText(r);
+  const arcSignals = (ctx?.arcTags?.length ? ctx.arcTags : [
+    'zero to one','zero-to-one','founding','platform','scale','scaled','ipo','acquisition','growth','pmf','product-market fit','greenfield','0 to 1'
+  ]).map(s => s.toLowerCase());
+  const hits = countMatches(text, arcSignals);
+
+  // Stage coherence: founding title vs early-stage investor signal.
+  const investors = (r.investors + ' ' + r.crunchbase).toLowerCase();
+  const earlyStage = /seed|series a|series b|pre-seed/.test(investors);
+  const lateStage = /series d|series e|late stage|public/.test(investors);
+  const isFounding = /founding (pm|product)/.test(r.title.toLowerCase());
+  const isSeniorScale = /senior|staff|principal|head of|director|vp/.test(r.title.toLowerCase());
+
+  let coherence = 0;
+  if (isFounding && earlyStage) coherence += 4;
+  if (isSeniorScale && !earlyStage && !lateStage) coherence += 2;
+  if (isSeniorScale && lateStage) coherence -= 1;
+
+  const fromHits = Math.min(6, hits * 2);
+  return Math.max(0, Math.min(10, fromHits + coherence));
+}
+
+// ---------- Stage (max 10) ----------
 function scoreStage(r: RoleRow): { v: number; fail?: string } {
   const i = (r.investors + ' ' + r.crunchbase).toLowerCase();
-  // Public / mega-cap names — drop hard.
   if (/(?:^|\W)(google|meta|amazon|microsoft|apple|salesforce)(?:\W|$)/.test((r.company + ' ' + i).toLowerCase())) {
-    return { v: 5, fail: 'public / mega-cap' };
+    return { v: 2, fail: 'public / mega-cap' };
   }
-  if (/series d|series e|late stage/.test(i)) return { v: 10 };
-  if (/series a|series b|series c|seed|pre-seed/.test(i)) return { v: 20 };
-  // No signal — neutral 12.
-  return { v: 12 };
+  if (/series d|series e|late stage/.test(i)) return { v: 5 };
+  if (/series a|series b|series c|seed|pre-seed/.test(i)) return { v: 10 };
+  return { v: 6 };
 }
 
-// --- Sector scoring (max 20) ---
-function scoreSector(s: string): number {
-  const x = s.toLowerCase();
-  if (!x) return 8;
-  if (/health|medical|clinical|telehealth/.test(x)) return 20;
-  if (/edtech|education/.test(x)) return 20;
-  if (/ai-native|legal ai|productivity|saas|fintech/.test(x)) return 15;
-  if (/consumer|hardware|retail|marketplace/.test(x)) return 10;
-  if (/ad-?tech|crypto|gambling/.test(x)) return 0;
-  return 10;
-}
+// ---------- Geo (max 5) — most filtering happens upstream now ----------
+function scoreGeo(_r: RoleRow): { v: number; fail?: string } { return { v: 4 }; }
 
-// --- Geo scoring (max 15). Sheet has no geo column; default to neutral. ---
-function scoreGeo(_r: RoleRow): { v: number; fail?: string } {
-  return { v: 10 };
-}
-
-// --- Comp scoring (max 10). Parse $XXXk-$YYYk or $XXX,XXX-$YYY,YYY. ---
+// ---------- Comp (max 5) ----------
 function scoreComp(s: string): number {
-  if (!s) return 5;
+  if (!s) return 3;
   const txt = s.toLowerCase().replace(/[,$\s]/g, '');
   const nums = Array.from(txt.matchAll(/(\d+(?:\.\d+)?)(k)?/g)).map(m => {
     const n = parseFloat(m[1]);
     return m[2] === 'k' ? n * 1000 : n;
   });
-  if (!nums.length) return 5;
-  // Use top of range if present, else single number.
+  if (!nums.length) return 3;
   const top = Math.max(...nums);
-  if (top < 10000) return 5; // probably a percentage or bad parse
-  if (top >= 200000) return 10;
-  if (top >= 170000) return 6;
-  return 2;
-}
-
-// --- Source scoring (max 5) ---
-function scoreSource(s: string): number {
-  const x = s.toLowerCase();
-  if (x.includes('network')) return 5;
-  if (x.includes('linkedin saved')) return 4;
-  if (x.includes('linkedin recommended')) return 3;
-  if (x.includes('from company pages')) return 2;
+  if (top < 10000) return 3;
+  if (top >= 200000) return 5;
+  if (top >= 170000) return 3;
   return 1;
 }
 
-// --- Network signal (max 5). Bumped if a contact name is filled in. ---
-function scoreNetwork(r: RoleRow): number {
-  let v = 0;
-  if (r.contact && r.contact.trim().length > 1) v += 5;
-  return v;
+// ---------- Source (max 3) ----------
+function scoreSource(s: string): number {
+  const x = s.toLowerCase();
+  if (x.includes('network')) return 3;
+  if (x.includes('linkedin saved')) return 2;
+  if (x.includes('linkedin recommended')) return 2;
+  if (x.includes('from company pages')) return 1;
+  return 1;
 }
 
-export function computeFit(r: RoleRow): FitResult {
-  const title = scoreTitle(r.title);
-  const stage = scoreStage(r);
-  const geo = scoreGeo(r);
+// ---------- Network (max 2) ----------
+function scoreNetwork(r: RoleRow): number {
+  return r.contact && r.contact.trim().length > 1 ? 2 : 0;
+}
+
+// ---------- Compose ----------
+export function computeFit(r: RoleRow, ctx?: UserContext): FitResult {
+  const title   = scoreTitle(r.title);
+  const stage   = scoreStage(r);
+  const geo     = scoreGeo(r);
+  const mission = scoreMission(r, ctx);
+
   const breakdown: FitBreakdown = {
-    title: title.v,
-    stage: stage.v,
-    sector: scoreSector(r.sector),
-    geo: geo.v,
-    comp: scoreComp(r.salary),
-    source: scoreSource(r.source),
+    mission: mission.v,
+    domain:  scoreDomain(r, ctx),
+    skills:  scoreSkills(r, ctx),
+    title:   title.v,
+    arc:     scoreArc(r, ctx),
+    stage:   stage.v,
+    geo:     geo.v,
+    comp:    scoreComp(r.salary),
+    source:  scoreSource(r.source),
     network: scoreNetwork(r),
   };
-  const hardFails: string[] = [];
-  if (title.fail) hardFails.push(title.fail);
-  if (stage.fail) hardFails.push(stage.fail);
-  if (geo.fail) hardFails.push(geo.fail);
 
-  let raw = breakdown.title + breakdown.stage + breakdown.sector +
-            breakdown.geo + breakdown.comp + breakdown.source + breakdown.network;
+  const hardFails: string[] = [];
+  if (title.fail)   hardFails.push(title.fail);
+  if (stage.fail)   hardFails.push(stage.fail);
+  if (geo.fail)     hardFails.push(geo.fail);
+  if (mission.fail) hardFails.push(mission.fail);
+
+  let raw = breakdown.mission + breakdown.domain + breakdown.skills + breakdown.title +
+            breakdown.arc + breakdown.stage + breakdown.geo + breakdown.comp +
+            breakdown.source + breakdown.network;
   if (hardFails.length) raw = Math.min(raw, HARD_FAIL_CAP);
 
   return { score: Math.round(raw), breakdown, hardFails };

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -16,12 +16,12 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
-import { computeFit, type RoleRow } from '../jobs-pipe/fit.ts';
+import { computeFit, type RoleRow, type UserContext as FitUserContext } from '../jobs-pipe/fit.ts';
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 
-const VERSION = '0.3.4';
-console.log(`[pull-recommendations] v${VERSION} - Gmail: cap counts NEW work only (dedup-hits don't burn budget)`);
+const VERSION = '0.4.0';
+console.log(`[pull-recommendations] v${VERSION} - Fit v2: mission/domain/skills/arc scoring loaded from vision+skills+companies`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -56,14 +56,85 @@ serve(async (req) => {
   // bypasses both the enabled flag and the schedule, so the user can
   // trigger a single source from the UI without waiting for cron.
   let forceId: string | null = null;
+  let rescoreOnly = false;
   if (req.method === 'POST') {
     try {
       const body = await req.json();
       if (body && typeof body.id === 'string') forceId = body.id;
+      if (body && body.rescore === true) rescoreOnly = true;
     } catch { /* no body, that's fine */ }
   }
+  if (new URL(req.url).searchParams.get('rescore') === '1') rescoreOnly = true;
 
   const sql = db();
+
+  // Backfill rescore — recompute fit_score and fit_breakdown for every
+  // active recommended role using the v2 scorer + UserContext. Useful
+  // after weight/shape changes so existing rows pick up the new model.
+  if (rescoreOnly) {
+    const ctx = await loadFitContext(sql);
+    const rows = await sql<Array<{ id: string; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null }>>`
+      select id, title, company, description, sector, investors, salary, source
+        from job.recommended_roles
+       where dismissed_at is null and added_to_pipeline_slug is null
+    `;
+    let updated = 0;
+    for (const r of rows) {
+      const roleRow: RoleRow = {
+        status: '', rank: '',
+        company:    r.company || '',
+        title:      r.title || '',
+        url:        '',
+        source:     r.source || '',
+        contact:    '',
+        salary:     r.salary || '',
+        sector:     r.sector || '',
+        investors:  (r.investors || []).join(', '),
+        website:    '', crunchbase: '',
+        description: r.description || '',
+      };
+      const fit = computeFit(roleRow, ctx);
+      await sql`
+        update job.recommended_roles
+           set fit_score     = ${fit.score},
+               fit_breakdown = ${sql.json(fit.breakdown)},
+               hard_fails    = ${fit.hardFails}
+         where id = ${r.id}
+      `;
+      updated++;
+    }
+    // Also rescore pipeline_roles so the Saved/Active/Archive table picks
+    // up the v2 breakdown shape and weights.
+    const pipeRows = await sql<Array<{ slug: string; title: string | null; company_name: string | null; sector: string | null; investors: string[] | null; salary_range: string | null; source: string | null }>>`
+      select slug, title, company_name, sector, investors, salary_range, source
+        from job.pipeline_roles where deleted_at is null`;
+    let pipeUpdated = 0;
+    for (const r of pipeRows) {
+      const roleRow: RoleRow = {
+        status: '', rank: '',
+        company:    r.company_name || '',
+        title:      r.title || '',
+        url:        '',
+        source:     r.source || '',
+        contact:    '',
+        salary:     r.salary_range || '',
+        sector:     r.sector || '',
+        investors:  (r.investors || []).join(', '),
+        website:    '', crunchbase: '',
+        description: '',
+      };
+      const fit = computeFit(roleRow, ctx);
+      await sql`
+        update job.pipeline_roles
+           set fit_score     = ${fit.score},
+               fit_breakdown = ${sql.json(fit.breakdown)},
+               hard_fails    = ${fit.hardFails}
+         where slug = ${r.slug}`;
+      pipeUpdated++;
+    }
+    return new Response(JSON.stringify({ ok: true, version: VERSION, rescored: updated, pipelineRescored: pipeUpdated }, null, 2),
+      { status: 200, headers: { 'content-type': 'application/json' } });
+  }
   const sources = forceId
     ? await sql<UserSourceRow[]>`
         select id, user_email, type, config, schedule_cron, min_score, last_run_at
@@ -100,7 +171,8 @@ serve(async (req) => {
         ? onTarget.filter(r => geoMatches(r.location || '', targetGeos))
         : onTarget;
       const droppedOffGeo = onTarget.length - inGeo.length;
-      const { kept, dropped } = scoreAndFilter(inGeo, src.min_score);
+      const fitCtx = await loadFitContext(sql);
+      const { kept, dropped } = scoreAndFilter(inGeo, src.min_score, fitCtx);
       // Drop anything the user already has in their pipeline (any state —
       // active, archived, deleted). Match on (lower(company), lower(title))
       // so a different ATS URL for the same posting still dedupes.
@@ -246,15 +318,55 @@ interface ScoredRow {
   hardFails: string[];
 }
 
-function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number): { kept: ScoredRow[]; dropped: number } {
+function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number, ctx?: FitUserContext): { kept: ScoredRow[]; dropped: number } {
   const kept: ScoredRow[] = [];
   let dropped = 0;
   for (const r of rows) {
-    const fit = computeFit(toRoleRow(r));
+    const fit = computeFit(toRoleRow(r), ctx);
     if (fit.hardFails.length || fit.score < minScore) { dropped++; continue; }
     kept.push({ input: r, fitScore: fit.score, breakdown: fit.breakdown as unknown as Record<string, number>, hardFails: fit.hardFails });
   }
   return { kept, dropped };
+}
+
+// ---------- Fit context loader ----------
+// Pulls everything computeFit needs to score against the user's profile:
+//   - mission keywords + anti-mission terms + missionRequired from job.vision
+//   - skill names + years from job.skills
+//   - past sector blobs from job.companies
+//   - arc tags derived from narrative_arc (light keyword extraction)
+let _fitCtxCache: { ctx: FitUserContext; at: number } | null = null;
+const FIT_CTX_CACHE_MS = 60_000;
+
+async function loadFitContext(sql: ReturnType<typeof db>): Promise<FitUserContext> {
+  if (_fitCtxCache && Date.now() - _fitCtxCache.at < FIT_CTX_CACHE_MS) return _fitCtxCache.ctx;
+  const [visionRows, skillRows, companyRows] = await Promise.all([
+    sql`select impact_themes, mission_keywords, mission_required, anti_mission_terms,
+               coalesce(narrative_arc,'') as narrative_arc
+          from job.vision order by updated_at desc limit 1`,
+    sql`select name, years_practiced from job.skills`,
+    sql`select coalesce(sector,'') as sector from job.companies`,
+  ]);
+  const v = (visionRows as Array<Record<string, unknown>>)[0] || {};
+  const arcSrc = (v.narrative_arc as string || '').toLowerCase();
+  const arcTags: string[] = [];
+  for (const tag of ['founding','zero-to-one','zero to one','platform','scale','scaled','ipo','acquisition','fractional','pmf','product-market fit','growth','greenfield']) {
+    if (arcSrc.includes(tag)) arcTags.push(tag);
+  }
+  const ctx: FitUserContext = {
+    missionKeywords:   (v.mission_keywords as string[] | null) || [],
+    antiMissionTerms:  (v.anti_mission_terms as string[] | null) || [],
+    impactThemes:      (v.impact_themes as string[] | null) || [],
+    missionRequired:   Boolean(v.mission_required),
+    skills:            (skillRows as Array<Record<string, unknown>>).map(s => ({
+      name: String(s.name || ''),
+      years: (s.years_practiced as number | null) ?? null,
+    })),
+    pastSectors: (companyRows as Array<Record<string, unknown>>).map(c => String(c.sector || '')).filter(Boolean),
+    arcTags,
+  };
+  _fitCtxCache = { ctx, at: Date.now() };
+  return ctx;
 }
 
 // Map a RecommendedRoleInput → the RoleRow shape computeFit expects.
@@ -274,6 +386,7 @@ function toRoleRow(r: RecommendedRoleInput): RoleRow {
     investors:  (r.investors || []).join(', '),
     website:    '',
     crunchbase: '',
+    description: r.description || '',
   };
 }
 

--- a/supabase/migrations/065_vision_mission_fit.sql
+++ b/supabase/migrations/065_vision_mission_fit.sql
@@ -1,0 +1,30 @@
+-- 065_vision_mission_fit.sql
+-- Fit-score v2: capture mission/impact preferences in job.vision so the
+-- scorer can weight cultural alignment alongside title/skills/arc.
+
+alter table job.vision
+  add column if not exists impact_themes      text[] default '{}',
+  add column if not exists mission_keywords   text[] default '{}',
+  add column if not exists mission_required   boolean not null default false,
+  add column if not exists anti_mission_terms text[] default '{}';
+
+-- Seed Ian's selected themes + the keyword expansion the scorer matches
+-- posting text against. Anti-mission mirrors the deal-breakers list.
+update job.vision
+   set impact_themes = array['ai_ethics','healthcare_outcomes','cost_reduction','education_access'],
+       mission_keywords = array[
+         -- healthcare_outcomes
+         'patient','clinical','clinician','provider','care','outcomes','health equity',
+         'chronic','therapeutic','telehealth','payer','medicare','medicaid','mental health',
+         -- cost_reduction
+         'affordable','affordability','lower cost','cost reduction','reduce cost','savings',
+         'access','underserved','equity',
+         -- education_access
+         'student','learner','teacher','classroom','school','curriculum','literacy','tutoring','workforce','reskill',
+         -- ai_ethics
+         'responsible ai','ai safety','alignment','model evaluation','trust and safety','interpretability','fairness','bias'
+       ],
+       anti_mission_terms = array['gambling','casino','crypto','web3','token','payday','tobacco','vape','defense contractor','surveillance'],
+       mission_required = false,
+       updated_at = now()
+ where id = (select id from job.vision order by updated_at desc limit 1);


### PR DESCRIPTION
## Summary
- New scoring model captures cultural/impact alignment (mission 20) and replaces single-dim title overlap with title 15 + skills 15 + domain 15 + arc 10 (drawn from `job.vision`, `job.skills`, `job.companies`).
- `vision.impact_themes / mission_keywords / anti_mission_terms / mission_required` columns added (mig 065) and seeded with Ian's selections (ai_ethics, healthcare_outcomes, cost_reduction, education_access).
- `POST /pull-recommendations { rescore: true }` backfills `recommended_roles` + `pipeline_roles`. Already invoked against prod (123 recs + 54 pipeline rows updated).

## Test plan
- [x] Migration applied; `vision.mission_keywords` = 41 terms
- [x] Edge function `pull-recommendations` v0.4.0 deployed
- [x] Backfill rescore — top rec is now Clover Health Staff PM Member Experience (mission 14, domain 12, title 12 = 58); previously Abridge Product Lead anchored at 70 on title alone
- [ ] Verify Fit modal labels switch to the v2 buckets after Pages deploys