### PR TITLE
job: fit breakdown modal on Recommended cards

### DIFF
--- a/job/js/components/job-fit-modal.js
+++ b/job/js/components/job-fit-modal.js
@@ -1,0 +1,83 @@
+// job-fit-modal — shared fit-score breakdown modal. Used by the pipeline
+// table and the recommendations carousel/page so the tooltip is reachable
+// everywhere a fit pill appears.
+import { html, nothing } from 'https://esm.run/lit@3';
+
+export const DIM_LABELS = {
+  mission: { label: 'Mission & impact', max: 20, hint: 'Posting text matches your impact themes (health outcomes, cost reduction, education access, AI ethics). Anti-themes zero this out.' },
+  domain:  { label: 'Domain experience', max: 15, hint: 'Posting sector overlaps with companies you have worked at — healthtech, edtech, consumer SaaS surface automatically.' },
+  skills:  { label: 'Skills match',     max: 15, hint: 'Posting mentions skills from your profile (UX, platform thinking, zero-to-one, growth experimentation). Years-weighted.' },
+  title:   { label: 'Title match',      max: 15, hint: 'Founding / Senior / Staff PM scores higher; below seniority hard-fails.' },
+  arc:     { label: 'Career arc',       max: 10, hint: 'Stage + scope coherence: founding at seed/A, scale-up at B+, IPO/acquisition language.' },
+  stage:   { label: 'Stage',            max: 10, hint: 'Inferred from investors. Pre-seed → C scores high; public / mega-cap hard-fails.' },
+  geo:     { label: 'Geography',        max: 5,  hint: 'Most geo filtering happens upstream — this is a small bonus.' },
+  comp:    { label: 'Compensation',     max: 5,  hint: 'Top of range ≥ $200k = full marks.' },
+  source:  { label: 'Source',           max: 3,  hint: 'Network > LinkedIn Saved > LinkedIn Recommended > Company Pages.' },
+  network: { label: 'Network',          max: 2,  hint: 'A named contact in the row gets +2.' },
+};
+
+export function scoreClass(s) {
+  if (s == null) return 'fit-pill fit-pill--poor';
+  if (s >= 70) return 'fit-pill fit-pill--strong';
+  if (s >= 50) return 'fit-pill fit-pill--ok';
+  if (s >= 30) return 'fit-pill fit-pill--weak';
+  return 'fit-pill fit-pill--poor';
+}
+
+// Render the modal. `row` is the role-like object — expects { company, title,
+// score, breakdown, hardFails }. `onClose` is called when the user dismisses.
+// Returns a lit-html template (or `nothing` if row is null).
+export function renderFitModal(row, onClose) {
+  if (!row) return nothing;
+  const score = row.score ?? row.fitScore ?? null;
+  const breakdown = row.breakdown || row.fitBreakdown || {};
+  const hardFails = row.hardFails || [];
+  const dims = Object.keys(DIM_LABELS);
+  const onBackdrop = (e) => { if (e.target.classList.contains('fit-modal__backdrop')) onClose(); };
+  return html`
+    <div class="fit-modal__backdrop" @click=${onBackdrop}>
+      <div class="fit-modal" role="dialog" aria-modal="true" aria-label="Fit score breakdown">
+        <header class="fit-modal__head">
+          <div>
+            <p class="fit-modal__eyebrow">${row.company}</p>
+            <h2>${row.title || 'Untitled role'}</h2>
+          </div>
+          <button class="fit-modal__close" @click=${() => onClose()} aria-label="Close">×</button>
+        </header>
+        <div class="fit-modal__score">
+          <span class=${scoreClass(score)}>${score == null ? '—' : score}</span>
+          <div>
+            <p class="fit-modal__score-label">Fit score</p>
+            <p class="fit-modal__score-sub">Out of 100. Sum of ten weighted dimensions; hard fails cap at 30.</p>
+          </div>
+        </div>
+        ${hardFails.length ? html`
+          <div class="fit-modal__fails">
+            <strong>Hard fail${hardFails.length > 1 ? 's' : ''}:</strong>
+            ${hardFails.join(', ')}. Score capped at 30.
+          </div>
+        ` : nothing}
+        <ul class="fit-breakdown">
+          ${dims.map(k => {
+            const meta = DIM_LABELS[k];
+            const v = (breakdown && breakdown[k]) || 0;
+            const pct = Math.max(0, Math.min(100, (v / meta.max) * 100));
+            return html`
+              <li class="fit-breakdown__row">
+                <div class="fit-breakdown__head">
+                  <span class="fit-breakdown__label">${meta.label}</span>
+                  <span class="fit-breakdown__value">${v} / ${meta.max}</span>
+                </div>
+                <div class="fit-breakdown__bar"><span style=${`width:${pct}%`}></span></div>
+                <p class="fit-breakdown__hint">${meta.hint}</p>
+              </li>
+            `;
+          })}
+        </ul>
+        <footer class="fit-modal__foot">
+          <p class="muted">v2 weights: mission/domain/skills/title weighted from your vision + work history.</p>
+        </footer>
+      </div>
+    </div>
+  `;
+}

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -4,6 +4,7 @@ import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
 const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
 const { logoSrc, logoInitial } = await import('../logo.js' + V);
+const { renderFitModal, scoreClass: sharedScoreClass } = await import('./job-fit-modal.js' + V);
 // Mount the recommendations widget. It self-loads when the user is signed in.
 import('./job-recommendations.js' + V);
 
@@ -44,18 +45,8 @@ function bucketFor(r) {
   }
 }
 
-const DIM_LABELS = {
-  mission: { label: 'Mission & impact', max: 20, hint: 'Posting text matches your impact themes (health outcomes, cost reduction, education access, AI ethics). Anti-themes zero this out.' },
-  domain:  { label: 'Domain experience', max: 15, hint: 'Posting sector overlaps with companies you have worked at — healthtech, edtech, consumer SaaS surface automatically.' },
-  skills:  { label: 'Skills match',     max: 15, hint: 'Posting mentions skills from your profile (UX, platform thinking, zero-to-one, growth experimentation). Years-weighted.' },
-  title:   { label: 'Title match',      max: 15, hint: 'Founding / Senior / Staff PM scores higher; below seniority hard-fails.' },
-  arc:     { label: 'Career arc',       max: 10, hint: 'Stage + scope coherence: founding at seed/A, scale-up at B+, IPO/acquisition language.' },
-  stage:   { label: 'Stage',            max: 10, hint: 'Inferred from investors. Pre-seed → C scores high; public / mega-cap hard-fails.' },
-  geo:     { label: 'Geography',        max: 5,  hint: 'Most geo filtering happens upstream — this is a small bonus.' },
-  comp:    { label: 'Compensation',     max: 5,  hint: 'Top of range ≥ $200k = full marks.' },
-  source:  { label: 'Source',           max: 3,  hint: 'Network > LinkedIn Saved > LinkedIn Recommended > Company Pages.' },
-  network: { label: 'Network',          max: 2,  hint: 'A named contact in the row gets +2.' },
-};
+// Fit modal labels + render helper live in ./job-fit-modal.js so the
+// recommendations carousel can reuse the same tooltip.
 
 // Each column entry: { id, label, sortKey | null, type: 'num'|'text'|'bool' }.
 // sortKey null → header isn't clickable.
@@ -839,55 +830,7 @@ export class JobPipeline extends LitElement {
   }
 
   _renderFitModal() {
-    const r = this.selectedRow;
-    if (!r) return nothing;
-    const dims = Object.keys(DIM_LABELS);
-    return html`
-      <div class="fit-modal__backdrop" @click=${this._onBackdropClick}>
-        <div class="fit-modal" role="dialog" aria-modal="true" aria-label="Fit score breakdown">
-          <header class="fit-modal__head">
-            <div>
-              <p class="fit-modal__eyebrow">${r.company}</p>
-              <h2>${r.title || 'Untitled role'}</h2>
-            </div>
-            <button class="fit-modal__close" @click=${() => this._closeFitModal()} aria-label="Close">×</button>
-          </header>
-          <div class="fit-modal__score">
-            <span class=${this._scoreClass(r.score)}>${r.score == null ? '—' : r.score}</span>
-            <div>
-              <p class="fit-modal__score-label">Fit score</p>
-              <p class="fit-modal__score-sub">Out of 100. Sum of seven weighted dimensions; hard fails cap at 30.</p>
-            </div>
-          </div>
-          ${r.hardFails && r.hardFails.length ? html`
-            <div class="fit-modal__fails">
-              <strong>Hard fail${r.hardFails.length > 1 ? 's' : ''}:</strong>
-              ${r.hardFails.join(', ')}. Score capped at 30.
-            </div>
-          ` : nothing}
-          <ul class="fit-breakdown">
-            ${dims.map(k => {
-              const meta = DIM_LABELS[k];
-              const v = (r.breakdown && r.breakdown[k]) || 0;
-              const pct = Math.max(0, Math.min(100, (v / meta.max) * 100));
-              return html`
-                <li class="fit-breakdown__row">
-                  <div class="fit-breakdown__head">
-                    <span class="fit-breakdown__label">${meta.label}</span>
-                    <span class="fit-breakdown__value">${v} / ${meta.max}</span>
-                  </div>
-                  <div class="fit-breakdown__bar"><span style=${`width:${pct}%`}></span></div>
-                  <p class="fit-breakdown__hint">${meta.hint}</p>
-                </li>
-              `;
-            })}
-          </ul>
-          <footer class="fit-modal__foot">
-            <p class="muted">Weights are fixed in v1. Tunable in v2 once Vision integration lands.</p>
-          </footer>
-        </div>
-      </div>
-    `;
+    return renderFitModal(this.selectedRow, () => this._closeFitModal());
   }
 
   render() {

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -5,10 +5,11 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }, { logoSrc, logoInitial }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }, { logoSrc, logoInitial }, { renderFitModal }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../logo.js' + V),
+  import('./job-fit-modal.js' + V),
 ]);
 
 function relTime(iso) {
@@ -31,6 +32,7 @@ export class JobRecommendations extends LitElement {
     items: { state: true },
     error: { state: true },
     addingId: { state: true },
+    selectedRec: { state: true },
   };
 
   constructor() {
@@ -39,6 +41,7 @@ export class JobRecommendations extends LitElement {
     this.items = [];
     this.error = '';
     this.addingId = null;
+    this.selectedRec = null;
   }
 
   connectedCallback() {
@@ -96,6 +99,17 @@ export class JobRecommendations extends LitElement {
     }
   }
 
+  _openFitModal(rec) {
+    this.selectedRec = {
+      company:   rec.company,
+      title:     rec.title,
+      score:     rec.fitScore,
+      breakdown: rec.breakdown || rec.fitBreakdown || {},
+      hardFails: rec.hardFails || [],
+    };
+  }
+  _closeFitModal() { this.selectedRec = null; }
+
   _fitClass(s) {
     if (s == null) return 'fit-pill fit-pill--poor';
     if (s >= 70) return 'fit-pill fit-pill--strong';
@@ -127,7 +141,11 @@ export class JobRecommendations extends LitElement {
             <div class="rec-card__title-row">
               <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
               ${rec.fitScore != null
-                ? html`<span class=${this._fitClass(rec.fitScore)} title="Fit score">${rec.fitScore}</span>`
+                ? html`<button class=${this._fitClass(rec.fitScore) + ' fit-pill--button'}
+                          title="Tap to see the breakdown"
+                          @click=${(e) => { e.stopPropagation(); this._openFitModal(rec); }}>
+                          ${rec.fitScore}
+                        </button>`
                 : nothing}
             </div>
             ${meta ? html`<p class="rec-card__meta">${meta}</p>` : nothing}
@@ -210,6 +228,7 @@ export class JobRecommendations extends LitElement {
             See all recommendations →
           </a>
         </footer>
+        ${renderFitModal(this.selectedRec, () => this._closeFitModal())}
       </section>
     `;
   }


### PR DESCRIPTION
## Summary
The Fit pill on the Recommended-for-you carousel was a label-only badge; the breakdown tooltip lived only on the pipeline table. Now both surfaces share the same modal.

- Extracted DIM_LABELS + renderFitModal into job/js/components/job-fit-modal.js.
- job-recommendations.js: pill is now a button that opens the shared modal.
- job-pipeline.js: imports the shared helper instead of duplicating markup.

## Test plan
- [ ] Click a Fit pill on a recommendation card → modal opens with the v2 breakdown
- [ ] Existing pipeline-table fit pill still works