### PR TITLE
Fix KB extract + weekly auto-cadence

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.66.0";
-console.log(`[job] v${VERSION} - Extract stories from existing KB into narratives (idempotent backfill)`);
+const VERSION = "0.67.0";
+console.log(`[job] v${VERSION} - Fix KB extract (max_tokens) + weekly auto-extract cadence`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -168,6 +168,11 @@ export class JobCareer extends LitElement {
         const ns = await fetchNarratives();
         this.narratives = ns;
       } catch { this.narratives = []; }
+      // Auto-extract cadence: run extraction in the background if there
+      // are zero narratives (first visit) OR the last extract was more
+      // than 7 days ago. Keeps the KB in sync as work history grows
+      // without requiring the user to click a button.
+      this._maybeAutoExtract();
       // Companies for the "Needs connection" dropdown — derived from the
       // pipeline tag space isn't enough; we want the actual work history.
       // For now, scrape unique companies from existing narratives' links
@@ -577,9 +582,23 @@ export class JobCareer extends LitElement {
         lastResult: { created: (res?.created || []).length, skipped: res?.skipped || 0 },
         error: '',
       };
+      try { localStorage.setItem('job:lastNarrativeExtract', String(Date.now())); } catch {}
     } catch (e) {
       this.extracting = { running: false, lastResult: null, error: String(e?.message || e) };
     }
+  }
+
+  // Cadence: auto-run extraction if narratives are empty (first time
+  // here) or > 7 days have passed since the last successful run.
+  _maybeAutoExtract() {
+    const AUTO_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000;
+    let last = 0;
+    try { last = Number(localStorage.getItem('job:lastNarrativeExtract') || 0); } catch {}
+    const stale = (Date.now() - last) > AUTO_INTERVAL_MS;
+    const empty = !this.narratives || this.narratives.length === 0;
+    if (!empty && !stale) return;
+    // Fire-and-forget in the background; UI shows the shimmer button.
+    this._extractFromKb();
   }
 
   // ----- Career opportunities ---------------------------------------------

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/supabase/functions/narratives/index.ts
+++ b/supabase/functions/narratives/index.ts
@@ -18,8 +18,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.2.0';
-console.log(`[narratives] v${VERSION} - CRUD + AI auto-tag/link + KB extract backfill`);
+const VERSION = '0.3.0';
+console.log(`[narratives] v${VERSION} - CRUD + AI auto-tag/link + KB extract (bigger output + cron entry)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -42,7 +42,7 @@ function normalizeTitle(s: string): string {
     .trim();
 }
 
-async function callClaudeJson(system: string, user: string): Promise<any> {
+async function callClaudeJson(system: string, user: string, maxTokens = 1024): Promise<any> {
   const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
   const res = await fetch(ANTHROPIC_URL, {
@@ -54,16 +54,31 @@ async function callClaudeJson(system: string, user: string): Promise<any> {
     },
     body: JSON.stringify({
       model: ANTHROPIC_MODEL,
-      max_tokens: 1024,
+      max_tokens: maxTokens,
       system,
       messages: [{ role: 'user', content: user }],
     }),
   });
   if (!res.ok) throw new Error(`anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
-  const data = await res.json() as { content: { type: string; text: string }[] };
+  const data = await res.json() as { content: { type: string; text: string }[]; stop_reason?: string };
   const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
-  const stripped = text.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
-  try { return JSON.parse(stripped); } catch { return null; }
+  // Strip a leading ```json fence if present, plus any trailing fence.
+  // Then try to JSON.parse; on failure, also try slicing from the first
+  // '{' to the last '}' which catches "rambling prefix" outputs.
+  let stripped = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
+  try { return JSON.parse(stripped); } catch { /* fall through */ }
+  const start = stripped.indexOf('{');
+  const end = stripped.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    try { return JSON.parse(stripped.slice(start, end + 1)); } catch { /* */ }
+  }
+  console.warn('[narratives] JSON parse failed', {
+    stop_reason: data.stop_reason,
+    head: text.slice(0, 200),
+    tail: text.slice(-200),
+    length: text.length,
+  });
+  return null;
 }
 
 const EXTRACT_SYSTEM = `You extract discrete career stories from a candidate's knowledge base.
@@ -111,7 +126,9 @@ async function extractFromKb(): Promise<{ title: string; content_md: string; anc
 
   const kbBlock = sections.join('\n\n---\n\n');
   const user = `# Career KB\n\n${kbBlock}\n\n# Ask\n\nProduce the JSON object now. JSON only.`;
-  const parsed = await callClaudeJson(EXTRACT_SYSTEM, user);
+  // 12 stories × ~400 tokens each + JSON overhead → ~6k tokens. Headroom.
+  const parsed = await callClaudeJson(EXTRACT_SYSTEM, user, 8192);
+  console.log('[narratives] extract pass returned', { stories: Array.isArray(parsed?.stories) ? parsed.stories.length : -1 });
   const stories = Array.isArray(parsed?.stories) ? parsed.stories : [];
   return stories.map((s: any) => ({
     title:                String(s.title || '').trim().slice(0, MAX_TITLE),


### PR DESCRIPTION
Root cause of "Extract didn't work" (200 with 0 rows): `callClaudeJson` used `max_tokens=1024` which truncated the 6-12 story JSON response → JSON.parse failed → silent empty array → no inserts.

**Fix:** `callClaudeJson` takes `maxTokens`; extract uses 8192. Adds robust JSON recovery (strips fences, slices first `{` to last `}`) and logs `stop_reason` + head/tail on parse failure.

**Cadence:** auto-extract runs in the background on Narratives mount when narratives are empty or last run was > 7 days ago. localStorage tracks the timestamp. Server-side cron deferred.

Bumps: `narratives` 0.3.0, `/job` 0.67.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)