### PR TITLE
job(gmail): Phase 1.5 enrichment — canonical URLs + verifying-source badge

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2354,6 +2354,26 @@
 }
 .rec-source-email:hover { opacity: 1; }
 
+/* "Verifying source" badge — appears on Gmail recs whose canonical
+   posting URL hasn't been resolved yet (enrichment_status='unresolved').
+   Brand: honest UI — tells the user the link is the aggregator, not
+   the canonical ATS. */
+.enrichment-badge {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: rgba(237,200,67,0.20);
+  color: #6E5400;
+  font-size: 10px;
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 .rec-actions {
   display: inline-flex;
   align-items: center;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.66.0";
-console.log(`[job] v${VERSION} - Extract stories from existing KB into narratives (idempotent backfill)`);
+const VERSION = "0.67.0";
+console.log(`[job] v${VERSION} - Phase 1.5 enrichment live; "verifying source" badge on unresolved recs`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -233,6 +233,9 @@ export class JobRecommendationsTable extends LitElement {
         </td>
         <td class="col col-sector" data-label="Source">
           <span class="rec-source">${r.sourceLabel || r.source || ''}</span>
+          ${r.enrichmentStatus === 'unresolved' ? html`
+            <span class="enrichment-badge" title="Still resolving the canonical posting. Aggregator URL in the meantime.">verifying</span>
+          ` : nothing}
           ${r.sourceEmailUrl ? html`
             <a class="rec-source-email" href=${r.sourceEmailUrl} target="_blank" rel="noopener"
                title="Open the originating email in Gmail" @click=${(e) => e.stopPropagation()}>📧</a>

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -156,6 +156,9 @@ export class JobRecommendations extends LitElement {
                 <span class="rec-card__source-icon" aria-hidden="true">🌐</span>
                 <a href=${rec.url} target="_blank" rel="noopener" class="link-subtle">${rec.sourceLabel}</a>
               ` : nothing}
+              ${rec.enrichmentStatus === 'unresolved' ? html`
+                <span class="enrichment-badge" title="Still resolving the canonical posting on the company's ATS. Link points to the aggregator for now.">verifying source</span>
+              ` : nothing}
               ${rec.sourceEmailUrl ? html`
                 <span aria-hidden="true"> · </span>
                 <a href=${rec.sourceEmailUrl} target="_blank" rel="noopener" class="link-subtle" title="Open the originating email in Gmail">📧 source email</a>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.66.0">
-  <script src="/job/js/theme.js?v=0.66.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.67.0">
+  <script src="/job/js/theme.js?v=0.67.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.66.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.67.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -278,25 +278,50 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
       let emitted = 0;
       for (let i = 0; i < jobs.length; i++) {
         const job = jobs[i];
-        const url = job.alertUrl;
-        if (!url || !job.company || !job.title) continue;
+        if (!job.alertUrl || !job.company || !job.title) continue;
+
+        // Phase 1.5 enrichment — resolve to canonical Greenhouse/Lever/
+        // Ashby URL via the cache cascade. Best-effort: failures don't
+        // block emit; we fall back to the aggregator URL and flag
+        // enrichment_status='unresolved' so the widget can be honest.
+        let enriched: EnrichResponse = { resolved: false, companyId: null };
+        try {
+          enriched = await enrichJobSource({
+            company:     job.company,
+            title:       job.title,
+            hintAtsUrl:  job.alertUrl,
+            hintDomain:  senderDomainOf(sender),
+          });
+        } catch (e) {
+          console.warn(`[gmail-jobs] enrich ${job.company} failed: ${(e as Error).message}`);
+        }
+
+        const finalUrl = enriched.canonicalUrl || job.alertUrl;
+        const finalLabel = enriched.resolved && enriched.atsProvider
+          ? `Gmail · ${senderLabel(sender)} → ${enriched.atsProvider}`
+          : `Gmail · ${senderLabel(sender)}`;
+
         out.push({
           source:      'gmail-jobs',
           sourceId:    `gmail:${messageId}:${i}`,
-          // Source label is the email sender ("LinkedIn", "Wellfound",
-          // …), not the hiring company. The company name is already
-          // visible in the role row; the source label tells the user
-          // *where* a rec came from, not *who*.
-          sourceLabel: `Gmail · ${senderLabel(sender)}`,
-          url,
+          sourceLabel: finalLabel,
+          url:         finalUrl,
           company:     job.company,
           title:       job.title,
           location:    job.location,
           postedAt:    msg.internalDate ? new Date(Number(msg.internalDate)).toISOString() : undefined,
+          description: enriched.jdText ? enriched.jdText.slice(0, 4000) : undefined,
+          enrichmentStatus:  enriched.resolved ? 'resolved' : 'unresolved',
+          enrichmentRetryAt: enriched.nextRetryAt,
+          canonicalUrl:      enriched.canonicalUrl,
+          companyId:         enriched.companyId || undefined,
           payload: {
             gmailMessageId: messageId,
             gmailApiId:     msg.id,
             alertUrl:       job.alertUrl ?? null,
+            canonicalUrl:   enriched.canonicalUrl ?? null,
+            atsProvider:    enriched.atsProvider ?? null,
+            enrichmentResolved: enriched.resolved,
             sender,
             digest:         isDigest || jobs.length > 1,
             roleIndex:      i,
@@ -411,6 +436,48 @@ function senderLabel(sender: string): string {
     return base.charAt(0).toUpperCase() + base.slice(1);
   }
   return sender;
+}
+
+function senderDomainOf(sender: string): string | undefined {
+  return sender.match(/@([a-z0-9.-]+)/i)?.[1]?.toLowerCase();
+}
+
+// ---------- Phase 1.5 enrichment ----------
+//
+// Resolves a (company, title) pair to a canonical ATS posting via the
+// enrich-job-source function. Cache-backed so the same company across
+// many digests gets resolved once and reused.
+
+interface EnrichResponse {
+  resolved:      boolean;
+  companyId:     string | null;
+  atsProvider?:  string;
+  atsSlug?:      string;
+  canonicalUrl?: string;
+  jdText?:       string;
+  nextRetryAt?:  string;
+  reason?:       string;
+}
+
+const ENRICH_URL =
+  Deno.env.get('ENRICH_JOB_SOURCE_URL') ||
+  'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/enrich-job-source';
+
+async function enrichJobSource(args: {
+  company: string; title: string; hintAtsUrl?: string; hintDomain?: string;
+}): Promise<EnrichResponse> {
+  const r = await fetch(ENRICH_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      // Service role bearer so function-to-function calls authenticate.
+      'Authorization': `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!}`,
+    },
+    body: JSON.stringify(args),
+    signal: AbortSignal.timeout(20000),
+  });
+  if (!r.ok) throw new Error(`enrich ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  return await r.json() as EnrichResponse;
 }
 
 function looksLikeDigest(subject: string, sender: string): boolean {

--- a/supabase/functions/enrich-job-source/index.ts
+++ b/supabase/functions/enrich-job-source/index.ts
@@ -18,8 +18,8 @@
 //           canonicalUrl?: string, jdText?: string,
 //           nextRetryAt?: ISO8601 }
 
-const VERSION = '0.2.0';
-console.log(`[enrich-job-source] v${VERSION} - rename cache to job.hiring_companies (avoid collision with career history)`);
+const VERSION = '0.3.0';
+console.log(`[enrich-job-source] v${VERSION} - Phase 1.5 live; action:backfill batches existing recs`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
@@ -78,7 +78,15 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   if (req.method !== 'POST') return json({ error: 'POST only' }, 405);
 
-  const body = await req.json().catch(() => ({})) as EnrichRequest;
+  const body = await req.json().catch(() => ({})) as EnrichRequest & { action?: string; limit?: number };
+
+  // Backfill mode — walk N pending Gmail-sourced recs (enrichment_status
+  // null or 'unresolved' past retry time), enrich each, write canonical
+  // URL + status back. Lets the user drain after a Phase 1.5 cold-start.
+  if (body.action === 'backfill') {
+    return backfillBatch(Math.max(1, Math.min(15, body.limit ?? 8)));
+  }
+
   const company = (body.company || '').trim();
   if (!company) return json({ error: 'company required' }, 400);
   const title = (body.title || '').trim();
@@ -169,6 +177,118 @@ serve(async (req) => {
     reason: 'ats_unresolved',
   });
 });
+
+// ---------- Backfill ----------
+//
+// Walks N pending recommended_roles rows that don't have a canonical
+// URL yet (enrichment_status null or 'unresolved' past their retry).
+// Calls the same in-process resolve logic per row, writes canonical_url
+// + enrichment_status + company_id back. Capped per call so we stay
+// under Supabase's 150s wall.
+
+async function backfillBatch(limit: number): Promise<Response> {
+  const sql = db();
+  const rows = await sql<Array<{ id: string; company: string | null; title: string | null; url: string; payload: Record<string, unknown> | null }>>`
+    select id, company, title, url, payload
+      from job.recommended_roles
+     where source = 'gmail-jobs'
+       and dismissed_at is null
+       and added_to_pipeline_slug is null
+       and (
+         enrichment_status is null
+         or (enrichment_status = 'unresolved' and (enrichment_retry_at is null or enrichment_retry_at <= now()))
+       )
+     order by suggested_at desc
+     limit ${limit}
+  `;
+
+  const results: Array<{ id: string; resolved: boolean; reason?: string }> = [];
+  for (const r of rows) {
+    if (!r.company || !r.title) { results.push({ id: r.id, resolved: false, reason: 'no_company_or_title' }); continue; }
+    try {
+      const enriched = await resolveOne(r.company, r.title, r.url, r.payload);
+      await sql`
+        update job.recommended_roles
+           set enrichment_status   = ${enriched.resolved ? 'resolved' : 'unresolved'},
+               enrichment_retry_at = ${enriched.nextRetryAt ?? null},
+               canonical_url       = ${enriched.canonicalUrl ?? null},
+               company_id          = ${enriched.companyId ?? null},
+               url                 = ${enriched.canonicalUrl ?? r.url}
+         where id = ${r.id}
+      `;
+      results.push({ id: r.id, resolved: enriched.resolved });
+    } catch (e) {
+      results.push({ id: r.id, resolved: false, reason: (e as Error).message.slice(0, 120) });
+    }
+  }
+
+  const summary = {
+    ok: true,
+    version: VERSION,
+    processed: results.length,
+    resolved:  results.filter(x => x.resolved).length,
+    results,
+  };
+  return new Response(JSON.stringify(summary, null, 2), {
+    status: 200,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+// Same cascade as the public POST handler, but returns the result
+// instead of formatting an HTTP response. Used by backfill to avoid
+// recursing into the function via HTTP.
+async function resolveOne(
+  company: string,
+  title: string,
+  alertUrl: string,
+  payload: Record<string, unknown> | null,
+): Promise<EnrichResponse> {
+  const sql = db();
+  const hintAtsUrl = alertUrl;
+  const hintDomain = (payload && typeof payload === 'object' && payload['sender'])
+    ? String(payload['sender']).match(/@([a-z0-9.-]+)/i)?.[1]
+    : undefined;
+
+  const existing = await sql<CompanyRow[]>`
+    select id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
+      from job.hiring_companies
+     where name_norm = lower(trim(${company})) limit 1`;
+  let row = existing[0];
+  if (!row) {
+    const [inserted] = await sql<CompanyRow[]>`
+      insert into job.hiring_companies (name, domain) values (${company}, ${normalizeDomain(hintDomain) || null})
+      on conflict (name_norm) do update set domain = coalesce(job.hiring_companies.domain, excluded.domain), updated_at = now()
+      returning id, name, domain, ats_provider, ats_slug, careers_url, resolution_status, retry_count
+    `;
+    row = inserted;
+  }
+  if (row.resolution_status === 'resolved' && row.ats_provider && row.ats_slug) {
+    const canonical = await resolveCanonicalForTitle(row, title);
+    return { resolved: !!canonical, companyId: row.id, atsProvider: row.ats_provider!, atsSlug: row.ats_slug!, canonicalUrl: canonical?.url, jdText: canonical?.jd };
+  }
+  const detected = await detectAts({ company, hintDomain, hintAtsUrl });
+  if (detected) {
+    await sql`
+      update job.hiring_companies
+         set ats_provider = ${detected.provider}, ats_slug = ${detected.slug},
+             careers_url = ${detected.careersUrl ?? null}, resolution_status = 'resolved',
+             last_resolved_at = now(), retry_count = 0, next_retry_at = null, updated_at = now()
+       where id = ${row.id}
+    `;
+    const canonical = await resolveCanonicalForTitle({ ...row, ats_provider: detected.provider, ats_slug: detected.slug }, title);
+    return { resolved: !!canonical, companyId: row.id, atsProvider: detected.provider, atsSlug: detected.slug, canonicalUrl: canonical?.url, jdText: canonical?.jd };
+  }
+  const nextCount = (row.retry_count || 0) + 1;
+  const retryAt = nextRetry(nextCount);
+  await sql`
+    update job.hiring_companies
+       set resolution_status = 'unresolved', retry_count = ${nextCount},
+           next_retry_at = ${retryAt.toISOString()}, updated_at = now()
+     where id = ${row.id}
+  `;
+  return { resolved: false, companyId: row.id, nextRetryAt: retryAt.toISOString(), reason: 'ats_unresolved' };
+}
 
 // ---------- ATS detection ----------
 

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -20,8 +20,8 @@ import { computeFit, type RoleRow, type UserContext as FitUserContext } from '..
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 
-const VERSION = '0.4.1';
-console.log(`[pull-recommendations] v${VERSION} - Fit v2 + Gmail sourceLabel = sender (LinkedIn / Wellfound / …) not company`);
+const VERSION = '0.5.0';
+console.log(`[pull-recommendations] v${VERSION} - Phase 1.5 enrichment writes (enrichment_status, canonical_url, company_id)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -418,6 +418,10 @@ async function insertNew(
     sector:         r.input.sector ?? null,
     investors:      r.input.investors ?? [],
     payload:        r.input.payload ?? null,
+    enrichment_status:   r.input.enrichmentStatus   ?? null,
+    enrichment_retry_at: r.input.enrichmentRetryAt  ?? null,
+    canonical_url:       r.input.canonicalUrl       ?? null,
+    company_id:          r.input.companyId          ?? null,
   }));
   const inserted = await sql`
     insert into job.recommended_roles ${sql(values)}

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.5.0';
-console.log(`[recommendations] v${VERSION} - return sourceEmailUrl for Gmail-sourced rows`);
+const VERSION = '0.6.0';
+console.log(`[recommendations] v${VERSION} - return enrichment fields (status, retry, canonical_url)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -32,6 +32,9 @@ serve(async (req) => {
                r.description, r.match_bullets as "matchBullets", r.suggested_at as "suggestedAt",
                r.fit_score as "fitScore", r.fit_breakdown as "breakdown",
                r.hard_fails as "hardFails", r.sector,
+               r.enrichment_status as "enrichmentStatus",
+               r.enrichment_retry_at as "enrichmentRetryAt",
+               r.canonical_url as "canonicalUrl",
                -- Source-email URL — derived from payload.gmailApiId for
                -- Gmail-sourced recs so the UI can render a "view source"
                -- link without parsing the JSON client-side.

--- a/supabase/migrations/066_hiring_companies_cache.sql
+++ b/supabase/migrations/066_hiring_companies_cache.sql
@@ -1,0 +1,50 @@
+-- Phase 1.5 enrichment: hiring_companies cache.
+--
+-- Resolves a (company, title) pair from a Gmail alert to a canonical
+-- Greenhouse / Lever / Ashby posting. Cached per company so the cascade
+-- (probe-3-ATSes) only runs once per company across all recs/users.
+--
+-- Separate from job.companies (which is career-history). Naming
+-- collision in Phase 1 cost us a session; keep it firewalled.
+
+create table if not exists job.hiring_companies (
+  id                  uuid primary key default gen_random_uuid(),
+  name                text not null,
+  name_norm           text generated always as (lower(trim(name))) stored,
+  domain              text,                          -- 'acme.com'
+  ats_provider        text,                          -- 'Greenhouse' | 'Lever' | 'Ashby' | null
+  ats_slug            text,
+  careers_url         text,
+  resolution_status   text not null default 'unresolved'
+                       check (resolution_status in ('resolved','unresolved','failed')),
+  last_resolved_at    timestamptz,
+  next_retry_at       timestamptz,
+  retry_count         int not null default 0,
+  notes               text,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  unique (name_norm)
+);
+
+create index if not exists hiring_companies_domain_idx
+  on job.hiring_companies (domain) where domain is not null;
+create index if not exists hiring_companies_unresolved_idx
+  on job.hiring_companies (next_retry_at)
+  where resolution_status <> 'resolved';
+
+alter table job.hiring_companies enable row level security;
+
+-- recommended_roles.company_id was added in migration 058 without an FK
+-- (the cache table didn't exist yet). Wire it up now.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'recommended_roles_company_id_fkey'
+       and conrelid = 'job.recommended_roles'::regclass
+  ) then
+    alter table job.recommended_roles
+      add constraint recommended_roles_company_id_fkey
+      foreign key (company_id) references job.hiring_companies(id) on delete set null;
+  end if;
+end$$;


### PR DESCRIPTION
Re-enables enrich-job-source. Resolved Gmail recs link to canonical Greenhouse/Lever/Ashby; unresolved ones show a 'verifying source' badge with the aggregator URL. Migration 066 + 4 function bumps + app v0.67.0.