### PR TITLE
Career Opportunities persisted in BE + stale-refresh

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1835,11 +1835,25 @@
 }
 .career-op__title {
   margin: 0;
+  flex: 1;
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
   font-size: var(--font-size-body);
   letter-spacing: -0.005em;
 }
+.career-op__dismiss {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 14px;
+  margin-left: auto;
+}
+.career-op__dismiss:hover { background: var(--bg-surface); color: var(--fg); }
 .career-op__gap { margin: 0; font-size: var(--font-size-small); color: var(--fg-muted); line-height: 1.5; }
 .career-op__ask {
   margin: 0;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.68.0">
-  <script src="/job/js/theme.js?v=0.68.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
+  <script src="/job/js/theme.js?v=0.69.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.68.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.68.0">
-  <script src="/job/js/theme.js?v=0.68.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
+  <script src="/job/js/theme.js?v=0.69.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.68.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.68.0">
-  <script src="/job/js/theme.js?v=0.68.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
+  <script src="/job/js/theme.js?v=0.69.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.68.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.68.0">
-  <script src="/job/js/theme.js?v=0.68.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
+  <script src="/job/js/theme.js?v=0.69.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.68.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.68.0";
-console.log(`[job] v${VERSION} - Phase 1.5 enrichment + verifying-source badge; KB extract max_tokens fix from master`);
+const VERSION = "0.69.0";
+console.log(`[job] v${VERSION} - Career Opportunities persisted in BE; auto-refresh only when a new story lands`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -6,7 +6,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, saveNarrative, linkNarrative, deleteNarrative, fetchCareerOpportunities, extractNarrativesFromKb }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
+const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, saveNarrative, linkNarrative, deleteNarrative, fetchCareerOpportunities, auditCareerOpportunities, dismissOpportunity, resolveOpportunity, extractNarrativesFromKb }, { readRoleAsset, writeRoleAsset }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -117,7 +117,7 @@ export class JobCareer extends LitElement {
     this.narratives = [];
     this.companies = [];
     this.composing = null;
-    this.opportunities = { items: [], loading: false, error: '' };
+    this.opportunities = { items: [], loading: false, auditing: false, stale: false, last_audit_ts: null, error: '' };
     this.opportunityThreads = {};
     this.extracting = { running: false, lastResult: null, error: '' };
   }
@@ -173,6 +173,11 @@ export class JobCareer extends LitElement {
       // than 7 days ago. Keeps the KB in sync as work history grows
       // without requiring the user to click a button.
       this._maybeAutoExtract();
+      // Pull persisted opportunities. Cheap cache hit on every page
+      // load; the server flags stale=true if a narrative has landed
+      // since the last audit, and _loadOpportunities then kicks a
+      // background re-audit.
+      this._loadOpportunities();
       // Companies for the "Needs connection" dropdown — derived from the
       // pipeline tag space isn't enough; we want the actual work history.
       // For now, scrape unique companies from existing narratives' links
@@ -603,56 +608,107 @@ export class JobCareer extends LitElement {
 
   // ----- Career opportunities ---------------------------------------------
 
+  // Page load: pull the cached open opportunities from the BE. If the
+  // server says they're stale (a narrative has landed since the last
+  // audit), trigger a background re-audit so the cards refresh — but
+  // show the cached list immediately so the page doesn't flicker.
   async _loadOpportunities() {
     if (this.opportunities.loading) return;
-    this.opportunities = { items: [], loading: true, error: '' };
+    this.opportunities = { ...this.opportunities, loading: true, error: '' };
     try {
-      const items = await fetchCareerOpportunities();
-      this.opportunities = { items, loading: false, error: '' };
+      const { items, last_audit_ts, stale } = await fetchCareerOpportunities();
+      this.opportunities = { items, loading: false, error: '', stale, last_audit_ts };
+      if (stale) queueMicrotask(() => this._auditOpportunities(/* silent */ true));
     } catch (e) {
-      this.opportunities = { items: [], loading: false, error: String(e?.message || e) };
+      this.opportunities = { items: [], loading: false, error: String(e?.message || e), stale: false, last_audit_ts: null };
     }
   }
 
-  _getOpThread(idx) {
-    return this.opportunityThreads[idx] || { messages: [], sending: false, error: '' };
+  // Force a fresh audit. `silent=true` keeps the existing items visible
+  // while the AI pass runs in the background (used by the stale-refresh
+  // path); `silent=false` shows the standard auditing shimmer.
+  async _auditOpportunities(silent = false) {
+    if (this.opportunities.auditing) return;
+    this.opportunities = { ...this.opportunities, auditing: true, error: '' };
+    try {
+      const { items, last_audit_ts } = await auditCareerOpportunities();
+      this.opportunities = { items, loading: false, auditing: false, error: '', stale: false, last_audit_ts };
+    } catch (e) {
+      this.opportunities = { ...this.opportunities, auditing: false, error: String(e?.message || e) };
+    }
   }
 
-  _setOpThread(idx, t) {
-    this.opportunityThreads = { ...this.opportunityThreads, [idx]: t };
+  async _dismissOpportunity(id) {
+    try {
+      await dismissOpportunity(id);
+      this.opportunities = {
+        ...this.opportunities,
+        items: this.opportunities.items.filter(o => o.id !== id),
+      };
+    } catch (e) {
+      alert(`Dismiss failed: ${String(e?.message || e)}`);
+    }
+  }
+
+  _getOpThread(key) {
+    return this.opportunityThreads[key] || { messages: [], sending: false, error: '' };
+  }
+
+  _setOpThread(key, t) {
+    this.opportunityThreads = { ...this.opportunityThreads, [key]: t };
+  }
+
+  _opAgo(ts) {
+    const sec = Math.max(0, Math.round((Date.now() - new Date(ts).getTime()) / 1000));
+    if (sec < 60) return 'just now';
+    const m = Math.round(sec / 60);
+    if (m < 60) return `${m}m ago`;
+    const h = Math.round(m / 60);
+    if (h < 48) return `${h}h ago`;
+    return `${Math.round(h / 24)}d ago`;
   }
 
   // Answering an opportunity creates a new narrative anchored to the
-  // company the opportunity was flagged against. The server's tag pass
-  // will reaffirm the link + assign tags consistent with the vision.
-  async _sendOpportunityAnswer(idx, userText) {
-    const op = this.opportunities.items[idx];
+  // company the opportunity was flagged against. After the narrative
+  // saves, we mark the opportunity resolved so it disappears from the
+  // open set on next reload (and the BE knows which story resolved it).
+  async _sendOpportunityAnswer(op, userText) {
     if (!op) return;
     const text = String(userText || '').trim();
     if (!text) return;
-    const prev = this._getOpThread(idx);
-    this._setOpThread(idx, {
+    const key = op.id || op.title;
+    const prev = this._getOpThread(key);
+    this._setOpThread(key, {
       messages: [...prev.messages, { role: 'user', text }],
       sending: true, error: '',
     });
     try {
-      const title = op.title || `Captured from opportunity #${idx + 1}`;
       const body = `> ${op.ask || op.gap || ''}\n\n${text}`;
-      const saved = await saveNarrative({ title, content_md: body, source_role: op.anchor_company_slug || '' });
+      const saved = await saveNarrative({ title: op.title || 'Captured story', content_md: body, source_role: op.anchor_company_slug || '' });
       this.narratives = [saved, ...this.narratives.filter(n => n.id !== saved.id)];
-      const cur = this._getOpThread(idx);
-      this._setOpThread(idx, {
-        messages: [...cur.messages, { role: 'assistant', text: 'Saved as a new story. Tags and link inferred.' }],
+      // Mark the opportunity resolved on the server so it doesn't come
+      // back on next page load. Best-effort; failure isn't fatal.
+      if (op.id) {
+        try { await resolveOpportunity(op.id, saved.id); } catch {}
+        this.opportunities = {
+          ...this.opportunities,
+          items: this.opportunities.items.filter(o => o.id !== op.id),
+        };
+      }
+      const cur = this._getOpThread(key);
+      this._setOpThread(key, {
+        messages: [...cur.messages, { role: 'assistant', text: 'Saved as a story and resolved this opportunity.' }],
         sending: false, error: '',
       });
     } catch (e) {
-      const cur = this._getOpThread(idx);
-      this._setOpThread(idx, { messages: cur.messages, sending: false, error: String(e?.message || e) });
+      const cur = this._getOpThread(key);
+      this._setOpThread(key, { messages: cur.messages, sending: false, error: String(e?.message || e) });
     }
   }
 
   _renderOpportunities() {
     const o = this.opportunities;
+    const busy = o.loading || o.auditing;
     return html`
       <section class="career-ops">
         <header class="career-ops__head">
@@ -660,10 +716,14 @@ export class JobCareer extends LitElement {
             <h3 class="career-ops__title">✦ Opportunities to strengthen your career KB</h3>
             <p class="muted" style="margin:0;font-size:var(--font-size-small);">
               AI-flagged gaps. Answer in a thread and the response saves as a new story.
+              ${o.stale ? html` <span style="color:var(--accent-strong);">A new story has landed — re-auditing in the background.</span>` : nothing}
+              ${!o.stale && o.last_audit_ts ? html` <span class="muted">Last audited ${this._opAgo(o.last_audit_ts)}.</span>` : nothing}
             </p>
           </div>
-          <button class="btn btn--sm" ?disabled=${o.loading} @click=${() => this._loadOpportunities()}>
-            ${o.loading ? html`<span class="gen-shimmer">Auditing</span>` : (o.items.length ? 'Re-audit' : 'Find opportunities')}
+          <button class="btn btn--sm" ?disabled=${busy} @click=${() => this._auditOpportunities()}>
+            ${o.auditing ? html`<span class="gen-shimmer">Auditing</span>`
+              : o.loading ? html`<span class="gen-shimmer">Loading</span>`
+              : (o.items.length ? 'Re-audit' : 'Find opportunities')}
           </button>
         </header>
         ${o.error ? html`<p class="muted" style="color:var(--error);">${o.error}</p>` : nothing}
@@ -679,12 +739,14 @@ export class JobCareer extends LitElement {
   }
 
   _renderOpportunityCard(op, idx) {
-    const thread = this._getOpThread(idx);
+    const key = op.id || `idx-${idx}`;
+    const thread = this._getOpThread(key);
     return html`
       <article class="career-op">
         <header class="career-op__head">
           <span class="career-op__scope" data-scope=${op.scope || 'narrative'}>${op.scope || 'narrative'}</span>
           <h4 class="career-op__title">${op.title}</h4>
+          ${op.id ? html`<button class="career-op__dismiss" title="Dismiss" @click=${() => this._dismissOpportunity(op.id)}>×</button>` : nothing}
         </header>
         ${op.gap ? html`<p class="career-op__gap">${op.gap}</p>` : nothing}
         ${op.ask ? html`<p class="career-op__ask">${op.ask}</p>` : nothing}
@@ -715,7 +777,7 @@ export class JobCareer extends LitElement {
           const input = e.currentTarget.querySelector('textarea');
           const v = input.value;
           input.value = '';
-          this._sendOpportunityAnswer(idx, v);
+          this._sendOpportunityAnswer(op, v);
         }}>
           <textarea class="cover-thread__input"
                     rows="1"

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -228,18 +228,60 @@ export async function applyCoverEdit({ coverText, instruction, comment }) {
   return j.content;
 }
 
-// Audit the career KB (companies/projects/clients + narratives + vision)
-// and return highest-leverage gaps to fill. Stateless on the server.
+// Persisted career opportunities — backed by job.career_opportunities.
+// GET returns cached open rows + a `stale` flag the UI uses to decide
+// whether to trigger a background re-audit.
+const OPPORTUNITIES_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/opportunities';
+
 export async function fetchCareerOpportunities() {
   const headers = await authHeader();
-  const res = await fetch(GEN_ASSET_URL, {
+  const res = await fetch(OPPORTUNITIES_URL, { headers });
+  if (!res.ok) throw new Error(`opportunities ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return {
+    items:          Array.isArray(j.opportunities) ? j.opportunities : [],
+    last_audit_ts:  j.last_audit_ts || null,
+    stale:          !!j.stale,
+  };
+}
+
+// Force a fresh AI audit; replaces the open set on the server.
+export async function auditCareerOpportunities() {
+  const headers = await authHeader();
+  const res = await fetch(OPPORTUNITIES_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ kind: 'career-opportunities' }),
+    body: JSON.stringify({ audit: true }),
   });
-  if (!res.ok) throw new Error(`gen-asset ${res.status}: ${await res.text()}`);
+  if (!res.ok) throw new Error(`opportunities ${res.status}: ${await res.text()}`);
   const j = await res.json();
-  return Array.isArray(j.opportunities) ? j.opportunities : [];
+  return {
+    items:          Array.isArray(j.opportunities) ? j.opportunities : [],
+    last_audit_ts:  j.last_audit_ts || null,
+    stale:          !!j.stale,
+  };
+}
+
+export async function dismissOpportunity(id) {
+  const headers = await authHeader();
+  const res = await fetch(OPPORTUNITIES_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dismiss: id }),
+  });
+  if (!res.ok) throw new Error(`opportunities ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function resolveOpportunity(id, narrativeId) {
+  const headers = await authHeader();
+  const res = await fetch(OPPORTUNITIES_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ resolve: id, narrative_id: narrativeId || undefined }),
+  });
+  if (!res.ok) throw new Error(`opportunities ${res.status}: ${await res.text()}`);
+  return res.json();
 }
 
 // ----- Narratives (job.narratives) ----------------------------------------
@@ -367,5 +409,5 @@ window.JobPipeline = {
   fetchPipeline, setStatus, generateAsset, formatResumeText, fetchCoverRationale, applyCoverEdit, addNarrative,
   fetchNarratives, saveNarrative, linkNarrative, deleteNarrative, extractNarrativesFromKb,
   fetchRoleProjects, saveRoleProject, deleteRoleProject, saveProjectClient, deleteProjectClient,
-  fetchCareerOpportunities,
+  fetchCareerOpportunities, auditCareerOpportunities, dismissOpportunity, resolveOpportunity,
 };

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.68.0">
-  <script src="/job/js/theme.js?v=0.68.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
+  <script src="/job/js/theme.js?v=0.69.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.68.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
 </body>
 </html>

--- a/supabase/functions/opportunities/index.ts
+++ b/supabase/functions/opportunities/index.ts
@@ -1,0 +1,217 @@
+// opportunities — persisted Career-Opportunities cache + on-demand audit.
+//
+//   GET                          → { opportunities: [...open...], last_audit_ts, stale }
+//   POST { audit: true }         → run a fresh AI audit; replace open rows
+//   POST { dismiss: id }         → mark dismissed_at
+//   POST { resolve: id, narrative_id? } → mark resolved_at + link narrative
+//
+// "stale" is true when the latest narrative.updated_at is newer than the
+// most recent audit_ts. The frontend reuses the cached list on every
+// page load (instant) and triggers a background re-audit only when
+// stale — matching the user's "reuse from BE unless a new matching
+// story has been added since last load" requirement.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[opportunities] v${VERSION} - persisted audit cache + stale check`);
+
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const ID_RE = /^[a-z0-9_-]+$/;
+
+function newId(): string { return Math.random().toString(36).slice(2, 12); }
+
+const AUDIT_SYSTEM = `You audit a candidate's career KB and surface the highest-leverage gaps to fill — places where adding a story, project detail, metric, or client name would materially improve every future cover letter, resume, or pitch.
+
+You will receive:
+- The candidate's vision (job goals / industry framing).
+- Their work history (companies + roles + role-projects + clients).
+- Their existing narratives (titles + tags + linked company).
+
+Return 4–8 opportunities, prioritized by leverage. Each:
+- "title":      short, action-oriented (≤8 words).
+- "gap":        one sentence (≤25 words) — what's missing and why it matters for the job-search target. Reference specific company/role/project slugs when relevant.
+- "ask":        one short question (≤20 words), second person, the candidate can answer to fill the gap.
+- "scope":      one of "narrative" | "project" | "client" | "metric".
+- "anchor_company_slug": exact slug from the work history if anchored; null otherwise.
+
+Output ONLY a JSON object: { "opportunities": [...] }. No prose, no code fence.
+
+Rules:
+- Don't suggest filling things already captured in the narratives.
+- Be specific. Skip generic asks.
+- Prefer fillable gaps (one metric, one story) over open-ended ones.
+- Lean toward the candidate's job-search target when prioritizing.`;
+
+async function callClaudeJson(system: string, user: string, maxTokens = 4096): Promise<any> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json() as { content: { type: string; text: string }[]; stop_reason?: string };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  let stripped = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
+  try { return JSON.parse(stripped); } catch { /* */ }
+  const start = stripped.indexOf('{');
+  const end = stripped.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    try { return JSON.parse(stripped.slice(start, end + 1)); } catch { /* */ }
+  }
+  console.warn('[opportunities] JSON parse failed', { stop_reason: data.stop_reason, head: text.slice(0, 200), tail: text.slice(-200) });
+  return null;
+}
+
+async function runAudit(sql: any): Promise<any[]> {
+  const [vision, companies, projects, clients, narratives] = await Promise.all([
+    sql`select narrative_arc, raw_md from job.vision where id = 1`,
+    sql`select slug, name, sector, body_md from job.companies`,
+    sql`select id, company_slug, role_title, name, description, outcome, metric from job.role_projects`,
+    sql`select project_id, name, kind, description from job.project_clients`,
+    sql`select id, title, tags, linked_company_slug, content_md from job.narratives`,
+  ]);
+  const visionText = (vision[0]?.narrative_arc || vision[0]?.raw_md || '').slice(0, 6000);
+  const clientsByProject = new Map<string, any[]>();
+  for (const c of clients) {
+    if (!clientsByProject.has(c.project_id)) clientsByProject.set(c.project_id, []);
+    clientsByProject.get(c.project_id)!.push(c);
+  }
+  const projectsByCompany = new Map<string, any[]>();
+  for (const p of projects) {
+    if (!projectsByCompany.has(p.company_slug)) projectsByCompany.set(p.company_slug, []);
+    projectsByCompany.get(p.company_slug)!.push({ ...p, clients: clientsByProject.get(p.id) || [] });
+  }
+  const companyBlocks = companies.map((c: any) => {
+    const ps = (projectsByCompany.get(c.slug) || []).map((p: any) =>
+      `  - Project ${p.id}: ${p.name}${p.metric ? ` (metric: ${p.metric})` : ''}${p.outcome ? ` — outcome: ${p.outcome.slice(0, 160)}` : ''}${p.clients.length ? ` — clients: ${p.clients.map((c: any) => `${c.name} [${c.kind}]`).join(', ')}` : ''}`
+    ).join('\n');
+    return `## ${c.slug}: ${c.name}${c.sector ? ` — ${c.sector}` : ''}\n${ps || '  (no projects captured)'}`;
+  }).join('\n\n');
+  const narrativeBlocks = narratives.map((n: any) =>
+    `- ${n.id}: "${n.title}" — tags: ${(n.tags || []).join(', ') || '(none)'} — linked: ${n.linked_company_slug || '(unlinked)'}`
+  ).join('\n');
+
+  const user = `# Vision\n\n${visionText || '(no vision recorded)'}\n\n# Work history\n\n${companyBlocks || '(no companies)'}\n\n# Existing narratives\n\n${narrativeBlocks || '(no narratives yet)'}\n\n# Ask\n\nProduce the JSON object now. JSON only.`;
+  const parsed = await callClaudeJson(AUDIT_SYSTEM, user, 4096);
+  return Array.isArray(parsed?.opportunities) ? parsed.opportunities : [];
+}
+
+async function loadOpen(sql: any) {
+  return await sql`
+    select id, audit_ts, title, gap, ask, scope, anchor_company_slug,
+           resolved_at, dismissed_at, created_at
+    from job.career_opportunities
+    where resolved_at is null and dismissed_at is null
+    order by audit_ts desc, created_at;
+  `;
+}
+
+async function lastAuditTs(sql: any): Promise<string | null> {
+  const r = await sql`select max(audit_ts) as ts from job.career_opportunities`;
+  return r[0]?.ts ? new Date(r[0].ts).toISOString() : null;
+}
+
+async function isStale(sql: any, lastTs: string | null): Promise<boolean> {
+  if (!lastTs) return true;
+  const r = await sql`select count(*)::int as n from job.narratives where updated_at > ${lastTs}`;
+  return (r[0]?.n || 0) > 0;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const opportunities = await loadOpen(sql);
+      const last = await lastAuditTs(sql);
+      const stale = await isStale(sql, last);
+      return jsonResp({ opportunities, last_audit_ts: last, stale });
+    }
+
+    if (req.method !== 'POST') return err('GET or POST only', 405);
+
+    const body = await req.json().catch(() => ({}));
+
+    if (body.audit === true) {
+      const items = await runAudit(sql);
+      const auditTs = new Date().toISOString();
+      // Replace the open set with the fresh audit. Resolved + dismissed
+      // rows are preserved so the user keeps their history.
+      await sql`
+        delete from job.career_opportunities
+        where resolved_at is null and dismissed_at is null;
+      `;
+      const inserted: any[] = [];
+      for (const o of items) {
+        const title = String(o?.title || '').trim();
+        if (!title) continue;
+        const id = newId();
+        const rows = await sql`
+          insert into job.career_opportunities
+            (id, audit_ts, title, gap, ask, scope, anchor_company_slug)
+          values
+            (${id}, ${auditTs}, ${title},
+             ${String(o.gap || '')}, ${String(o.ask || '')},
+             ${String(o.scope || 'narrative')},
+             ${o.anchor_company_slug ? String(o.anchor_company_slug) : null})
+          returning id, audit_ts, title, gap, ask, scope, anchor_company_slug,
+                    resolved_at, dismissed_at, created_at;
+        `;
+        inserted.push(rows[0]);
+      }
+      return jsonResp({ opportunities: inserted, last_audit_ts: auditTs, stale: false, audited: inserted.length });
+    }
+
+    if (body.dismiss) {
+      const id = String(body.dismiss);
+      if (!ID_RE.test(id)) return err('invalid id', 400);
+      const rows = await sql`
+        update job.career_opportunities
+           set dismissed_at = now()
+         where id = ${id}
+         returning id, dismissed_at;
+      `;
+      if (rows.length === 0) return err('not found', 404);
+      return jsonResp({ ok: true, ...rows[0] });
+    }
+
+    if (body.resolve) {
+      const id = String(body.resolve);
+      if (!ID_RE.test(id)) return err('invalid id', 400);
+      const nid = body.narrative_id ? String(body.narrative_id) : null;
+      if (nid && !ID_RE.test(nid)) return err('invalid narrative_id', 400);
+      const rows = await sql`
+        update job.career_opportunities
+           set resolved_at = now(),
+               resolved_by_narrative_id = ${nid}
+         where id = ${id}
+         returning id, resolved_at, resolved_by_narrative_id;
+      `;
+      if (rows.length === 0) return err('not found', 404);
+      return jsonResp({ ok: true, ...rows[0] });
+    }
+
+    return err('unknown action', 400);
+  } catch (e) {
+    console.error('[opportunities] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/068_career_opportunities.sql
+++ b/supabase/migrations/068_career_opportunities.sql
@@ -1,0 +1,25 @@
+-- 068_career_opportunities — persist AI-flagged opportunities so they
+-- survive page reload. Each row carries the audit timestamp of the AI
+-- run that produced it; we treat them as "open" until resolved_at or
+-- dismissed_at is set. On load, the frontend reuses the cached set
+-- unchanged unless a new narrative has been added since the latest
+-- audit_ts — in which case the server re-audits in the background.
+
+create table if not exists job.career_opportunities (
+  id                  text primary key,
+  audit_ts            timestamptz not null default now(),
+  title               text not null,
+  gap                 text not null default '',
+  ask                 text not null default '',
+  scope               text not null default 'narrative',  -- narrative|project|client|metric
+  anchor_company_slug text references job.companies(slug) on delete set null,
+  resolved_at         timestamptz,
+  resolved_by_narrative_id text references job.narratives(id) on delete set null,
+  dismissed_at        timestamptz,
+  created_at          timestamptz not null default now()
+);
+
+-- Frequent filter: open rows only.
+create index if not exists idx_career_opps_open
+  on job.career_opportunities (audit_ts desc)
+  where resolved_at is null and dismissed_at is null;


### PR DESCRIPTION
Persists AI-flagged opportunities in `job.career_opportunities` so they survive page reload. On load, cache served immediately; server flags `stale` when any narrative.updated_at > max(audit_ts), and the frontend triggers a background re-audit only then.

Resolving an opportunity (via the thread answer) writes `resolved_at` + `resolved_by_narrative_id` so it doesn't reappear. Dismiss button per card. Threads keyed by op.id so they survive re-audits.

Migration: `068_career_opportunities.sql`. New edge function `opportunities` v0.1.0. `/job` 0.69.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)