### PR TITLE
job: drill page auto-regenerates analysis on stale role data

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
-  <script src="/job/js/theme.js?v=0.69.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
+  <script src="/job/js/theme.js?v=0.70.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
-  <script src="/job/js/theme.js?v=0.69.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
+  <script src="/job/js/theme.js?v=0.70.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
-  <script src="/job/js/theme.js?v=0.69.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
+  <script src="/job/js/theme.js?v=0.70.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
-  <script src="/job/js/theme.js?v=0.69.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
+  <script src="/job/js/theme.js?v=0.70.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.69.0";
-console.log(`[job] v${VERSION} - Career Opportunities persisted in BE; auto-refresh only when a new story lands`);
+const VERSION = "0.70.0";
+console.log(`[job] v${VERSION} - Drill page auto-regenerates analysis when role row was updated since last gen`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -186,6 +186,13 @@ export class JobRoleDetail extends LitElement {
       queueMicrotask(() => this._refreshEditHtml('resume'));
       // Auto-generate any missing asset.
       this._autoGenerateMissing();
+      // Auto-refresh stale analysis. If the role row was updated more
+      // recently than the analysis asset (e.g. company/title/url got
+      // patched after we generated a "(unknown company) / Careers"
+      // analysis), regenerate from the current JD. The user gets a
+      // refresh-banner; resume + cover stay untouched (those have user
+      // edits; regenerating them silently is destructive).
+      this._maybeRefreshStaleAnalysis();
     } catch (e) {
       this.state = 'error';
       this.error = String(e);
@@ -196,7 +203,11 @@ export class JobRoleDetail extends LitElement {
     try {
       const r = await readRoleAsset(this.slug, kind);
       if (!r) return this._emptyAsset(kind);
-      return this._viewAsset(kind, r.content_md);
+      const view = this._viewAsset(kind, r.content_md);
+      // Stash generated_at / updated_at so the stale-check can compare
+      // them against the role row's updated_at on load.
+      view._generatedAt = r.generated_at || r.updated_at || null;
+      return view;
     } catch (e) {
       return { ...this._emptyAsset(kind), error: String(e) };
     }
@@ -297,6 +308,33 @@ export class JobRoleDetail extends LitElement {
       const a = this.assets[kind];
       if (a && a.mode === 'empty' && !a.saving) this._onGenerate(kind);
     }
+  }
+
+  // Re-run analysis when the role row has been touched (URL / company /
+  // title fix, manual edit, enrichment cycle) after the last analysis
+  // was generated. Resume + cover are left alone because the user may
+  // have hand-edited them; regenerating destroys edits.
+  //
+  // Threshold: 30s grace window — `engageRole` itself updates
+  // `pipeline_roles.updated_at`, and we don't want to ping-pong a
+  // regenerate every page open.
+  async _maybeRefreshStaleAnalysis() {
+    if (!this.role) return;
+    const a = this.assets['analysis'];
+    if (!a || a.mode === 'empty' || a.saving) return;     // empty path is handled by _autoGenerateMissing
+    const roleUpdated = Date.parse(this.role.updatedAt || '');
+    // generated_at sits on the asset row but isn't surfaced through
+    // _viewAsset; we hold it on a._generatedAt when present via the
+    // role-asset response.
+    const assetGenerated = Date.parse(a._generatedAt || '');
+    if (!isFinite(roleUpdated) || !isFinite(assetGenerated)) return;
+    if (roleUpdated - assetGenerated < 30_000) return;
+    console.log(`[role-detail] auto-refresh analysis (role +${Math.round((roleUpdated - assetGenerated)/1000)}s newer)`);
+    this._analysisAutoRefreshing = true;
+    this.requestUpdate();
+    await this._onGenerate('analysis');
+    this._analysisAutoRefreshing = false;
+    this.requestUpdate();
   }
 
   _switchTab(id) {

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.69.0">
-  <script src="/job/js/theme.js?v=0.69.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
+  <script src="/job/js/theme.js?v=0.70.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.69.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.10.1';
-console.log(`[jobs-pipe] v${VERSION} - return sourceEmailUrl for Gmail-sourced rows`);
+const VERSION = '0.10.2';
+console.log(`[jobs-pipe] v${VERSION} - return updatedAt so drill page can auto-regen stale assets`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -54,6 +54,7 @@ async function listRoles() {
       r.liveness_checked_at as "livenessCheckedAt",
       r.engaged_at as "engagedAt",
       r.source_email_url as "sourceEmailUrl",
+      r.updated_at as "updatedAt",
       coalesce(ra_resume.role_slug is not null, false) as "hasResume",
       coalesce(ra_cover.role_slug is not null, false) as "hasCoverLetter",
       coalesce((
@@ -111,9 +112,12 @@ serve(async (req) => {
       if (body.action === 'engage') {
         await sql`
           update job.pipeline_roles
-             set engaged_at = coalesce(engaged_at, now()),
-                 updated_at = now()
+             set engaged_at = coalesce(engaged_at, now())
            where slug = ${slug};
+        -- engage is a passive UI signal; deliberately do NOT touch
+        -- updated_at so the drill page's stale-detection (which uses
+        -- updated_at as a freshness proxy) doesn't ping-pong a
+        -- regenerate on every page open.
         `;
         return jsonResp({ ok: true, slug, engaged: true });
       }


### PR DESCRIPTION
Closes the loop on roles that were imported with bad data and later patched (e.g. Assort Health '(unknown company) / Careers' fix). Resume + cover unaffected. v0.70.0.