### PR TITLE
Row click → in-page nav; "N new jobs added" banner

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2306,6 +2306,41 @@
 [data-theme="generic-dark"] .liveness-banner--clean  { background: rgba(159,232,112,0.08); border-color: rgba(159,232,112,0.22); }
 [data-theme="generic-dark"] .liveness-banner--closed { background: rgba(255,122,110,0.08); border-color: rgba(255,122,110,0.24); }
 
+/* --- "N new jobs added" banner --- */
+.added-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
+  margin: 0 0 var(--space-4);
+  border-radius: var(--radius-md);
+  background: rgba(0, 120, 255, 0.06);
+  border: 1px solid rgba(0, 120, 255, 0.22);
+  font-size: var(--font-size-small);
+}
+.added-banner__body { display: flex; flex-wrap: wrap; align-items: baseline; gap: var(--space-3); }
+.added-banner strong { color: var(--fg); }
+.added-banner__roles { color: var(--fg-muted); }
+.added-banner__roles a {
+  color: var(--accent-strong);
+  text-decoration: none;
+  font-weight: var(--fw-medium);
+}
+.added-banner__roles a:hover { text-decoration: underline; }
+.added-banner__close {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 16px;
+}
+.added-banner__close:hover { background: rgba(0, 120, 255, 0.08); color: var(--fg); }
+
 /* --- Animated 'Generating' dots --- */
 .dots-anim::after {
   content: '';

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
-  <script src="/job/js/theme.js?v=0.70.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
+  <script src="/job/js/theme.js?v=0.71.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
-  <script src="/job/js/theme.js?v=0.70.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
+  <script src="/job/js/theme.js?v=0.71.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
-  <script src="/job/js/theme.js?v=0.70.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
+  <script src="/job/js/theme.js?v=0.71.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
-  <script src="/job/js/theme.js?v=0.70.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
+  <script src="/job/js/theme.js?v=0.71.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.70.0";
-console.log(`[job] v${VERSION} - Drill page auto-regenerates analysis when role row was updated since last gen`);
+const VERSION = "0.71.0";
+console.log(`[job] v${VERSION} - Row click → in-page nav; "N new jobs added" banner instead of opening details`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -112,6 +112,9 @@ export class JobPipeline extends LitElement {
     pasteUrl: { state: true },
     pasteSaving: { state: true },
     pasteError: { state: true },
+    // "N new jobs added" banner. Accumulates entries dispatched via
+    // job:pipeline:added until the user dismisses it.
+    addedBanner: { state: true },
     // Active sub-stage tab filter. null = "All".
     activeStageFilter: { state: true },
     // Archive-flow modal state.
@@ -159,6 +162,7 @@ export class JobPipeline extends LitElement {
     this.pasteUrl = '';
     this.pasteSaving = false;
     this.pasteError = '';
+    this.addedBanner = { roles: [], dismissed: false };
     const stageQ = params.get('stage');
     this.activeStageFilter = STAGES.some(s => s.id === stageQ) ? stageQ : null;
     this.archivingRow = null;
@@ -192,6 +196,20 @@ export class JobPipeline extends LitElement {
       } catch {}
     };
     document.addEventListener('job:pipeline:refresh', this._onRefresh);
+    // Surface added jobs (paste-URL, recs, future batch import) via a
+    // dismissible banner at the top of the table. Accumulates entries
+    // until the user dismisses or navigates away.
+    this._onAdded = (e) => {
+      const role = e.detail?.role;
+      const roles = e.detail?.roles;
+      const next = Array.isArray(roles) ? roles : (role ? [role] : []);
+      if (!next.length) return;
+      // De-dupe by slug so re-fires don't double-count.
+      const existing = new Map((this.addedBanner.roles || []).map(r => [r.slug, r]));
+      for (const r of next) if (r?.slug) existing.set(r.slug, r);
+      this.addedBanner = { roles: Array.from(existing.values()), dismissed: false };
+    };
+    document.addEventListener('job:pipeline:added', this._onAdded);
     this._onPopState = () => {
       const b = new URLSearchParams(location.search).get('bucket') || 'leads';
       if (b !== this.bucket) {
@@ -207,6 +225,7 @@ export class JobPipeline extends LitElement {
     document.removeEventListener('keydown', this._onKey);
     document.removeEventListener('click', this._onDocClick);
     document.removeEventListener('job:pipeline:refresh', this._onRefresh);
+    document.removeEventListener('job:pipeline:added', this._onAdded);
     window.removeEventListener('popstate', this._onPopState);
     super.disconnectedCallback();
   }
@@ -223,8 +242,12 @@ export class JobPipeline extends LitElement {
       this.roles = (data.roles || []).slice();
       this.pasteOpen = false;
       this.pasteUrl = '';
-      // Open the new role's detail page in a new tab so the user can flesh it out.
-      window.open(`/job/jobs/${r.slug}/`, '_blank', 'noopener');
+      // Surface the new role via a banner rather than navigating away.
+      // Dispatch globally so other components (recs table, future batch
+      // import) feed the same banner.
+      document.dispatchEvent(new CustomEvent('job:pipeline:added', {
+        detail: { role: { slug: r.slug, company: r.company, title: r.title } },
+      }));
     } catch (err) {
       this.pasteError = String(err);
     } finally {
@@ -733,8 +756,15 @@ export class JobPipeline extends LitElement {
     // Don't navigate when the click landed on an interactive child
     // (status select, fit pill, View button, triple-dot menu).
     if (e.target.closest('button, select, a, .row-menu, .fit-pill--button')) return;
+    // Cmd/Ctrl-click or middle-click → new tab (browser standard);
+    // plain click → in-page navigation.
     stashRolePrefill(r);
-    window.open(this._detailHref(r), '_blank', 'noopener');
+    const href = this._detailHref(r);
+    if (e.metaKey || e.ctrlKey || e.button === 1) {
+      window.open(href, '_blank', 'noopener');
+    } else {
+      window.location.assign(href);
+    }
   }
 
   _renderRow(r) {
@@ -833,6 +863,34 @@ export class JobPipeline extends LitElement {
     return renderFitModal(this.selectedRow, () => this._closeFitModal());
   }
 
+  // "N new jobs added" banner. Pluralizes correctly, links the most
+  // recent N entries inline (cap 3) and shows a "+M more" tail. Click
+  // a role link → in-page nav to its detail page.
+  _renderAddedBanner(roles) {
+    const total = roles.length;
+    const preview = roles.slice(-3);     // most recent at the end
+    const moreCount = Math.max(0, total - preview.length);
+    return html`
+      <div class="added-banner" role="status">
+        <div class="added-banner__body">
+          <strong>${total} new job${total === 1 ? '' : 's'} added.</strong>
+          <span class="added-banner__roles">
+            ${preview.map((r, i) => html`${i > 0 ? ' · ' : ''}<a href=${`/job/jobs/${r.slug}/`} @click=${(e) => this._onAddedClick(r, e)}>${r.company ? `${r.company}` : r.slug}${r.title ? ` — ${r.title}` : ''}</a>`)}
+            ${moreCount > 0 ? html` <span class="muted">+${moreCount} more</span>` : nothing}
+          </span>
+        </div>
+        <button class="added-banner__close" @click=${() => this.addedBanner = { roles: [], dismissed: true }} aria-label="Dismiss">×</button>
+      </div>
+    `;
+  }
+
+  _onAddedClick(r, e) {
+    if (e.metaKey || e.ctrlKey || e.button === 1) return; // standard new-tab
+    e.preventDefault();
+    stashRolePrefill({ slug: r.slug, company: r.company, title: r.title });
+    window.location.assign(`/job/jobs/${r.slug}/`);
+  }
+
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
       // Render the same shell that the loaded view will use, with skeleton
@@ -858,8 +916,13 @@ export class JobPipeline extends LitElement {
     }
     const rows = this._sorted();
     const bucketLabel = { leads: 'Saved', active: 'Active', archive: 'Archive' }[this.bucket];
+    const added = this.addedBanner?.roles || [];
+    const showAddedBanner = added.length > 0 && !this.addedBanner.dismissed;
+
     return html`
       ${this.bucket === 'leads' ? html`<job-recommendations></job-recommendations>` : nothing}
+
+      ${showAddedBanner ? this._renderAddedBanner(added) : nothing}
 
       ${this.livenessResult && !this.livenessResultDismissed ? html`
         <div class="liveness-banner ${this.livenessResult.closed.length ? 'liveness-banner--closed' : 'liveness-banner--clean'}" role="status">

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -156,6 +156,9 @@ export class JobRecommendationsTable extends LitElement {
       });
       this.items = this.items.filter(x => x.id !== rec.id);
       document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
+      document.dispatchEvent(new CustomEvent('job:pipeline:added', {
+        detail: { role: { slug: r.slug, company: r.company || rec.company, title: r.title || rec.title } },
+      }));
     } catch (e) {
       console.warn('[recs-table] add failed', e);
     } finally {

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -90,8 +90,12 @@ export class JobRecommendations extends LitElement {
       });
       // Optimistic: pop from the carousel.
       this.items = this.items.filter(x => x.id !== rec.id);
-      // Invite the pipeline to refresh.
+      // Invite the pipeline to refresh + surface the new row in the
+      // "N new jobs added" banner instead of navigating.
       document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
+      document.dispatchEvent(new CustomEvent('job:pipeline:added', {
+        detail: { role: { slug: r.slug, company: r.company || rec.company, title: r.title || rec.title } },
+      }));
     } catch (e) {
       console.warn('[recommendations] add failed', e);
     } finally {

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.70.0">
-  <script src="/job/js/theme.js?v=0.70.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
+  <script src="/job/js/theme.js?v=0.71.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.70.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Pipeline rows now navigate in-page on plain click (Cmd/Ctrl/middle still opens new tab). Adding a role via paste-URL, recs carousel, or recs table no longer hijacks the page — instead it dispatches `job:pipeline:added` and shows a single accumulating banner at the top of the table: "N new job(s) added — Company — Title +M more". De-duped by slug, pluralizes for batches, dismissible.

/job 0.71.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)