### PR TITLE
job: auto-rescore fit_score after analysis regen (per-slug)

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
-  <script src="/job/js/theme.js?v=0.71.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.72.0">
+  <script src="/job/js/theme.js?v=0.72.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.72.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
-  <script src="/job/js/theme.js?v=0.71.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.72.0">
+  <script src="/job/js/theme.js?v=0.72.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.72.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
-  <script src="/job/js/theme.js?v=0.71.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.72.0">
+  <script src="/job/js/theme.js?v=0.72.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.72.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
-  <script src="/job/js/theme.js?v=0.71.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.72.0">
+  <script src="/job/js/theme.js?v=0.72.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.72.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.71.0";
-console.log(`[job] v${VERSION} - Row click → in-page nav; "N new jobs added" banner instead of opening details`);
+const VERSION = "0.72.0";
+console.log(`[job] v${VERSION} - Auto-rescore fit_score after analysis regen (per-slug pull-recommendations call)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -24,7 +24,7 @@ async function getTurndown() {
   return td;
 }
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative, engageRole }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative, engageRole, rescoreRole }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -351,8 +351,30 @@ export class JobRoleDetail extends LitElement {
     try {
       const res = await generateAsset(this.slug, kind);
       this.assets = { ...this.assets, [kind]: this._viewAsset(kind, res.content) };
+      // Analysis carries the signals fit_score depends on (company,
+      // title-match accuracy, sector inference). Trigger a per-slug
+      // rescore so the breakdown picks up changes without waiting for
+      // a manual ?rescore=1 sweep. Fire-and-forget; refresh role data
+      // after it lands so the UI shows the new score.
+      if (kind === 'analysis') this._rescoreAfterAnalysis();
     } catch (e) {
       this.assets = { ...this.assets, [kind]: { ...this.assets[kind], saving: false, error: String(e) } };
+    }
+  }
+
+  async _rescoreAfterAnalysis() {
+    try {
+      const result = await rescoreRole(this.slug);
+      if (!result?.ok) return;
+      // Refresh the role row to pick up the new fit_score + breakdown.
+      const pipeline = await fetchPipeline();
+      const fresh = (pipeline.roles || []).find(r => r.slug === this.slug);
+      if (fresh) {
+        this.role = fresh;
+        this.requestUpdate();
+      }
+    } catch (e) {
+      console.warn('[role-detail] rescoreAfterAnalysis failed:', (e && e.message) || e);
     }
   }
 

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -39,6 +39,28 @@ export async function updateRole(role, patch) {
   return res.json();
 }
 
+// Trigger a fit-score rescore scoped to one slug. Fires after analysis
+// regen so fit_score + fit_breakdown pick up any changes in company /
+// title / url / sector without rescoring the whole pipeline.
+const PULL_REC_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations';
+export async function rescoreRole(slug, { haiku = true } = {}) {
+  if (!slug) return null;
+  try {
+    const headers = await authHeader();
+    const qs = new URLSearchParams({ rescore: '1', slug });
+    if (!haiku) qs.set('haiku', '0');
+    const res = await fetch(`${PULL_REC_URL}?${qs}`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) throw new Error(`rescore ${res.status}: ${await res.text()}`);
+    return await res.json();
+  } catch (e) {
+    console.warn(`[pipeline] rescoreRole(${slug}) failed:`, (e && e.message) || e);
+    return null;
+  }
+}
+
 // Stamp engaged_at on a pipeline row. Called from the drill page on
 // open and from Apply-button clicks — a passive signal that drives
 // the "In progress" pill on Saved rows. Idempotent (server only

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.71.0">
-  <script src="/job/js/theme.js?v=0.71.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.72.0">
+  <script src="/job/js/theme.js?v=0.72.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.71.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.72.0"></script>
 </body>
 </html>

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -16,12 +16,13 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
+import { verifyJobUser } from '../_shared/job-auth.ts';
 import { computeFit, type RoleRow, type UserContext as FitUserContext } from '../jobs-pipe/fit.ts';
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 
-const VERSION = '0.5.1';
-console.log(`[pull-recommendations] v${VERSION} - Fit v3 + Phase 1.5 enrichment writes`);
+const VERSION = '0.6.0';
+console.log(`[pull-recommendations] v${VERSION} - user-auth rescore + ?slug=X scopes to one pipeline_role`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -47,8 +48,13 @@ serve(async (req) => {
   if (req.method !== 'POST' && req.method !== 'GET') {
     return new Response('POST only', { status: 405 });
   }
+  // Two auth paths:
+  //   - X-Cron-Secret: the pg_cron schedule + back-end function-to-function calls
+  //   - verifyJobUser: a signed-in user triggering a per-slug rescore from the drill page
   const secret = Deno.env.get('CRON_SECRET');
-  if (secret && req.headers.get('x-cron-secret') !== secret) {
+  const hasCronSecret = !!secret && req.headers.get('x-cron-secret') === secret;
+  const userEmail = hasCronSecret ? null : await verifyJobUser(req);
+  if (!hasCronSecret && !userEmail) {
     return new Response('forbidden', { status: 403 });
   }
 
@@ -74,7 +80,13 @@ serve(async (req) => {
   if (rescoreOnly) {
     const ctx = await loadFitContext(sql);
     const useHaiku = new URL(req.url).searchParams.get('haiku') !== '0';
-    const rows = await sql<Array<{ id: string; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null; role_match_score: number | null }>>`
+    // ?slug=X → scope rescore to one pipeline_role. Skips the recommended_roles
+    // pass entirely (a single pipeline row doesn't need the widget rescored).
+    // Used by the drill page's auto-regen-analysis hook so picking up new
+    // company/title/url data refreshes the fit_score without rescoring the
+    // whole pipeline.
+    const slugParam = new URL(req.url).searchParams.get('slug')?.trim() || null;
+    const rows = slugParam ? [] : await sql<Array<{ id: string; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null; role_match_score: number | null }>>`
       select id, title, company, description, sector, investors, salary, source, role_match_score
         from job.recommended_roles
        where dismissed_at is null and added_to_pipeline_slug is null
@@ -108,9 +120,13 @@ serve(async (req) => {
       `;
       updated++;
     }
-    const pipeRows = await sql<Array<{ slug: string; title: string | null; company_name: string | null; sector: string | null; investors: string[] | null; salary_range: string | null; source: string | null; role_match_score: number | null }>>`
-      select slug, title, company_name, sector, investors, salary_range, source, role_match_score
-        from job.pipeline_roles where deleted_at is null`;
+    const pipeRows = slugParam
+      ? await sql<Array<{ slug: string; title: string | null; company_name: string | null; sector: string | null; investors: string[] | null; salary_range: string | null; source: string | null; role_match_score: number | null }>>`
+          select slug, title, company_name, sector, investors, salary_range, source, role_match_score
+            from job.pipeline_roles where deleted_at is null and slug = ${slugParam}`
+      : await sql<Array<{ slug: string; title: string | null; company_name: string | null; sector: string | null; investors: string[] | null; salary_range: string | null; source: string | null; role_match_score: number | null }>>`
+          select slug, title, company_name, sector, investors, salary_range, source, role_match_score
+            from job.pipeline_roles where deleted_at is null`;
     let pipeUpdated = 0;
     for (const r of pipeRows) {
       const roleRow: RoleRow = {


### PR DESCRIPTION
Closes the auto-refresh loop: when analysis regenerates (manual or stale-auto-fire), per-slug rescore runs immediately so the displayed fit_score updates without a pipeline-wide sweep. v0.72.0.