### PR TITLE
job(gmail-tracker): Phase 2.0 backend — application_events + classifier + scan

### DIFF
--- a/docs/strategy/prds/gmail-application-tracker.md
+++ b/docs/strategy/prds/gmail-application-tracker.md
@@ -250,6 +250,35 @@ User can override anything from the drill page menu (existing flow). Override re
 2. **Stage taxonomy unchanged.** Top-level `stage` stays the 4-value enum. Granularity (which round, what kind) lives in `application_events.round_label` and `pipeline_roles.process_outline`.
 3. **Process detection: 3 sources, ranked.** Recruiter email > JD extract > inferred from events. Higher-confidence source never gets overwritten by a lower one.
 4. **Backfill: 30 days, Active applied roles only.** Process_outline only updated from explicit signals on backfill; inferred-from-events is disabled retroactively.
+5. **Stale-14d nudge is on-open only.** No banner, no push. Renders as a yellow chip on row + Needs-Attention card only when the user lands on /job/jobs/. Reason: banners are reserved for live arrivals in the last 30 min; a 14d-quiet signal is the inverse of live and would dilute the banner contract.
+6. **Calendar read pulled into 2.0 (narrow slice).** `calendar-api` already holds the `calendar` scope from Phase 1. 2.0 adds a single `events.list(timeMin=now, timeMax=now+48h)` query, matched to a role by attendee email domain first, title-token second. No write-back, no recurring-event handling, no calendar-event creation. Ambiguous matches → no chip (silent fail beats wrong chip). Tightening match precision + reply-cadence analytics move to 2.1.
+
+---
+
+## Feedback-loop UI — the five-signal catalog
+
+The UI exposes exactly five signal types per role. Each role surfaces **the single highest-priority signal that applies** — never two chips on one row. Priority (highest → lowest):
+
+| Priority | Signal | Trigger condition | Color | Render surfaces |
+|---|---|---|---|---|
+| 1 | **Action needed** | `application_events.needs_review = true` AND not yet acted on (offer / rejection / low-confidence classification) | red | row chip · Needs-Attention card · banner if live |
+| 2 | **Calendar today/tomorrow** | A calendar event in the next 48h matches this role (attendee-domain or title-token) | blue | row chip · Needs-Attention card · banner if within 2h |
+| 3 | **Reply pending** | Latest inbound event has no outbound message from `fike101@gmail.com` after it on the same thread, and inbound is ≥ 24h old | amber | row chip · Needs-Attention card |
+| 4 | **New update** | An event landed in the last 72h that did NOT auto-advance (informational, rescheduled, follow-up) and user hasn't opened the drill page since | green | row chip · Needs-Attention card · banner if landed in last 30 min |
+| 5 | **Stale — quiet for 14d** | `last_activity_at < now() - 14d` AND `status = 'Active'` | yellow | row chip · Needs-Attention card *(on-open only, no push)* |
+
+### Surface rules
+
+- **Row chip**: single highest-priority signal only. No chip = nothing actionable.
+- **Needs-Attention widget** (above /job/jobs/?bucket=active table): one card per actionable role. Hidden entirely when the actionable set is empty. Cards are clickable → drill page.
+- **Banner**: ONLY for live arrivals in the last 30 min — auto-advance just happened, offer just arrived, or calendar event within 2h. Auto-fades after 30 min. Same trigger never re-banners. Stale + reply-pending are *never* banners (no live arrival).
+- **Auto-advance toast** (sub-case of banner): when auto-advance moves a role forward, the banner names the transition ("Auto-advanced Acme → Interviewing"). User can undo within 30 min.
+
+### Honest-UI guardrails
+
+- `needs_review=true` events remain visible (red chip + Needs-Attention card) until the user explicitly acts. Never silently fade.
+- Rejection events never auto-archive — they always surface as Action-needed so user captures `exit_reason`.
+- A role with `status='Archived'` never produces signals, even if events land afterward.
 
 ---
 

--- a/supabase/functions/_shared/gmail-application-classifier.ts
+++ b/supabase/functions/_shared/gmail-application-classifier.ts
@@ -1,0 +1,222 @@
+// gmail-application-classifier — Haiku-backed classifier for inbox
+// messages that *might* be progress on an open pipeline application.
+//
+// Returns a typed event when confidence is meaningful; null when the
+// message is unrelated. Confidence floors are enforced by the caller
+// (gmail-jobs.ts second emitter) per the taxonomy in the PRD.
+
+export const APPLICATION_EVENT_TYPES = [
+  'applied_confirmation',
+  'screen_scheduled',
+  'next_round_invited',
+  'take_home_assigned',
+  'offer_received',
+  'rejection_any_stage',
+  'follow_up_needed',
+  'interview_rescheduled',
+  'informational',
+] as const;
+
+export type ApplicationEventType = typeof APPLICATION_EVENT_TYPES[number];
+
+// Forward-stage auto-advance: event_type → stage to write on pipeline_roles.
+// Forward only — offers + rejections never auto-advance per locked decision.
+export const FORWARD_AUTO_ADVANCE: Record<ApplicationEventType, { stage: 'applied' | 'interviewing'; floor: number } | null> = {
+  applied_confirmation:  { stage: 'applied',       floor: 0.8  },
+  screen_scheduled:      { stage: 'interviewing',  floor: 0.8  },
+  next_round_invited:    { stage: 'interviewing',  floor: 0.7  },
+  take_home_assigned:    { stage: 'interviewing',  floor: 0.8  },
+  offer_received:        null,   // surfaces in Needs-Attention, user confirms
+  rejection_any_stage:   null,   // surfaces in Needs-Attention, captures exit_reason
+  follow_up_needed:      null,
+  interview_rescheduled: null,
+  informational:         null,
+};
+
+// Confidence floor to even *persist* the event row. Below this we drop
+// the classification entirely (treat the message as informational noise
+// rather than poisoning the timeline).
+export const PERSIST_CONFIDENCE_FLOOR = 0.6;
+
+// Confidence floor to associate gmail_thread_id with the role. Below
+// this we still write the event but don't pin the thread → role mapping
+// (poison-resistance per the brief).
+export const THREAD_ASSOCIATION_FLOOR = 0.8;
+
+// Auto-advance is forward only; offers + rejections always need_review.
+// follow_up_needed / interview_rescheduled / informational write
+// needs_review=true so they bubble into Needs-Attention on UI open.
+export function shouldNeedReview(eventType: ApplicationEventType): boolean {
+  return eventType === 'offer_received' || eventType === 'rejection_any_stage';
+}
+
+// Stages classifier may emit (used to populate application_events.detected_stage).
+// Maps cleanly to the existing top-level stage enum.
+export function stageForEventType(eventType: ApplicationEventType): 'applied' | 'interviewing' | 'offer' | 'rejected' | null {
+  switch (eventType) {
+    case 'applied_confirmation':  return 'applied';
+    case 'screen_scheduled':
+    case 'next_round_invited':
+    case 'take_home_assigned':
+    case 'interview_rescheduled': return 'interviewing';
+    case 'offer_received':        return 'offer';
+    case 'rejection_any_stage':   return 'rejected';
+    default:                      return null;
+  }
+}
+
+export interface ClassifiedApplicationEvent {
+  event_type: ApplicationEventType;
+  summary: string;
+  confidence: number;
+  round_label?: string;
+  round_n?: number;
+  expected_total_rounds?: number;
+}
+
+const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+
+const CLASSIFY_SYSTEM = `You classify a single Gmail message that is suspected to be progress on a job application the candidate has applied to.
+
+Return STRICT JSON, no prose:
+{
+  "event_type": "applied_confirmation" | "screen_scheduled" | "next_round_invited" | "take_home_assigned" | "offer_received" | "rejection_any_stage" | "follow_up_needed" | "interview_rescheduled" | "informational",
+  "summary": "one short sentence (≤140 chars) — what this email says, no PII beyond what's already in the subject",
+  "confidence": 0.0–1.0,
+  "round_label": "phone screen" | "recruiter screen" | "hiring manager" | "take-home" | "onsite — coding" | "onsite — system design" | "debrief" | "...",
+  "round_n": <int or null>,
+  "expected_total_rounds": <int or null>
+}
+
+Rules:
+- "applied_confirmation": automated "thanks for applying / we got your application" receipts.
+- "screen_scheduled": recruiter is scheduling an INITIAL call.
+- "next_round_invited": invited to a subsequent round.
+- "take_home_assigned": assignment / coding exercise sent.
+- "offer_received": offer letter or explicit offer language. Confidence ≥ 0.85 to count.
+- "rejection_any_stage": ANY rejection or "moving forward with other candidates". Confidence ≥ 0.75.
+- "follow_up_needed": "are you still interested? haven't heard from you" prompts.
+- "interview_rescheduled": existing interview moved.
+- "informational": no state change (newsletter, general note, FYI).
+- round_label / round_n / expected_total_rounds ONLY when the email explicitly says so. Never invent them.
+- If the email is ambiguous (could be applied OR could be screen), pick the lower-bound classification and lower confidence.
+- NEVER fabricate. Empty / null > guess.
+- The body may be truncated. Trust what you see; do not extrapolate.`;
+
+export async function classifyApplicationMessage(args: {
+  subject: string;
+  sender: string;
+  body: string;
+  companyName: string;
+  roleTitle: string;
+  // Optional context to nudge the classifier when association is known
+  appliedAt?: string;
+  currentStage?: string | null;
+}): Promise<ClassifiedApplicationEvent | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) {
+    console.warn('[gmail-app-classifier] ANTHROPIC_API_KEY missing');
+    return null;
+  }
+
+  const trimmed = args.body.slice(0, 6000);
+  const userPrompt = [
+    `Candidate applied to: ${args.companyName} — ${args.roleTitle}`,
+    args.appliedAt ? `Applied at: ${args.appliedAt}` : '',
+    args.currentStage ? `Current pipeline stage: ${args.currentStage}` : '',
+    `Subject: ${args.subject}`,
+    `From: ${args.sender}`,
+    `---`,
+    trimmed,
+  ].filter(Boolean).join('\n');
+
+  const r = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 400,
+      system: CLASSIFY_SYSTEM,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  });
+  if (!r.ok) throw new Error(`anthropic ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json() as { content: Array<{ type: string; text: string }> };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  const parsed = extractFirstJsonObject(text) as Partial<ClassifiedApplicationEvent> | null;
+  if (!parsed) {
+    console.warn(`[gmail-app-classifier] bad JSON: ${text.slice(0, 120)}`);
+    return null;
+  }
+
+  const eventType = parsed.event_type as ApplicationEventType | undefined;
+  if (!eventType || !APPLICATION_EVENT_TYPES.includes(eventType)) return null;
+  const confidence = typeof parsed.confidence === 'number' ? parsed.confidence : 0;
+  const summary = (parsed.summary || '').trim().slice(0, 180);
+
+  return {
+    event_type:            eventType,
+    summary,
+    confidence,
+    round_label:           parsed.round_label   ? String(parsed.round_label).trim().slice(0, 80) : undefined,
+    round_n:               typeof parsed.round_n === 'number' ? parsed.round_n : undefined,
+    expected_total_rounds: typeof parsed.expected_total_rounds === 'number' ? parsed.expected_total_rounds : undefined,
+  };
+}
+
+// Tolerant JSON extractor — mirrors the pattern in gmail-jobs.ts. Haiku
+// occasionally appends commentary or wraps in fences; this absorbs that.
+function extractFirstJsonObject(text: string): unknown {
+  const stripped = text.replace(/```json\s*/gi, '').replace(/```/g, '');
+  const start = stripped.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < stripped.length; i++) {
+    const c = stripped[i];
+    if (escape) { escape = false; continue; }
+    if (c === '\\') { escape = true; continue; }
+    if (c === '"') { inString = !inString; continue; }
+    if (inString) continue;
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) {
+        const candidate = stripped.slice(start, i + 1);
+        try { return JSON.parse(candidate); } catch { return null; }
+      }
+    }
+  }
+  return null;
+}
+
+// Known ATS-platform sender domains. Messages from these addresses about
+// pipeline companies are first-class candidates for classification even
+// when the company domain doesn't match the sender.
+export const ATS_PLATFORM_DOMAINS = [
+  'greenhouse.io',
+  'greenhouse-mail.io',
+  'us.greenhouse-mail.io',
+  'eu.greenhouse-mail.io',
+  'mail.greenhouse.io',
+  'lever.co',
+  'hire.lever.co',
+  'ashbyhq.com',
+  'us.ashbyhq.com',
+  'smartrecruiters.com',
+  'icims.com',
+  'workday.com',
+  'myworkday.com',
+  'myworkdayjobs.com',
+  'jobvite.com',
+  'bamboohr.com',
+  'workable.com',
+  'rippling.com',
+  'gem.com',
+];

--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -1,0 +1,403 @@
+// gmail-application-scan — second-pass scan over the inbox that looks
+// for progress signals on pipeline applications (not new role recs).
+//
+// Called by:
+//   - gmail-jobs.ts as a side-effect at the end of pull() (live scan,
+//     rolling 7-day window with Message-ID dedup).
+//   - application-events function with action='backfill' (30-day window,
+//     batches of 5 messages, processed across ScheduleWakeup intervals).
+//
+// Privacy contract is identical to gmail-jobs.ts: raw bodies never
+// persist. Only Haiku-extracted summary + structured fields land in
+// job.application_events.
+
+import { db } from './job-db.ts';
+import {
+  type GmailMessage,
+  extractBody,
+  getHeader,
+  getMessage,
+  getMessageIdHeader,
+} from './gmail.ts';
+import {
+  classifyApplicationMessage,
+  type ApplicationEventType,
+  type ClassifiedApplicationEvent,
+  ATS_PLATFORM_DOMAINS,
+  FORWARD_AUTO_ADVANCE,
+  PERSIST_CONFIDENCE_FLOOR,
+  THREAD_ASSOCIATION_FLOOR,
+  shouldNeedReview,
+  stageForEventType,
+} from './gmail-application-classifier.ts';
+
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+// Top-level stage ordering. Used to enforce forward-only auto-advance.
+// drafting / null < applied < interviewing < offer
+const STAGE_RANK: Record<string, number> = {
+  '':            0,
+  'drafting':    0,
+  'applied':     1,
+  'interviewing': 2,
+  'offer':       3,
+};
+
+interface PipelineRoleRow {
+  slug:               string;
+  company_name:       string;
+  company_norm:       string;
+  title:              string;
+  stage:              string | null;
+  status:             string;
+  applied_at:         string | null;
+  gmail_thread_ids:   string[];
+  process_outline:    Record<string, unknown> | null;
+  hiring_domain:      string | null;
+}
+
+export interface ApplicationScanResult {
+  classified:    number;        // messages handed to Haiku
+  inserted:      number;        // event rows actually inserted
+  autoAdvanced:  number;        // roles whose stage moved forward
+  needsReview:   number;        // events flagged for user attention
+  skippedNoMatch:number;        // messages where no role could be matched
+}
+
+export async function scanApplicationResponses(args: {
+  userEmail: string;
+  accessToken: string;
+  mode?: 'live' | 'backfill';
+  // backfill caps the number of getMessage / Haiku calls per invocation;
+  // the caller paginates by re-firing across ScheduleWakeup intervals.
+  maxMessages?: number;
+  // backfill window override (live defaults to 7d, backfill to 30d)
+  windowDays?: number;
+  // backfill optional role-slug filter (process one role at a time)
+  roleSlug?: string;
+}): Promise<ApplicationScanResult> {
+  const sql = db();
+  const mode = args.mode ?? 'live';
+  const maxMessages = Math.max(1, Math.min(50, args.maxMessages ?? (mode === 'backfill' ? 5 : 30)));
+  const windowDays = Math.max(1, args.windowDays ?? (mode === 'backfill' ? 30 : 7));
+
+  const out: ApplicationScanResult = {
+    classified: 0, inserted: 0, autoAdvanced: 0, needsReview: 0, skippedNoMatch: 0,
+  };
+
+  // Load active pipeline roles + best-known domain via hiring_companies cache.
+  // company_name is the join key (case-insensitive). hiring_companies.name_norm
+  // is a generated column.
+  const roles = await sql<PipelineRoleRow[]>`
+    select r.slug,
+           r.company_name,
+           lower(trim(r.company_name))         as company_norm,
+           r.title,
+           r.stage,
+           r.status,
+           r.applied_at::text                  as applied_at,
+           coalesce(r.gmail_thread_ids, '{}')  as gmail_thread_ids,
+           r.process_outline,
+           hc.domain                           as hiring_domain
+      from job.pipeline_roles r
+      left join job.hiring_companies hc
+        on hc.name_norm = lower(trim(r.company_name))
+     where r.status in ('Active', 'Saved')
+       and (r.applied_at is not null or r.engaged_at is not null)
+       and (${args.roleSlug ?? null}::text is null or r.slug = ${args.roleSlug ?? null})
+       and r.deleted_at is null
+  `;
+  if (!roles.length) return out;
+
+  // Build domain → role lookup. Multiple roles may share a domain
+  // (same company, multiple openings) — keep all candidates so the
+  // classifier-time match can disambiguate via title-token overlap.
+  const domainToRoles = new Map<string, PipelineRoleRow[]>();
+  for (const r of roles) {
+    if (r.hiring_domain) {
+      const k = r.hiring_domain.toLowerCase();
+      const arr = domainToRoles.get(k) ?? [];
+      arr.push(r);
+      domainToRoles.set(k, arr);
+    }
+  }
+
+  // Thread → role association (poison-resistant: thread_ids only land
+  // after confidence ≥ 0.8 events).
+  const threadToRole = new Map<string, PipelineRoleRow>();
+  for (const r of roles) {
+    for (const t of r.gmail_thread_ids) threadToRole.set(t, r);
+  }
+
+  // Build the Gmail query. Include pipeline-company domains AND known
+  // ATS-platform domains. -in:spam -in:trash to avoid the noisy buckets.
+  const senderDomains = new Set<string>();
+  for (const d of domainToRoles.keys()) senderDomains.add(d);
+  for (const d of ATS_PLATFORM_DOMAINS) senderDomains.add(d);
+  if (senderDomains.size === 0) return out;
+
+  const fromClause = [...senderDomains].map(d => `from:${d}`).join(' OR ');
+  const query = `(${fromClause}) -in:spam -in:trash newer_than:${windowDays}d`;
+
+  // List messages. We use messages.list directly here (not historyId)
+  // because the application-scan cursor is independent from the
+  // recs-scan cursor, and Message-ID dedup makes re-listing safe.
+  const ids = await listMessagesByQuery(args.accessToken, query, maxMessages * 3);
+
+  let processed = 0;
+  for (const id of ids) {
+    if (processed >= maxMessages) break;
+
+    let msg: GmailMessage;
+    try {
+      msg = await getMessage(args.accessToken, id, 'full');
+    } catch (e) {
+      console.warn(`[gmail-app-scan] fetch ${id} failed: ${(e as Error).message}`);
+      continue;
+    }
+    const messageId = getMessageIdHeader(msg);
+
+    // Dedup against events already persisted.
+    const dup = await sql<{ id: string }[]>`
+      select id from job.application_events
+       where gmail_message_id = ${messageId} limit 1`;
+    if (dup.length) continue;
+
+    processed++;
+
+    const sender = (getHeader(msg, 'From') || '').toLowerCase();
+    const subject = getHeader(msg, 'Subject') || '';
+    const body = extractBody(msg);
+    if (!body) continue;
+
+    const senderDomain = extractDomain(sender);
+
+    // Step 1 — thread continuity wins. If the thread is already
+    // associated with a role, classify in that role's context.
+    let matchedRole: PipelineRoleRow | null = threadToRole.get(msg.threadId) ?? null;
+
+    // Step 2 — sender-domain match against a pipeline company.
+    if (!matchedRole && senderDomain && domainToRoles.has(senderDomain)) {
+      const candidates = domainToRoles.get(senderDomain)!;
+      matchedRole = candidates.length === 1
+        ? candidates[0]
+        : pickByTitleOverlap(candidates, subject, body);
+    }
+
+    // Step 3 — ATS-platform sender: scan the body for pipeline company
+    // name. Require an actual name match to avoid cross-pollination.
+    if (!matchedRole && senderDomain && isAtsPlatformDomain(senderDomain)) {
+      const haystack = `${subject}\n${body}`.toLowerCase();
+      const hits = roles.filter(r => {
+        const nm = r.company_norm;
+        return nm.length >= 3 && haystack.includes(nm);
+      });
+      if (hits.length === 1) matchedRole = hits[0];
+      else if (hits.length > 1) matchedRole = pickByTitleOverlap(hits, subject, body);
+    }
+
+    if (!matchedRole) { out.skippedNoMatch++; continue; }
+
+    // Step 4 — classify with Haiku.
+    out.classified++;
+    let classified: ClassifiedApplicationEvent | null = null;
+    try {
+      classified = await classifyApplicationMessage({
+        subject,
+        sender,
+        body,
+        companyName:  matchedRole.company_name,
+        roleTitle:    matchedRole.title,
+        appliedAt:    matchedRole.applied_at ?? undefined,
+        currentStage: matchedRole.stage,
+      });
+    } catch (e) {
+      console.warn(`[gmail-app-scan] classify failed: ${(e as Error).message}`);
+      continue;
+    }
+    if (!classified) continue;
+
+    // Below the persist floor → drop entirely. Don't poison the timeline
+    // with low-confidence guesses.
+    if (classified.confidence < PERSIST_CONFIDENCE_FLOOR) continue;
+
+    // Decide auto-advance + needs_review per the locked policy.
+    const adv = FORWARD_AUTO_ADVANCE[classified.event_type];
+    const currentRank = STAGE_RANK[matchedRole.stage ?? ''] ?? 0;
+    const wouldRank   = adv ? STAGE_RANK[adv.stage] : 0;
+    const autoApply   = !!adv
+                      && classified.confidence >= adv.floor
+                      && wouldRank > currentRank;
+    const needsReview = shouldNeedReview(classified.event_type);
+
+    const detectedStage = stageForEventType(classified.event_type);
+    const receivedAt    = msg.internalDate
+                            ? new Date(Number(msg.internalDate)).toISOString()
+                            : new Date().toISOString();
+    const eventSource   = mode === 'backfill' ? 'gmail-backfill' : 'gmail-scan';
+
+    // Insert event row. ON CONFLICT no-op on Message-ID; if some other
+    // process already inserted this event, skip silently.
+    const inserted = await sql<{ id: string }[]>`
+      insert into job.application_events (
+        role_slug, gmail_message_id, gmail_thread_id, gmail_api_id,
+        sender, subject, event_type, detected_stage,
+        summary, confidence, round_label, round_n,
+        auto_applied, needs_review, received_at, source
+      ) values (
+        ${matchedRole.slug}, ${messageId}, ${msg.threadId}, ${msg.id},
+        ${sender}, ${subject}, ${classified.event_type}, ${detectedStage},
+        ${classified.summary}, ${classified.confidence},
+        ${classified.round_label ?? null}, ${classified.round_n ?? null},
+        ${autoApply}, ${needsReview}, ${receivedAt}, ${eventSource}
+      )
+      on conflict (gmail_message_id) do nothing
+      returning id`;
+    if (!inserted.length) continue;
+    out.inserted++;
+    if (needsReview) out.needsReview++;
+
+    // Update role: last_activity_at always; gmail_thread_ids only at
+    // THREAD_ASSOCIATION_FLOOR (poison-resistance); stage on auto-advance.
+    const associateThread = classified.confidence >= THREAD_ASSOCIATION_FLOOR;
+    if (autoApply && adv) {
+      await sql`
+        update job.pipeline_roles
+           set stage             = ${adv.stage},
+               status_changed_at = now(),
+               last_activity_at  = ${receivedAt},
+               gmail_thread_ids  = case
+                 when ${associateThread} and not (${msg.threadId} = any(gmail_thread_ids))
+                   then gmail_thread_ids || ${msg.threadId}::text
+                 else gmail_thread_ids
+               end,
+               updated_at        = now()
+         where slug = ${matchedRole.slug}`;
+      out.autoAdvanced++;
+    } else {
+      await sql`
+        update job.pipeline_roles
+           set last_activity_at  = ${receivedAt},
+               gmail_thread_ids  = case
+                 when ${associateThread} and not (${msg.threadId} = any(gmail_thread_ids))
+                   then gmail_thread_ids || ${msg.threadId}::text
+                 else gmail_thread_ids
+               end,
+               updated_at        = now()
+         where slug = ${matchedRole.slug}`;
+    }
+
+    // Update process_outline when classifier emitted explicit round
+    // signal. Source ranking: recruiter_email > jd_extract > inferred.
+    // Backfill never writes inferred_from_events (per locked decision).
+    await maybeUpdateProcessOutline(sql, matchedRole, classified, mode);
+  }
+
+  return out;
+}
+
+// ---------- helpers ----------
+
+async function listMessagesByQuery(accessToken: string, query: string, maxIds: number): Promise<string[]> {
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < 5; page++) {
+    const url = new URL(`${GMAIL_BASE}/messages`);
+    url.searchParams.set('q', query);
+    url.searchParams.set('maxResults', String(Math.min(100, maxIds - ids.length)));
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!r.ok) throw new Error(`gmail messages.list ${r.status}: ${(await r.text()).slice(0, 200)}`);
+    const data = await r.json() as { messages?: Array<{ id: string }>; nextPageToken?: string };
+    for (const m of (data.messages || [])) ids.push(m.id);
+    if (ids.length >= maxIds || !data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  return ids;
+}
+
+function extractDomain(sender: string): string | null {
+  const m = sender.match(/@([a-z0-9.-]+)/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function isAtsPlatformDomain(domain: string): boolean {
+  return ATS_PLATFORM_DOMAINS.some(d => domain === d || domain.endsWith(`.${d}`));
+}
+
+// Pick the most likely role among multiple candidates with the same
+// sender domain. Counts shared meaningful tokens between the role title
+// and the message subject/body. Falls back to "most recently active"
+// when no signal differentiates.
+function pickByTitleOverlap(candidates: PipelineRoleRow[], subject: string, body: string): PipelineRoleRow {
+  const haystack = `${subject}\n${body.slice(0, 2000)}`.toLowerCase();
+  let best = candidates[0];
+  let bestScore = -1;
+  for (const c of candidates) {
+    const tokens = c.title.toLowerCase().split(/[\s\-/_]+/).filter(t => t.length >= 4);
+    let hits = 0;
+    for (const t of tokens) if (haystack.includes(t)) hits++;
+    if (hits > bestScore) { bestScore = hits; best = c; }
+  }
+  return best;
+}
+
+// process_outline ranking: recruiter_email > jd_extract > inferred_from_events.
+// Backfill never overwrites with inferred. Live scan: only update when
+// explicit signal (round_n or expected_total_rounds) is present.
+async function maybeUpdateProcessOutline(
+  sql: ReturnType<typeof db>,
+  role: PipelineRoleRow,
+  c: ClassifiedApplicationEvent,
+  mode: 'live' | 'backfill',
+): Promise<void> {
+  const hasExplicit = !!c.round_label && (c.round_n !== undefined || c.expected_total_rounds !== undefined);
+  if (!hasExplicit) return;
+
+  const SOURCE_RANK: Record<string, number> = {
+    'recruiter_email':     3,
+    'jd_extract':          2,
+    'inferred_from_events':1,
+  };
+
+  const existing = role.process_outline as (
+    | { source?: string; confidence?: number; rounds?: Array<{ label: string; order: number; completed: boolean }>; expected_total_rounds?: number }
+    | null
+  );
+
+  // Per the decision: backfill only writes explicit signals (recruiter_email).
+  const newSource = 'recruiter_email';
+  if (existing && existing.source && (SOURCE_RANK[existing.source] ?? 0) > SOURCE_RANK[newSource]) return;
+
+  // Merge / build rounds. Insert this round_label at round_n (1-based)
+  // and mark it complete. Don't clobber other rounds.
+  const rounds = (existing?.rounds ?? []).slice();
+  const order = c.round_n ?? (rounds.length + 1);
+  const labelExisting = rounds.find(r => r.order === order);
+  if (labelExisting) {
+    labelExisting.label = c.round_label || labelExisting.label;
+    labelExisting.completed = true;
+  } else {
+    rounds.push({ label: c.round_label || `round ${order}`, order, completed: true });
+  }
+  rounds.sort((a, b) => a.order - b.order);
+
+  const expectedTotal = c.expected_total_rounds ?? existing?.expected_total_rounds ?? rounds.length;
+
+  const outline = {
+    expected_total_rounds: expectedTotal,
+    rounds,
+    source: newSource,
+    confidence: c.confidence,
+    last_updated_at: new Date().toISOString(),
+  };
+  await sql`
+    update job.pipeline_roles
+       set process_outline = ${sql.json(outline)},
+           updated_at      = now()
+     where slug = ${role.slug}`;
+  // Mode-aware logging: useful when debugging a backfill run.
+  if (mode === 'backfill') {
+    console.log(`[gmail-app-scan] backfill set process_outline for ${role.slug}: ${rounds.length} rounds`);
+  }
+}

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -36,6 +36,7 @@ import {
   getProfileHistoryId,
   listSinceCursor,
 } from '../gmail.ts';
+import { scanApplicationResponses } from '../gmail-application-scan.ts';
 
 interface GmailJobsCfg {
   allowSenders?: string[];
@@ -368,6 +369,23 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
             last_error = null,
             updated_at = now()
     `;
+
+    // Phase 2.0 — application-tracker scan. Looks at inbox messages from
+    // pipeline-company domains + known ATS-platform senders, classifies
+    // with Haiku, writes application_events, auto-advances forward stages.
+    // Side-effect only — does not contribute to RecommendedRoleInput[].
+    try {
+      const appScan = await scanApplicationResponses({
+        userEmail:   ctx.userEmail,
+        accessToken,
+        mode:        'live',
+      });
+      if (appScan.classified || appScan.inserted) {
+        console.log(`[gmail-jobs] application-scan: ${appScan.inserted}/${appScan.classified} events, ${appScan.autoAdvanced} auto-advanced, ${appScan.needsReview} needs-review`);
+      }
+    } catch (e) {
+      console.warn(`[gmail-jobs] application-scan failed: ${(e as Error).message}`);
+    }
 
     return out;
   },

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -1,0 +1,342 @@
+// application-events — read + maintenance endpoint for the
+// job.application_events table. Phase 2.0 of the Gmail jobs pipe.
+//
+// Actions:
+//   POST { action: 'list', roleSlug, withReplyStatus? }
+//     Returns events for a role, reverse-chronological, with optional
+//     needs_user_reply derivation (walks Gmail thread for outbound
+//     messages from fike101@gmail.com after the latest inbound event).
+//
+//   POST { action: 'needs-attention' }
+//     Returns a flattened list of actionables across all Active /
+//     Saved-engaged roles: offers, rejections, low-confidence, stale,
+//     reply-pending. Powers the /job/jobs/ Needs-Attention widget.
+//
+//   POST { action: 'ack', eventId }
+//     User saw the event. Clears needs_review + stamps reviewed_at.
+//
+//   POST { action: 'backfill', roleSlug?, batchSize?, windowDays? }
+//     Runs the application-scan in backfill mode for one role (or all
+//     active roles if no slug), in batches of `batchSize` (default 5).
+//     Self-paced — caller re-fires across ScheduleWakeup intervals.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { db } from '../_shared/job-db.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import {
+  getServiceClient,
+  GMAIL_READONLY_SCOPE,
+  getAccessToken,
+  userIdForEmail,
+} from '../_shared/google-tokens.ts';
+import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
+
+const VERSION = '1.0.0';
+console.log(`[application-events] v${VERSION} - Phase 2.0 read + needs-attention + backfill`);
+
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
+const USER_EMAIL_LC = 'fike101@gmail.com';
+const STALE_DAYS = 14;
+
+interface EventRow {
+  id:               string;
+  role_slug:        string;
+  gmail_message_id: string;
+  gmail_thread_id:  string;
+  gmail_api_id:     string | null;
+  sender:           string | null;
+  subject:          string | null;
+  event_type:       string;
+  detected_stage:   string | null;
+  summary:          string | null;
+  confidence:       number | null;
+  round_label:      string | null;
+  round_n:          number | null;
+  auto_applied:     boolean;
+  needs_review:     boolean;
+  reviewed_at:      string | null;
+  received_at:      string;
+  source:           string;
+  created_at:       string;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  const userEmail = await verifyJobUser(req);
+  if (!userEmail) return err('Unauthorized', 401);
+
+  let body: { action?: string; [k: string]: unknown };
+  try { body = await req.json(); } catch { return err('invalid JSON'); }
+  const action = String(body.action || 'list');
+
+  try {
+    if (action === 'list') {
+      return await listEvents(body, userEmail);
+    }
+    if (action === 'needs-attention') {
+      return await needsAttention(userEmail);
+    }
+    if (action === 'ack') {
+      return await ackEvent(body);
+    }
+    if (action === 'backfill') {
+      return await runBackfill(body, userEmail);
+    }
+    return err(`unknown action: ${action}`);
+  } catch (e) {
+    console.error(`[application-events] ${action} failed:`, (e as Error).message);
+    return err((e as Error).message, 500);
+  }
+});
+
+// ---------- list ----------
+
+async function listEvents(body: Record<string, unknown>, userEmail: string): Promise<Response> {
+  const roleSlug = String(body.roleSlug || '');
+  if (!roleSlug) return err('roleSlug required');
+  const withReplyStatus = body.withReplyStatus === true || body.withReplyStatus === 1;
+
+  const sql = db();
+  const events = await sql<EventRow[]>`
+    select * from job.application_events
+     where role_slug = ${roleSlug}
+     order by received_at desc, created_at desc
+     limit 200`;
+  const role = await sql<{ process_outline: Record<string, unknown> | null; last_activity_at: string | null }[]>`
+    select process_outline, last_activity_at::text as last_activity_at
+      from job.pipeline_roles where slug = ${roleSlug} limit 1`;
+
+  let replyStatus: Record<string, boolean> = {};
+  if (withReplyStatus && events.length) {
+    replyStatus = await deriveReplyStatus(userEmail, events);
+  }
+
+  const annotated = events.map(e => ({
+    ...e,
+    needs_user_reply: withReplyStatus
+      ? !!replyStatus[e.gmail_thread_id] && isOldEnoughToWarrantReply(e.received_at)
+      : undefined,
+  }));
+
+  return jsonResp({
+    version:          VERSION,
+    events:           annotated,
+    process_outline:  role[0]?.process_outline ?? null,
+    last_activity_at: role[0]?.last_activity_at ?? null,
+  });
+}
+
+// Map of threadId → needs_user_reply (true when latest inbound has no
+// outbound from fike101@gmail.com after it). One Gmail API call per
+// unique thread, capped at 10 to bound the cost.
+async function deriveReplyStatus(userEmail: string, events: EventRow[]): Promise<Record<string, boolean>> {
+  const out: Record<string, boolean> = {};
+  const sb = getServiceClient();
+  const userId = await userIdForEmail(sb, userEmail);
+  if (!userId) return out;
+  const tokenRes = await getAccessToken(sb, userId, [GMAIL_READONLY_SCOPE]);
+  if (!tokenRes) return out;
+
+  // Take the latest event per thread (events arrive in reverse-chron).
+  const latestByThread = new Map<string, EventRow>();
+  for (const e of events) {
+    if (!latestByThread.has(e.gmail_thread_id)) latestByThread.set(e.gmail_thread_id, e);
+  }
+  let calls = 0;
+  for (const [threadId, latest] of latestByThread.entries()) {
+    if (calls++ >= 10) break;
+    try {
+      const r = await fetch(`${GMAIL_BASE}/threads/${encodeURIComponent(threadId)}?format=metadata&metadataHeaders=From&metadataHeaders=Date`,
+        { headers: { Authorization: `Bearer ${tokenRes.accessToken}` } });
+      if (!r.ok) { out[threadId] = false; continue; }
+      const data = await r.json() as { messages?: Array<{ internalDate?: string; payload?: { headers?: Array<{ name: string; value: string }> } }> };
+      const latestInboundMs = new Date(latest.received_at).getTime();
+      let lastOutboundMs = 0;
+      for (const m of (data.messages || [])) {
+        const fromHeader = (m.payload?.headers || []).find(h => h.name.toLowerCase() === 'from')?.value || '';
+        if (fromHeader.toLowerCase().includes(USER_EMAIL_LC)) {
+          const ts = Number(m.internalDate || 0);
+          if (ts > lastOutboundMs) lastOutboundMs = ts;
+        }
+      }
+      out[threadId] = latestInboundMs > lastOutboundMs;
+    } catch {
+      out[threadId] = false;
+    }
+  }
+  return out;
+}
+
+function isOldEnoughToWarrantReply(receivedAt: string): boolean {
+  // 24h grace before flagging "you haven't replied" — gives the user
+  // time to respond before we nag.
+  return Date.now() - new Date(receivedAt).getTime() > 24 * 60 * 60 * 1000;
+}
+
+// ---------- needs-attention ----------
+
+interface AttentionItem {
+  role_slug:  string;
+  company:    string;
+  title:      string;
+  signal:     'action_needed' | 'calendar_today' | 'reply_pending' | 'new_update' | 'stale_14d';
+  priority:   number;
+  detail:     string;
+  event_id?:  string;
+  received_at?: string;
+}
+
+async function needsAttention(userEmail: string): Promise<Response> {
+  const sql = db();
+
+  // Unreviewed events (Action-needed) — top priority.
+  const action = await sql<Array<{ event_id: string; role_slug: string; company_name: string; title: string; summary: string | null; event_type: string; received_at: string }>>`
+    select ae.id as event_id, ae.role_slug, r.company_name, r.title,
+           ae.summary, ae.event_type, ae.received_at::text as received_at
+      from job.application_events ae
+      join job.pipeline_roles r on r.slug = ae.role_slug
+     where ae.needs_review = true
+       and ae.reviewed_at is null
+       and r.deleted_at is null
+       and r.status in ('Active', 'Saved')
+     order by ae.received_at desc`;
+
+  // New-update events (≥72h fresh, not auto-advanced, not needs_review).
+  const newUpdate = await sql<Array<{ event_id: string; role_slug: string; company_name: string; title: string; summary: string | null; event_type: string; received_at: string }>>`
+    select ae.id as event_id, ae.role_slug, r.company_name, r.title,
+           ae.summary, ae.event_type, ae.received_at::text as received_at
+      from job.application_events ae
+      join job.pipeline_roles r on r.slug = ae.role_slug
+     where ae.needs_review = false
+       and ae.auto_applied = false
+       and ae.received_at > now() - interval '72 hours'
+       and ae.event_type in ('follow_up_needed', 'interview_rescheduled', 'informational')
+       and r.deleted_at is null
+       and r.status in ('Active', 'Saved')
+     order by ae.received_at desc`;
+
+  // Stale roles — Active, no activity for 14+ days.
+  const stale = await sql<Array<{ role_slug: string; company_name: string; title: string; last_activity_at: string | null; applied_at: string | null }>>`
+    select r.slug as role_slug, r.company_name, r.title,
+           r.last_activity_at::text as last_activity_at,
+           r.applied_at::text as applied_at
+      from job.pipeline_roles r
+     where r.status = 'Active'
+       and r.deleted_at is null
+       and coalesce(r.last_activity_at, r.applied_at, r.engaged_at) < now() - make_interval(days => ${STALE_DAYS})
+     order by r.last_activity_at desc nulls last`;
+
+  // Build the response, deduplicated by role (one card per role —
+  // highest priority signal wins).
+  const byRole = new Map<string, AttentionItem>();
+
+  const upsert = (item: AttentionItem) => {
+    const cur = byRole.get(item.role_slug);
+    if (!cur || item.priority < cur.priority) byRole.set(item.role_slug, item);
+  };
+
+  for (const a of action) {
+    upsert({
+      role_slug:    a.role_slug,
+      company:      a.company_name,
+      title:        a.title,
+      signal:       'action_needed',
+      priority:     1,
+      detail:       a.summary || labelForEvent(a.event_type),
+      event_id:     a.event_id,
+      received_at:  a.received_at,
+    });
+  }
+  for (const n of newUpdate) {
+    upsert({
+      role_slug:    n.role_slug,
+      company:      n.company_name,
+      title:        n.title,
+      signal:       'new_update',
+      priority:     4,
+      detail:       n.summary || labelForEvent(n.event_type),
+      event_id:     n.event_id,
+      received_at:  n.received_at,
+    });
+  }
+  for (const s of stale) {
+    upsert({
+      role_slug:   s.role_slug,
+      company:     s.company_name,
+      title:       s.title,
+      signal:      'stale_14d',
+      priority:    5,
+      detail:      s.last_activity_at
+                     ? `Quiet since ${relativeDays(s.last_activity_at)}`
+                     : `No activity in 14+ days`,
+      received_at: s.last_activity_at ?? undefined,
+    });
+  }
+
+  const items = [...byRole.values()].sort((a, b) => a.priority - b.priority);
+  return jsonResp({ version: VERSION, items });
+}
+
+function labelForEvent(eventType: string): string {
+  switch (eventType) {
+    case 'offer_received':         return 'Offer received — confirm to move to Offer stage';
+    case 'rejection_any_stage':    return 'Rejection — set exit reason to capture context';
+    case 'applied_confirmation':   return 'Application confirmed';
+    case 'screen_scheduled':       return 'Screen scheduled';
+    case 'next_round_invited':     return 'Next round invited';
+    case 'take_home_assigned':     return 'Take-home assigned';
+    case 'follow_up_needed':       return 'They\'re asking if you\'re still interested';
+    case 'interview_rescheduled':  return 'Interview rescheduled';
+    case 'informational':          return 'Update from the company';
+    default:                       return eventType;
+  }
+}
+
+function relativeDays(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(ms / (24 * 60 * 60 * 1000));
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return `${days}d ago`;
+}
+
+// ---------- ack ----------
+
+async function ackEvent(body: Record<string, unknown>): Promise<Response> {
+  const eventId = String(body.eventId || '');
+  if (!eventId) return err('eventId required');
+  const sql = db();
+  await sql`
+    update job.application_events
+       set needs_review = false,
+           reviewed_at  = now()
+     where id = ${eventId}`;
+  return jsonResp({ ok: true });
+}
+
+// ---------- backfill ----------
+
+async function runBackfill(body: Record<string, unknown>, userEmail: string): Promise<Response> {
+  const roleSlug   = body.roleSlug   ? String(body.roleSlug) : undefined;
+  const batchSize  = Math.max(1, Math.min(20, Number(body.batchSize)  || 5));
+  const windowDays = Math.max(1, Math.min(60, Number(body.windowDays) || 30));
+
+  const sb = getServiceClient();
+  const userId = await userIdForEmail(sb, userEmail);
+  if (!userId) return err('user not found', 400);
+  const tokenRes = await getAccessToken(sb, userId, [GMAIL_READONLY_SCOPE]);
+  if (!tokenRes) return err('gmail not connected', 400);
+
+  const result = await scanApplicationResponses({
+    userEmail,
+    accessToken: tokenRes.accessToken,
+    mode:        'backfill',
+    maxMessages: batchSize,
+    windowDays,
+    roleSlug,
+  });
+
+  return jsonResp({ version: VERSION, ...result });
+}

--- a/supabase/functions/calendar-api/index.ts
+++ b/supabase/functions/calendar-api/index.ts
@@ -6,11 +6,12 @@
 // POST /functions/v1/calendar-api
 // Body: { action, ... }
 
-const VERSION = '1.4.0'
-console.log(`[calendar-api] v${VERSION} - google calendar integration`)
+const VERSION = '1.5.0'
+console.log(`[calendar-api] v${VERSION} - Phase 2.0 role-matched-events action`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { db as jobDb } from '../_shared/job-db.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -713,6 +714,96 @@ serve(async (req) => {
         }))
 
       return json({ events })
+    }
+
+    // ── role-matched-events: 48h window matched to pipeline roles ──
+    // Phase 2.0 of the application tracker. Returns events that match a
+    // pipeline role by attendee email domain or title-token overlap.
+    // Narrow scope: read-only, ambiguous matches → no result (silent
+    // fail beats wrong chip). Caller renders a "📅 Today 10am" chip.
+    if (action === 'role-matched-events') {
+      const userId = await getUserId(req)
+      if (!userId) return json({ error: 'Unauthorized' }, 401)
+
+      const accessToken = await getAccessToken(db, userId)
+      if (!accessToken) return json({ matches: [], disconnected: true })
+
+      const windowHours = Math.max(1, Math.min(168, Number(body.windowHours) || 48))
+      const timeMin = new Date().toISOString()
+      const timeMax = new Date(Date.now() + windowHours * 60 * 60 * 1000).toISOString()
+
+      const params = new URLSearchParams({
+        timeMin,
+        timeMax,
+        singleEvents: 'true',
+        orderBy: 'startTime',
+        maxResults: '50',
+      })
+      const resp = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events?${params}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      })
+      if (!resp.ok) {
+        console.error('[calendar-api] role-matched-events fetch error:', await resp.text())
+        return json({ matches: [] })
+      }
+      const data = await resp.json() as { items?: Array<{ id: string; summary?: string; start?: { dateTime?: string }; end?: { dateTime?: string }; attendees?: Array<{ email?: string }>; hangoutLink?: string; htmlLink?: string }> }
+
+      const sql = jobDb()
+      const roles = await sql<Array<{ slug: string; company_name: string; company_norm: string; title: string; hiring_domain: string | null; status: string }>>`
+        select r.slug, r.company_name,
+               lower(trim(r.company_name)) as company_norm,
+               r.title, hc.domain as hiring_domain, r.status
+          from job.pipeline_roles r
+          left join job.hiring_companies hc
+            on hc.name_norm = lower(trim(r.company_name))
+         where r.status in ('Active', 'Saved')
+           and r.deleted_at is null`
+
+      type Match = { event_id: string; role_slug: string; company: string; title: string; summary: string; start: string; end: string; link: string | null }
+      const matches: Match[] = []
+
+      for (const ev of (data.items || [])) {
+        if (!ev.start?.dateTime) continue
+        const summary = (ev.summary || '').toLowerCase()
+        const attendeeDomains = (ev.attendees || [])
+          .map(a => (a.email || '').toLowerCase().split('@')[1])
+          .filter(Boolean)
+
+        // Step 1: attendee domain match.
+        let matched = roles.find(r => r.hiring_domain && attendeeDomains.includes(r.hiring_domain.toLowerCase()))
+
+        // Step 2: title-token / company-token in event summary.
+        if (!matched) {
+          const candidates = roles.filter(r => r.company_norm.length >= 3 && summary.includes(r.company_norm))
+          if (candidates.length === 1) matched = candidates[0]
+          else if (candidates.length > 1) {
+            // Disambiguate by title-token overlap; bail if still ambiguous.
+            let best: typeof candidates[number] | undefined
+            let bestScore = 0
+            for (const c of candidates) {
+              const tokens = c.title.toLowerCase().split(/[\s\-/_]+/).filter(t => t.length >= 4)
+              let hits = 0
+              for (const t of tokens) if (summary.includes(t)) hits++
+              if (hits > bestScore) { bestScore = hits; best = c }
+            }
+            if (best && bestScore >= 1) matched = best
+          }
+        }
+
+        if (!matched) continue
+        matches.push({
+          event_id:    ev.id,
+          role_slug:   matched.slug,
+          company:     matched.company_name,
+          title:       matched.title,
+          summary:     ev.summary || '(no title)',
+          start:       ev.start.dateTime,
+          end:         ev.end?.dateTime || ev.start.dateTime,
+          link:        ev.hangoutLink || ev.htmlLink || null,
+        })
+      }
+
+      return json({ version: VERSION, matches })
     }
 
     return json({ error: `Unknown action: ${action}` }, 400)

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -20,8 +20,8 @@ import { computeFit, type RoleRow, type UserContext as FitUserContext } from '..
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 
-const VERSION = '0.5.1';
-console.log(`[pull-recommendations] v${VERSION} - Fit v3 + Phase 1.5 enrichment writes`);
+const VERSION = '0.6.0';
+console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 application-tracker scan side-effect in gmail-jobs source`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';

--- a/supabase/migrations/069_application_events.sql
+++ b/supabase/migrations/069_application_events.sql
@@ -1,0 +1,69 @@
+-- Phase 2.0 — Gmail application tracker.
+--
+-- New event-level metadata for application progress signals classified
+-- out of the inbox. Stage taxonomy stays the 4-value enum (drafting →
+-- applied → interviewing → offer); per-event granularity lives in
+-- application_events.round_label + pipeline_roles.process_outline.
+--
+-- See: docs/strategy/prds/gmail-application-tracker.md
+
+create table if not exists job.application_events (
+  id                uuid primary key default gen_random_uuid(),
+  role_slug         text not null references job.pipeline_roles(slug) on delete cascade,
+  gmail_message_id  text not null,                    -- RFC822 Message-ID header
+  gmail_thread_id   text not null,
+  gmail_api_id      text,                             -- for the "source email" link
+  sender            text,
+  subject           text,
+  event_type        text not null check (event_type in (
+    'applied_confirmation',
+    'screen_scheduled',
+    'next_round_invited',
+    'take_home_assigned',
+    'offer_received',
+    'rejection_any_stage',
+    'follow_up_needed',
+    'interview_rescheduled',
+    'informational'
+  )),
+  detected_stage    text check (detected_stage in ('applied','interviewing','offer','rejected') or detected_stage is null),
+  summary           text,                             -- 1-line Haiku summary (NEVER raw body)
+  confidence        numeric,                          -- 0..1
+  round_label       text,                             -- "phone screen", "onsite #2", etc.
+  round_n           int,                              -- when explicit, e.g. "round 2 of 4"
+  auto_applied      boolean not null default false,
+  needs_review      boolean not null default false,
+  reviewed_at       timestamptz,                      -- when the user acted (Action-needed clear)
+  received_at       timestamptz not null,
+  source            text not null default 'gmail-scan' check (source in ('gmail-scan','gmail-backfill','manual')),
+  created_at        timestamptz not null default now(),
+  unique (gmail_message_id)
+);
+
+create index if not exists ae_role_idx
+  on job.application_events (role_slug, received_at desc);
+create index if not exists ae_thread_idx
+  on job.application_events (gmail_thread_id);
+create index if not exists ae_review_idx
+  on job.application_events (needs_review) where needs_review;
+create index if not exists ae_unreviewed_action_idx
+  on job.application_events (role_slug, received_at desc)
+  where needs_review and reviewed_at is null;
+
+alter table job.application_events enable row level security;
+
+-- pipeline_roles columns.
+--   gmail_thread_ids  — threads associated with this role (poison-resistant:
+--                       only persisted after an event lands at conf >= 0.8).
+--   last_activity_at  — most recent event received_at, used for stale-14d chip.
+--   process_outline   — semi-structured per-role round map; see PRD.
+alter table job.pipeline_roles
+  add column if not exists gmail_thread_ids text[] not null default '{}',
+  add column if not exists last_activity_at timestamptz,
+  add column if not exists process_outline  jsonb;
+
+create index if not exists pipeline_roles_thread_gin
+  on job.pipeline_roles using gin (gmail_thread_ids);
+create index if not exists pipeline_roles_last_activity_idx
+  on job.pipeline_roles (last_activity_at desc)
+  where last_activity_at is not null;


### PR DESCRIPTION
## Summary

- Phase 2.0 backend slice of the Gmail → Jobs pipe application tracker.
- New `job.application_events` table + `pipeline_roles` columns (`gmail_thread_ids`, `last_activity_at`, `process_outline`). Migration 069 already applied to Boards via Supabase MCP.
- Haiku classifier (`_shared/gmail-application-classifier.ts`) with the locked event-type taxonomy + confidence floors per the PRD.
- Second-pass scan (`_shared/gmail-application-scan.ts`) — pipeline-domain / ATS-platform senders → match → classify → insert event → forward auto-advance. Side-effect call wired into the existing `gmail-jobs` source plugin.
- `application-events` function: `list` / `needs-attention` / `ack` / `backfill` actions. `needs_user_reply` derived per-thread on demand. Backfill is self-paced batches-of-5 (same shape as Phase 1.5 enrichment).
- `calendar-api` v1.5.0 — new `role-matched-events` action: 48h window matched by attendee email domain → title-token. Ambiguous → no chip.
- `pull-recommendations` v0.6.0 — picks up the side-effect via gmail-jobs.

Locked decisions captured in the PRD: forward-only auto-advance, 4-value top-level stage taxonomy unchanged, 3-source process detection ranking, 30-day backfill, **stale-14d on-open only**, **calendar read pulled into 2.0**. Five-signal feedback-loop UI catalog folded in.

Frontend (drill timeline, process tracker, row chip, Needs-Attention widget, banners) ships in a follow-up PR.

## Test plan

- [ ] Deploy after merge: \`supabase functions deploy pull-recommendations\`, \`supabase functions deploy application-events\`, \`supabase functions deploy calendar-api\`
- [ ] Confirm next \`pull-recommendations\` tick logs \`[gmail-jobs] application-scan: …\` line
- [ ] POST application-events \`{ action: 'needs-attention' }\` and verify shape
- [ ] POST application-events \`{ action: 'backfill', batchSize: 5 }\` and confirm batch processing
- [ ] POST calendar-api \`{ action: 'role-matched-events' }\` with calendar connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)