### PR TITLE
job(gmail-tracker): Phase 2.0 FE — chips, Needs-Attention, Activity timeline

### DIFF
--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -32,6 +32,7 @@
 | [Phase 12: Lookback](./phase-12-lookback.md) | IN PROGRESS | 47/249 |
 | [Phase 13: Boards React Rewrite](./phase-13-react-rewrite.md) | Pending | 0/272 |
 | [Phase 14: Gmail → Jobs Pipe](./phase-14-gmail-jobs-pipe.md) | IN PROGRESS | 0/73 |
+| [Phase 15: Gmail Application Tracker](./phase-15-gmail-application-tracker.md) | IN PROGRESS | 23/25 |
 | [Backlog](./backlog.md) | Future | 1/118 |
 
 ---

--- a/docs/execution/project-plan/phase-15-gmail-application-tracker.md
+++ b/docs/execution/project-plan/phase-15-gmail-application-tracker.md
@@ -1,0 +1,156 @@
+# Phase 15: Gmail Application Tracker (Phase 2.0)
+
+> Back to [Project Plan](./index.md)
+>
+> **Reference**: [PRD: Gmail Application Tracker](/docs/strategy/prds/gmail-application-tracker.md)
+>
+> **Predecessor**: [Phase 14 — Gmail Jobs Pipe](./phase-14-gmail-jobs-pipe.md)
+>
+> **Vision**: Same Gmail OAuth + scan tick as Phase 1, second pass: classify inbox messages that look like progress on open applications, attach them to a `pipeline_role`, auto-advance forward stages, surface offers / rejections / stale / calendar-today / new-update as a single chip on the pipeline row and a Needs-Attention card on /job/jobs/.
+
+---
+
+## Goal
+
+Every email response on an open application gets classified, attached to the role, and timestamped on a per-role timeline. Stage auto-advances forward on high-confidence signals; offers + rejections never auto-apply.
+
+## Success Criteria
+
+- [x] `job.application_events` table + `pipeline_roles` columns (`gmail_thread_ids`, `last_activity_at`, `process_outline`) live
+- [x] Haiku classifier emits one of 9 event types with confidence + optional round metadata
+- [x] gmail-jobs source plugin runs a second-pass scan over pipeline-domain / ATS-platform senders
+- [x] Auto-advance writes `auto_applied=true` on forward stages (applied → interviewing); offers + rejections set `needs_review=true` instead
+- [x] `application-events` function exposes `list` / `needs-attention` / `ack` / `backfill` actions
+- [x] `needs_user_reply` derived per-thread on demand (walks Gmail thread, looks for outbound from fike101@gmail.com after latest inbound, ≥ 24h grace)
+- [x] `calendar-api` `role-matched-events` action returns 48h-window events matched to roles by attendee domain → title-token (ambiguous = no match)
+- [x] Drill page Activity tab + process-tracker strip live
+- [x] Pipeline rows render single highest-priority signal chip
+- [x] Needs-Attention widget above the Active table (hidden when 0 actionables)
+- [x] Live-arrival banners (≤ 30 min) with persisted dismissal
+- [ ] 30-day backfill triggered + complete
+
+## Decisions locked (per PRD)
+
+1. Auto-advance forward only. Offers + rejections wait for user touch.
+2. Top-level `stage` enum unchanged. Granularity in `application_events.round_label` + `pipeline_roles.process_outline`.
+3. Process detection ranking: recruiter_email > jd_extract > inferred_from_events. Higher source never overwritten by lower.
+4. Backfill: 30 days, Active applied roles only. Explicit signals only for `process_outline` on backfill (no inferred).
+5. Stale-14d nudge is **on-open only** — no banner, no push.
+6. Calendar read pulled into 2.0 (narrow slice: 48h events.list + attendee-domain / title-token match).
+
+---
+
+## Out of Scope — Phase 2.1+ (Deferred)
+
+- Calendar match precision tightening (recurring interviews, multi-role-per-company)
+- Reply-cadence analytics ("they reply in 4d on average — it's been 5d")
+- Multi-role-per-company disambiguation
+- Cross-thread classifier retry / quarantine queue
+
+---
+
+## Epic 1: Schema + Classifier
+
+### Story 1.1 — Migration
+
+| Task | Status |
+|------|--------|
+| Migration 069 — `job.application_events` table with `event_type` check enum + indexes | ✓ |
+| `pipeline_roles.gmail_thread_ids text[]`, `last_activity_at timestamptz`, `process_outline jsonb` | ✓ |
+| GIN index on `gmail_thread_ids`; partial index on `last_activity_at` | ✓ |
+| Applied via supabase-boards MCP | ✓ |
+
+### Story 1.2 — Haiku Classifier
+
+| Task | Status |
+|------|--------|
+| `_shared/gmail-application-classifier.ts` with 9-value event_type enum + per-type confidence floors + auto-advance mapping | ✓ |
+| Tolerant JSON parser mirroring gmail-jobs.ts patterns | ✓ |
+| `ATS_PLATFORM_DOMAINS` allowlist (Greenhouse / Lever / Ashby / Workday / Smart / etc.) | ✓ |
+
+### Story 1.3 — Application-scan Module
+
+| Task | Status |
+|------|--------|
+| `_shared/gmail-application-scan.ts` — match (thread → domain → ATS+name) → classify → insert → auto-advance | ✓ |
+| Thread association only after confidence ≥ 0.8 (poison resistance) | ✓ |
+| Forward stage rank check prevents backward auto-advance | ✓ |
+| `process_outline` update with source ranking + backfill-explicit-only rule | ✓ |
+
+---
+
+## Epic 2: Edge Functions
+
+### Story 2.1 — gmail-jobs side-effect
+
+| Task | Status |
+|------|--------|
+| `scanApplicationResponses` called at end of `gmail-jobs.ts` `pull()`; non-fatal on error | ✓ |
+| `pull-recommendations` v0.7.0 deployed | ✓ |
+
+### Story 2.2 — application-events
+
+| Task | Status |
+|------|--------|
+| New function `application-events` with `list` / `needs-attention` / `ack` / `backfill` actions | ✓ |
+| `needs_user_reply` derived via Gmail thread walk (capped at 10 threads per request) | ✓ |
+| Backfill self-paced batches of 5 messages | ✓ |
+| Deployed to Boards | ✓ |
+
+### Story 2.3 — calendar-api role-matched-events
+
+| Task | Status |
+|------|--------|
+| `role-matched-events` action — 48h events.list + attendee-domain / title-token match | ✓ |
+| Ambiguous matches → no chip (silent fail) | ✓ |
+| `calendar-api` v1.5.0 deployed | ✓ |
+
+---
+
+## Epic 3: Frontend
+
+### Story 3.1 — Shared client
+
+| Task | Status |
+|------|--------|
+| `job/js/applicationEvents.js` — list / needs-attention / ack / backfill / role-matched-events | ✓ |
+| `loadRoleSignals()` aggregates needs-attention + calendar matches into one `Map<roleSlug, highestPrioritySignal>` | ✓ |
+
+### Story 3.2 — Pipeline row chip + widget + banners
+
+| Task | Status |
+|------|--------|
+| `signal` column added to pipeline table with single highest-priority chip per row | ✓ |
+| `Needs-Attention` widget above Active table — one card per actionable role, hidden when empty | ✓ |
+| Live-arrival banners (< 30 min, auto-fade, dismissal persisted) | ✓ |
+| `.signal-chip` + `.needs-attention` + `.live-banner` CSS using existing semantic tokens | ✓ |
+
+### Story 3.3 — Drill page
+
+| Task | Status |
+|------|--------|
+| Activity tab on drill page — reverse-chron event list + per-event "you haven't replied yet" flag | ✓ |
+| Source-email link per event (📧) | ✓ |
+| Ack button on `needs_review` events | ✓ |
+| Process-tracker strip below role header rendering `process_outline.rounds` | ✓ |
+| Auto-load activity on drill page open (process tracker visible on all tabs) | ✓ |
+
+---
+
+## Epic 4: Backfill + Verification
+
+### Story 4.1 — 30-day backfill
+
+| Task | Status |
+|------|--------|
+| Trigger `application-events { action: 'backfill', batchSize: 5 }` until empty | Pending |
+| Verify Active roles with applied_at >= 30d picked up | Pending |
+
+### Story 4.2 — Live verification in Chrome
+
+| Task | Status |
+|------|--------|
+| Drill page Activity tab renders for a role with events | Pending |
+| Pipeline row chip visible on Active rows | Pending |
+| Needs-Attention widget shows when actionables exist | Pending |
+| Process-tracker strip renders when `process_outline` populated | Pending |

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -3447,3 +3447,202 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   .app > .app__rail { grid-area: rail; }
   .app__main { padding: var(--space-4); }
 }
+
+/* ── Phase 2.0 — application-tracker UI ─────────────────────────── */
+
+/* Signal chips: single highest-priority indicator on a pipeline row,
+   plus the per-card chip inside the Needs-Attention widget. Color
+   semantics mirror the five-signal catalog in the PRD. */
+.signal-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-caption);
+  font-weight: 500;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--fg-muted);
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.signal-chip--red    { color: var(--error);   border-color: var(--error);   background: color-mix(in srgb, var(--error)   12%, transparent); }
+.signal-chip--amber  { color: var(--warning); border-color: var(--warning); background: color-mix(in srgb, var(--warning) 12%, transparent); }
+.signal-chip--yellow { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 60%, transparent); background: color-mix(in srgb, var(--warning)  6%, transparent); }
+.signal-chip--green  { color: var(--success); border-color: var(--success); background: color-mix(in srgb, var(--success) 12%, transparent); }
+.signal-chip--blue   { color: #60a5fa;        border-color: #60a5fa;        background: color-mix(in srgb, #60a5fa        14%, transparent); }
+
+/* Compact chip cell inside the pipeline table — small column. */
+.col-signal { width: 1%; white-space: nowrap; }
+.col-signal .signal-chip { font-size: 11px; max-width: 240px; }
+
+/* Needs-Attention widget — above the Active table. */
+.needs-attention {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  background: var(--bg-elev);
+}
+.needs-attention__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.needs-attention__header strong { color: var(--fg); }
+.needs-attention__list {
+  display: grid;
+  gap: var(--space-2);
+}
+.needs-attention__card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2) var(--space-3);
+  align-items: center;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-1);
+  background: var(--bg);
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+.needs-attention__card:hover { border-color: var(--border-strong); background: var(--bg-elev); }
+.needs-attention__title { font-weight: 500; color: var(--fg); }
+.needs-attention__title .muted { color: var(--fg-muted); font-weight: 400; }
+.needs-attention__detail { font-size: var(--font-size-small); color: var(--fg-muted); margin-top: 2px; }
+.needs-attention__signal { justify-self: end; }
+
+/* Live-arrival banners — auto-fade target. */
+.live-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--accent-strong);
+  border-radius: var(--radius-2);
+  background: color-mix(in srgb, var(--accent-strong) 8%, var(--bg-elev));
+  margin: 0 0 var(--space-3);
+}
+.live-banner__icon { font-size: 20px; line-height: 1; }
+.live-banner__body { flex: 1 1 auto; font-size: var(--font-size-small); }
+.live-banner__body strong { color: var(--fg); }
+.live-banner__close {
+  background: transparent;
+  border: 0;
+  font-size: 20px;
+  line-height: 1;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 0 var(--space-1);
+}
+.live-banner__close:hover { color: var(--fg); }
+
+/* Activity timeline tab on drill page. */
+.activity-timeline {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+}
+.activity-event {
+  display: grid;
+  grid-template-columns: 6px minmax(0, 1fr);
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  background: var(--bg-elev);
+}
+.activity-event__rail {
+  background: var(--border);
+  border-radius: var(--radius-pill);
+  align-self: stretch;
+}
+.activity-event--auto    .activity-event__rail { background: var(--success); }
+.activity-event--review  .activity-event__rail { background: var(--error); }
+.activity-event__head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-3);
+  margin-bottom: var(--space-1);
+}
+.activity-event__type {
+  font-weight: 500;
+  font-size: var(--font-size-small);
+}
+.activity-event__round {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+}
+.activity-event__time {
+  margin-left: auto;
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+}
+.activity-event__summary {
+  font-size: var(--font-size-small);
+  color: var(--fg);
+}
+.activity-event__meta {
+  margin-top: var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+}
+.activity-event__meta a { color: var(--accent-strong); text-decoration: none; }
+.activity-event__meta a:hover { text-decoration: underline; }
+.activity-event__reply-flag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--warning);
+  font-weight: 500;
+}
+.activity-event__ack {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  padding: 2px var(--space-2);
+  cursor: pointer;
+}
+.activity-event__ack:hover { color: var(--fg); border-color: var(--border-strong); }
+
+/* Per-role process tracker — horizontal pill strip. */
+.process-tracker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+  margin: var(--space-2) 0;
+  font-size: var(--font-size-caption);
+}
+.process-tracker__pill {
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  background: var(--bg);
+  white-space: nowrap;
+}
+.process-tracker__pill--done    { color: var(--success); border-color: var(--success); background: color-mix(in srgb, var(--success) 10%, transparent); }
+.process-tracker__pill--current { color: var(--fg);      border-color: var(--accent-strong); }
+.process-tracker__sep { color: var(--fg-muted); padding: 0 2px; }
+.process-tracker__source {
+  margin-left: var(--space-2);
+  color: var(--fg-muted);
+  font-style: italic;
+}
+

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.74.0">
-  <script src="/job/js/theme.js?v=0.74.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
+  <script src="/job/js/theme.js?v=0.75.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.74.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.74.0">
-  <script src="/job/js/theme.js?v=0.74.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
+  <script src="/job/js/theme.js?v=0.75.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.74.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.74.0">
-  <script src="/job/js/theme.js?v=0.74.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
+  <script src="/job/js/theme.js?v=0.75.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.74.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.74.0">
-  <script src="/job/js/theme.js?v=0.74.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
+  <script src="/job/js/theme.js?v=0.75.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.74.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
 </body>
 </html>

--- a/job/js/applicationEvents.js
+++ b/job/js/applicationEvents.js
@@ -1,0 +1,160 @@
+// applicationEvents.js — thin client for the application-events Edge Function.
+// Auth: forwards the current Supabase access token from CtrlAuth.
+
+const APP_EVENTS_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/application-events';
+const CAL_API_URL    = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/calendar-api';
+
+async function authHeaders() {
+  const supabase = window.CtrlAuth?.getSupabaseClient?.();
+  if (!supabase) throw new Error('CtrlAuth not ready');
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('not signed in');
+  return {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type':  'application/json',
+  };
+}
+
+async function post(url, body) {
+  const headers = await authHeaders();
+  const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  if (!res.ok) throw new Error(`${url} ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  return res.json();
+}
+
+export async function listEvents(roleSlug, { withReplyStatus = false } = {}) {
+  return post(APP_EVENTS_URL, { action: 'list', roleSlug, withReplyStatus });
+}
+
+export async function needsAttention() {
+  return post(APP_EVENTS_URL, { action: 'needs-attention' });
+}
+
+export async function ackEvent(eventId) {
+  return post(APP_EVENTS_URL, { action: 'ack', eventId });
+}
+
+export async function runBackfill({ roleSlug, batchSize = 5, windowDays = 30 } = {}) {
+  return post(APP_EVENTS_URL, { action: 'backfill', roleSlug, batchSize, windowDays });
+}
+
+export async function roleMatchedEvents({ windowHours = 48 } = {}) {
+  return post(CAL_API_URL, { action: 'role-matched-events', windowHours });
+}
+
+// Aggregator: returns a Map<roleSlug, { signal, priority, detail, ... }>
+// representing the SINGLE highest-priority signal for each role. Used
+// by the pipeline table row chip + the Needs-Attention widget.
+//
+// Priority (lowest number wins):
+//   1 action_needed   — needs_review event, not yet acked
+//   2 calendar_today  — calendar event in next 48h matched to role
+//   3 reply_pending   — server returns this on `needs-attention` but
+//                       only when needs_user_reply is true (not in MVP)
+//   4 new_update      — non-auto-advanced event in last 72h
+//   5 stale_14d       — last_activity_at + applied_at < now - 14d
+export async function loadRoleSignals() {
+  const out = new Map();
+  let attention = { items: [] };
+  let calMatches = { matches: [] };
+
+  try { attention = await needsAttention(); } catch (e) { console.warn('[applicationEvents] needs-attention failed:', e.message); }
+  try { calMatches = await roleMatchedEvents({ windowHours: 48 }); } catch (e) { console.warn('[applicationEvents] role-matched-events failed:', e.message); }
+
+  // Calendar matches at priority 2.
+  for (const m of (calMatches.matches || [])) {
+    const startMs = new Date(m.start).getTime();
+    const hoursOut = (startMs - Date.now()) / (60 * 60 * 1000);
+    let detail;
+    if (hoursOut < 0) continue;
+    else if (hoursOut < 2)  detail = `📅 In ${Math.max(1, Math.round(hoursOut * 60))}m: ${m.summary}`;
+    else if (hoursOut < 24) detail = `📅 Today ${formatLocalTime(m.start)}: ${m.summary}`;
+    else                    detail = `📅 ${formatLocalDay(m.start)} ${formatLocalTime(m.start)}: ${m.summary}`;
+    upsert(out, m.role_slug, {
+      role_slug:  m.role_slug,
+      company:    m.company,
+      title:      m.title,
+      signal:     'calendar_today',
+      priority:   2,
+      detail,
+      eventId:    m.event_id,
+      receivedAt: m.start,
+      isLive:     hoursOut < 2,         // <2h → banner-eligible
+    });
+  }
+
+  for (const a of (attention.items || [])) {
+    const isLive = (a.signal === 'action_needed' || a.signal === 'new_update')
+                && a.received_at
+                && (Date.now() - new Date(a.received_at).getTime()) < 30 * 60 * 1000;  // last 30 min
+    upsert(out, a.role_slug, {
+      role_slug:  a.role_slug,
+      signal:     a.signal,
+      priority:   a.priority,
+      detail:     a.detail,
+      eventId:    a.event_id,
+      receivedAt: a.received_at,
+      company:    a.company,
+      title:      a.title,
+      isLive,
+    });
+  }
+
+  return { byRole: out, calMatches: calMatches.matches || [], attention: attention.items || [] };
+}
+
+function upsert(map, slug, item) {
+  const cur = map.get(slug);
+  if (!cur || item.priority < cur.priority) map.set(slug, item);
+}
+
+function formatLocalTime(iso) {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  } catch { return iso; }
+}
+
+function formatLocalDay(iso) {
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diff = Math.round((d.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
+    if (diff === 0) return 'Today';
+    if (diff === 1) return 'Tomorrow';
+    return d.toLocaleDateString([], { weekday: 'short' });
+  } catch { return ''; }
+}
+
+// Render-helper: returns the CSS class for a row/widget chip given a signal.
+export function chipClassForSignal(signal) {
+  switch (signal) {
+    case 'action_needed':  return 'signal-chip signal-chip--red';
+    case 'calendar_today': return 'signal-chip signal-chip--blue';
+    case 'reply_pending':  return 'signal-chip signal-chip--amber';
+    case 'new_update':     return 'signal-chip signal-chip--green';
+    case 'stale_14d':      return 'signal-chip signal-chip--yellow';
+    default:               return 'signal-chip';
+  }
+}
+
+export function eventTypeLabel(eventType) {
+  switch (eventType) {
+    case 'applied_confirmation':   return 'Applied';
+    case 'screen_scheduled':       return 'Screen scheduled';
+    case 'next_round_invited':     return 'Next round';
+    case 'take_home_assigned':     return 'Take-home';
+    case 'offer_received':         return 'Offer';
+    case 'rejection_any_stage':    return 'Rejection';
+    case 'follow_up_needed':       return 'Follow-up';
+    case 'interview_rescheduled':  return 'Rescheduled';
+    case 'informational':          return 'Update';
+    default:                       return eventType;
+  }
+}
+
+window.JobApplicationEvents = {
+  listEvents, needsAttention, ackEvent, runBackfill, roleMatchedEvents,
+  loadRoleSignals, chipClassForSignal, eventTypeLabel,
+};

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -5,6 +5,7 @@ const V = (new URL(import.meta.url)).search;
 const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
 const { logoSrc, logoInitial } = await import('../logo.js' + V);
 const { renderFitModal, scoreClass: sharedScoreClass } = await import('./job-fit-modal.js' + V);
+const { loadRoleSignals, chipClassForSignal, ackEvent } = await import('../applicationEvents.js' + V);
 // Mount the recommendations widget. It self-loads when the user is signed in.
 import('./job-recommendations.js' + V);
 
@@ -54,6 +55,7 @@ const COLUMNS = [
   { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
   { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
   { id: 'role',   label: 'Role',   sortKey: 'title',   type: 'text' },
+  { id: 'signal', label: '',       sortKey: null },
   { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
   { id: 'menu',   label: '',       sortKey: null },
 ];
@@ -122,6 +124,10 @@ export class JobPipeline extends LitElement {
     archiveReason:   { state: true },
     archiveContext:  { state: true },
     archiveSaving:   { state: true },
+    // Phase 2.0 — per-role signals (action_needed / calendar_today /
+    // reply_pending / new_update / stale_14d). Keyed by role slug.
+    roleSignals:     { state: true },
+    liveBanners:     { state: true },
   };
 
   constructor() {
@@ -169,6 +175,11 @@ export class JobPipeline extends LitElement {
     this.archiveReason = null;
     this.archiveContext = '';
     this.archiveSaving = false;
+    this.roleSignals = new Map();
+    this.liveBanners = [];
+    this._dismissedBannerKeys = (() => {
+      try { return new Set(JSON.parse(localStorage.getItem('job:jobs:dismissedBanners') || '[]')); } catch { return new Set(); }
+    })();
     this._lastVisitAt = (() => {
       try { return localStorage.getItem('job:jobs:lastVisitAt') || null; } catch { return null; }
     })();
@@ -267,9 +278,47 @@ export class JobPipeline extends LitElement {
       // this session.
       try { localStorage.setItem('job:jobs:lastVisitAt', new Date().toISOString()); } catch {}
       this.state = 'loaded';
+      // Phase 2.0 — load signals after the table renders so the page
+      // isn't blocked on Gmail/Calendar fetches. Re-render on completion.
+      this._loadSignals();
     } catch (e) {
       this.error = String(e);
       this.state = 'error';
+    }
+  }
+
+  async _loadSignals() {
+    try {
+      const { byRole } = await loadRoleSignals();
+      this.roleSignals = byRole;
+      // Live banner candidates: signals < 30 min old + not previously dismissed.
+      this.liveBanners = [...byRole.values()]
+        .filter(s => s.isLive && !this._dismissedBannerKeys.has(this._bannerKey(s)))
+        .slice(0, 3);
+    } catch (e) {
+      console.warn('[job-pipeline] _loadSignals failed:', e.message);
+    }
+  }
+
+  _bannerKey(s) { return `${s.signal}:${s.eventId || s.receivedAt || ''}`; }
+
+  _dismissBanner(s) {
+    this._dismissedBannerKeys.add(this._bannerKey(s));
+    try { localStorage.setItem('job:jobs:dismissedBanners', JSON.stringify([...this._dismissedBannerKeys])); } catch {}
+    this.liveBanners = this.liveBanners.filter(b => this._bannerKey(b) !== this._bannerKey(s));
+  }
+
+  async _onAckSignal(s, e) {
+    e?.stopPropagation();
+    if (!s.eventId) return;
+    try {
+      await ackEvent(s.eventId);
+      // Drop the signal locally — UI updates without round-tripping.
+      this.roleSignals.delete(s.role_slug || s.roleSlug);
+      this.liveBanners = this.liveBanners.filter(b => b.eventId !== s.eventId);
+      this.requestUpdate();
+    } catch (err) {
+      console.warn('[job-pipeline] ack failed:', err.message);
     }
   }
 
@@ -805,6 +854,7 @@ export class JobPipeline extends LitElement {
             </div>
           </div>
         </td>
+        <td class="col col-signal" data-label="">${this._renderSignalCell(r)}</td>
         <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
         <td class="col col-menu">${this._renderMenuCell(r)}</td>
       </tr>
@@ -831,6 +881,18 @@ export class JobPipeline extends LitElement {
     `;
   }
 
+  _renderSignalCell(r) {
+    const s = this.roleSignals?.get(r.slug);
+    if (!s) return nothing;
+    const cls = chipClassForSignal(s.signal);
+    return html`<span class=${cls} title=${s.detail}>${s.detail}</span>`;
+  }
+
+  // Update the skeleton row too — silent here, just leave it empty.
+  _renderSkeletonSignalCell() {
+    return html`<td class="col col-signal"></td>`;
+  }
+
   _renderSectorCell(r) {
     const tags = Array.isArray(r.sectorTags) ? r.sectorTags : [];
     if (!tags.length) {
@@ -853,6 +915,7 @@ export class JobPipeline extends LitElement {
           <span class="skeleton" style="width:80%;height:14px;display:block;margin-bottom:6px;"></span>
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
         </td>
+        <td class="col col-signal"></td>
         <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
         <td class="col col-menu"><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
       </tr>
@@ -882,6 +945,86 @@ export class JobPipeline extends LitElement {
         <button class="added-banner__close" @click=${() => this.addedBanner = { roles: [], dismissed: true }} aria-label="Dismiss">×</button>
       </div>
     `;
+  }
+
+  // Phase 2.0 — live-arrival banners. Render at most 3 at a time.
+  // Auto-fade is enforced by `loadRoleSignals` (only includes < 30 min);
+  // dismissal is persisted in localStorage so the same trigger never
+  // re-banners.
+  _renderLiveBanners() {
+    if (!this.liveBanners?.length) return nothing;
+    return html`${this.liveBanners.map(s => html`
+      <div class="live-banner" role="status">
+        <span class="live-banner__icon">${this._iconForSignal(s.signal)}</span>
+        <div class="live-banner__body">
+          <strong>${s.company || ''}${s.company && s.title ? ' · ' : ''}${s.title || ''}</strong>
+          <span class="muted"> ${s.detail || ''}</span>
+        </div>
+        <a class="btn btn--sm" href=${`/job/jobs/${s.role_slug || s.roleSlug}/`}
+           @click=${(ev) => this._onAttentionClick(s, ev)}>Open</a>
+        <button class="live-banner__close" aria-label="Dismiss"
+                @click=${() => this._dismissBanner(s)}>×</button>
+      </div>
+    `)}`;
+  }
+
+  _iconForSignal(signal) {
+    switch (signal) {
+      case 'action_needed':  return '⚠';
+      case 'calendar_today': return '📅';
+      case 'new_update':     return '🔔';
+      default:               return '•';
+    }
+  }
+
+  // Phase 2.0 — Needs-Attention widget. Single card per actionable role,
+  // sorted by priority. Hidden when nothing is actionable.
+  _renderNeedsAttention() {
+    const items = [...(this.roleSignals?.values() || [])].sort((a, b) => a.priority - b.priority);
+    if (!items.length) return nothing;
+    return html`
+      <section class="needs-attention" aria-label="Needs your attention">
+        <div class="needs-attention__header">
+          <strong>Needs your attention</strong>
+          <span>${items.length} ${items.length === 1 ? 'role' : 'roles'}</span>
+        </div>
+        <div class="needs-attention__list">
+          ${items.map(s => html`
+            <a class="needs-attention__card"
+               href=${`/job/jobs/${s.role_slug || s.roleSlug || ''}/`}
+               @click=${(e) => this._onAttentionClick(s, e)}>
+              <div>
+                <div class="needs-attention__title">
+                  ${s.company || s.role_slug}
+                  ${s.title ? html`<span class="muted"> · ${s.title}</span>` : nothing}
+                </div>
+                <div class="needs-attention__detail">${s.detail || ''}</div>
+              </div>
+              <span class="needs-attention__signal ${chipClassForSignal(s.signal)}">${this._signalLabel(s.signal)}</span>
+            </a>
+          `)}
+        </div>
+      </section>
+    `;
+  }
+
+  _signalLabel(signal) {
+    switch (signal) {
+      case 'action_needed':  return 'Action needed';
+      case 'calendar_today': return 'Calendar';
+      case 'reply_pending':  return 'Reply pending';
+      case 'new_update':     return 'New update';
+      case 'stale_14d':      return 'Quiet 14d+';
+      default:               return signal;
+    }
+  }
+
+  _onAttentionClick(s, e) {
+    if (e.metaKey || e.ctrlKey || e.button === 1) return;
+    const slug = s.role_slug || s.roleSlug;
+    if (!slug) return;
+    e.preventDefault();
+    window.location.assign(`/job/jobs/${slug}/`);
   }
 
   _onAddedClick(r, e) {
@@ -921,6 +1064,9 @@ export class JobPipeline extends LitElement {
 
     return html`
       ${this.bucket === 'leads' ? html`<job-recommendations></job-recommendations>` : nothing}
+
+      ${this.bucket === 'active' ? this._renderLiveBanners() : nothing}
+      ${this.bucket === 'active' ? this._renderNeedsAttention() : nothing}
 
       ${showAddedBanner ? this._renderAddedBanner(added) : nothing}
 

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -37,15 +37,19 @@ const BASE_RESUME_SLUG = '__base__';
 
 const TABS = [
   { id: 'details',      label: 'Role details' },
+  { id: 'activity',     label: 'Activity' },
   { id: 'resume',       label: 'Resume' },
   { id: 'cover-letter', label: 'Cover letter' },
 ];
 
 const KIND_BY_TAB = {
   details: 'analysis',
+  activity: null,                  // Activity tab has no role_asset; fetched live.
   resume: 'resume',
   'cover-letter': 'cover-letter',
 };
+
+const { listEvents, ackEvent: ackApplicationEvent, eventTypeLabel } = await import('../applicationEvents.js' + V);
 
 function fmtDate(s) {
   if (!s) return '—';
@@ -84,6 +88,10 @@ export class JobRoleDetail extends LitElement {
     selectionPopover: { state: true },// { visible, x, y, text, savedRange } | null — floating "edit selection" UI
     coverHistory: { state: true },    // [{ id, ts, source, content, label, instruction? }] reverse-chrono
     genTick: { state: true },         // 0..n — drives the rotating-word label inside shimmer indicators
+    // Phase 2.0 — Activity timeline.
+    activityState:  { state: true },  // 'idle' | 'loading' | 'loaded' | 'error'
+    activityEvents: { state: true },  // EventRow[]
+    processOutline: { state: true },  // { rounds, expected_total_rounds, source, ... } | null
   };
 
   constructor() {
@@ -109,6 +117,9 @@ export class JobRoleDetail extends LitElement {
     this.selectionPopover = null;
     this.coverHistory = [];
     this.genTick = 0;
+    this.activityState  = 'idle';
+    this.activityEvents = [];
+    this.processOutline = null;
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/job\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -182,6 +193,10 @@ export class JobRoleDetail extends LitElement {
       document.title = this.role
         ? `${this.role.company} — ${this.role.title} — /job`
         : `${this.slug} — /job`;
+      // Phase 2.0 — fetch activity events + process_outline so the
+      // process-tracker strip + Activity tab paint without waiting for
+      // a tab switch. Fire-and-forget; failure is silent.
+      this._loadActivity();
       // Now that base resume is in hand, fold the diff into the resume's
       // editable HTML so it shows up on first paint.
       queueMicrotask(() => this._refreshEditHtml('resume'));
@@ -344,6 +359,33 @@ export class JobRoleDetail extends LitElement {
     this.activeTab = id;
     const qs = id !== 'details' ? `?tab=${id}` : '';
     history.replaceState(null, '', `/job/jobs/${this.slug}/${qs}`);
+    // Phase 2.0 — lazy-load Activity timeline the first time it opens.
+    if (id === 'activity' && this.activityState === 'idle') this._loadActivity();
+  }
+
+  async _loadActivity() {
+    this.activityState = 'loading';
+    try {
+      const res = await listEvents(this.slug, { withReplyStatus: true });
+      this.activityEvents = res.events || [];
+      this.processOutline = res.process_outline || null;
+      this.activityState = 'loaded';
+    } catch (e) {
+      this.error = (e && e.message) || String(e);
+      this.activityState = 'error';
+    }
+  }
+
+  async _onAckActivityEvent(ev, dom) {
+    dom?.stopPropagation();
+    try {
+      await ackApplicationEvent(ev.id);
+      this.activityEvents = this.activityEvents.map(e =>
+        e.id === ev.id ? { ...e, needs_review: false, reviewed_at: new Date().toISOString() } : e
+      );
+    } catch (e) {
+      console.warn('[role-detail] ack failed:', e.message);
+    }
   }
 
   async _onGenerate(kind) {
@@ -1726,11 +1768,101 @@ export class JobRoleDetail extends LitElement {
         `)}
       </div>
 
+      ${this._renderProcessTracker()}
+
       <section class="asset-panel">
-        ${this.activeTab === 'details' ? this._renderDetails() : this._renderAssetTab(this.activeTab)}
+        ${this.activeTab === 'details'  ? this._renderDetails()
+        : this.activeTab === 'activity' ? this._renderActivityTab()
+        : this._renderAssetTab(this.activeTab)}
       </section>
     `;
   }
+
+  _renderProcessTracker() {
+    const po = this.processOutline;
+    if (!po || !Array.isArray(po.rounds) || !po.rounds.length) return nothing;
+    const rounds = po.rounds.slice().sort((a, b) => a.order - b.order);
+    return html`
+      <div class="process-tracker" title="Source: ${po.source || 'unknown'}">
+        ${rounds.map((r, i) => html`
+          ${i > 0 ? html`<span class="process-tracker__sep">→</span>` : nothing}
+          <span class="process-tracker__pill ${r.completed ? 'process-tracker__pill--done' : ''}">
+            ${r.label}${r.completed ? ' ✓' : ''}
+          </span>
+        `)}
+        <span class="process-tracker__source">${po.source ? po.source.replace(/_/g, ' ') : ''}</span>
+      </div>
+    `;
+  }
+
+  _renderActivityTab() {
+    if (this.activityState === 'loading' || this.activityState === 'idle') {
+      return html`<div class="placeholder"><p class="muted">Loading activity…</p></div>`;
+    }
+    if (this.activityState === 'error') {
+      return html`<div class="placeholder"><p class="muted">Couldn't load activity timeline.</p></div>`;
+    }
+    if (!this.activityEvents.length) {
+      return html`
+        <div class="placeholder">
+          <h2>No activity yet</h2>
+          <p>Emails from this company on a Gmail thread linked to this role will appear here once classified.</p>
+        </div>
+      `;
+    }
+    return html`
+      <div class="activity-timeline">
+        ${this.activityEvents.map(ev => this._renderActivityEvent(ev))}
+      </div>
+    `;
+  }
+
+  _renderActivityEvent(ev) {
+    const cls = 'activity-event'
+      + (ev.auto_applied ? ' activity-event--auto' : '')
+      + (ev.needs_review && !ev.reviewed_at ? ' activity-event--review' : '');
+    const when = fmtRelativeTime(ev.received_at);
+    const gmailUrl = ev.gmail_api_id
+      ? `https://mail.google.com/mail/u/0/#inbox/${encodeURIComponent(ev.gmail_thread_id || ev.gmail_api_id)}`
+      : null;
+    return html`
+      <article class=${cls}>
+        <span class="activity-event__rail" aria-hidden="true"></span>
+        <div>
+          <div class="activity-event__head">
+            <span class="activity-event__type">${eventTypeLabel(ev.event_type)}</span>
+            ${ev.round_label ? html`<span class="activity-event__round">${ev.round_label}${ev.round_n ? ` · round ${ev.round_n}` : ''}</span>` : nothing}
+            <span class="activity-event__time" title=${ev.received_at}>${when}</span>
+          </div>
+          <div class="activity-event__summary">${ev.summary || '(no summary)'}</div>
+          <div class="activity-event__meta">
+            ${ev.auto_applied ? html`<span class="muted">Auto-advanced to ${ev.detected_stage || '—'}</span>` : nothing}
+            ${ev.needs_user_reply ? html`<span class="activity-event__reply-flag">⚠ You haven't replied yet</span>` : nothing}
+            ${gmailUrl ? html`<a href=${gmailUrl} target="_blank" rel="noopener noreferrer">📧 Source email</a>` : nothing}
+            ${ev.confidence != null ? html`<span class="muted">Confidence ${(ev.confidence * 100).toFixed(0)}%</span>` : nothing}
+            ${ev.needs_review && !ev.reviewed_at ? html`
+              <button class="activity-event__ack" @click=${(e) => this._onAckActivityEvent(ev, e)}>Mark as seen</button>
+            ` : nothing}
+          </div>
+        </div>
+      </article>
+    `;
+  }
+}
+
+function fmtRelativeTime(iso) {
+  if (!iso) return '';
+  try {
+    const ms = Date.now() - new Date(iso).getTime();
+    const min = Math.round(ms / 60000);
+    if (min < 1) return 'just now';
+    if (min < 60) return `${min}m ago`;
+    const h = Math.round(min / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.round(h / 24);
+    if (d < 14) return `${d}d ago`;
+    return new Date(iso).toLocaleDateString();
+  } catch { return ''; }
 }
 
 customElements.define('job-role-detail', JobRoleDetail);

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.74.0">
-  <script src="/job/js/theme.js?v=0.74.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
+  <script src="/job/js/theme.js?v=0.75.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.74.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Frontend slice of Phase 2.0. Backend shipped in #783.

- **Pipeline rows** get a single highest-priority chip from a new `signal` column: red Action-needed > blue Calendar today/tomorrow > amber Reply-pending > green New-update > yellow Stale-14d.
- **Needs-Attention widget** above the Active table — one card per actionable role, hidden when 0. Stale chip renders here on-open only (no banner, per locked decision).
- **Live-arrival banners** for items < 30 min old (action_needed / calendar within 2h / new_update). Dismissals persisted to localStorage so the same trigger never re-banners.
- **Drill page Activity tab** — reverse-chron event list with per-event `you haven't replied yet` flag, source-email link, ack button. Process-tracker strip below the role header (visible on every tab) rendering `process_outline.rounds`.
- Shared client [applicationEvents.js](job/js/applicationEvents.js) wraps the new `application-events` + `calendar-api role-matched-events` actions.

Plan: [Phase 15](docs/execution/project-plan/phase-15-gmail-application-tracker.md).

## Test plan

- [ ] /job/jobs/?bucket=active: chip column visible on rows; Needs-Attention widget renders only when actionables exist
- [ ] Drill page on a role with events: Activity tab paints reverse-chron; process-tracker shows when outline populated
- [ ] Live banner appears for a newly-arrived auto-advance; dismissing it persists across reload
- [ ] Backfill via `POST application-events { action: 'backfill', batchSize: 5 }` populates events for 30d window
- [ ] Confirm cache-bust `v=0.75.0` busts the old CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)