### PR TITLE
job(pipeline): move Status column to the right side of every row

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
-  <script src="/job/js/theme.js?v=0.75.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
+  <script src="/job/js/theme.js?v=0.75.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
-  <script src="/job/js/theme.js?v=0.75.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
+  <script src="/job/js/theme.js?v=0.75.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
-  <script src="/job/js/theme.js?v=0.75.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
+  <script src="/job/js/theme.js?v=0.75.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
-  <script src="/job/js/theme.js?v=0.75.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
+  <script src="/job/js/theme.js?v=0.75.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.75.0";
-console.log(`[job] v${VERSION} - Phase 2.0 application tracker: signal chips, Needs-Attention, Activity timeline, process tracker`);
+const VERSION = "0.75.1";
+console.log(`[job] v${VERSION} - Phase 2.0 + status-column moved to right of pipeline rows`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -53,10 +53,10 @@ function bucketFor(r) {
 // sortKey null → header isn't clickable.
 const COLUMNS = [
   { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
-  { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
   { id: 'role',   label: 'Role',   sortKey: 'title',   type: 'text' },
   { id: 'signal', label: '',       sortKey: null },
   { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
+  { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
   { id: 'menu',   label: '',       sortKey: null },
 ];
 
@@ -839,7 +839,6 @@ export class JobPipeline extends LitElement {
             ${r.score == null ? '—' : r.score}
           </button>
         </td>
-        ${showStatus ? html`<td class="col col-status status-cell" data-label="Status">${this._renderStatusCell(r)}</td>` : nothing}
         <td class="col col-role role-cell" data-label="Role">
           <div class="role-cell__inner">
             ${this._renderLogo(r, 'sm')}
@@ -856,6 +855,7 @@ export class JobPipeline extends LitElement {
         </td>
         <td class="col col-signal" data-label="">${this._renderSignalCell(r)}</td>
         <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
+        ${showStatus ? html`<td class="col col-status status-cell" data-label="Status">${this._renderStatusCell(r)}</td>` : nothing}
         <td class="col col-menu">${this._renderMenuCell(r)}</td>
       </tr>
     `;
@@ -910,13 +910,13 @@ export class JobPipeline extends LitElement {
     return html`
       <tr class="skeleton-row">
         <td class="col col-fit"><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
-        ${showStatus ? html`<td class="col col-status"><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
         <td class="col col-role">
           <span class="skeleton" style="width:80%;height:14px;display:block;margin-bottom:6px;"></span>
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
         </td>
         <td class="col col-signal"></td>
         <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
+        ${showStatus ? html`<td class="col col-status"><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
         <td class="col col-menu"><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
       </tr>
     `;

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.0">
-  <script src="/job/js/theme.js?v=0.75.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
+  <script src="/job/js/theme.js?v=0.75.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Status was at position 2 (right after Fit), crowding the Role cell. Move it to second-to-last so Fit → Role → Sector → Status flows visually right. Active + Archive only (Leads has no status). Bumps cache-bust to 0.75.1.