### PR TITLE
job(gmail-tracker): catch direct human emails via per-role name search

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -129,20 +129,54 @@ export async function scanApplicationResponses(args: {
     for (const t of r.gmail_thread_ids) threadToRole.set(t, r);
   }
 
-  // Build the Gmail query. Include pipeline-company domains AND known
-  // ATS-platform domains. -in:spam -in:trash to avoid the noisy buckets.
+  // Build the Gmail query set. Three passes — each contributes message
+  // IDs that we then dedup, fetch, and try to classify:
+  //
+  //   1. Sender-domain pass — companies with a known domain in
+  //      hiring_companies, plus the ATS-platform allowlist. Cheap, broad.
+  //   2. Per-role name pass — for each active role, search the inbox
+  //      for the literal company name. Catches direct human emails from
+  //      a recruiter's personal gmail / hiring-manager's @yahoo / any
+  //      sender whose domain we don't have cached. Capped at 20 IDs per
+  //      role and we exclude the obvious noise senders.
+  //
+  // All three streams hit the same matching gauntlet below; Message-ID
+  // dedup against application_events ensures we never re-classify.
   const senderDomains = new Set<string>();
   for (const d of domainToRoles.keys()) senderDomains.add(d);
   for (const d of ATS_PLATFORM_DOMAINS) senderDomains.add(d);
-  if (senderDomains.size === 0) return out;
 
-  const fromClause = [...senderDomains].map(d => `from:${d}`).join(' OR ');
-  const query = `(${fromClause}) -in:spam -in:trash newer_than:${windowDays}d`;
+  const idSet = new Set<string>();
 
-  // List messages. We use messages.list directly here (not historyId)
-  // because the application-scan cursor is independent from the
-  // recs-scan cursor, and Message-ID dedup makes re-listing safe.
-  const ids = await listMessagesByQuery(args.accessToken, query, maxMessages * 3);
+  if (senderDomains.size > 0) {
+    const fromClause = [...senderDomains].map(d => `from:${d}`).join(' OR ');
+    const domainQuery = `(${fromClause}) -in:spam -in:trash newer_than:${windowDays}d`;
+    for (const id of await listMessagesByQuery(args.accessToken, domainQuery, maxMessages * 3)) {
+      idSet.add(id);
+    }
+  }
+
+  // Pass 2: per-role name search. The filter strips aggregator newsletter
+  // senders + the role's own canonical URL — those messages are either
+  // already on the recs path (linkedin alerts) or noisy (job board
+  // newsletters mentioning the company in passing).
+  const NEWSLETTER_NEGATIVES = '-from:linkedin.com -from:wellfound.com -from:otta.com -from:builtin.com -from:hnhiring.com';
+  for (const role of roles.slice(0, 20)) {
+    if (role.company_norm.length < 3) continue;
+    // Quote the name so multi-word companies match exactly. Escape any
+    // embedded quotes for safety.
+    const quoted = `"${role.company_name.replace(/"/g, '\\"')}"`;
+    const nameQuery = `${quoted} in:inbox -in:spam newer_than:${windowDays}d ${NEWSLETTER_NEGATIVES}`;
+    try {
+      for (const id of await listMessagesByQuery(args.accessToken, nameQuery, 20)) {
+        idSet.add(id);
+      }
+    } catch (e) {
+      console.warn(`[gmail-app-scan] name-search '${role.company_name}' failed: ${(e as Error).message}`);
+    }
+  }
+
+  const ids = [...idSet];
 
   let processed = 0;
   for (const id of ids) {
@@ -184,9 +218,13 @@ export async function scanApplicationResponses(args: {
         : pickByTitleOverlap(candidates, subject, body);
     }
 
-    // Step 3 — ATS-platform sender: scan the body for pipeline company
-    // name. Require an actual name match to avoid cross-pollination.
-    if (!matchedRole && senderDomain && isAtsPlatformDomain(senderDomain)) {
+    // Step 3 — company-name-in-body match. Originally gated to ATS
+    // senders, now generalized: applies to ANY sender whose domain we
+    // didn't already match in step 2. Catches direct human emails from
+    // recruiter @gmail addresses, hiring-manager @yahoo addresses, and
+    // any sender whose company domain we don't have cached. The
+    // confidence floor in classifyApplicationMessage still gates poison.
+    if (!matchedRole) {
       const haystack = `${subject}\n${body}`.toLowerCase();
       const hits = roles.filter(r => {
         const nm = r.company_norm;

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -31,8 +31,8 @@ import {
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
 
-const VERSION = '1.0.0';
-console.log(`[application-events] v${VERSION} - Phase 2.0 read + needs-attention + backfill`);
+const VERSION = '1.1.0';
+console.log(`[application-events] v${VERSION} - backfill uses per-role name search to catch direct human emails`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 // loadFitContext for now. add-role uses the canonical versions in
 // ../_shared/job-fit-haiku.ts. TODO: consolidate to one source of truth.
 
-const VERSION = '0.7.0';
-console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 application-tracker scan side-effect in gmail-jobs source`);
+const VERSION = '0.8.0';
+console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 application-tracker scan: + per-role name search to catch direct human emails`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
## Summary

Phase 2.0 scan was missing emails from real people because the Gmail query was restricted to sender domains we had cached (\`hiring_companies.domain\` + ATS platforms). A recruiter emailing from their personal gmail, or a hiring manager from a company domain not yet in \`hiring_companies\`, would never enter the candidate-message set.

- Add a second Gmail pass: per-active-role text search (\`\"Company Name\" in:inbox newer_than:Nd\`, capped at 20 IDs/role, newsletter senders excluded). Merge with the existing sender-domain pass into a single Set so dedup + classify still runs once per unique Message-ID.
- Generalize the body+subject name-match: previously only fired for ATS-platform senders; now applies to any sender we couldn't match by domain. The 0.6 PERSIST_CONFIDENCE_FLOOR still guards against poison from coincidental name mentions.
- pull-recommendations 0.7.0→0.8.0, application-events 1.0.0→1.1.0.

## Test plan

- [ ] Deploy both functions after merge
- [ ] Run backfill from the live UI; verify events land for roles whose recruiter emails come from personal addresses
- [ ] Check application_events shows the expected new rows