### PR TITLE
job(gmail-tracker): drop in:inbox so labeled/archived recruiter threads are scanned

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -160,13 +160,18 @@ export async function scanApplicationResponses(args: {
   // senders + the role's own canonical URL — those messages are either
   // already on the recs path (linkedin alerts) or noisy (job board
   // newsletters mentioning the company in passing).
+  //
+  // NOTE: we do NOT restrict to `in:inbox`. Many recruiter threads get
+  // filed into labels (e.g. Career/Networking) which removes them from
+  // the inbox view. `-in:spam -in:trash` keeps the obvious junk out
+  // without losing labeled-but-archived recruiter conversations.
   const NEWSLETTER_NEGATIVES = '-from:linkedin.com -from:wellfound.com -from:otta.com -from:builtin.com -from:hnhiring.com';
   for (const role of roles.slice(0, 20)) {
     if (role.company_norm.length < 3) continue;
     // Quote the name so multi-word companies match exactly. Escape any
     // embedded quotes for safety.
     const quoted = `"${role.company_name.replace(/"/g, '\\"')}"`;
-    const nameQuery = `${quoted} in:inbox -in:spam newer_than:${windowDays}d ${NEWSLETTER_NEGATIVES}`;
+    const nameQuery = `${quoted} -in:spam -in:trash newer_than:${windowDays}d ${NEWSLETTER_NEGATIVES}`;
     try {
       for (const id of await listMessagesByQuery(args.accessToken, nameQuery, 20)) {
         idSet.add(id);

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -31,8 +31,8 @@ import {
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
 
-const VERSION = '1.1.0';
-console.log(`[application-events] v${VERSION} - backfill uses per-role name search to catch direct human emails`);
+const VERSION = '1.1.1';
+console.log(`[application-events] v${VERSION} - backfill name-search no longer restricts to in:inbox (covers labeled/archived threads)`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 // loadFitContext for now. add-role uses the canonical versions in
 // ../_shared/job-fit-haiku.ts. TODO: consolidate to one source of truth.
 
-const VERSION = '0.8.0';
-console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 application-tracker scan: + per-role name search to catch direct human emails`);
+const VERSION = '0.8.1';
+console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: name-search no longer restricts to in:inbox so labeled/archived recruiter threads land`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Repro: bryce.keithley@angellist.com emails about Code for America were filed into Career/Networking label (and out of the inbox). Per-role name search had `in:inbox` which excluded them. Switch to `-in:spam -in:trash` to match the existing sender-domain pass. pull-recommendations 0.8.0→0.8.1, application-events 1.1.0→1.1.1.