### PR TITLE
job(gmail-tracker): scan all Saved+Active roles so cold recruiter outreach is caught

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -103,9 +103,12 @@ export async function scanApplicationResponses(args: {
       left join job.hiring_companies hc
         on hc.name_norm = lower(trim(r.company_name))
      where r.status in ('Active', 'Saved')
-       and (r.applied_at is not null or r.engaged_at is not null)
        and (${args.roleSlug ?? null}::text is null or r.slug = ${args.roleSlug ?? null})
        and r.deleted_at is null
+     order by
+       case when r.status = 'Active' then 0 else 1 end,
+       coalesce(r.engaged_at, r.applied_at) desc nulls last,
+       r.created_at desc
   `;
   if (!roles.length) return out;
 
@@ -166,7 +169,10 @@ export async function scanApplicationResponses(args: {
   // the inbox view. `-in:spam -in:trash` keeps the obvious junk out
   // without losing labeled-but-archived recruiter conversations.
   const NEWSLETTER_NEGATIVES = '-from:linkedin.com -from:wellfound.com -from:otta.com -from:builtin.com -from:hnhiring.com';
-  for (const role of roles.slice(0, 20)) {
+  // Cap covers the whole current pipeline; roles are pre-sorted Active
+  // first, then by most-recent engagement. If the pipeline ever grows
+  // past this, the tail is silently skipped — bump or paginate.
+  for (const role of roles.slice(0, 60)) {
     // Build a candidate-name set per role. Start with company_name when
     // it looks real; add the title-derived company token when it
     // doesn't (rows added via /add-role sometimes land as

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -31,8 +31,8 @@ import {
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
 
-const VERSION = '1.2.0';
-console.log(`[application-events] v${VERSION} - backfill: title-derived company tokens + label coverage`);
+const VERSION = '1.3.0';
+console.log(`[application-events] v${VERSION} - backfill scans ALL Saved+Active roles so cold recruiter outreach on Saved roles is caught`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 // loadFitContext for now. add-role uses the canonical versions in
 // ../_shared/job-fit-haiku.ts. TODO: consolidate to one source of truth.
 
-const VERSION = '0.9.0';
-console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: title-derived company tokens for (unknown company) rows + non-inbox label coverage`);
+const VERSION = '0.10.0';
+console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: all Saved+Active roles included regardless of engaged_at; cap bumped to 60`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
The (applied_at OR engaged_at) filter was cutting off a real use case: cold recruiter emails about a Saved role you haven't touched yet are exactly the signal we'd want to promote it to Active. Drop the filter, order Active-first then most-recent engagement, bump per-role search cap 20→60.