### PR TITLE
job(gmail-tracker): skip user's own outbound messages in the scan

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -220,6 +220,12 @@ export async function scanApplicationResponses(args: {
     const body = extractBody(msg);
     if (!body) continue;
 
+    // Skip user's own outbound messages — those are replies *from* the
+    // candidate, not status updates *about* the application. The thread-
+    // walk in application-events handles outbound detection separately
+    // (for needs_user_reply); here we only want inbound classifications.
+    if (sender.includes(args.userEmail.toLowerCase())) continue;
+
     const senderDomain = extractDomain(sender);
 
     // Step 1 — thread continuity wins. If the thread is already

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -31,8 +31,8 @@ import {
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
 
-const VERSION = '1.3.0';
-console.log(`[application-events] v${VERSION} - backfill scans ALL Saved+Active roles so cold recruiter outreach on Saved roles is caught`);
+const VERSION = '1.3.1';
+console.log(`[application-events] v${VERSION} - backfill skips user's own outbound messages`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 // loadFitContext for now. add-role uses the canonical versions in
 // ../_shared/job-fit-haiku.ts. TODO: consolidate to one source of truth.
 
-const VERSION = '0.10.0';
-console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: all Saved+Active roles included regardless of engaged_at; cap bumped to 60`);
+const VERSION = '0.10.1';
+console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: skip user's own outbound messages (never classify candidate replies)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Bug: per-role name search was returning Ian's own replies (his outbound matched the role's company name in body), classifier then produced a bogus inbound-status event with sender='ian fike <fike101@gmail.com>'. Skip messages where From: matches userEmail.