### PR TITLE
job(scheduler): Refresh button + auto-fire pull-recommendations on first load

### DIFF
--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
-  <script src="/job/js/theme.js?v=0.75.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
+  <script src="/job/js/theme.js?v=0.76.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
-  <script src="/job/js/theme.js?v=0.75.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
+  <script src="/job/js/theme.js?v=0.76.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
-  <script src="/job/js/theme.js?v=0.75.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
+  <script src="/job/js/theme.js?v=0.76.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
-  <script src="/job/js/theme.js?v=0.75.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
+  <script src="/job/js/theme.js?v=0.76.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.75.1";
-console.log(`[job] v${VERSION} - Phase 2.0 + status-column moved to right of pipeline rows`);
+const VERSION = "0.76.0";
+console.log(`[job] v${VERSION} - Refresh button + auto-refresh on first load`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-pipeline.js
+++ b/job/js/components/job-pipeline.js
@@ -2,7 +2,7 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole } = await import('../pipeline.js' + V);
+const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole, refreshSources } = await import('../pipeline.js' + V);
 const { logoSrc, logoInitial } = await import('../logo.js' + V);
 const { renderFitModal, scoreClass: sharedScoreClass } = await import('./job-fit-modal.js' + V);
 const { loadRoleSignals, chipClassForSignal, ackEvent } = await import('../applicationEvents.js' + V);
@@ -128,6 +128,9 @@ export class JobPipeline extends LitElement {
     // reply_pending / new_update / stale_14d). Keyed by role slug.
     roleSignals:     { state: true },
     liveBanners:     { state: true },
+    // Refresh button feedback.
+    _refreshing:      { state: true },
+    _refreshFeedback: { state: true },
   };
 
   constructor() {
@@ -177,6 +180,8 @@ export class JobPipeline extends LitElement {
     this.archiveSaving = false;
     this.roleSignals = new Map();
     this.liveBanners = [];
+    this._refreshing = false;
+    this._refreshFeedback = '';
     this._dismissedBannerKeys = (() => {
       try { return new Set(JSON.parse(localStorage.getItem('job:jobs:dismissedBanners') || '[]')); } catch { return new Set(); }
     })();
@@ -281,9 +286,42 @@ export class JobPipeline extends LitElement {
       // Phase 2.0 — load signals after the table renders so the page
       // isn't blocked on Gmail/Calendar fetches. Re-render on completion.
       this._loadSignals();
+      // Kick a sources refresh in the background. Server-side gates by
+      // schedule_cron + last_run_at, so frequent kicks are no-ops when
+      // nothing is due. Client-side throttle in refreshSources() avoids
+      // tab-hop hammering.
+      refreshSources({ silent: true });
     } catch (e) {
       this.error = String(e);
       this.state = 'error';
+    }
+  }
+
+  async _onRefreshSources() {
+    if (this._refreshing) return;
+    this._refreshing = true;
+    this.requestUpdate();
+    try {
+      const r = await refreshSources();
+      // Refresh isn't synchronous on the server — show a brief toast and
+      // re-fetch the pipeline so any newly-landed events surface as the
+      // user keeps interacting. Signals refresh too.
+      this._refreshFeedback = r.throttled
+        ? 'Recently refreshed — try again in a few minutes.'
+        : 'Scanning Gmail for updates…';
+      setTimeout(async () => {
+        try {
+          const data = await fetchPipeline();
+          this.roles = (data.roles || []).slice();
+        } catch { /* keep stale state */ }
+        this._loadSignals();
+        this.requestUpdate();
+      }, 8000);
+    } finally {
+      this._refreshing = false;
+      this.requestUpdate();
+      // Auto-dismiss the toast after ~10s.
+      setTimeout(() => { this._refreshFeedback = ''; this.requestUpdate(); }, 10000);
     }
   }
 
@@ -1112,6 +1150,11 @@ export class JobPipeline extends LitElement {
         ${this.bucket === 'leads' && this.sortKey !== 'manual' && !this._manualOrders.leads.length ? html`
           <button class="btn btn--sm" @click=${() => this._useCustomOrder()}>Arrange manually</button>
         ` : nothing}
+        <button class="btn btn--sm" ?disabled=${this._refreshing}
+                title="Scan Gmail for new role alerts and application updates"
+                @click=${() => this._onRefreshSources()}>
+          ${this._refreshing ? 'Scanning…' : '↻ Refresh'}
+        </button>
         <button class="btn btn--sm" ?disabled=${this.livenessChecking}
                 @click=${() => this._onCheckLiveness()}>
           ${this.livenessChecking ? 'Checking…' : 'Check liveness'}
@@ -1120,6 +1163,7 @@ export class JobPipeline extends LitElement {
                 @click=${() => { this.pasteOpen = !this.pasteOpen; this.pasteError = ''; }}>
           ${this.pasteOpen ? 'Cancel' : '＋ Add a role'}
         </button>
+        ${this._refreshFeedback ? html`<span class="muted" style="margin-left:var(--space-3);font-size:var(--font-size-caption);">${this._refreshFeedback}</span>` : nothing}
       </div>
 
       ${this.pasteOpen ? html`

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -3,6 +3,43 @@ const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/jobs-pipe'
 const LIVENESS_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/check-liveness';
 const ADD_ROLE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/add-role';
 const REC_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recommendations';
+const PULL_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations';
+
+// Soft client-side rate limit so first-load auto-fire doesn't hammer the
+// endpoint when the user tab-hops. Server-side gating is the source of
+// truth (user_sources.schedule_cron vs last_run_at).
+const PULL_MIN_INTERVAL_MS = 5 * 60 * 1000;     // 5 min — half the server's 15-min cadence
+
+export async function refreshSources({ silent = false } = {}) {
+  // Throttle: if we kicked a pull within PULL_MIN_INTERVAL_MS, skip.
+  try {
+    const lastTs = Number(localStorage.getItem('job:lastPullKickAt') || 0);
+    if (Date.now() - lastTs < PULL_MIN_INTERVAL_MS) {
+      return { kicked: false, throttled: true, lastKickAt: new Date(lastTs).toISOString() };
+    }
+    localStorage.setItem('job:lastPullKickAt', String(Date.now()));
+  } catch { /* ignore */ }
+
+  const headers = await authHeader();
+  // Fire-and-forget. The function can take 30–90s on a backlog drain;
+  // keepalive lets the browser deliver even if the user navigates. The
+  // page never blocks on this — fresh recs / events show up after the
+  // next fetchPipeline() / Activity refresh.
+  let kickedOk = true;
+  try {
+    fetch(PULL_URL, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      // No body → all enabled+due user_sources run, same as the cron path.
+      body: JSON.stringify({}),
+      keepalive: true,
+    }).catch(() => { /* fire-and-forget; server completes its own work */ });
+  } catch (e) {
+    kickedOk = false;
+    if (!silent) console.warn('[refreshSources] kick failed:', e.message);
+  }
+  return { kicked: kickedOk, throttled: false };
+}
 
 async function authHeader() {
   const supabase = window.CtrlAuth?.getSupabaseClient?.();

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.75.1">
-  <script src="/job/js/theme.js?v=0.75.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
+  <script src="/job/js/theme.js?v=0.76.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.75.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Server scheduler is dead (no pg_cron, no GH Actions); meanwhile give the user explicit + implicit kicks from the UI. Function gates on schedule_cron + last_run_at, so over-firing is safe. 5-min client-side throttle in localStorage. New ↻ Refresh button on /job/jobs/, plus auto-fire on first load. Cache-bust 0.76.0.