### PR TITLE
job(gmail-scan): unstick cappedRun + run app-scan before early return

### DIFF
--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -195,22 +195,24 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
          limit 1`;
       if (recMatch.length) continue;
 
-      // Past dedup — this message is going to consume real work (Haiku
-      // and / or skip-log writes). Count it against the cap so the next
-      // tick continues past whatever we manage to process here.
-      newWork++;
-
       const sender = (getHeader(msg, 'From') || '').toLowerCase();
       if (blockSenders.some(b => sender.includes(b))) {
         await logSkipped(sql, ctx.userEmail, msg, messageId, 'blocked_sender');
         continue;
       }
       if (!allowSenders.some(a => sender.includes(a.toLowerCase()))) {
-        // Out of allowlist — silently skip. Don't fill gmail_skipped
-        // with every newsletter the user gets; only log when we tried
-        // and failed.
+        // Out of allowlist — silently skip. history.list returns ALL
+        // messageAdded events regardless of sender, so on a busy inbox
+        // most of what we see here is unrelated mail; counting it
+        // toward newWork would fill the cap before we reach any actual
+        // job alert and the cursor would never advance.
         continue;
       }
+
+      // Past dedup AND allowlist — this message is going to consume real
+      // work (Haiku and / or skip-log writes). Count it against the cap
+      // so the next tick continues past whatever we manage to process.
+      newWork++;
 
       const subject = getHeader(msg, 'Subject') || '';
       const body = extractBody(msg);
@@ -338,6 +340,23 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
       }
     }
 
+    // Phase 2.0 — application-tracker scan runs UNCONDITIONALLY (before
+    // the cap-vs-drain split). It does its own Gmail query, independent
+    // of the recs cursor, so keeping it inside the capped-run early
+    // return would silently mute the application timeline on busy inboxes.
+    try {
+      const appScan = await scanApplicationResponses({
+        userEmail:   ctx.userEmail,
+        accessToken,
+        mode:        'live',
+      });
+      if (appScan.classified || appScan.inserted) {
+        console.log(`[gmail-jobs] application-scan: ${appScan.inserted}/${appScan.classified} events, ${appScan.autoAdvanced} auto-advanced, ${appScan.needsReview} needs-review`);
+      }
+    } catch (e) {
+      console.warn(`[gmail-jobs] application-scan failed: ${(e as Error).message}`);
+    }
+
     // Persist new cursor — but ONLY when we drained the whole queue.
     // If the cap kicked in, leave the cursor where it was so the next
     // tick re-fetches the same window and picks up the remainder. The
@@ -369,23 +388,6 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
             last_error = null,
             updated_at = now()
     `;
-
-    // Phase 2.0 — application-tracker scan. Looks at inbox messages from
-    // pipeline-company domains + known ATS-platform senders, classifies
-    // with Haiku, writes application_events, auto-advances forward stages.
-    // Side-effect only — does not contribute to RecommendedRoleInput[].
-    try {
-      const appScan = await scanApplicationResponses({
-        userEmail:   ctx.userEmail,
-        accessToken,
-        mode:        'live',
-      });
-      if (appScan.classified || appScan.inserted) {
-        console.log(`[gmail-jobs] application-scan: ${appScan.inserted}/${appScan.classified} events, ${appScan.autoAdvanced} auto-advanced, ${appScan.needsReview} needs-review`);
-      }
-    } catch (e) {
-      console.warn(`[gmail-jobs] application-scan failed: ${(e as Error).message}`);
-    }
 
     return out;
   },

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 // loadFitContext for now. add-role uses the canonical versions in
 // ../_shared/job-fit-haiku.ts. TODO: consolidate to one source of truth.
 
-const VERSION = '0.10.1';
-console.log(`[pull-recommendations] v${VERSION} - Phase 2.0 scan: skip user's own outbound messages (never classify candidate replies)`);
+const VERSION = '0.11.0';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: newWork++ moved past allowlist filter; app-scan runs even on cappedRun`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Cron firing every 15 min but cursor stuck at 2026-05-11 18:05 because newWork++ ran before allowlist filter — busy inbox filled cap with unrelated mail. Move newWork++ after allowlist, plus run app-scan side-effect before cappedRun early-return.