### PR TITLE
job(recs): Refresh button on For You header — primary entry point

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2199,7 +2199,7 @@
 .rec-shell__head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-bottom: var(--space-3);
 }
@@ -2210,6 +2210,9 @@
   font-size: var(--font-size-title-3);
   letter-spacing: -0.01em;
 }
+.rec-shell__head > .muted { margin-right: auto; }
+.rec-shell__refresh { align-self: center; }
+.rec-shell__refresh-status { font-size: var(--font-size-caption); }
 .rec-row {
   display: grid;
   grid-auto-flow: column;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
-  <script src="/job/js/theme.js?v=0.76.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.1">
+  <script src="/job/js/theme.js?v=0.76.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
-  <script src="/job/js/theme.js?v=0.76.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.1">
+  <script src="/job/js/theme.js?v=0.76.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
-  <script src="/job/js/theme.js?v=0.76.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.1">
+  <script src="/job/js/theme.js?v=0.76.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
-  <script src="/job/js/theme.js?v=0.76.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.1">
+  <script src="/job/js/theme.js?v=0.76.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.76.0";
-console.log(`[job] v${VERSION} - Refresh button + auto-refresh on first load`);
+const VERSION = "0.76.1";
+console.log(`[job] v${VERSION} - Refresh button moved to For You header (primary entry)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations.js
+++ b/job/js/components/job-recommendations.js
@@ -5,7 +5,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole }, { logoSrc, logoInitial }, { renderFitModal }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole, refreshSources }, { logoSrc, logoInitial }, { renderFitModal }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../logo.js' + V),
@@ -33,6 +33,8 @@ export class JobRecommendations extends LitElement {
     error: { state: true },
     addingId: { state: true },
     selectedRec: { state: true },
+    _refreshing:      { state: true },
+    _refreshFeedback: { state: true },
   };
 
   constructor() {
@@ -42,6 +44,34 @@ export class JobRecommendations extends LitElement {
     this.error = '';
     this.addingId = null;
     this.selectedRec = null;
+    this._refreshing = false;
+    this._refreshFeedback = '';
+  }
+
+  async _onRefresh() {
+    if (this._refreshing) return;
+    this._refreshing = true;
+    this.requestUpdate();
+    try {
+      const r = await refreshSources();
+      this._refreshFeedback = r.throttled
+        ? 'Recently refreshed — try again in a few minutes.'
+        : 'Scanning Gmail for new roles…';
+      // Re-fetch recs after the server has had time to land new rows.
+      // The function runs async; 8s is enough for a typical tick of
+      // gmail-jobs + ATS sources to settle.
+      setTimeout(async () => {
+        try {
+          const data = await fetchRecommendations();
+          this.items = data.items || data || [];
+        } catch { /* keep stale */ }
+        this.requestUpdate();
+      }, 8000);
+    } finally {
+      this._refreshing = false;
+      this.requestUpdate();
+      setTimeout(() => { this._refreshFeedback = ''; this.requestUpdate(); }, 10000);
+    }
   }
 
   connectedCallback() {
@@ -226,6 +256,12 @@ export class JobRecommendations extends LitElement {
           <span class="muted">
             Top ${top.length} of ${total} ${total === 1 ? 'role' : 'roles'}
           </span>
+          <button class="btn btn--sm rec-shell__refresh" ?disabled=${this._refreshing}
+                  title="Scan Gmail for new role alerts and application updates"
+                  @click=${() => this._onRefresh()}>
+            ${this._refreshing ? 'Scanning…' : '↻ Refresh'}
+          </button>
+          ${this._refreshFeedback ? html`<span class="muted rec-shell__refresh-status">${this._refreshFeedback}</span>` : nothing}
         </header>
         <div class="rec-row" role="list">
           ${top.map(r => this._renderCard(r))}

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.76.0">
-  <script src="/job/js/theme.js?v=0.76.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.76.1">
+  <script src="/job/js/theme.js?v=0.76.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.76.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.76.1"></script>
 </body>
 </html>


### PR DESCRIPTION
For You is where new roles flow in, so Refresh belongs at the top of that widget. Adds the same fire-and-forget pull-recommendations kick on the rec-shell header. Existing pipeline-meta button stays. Cache-bust 0.76.1.