### PR TITLE
job(gmail-tracker): drop 'informational' events at persist time

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -286,6 +286,14 @@ export async function scanApplicationResponses(args: {
     // with low-confidence guesses.
     if (classified.confidence < PERSIST_CONFIDENCE_FLOOR) continue;
 
+    // 'informational' events are signal-free by definition — newsletters,
+    // LinkedIn job-alert digests that mention the company in passing,
+    // newsletter pieces about industry news. The per-role name search
+    // surfaces these because the company appears somewhere in the body,
+    // but they don't represent application progress. Skip them entirely
+    // rather than polluting the Activity timeline with newsletter noise.
+    if (classified.event_type === 'informational') continue;
+
     // Decide auto-advance + needs_review per the locked policy.
     const adv = FORWARD_AUTO_ADVANCE[classified.event_type];
     const currentRank = STAGE_RANK[matchedRole.stage ?? ''] ?? 0;

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
 
-const VERSION = '1.3.1';
+const VERSION = '1.4.0';
 console.log(`[application-events] v${VERSION} - backfill skips user's own outbound messages`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -21,8 +21,8 @@ import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-haiku.ts';
 
-const VERSION = '0.6.0';
-console.log(`[pull-recommendations] v${VERSION} - Fit v3: values/culture/role-match with Haiku-graded role scoring; Phase 1.5 enrichment writes`);
+const VERSION = '0.12.0';
+console.log(`[pull-recommendations] v${VERSION} - cappedRun unstuck + drop 'informational' app events (newsletter noise)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
After the cappedRun fix in #797, 27 application_events landed but 25 were newsletter / LinkedIn-alert pollution (per-role name search surfaces any email containing the role's company name, classifier correctly labels them 'informational', but they have zero application-progress signal). Skip persisting 'informational' entirely. 26 polluting rows cleaned via MCP. pull-recommendations 0.6.0→0.12.0 (cosmetic version-string repair after merge-order revert), application-events 1.3.1→1.4.0.