### PR TITLE
job(recs): Refresh button on /job/jobs/recommended/ + fix stale 0.61.0 cache-bust

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2444,7 +2444,7 @@
 .recs-page__head {
   display: flex;
   align-items: baseline;
-  justify-content: space-between;
+  flex-wrap: wrap;
   gap: var(--space-3);
   margin-bottom: var(--space-4);
 }
@@ -2453,6 +2453,9 @@
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
 }
+.recs-page__head > .muted { margin-right: auto; }
+.recs-page__refresh { align-self: center; }
+.recs-page__refresh-status { font-size: var(--font-size-caption); }
 
 /* Columns specific to the recs table — sizes mirror existing pipeline
    col-* declarations (around line 2500). */

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.77.0">
-  <script src="/job/js/theme.js?v=0.77.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.77.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.77.0">
-  <script src="/job/js/theme.js?v=0.77.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.77.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.77.0">
-  <script src="/job/js/theme.js?v=0.77.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.77.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.77.0">
-  <script src="/job/js/theme.js?v=0.77.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.77.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.61.0">
-  <script src="/job/js/theme.js?v=0.61.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.61.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,7 +2,7 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.77.0";
+const VERSION = "0.77.1";
 console.log(`[job] v${VERSION} - Auto-liveness on Saved load; Refresh only on For You; explicit liveness button removed`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -8,7 +8,7 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, addRole }, { logoSrc, logoInitial }, { renderFitModal }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, addRole, refreshSources }, { logoSrc, logoInitial }, { renderFitModal }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./job-fit-modal.js' + V),
@@ -56,6 +56,8 @@ export class JobRecommendationsTable extends LitElement {
     sortDir:  { state: true },
     addingId: { state: true },
     selectedRec: { state: true },
+    _refreshing:      { state: true },
+    _refreshFeedback: { state: true },
   };
 
   constructor() {
@@ -68,6 +70,31 @@ export class JobRecommendationsTable extends LitElement {
     this.sortDir = 'desc';
     this.addingId = null;
     this.selectedRec = null;
+    this._refreshing = false;
+    this._refreshFeedback = '';
+  }
+
+  async _onRefresh() {
+    if (this._refreshing) return;
+    this._refreshing = true;
+    this.requestUpdate();
+    try {
+      const r = await refreshSources();
+      this._refreshFeedback = r.throttled
+        ? 'Recently refreshed — try again in a few minutes.'
+        : 'Scanning Gmail for new roles…';
+      setTimeout(async () => {
+        try {
+          const data = await fetchRecommendations({ view: 'all' });
+          this.items = data.items || data || [];
+        } catch { /* keep stale */ }
+        this.requestUpdate();
+      }, 8000);
+    } finally {
+      this._refreshing = false;
+      this.requestUpdate();
+      setTimeout(() => { this._refreshFeedback = ''; this.requestUpdate(); }, 10000);
+    }
   }
 
   _openFitModal(rec) {
@@ -300,6 +327,12 @@ export class JobRecommendationsTable extends LitElement {
       <header class="recs-page__head">
         <h1>Recommended for you</h1>
         <span class="muted">${rows.length} ${rows.length === 1 ? 'role' : 'roles'}</span>
+        <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
+                title="Scan Gmail for new role alerts and application updates"
+                @click=${() => this._onRefresh()}>
+          ${this._refreshing ? 'Scanning…' : '↻ Refresh'}
+        </button>
+        ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
       </header>
       ${rows.length === 0 ? html`
         <div class="placeholder">

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.77.0">
-  <script src="/job/js/theme.js?v=0.77.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.77.1">
+  <script src="/job/js/theme.js?v=0.77.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.77.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.77.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds the same fire-and-forget pull-recommendations kick on the full Recommended-for-you table page header. Also fixes a separate latent bug — that page's index.html was still loading assets with ?v=0.61.0 (months out of date), so it was serving stale JS/CSS regardless of intervening bumps. Synced to 0.77.1.