### PR TITLE
job(recs): surface all recs + fix theirstack seniority 422s

### DIFF
--- a/supabase/functions/_shared/sources/theirstack.ts
+++ b/supabase/functions/_shared/sources/theirstack.ts
@@ -40,7 +40,12 @@ interface TheirStackConfig {
 // Default seniority + exclusion floor. Same intent as the title
 // keyword filter the worker applies, just pushed down to the API so
 // the 25-result page budget isn't wasted on junior roles.
-const DEFAULT_SENIORITY    = ['senior', 'staff', 'principal', 'director', 'vp', 'cxo'];
+//
+// theirstack's API only accepts: c_level | staff | senior | junior |
+// mid_level. We used to pass 'principal' / 'director' / 'vp' / 'cxo'
+// which returned a 422 every tick. Mapping: principal/director/vp/cxo
+// → c_level (closest equivalent in their taxonomy).
+const DEFAULT_SENIORITY    = ['senior', 'staff', 'c_level'];
 const DEFAULT_TITLE_NOT    = ['junior', 'intern', 'associate', 'contract', 'apprentice'];
 const DEFAULT_INDUSTRY_NOT = ['Staffing and Recruiting', 'Government Administration', 'Defense & Space'];
 

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -22,8 +22,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-haiku.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 
-const VERSION = '0.13.0';
-console.log(`[pull-recommendations] v${VERSION} - Fit v3 + Candidate Strength + word-boundary keyword matching`);
+const VERSION = '0.14.0';
+console.log(`[pull-recommendations] v${VERSION} - surface all recs (drop off-target/off-geo/min-score filters); theirstack seniority fix`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -278,25 +278,17 @@ serve(async (req) => {
     try {
       const since = src.last_run_at ? new Date(src.last_run_at) : null;
       const pulled = await plugin.pull(src.config, { userEmail: src.user_email, since });
-      // Drop anything whose title doesn't match the user's target titles.
-      const targetTitles = await loadTargetTitles(sql);
-      const onTarget = targetTitles.length
-        ? pulled.filter(r => titleMatches(r.title || '', targetTitles))
-        : pulled;
-      const droppedOffTarget = pulled.length - onTarget.length;
-      // Drop anything whose location isn't one the user wants. Postings
-      // with no location (rare on ATS; common on RSS) get the benefit of
-      // the doubt — kept and flagged for the user via the bullet.
-      const targetGeos = await loadTargetGeographies(sql);
-      const inGeo = targetGeos.length
-        ? onTarget.filter(r => geoMatches(r.location || '', targetGeos))
-        : onTarget;
-      const droppedOffGeo = onTarget.length - inGeo.length;
+      // Surface every rec — don't drop at off-target / off-geo / min_score.
+      // The fit_score breakdown already reflects sector/geo mismatch, so a
+      // role that fails the user's preferences just gets a low fit_score
+      // and surfaces low in the sorted list. The UI can filter at read
+      // time; here we insert the honest score and let the user decide.
+      //
+      // We still drop pipeline-duplicates (same company+title already
+      // tracked) so the recs widget doesn't surface roles the user is
+      // already on top of.
       const fitCtx = await loadFitContext(sql);
-      const { kept, dropped } = scoreAndFilter(inGeo, src.min_score, fitCtx);
-      // Drop anything the user already has in their pipeline (any state —
-      // active, archived, deleted). Match on (lower(company), lower(title))
-      // so a different ATS URL for the same posting still dedupes.
+      const { kept } = scoreAndFilter(pulled, /* minScore */ 0, fitCtx);
       const pipelineKeys = await sql<{ key: string }[]>`
         select distinct lower(company_name) || '|' || lower(title) as key
           from job.pipeline_roles
@@ -335,8 +327,8 @@ serve(async (req) => {
         const ctx = await loadUserContext(sql);
         await Promise.all(toBullet.map(row => generateBullets(sql, row, ctx)));
       }
-      await markRun(sql, src.id, { count: inserted.length, dropped: dropped + droppedToPipeline + droppedOffTarget + droppedOffGeo, error: null });
-      summary.push({ id: src.id, type: src.type, pulled: pulled.length, droppedOffTarget, droppedOffGeo, kept: kept.length, dropped, droppedToPipeline, inserted: inserted.length });
+      await markRun(sql, src.id, { count: inserted.length, dropped: droppedToPipeline, error: null });
+      summary.push({ id: src.id, type: src.type, pulled: pulled.length, kept: kept.length, droppedToPipeline, inserted: inserted.length });
     } catch (e) {
       await markRun(sql, src.id, { count: 0, dropped: 0, error: (e as Error).message });
       summary.push({ id: src.id, type: src.type, error: (e as Error).message });
@@ -452,7 +444,9 @@ function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number, ctx?: Fi
   let dropped = 0;
   for (const r of rows) {
     const fit = computeFit(toRoleRow(r), ctx);
-    if (fit.hardFails.length || fit.score < minScore) { dropped++; continue; }
+    // Only drop when min_score floor is set AND not met. Hard-fails are
+    // kept with their flag so they surface in the UI rather than vanish.
+    if (minScore > 0 && fit.score < minScore) { dropped++; continue; }
     kept.push({ input: r, fitScore: fit.score, breakdown: fit.breakdown as unknown as Record<string, number>, hardFails: fit.hardFails });
   }
   return { kept, dropped };


### PR DESCRIPTION
pull-recommendations: stop dropping at off-target/off-geo/min_score — insert with honest fit scores so the user sees what's actually flowing in (UI can filter at read time). theirstack: DEFAULT_SENIORITY had ['principal','director','vp','cxo'] which return 422 from their API; mapped to ['senior','staff','c_level']. pull-recommendations 0.14.0. SQL pre-applied: maxMessagesPerRun 8→50, min_score 50→0.