### PR TITLE
job(theirstack): property_exists_or 'salary' → 'final_url' (API rejected previous)

### DIFF
--- a/supabase/functions/_shared/sources/theirstack.ts
+++ b/supabase/functions/_shared/sources/theirstack.ts
@@ -136,7 +136,14 @@ export const theirstackSource: Source<TheirStackConfig> = {
       job_seniority_or:        DEFAULT_SENIORITY,
       job_title_pattern_not:   DEFAULT_TITLE_NOT,
       industry_not:            DEFAULT_INDUSTRY_NOT,
-      property_exists_or:      ['salary'],   // require comp present so scoring fires
+      // property_exists_or used to filter for 'salary' but theirstack's
+      // API now only accepts a fixed list (company_object.domain |
+      // company_object.linkedin_url | final_url | hiring_team |
+      // employment_statuses). Use 'final_url' to require an actual
+      // apply link — postings without one are unusable for the user
+      // regardless of comp. The fit-score already weights comp, so
+      // filtering for comp-present at API level is no longer needed.
+      property_exists_or:      ['final_url'],
       // From the convenience config (or fallback).
       job_title_or:            cfg.job_title_or && cfg.job_title_or.length ? cfg.job_title_or : ['product manager'],
       ...(cfg.job_location_or?.length ? { job_location_or: cfg.job_location_or } : {}),

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -22,8 +22,8 @@ import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-haiku.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 
-const VERSION = '0.14.0';
-console.log(`[pull-recommendations] v${VERSION} - surface all recs (drop off-target/off-geo/min-score filters); theirstack seniority fix`);
+const VERSION = '0.14.1';
+console.log(`[pull-recommendations] v${VERSION} - theirstack property_exists_or fix (salary → final_url)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Second 422 surfaced after the seniority fix: theirstack's property_exists_or now only accepts a fixed enum. 'salary' isn't on it. Switch to 'final_url' (require apply link), which is the more useful filter anyway. Comp weighting stays in fit-score. pull-recommendations 0.14.1.