### PR TITLE
job: Phase 1 onboarding — user_profile table + multi-user auth gate

### DIFF
--- a/docs/strategy/prds/job-onboarding-flow.md
+++ b/docs/strategy/prds/job-onboarding-flow.md
@@ -1,0 +1,230 @@
+# /job — onboarding flow
+
+**Status:** Draft → Phase 1 in progress
+**Owner:** Ian
+**Last updated:** 2026-05-12
+
+---
+
+## One-liner
+
+A single-page, six-stage flow that turns a new user from cold-stranger into a scored pipeline in under 8 minutes. Upload → confirm → talk → tune → preview → go.
+
+## Why now
+
+`/job` is currently single-tenant (gated to `fike101@gmail.com` in `job/js/app.js` and `supabase/functions/_shared/job-auth.ts`). To open it up we need a frictionless way to collect the *seed* that powers Fit scoring, JD pulls, and cover-letter generation — without making it feel like a form.
+
+## Success criteria
+
+- New user finishes in <8 min, profile complete enough to score real JDs.
+- Three sample roles render a believable Fit breakdown on Stage 5.
+- Zero net-new schemas in `fit.ts` — onboarding output drops into existing `UserContext` shape.
+- ≥70% of users skip Stage 1 upload and still finish (the chat path stands alone).
+
+## Non-goals
+
+- Team/org accounts.
+- Recruiter view.
+- Redesigning Fit scoring.
+
+---
+
+## Core information to gather
+
+Mapped 1:1 to what the existing scorer + cover-letter generation already consume, so onboarding output drops straight into `vision` JSON + `narratives` rows with no schema gymnastics.
+
+### A. Identity & contact
+- Full name, email, phone, LinkedIn, optional portfolio/GitHub.
+
+### B. Location (first-class)
+Single canonical input — user types one city, everything else infers.
+
+```
+location: {
+  city:               "Toronto"             // user-entered
+  region:             "ON"                  // inferred
+  country:            "CA"                  // inferred
+  timezone:           "America/Toronto"     // inferred (IANA)
+  remotePreference:   "remote" | "hybrid" | "onsite" | "any"
+  willingToRelocate:  ["NYC", "SF", "Remote-EU"]
+  workAuth:           ["CA-citizen", "US-TN-eligible"]
+}
+```
+
+Drives the `geo` Fit bucket (`fit.ts`), JD pull pre-filter, and cover-letter "based in" line. Mirrored into `vision/intents.md` `**Geo:**` field so jobs-pipe reads it natively.
+
+**Inference:** Resume parse returns `city` → static IANA city→tz map (bundled JSON, ~200kB, no external API) resolves region/country/tz. Ambiguous cities → disambiguator dropdown.
+
+### C. Targeting seed (drives JD pulls + Fit score)
+- Target roles — 2–4 title patterns.
+- Target sectors — `targetSectors[]`.
+- Stage preference — pre-seed / seed / A / B / growth / public.
+- Comp floor — base + total OK range.
+- Dealbreakers — `antiMissionTerms[]`.
+- Mission required? — boolean → `missionRequired`.
+
+### D. Values & worldview (drives `values` + `culture` buckets, 40% of Fit)
+- Mission keywords — what impact themes resonate (3–6 phrases).
+- Impact themes — the verbs.
+- Culture keywords — what working environment they thrive in (3–6).
+- Anti-culture.
+
+### E. Capability seed (drives `role` + `domain` + `arc` buckets)
+- Skills — `{name, years}[]` (top 8–12, self-rated proficiency).
+- Past sectors — `pastSectors[]`.
+- Arc tags — `arcTags[]` (zero-to-one, scale-up, turnaround, ic→manager…).
+- Job history — companies, titles, dates, 1-line scope each.
+
+### F. Stories (drives cover letters + Haiku role-match)
+- Wins — 3–5 `{headline, metric}` (the Haiku-only signal).
+- Narratives — 2–4 long-form stories: values, leadership, craft, failure/learning.
+
+### G. Source docs (optional uploads)
+- Resume (PDF/DOCX) → parse → pre-fill A/B/E.
+- LinkedIn export / About blurb → pre-fill E/F.
+- Past cover letters, writing samples → seed voice for cover-letter agent.
+- Job descriptions of dream roles → reverse-engineer C/D.
+
+---
+
+## The flow
+
+Single page, six stages, one question per screen on Stage 3. Wise tokens, sentence case, generous radius. Mobile = vertical stack.
+
+### Stage 0 — Pitch
+One screen, ~40 words:
+> "/job is your career operating system. Upload what you've already written, answer a few open questions, and we'll start pulling roles that match what you actually want — and draft the cover letters too."
+
+CTA: **Get started**.
+
+### Stage 1 — Upload (skippable)
+Drop resume · LinkedIn · cover letters · dream JDs. Haiku parses → staged draft profile. Strong nudge but skip allowed.
+
+### Stage 2 — Confirm what we found
+Three editable cards (skipped if Stage 1 skipped):
+
+- **You** — name, contact, links.
+- **Location** — city input + inferred region/country/tz (read-only with edit override) + relocate chips + work auth chips.
+- **Career** — companies/titles/dates (chips, click to edit).
+- **Skills we spotted** — chips, click to remove or add.
+
+### Stage 3 — Open questions (chat-style, 5–6 prompts, one per screen)
+Each prompt is a textarea with placeholder example + "skip for now". Haiku auto-extracts structured tags between screens. Extracted tags surface on next screen ("we heard: civic-tech, public services, calm teams") — the magic moment.
+
+1. **"What problem do you want to spend the next five years on?"**
+   → `missionKeywords`, `impactThemes`, `targetSectors`
+2. **"Describe a time at work where you felt most yourself. What were you doing, and what made it click?"**
+   → `cultureKeywords`, `arcTags`, Narrative #1
+3. **"What's a win you're proud of — ideally with a number attached?"** (×2)
+   → `wins[]` + Narrative #2
+4. **"What kind of company or team would make you walk away from a great offer?"**
+   → `antiMissionTerms`, anti-culture, dealbreakers
+5. **"What roles and titles should we be hunting for? Anything off-limits?"**
+   → target titles, stage prefs
+6. **"Where are you based, and how far are you willing to go?"** *(only if Stage 2 didn't capture location)*
+   → `city`, `willingToRelocate[]`, `remotePreference`
+
+### Stage 4 — Fast knobs
+- Comp floor slider.
+- Stage multi-select chips.
+- Remote/hybrid/onsite (binds to `location.remotePreference`).
+- "Mission alignment is a hard requirement" toggle.
+
+### Stage 5 — Preview + commit
+Live Fit-score breakdown on 3 sample JDs using the seed they just gave us. CTAs: **Start the pipeline** / **Tweak something**.
+
+Commits to `vision/*.md`, `narratives` table, `user_profile` JSON; flips `onboarding_complete_at`.
+
+---
+
+## Data spine — what each stage produces
+
+| Stage | Lands in… | Used by… |
+|---|---|---|
+| 1 Upload | staged draft (memory only) | feeds Stage 2 |
+| 2 Confirm — You | `user_profile.identity` | resume gen, cover-letter header |
+| 2 Confirm — Location | `user_profile.location` + `vision/intents.md` `**Geo:**` | Fit `geo` bucket, JD pull filter, cover letter |
+| 2 Confirm — Career | `user_profile.history[]` | resume bones |
+| 2 Confirm — Skills | `user_profile.skills[]` | Fit `role` bucket |
+| 3 Q1 | `vision/goals.md` → `missionKeywords`, `impactThemes`, `targetSectors` | Fit `values` + `domain` |
+| 3 Q2 | `narratives` row (tagged) + `vision/narrative.md` `cultureKeywords`, `arcTags` | Fit `culture` + `arc`, cover-letter voice |
+| 3 Q3 | `user_profile.wins[]` + `narratives` row | Haiku role-match, cover-letter hooks |
+| 3 Q4 | `vision/filters.md` → `antiMissionTerms` | Fit hard-fail cap |
+| 3 Q5 | `vision/intents.md` → titles, stage | JD pull queries |
+| 3 Q6 | `user_profile.location` (if not set in Stage 2) | same as Stage 2 Location |
+| 4 Knobs | `user_profile.preferences` | Fit `stage`, `comp`, `geo` |
+| 5 Commit | flips `onboarding_complete_at` | unlocks rest of /job |
+
+---
+
+## Design language
+
+**Reference:** [wise.design](https://wise.design) — form patterns, stepper, inline help text.
+
+**Token contract (mandatory, per `job/DESIGN.md`):**
+- All color from `--bg / --fg / --accent / --accent-strong / --border / --muted`. No hex.
+- Spacing: `var(--space-N)` only (4px base).
+- Radii: cards 30px, buttons `--radius-pill`, inputs 16px. Never 4px.
+- Type: `--font-size-title-1` (36) pitch H1, `--font-size-title-3` (22) step headers, `--font-size-body` prompts, `--font-size-small` helpers.
+- Sentence case everywhere. No emoji.
+
+**Components to reuse:**
+
+| Need | Existing | Source |
+|---|---|---|
+| Sign-in / magic link | `ctrl-auth` | `auth/ctrl-auth.js` |
+| Page shell (rail + main grid) | `<job-rail>` | `job/js/components/job-rail.js` |
+| Footer + theme toggle | `<job-footer>` | injected via `app.js` |
+| Markdown rendering | `renderMarkdown` | `job/js/markdown.js` |
+| KB read/write | `kb-read` / `kbwrite.js` | `job/js/kbwrite.js` |
+| Narrative create + AI tag | existing `narratives` POST | `supabase/functions/narratives/index.ts` |
+| Fit preview Stage 5 | `scoreRole()` | `supabase/functions/jobs-pipe/fit.ts` |
+| Card / chip / button / input | `job/css/components.css` classes | same |
+| Lit component pattern | mirror `<job-vision>` | `job/js/components/job-vision.js` |
+| Diff/edit affordance | `diff.js` | same |
+
+**New shared CSS (promote into `job/css/components.css`):**
+- `.stepper` — horizontal pill stepper. Current = `--accent-strong` fill, complete = `--accent` outline, future = `--muted`. Sentence case.
+- `.dropzone` — 30px radius, dashed `--border`, hover lifts to `--accent`.
+- `.chat-prompt` — large textarea (min 120px), Inter, helper-text caption above, ghost "skip for now" below-right.
+- `.chip--editable` — extends existing chip with inline `×` and click-to-edit.
+
+---
+
+## Build phases
+
+### Phase 1 — Schema + auth ungate *(this PR)*
+- New table `user_profile` keyed by `auth.users.id`. JSONB columns: `identity`, `location`, `targeting`, `values`, `capability`, `preferences`, `wins`. Plus `onboarding_step` int, `onboarding_complete_at` timestamptz. RLS: user can only read/write own row.
+- Seed `fike101@gmail.com`'s row with `onboarding_complete_at = now()` so existing access is preserved.
+- Replace `ALLOWED_EMAIL` hardcode in `job/js/app.js` and `ALLOWLIST` in `_shared/job-auth.ts` with a `user_profile` row check.
+- Sign-in flow: authenticated user with no `user_profile` row → redirect to `/job/onboarding` (placeholder page in this PR; real flow in Phase 3).
+
+### Phase 2 — Upload + parse
+- New edge function `onboard-ingest`: file upload → Haiku JSON-schema prompt → draft profile + extracted narratives.
+- Storage bucket `onboarding-uploads` (private).
+- Reuse JSON-fence parser from `narratives/index.ts`.
+
+### Phase 3 — Onboarding page
+- `/job/onboarding/index.html` + `job/js/components/job-onboarding.js` (Lit, mirror `<job-vision>` pattern).
+- Stepper, one-question-per-screen on Stage 3, localStorage draft persistence.
+- Dropzone, chip editors, chat prompts. Per-prompt Haiku tag extraction with visible "we heard:" surfacing.
+
+### Phase 4 — Profile commit + preview
+- New edge function `onboard-finalize`: staged JSON → writes `vision/narrative.md`, `vision/goals.md`, `vision/intents.md`, `vision/filters.md` (matches existing KB shape) + inserts narratives + flips `onboarding_complete_at`.
+- Stage 5 preview calls existing `pull-recommendations` against a 3-role sample set and runs `fit.ts` live.
+
+### Phase 5 — Sign-in entry
+- `/job/not-authorized.html` → "Create your /job" CTA (or just remove the page now that onboarding is the default).
+- Magic-link auth via existing `ctrl-auth` → row create → `/job/onboarding`.
+
+### Phase 6 — Demo + QA
+- Chrome MCP walkthrough: cold user → upload resume → 5 prompts → Fit preview.
+- Bump `VERSION` in `app.js`.
+
+---
+
+## Open decisions
+
+- **Storage of `user_profile` JSON vs. per-user KB markdown files:** dual-write for now — `user_profile` JSONB is canonical for fast reads (Fit scoring, JD pulls); markdown files mirror it for human editing in `<job-vision>`. Finalize step keeps them in sync.
+- **Q3 wins repetition (×2):** if first answer is rich (>40 words + has a number), skip the second. Detect via Haiku.
+- **Profile editability post-onboarding:** existing `<job-vision>` already supports editing `vision/*.md`. We add a "Profile" tab to it rather than building a separate settings page.

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.78.2">
-  <script src="/job/js/theme.js?v=0.78.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.78.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.78.2">
-  <script src="/job/js/theme.js?v=0.78.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.78.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.78.2">
-  <script src="/job/js/theme.js?v=0.78.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.78.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.78.2">
-  <script src="/job/js/theme.js?v=0.78.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.78.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,14 +2,18 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.78.2";
-console.log(`[job] v${VERSION} - Active bucket shows interview stage as the primary pill`);
+const VERSION = "0.79.0";
+console.log(`[job] v${VERSION} - Multi-user gate: user_profile row check + onboarding redirect`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
-const ALLOWED_EMAIL = 'fike101@gmail.com';
+
+// Auth model: any signed-in user with a user_profile row is allowed. Users
+// without a row are routed to /job/onboarding. Row is created lazily there.
+// The legacy ALLOWED_EMAIL hardcode is gone — see migrations/070_user_profile.sql.
+const ONBOARDING_PATH = '/job/onboarding';
 
 import('./components/job-rail.js' + V);
 import('./components/job-footer.js' + V);
@@ -31,13 +35,31 @@ if (location.pathname.startsWith('/job/vision')) {
   import('./components/job-vision.js' + V);
 }
 
-function applySignedInState(email) {
-  if (email !== ALLOWED_EMAIL) {
-    location.replace('/job/not-authorized.html');
+async function applySignedInState(email) {
+  const sb = window.CtrlAuth?.getSupabaseClient?.();
+  // Gate: user must have a user_profile row with onboarding_complete_at set.
+  // No row → first-time user; redirect to onboarding (which will create one).
+  // Row but not complete → resume onboarding.
+  // Already on the onboarding page → let it render regardless of status.
+  const onOnboarding = location.pathname.startsWith(ONBOARDING_PATH);
+  let profile = null;
+  if (sb) {
+    try {
+      const { data, error } = await sb
+        .from('user_profile')
+        .select('onboarding_complete_at')
+        .maybeSingle();
+      if (error) console.warn('[job] user_profile query failed', error);
+      profile = data;
+    } catch (e) {
+      console.warn('[job] user_profile query threw', e);
+    }
+  }
+  if (!onOnboarding && (!profile || !profile.onboarding_complete_at)) {
+    location.replace(ONBOARDING_PATH + '/');
     return;
   }
   document.body.dataset.authState = 'in';
-  // Notify components that may have mounted before the event arrived.
   document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
   injectFooter();
   injectMobileBar();
@@ -118,7 +140,6 @@ window.CtrlAuth.init({
   supabaseUrl: SUPABASE_URL,
   supabaseAnonKey: SUPABASE_ANON_KEY,
   redirectTo: window.location.origin + window.location.pathname,
-  adminEmails: [ALLOWED_EMAIL],
   mountTo: '#ctrl-auth-root'
 });
 

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Jobs — /job</title>
+  <title>Welcome to /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.79.0">
   <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -16,19 +17,19 @@
   <section id="signin-gate" class="gate">
     <div class="gate__card">
       <h1>/job</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
-      <button class="btn btn--primary" id="signin-btn">Sign in</button>
+      <p>Your career operating system. Upload what you've already written, answer a few open questions, and we'll start pulling roles that match what you actually want — and draft the cover letters too.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in to get started</button>
       <div id="ctrl-auth-root"></div>
     </div>
   </section>
 
   <div class="app">
-    <job-rail></job-rail>
     <main class="app__main">
-      <header class="page-header">
-        <h1>Jobs</h1>
-      </header>
-      <job-pipeline></job-pipeline>
+      <section class="onboarding-placeholder">
+        <h1>Welcome to /job</h1>
+        <p>The onboarding flow is being built. For now, your account is set up — check back soon.</p>
+        <p class="muted">PRD: <code>docs/strategy/prds/job-onboarding-flow.md</code></p>
+      </section>
     </main>
   </div>
 

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.78.2">
-  <script src="/job/js/theme.js?v=0.78.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
+  <script src="/job/js/theme.js?v=0.79.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.78.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/job-auth.ts
+++ b/supabase/functions/_shared/job-auth.ts
@@ -1,9 +1,21 @@
 // Shared auth check for /job product Edge Functions.
+//
+// Multi-user since Phase 1 of the onboarding flow: any signed-in user with a
+// public.user_profile row is authorized. The legacy single-tenant email
+// allowlist is gone — see migrations/070_user_profile.sql and
+// docs/strategy/prods/job-onboarding-flow.md.
+//
+// Returns the user's email when authorized so existing call sites that pass
+// it along to the per-user KB path (fikei/job/...) keep working. Edge
+// functions that need the user UUID can call verifyJobUserDetailed().
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
 
-const ALLOWLIST = ['fike101@gmail.com'];
+export interface JobUser {
+  id: string;
+  email: string;
+}
 
-export async function verifyJobUser(req: Request): Promise<string | null> {
+export async function verifyJobUserDetailed(req: Request): Promise<JobUser | null> {
   const auth = req.headers.get('Authorization') || '';
   const token = auth.replace(/^Bearer\s+/i, '');
   if (!token) return null;
@@ -14,10 +26,22 @@ export async function verifyJobUser(req: Request): Promise<string | null> {
     global: { headers: { Authorization: `Bearer ${token}` } },
   });
   const { data, error } = await supabase.auth.getUser(token);
-  if (error || !data?.user?.email) return null;
-  const email = data.user.email.toLowerCase();
-  if (!ALLOWLIST.includes(email)) return null;
-  return email;
+  if (error || !data?.user?.id || !data?.user?.email) return null;
+  // Authorization gate: user must have a user_profile row. RLS scopes the
+  // query to auth.uid(), so a row coming back proves both existence and
+  // ownership without us having to filter by id.
+  const { data: profile, error: profileError } = await supabase
+    .from('user_profile')
+    .select('user_id')
+    .maybeSingle();
+  if (profileError) return null;
+  if (!profile) return null;
+  return { id: data.user.id, email: data.user.email.toLowerCase() };
+}
+
+export async function verifyJobUser(req: Request): Promise<string | null> {
+  const u = await verifyJobUserDetailed(req);
+  return u?.email ?? null;
 }
 
 export const corsHeaders = {

--- a/supabase/migrations/070_user_profile.sql
+++ b/supabase/migrations/070_user_profile.sql
@@ -1,0 +1,93 @@
+-- Phase 1 — /job onboarding flow.
+--
+-- New table: user_profile. Per-user JSONB seed for Fit scoring
+-- (fit.ts UserContext), JD pulls, and cover-letter generation. Keyed by
+-- auth.users.id. RLS-enabled — each user only reads/writes their own row.
+--
+-- Ungates /job from the single-tenant email allowlist that lived in
+-- job/js/app.js and supabase/functions/_shared/job-auth.ts. Going forward
+-- the runtime check is "user has a user_profile row" rather than
+-- "email equals fike101@gmail.com".
+--
+-- See: docs/strategy/prds/job-onboarding-flow.md
+
+create table if not exists public.user_profile (
+  user_id              uuid primary key references auth.users(id) on delete cascade,
+  identity             jsonb not null default '{}'::jsonb,
+  location             jsonb not null default '{}'::jsonb,
+  targeting            jsonb not null default '{}'::jsonb,
+  values_seed          jsonb not null default '{}'::jsonb,
+  capability           jsonb not null default '{}'::jsonb,
+  preferences          jsonb not null default '{}'::jsonb,
+  wins                 jsonb not null default '[]'::jsonb,
+  onboarding_step      smallint not null default 0,
+  onboarding_complete_at timestamptz,
+  created_at           timestamptz not null default now(),
+  updated_at           timestamptz not null default now()
+);
+
+comment on table public.user_profile is
+  '/job onboarding seed. Drives Fit scoring (fit.ts UserContext), JD pull queries, and cover-letter generation. One row per authenticated user; created on first sign-in to /job.';
+comment on column public.user_profile.identity is
+  'Name, contact, links. Resume header source.';
+comment on column public.user_profile.location is
+  'city (user-entered) + inferred region/country/timezone + remotePreference + willingToRelocate[] + workAuth[]. Mirrored to vision/intents.md **Geo:** field.';
+comment on column public.user_profile.targeting is
+  'targetRoles[], targetSectors[], stagePreference[], compFloor, antiMissionTerms[], missionRequired bool.';
+comment on column public.user_profile.values_seed is
+  'missionKeywords[], impactThemes[], cultureKeywords[], antiCulture[]. Drives values + culture Fit buckets (40% of score).';
+comment on column public.user_profile.capability is
+  'skills [{name, years}], pastSectors[], arcTags[], history [{company, title, dates, scope}].';
+comment on column public.user_profile.preferences is
+  'compFloor, remote/hybrid/onsite, hard-fail toggles. Bound to Stage 4 fast-knobs.';
+comment on column public.user_profile.wins is
+  '[{headline, metric}]. Haiku-only signal — feeds role-match prompt + cover-letter hooks.';
+
+create index if not exists user_profile_complete_idx
+  on public.user_profile (onboarding_complete_at)
+  where onboarding_complete_at is not null;
+
+create or replace function public.user_profile_touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists user_profile_touch on public.user_profile;
+create trigger user_profile_touch
+  before update on public.user_profile
+  for each row execute function public.user_profile_touch_updated_at();
+
+alter table public.user_profile enable row level security;
+
+drop policy if exists "user_profile_self_select" on public.user_profile;
+create policy "user_profile_self_select"
+  on public.user_profile for select
+  using (auth.uid() = user_id);
+
+drop policy if exists "user_profile_self_insert" on public.user_profile;
+create policy "user_profile_self_insert"
+  on public.user_profile for insert
+  with check (auth.uid() = user_id);
+
+drop policy if exists "user_profile_self_update" on public.user_profile;
+create policy "user_profile_self_update"
+  on public.user_profile for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+drop policy if exists "user_profile_self_delete" on public.user_profile;
+create policy "user_profile_self_delete"
+  on public.user_profile for delete
+  using (auth.uid() = user_id);
+
+-- Seed Ian's row so the ungated auth check doesn't lock him out post-deploy.
+insert into public.user_profile (user_id, onboarding_complete_at, onboarding_step)
+select id, now(), 5
+from auth.users
+where lower(email) = 'fike101@gmail.com'
+on conflict (user_id) do update
+  set onboarding_complete_at = coalesce(public.user_profile.onboarding_complete_at, now()),
+      onboarding_step = greatest(public.user_profile.onboarding_step, 5);


### PR DESCRIPTION
## Summary

Phase 1 of the /job onboarding flow. PRD: [`docs/strategy/prds/job-onboarding-flow.md`](docs/strategy/prds/job-onboarding-flow.md).

- New table `public.user_profile` — per-user JSONB seed for Fit scoring (`fit.ts` `UserContext`), JD pulls, and cover-letter generation. RLS-scoped to `auth.uid()`.
- Drops the single-tenant `fike101@gmail.com` hardcode from `job/js/app.js` and `supabase/functions/_shared/job-auth.ts`. New gate is "user has a `user_profile` row".
- Seeds Ian's row with `onboarding_complete_at = now()` so existing access is preserved.
- Signed-in users without a completed profile are redirected to `/job/onboarding/` (placeholder page; full Lit flow lands in Phase 3).
- Bump VERSION 0.78.2 → 0.79.0 across `app.js` + all `/job` HTML.

## What this unblocks

- Phase 2: `onboard-ingest` edge function (resume parse → staged profile).
- Phase 3: `<job-onboarding>` six-stage flow.
- Phase 4: `onboard-finalize` commits to `vision/*.md` + `narratives`.

## Test plan

- [ ] After merge, run migration `070_user_profile.sql` (already applied via Supabase MCP — verify with `list_migrations`).
- [ ] Sign in as `fike101@gmail.com` → land on `/job/jobs/` normally (no redirect to onboarding).
- [ ] Sign in as a new user → redirected to `/job/onboarding/` placeholder.
- [ ] Edge functions that call `verifyJobUser()` still work for Ian (callers unchanged — function signature preserved).
- [ ] Chrome MCP smoke test of `/job/jobs/`, `/job/history`, `/job/vision`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)