### PR TITLE
job: onboarding rev — insight hero, chat UX, tailor groups, multi-doc upload

### DIFF
--- a/docs/strategy/prds/job-onboarding-flow.md
+++ b/docs/strategy/prds/job-onboarding-flow.md
@@ -157,6 +157,51 @@ Commits to `vision/*.md`, `narratives` table, `user_profile` JSON; flips `onboar
 
 ---
 
+## Structured vs. freeform — capture mode per field
+
+Guiding rule: **structured wherever a finite taxonomy exists, freeform wherever the prose itself is the signal.** Every freeform field has a "tags we extracted" preview the user can click-edit. Every chip palette has "Add custom" so the taxonomy never locks them in.
+
+| Field | Mode | Stage |
+|---|---|---|
+| Name, email, phone, LinkedIn, portfolio | Structured | 2 |
+| City | Structured (autocomplete) | 2 |
+| Region / country / timezone | Inferred (read-only + override) | 2 |
+| Remote / hybrid / onsite | Structured (segmented) | 4 |
+| Willing to relocate | Structured (chip palette) | 4 |
+| Work auth | Structured chips + "Other" | 4 |
+| Target roles | Hybrid (chips + write-in) | 4 |
+| Target sectors | Structured (chip palette + custom) | 4 |
+| Stage preference | Structured (multi-select chips) | 4 |
+| Comp floor | Structured (slider + $ override) | 4 |
+| Skills + years | Structured (chip + years selector) | 2 pre-fill / 4 |
+| Job history (company, title, dates) | Structured (form rows) | 2 |
+| Job history scope (1-line per role) | Freeform | 2 |
+| Arc tags | Structured (chip palette) | 4 |
+| Dealbreakers | Hybrid (chips: defense / gambling / crypto / adtech / surveillance / fossil + "anything else") | 4 |
+| Mission alignment required | Structured (toggle) | 4 |
+| Culture keywords | Hybrid (chip palette + Q2 prose auto-tagging) | 4 |
+| Q1 "problem to spend 5 yrs on" | Freeform → extracts `missionKeywords`, `impactThemes`, `targetSectors` | 3 |
+| Q2 "felt most yourself" | Freeform → Narrative + `cultureKeywords`, `arcTags` | 3 |
+| Q3 wins (×2) | Hybrid (freeform headline + structured metric field) | 3 |
+| Q4 walk-away criteria | Freeform → `antiMissionTerms` + anti-culture | 3 |
+| Q5 titles to hunt | Hybrid (chips + "or describe") | 3 |
+| Q6 location (fallback if Stage 2 didn't capture) | Freeform → extracts city, relocate, remote pref | 3 |
+
+**Two design rules that fall out of this:**
+1. Every freeform field surfaces an "we heard:" tag strip after the user types. They click-remove any wrong ones — closes the loop without forcing manual chip work.
+2. Every chip palette ships an "Add custom" inline text input. Never lock the user into our taxonomy.
+
+**Net effect on flow:** Stage 3 stays *focused on freeform stories* (the magic moment). All structured chips, sliders, toggles consolidate into **Stage 4 — Fast knobs**, which is now meatier. Stage 2 confirm cards stay structured.
+
+## Settings access for existing users
+
+So Ian (and any user with `onboarding_complete_at IS NOT NULL`) can re-test the flow without losing their committed data:
+
+- New rail link **"Settings"** (subdued, bottom of `<job-rail>`) → `/job/settings/`.
+- `/job/settings/` lists profile fields with an "Edit your profile" link to `/job/onboarding/?demo=1`.
+- `?demo=1` query param tells the onboarding component to enter **demo mode**: stepping through works exactly the same, but Stage 5's commit is replaced by a "this would commit X" preview that does not write to `user_profile` or flip `onboarding_complete_at`. localStorage draft state still persists so the user can step in and out.
+- Without `?demo=1`, the page enforces the live commit path.
+
 ## Design language
 
 **Reference:** [wise.design](https://wise.design) — form patterns, stepper, inline help text.

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -4044,3 +4044,250 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   max-height: 320px;
   overflow: auto;
 }
+
+/* ============================================================== */
+/* Onboarding rev: insight hero, chat, tailor groups                */
+/* ============================================================== */
+
+.onboard__busy {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  padding: var(--space-2) var(--space-4);
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-surface));
+  border: 1px dashed var(--accent);
+  border-radius: 16px;
+}
+
+/* Multi-file dropzone */
+.dropzone--multi { cursor: pointer; display: block; }
+.dropzone__files {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-3) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  text-align: left;
+}
+.dropzone__files li {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-small);
+  color: var(--fg);
+}
+
+/* Insight hero + tracks */
+.insight-hero {
+  font-size: var(--font-size-body-lg);
+  line-height: var(--lh-body);
+  color: var(--fg);
+  background: color-mix(in srgb, var(--accent-strong) 12%, transparent);
+  border: 1px solid var(--accent-strong);
+  border-radius: 30px;
+  padding: var(--space-5) var(--space-6);
+}
+
+.insight-track {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+.insight-track__head h2 {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  margin: 0 0 var(--space-1);
+}
+.insight-track__rows {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.insight-track__rows li {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) auto minmax(200px, 2fr);
+  gap: var(--space-3);
+  align-items: start;
+}
+.insight-track__have {
+  font-weight: 600;
+  color: var(--fg);
+}
+.insight-track__arrow {
+  color: var(--fg-muted);
+  font-size: var(--font-size-body);
+}
+.insight-track__to {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+@media (max-width: 600px) {
+  .insight-track__rows li {
+    grid-template-columns: 1fr;
+  }
+  .insight-track__arrow { display: none; }
+}
+
+/* Collapsible edit footer */
+.insight-edit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.insight-edit__toggle {
+  appearance: none;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: var(--space-2) var(--space-4);
+  font: inherit;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  cursor: pointer;
+  text-align: left;
+}
+.insight-edit__toggle:hover { border-color: var(--border-strong); color: var(--fg); }
+.insight-edit__toggle strong { color: var(--fg); font-weight: 600; }
+.insight-edit__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: var(--space-4) var(--space-5);
+}
+
+/* Chat (Stage 3) */
+.chat {
+  min-height: 60vh;
+  position: relative;
+  padding-bottom: 200px; /* leave room for the fixed composer */
+}
+.chat__progress {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  text-transform: none;
+}
+.chat__ack {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+}
+.chat__ack-prefix {
+  color: var(--fg-muted);
+  font-size: var(--font-size-caption);
+}
+.chat__question {
+  font-size: var(--font-size-title-2);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: var(--lh-title);
+  color: var(--fg);
+  padding: var(--space-4) 0;
+}
+.chat__composer {
+  position: sticky;
+  bottom: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  background: var(--bg);
+  padding-top: var(--space-3);
+}
+.chat__composer textarea {
+  width: 100%;
+  min-height: 100px;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  line-height: var(--lh-body);
+  resize: vertical;
+}
+.chat__composer textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.chat__composer-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+.chat__composer-pills {
+  display: flex;
+  gap: var(--space-2);
+}
+.chat__pill {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: var(--space-2) var(--space-3);
+  font: inherit;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.chat__pill:hover { border-color: var(--border-strong); color: var(--fg); }
+.btn--send {
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  padding: 0;
+  font-size: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.chat__composer-hint {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  text-align: right;
+}
+
+/* Tailor groups (Stage 4) */
+.tailor-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: var(--space-5);
+  background: var(--bg-surface);
+}
+.tailor-group__head h2 {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  margin: 0 0 var(--space-2);
+}
+.tailor-group__excerpt {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  margin: 0;
+  font-style: italic;
+  line-height: var(--lh-body);
+}
+.tailor-group__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.tailor-group__label {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+}

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -3729,3 +3729,318 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   font-style: italic;
 }
 
+
+/* ============================================================== */
+/* Onboarding flow (/job/onboarding)                                */
+/* New primitives + page-specific layout. Promote primitives        */
+/* (.stepper .dropzone .chat-prompt .chip-palette .segmented)       */
+/* back to the rest of /job whenever a second consumer shows up.    */
+/* ============================================================== */
+
+.onboard {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-7) var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+.onboard__stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+.onboard__stage h1 {
+  font-size: var(--font-size-title-1);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: var(--lh-title);
+  margin: 0;
+}
+.onboard__stage h2 {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  margin: 0;
+}
+.onboard__stage p.lede {
+  font-size: var(--font-size-body-lg);
+  color: var(--fg-muted);
+  line-height: var(--lh-body);
+  margin: 0;
+}
+.onboard__hint {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.onboard__nav {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+.onboard__nav .btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--fg-muted);
+}
+.onboard__nav .btn--ghost:hover { color: var(--fg); }
+.onboard__demo-banner {
+  background: color-mix(in srgb, var(--accent-strong) 18%, transparent);
+  border: 1px solid var(--accent-strong);
+  color: var(--fg);
+  border-radius: 16px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-small);
+}
+
+/* Stepper — current = accent-strong fill, complete = accent outline, future = muted. */
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-caption);
+  flex-wrap: wrap;
+}
+.stepper__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--fg-muted);
+}
+.stepper__dot {
+  width: 10px; height: 10px;
+  border-radius: 999px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  flex: none;
+}
+.stepper__item--current .stepper__dot {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+.stepper__item--complete .stepper__dot {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.stepper__item--current  { color: var(--fg); }
+.stepper__item--complete { color: var(--fg-muted); }
+.stepper__sep {
+  width: 24px; height: 1px;
+  background: var(--border);
+}
+
+/* Dropzone — used for paste-resume + (future) file upload. */
+.dropzone {
+  border: 1.5px dashed var(--border);
+  border-radius: 30px;
+  padding: var(--space-6);
+  text-align: center;
+  background: var(--bg-surface);
+  transition: border-color 120ms, background 120ms;
+}
+.dropzone:hover, .dropzone--active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-surface));
+}
+.dropzone__title { font-weight: 600; margin-bottom: var(--space-2); }
+.dropzone__hint  { color: var(--fg-muted); font-size: var(--font-size-small); }
+.dropzone textarea {
+  width: 100%;
+  min-height: 180px;
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  resize: vertical;
+}
+.dropzone textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+
+/* Chat-prompt — the freeform Stage 3 questions. */
+.chat-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.chat-prompt__label {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  line-height: var(--lh-title);
+}
+.chat-prompt__help {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  margin: 0;
+}
+.chat-prompt textarea {
+  width: 100%;
+  min-height: 140px;
+  padding: var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  line-height: var(--lh-body);
+  resize: vertical;
+}
+.chat-prompt textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.chat-prompt__extracted {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: var(--space-3) var(--space-4);
+}
+.chat-prompt__extracted-title {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.chat-prompt__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+.chat-prompt__row-label {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  min-width: 90px;
+}
+
+/* Chip palette — multi-select chip group with "Add custom" inline. */
+.chip-palette {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.chip-palette__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.chip-palette__add {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.chip-palette__add input {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+.chip-palette__add input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+
+/* Editable chip — extends .chip with an inline remove affordance. */
+.chip--editable {
+  cursor: default;
+  padding-right: var(--space-2);
+}
+.chip--editable button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  margin-left: var(--space-2);
+  padding: 0 var(--space-1);
+  font: inherit;
+  opacity: 0.6;
+}
+.chip--editable button:hover { opacity: 1; }
+
+/* Segmented control — for remote / hybrid / onsite. */
+.segmented {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 2px;
+  background: var(--bg-surface);
+}
+.segmented button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--fg-muted);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+.segmented button[aria-pressed="true"] {
+  background: var(--accent-strong);
+  color: var(--accent-strong-fg);
+}
+
+/* Confirm cards (Stage 2) — reuse .company-card vibes but lighter. */
+.onboard-card {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: var(--space-5);
+  background: var(--bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.onboard-card__title {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  margin: 0;
+}
+.onboard-card__row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: var(--space-3);
+  align-items: center;
+}
+.onboard-card__row label {
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.onboard-card__row input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+}
+.onboard-card__row input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.onboard-card__row .read-only {
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+}
+
+/* Stage 5 preview block. */
+.onboard-preview {
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: var(--space-5);
+  background: var(--bg-surface);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.onboard-preview pre {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+  max-height: 320px;
+  overflow: auto;
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.79.0";
-console.log(`[job] v${VERSION} - Multi-user gate: user_profile row check + onboarding redirect`);
+const VERSION = "0.80.0";
+console.log(`[job] v${VERSION} - Onboarding flow Phase 2/3: <job-onboarding> + settings entry`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -33,6 +33,12 @@ if (location.pathname.startsWith('/job/jobs/drill')) {
 }
 if (location.pathname.startsWith('/job/vision')) {
   import('./components/job-vision.js' + V);
+}
+if (location.pathname.startsWith('/job/onboarding')) {
+  import('./components/job-onboarding.js' + V);
+}
+if (location.pathname.startsWith('/job/settings')) {
+  import('./components/job-settings.js' + V);
 }
 
 async function applySignedInState(email) {

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.80.0";
-console.log(`[job] v${VERSION} - Onboarding flow Phase 2/3: <job-onboarding> + settings entry`);
+const VERSION = "0.81.0";
+console.log(`[job] v${VERSION} - Onboarding rev: insight hero, chat UX, tailor groups, multi-doc upload, ?debug=1`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-career.js
+++ b/job/js/components/job-career.js
@@ -14,53 +14,8 @@ const [{ renderMarkdown }, { fetchPipeline, formatResumeText, fetchNarratives, s
 
 const BASE_RESUME_SLUG = '__base__';
 
-// File → string. .md/.txt are read as UTF-8 text. .pdf uses pdfjs-dist
-// (loaded on first use) to extract text from each page. Anything else
-// is read as text and best-effort.
-async function readFileAsText(file) {
-  const name = (file.name || '').toLowerCase();
-  if (name.endsWith('.pdf') || file.type === 'application/pdf') {
-    return await readPdfAsText(file);
-  }
-  return await file.text();
-}
-
-let _pdfLib = null;
-async function getPdfLib() {
-  if (_pdfLib) return _pdfLib;
-  // pdfjs-dist v4 requires a worker. Pin both main + worker to the same
-  // version on jsdelivr so they stay in sync.
-  const PDFJS_VERSION = '4.7.76';
-  const mod = await import(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.mjs`);
-  mod.GlobalWorkerOptions.workerSrc =
-    `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.worker.min.mjs`;
-  _pdfLib = mod;
-  return mod;
-}
-
-async function readPdfAsText(file) {
-  const lib = await getPdfLib();
-  const buf = await file.arrayBuffer();
-  const doc = await lib.getDocument({ data: buf, isEvalSupported: false }).promise;
-  const pages = [];
-  for (let i = 1; i <= doc.numPages; i++) {
-    const page = await doc.getPage(i);
-    const tc = await page.getTextContent();
-    // Re-flow text items into lines using their y coordinates.
-    const lines = new Map();
-    for (const item of tc.items) {
-      const y = Math.round(item.transform[5]);
-      if (!lines.has(y)) lines.set(y, []);
-      lines.get(y).push(item);
-    }
-    const ordered = Array.from(lines.entries())
-      .sort((a, b) => b[0] - a[0])
-      .map(([, items]) => items.sort((a, b) => a.transform[4] - b.transform[4]).map(i => i.str).join(' ').replace(/\s+/g, ' ').trim())
-      .filter(Boolean);
-    pages.push(ordered.join('\n'));
-  }
-  return pages.join('\n\n').trim();
-}
+// File → text extraction lives in ../pdf-extract.js (shared with onboarding).
+const { readFileAsText } = await import('../pdf-extract.js' + V);
 
 // Lazy-load the resume sub-component so the Work History tab doesn't
 // pull markdown deps when only the Narratives tab is active.

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -1,23 +1,28 @@
-// job-onboarding — six-stage onboarding flow for /job.
+// job-onboarding — five-stage onboarding for /job.
 //
-//   0  Pitch         — value prop + Get started
-//   1  Upload        — paste resume text (file drop is post-MVP)
-//   2  Confirm       — You / Location / Career / Skills cards (editable)
-//   3  Questions     — five freeform prompts, one per screen, with
-//                      Haiku tag extraction surfacing between screens
-//   4  Fast knobs    — structured chips/sliders/toggles
-//   5  Preview       — diff of the staged profile + commit
+//   0  Welcome   — pitch + Get started
+//   1  Upload    — multi-file dropzone (resume + supporting docs); pdf
+//                  extraction runs client-side via shared pdf-extract.js
+//   2  Insights  — celebration narrative with three translation tracks
+//                  (Domains / Work areas / Skills) + collapsible edit panel
+//   3  Questions — chat-style UI (tryapt pattern, Wise tokens)
+//   4  Tailor    — "How we'll tailor your search" — four grouped sections
+//                  with "you said:" excerpts + commit CTA at the bottom
 //
-// State lives in localStorage under `job:onboarding:draft` so users can
-// step away and come back. ?demo=1 switches Stage 5 to a non-committing
-// preview so existing users (Ian) can test without losing their profile.
+//   debug       — hidden JSON dump, mounted only when ?debug=1 is set.
+//                 Kept for QA, never shown in the live flow.
 //
-// Talks to the `onboard` edge function in three modes:
-//   { mode: 'parse',    text }
-//   { mode: 'extract',  questionId, answer }
-//   { mode: 'finalize', profile, demo }
+// State lives in localStorage under `job:onboarding:draft`. ?demo=1 switches
+// the commit step to a non-writing preview so existing users can re-walk
+// without losing their live profile.
+//
+// Talks to the `onboard` edge function in five modes: parse, bundle,
+// insights, extract, finalize.
 
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+
+const V = (new URL(import.meta.url)).search;
+const { readFileAsText } = await import('../pdf-extract.js' + V);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const ONBOARD_FN_URL = `${SUPABASE_URL}/functions/v1/onboard`;
@@ -26,28 +31,27 @@ const DRAFT_KEY = 'job:onboarding:draft';
 const STAGES = [
   { id: 0, label: 'Welcome' },
   { id: 1, label: 'Upload' },
-  { id: 2, label: 'Confirm' },
+  { id: 2, label: 'Insights' },
   { id: 3, label: 'Questions' },
-  { id: 4, label: 'Knobs' },
-  { id: 5, label: 'Preview' },
+  { id: 4, label: 'Tailor' },
 ];
 
 const QUESTIONS = [
   { id: 'q1_mission',   label: 'What problem do you want to spend the next five years on?',
-    placeholder: 'e.g. I want to make public services feel like apps people actually want to use…',
-    help: 'Tell us what you\'d work on if no one was watching.' },
-  { id: 'q2_self',      label: 'Describe a time at work where you felt most yourself. What were you doing, and what made it click?',
-    placeholder: 'e.g. Six months at a tiny civic-tech team — I was rebuilding a benefits-eligibility tool from scratch with two engineers and a research partner…',
-    help: 'The story matters; we\'ll use it for the cover-letter voice too.' },
+    placeholder: 'I want to make public services feel less like waiting rooms…',
+    ack: 'Got it.' },
+  { id: 'q2_self',      label: 'Describe a time at work where you felt most yourself.',
+    placeholder: 'Six months at a tiny civic-tech team — I was rebuilding a benefits tool…',
+    ack: 'That helps a lot — the voice carries through to the cover letters.' },
   { id: 'q3_win',       label: 'A win you\'re proud of — ideally with a number attached.',
-    placeholder: 'e.g. Took our retention from 41% to 67% in eight months by rebuilding the first-week experience.',
-    help: 'Numbers make this fly. We extract them for cover letters.' },
-  { id: 'q4_walkaway',  label: 'What kind of company or team would make you walk away from a great offer?',
-    placeholder: 'e.g. Anything in surveillance, defense, or with a return-to-office mandate. Also no patience for hustle-culture leadership.',
-    help: 'Be specific — these become hard filters.' },
+    placeholder: 'Took retention from 41% to 67% in eight months by rebuilding the first-week experience.',
+    ack: 'Noted.' },
+  { id: 'q4_walkaway',  label: 'What would make you walk away from a great offer?',
+    placeholder: 'Anything in surveillance or defense. No patience for hustle-culture leadership.',
+    ack: 'These become hard filters.' },
   { id: 'q5_titles',    label: 'What roles and titles should we be hunting for? Anything off-limits?',
-    placeholder: 'e.g. Head of Product, Founding PM, VP Product at seed-to-series-A startups. No people-manager-only roles.',
-    help: 'Title patterns + stage preference.' },
+    placeholder: 'Head of Product, Founding PM, VP Product at seed-to-A startups. No people-manager-only roles.',
+    ack: 'On it.' },
 ];
 
 const SECTORS_PALETTE = ['climate', 'civic-tech', 'healthtech', 'fintech', 'edtech', 'consumer-social', 'developer-tools', 'AI-infrastructure', 'biotech', 'space', 'public-benefit'];
@@ -63,10 +67,12 @@ function emptyDraft() {
     capability: { skills: [], pastSectors: [], arcTags: [], history: [] },
     values_seed: { missionKeywords: [], impactThemes: [], cultureKeywords: [], antiCulture: [] },
     targeting: { targetRoles: [], targetSectors: [], stagePreference: [], antiMissionTerms: [], missionRequired: false },
-    preferences: { compFloor: null, remotePreference: 'any', missionRequired: false },
+    preferences: { compFloor: 150000, remotePreference: 'any', missionRequired: false },
     wins: [],
     narratives: [],
-    _meta: { stage: 0, questionIdx: 0, answers: {}, extractions: {} },
+    insights: null,
+    bundle: null,
+    _meta: { stage: 0, questionIdx: 0, answers: {}, extractions: {}, uploadedFiles: [], editOpen: false },
   };
 }
 
@@ -76,30 +82,18 @@ function loadDraft() {
     if (!raw) return emptyDraft();
     const parsed = JSON.parse(raw);
     return { ...emptyDraft(), ...parsed, _meta: { ...emptyDraft()._meta, ...(parsed._meta || {}) } };
-  } catch {
-    return emptyDraft();
-  }
+  } catch { return emptyDraft(); }
 }
-function saveDraft(d) {
-  try { localStorage.setItem(DRAFT_KEY, JSON.stringify(d)); } catch { /* */ }
-}
-function clearDraft() {
-  try { localStorage.removeItem(DRAFT_KEY); } catch { /* */ }
-}
+function saveDraft(d) { try { localStorage.setItem(DRAFT_KEY, JSON.stringify(d)); } catch { /* */ } }
+function clearDraft() { try { localStorage.removeItem(DRAFT_KEY); } catch { /* */ } }
 
 async function callOnboard(token, body) {
   const res = await fetch(ONBOARD_FN_URL, {
     method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`onboard ${res.status}: ${text.slice(0, 300)}`);
-  }
+  if (!res.ok) throw new Error(`onboard ${res.status}: ${(await res.text()).slice(0, 300)}`);
   return await res.json();
 }
 
@@ -107,83 +101,125 @@ export class JobOnboarding extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
-    draft:       { state: true },
-    busy:        { state: true },
-    busyLabel:   { state: true },
-    error:       { state: true },
-    finalized:   { state: true },
-    demoMode:    { state: true },
+    draft:      { state: true },
+    busy:       { state: true },
+    busyLabel:  { state: true },
+    error:      { state: true },
+    finalized:  { state: true },
+    demoMode:   { state: true },
+    debugMode:  { state: true },
   };
 
   constructor() {
     super();
     this.draft = loadDraft();
-    this.busy = false;
-    this.busyLabel = '';
-    this.error = '';
+    this.busy = false; this.busyLabel = ''; this.error = '';
     this.finalized = null;
-    this.demoMode = new URLSearchParams(location.search).get('demo') === '1';
+    const params = new URLSearchParams(location.search);
+    this.demoMode  = params.get('demo')  === '1';
+    this.debugMode = params.get('debug') === '1';
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    document.addEventListener('ctrl:auth:signedin', this._authPing = () => this.requestUpdate());
-    document.addEventListener('job:auth:ready', this._authReady = () => this.requestUpdate());
-  }
-  disconnectedCallback() {
-    document.removeEventListener('ctrl:auth:signedin', this._authPing);
-    document.removeEventListener('job:auth:ready', this._authReady);
-    super.disconnectedCallback();
-  }
-
-  _token() {
+  async _token() {
     const sb = window.CtrlAuth?.getSupabaseClient?.();
     if (!sb) return null;
-    // Synchronous-ish: the session lives in localStorage so getSession resolves fast.
-    return sb.auth.getSession().then(({ data }) => data?.session?.access_token || null);
+    const { data } = await sb.auth.getSession();
+    return data?.session?.access_token || null;
   }
 
   _commit() { saveDraft(this.draft); this.requestUpdate(); }
   _setStage(stage) { this.draft._meta.stage = stage; this._commit(); }
   _patch(path, value) {
-    const segs = path.split('.');
-    let o = this.draft;
-    for (let i = 0; i < segs.length - 1; i++) {
-      o[segs[i]] = o[segs[i]] || {};
-      o = o[segs[i]];
-    }
+    const segs = path.split('.'); let o = this.draft;
+    for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
     o[segs[segs.length - 1]] = value;
     this._commit();
   }
   _toggleInArr(path, value) {
-    const segs = path.split('.');
-    let o = this.draft;
+    const segs = path.split('.'); let o = this.draft;
     for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
     const arr = o[segs[segs.length - 1]] = o[segs[segs.length - 1]] || [];
     const idx = arr.indexOf(value);
     if (idx >= 0) arr.splice(idx, 1); else arr.push(value);
     this._commit();
   }
+  _mergeArr(path, incoming) {
+    const segs = path.split('.'); let o = this.draft;
+    for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
+    const k = segs[segs.length - 1];
+    const cur = new Set(o[k] || []);
+    for (const v of (incoming || [])) cur.add(v);
+    o[k] = [...cur];
+  }
 
-  // ---- Stage 1: parse uploaded resume text ----
-  async _parseResume() {
-    const text = this.shadowRoot ? null : this.querySelector('#resume-text')?.value || '';
-    if (!text.trim()) { this.error = 'Paste your resume text first.'; return; }
+  // -------- Stage 1: multi-file ingest --------
+
+  async _handleFiles(fileList) {
+    const files = Array.from(fileList || []);
+    if (!files.length) return;
     this.error = '';
-    this.busy = true; this.busyLabel = 'Reading your resume…';
+    this.busy = true; this.busyLabel = `Reading ${files.length} file${files.length > 1 ? 's' : ''}…`;
     try {
+      // Classify by filename: anything with "resume" or "cv" is the primary
+      // resume; everything else is bundle context. If no name match, the
+      // largest file (likely the resume) wins.
+      const named = [];
+      for (const f of files) {
+        const text = await readFileAsText(f);
+        named.push({ name: f.name, size: text.length, text });
+      }
+      const resumeMatch = named.find(f => /(^|[\s_-])(resume|cv)/i.test(f.name));
+      const resume = resumeMatch || named.slice().sort((a, b) => b.size - a.size)[0];
+      const others = named.filter(f => f !== resume);
+
+      this.draft._meta.uploadedFiles = named.map(f => ({ name: f.name, size: f.size, isResume: f === resume }));
+      this._commit();
+
       const token = await this._token();
       if (!token) throw new Error('Not signed in.');
-      const { draft } = await callOnboard(token, { mode: 'parse', text });
-      // Merge parsed into draft (don't clobber any user-entered values).
-      this.draft.identity = { ...this.draft.identity, ...draft.identity };
-      this.draft.location = { ...this.draft.location, ...draft.location };
-      if (draft.capability) {
-        this.draft.capability.skills      = draft.capability.skills      || this.draft.capability.skills;
-        this.draft.capability.pastSectors = draft.capability.pastSectors || this.draft.capability.pastSectors;
-        this.draft.capability.arcTags     = draft.capability.arcTags     || this.draft.capability.arcTags;
-        this.draft.capability.history     = draft.capability.history     || this.draft.capability.history;
+
+      // Two passes in parallel: parse resume → structured profile; bundle
+      // everything else (or the same resume if it's the only doc) → voice
+      // + values + projects + dream signals.
+      const bundleText = (others.length ? others : [resume]).map(f => `--- ${f.name} ---\n${f.text}`).join('\n\n');
+      this.busyLabel = 'Pulling out the bones (resume) and the voice (everything else)…';
+
+      const [parseRes, bundleRes] = await Promise.all([
+        callOnboard(token, { mode: 'parse',  text: resume.text }),
+        callOnboard(token, { mode: 'bundle', text: bundleText }),
+      ]);
+      const draftIncoming = parseRes.draft || {};
+      const bundle = bundleRes.bundle || {};
+
+      // Merge parse output.
+      this.draft.identity = { ...this.draft.identity, ...draftIncoming.identity };
+      this.draft.location = { ...this.draft.location, ...draftIncoming.location };
+      if (draftIncoming.capability) {
+        this.draft.capability.skills      = draftIncoming.capability.skills      || this.draft.capability.skills;
+        this.draft.capability.pastSectors = draftIncoming.capability.pastSectors || this.draft.capability.pastSectors;
+        this.draft.capability.arcTags     = draftIncoming.capability.arcTags     || this.draft.capability.arcTags;
+        this.draft.capability.history     = draftIncoming.capability.history     || this.draft.capability.history;
       }
+
+      // Merge bundle output.
+      this.draft.bundle = bundle;
+      this._mergeArr('values_seed.cultureKeywords', bundle.values);
+      this._mergeArr('targeting.targetRoles', bundle.dreamRoleSignals);
+      if (Array.isArray(bundle.wins)) {
+        for (const w of bundle.wins) this.draft.wins.push(w);
+      }
+
+      // Now generate insights for Stage 2.
+      this.busyLabel = 'Mapping where this experience travels…';
+      const profileForInsights = {
+        identity: this.draft.identity,
+        location: this.draft.location,
+        capability: this.draft.capability,
+        bundle: this.draft.bundle,
+      };
+      const insightsRes = await callOnboard(token, { mode: 'insights', profile: profileForInsights });
+      this.draft.insights = insightsRes.insights || null;
+
       this._setStage(2);
     } catch (e) {
       this.error = e.message;
@@ -192,24 +228,39 @@ export class JobOnboarding extends LitElement {
     }
   }
 
-  // ---- Stage 3: extract tags from a freeform answer ----
-  async _submitAnswer(question) {
-    const answer = this.querySelector(`#answer-${question.id}`)?.value || '';
-    if (!answer.trim()) {
-      // Allow skip
+  async _skipUpload() {
+    // Manual start — no insights to show, but we still need an insights card.
+    this.draft.insights = null;
+    this._setStage(2);
+  }
+
+  // -------- Stage 2: insight hero --------
+
+  _toggleEdit() { this.draft._meta.editOpen = !this.draft._meta.editOpen; this._commit(); }
+
+  // -------- Stage 3: chat questions --------
+
+  async _submitAnswer() {
+    const i = this.draft._meta.questionIdx;
+    const q = QUESTIONS[i];
+    const ta = this.querySelector('#chat-input');
+    const answer = (ta?.value || '').trim();
+    if (!answer) {
+      // Empty submit = skip
       this._nextQuestion();
       return;
     }
-    this.draft._meta.answers[question.id] = answer;
+    this.draft._meta.answers[q.id] = answer;
     this._commit();
     this.error = '';
     this.busy = true; this.busyLabel = 'Pulling out the signal…';
     try {
       const token = await this._token();
       if (!token) throw new Error('Not signed in.');
-      const { tags } = await callOnboard(token, { mode: 'extract', questionId: question.id, answer });
-      this.draft._meta.extractions[question.id] = tags;
-      this._applyExtraction(question.id, tags);
+      const { tags } = await callOnboard(token, { mode: 'extract', questionId: q.id, answer });
+      this.draft._meta.extractions[q.id] = tags;
+      this._applyExtraction(q.id, tags);
+      if (ta) ta.value = '';
       this._nextQuestion();
     } catch (e) {
       this.error = e.message;
@@ -219,36 +270,23 @@ export class JobOnboarding extends LitElement {
   }
 
   _applyExtraction(qid, tags) {
-    const merge = (path, incoming) => {
-      const segs = path.split('.');
-      let o = this.draft;
-      for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
-      const k = segs[segs.length - 1];
-      const cur = new Set(o[k] || []);
-      for (const v of (incoming || [])) cur.add(v);
-      o[k] = [...cur];
-    };
     if (qid === 'q1_mission') {
-      merge('values_seed.missionKeywords', tags.missionKeywords);
-      merge('values_seed.impactThemes', tags.impactThemes);
-      merge('targeting.targetSectors', tags.targetSectors);
+      this._mergeArr('values_seed.missionKeywords', tags.missionKeywords);
+      this._mergeArr('values_seed.impactThemes', tags.impactThemes);
+      this._mergeArr('targeting.targetSectors', tags.targetSectors);
     } else if (qid === 'q2_self') {
-      merge('values_seed.cultureKeywords', tags.cultureKeywords);
-      merge('capability.arcTags', tags.arcTags);
-      if (tags.narrativeMd) {
-        this.draft.narratives.push({ title: tags.narrativeTitle || 'A time I felt myself', content_md: tags.narrativeMd, source_question: qid });
-      }
+      this._mergeArr('values_seed.cultureKeywords', tags.cultureKeywords);
+      this._mergeArr('capability.arcTags', tags.arcTags);
+      if (tags.narrativeMd) this.draft.narratives.push({ title: tags.narrativeTitle || 'A time I felt myself', content_md: tags.narrativeMd, source_question: qid });
     } else if (qid === 'q3_win') {
       if (tags.headline) this.draft.wins.push({ headline: tags.headline, metric: tags.metric || null });
-      if (tags.narrativeMd) {
-        this.draft.narratives.push({ title: tags.narrativeTitle || 'A win', content_md: tags.narrativeMd, source_question: qid });
-      }
+      if (tags.narrativeMd) this.draft.narratives.push({ title: tags.narrativeTitle || 'A win', content_md: tags.narrativeMd, source_question: qid });
     } else if (qid === 'q4_walkaway') {
-      merge('targeting.antiMissionTerms', tags.antiMissionTerms);
-      merge('values_seed.antiCulture', tags.antiCulture);
+      this._mergeArr('targeting.antiMissionTerms', tags.antiMissionTerms);
+      this._mergeArr('values_seed.antiCulture', tags.antiCulture);
     } else if (qid === 'q5_titles') {
-      merge('targeting.targetRoles', tags.targetRoles);
-      merge('targeting.stagePreference', tags.stagePreference);
+      this._mergeArr('targeting.targetRoles', tags.targetRoles);
+      this._mergeArr('targeting.stagePreference', tags.stagePreference);
     }
     this._commit();
   }
@@ -264,27 +302,25 @@ export class JobOnboarding extends LitElement {
   }
   _prevQuestion() {
     const i = this.draft._meta.questionIdx;
-    if (i > 0) {
-      this.draft._meta.questionIdx = i - 1;
-      this._commit();
-    } else {
-      this._setStage(2);
-    }
+    if (i > 0) { this.draft._meta.questionIdx = i - 1; this._commit(); }
+    else { this._setStage(2); }
   }
 
-  // ---- Stage 5: commit ----
+  // -------- Stage 4: tailor --------
+
   async _finalize() {
     this.error = '';
     this.busy = true; this.busyLabel = this.demoMode ? 'Building demo preview…' : 'Saving your profile…';
     try {
       const token = await this._token();
       if (!token) throw new Error('Not signed in.');
-      // Strip _meta from what we send up.
       const { _meta, ...profile } = this.draft;
       const result = await callOnboard(token, { mode: 'finalize', profile, demo: this.demoMode });
       this.finalized = result;
       if (!this.demoMode && result.ok) {
         clearDraft();
+        // Live mode: route to recommended.
+        setTimeout(() => { window.location.href = '/job/jobs/recommended/'; }, 600);
       }
     } catch (e) {
       this.error = e.message;
@@ -300,25 +336,28 @@ export class JobOnboarding extends LitElement {
     this.requestUpdate();
   }
 
-  // ---------- render ----------
+  // ============================================================
+  // Render
+  // ============================================================
 
   render() {
     const stage = this.draft._meta.stage || 0;
+    const showDebug = this.debugMode && stage > 0;
     return html`
       <div class="onboard">
         ${this._renderStepper(stage)}
         ${this.demoMode ? html`
           <div class="onboard__demo-banner">
-            Demo mode — nothing you do here will overwrite your live profile. Drop <code>?demo=1</code> to commit for real.
+            Demo mode — nothing you do here will overwrite your live profile.
           </div>` : nothing}
         ${this.error ? html`<div class="onboard__demo-banner" style="border-color: var(--error); background: rgba(168,32,13,0.10);">${this.error}</div>` : nothing}
-        ${this.busy ? html`<div class="onboard__hint">${this.busyLabel}</div>` : nothing}
+        ${this.busy ? html`<div class="onboard__busy">${this.busyLabel}</div>` : nothing}
         ${stage === 0 ? this._renderPitch() : nothing}
         ${stage === 1 ? this._renderUpload() : nothing}
-        ${stage === 2 ? this._renderConfirm() : nothing}
-        ${stage === 3 ? this._renderQuestions() : nothing}
-        ${stage === 4 ? this._renderKnobs() : nothing}
-        ${stage === 5 ? this._renderPreview() : nothing}
+        ${stage === 2 ? this._renderInsights() : nothing}
+        ${stage === 3 ? this._renderChat() : nothing}
+        ${stage === 4 ? this._renderTailor() : nothing}
+        ${showDebug ? this._renderDebug() : nothing}
       </div>
     `;
   }
@@ -328,8 +367,7 @@ export class JobOnboarding extends LitElement {
       <div class="stepper">
         ${STAGES.map((s, i) => html`
           <span class="stepper__item ${s.id === stage ? 'stepper__item--current' : s.id < stage ? 'stepper__item--complete' : ''}">
-            <span class="stepper__dot"></span>
-            ${s.label}
+            <span class="stepper__dot"></span>${s.label}
           </span>
           ${i < STAGES.length - 1 ? html`<span class="stepper__sep"></span>` : ''}
         `)}
@@ -352,86 +390,121 @@ export class JobOnboarding extends LitElement {
   }
 
   _renderUpload() {
+    const files = this.draft._meta.uploadedFiles || [];
     return html`
       <section class="onboard__stage">
-        <h1>Drop in what you've got.</h1>
-        <p class="lede">Paste your resume below. We'll pull out the bones (companies, titles, skills, location) so you don't retype them. Skip if you'd rather start from scratch.</p>
-        <div class="dropzone">
-          <div class="dropzone__title">Paste your resume</div>
-          <div class="dropzone__hint">PDF parsing is coming. For now, paste the text — copying from your resume usually works.</div>
-          <textarea id="resume-text" placeholder="Paste resume text here…"></textarea>
-        </div>
+        <h1>Drop in everything you've already got.</h1>
+        <p class="lede">Resume is the headline. Cover letters, writing samples, LLM career docs, project descriptions, dream JDs — anything you've already written that shows your shape. We'll pull the bones from the resume and the voice from the rest.</p>
+        <label class="dropzone dropzone--multi" for="resume-file"
+               @dragover=${(e) => { e.preventDefault(); e.currentTarget.classList.add('dropzone--active'); }}
+               @dragleave=${(e) => e.currentTarget.classList.remove('dropzone--active')}
+               @drop=${(e) => { e.preventDefault(); e.currentTarget.classList.remove('dropzone--active'); this._handleFiles(e.dataTransfer.files); }}>
+          <div class="dropzone__title">Drag in PDFs, .md, or .txt — or click to choose</div>
+          <div class="dropzone__hint">Anything with "resume" or "cv" in the name is treated as the primary resume. The rest become voice/values context.</div>
+          <input id="resume-file" type="file" multiple accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+                 style="display:none" @change=${(e) => this._handleFiles(e.target.files)}/>
+          ${files.length ? html`
+            <ul class="dropzone__files">
+              ${files.map(f => html`<li><strong>${f.name}</strong> ${f.isResume ? html`<span class="chip chip--on" style="font-size:var(--font-size-caption);">resume</span>` : ''}</li>`)}
+            </ul>` : nothing}
+        </label>
         <div class="onboard__nav">
-          <button class="btn btn--ghost" @click=${() => this._setStage(2)}>Skip — I'll fill it in</button>
-          <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._parseResume()}>Parse and continue</button>
+          <button class="btn btn--ghost" @click=${() => this._skipUpload()}>Skip — I'll start from scratch</button>
+          <span></span>
         </div>
       </section>
     `;
   }
 
-  _renderConfirm() {
-    const id = this.draft.identity || {};
-    const loc = this.draft.location || {};
-    const cap = this.draft.capability || {};
+  _renderInsights() {
+    const ins = this.draft.insights;
+    const hasResume = (this.draft._meta.uploadedFiles || []).length > 0;
+    if (!hasResume || !ins) {
+      // Cold-start path — no upload, no insights.
+      return html`
+        <section class="onboard__stage">
+          <h1>Let's start with the basics.</h1>
+          <p class="lede">No upload, no problem. We'll get what we need from the next few questions.</p>
+          <div class="onboard-card">
+            <h2 class="onboard-card__title">Your name and city</h2>
+            ${this._row('Name', 'identity.name', this.draft.identity.name)}
+            ${this._row('Email', 'identity.email', this.draft.identity.email)}
+            ${this._row('City', 'location.city', this.draft.location.city)}
+          </div>
+          <div class="onboard__nav">
+            <button class="btn btn--ghost" @click=${() => this._setStage(1)}>Back</button>
+            <button class="btn btn--primary" @click=${() => this._setStage(3)}>Continue</button>
+          </div>
+        </section>
+      `;
+    }
     return html`
       <section class="onboard__stage">
-        <h1>Here's what we found.</h1>
-        <p class="lede">Fix anything that's off. Empty cards mean we didn't have enough to pull from your upload — fill what you can.</p>
+        <h1>Here's where your experience travels.</h1>
+        <div class="insight-hero">${ins.hero || ''}</div>
+        ${this._renderTrack('Domains you know', 'industries / verticals → adjacent verticals that hire you', ins.domains || [])}
+        ${this._renderTrack('Work areas you\'ve shipped', 'problems and flows you\'ve actually built → what those ship into next', ins.workAreas || [])}
+        ${this._renderTrack('Craft you bring', 'product / IC skills → role shapes this unlocks', ins.skills || [])}
 
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">You</h2>
-          ${this._row('Name', 'identity.name', id.name)}
-          ${this._row('Email', 'identity.email', id.email)}
-          ${this._row('Phone', 'identity.phone', id.phone)}
-          ${this._row('LinkedIn', 'identity.linkedin', id.linkedin)}
-          ${this._row('Portfolio', 'identity.portfolio', id.portfolio)}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Location</h2>
-          ${this._row('City', 'location.city', loc.city)}
-          <div class="onboard-card__row">
-            <label>Region</label>
-            <span class="read-only">${[loc.region, loc.country].filter(Boolean).join(' · ') || '—'}${loc.timezone ? ` · ${loc.timezone}` : ''}</span>
-          </div>
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Career</h2>
-          ${(cap.history || []).length === 0
-            ? html`<p class="onboard__hint">No history pulled. Skip — you can come back to this.</p>`
-            : html`
-              <ul style="display:flex;flex-direction:column;gap:var(--space-3);list-style:none;padding:0;margin:0;">
-                ${cap.history.map((h, i) => html`
-                  <li style="display:flex;flex-direction:column;gap:2px;">
-                    <strong>${h.title || '—'}</strong>
-                    <span class="onboard__hint">${h.company || ''} · ${h.start || ''}${h.end ? `–${h.end}` : ''}</span>
-                    ${h.scope ? html`<span class="onboard__hint">${h.scope}</span>` : ''}
-                  </li>
-                `)}
-              </ul>`}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Skills we spotted</h2>
-          <div class="chip-row">
-            ${(cap.skills || []).map(s => html`
-              <span class="chip chip--editable chip--on">
-                ${s.name}${s.years ? html` · ${s.years}y` : ''}
-                <button @click=${() => { this.draft.capability.skills = cap.skills.filter(x => x !== s); this._commit(); }}>×</button>
-              </span>
-            `)}
-          </div>
-          ${this._chipAdd('Add a skill', (v) => {
-            this.draft.capability.skills.push({ name: v, years: null }); this._commit();
-          })}
-        </div>
+        ${this._renderEditFooter()}
 
         <div class="onboard__nav">
           <button class="btn btn--ghost" @click=${() => this._setStage(1)}>Back</button>
-          <button class="btn btn--primary" @click=${() => this._setStage(3)}>Continue</button>
+          <button class="btn btn--primary" @click=${() => this._setStage(3)}>Looks right — keep going</button>
         </div>
       </section>
+    `;
+  }
+
+  _renderTrack(title, sub, items) {
+    if (!items.length) return nothing;
+    return html`
+      <div class="insight-track">
+        <div class="insight-track__head">
+          <h2>${title}</h2>
+          <p class="onboard__hint">${sub}</p>
+        </div>
+        <ul class="insight-track__rows">
+          ${items.map(it => html`
+            <li>
+              <span class="insight-track__have">${it.have}</span>
+              <span class="insight-track__arrow">→</span>
+              <span class="insight-track__to">
+                ${(it.translatesTo || []).map(t => html`<span class="chip chip--on">${t}</span>`)}
+              </span>
+            </li>
+          `)}
+        </ul>
+      </div>
+    `;
+  }
+
+  _renderEditFooter() {
+    const id = this.draft.identity || {};
+    const loc = this.draft.location || {};
+    const cap = this.draft.capability || {};
+    const open = !!this.draft._meta.editOpen;
+    const summary = [
+      id.name || '—',
+      loc.city || '—',
+      `${(cap.history || []).length} roles`,
+      `${(cap.skills || []).length} skills`,
+    ].join(' · ');
+    return html`
+      <div class="insight-edit">
+        <button class="insight-edit__toggle" @click=${() => this._toggleEdit()}>
+          Got the basics right? <strong>${summary}</strong> · ${open ? 'close' : 'edit'}
+        </button>
+        ${open ? html`
+          <div class="insight-edit__panel">
+            ${this._row('Name', 'identity.name', id.name)}
+            ${this._row('City', 'location.city', loc.city)}
+            ${this._row('Email', 'identity.email', id.email)}
+            ${this._row('LinkedIn', 'identity.linkedin', id.linkedin)}
+            <div class="onboard__hint">Need to fix career or skills? Open <a href="/job/history/">Your career</a> after onboarding — it edits the same fields.</div>
+          </div>
+        ` : nothing}
+      </div>
     `;
   }
 
@@ -441,6 +514,205 @@ export class JobOnboarding extends LitElement {
         <label>${label}</label>
         <input type="text" .value=${value || ''}
                @change=${(e) => this._patch(path, e.target.value)}/>
+      </div>
+    `;
+  }
+
+  // -------- Stage 3: chat --------
+
+  _renderChat() {
+    const i = this.draft._meta.questionIdx || 0;
+    const q = QUESTIONS[i];
+    const lastQid = i > 0 ? QUESTIONS[i - 1].id : null;
+    const lastExtraction = lastQid ? this.draft._meta.extractions[lastQid] : null;
+    return html`
+      <section class="onboard__stage chat">
+        <div class="chat__progress">Question ${i + 1} of ${QUESTIONS.length}</div>
+        ${lastExtraction ? html`
+          <div class="chat__ack">
+            <span class="chat__ack-prefix">We heard:</span>
+            ${this._renderExtractionChips(lastQid, lastExtraction)}
+          </div>
+        ` : nothing}
+        <div class="chat__question">${q.label}</div>
+
+        <div class="chat__composer">
+          <textarea id="chat-input" placeholder=${q.placeholder}
+                    @keydown=${(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); this._submitAnswer(); } }}></textarea>
+          <div class="chat__composer-actions">
+            <div class="chat__composer-pills">
+              <button class="chat__pill" @click=${() => this._submitAnswer()} title="Or just leave it blank">Skip</button>
+              ${i > 0 ? html`<button class="chat__pill" @click=${() => this._prevQuestion()}>Back</button>` : nothing}
+            </div>
+            <button class="btn btn--primary btn--send" ?disabled=${this.busy} @click=${() => this._submitAnswer()}
+                    aria-label="Send">↑</button>
+          </div>
+          <div class="chat__composer-hint">⌘+Enter to send</div>
+        </div>
+      </section>
+    `;
+  }
+
+  _renderExtractionChips(qid, tags) {
+    const items = [];
+    if (qid === 'q1_mission') {
+      items.push(...(tags.missionKeywords || []), ...(tags.impactThemes || []), ...(tags.targetSectors || []));
+    } else if (qid === 'q2_self') {
+      items.push(...(tags.cultureKeywords || []), ...(tags.arcTags || []));
+    } else if (qid === 'q3_win') {
+      if (tags.headline) items.push(tags.headline + (tags.metric ? ` · ${tags.metric}` : ''));
+    } else if (qid === 'q4_walkaway') {
+      items.push(...(tags.antiMissionTerms || []), ...(tags.antiCulture || []));
+    } else if (qid === 'q5_titles') {
+      items.push(...(tags.targetRoles || []), ...(tags.stagePreference || []));
+    }
+    if (!items.length) return html`<span class="onboard__hint">noted.</span>`;
+    return html`${items.map(t => html`<span class="chip chip--on">${t}</span>`)}`;
+  }
+
+  // -------- Stage 4: tailor --------
+
+  _renderTailor() {
+    const t = this.draft.targeting || {};
+    const p = this.draft.preferences || {};
+    const loc = this.draft.location || {};
+    const c = this.draft.capability || {};
+    const v = this.draft.values_seed || {};
+    const ans = this.draft._meta.answers || {};
+    return html`
+      <section class="onboard__stage">
+        <h1>How we'll tailor your search.</h1>
+        <p class="lede">We've prepopulated this from your resume, your voice samples, and what you told us. Tweak anything that's off.</p>
+
+        <div class="tailor-group">
+          <div class="tailor-group__head">
+            <h2>What you're looking for</h2>
+            ${ans.q5_titles ? html`<p class="tailor-group__excerpt">You said: "${this._truncate(ans.q5_titles, 160)}"</p>` : ''}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Target roles</span>
+            ${this._chipList(t.targetRoles || [], 'targeting.targetRoles')}
+            ${this._chipAdd('Add a role…', (val) => { if (!(t.targetRoles || []).includes(val)) this._toggleInArr('targeting.targetRoles', val); })}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Target sectors</span>
+            ${this._palette(SECTORS_PALETTE, t.targetSectors || [], 'targeting.targetSectors')}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Stage</span>
+            ${this._palette(STAGE_PALETTE, t.stagePreference || [], 'targeting.stagePreference')}
+          </div>
+        </div>
+
+        <div class="tailor-group">
+          <div class="tailor-group__head">
+            <h2>What you bring</h2>
+            ${ans.q2_self ? html`<p class="tailor-group__excerpt">You said: "${this._truncate(ans.q2_self, 160)}"</p>` : ''}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Arc</span>
+            ${this._palette(ARC_PALETTE, c.arcTags || [], 'capability.arcTags')}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Past sectors</span>
+            <div class="chip-row">
+              ${(c.pastSectors || []).map(s => html`<span class="chip chip--editable chip--on">${s}<button @click=${() => this._toggleInArr('capability.pastSectors', s)}>×</button></span>`)}
+            </div>
+            ${this._chipAdd('Add a sector…', (val) => this._toggleInArr('capability.pastSectors', val))}
+          </div>
+        </div>
+
+        <div class="tailor-group">
+          <div class="tailor-group__head">
+            <h2>Where & when</h2>
+            <p class="tailor-group__excerpt">Based in ${loc.city || '—'}${loc.region ? `, ${loc.region}` : ''}${loc.country ? ` · ${loc.country}` : ''}</p>
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Remote</span>
+            <div class="segmented">
+              ${['remote', 'hybrid', 'onsite', 'any'].map(opt => html`
+                <button aria-pressed=${(p.remotePreference || 'any') === opt ? 'true' : 'false'}
+                        @click=${() => { this._patch('preferences.remotePreference', opt); this._patch('location.remotePreference', opt); }}>${opt}</button>
+              `)}
+            </div>
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Willing to relocate</span>
+            <div class="chip-row">
+              ${(loc.willingToRelocate || []).map(s => html`<span class="chip chip--editable chip--on">${s}<button @click=${() => this._toggleInArr('location.willingToRelocate', s)}>×</button></span>`)}
+            </div>
+            ${this._chipAdd('Add a city or region…', (val) => this._toggleInArr('location.willingToRelocate', val))}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Comp floor</span>
+            <input type="range" min="0" max="400000" step="5000"
+                   .value=${String(p.compFloor ?? 150000)}
+                   @input=${(e) => this._patch('preferences.compFloor', Number(e.target.value))}/>
+            <span class="onboard__hint">$${(p.compFloor ?? 150000).toLocaleString()} minimum base</span>
+          </div>
+        </div>
+
+        <div class="tailor-group">
+          <div class="tailor-group__head">
+            <h2>Hard limits</h2>
+            ${ans.q4_walkaway ? html`<p class="tailor-group__excerpt">You said: "${this._truncate(ans.q4_walkaway, 160)}"</p>` : ''}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Dealbreakers</span>
+            ${this._palette(DEALBREAKER_PALETTE, t.antiMissionTerms || [], 'targeting.antiMissionTerms')}
+          </div>
+          <div class="tailor-group__field">
+            <span class="tailor-group__label">Work auth</span>
+            ${this._palette(WORK_AUTH_PALETTE, loc.workAuth || [], 'location.workAuth')}
+          </div>
+          <div class="tailor-group__field">
+            <label style="display:flex;gap:var(--space-3);align-items:center;cursor:pointer;">
+              <input type="checkbox" .checked=${!!p.missionRequired}
+                     @change=${(e) => { this._patch('preferences.missionRequired', e.target.checked); this._patch('targeting.missionRequired', e.target.checked); }}/>
+              <span>Mission alignment is a hard requirement</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._setStage(3)}>Back to questions</button>
+          <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._finalize()}>
+            ${this.demoMode ? 'Show me what we\'d save' : 'Save and start hunting'}
+          </button>
+        </div>
+
+        ${this.finalized && this.demoMode ? html`
+          <div class="onboard-card" style="margin-top:var(--space-4);">
+            <h2 class="onboard-card__title">Demo preview</h2>
+            <p class="onboard__hint">Nothing was written. This is what would have committed.</p>
+            <div class="onboard-preview"><pre>${JSON.stringify(this.finalized.preview?.wouldWrite || this.finalized, null, 2)}</pre></div>
+          </div>` : nothing}
+      </section>
+    `;
+  }
+
+  _truncate(s, n) { return s.length <= n ? s : s.slice(0, n - 1) + '…'; }
+
+  _chipList(items, path) {
+    if (!items.length) return html`<span class="onboard__hint">No targets yet.</span>`;
+    return html`<div class="chip-row">
+      ${items.map(s => html`<span class="chip chip--editable chip--on">${s}<button @click=${() => this._toggleInArr(path, s)}>×</button></span>`)}
+    </div>`;
+  }
+  _palette(options, selected, path) {
+    const sel = new Set(selected);
+    return html`
+      <div class="chip-palette">
+        <div class="chip-palette__chips">
+          ${options.map(opt => html`
+            <button class="chip ${sel.has(opt) ? 'chip--on' : ''}"
+                    @click=${() => this._toggleInArr(path, opt)}>${opt}</button>
+          `)}
+          ${[...sel].filter(v => !options.includes(v)).map(opt => html`
+            <span class="chip chip--editable chip--on">${opt}<button @click=${() => this._toggleInArr(path, opt)}>×</button></span>
+          `)}
+        </div>
+        ${this._chipAdd('Add custom…', (v) => { if (!sel.has(v)) this._toggleInArr(path, v); })}
       </div>
     `;
   }
@@ -455,188 +727,13 @@ export class JobOnboarding extends LitElement {
     `;
   }
 
-  _renderQuestions() {
-    const i = this.draft._meta.questionIdx || 0;
-    const q = QUESTIONS[i];
-    const prevAnswer = this.draft._meta.answers[q.id] || '';
-    const lastExtraction = i > 0 ? this.draft._meta.extractions[QUESTIONS[i - 1].id] : null;
-    return html`
-      <section class="onboard__stage">
-        <div class="onboard__hint">Question ${i + 1} of ${QUESTIONS.length}</div>
-        ${lastExtraction ? this._renderExtractionEcho(QUESTIONS[i - 1].id, lastExtraction) : nothing}
-        <div class="chat-prompt">
-          <div class="chat-prompt__label">${q.label}</div>
-          <p class="chat-prompt__help">${q.help}</p>
-          <textarea id="answer-${q.id}" placeholder=${q.placeholder} .value=${prevAnswer}></textarea>
-        </div>
-        <div class="onboard__nav">
-          <button class="btn btn--ghost" @click=${() => this._prevQuestion()}>Back</button>
-          <span>
-            <button class="btn btn--ghost" @click=${() => this._nextQuestion()}>Skip for now</button>
-            <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._submitAnswer(q)}>Continue</button>
-          </span>
-        </div>
-      </section>
-    `;
-  }
-
-  _renderExtractionEcho(qid, tags) {
-    const rows = [];
-    if (qid === 'q1_mission') {
-      if (tags.missionKeywords?.length) rows.push(['Mission', tags.missionKeywords]);
-      if (tags.impactThemes?.length) rows.push(['Impact', tags.impactThemes]);
-      if (tags.targetSectors?.length) rows.push(['Sectors', tags.targetSectors]);
-    } else if (qid === 'q2_self') {
-      if (tags.cultureKeywords?.length) rows.push(['Culture', tags.cultureKeywords]);
-      if (tags.arcTags?.length) rows.push(['Arc', tags.arcTags]);
-    } else if (qid === 'q3_win') {
-      if (tags.headline) rows.push(['Win', [tags.headline + (tags.metric ? ` · ${tags.metric}` : '')]]);
-    } else if (qid === 'q4_walkaway') {
-      if (tags.antiMissionTerms?.length) rows.push(['Dealbreakers', tags.antiMissionTerms]);
-      if (tags.antiCulture?.length) rows.push(['Anti-culture', tags.antiCulture]);
-    } else if (qid === 'q5_titles') {
-      if (tags.targetRoles?.length) rows.push(['Titles', tags.targetRoles]);
-      if (tags.stagePreference?.length) rows.push(['Stages', tags.stagePreference]);
-    }
-    if (!rows.length) return nothing;
-    return html`
-      <div class="chat-prompt__extracted">
-        <div class="chat-prompt__extracted-title">We heard:</div>
-        ${rows.map(([label, items]) => html`
-          <div class="chat-prompt__row">
-            <span class="chat-prompt__row-label">${label}</span>
-            ${items.map(t => html`<span class="chip chip--on">${t}</span>`)}
-          </div>
-        `)}
-      </div>
-    `;
-  }
-
-  _renderKnobs() {
-    const t = this.draft.targeting || {};
-    const p = this.draft.preferences || {};
-    const loc = this.draft.location || {};
-    const c = this.draft.capability || {};
-    return html`
-      <section class="onboard__stage">
-        <h1>The fast knobs.</h1>
-        <p class="lede">Things that are easier to click than to write.</p>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Target sectors</h2>
-          ${this._palette(SECTORS_PALETTE, t.targetSectors || [], 'targeting.targetSectors')}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Stage preference</h2>
-          ${this._palette(STAGE_PALETTE, t.stagePreference || [], 'targeting.stagePreference')}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Arc tags</h2>
-          <p class="onboard__hint">Stage/role-shape you want next.</p>
-          ${this._palette(ARC_PALETTE, c.arcTags || [], 'capability.arcTags')}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Dealbreakers</h2>
-          ${this._palette(DEALBREAKER_PALETTE, t.antiMissionTerms || [], 'targeting.antiMissionTerms')}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Work authorization</h2>
-          ${this._palette(WORK_AUTH_PALETTE, loc.workAuth || [], 'location.workAuth')}
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Remote / hybrid / onsite</h2>
-          <div class="segmented">
-            ${['remote', 'hybrid', 'onsite', 'any'].map(opt => html`
-              <button aria-pressed=${(p.remotePreference || 'any') === opt ? 'true' : 'false'}
-                      @click=${() => { this._patch('preferences.remotePreference', opt); this._patch('location.remotePreference', opt); }}>${opt}</button>
-            `)}
-          </div>
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Comp floor (base, USD)</h2>
-          <input type="range" min="0" max="400000" step="5000"
-                 .value=${String(p.compFloor ?? 150000)}
-                 @input=${(e) => this._patch('preferences.compFloor', Number(e.target.value))}/>
-          <div class="onboard__hint">${(p.compFloor ?? 150000).toLocaleString()} minimum</div>
-        </div>
-
-        <div class="onboard-card">
-          <h2 class="onboard-card__title">Mission alignment</h2>
-          <label style="display:flex;gap:var(--space-3);align-items:center;cursor:pointer;">
-            <input type="checkbox" .checked=${!!p.missionRequired}
-                   @change=${(e) => { this._patch('preferences.missionRequired', e.target.checked); this._patch('targeting.missionRequired', e.target.checked); }}/>
-            <span>Mission alignment is a hard requirement</span>
-          </label>
-        </div>
-
-        <div class="onboard__nav">
-          <button class="btn btn--ghost" @click=${() => this._setStage(3)}>Back</button>
-          <button class="btn btn--primary" @click=${() => this._setStage(5)}>See preview</button>
-        </div>
-      </section>
-    `;
-  }
-
-  _palette(options, selected, path) {
-    const sel = new Set(selected);
-    return html`
-      <div class="chip-palette">
-        <div class="chip-palette__chips">
-          ${options.map(opt => html`
-            <button class="chip ${sel.has(opt) ? 'chip--on' : ''}"
-                    @click=${() => this._toggleInArr(path, opt)}>${opt}</button>
-          `)}
-          ${[...sel].filter(v => !options.includes(v)).map(opt => html`
-            <span class="chip chip--editable chip--on">${opt}
-              <button @click=${() => this._toggleInArr(path, opt)}>×</button>
-            </span>
-          `)}
-        </div>
-        ${this._chipAdd('Add custom…', (v) => { if (!sel.has(v)) this._toggleInArr(path, v); })}
-      </div>
-    `;
-  }
-
-  _renderPreview() {
-    if (this.finalized) {
-      return html`
-        <section class="onboard__stage">
-          <h1>${this.demoMode ? 'Demo preview' : 'You\'re in.'}</h1>
-          <p class="lede">${this.demoMode
-            ? 'Nothing was saved — this is what would have been written.'
-            : 'Your profile is saved. /job is unlocked.'}</p>
-          <div class="onboard-preview">
-            <pre>${JSON.stringify(this.finalized, null, 2)}</pre>
-          </div>
-          <div class="onboard__nav">
-            ${this.demoMode
-              ? html`<button class="btn btn--ghost" @click=${() => this._reset()}>Start over</button>`
-              : html`<span></span>`}
-            <a class="btn btn--primary" href="/job/jobs/recommended/">Open /job</a>
-          </div>
-        </section>
-      `;
-    }
+  _renderDebug() {
     const { _meta, ...profile } = this.draft;
     return html`
-      <section class="onboard__stage">
-        <h1>Look right?</h1>
-        <p class="lede">${this.demoMode
-          ? 'You\'re in demo mode. Hit commit and we\'ll show what would be written.'
-          : 'Hit commit and we\'ll save this and start pulling roles.'}</p>
-        <div class="onboard-preview">
-          <pre>${JSON.stringify(profile, null, 2)}</pre>
-        </div>
-        <div class="onboard__nav">
-          <button class="btn btn--ghost" @click=${() => this._setStage(4)}>Back to tweak</button>
-          <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._finalize()}>${this.demoMode ? 'Show demo result' : 'Commit and open /job'}</button>
-        </div>
+      <section class="onboard-card" style="margin-top:var(--space-6);">
+        <h2 class="onboard-card__title">Debug — staged profile (live JSON)</h2>
+        <p class="onboard__hint">Only visible with <code>?debug=1</code>.</p>
+        <div class="onboard-preview"><pre>${JSON.stringify(profile, null, 2)}</pre></div>
       </section>
     `;
   }

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -1,0 +1,645 @@
+// job-onboarding — six-stage onboarding flow for /job.
+//
+//   0  Pitch         — value prop + Get started
+//   1  Upload        — paste resume text (file drop is post-MVP)
+//   2  Confirm       — You / Location / Career / Skills cards (editable)
+//   3  Questions     — five freeform prompts, one per screen, with
+//                      Haiku tag extraction surfacing between screens
+//   4  Fast knobs    — structured chips/sliders/toggles
+//   5  Preview       — diff of the staged profile + commit
+//
+// State lives in localStorage under `job:onboarding:draft` so users can
+// step away and come back. ?demo=1 switches Stage 5 to a non-committing
+// preview so existing users (Ian) can test without losing their profile.
+//
+// Talks to the `onboard` edge function in three modes:
+//   { mode: 'parse',    text }
+//   { mode: 'extract',  questionId, answer }
+//   { mode: 'finalize', profile, demo }
+
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const ONBOARD_FN_URL = `${SUPABASE_URL}/functions/v1/onboard`;
+const DRAFT_KEY = 'job:onboarding:draft';
+
+const STAGES = [
+  { id: 0, label: 'Welcome' },
+  { id: 1, label: 'Upload' },
+  { id: 2, label: 'Confirm' },
+  { id: 3, label: 'Questions' },
+  { id: 4, label: 'Knobs' },
+  { id: 5, label: 'Preview' },
+];
+
+const QUESTIONS = [
+  { id: 'q1_mission',   label: 'What problem do you want to spend the next five years on?',
+    placeholder: 'e.g. I want to make public services feel like apps people actually want to use…',
+    help: 'Tell us what you\'d work on if no one was watching.' },
+  { id: 'q2_self',      label: 'Describe a time at work where you felt most yourself. What were you doing, and what made it click?',
+    placeholder: 'e.g. Six months at a tiny civic-tech team — I was rebuilding a benefits-eligibility tool from scratch with two engineers and a research partner…',
+    help: 'The story matters; we\'ll use it for the cover-letter voice too.' },
+  { id: 'q3_win',       label: 'A win you\'re proud of — ideally with a number attached.',
+    placeholder: 'e.g. Took our retention from 41% to 67% in eight months by rebuilding the first-week experience.',
+    help: 'Numbers make this fly. We extract them for cover letters.' },
+  { id: 'q4_walkaway',  label: 'What kind of company or team would make you walk away from a great offer?',
+    placeholder: 'e.g. Anything in surveillance, defense, or with a return-to-office mandate. Also no patience for hustle-culture leadership.',
+    help: 'Be specific — these become hard filters.' },
+  { id: 'q5_titles',    label: 'What roles and titles should we be hunting for? Anything off-limits?',
+    placeholder: 'e.g. Head of Product, Founding PM, VP Product at seed-to-series-A startups. No people-manager-only roles.',
+    help: 'Title patterns + stage preference.' },
+];
+
+const SECTORS_PALETTE = ['climate', 'civic-tech', 'healthtech', 'fintech', 'edtech', 'consumer-social', 'developer-tools', 'AI-infrastructure', 'biotech', 'space', 'public-benefit'];
+const STAGE_PALETTE   = ['pre-seed', 'seed', 'series-a', 'series-b', 'growth', 'public'];
+const DEALBREAKER_PALETTE = ['defense', 'gambling', 'crypto', 'adtech', 'surveillance', 'fossil-fuels'];
+const WORK_AUTH_PALETTE = ['US-citizen', 'US-permanent-resident', 'US-TN-eligible', 'CA-citizen', 'EU-citizen', 'UK-citizen', 'requires-sponsorship'];
+const ARC_PALETTE     = ['zero-to-one', 'scale-up', 'turnaround', 'ic-to-manager', 'founder', 'scaling-team', 'scaling-revenue'];
+
+function emptyDraft() {
+  return {
+    identity: {},
+    location: { remotePreference: 'any', willingToRelocate: [], workAuth: [] },
+    capability: { skills: [], pastSectors: [], arcTags: [], history: [] },
+    values_seed: { missionKeywords: [], impactThemes: [], cultureKeywords: [], antiCulture: [] },
+    targeting: { targetRoles: [], targetSectors: [], stagePreference: [], antiMissionTerms: [], missionRequired: false },
+    preferences: { compFloor: null, remotePreference: 'any', missionRequired: false },
+    wins: [],
+    narratives: [],
+    _meta: { stage: 0, questionIdx: 0, answers: {}, extractions: {} },
+  };
+}
+
+function loadDraft() {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY);
+    if (!raw) return emptyDraft();
+    const parsed = JSON.parse(raw);
+    return { ...emptyDraft(), ...parsed, _meta: { ...emptyDraft()._meta, ...(parsed._meta || {}) } };
+  } catch {
+    return emptyDraft();
+  }
+}
+function saveDraft(d) {
+  try { localStorage.setItem(DRAFT_KEY, JSON.stringify(d)); } catch { /* */ }
+}
+function clearDraft() {
+  try { localStorage.removeItem(DRAFT_KEY); } catch { /* */ }
+}
+
+async function callOnboard(token, body) {
+  const res = await fetch(ONBOARD_FN_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`onboard ${res.status}: ${text.slice(0, 300)}`);
+  }
+  return await res.json();
+}
+
+export class JobOnboarding extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    draft:       { state: true },
+    busy:        { state: true },
+    busyLabel:   { state: true },
+    error:       { state: true },
+    finalized:   { state: true },
+    demoMode:    { state: true },
+  };
+
+  constructor() {
+    super();
+    this.draft = loadDraft();
+    this.busy = false;
+    this.busyLabel = '';
+    this.error = '';
+    this.finalized = null;
+    this.demoMode = new URLSearchParams(location.search).get('demo') === '1';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('ctrl:auth:signedin', this._authPing = () => this.requestUpdate());
+    document.addEventListener('job:auth:ready', this._authReady = () => this.requestUpdate());
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._authPing);
+    document.removeEventListener('job:auth:ready', this._authReady);
+    super.disconnectedCallback();
+  }
+
+  _token() {
+    const sb = window.CtrlAuth?.getSupabaseClient?.();
+    if (!sb) return null;
+    // Synchronous-ish: the session lives in localStorage so getSession resolves fast.
+    return sb.auth.getSession().then(({ data }) => data?.session?.access_token || null);
+  }
+
+  _commit() { saveDraft(this.draft); this.requestUpdate(); }
+  _setStage(stage) { this.draft._meta.stage = stage; this._commit(); }
+  _patch(path, value) {
+    const segs = path.split('.');
+    let o = this.draft;
+    for (let i = 0; i < segs.length - 1; i++) {
+      o[segs[i]] = o[segs[i]] || {};
+      o = o[segs[i]];
+    }
+    o[segs[segs.length - 1]] = value;
+    this._commit();
+  }
+  _toggleInArr(path, value) {
+    const segs = path.split('.');
+    let o = this.draft;
+    for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
+    const arr = o[segs[segs.length - 1]] = o[segs[segs.length - 1]] || [];
+    const idx = arr.indexOf(value);
+    if (idx >= 0) arr.splice(idx, 1); else arr.push(value);
+    this._commit();
+  }
+
+  // ---- Stage 1: parse uploaded resume text ----
+  async _parseResume() {
+    const text = this.shadowRoot ? null : this.querySelector('#resume-text')?.value || '';
+    if (!text.trim()) { this.error = 'Paste your resume text first.'; return; }
+    this.error = '';
+    this.busy = true; this.busyLabel = 'Reading your resume…';
+    try {
+      const token = await this._token();
+      if (!token) throw new Error('Not signed in.');
+      const { draft } = await callOnboard(token, { mode: 'parse', text });
+      // Merge parsed into draft (don't clobber any user-entered values).
+      this.draft.identity = { ...this.draft.identity, ...draft.identity };
+      this.draft.location = { ...this.draft.location, ...draft.location };
+      if (draft.capability) {
+        this.draft.capability.skills      = draft.capability.skills      || this.draft.capability.skills;
+        this.draft.capability.pastSectors = draft.capability.pastSectors || this.draft.capability.pastSectors;
+        this.draft.capability.arcTags     = draft.capability.arcTags     || this.draft.capability.arcTags;
+        this.draft.capability.history     = draft.capability.history     || this.draft.capability.history;
+      }
+      this._setStage(2);
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.busy = false; this.busyLabel = '';
+    }
+  }
+
+  // ---- Stage 3: extract tags from a freeform answer ----
+  async _submitAnswer(question) {
+    const answer = this.querySelector(`#answer-${question.id}`)?.value || '';
+    if (!answer.trim()) {
+      // Allow skip
+      this._nextQuestion();
+      return;
+    }
+    this.draft._meta.answers[question.id] = answer;
+    this._commit();
+    this.error = '';
+    this.busy = true; this.busyLabel = 'Pulling out the signal…';
+    try {
+      const token = await this._token();
+      if (!token) throw new Error('Not signed in.');
+      const { tags } = await callOnboard(token, { mode: 'extract', questionId: question.id, answer });
+      this.draft._meta.extractions[question.id] = tags;
+      this._applyExtraction(question.id, tags);
+      this._nextQuestion();
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.busy = false; this.busyLabel = '';
+    }
+  }
+
+  _applyExtraction(qid, tags) {
+    const merge = (path, incoming) => {
+      const segs = path.split('.');
+      let o = this.draft;
+      for (let i = 0; i < segs.length - 1; i++) o = o[segs[i]] = o[segs[i]] || {};
+      const k = segs[segs.length - 1];
+      const cur = new Set(o[k] || []);
+      for (const v of (incoming || [])) cur.add(v);
+      o[k] = [...cur];
+    };
+    if (qid === 'q1_mission') {
+      merge('values_seed.missionKeywords', tags.missionKeywords);
+      merge('values_seed.impactThemes', tags.impactThemes);
+      merge('targeting.targetSectors', tags.targetSectors);
+    } else if (qid === 'q2_self') {
+      merge('values_seed.cultureKeywords', tags.cultureKeywords);
+      merge('capability.arcTags', tags.arcTags);
+      if (tags.narrativeMd) {
+        this.draft.narratives.push({ title: tags.narrativeTitle || 'A time I felt myself', content_md: tags.narrativeMd, source_question: qid });
+      }
+    } else if (qid === 'q3_win') {
+      if (tags.headline) this.draft.wins.push({ headline: tags.headline, metric: tags.metric || null });
+      if (tags.narrativeMd) {
+        this.draft.narratives.push({ title: tags.narrativeTitle || 'A win', content_md: tags.narrativeMd, source_question: qid });
+      }
+    } else if (qid === 'q4_walkaway') {
+      merge('targeting.antiMissionTerms', tags.antiMissionTerms);
+      merge('values_seed.antiCulture', tags.antiCulture);
+    } else if (qid === 'q5_titles') {
+      merge('targeting.targetRoles', tags.targetRoles);
+      merge('targeting.stagePreference', tags.stagePreference);
+    }
+    this._commit();
+  }
+
+  _nextQuestion() {
+    const i = this.draft._meta.questionIdx;
+    if (i < QUESTIONS.length - 1) {
+      this.draft._meta.questionIdx = i + 1;
+      this._commit();
+    } else {
+      this._setStage(4);
+    }
+  }
+  _prevQuestion() {
+    const i = this.draft._meta.questionIdx;
+    if (i > 0) {
+      this.draft._meta.questionIdx = i - 1;
+      this._commit();
+    } else {
+      this._setStage(2);
+    }
+  }
+
+  // ---- Stage 5: commit ----
+  async _finalize() {
+    this.error = '';
+    this.busy = true; this.busyLabel = this.demoMode ? 'Building demo preview…' : 'Saving your profile…';
+    try {
+      const token = await this._token();
+      if (!token) throw new Error('Not signed in.');
+      // Strip _meta from what we send up.
+      const { _meta, ...profile } = this.draft;
+      const result = await callOnboard(token, { mode: 'finalize', profile, demo: this.demoMode });
+      this.finalized = result;
+      if (!this.demoMode && result.ok) {
+        clearDraft();
+      }
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.busy = false; this.busyLabel = '';
+    }
+  }
+
+  _reset() {
+    if (!confirm('Throw away your current onboarding draft?')) return;
+    clearDraft();
+    this.draft = emptyDraft();
+    this.requestUpdate();
+  }
+
+  // ---------- render ----------
+
+  render() {
+    const stage = this.draft._meta.stage || 0;
+    return html`
+      <div class="onboard">
+        ${this._renderStepper(stage)}
+        ${this.demoMode ? html`
+          <div class="onboard__demo-banner">
+            Demo mode — nothing you do here will overwrite your live profile. Drop <code>?demo=1</code> to commit for real.
+          </div>` : nothing}
+        ${this.error ? html`<div class="onboard__demo-banner" style="border-color: var(--error); background: rgba(168,32,13,0.10);">${this.error}</div>` : nothing}
+        ${this.busy ? html`<div class="onboard__hint">${this.busyLabel}</div>` : nothing}
+        ${stage === 0 ? this._renderPitch() : nothing}
+        ${stage === 1 ? this._renderUpload() : nothing}
+        ${stage === 2 ? this._renderConfirm() : nothing}
+        ${stage === 3 ? this._renderQuestions() : nothing}
+        ${stage === 4 ? this._renderKnobs() : nothing}
+        ${stage === 5 ? this._renderPreview() : nothing}
+      </div>
+    `;
+  }
+
+  _renderStepper(stage) {
+    return html`
+      <div class="stepper">
+        ${STAGES.map((s, i) => html`
+          <span class="stepper__item ${s.id === stage ? 'stepper__item--current' : s.id < stage ? 'stepper__item--complete' : ''}">
+            <span class="stepper__dot"></span>
+            ${s.label}
+          </span>
+          ${i < STAGES.length - 1 ? html`<span class="stepper__sep"></span>` : ''}
+        `)}
+      </div>
+    `;
+  }
+
+  _renderPitch() {
+    return html`
+      <section class="onboard__stage">
+        <h1>Your career operating system.</h1>
+        <p class="lede">Upload what you've already written, answer a few open questions, and we'll start pulling roles that match what you actually want — and draft the cover letters too.</p>
+        <p class="onboard__hint">Takes about 8 minutes. You can leave and come back; we'll save where you left off.</p>
+        <div class="onboard__nav">
+          <span></span>
+          <button class="btn btn--primary" @click=${() => this._setStage(1)}>Get started</button>
+        </div>
+      </section>
+    `;
+  }
+
+  _renderUpload() {
+    return html`
+      <section class="onboard__stage">
+        <h1>Drop in what you've got.</h1>
+        <p class="lede">Paste your resume below. We'll pull out the bones (companies, titles, skills, location) so you don't retype them. Skip if you'd rather start from scratch.</p>
+        <div class="dropzone">
+          <div class="dropzone__title">Paste your resume</div>
+          <div class="dropzone__hint">PDF parsing is coming. For now, paste the text — copying from your resume usually works.</div>
+          <textarea id="resume-text" placeholder="Paste resume text here…"></textarea>
+        </div>
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._setStage(2)}>Skip — I'll fill it in</button>
+          <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._parseResume()}>Parse and continue</button>
+        </div>
+      </section>
+    `;
+  }
+
+  _renderConfirm() {
+    const id = this.draft.identity || {};
+    const loc = this.draft.location || {};
+    const cap = this.draft.capability || {};
+    return html`
+      <section class="onboard__stage">
+        <h1>Here's what we found.</h1>
+        <p class="lede">Fix anything that's off. Empty cards mean we didn't have enough to pull from your upload — fill what you can.</p>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">You</h2>
+          ${this._row('Name', 'identity.name', id.name)}
+          ${this._row('Email', 'identity.email', id.email)}
+          ${this._row('Phone', 'identity.phone', id.phone)}
+          ${this._row('LinkedIn', 'identity.linkedin', id.linkedin)}
+          ${this._row('Portfolio', 'identity.portfolio', id.portfolio)}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Location</h2>
+          ${this._row('City', 'location.city', loc.city)}
+          <div class="onboard-card__row">
+            <label>Region</label>
+            <span class="read-only">${[loc.region, loc.country].filter(Boolean).join(' · ') || '—'}${loc.timezone ? ` · ${loc.timezone}` : ''}</span>
+          </div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Career</h2>
+          ${(cap.history || []).length === 0
+            ? html`<p class="onboard__hint">No history pulled. Skip — you can come back to this.</p>`
+            : html`
+              <ul style="display:flex;flex-direction:column;gap:var(--space-3);list-style:none;padding:0;margin:0;">
+                ${cap.history.map((h, i) => html`
+                  <li style="display:flex;flex-direction:column;gap:2px;">
+                    <strong>${h.title || '—'}</strong>
+                    <span class="onboard__hint">${h.company || ''} · ${h.start || ''}${h.end ? `–${h.end}` : ''}</span>
+                    ${h.scope ? html`<span class="onboard__hint">${h.scope}</span>` : ''}
+                  </li>
+                `)}
+              </ul>`}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Skills we spotted</h2>
+          <div class="chip-row">
+            ${(cap.skills || []).map(s => html`
+              <span class="chip chip--editable chip--on">
+                ${s.name}${s.years ? html` · ${s.years}y` : ''}
+                <button @click=${() => { this.draft.capability.skills = cap.skills.filter(x => x !== s); this._commit(); }}>×</button>
+              </span>
+            `)}
+          </div>
+          ${this._chipAdd('Add a skill', (v) => {
+            this.draft.capability.skills.push({ name: v, years: null }); this._commit();
+          })}
+        </div>
+
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._setStage(1)}>Back</button>
+          <button class="btn btn--primary" @click=${() => this._setStage(3)}>Continue</button>
+        </div>
+      </section>
+    `;
+  }
+
+  _row(label, path, value) {
+    return html`
+      <div class="onboard-card__row">
+        <label>${label}</label>
+        <input type="text" .value=${value || ''}
+               @change=${(e) => this._patch(path, e.target.value)}/>
+      </div>
+    `;
+  }
+  _chipAdd(label, onAdd) {
+    return html`
+      <div class="chip-palette__add">
+        <input type="text" placeholder=${label}
+               @keydown=${(e) => {
+                 if (e.key === 'Enter') { e.preventDefault(); const v = e.target.value.trim(); if (v) { onAdd(v); e.target.value = ''; } }
+               }}/>
+      </div>
+    `;
+  }
+
+  _renderQuestions() {
+    const i = this.draft._meta.questionIdx || 0;
+    const q = QUESTIONS[i];
+    const prevAnswer = this.draft._meta.answers[q.id] || '';
+    const lastExtraction = i > 0 ? this.draft._meta.extractions[QUESTIONS[i - 1].id] : null;
+    return html`
+      <section class="onboard__stage">
+        <div class="onboard__hint">Question ${i + 1} of ${QUESTIONS.length}</div>
+        ${lastExtraction ? this._renderExtractionEcho(QUESTIONS[i - 1].id, lastExtraction) : nothing}
+        <div class="chat-prompt">
+          <div class="chat-prompt__label">${q.label}</div>
+          <p class="chat-prompt__help">${q.help}</p>
+          <textarea id="answer-${q.id}" placeholder=${q.placeholder} .value=${prevAnswer}></textarea>
+        </div>
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._prevQuestion()}>Back</button>
+          <span>
+            <button class="btn btn--ghost" @click=${() => this._nextQuestion()}>Skip for now</button>
+            <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._submitAnswer(q)}>Continue</button>
+          </span>
+        </div>
+      </section>
+    `;
+  }
+
+  _renderExtractionEcho(qid, tags) {
+    const rows = [];
+    if (qid === 'q1_mission') {
+      if (tags.missionKeywords?.length) rows.push(['Mission', tags.missionKeywords]);
+      if (tags.impactThemes?.length) rows.push(['Impact', tags.impactThemes]);
+      if (tags.targetSectors?.length) rows.push(['Sectors', tags.targetSectors]);
+    } else if (qid === 'q2_self') {
+      if (tags.cultureKeywords?.length) rows.push(['Culture', tags.cultureKeywords]);
+      if (tags.arcTags?.length) rows.push(['Arc', tags.arcTags]);
+    } else if (qid === 'q3_win') {
+      if (tags.headline) rows.push(['Win', [tags.headline + (tags.metric ? ` · ${tags.metric}` : '')]]);
+    } else if (qid === 'q4_walkaway') {
+      if (tags.antiMissionTerms?.length) rows.push(['Dealbreakers', tags.antiMissionTerms]);
+      if (tags.antiCulture?.length) rows.push(['Anti-culture', tags.antiCulture]);
+    } else if (qid === 'q5_titles') {
+      if (tags.targetRoles?.length) rows.push(['Titles', tags.targetRoles]);
+      if (tags.stagePreference?.length) rows.push(['Stages', tags.stagePreference]);
+    }
+    if (!rows.length) return nothing;
+    return html`
+      <div class="chat-prompt__extracted">
+        <div class="chat-prompt__extracted-title">We heard:</div>
+        ${rows.map(([label, items]) => html`
+          <div class="chat-prompt__row">
+            <span class="chat-prompt__row-label">${label}</span>
+            ${items.map(t => html`<span class="chip chip--on">${t}</span>`)}
+          </div>
+        `)}
+      </div>
+    `;
+  }
+
+  _renderKnobs() {
+    const t = this.draft.targeting || {};
+    const p = this.draft.preferences || {};
+    const loc = this.draft.location || {};
+    const c = this.draft.capability || {};
+    return html`
+      <section class="onboard__stage">
+        <h1>The fast knobs.</h1>
+        <p class="lede">Things that are easier to click than to write.</p>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Target sectors</h2>
+          ${this._palette(SECTORS_PALETTE, t.targetSectors || [], 'targeting.targetSectors')}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Stage preference</h2>
+          ${this._palette(STAGE_PALETTE, t.stagePreference || [], 'targeting.stagePreference')}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Arc tags</h2>
+          <p class="onboard__hint">Stage/role-shape you want next.</p>
+          ${this._palette(ARC_PALETTE, c.arcTags || [], 'capability.arcTags')}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Dealbreakers</h2>
+          ${this._palette(DEALBREAKER_PALETTE, t.antiMissionTerms || [], 'targeting.antiMissionTerms')}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Work authorization</h2>
+          ${this._palette(WORK_AUTH_PALETTE, loc.workAuth || [], 'location.workAuth')}
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Remote / hybrid / onsite</h2>
+          <div class="segmented">
+            ${['remote', 'hybrid', 'onsite', 'any'].map(opt => html`
+              <button aria-pressed=${(p.remotePreference || 'any') === opt ? 'true' : 'false'}
+                      @click=${() => { this._patch('preferences.remotePreference', opt); this._patch('location.remotePreference', opt); }}>${opt}</button>
+            `)}
+          </div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Comp floor (base, USD)</h2>
+          <input type="range" min="0" max="400000" step="5000"
+                 .value=${String(p.compFloor ?? 150000)}
+                 @input=${(e) => this._patch('preferences.compFloor', Number(e.target.value))}/>
+          <div class="onboard__hint">${(p.compFloor ?? 150000).toLocaleString()} minimum</div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Mission alignment</h2>
+          <label style="display:flex;gap:var(--space-3);align-items:center;cursor:pointer;">
+            <input type="checkbox" .checked=${!!p.missionRequired}
+                   @change=${(e) => { this._patch('preferences.missionRequired', e.target.checked); this._patch('targeting.missionRequired', e.target.checked); }}/>
+            <span>Mission alignment is a hard requirement</span>
+          </label>
+        </div>
+
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._setStage(3)}>Back</button>
+          <button class="btn btn--primary" @click=${() => this._setStage(5)}>See preview</button>
+        </div>
+      </section>
+    `;
+  }
+
+  _palette(options, selected, path) {
+    const sel = new Set(selected);
+    return html`
+      <div class="chip-palette">
+        <div class="chip-palette__chips">
+          ${options.map(opt => html`
+            <button class="chip ${sel.has(opt) ? 'chip--on' : ''}"
+                    @click=${() => this._toggleInArr(path, opt)}>${opt}</button>
+          `)}
+          ${[...sel].filter(v => !options.includes(v)).map(opt => html`
+            <span class="chip chip--editable chip--on">${opt}
+              <button @click=${() => this._toggleInArr(path, opt)}>×</button>
+            </span>
+          `)}
+        </div>
+        ${this._chipAdd('Add custom…', (v) => { if (!sel.has(v)) this._toggleInArr(path, v); })}
+      </div>
+    `;
+  }
+
+  _renderPreview() {
+    if (this.finalized) {
+      return html`
+        <section class="onboard__stage">
+          <h1>${this.demoMode ? 'Demo preview' : 'You\'re in.'}</h1>
+          <p class="lede">${this.demoMode
+            ? 'Nothing was saved — this is what would have been written.'
+            : 'Your profile is saved. /job is unlocked.'}</p>
+          <div class="onboard-preview">
+            <pre>${JSON.stringify(this.finalized, null, 2)}</pre>
+          </div>
+          <div class="onboard__nav">
+            ${this.demoMode
+              ? html`<button class="btn btn--ghost" @click=${() => this._reset()}>Start over</button>`
+              : html`<span></span>`}
+            <a class="btn btn--primary" href="/job/jobs/recommended/">Open /job</a>
+          </div>
+        </section>
+      `;
+    }
+    const { _meta, ...profile } = this.draft;
+    return html`
+      <section class="onboard__stage">
+        <h1>Look right?</h1>
+        <p class="lede">${this.demoMode
+          ? 'You\'re in demo mode. Hit commit and we\'ll show what would be written.'
+          : 'Hit commit and we\'ll save this and start pulling roles.'}</p>
+        <div class="onboard-preview">
+          <pre>${JSON.stringify(profile, null, 2)}</pre>
+        </div>
+        <div class="onboard__nav">
+          <button class="btn btn--ghost" @click=${() => this._setStage(4)}>Back to tweak</button>
+          <button class="btn btn--primary" ?disabled=${this.busy} @click=${() => this._finalize()}>${this.demoMode ? 'Show demo result' : 'Commit and open /job'}</button>
+        </div>
+      </section>
+    `;
+  }
+}
+
+customElements.define('job-onboarding', JobOnboarding);

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -43,8 +43,9 @@ const ROUTES = [
       { href: '/job/jobs/?bucket=archive',   label: 'Archive',              bucket: 'archive' },
     ],
   },
-  { href: '/job/history/', label: 'Your career', match: /^\/job\/history\/?/ },
-  { href: '/job/vision/',  label: 'Search plan', match: /^\/job\/vision\/?/ }
+  { href: '/job/history/',  label: 'Your career', match: /^\/job\/history\/?/ },
+  { href: '/job/vision/',   label: 'Search plan', match: /^\/job\/vision\/?/ },
+  { href: '/job/settings/', label: 'Settings',    match: /^\/job\/settings\/?/ }
 ];
 
 export class JobRail extends LitElement {

--- a/job/js/components/job-settings.js
+++ b/job/js/components/job-settings.js
@@ -1,0 +1,118 @@
+// job-settings — minimal settings page.
+//
+// MVP scope: show the current user's profile (read from public.user_profile,
+// RLS-scoped to them) and give an entry point into the onboarding flow in
+// demo mode so they can re-walk it without overwriting their live profile.
+//
+// Out of scope here (lives elsewhere): editing structured fields is done in
+// <job-vision>'s tabbed editor on the markdown KB. This page is the
+// router/launcher.
+
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+
+export class JobSettings extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    profile: { state: true },
+    loading: { state: true },
+    email:   { state: true },
+  };
+
+  constructor() {
+    super();
+    this.profile = null;
+    this.loading = true;
+    this.email = '';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._load();
+    this._onReady = () => this._load();
+    document.addEventListener('job:auth:ready', this._onReady);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('job:auth:ready', this._onReady);
+    super.disconnectedCallback();
+  }
+
+  async _load() {
+    const sb = window.CtrlAuth?.getSupabaseClient?.();
+    if (!sb) return;
+    this.loading = true;
+    try {
+      const { data: { user } } = await sb.auth.getUser();
+      this.email = user?.email || '';
+      const { data, error } = await sb
+        .from('user_profile')
+        .select('*')
+        .maybeSingle();
+      if (error) { console.warn('[settings] profile fetch failed', error); }
+      this.profile = data;
+    } finally {
+      this.loading = false;
+    }
+  }
+
+  async _restartOnboarding(demo = true) {
+    if (demo) {
+      window.location.href = '/job/onboarding/?demo=1';
+      return;
+    }
+    if (!confirm('Re-run onboarding for real? This will overwrite your saved profile when you commit at the end.')) return;
+    window.location.href = '/job/onboarding/';
+  }
+
+  render() {
+    if (this.loading) return html`<p class="onboard__hint">Loading…</p>`;
+    const p = this.profile || {};
+    const completed = !!p.onboarding_complete_at;
+    return html`
+      <div class="onboard" style="max-width:760px;">
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Account</h2>
+          <div class="onboard-card__row">
+            <label>Email</label>
+            <span class="read-only">${this.email || '—'}</span>
+          </div>
+          <div class="onboard-card__row">
+            <label>Status</label>
+            <span class="read-only">
+              ${completed
+                ? `Onboarded ${new Date(p.onboarding_complete_at).toLocaleDateString()}`
+                : 'Onboarding incomplete'}
+            </span>
+          </div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Test the onboarding flow</h2>
+          <p class="onboard__hint">Demo mode walks you through the full flow without touching your live profile. Nothing is committed.</p>
+          <div style="display:flex;gap:var(--space-3);flex-wrap:wrap;">
+            <button class="btn btn--primary" @click=${() => this._restartOnboarding(true)}>Open onboarding (demo)</button>
+            <button class="btn" @click=${() => this._restartOnboarding(false)}>Re-run for real</button>
+          </div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">Your profile</h2>
+          <p class="onboard__hint">Read-only view. Edit structured fields on <a href="/job/vision/">Search plan</a>.</p>
+          <div class="onboard-preview">
+            <pre>${JSON.stringify({
+              identity: p.identity,
+              location: p.location,
+              targeting: p.targeting,
+              values_seed: p.values_seed,
+              capability: p.capability,
+              preferences: p.preferences,
+              wins: p.wins,
+            }, null, 2)}</pre>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('job-settings', JobSettings);

--- a/job/js/pdf-extract.js
+++ b/job/js/pdf-extract.js
@@ -1,0 +1,53 @@
+// pdf-extract — shared client-side file-to-text helper.
+//
+// .md / .txt → UTF-8.
+// .pdf       → pdfjs-dist v4, lazy-loaded from jsdelivr.
+// other      → best-effort .text().
+//
+// Used by:
+//   - job/js/components/job-career.js (Base resume / Work history uploads)
+//   - job/js/components/job-onboarding.js (Stage 1 multi-doc bundle)
+
+let _pdfLib = null;
+async function getPdfLib() {
+  if (_pdfLib) return _pdfLib;
+  const PDFJS_VERSION = '4.7.76';
+  const mod = await import(`https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.mjs`);
+  mod.GlobalWorkerOptions.workerSrc =
+    `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_VERSION}/legacy/build/pdf.worker.min.mjs`;
+  _pdfLib = mod;
+  return mod;
+}
+
+async function readPdfAsText(file) {
+  const lib = await getPdfLib();
+  const buf = await file.arrayBuffer();
+  const doc = await lib.getDocument({ data: buf, isEvalSupported: false }).promise;
+  const pages = [];
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i);
+    const tc = await page.getTextContent();
+    // Re-flow text items into lines using their y coordinates so page order
+    // matches reading order. Without this PDFs come out as a token soup.
+    const lines = new Map();
+    for (const item of tc.items) {
+      const y = Math.round(item.transform[5]);
+      if (!lines.has(y)) lines.set(y, []);
+      lines.get(y).push(item);
+    }
+    const ordered = Array.from(lines.entries())
+      .sort((a, b) => b[0] - a[0])
+      .map(([, items]) => items.sort((a, b) => a.transform[4] - b.transform[4]).map(i => i.str).join(' ').replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+    pages.push(ordered.join('\n'));
+  }
+  return pages.join('\n\n').trim();
+}
+
+export async function readFileAsText(file) {
+  const name = (file.name || '').toLowerCase();
+  if (name.endsWith('.pdf') || file.type === 'application/pdf') {
+    return await readPdfAsText(file);
+  }
+  return await file.text();
+}

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,9 +6,9 @@
   <title>Welcome to /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,6 +30,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,9 +6,9 @@
   <title>Welcome to /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -17,22 +17,19 @@
   <section id="signin-gate" class="gate">
     <div class="gate__card">
       <h1>/job</h1>
-      <p>Your career operating system. Upload what you've already written, answer a few open questions, and we'll start pulling roles that match what you actually want — and draft the cover letters too.</p>
-      <button class="btn btn--primary" id="signin-btn">Sign in to get started</button>
+      <p>Your career operating system. Sign in to start.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
   </section>
 
   <div class="app">
+    <job-rail></job-rail>
     <main class="app__main">
-      <section class="onboarding-placeholder">
-        <h1>Welcome to /job</h1>
-        <p>The onboarding flow is being built. For now, your account is set up — check back soon.</p>
-        <p class="muted">PRD: <code>docs/strategy/prds/job-onboarding-flow.md</code></p>
-      </section>
+      <job-onboarding></job-onboarding>
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -3,10 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Jobs — /job</title>
+  <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.80.0">
   <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -16,7 +17,7 @@
   <section id="signin-gate" class="gate">
     <div class="gate__card">
       <h1>/job</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <p>Sign in to view settings.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -26,9 +27,10 @@
     <job-rail></job-rail>
     <main class="app__main">
       <header class="page-header">
-        <h1>Jobs</h1>
+        <h1>Settings</h1>
+        <p>Profile, onboarding, and demo entry points.</p>
       </header>
-      <job-pipeline></job-pipeline>
+      <job-settings></job-settings>
     </main>
   </div>
 

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
-  <script src="/job/js/theme.js?v=0.80.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.81.0">
+  <script src="/job/js/theme.js?v=0.81.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.81.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.79.0">
-  <script src="/job/js/theme.js?v=0.79.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.80.0">
+  <script src="/job/js/theme.js?v=0.80.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.79.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.80.0"></script>
 </body>
 </html>

--- a/supabase/functions/onboard/index.ts
+++ b/supabase/functions/onboard/index.ts
@@ -1,0 +1,298 @@
+// onboard — Phase 2/3 of the /job onboarding flow.
+//
+// One edge function, three modes (kept together so the prompt-shape +
+// JSON-schema contract lives in one file):
+//
+//   POST { mode: 'parse',    text }                 → draft profile from resume/text
+//   POST { mode: 'extract',  questionId, answer }   → tags/structured bits for one freeform answer
+//   POST { mode: 'finalize', profile, demo? }       → commit (or preview) the full profile
+//
+// All routes require a signed-in user with a user_profile row
+// (verifyJobUserDetailed). RLS does the second-line enforcement when we
+// read/write user_profile.
+//
+// PRD: docs/strategy/prds/job-onboarding-flow.md
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[onboard] v${VERSION} - parse/extract/finalize for /job onboarding`);
+
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const MAX_INPUT_CHARS = 32 * 1024;
+
+interface Identity {
+  name?: string;
+  email?: string;
+  phone?: string;
+  linkedin?: string;
+  portfolio?: string;
+  github?: string;
+}
+interface Location {
+  city?: string;
+  region?: string;
+  country?: string;
+  timezone?: string;
+  remotePreference?: 'remote' | 'hybrid' | 'onsite' | 'any';
+  willingToRelocate?: string[];
+  workAuth?: string[];
+}
+interface HistoryItem {
+  company?: string;
+  title?: string;
+  start?: string;
+  end?: string;
+  scope?: string;
+}
+interface Skill { name: string; years?: number | null }
+interface DraftProfile {
+  identity: Identity;
+  location: Location;
+  capability: {
+    skills: Skill[];
+    pastSectors: string[];
+    arcTags: string[];
+    history: HistoryItem[];
+  };
+  values_seed: {
+    missionKeywords: string[];
+    impactThemes: string[];
+    cultureKeywords: string[];
+    antiCulture: string[];
+  };
+  targeting: {
+    targetRoles: string[];
+    targetSectors: string[];
+    stagePreference: string[];
+    antiMissionTerms: string[];
+    missionRequired: boolean;
+  };
+  preferences: {
+    compFloor: number | null;
+    remotePreference: 'remote' | 'hybrid' | 'onsite' | 'any';
+    missionRequired: boolean;
+  };
+  wins: Array<{ headline: string; metric?: string | null }>;
+  narratives: Array<{ title: string; content_md: string; source_question?: string }>;
+}
+
+function emptyDraft(): DraftProfile {
+  return {
+    identity: {},
+    location: {},
+    capability: { skills: [], pastSectors: [], arcTags: [], history: [] },
+    values_seed: { missionKeywords: [], impactThemes: [], cultureKeywords: [], antiCulture: [] },
+    targeting: { targetRoles: [], targetSectors: [], stagePreference: [], antiMissionTerms: [], missionRequired: false },
+    preferences: { compFloor: null, remotePreference: 'any', missionRequired: false },
+    wins: [],
+    narratives: [],
+  };
+}
+
+async function callClaudeJson(system: string, user: string, maxTokens = 2048): Promise<unknown> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  const stripped = text.replace(/^```(?:json)?\s*/, '').replace(/\s*```$/, '').trim();
+  try { return JSON.parse(stripped); } catch { /* fall through */ }
+  const start = stripped.indexOf('{');
+  const end = stripped.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    try { return JSON.parse(stripped.slice(start, end + 1)); } catch { /* */ }
+  }
+  throw new Error('claude returned non-JSON: ' + stripped.slice(0, 200));
+}
+
+// ---------- parse: resume text → draft profile ----------
+
+const PARSE_SYSTEM = `You parse a person's resume or LinkedIn export into a structured draft profile for their job-search workspace. Be conservative: extract only what's clearly stated. Empty array > guessed value. Return ONLY JSON matching this shape:
+
+{
+  "identity": { "name": string?, "email": string?, "phone": string?, "linkedin": string?, "portfolio": string?, "github": string? },
+  "location": { "city": string?, "region": string?, "country": string? },
+  "capability": {
+    "skills": [{ "name": string, "years": number|null }],
+    "pastSectors": [string],
+    "arcTags": [string],
+    "history": [{ "company": string, "title": string, "start": string, "end": string|null, "scope": string }]
+  }
+}
+
+Rules:
+- skills: top 8-12 max, ordered by depth/prominence. years inferred conservatively from role tenure.
+- pastSectors: sector tags like "fintech", "healthtech", "climate", "civic-tech", "edtech", "consumer-social".
+- arcTags: stage/role-shape tags. Use only: "zero-to-one", "scale-up", "turnaround", "ic-to-manager", "founder", "scaling-team", "scaling-revenue".
+- history: most recent first. Dates as "YYYY-MM" or "YYYY" or "Present" for end.
+- scope: one short line (≤ 12 words) describing what they did in that role.`;
+
+async function modeParse(text: string): Promise<unknown> {
+  const trimmed = text.slice(0, MAX_INPUT_CHARS);
+  return await callClaudeJson(PARSE_SYSTEM, trimmed, 3000);
+}
+
+// ---------- extract: per-question tag extraction ----------
+
+interface QuestionSpec {
+  id: string;
+  label: string;
+  schema: string;
+  notes?: string;
+}
+
+const QUESTIONS: Record<string, QuestionSpec> = {
+  q1_mission: {
+    id: 'q1_mission',
+    label: 'What problem do you want to spend the next five years on?',
+    schema: `{ "missionKeywords": [string], "impactThemes": [string], "targetSectors": [string], "summary": string }`,
+    notes: 'missionKeywords: 3-6 short phrases that capture the *problem domain*. impactThemes: the verbs/outcomes ("reduce friction in public services"). targetSectors: industry tags like "civic-tech", "climate", "healthtech". summary: one-sentence reframe of what they said.',
+  },
+  q2_self: {
+    id: 'q2_self',
+    label: 'Describe a time at work where you felt most yourself.',
+    schema: `{ "cultureKeywords": [string], "arcTags": [string], "narrativeTitle": string, "narrativeMd": string }`,
+    notes: 'cultureKeywords: 3-6 short phrases describing the working environment that energizes them ("high-agency", "research-led", "small team"). arcTags from: zero-to-one, scale-up, turnaround, ic-to-manager, founder, scaling-team, scaling-revenue. narrativeTitle: 4-8 word title. narrativeMd: the user\'s answer lightly cleaned (do not rewrite).',
+  },
+  q3_win: {
+    id: 'q3_win',
+    label: 'A win you\'re proud of — ideally with a number attached.',
+    schema: `{ "headline": string, "metric": string|null, "narrativeTitle": string, "narrativeMd": string }`,
+    notes: 'headline: ≤ 12 words capturing the win. metric: the number or measurable result if any (e.g. "+34% retention", "$2M ARR in 9 months", "team of 12"). null if none mentioned. narrative: same as q2.',
+  },
+  q4_walkaway: {
+    id: 'q4_walkaway',
+    label: 'What would make you walk away from a great offer?',
+    schema: `{ "antiMissionTerms": [string], "antiCulture": [string], "dealbreakers": [string] }`,
+    notes: 'antiMissionTerms: industry/category dealbreakers ("defense", "gambling", "crypto", "adtech"). antiCulture: environment dealbreakers ("hustle culture", "RTO", "ego-driven leadership"). dealbreakers: free-form catch-all for anything else.',
+  },
+  q5_titles: {
+    id: 'q5_titles',
+    label: 'What roles and titles should we be hunting for?',
+    schema: `{ "targetRoles": [string], "stagePreference": [string], "antiTitles": [string] }`,
+    notes: 'targetRoles: 2-4 title patterns ("Head of Product", "Founding PM"). stagePreference from: pre-seed, seed, series-a, series-b, growth, public. antiTitles: titles to exclude.',
+  },
+  q6_location: {
+    id: 'q6_location',
+    label: 'Where are you based, and how far are you willing to go?',
+    schema: `{ "city": string, "willingToRelocate": [string], "remotePreference": "remote"|"hybrid"|"onsite"|"any" }`,
+    notes: 'city: just the city name. willingToRelocate: city names + "Remote-US", "Remote-EU" style chips. remotePreference: the strongest signal in their answer.',
+  },
+};
+
+async function modeExtract(questionId: string, answer: string): Promise<unknown> {
+  const q = QUESTIONS[questionId];
+  if (!q) throw new Error(`unknown questionId: ${questionId}`);
+  const system = `You extract structured tags from a user's freeform answer to a single onboarding question. The question was: "${q.label}". Return ONLY JSON matching this shape:\n${q.schema}\n${q.notes || ''}\n\nBe specific and concise. Empty array > guessed value. Echo the user's own language where possible — do not impose vocabulary they didn't use.`;
+  return await callClaudeJson(system, answer.slice(0, 8000), 1500);
+}
+
+// ---------- finalize: commit profile ----------
+
+interface FinalizeBody {
+  profile: Partial<DraftProfile>;
+  demo?: boolean;
+}
+
+async function modeFinalize(userId: string, body: FinalizeBody): Promise<unknown> {
+  const merged = { ...emptyDraft(), ...body.profile };
+  if (body.demo) {
+    return {
+      ok: true,
+      demo: true,
+      preview: {
+        wouldWrite: {
+          identity: merged.identity,
+          location: merged.location,
+          targeting: merged.targeting,
+          values_seed: merged.values_seed,
+          capability: merged.capability,
+          preferences: merged.preferences,
+          wins: merged.wins,
+          narrativeCount: (merged.narratives || []).length,
+        },
+        note: 'Demo mode — nothing was written to user_profile and onboarding_complete_at was not flipped.',
+      },
+    };
+  }
+  const sql = db();
+  await sql`
+    insert into public.user_profile (
+      user_id, identity, location, targeting, values_seed, capability,
+      preferences, wins, onboarding_step, onboarding_complete_at
+    ) values (
+      ${userId},
+      ${sql.json(merged.identity)}, ${sql.json(merged.location)},
+      ${sql.json(merged.targeting)}, ${sql.json(merged.values_seed)},
+      ${sql.json(merged.capability)}, ${sql.json(merged.preferences)},
+      ${sql.json(merged.wins)}, 5, now()
+    )
+    on conflict (user_id) do update set
+      identity = excluded.identity,
+      location = excluded.location,
+      targeting = excluded.targeting,
+      values_seed = excluded.values_seed,
+      capability = excluded.capability,
+      preferences = excluded.preferences,
+      wins = excluded.wins,
+      onboarding_step = 5,
+      onboarding_complete_at = coalesce(public.user_profile.onboarding_complete_at, now())
+  `;
+  return { ok: true, demo: false, completed_at: new Date().toISOString() };
+}
+
+// ---------- HTTP ----------
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  const user = await verifyJobUserDetailed(req);
+  if (!user) return err('unauthorized', 401);
+
+  let body: { mode?: string; text?: string; questionId?: string; answer?: string; profile?: Partial<DraftProfile>; demo?: boolean };
+  try { body = await req.json(); } catch { return err('invalid json'); }
+
+  try {
+    switch (body.mode) {
+      case 'parse': {
+        if (!body.text) return err('text required');
+        const draft = await modeParse(body.text);
+        return jsonResp({ draft });
+      }
+      case 'extract': {
+        if (!body.questionId || !body.answer) return err('questionId + answer required');
+        const tags = await modeExtract(body.questionId, body.answer);
+        return jsonResp({ tags });
+      }
+      case 'finalize': {
+        if (!body.profile) return err('profile required');
+        const result = await modeFinalize(user.id, { profile: body.profile, demo: !!body.demo });
+        return jsonResp(result);
+      }
+      default:
+        return err(`unknown mode: ${body.mode}`);
+    }
+  } catch (e) {
+    console.error('[onboard] error', e);
+    return err((e as Error).message || 'internal error', 500);
+  }
+});

--- a/supabase/functions/onboard/index.ts
+++ b/supabase/functions/onboard/index.ts
@@ -17,8 +17,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.1.0';
-console.log(`[onboard] v${VERSION} - parse/extract/finalize for /job onboarding`);
+const VERSION = '0.2.0';
+console.log(`[onboard] v${VERSION} - parse/bundle/insights/extract/finalize`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -150,6 +150,65 @@ async function modeParse(text: string): Promise<unknown> {
   return await callClaudeJson(PARSE_SYSTEM, trimmed, 3000);
 }
 
+// ---------- insights: profile → "what you bring" celebration narrative ----------
+//
+// Three distinct translation tracks so the user sees what kind of move each
+// piece of their background unlocks. Domains (what industries you know) ≠
+// work areas (what flows/problems you've shipped) ≠ craft (PM/IC skills).
+// Each track lists what they HAVE and what it TRANSLATES TO so adjacent
+// sectors become legible without claiming they have experience they don't.
+
+const INSIGHTS_SYSTEM = `You generate a celebration / sector-translation insight card for a job-seeker's onboarding flow. Given their parsed profile (history, sectors, skills, scope lines), return ONLY JSON in this shape:
+
+{
+  "hero": string,
+  "domains":   [{ "have": string, "translatesTo": [string] }],
+  "workAreas": [{ "have": string, "translatesTo": [string] }],
+  "skills":    [{ "have": string, "translatesTo": [string] }]
+}
+
+Rules:
+- hero: one ≤ 60-word paragraph in Wise's voice (sentence case, warm, specific). Quote at least one number from their history. End by naming 2-3 directions their experience unlocks.
+- domains: industries / verticals they've operated in. translatesTo lists adjacent verticals that hire that domain knowledge ("public-benefit navigation", "civic-tech eligibility", "patient onboarding for DTC mental health"). 2-4 entries max.
+- workAreas: specific problem-spaces / flows / capabilities they've shipped — *not* industries ("user onboarding", "eligibility verification", "engagement loops", "retention", "growth experimentation"). translatesTo lists what that ships into next ("ID verification flows", "benefits applications", "conversion funnels for healthtech DTC"). 2-4 entries max.
+- skills: craft they bring — *not* domains, *not* workflows ("product management", "growth experimentation", "user research", "team leadership"). translatesTo lists role shapes their craft unlocks next ("founding PM at seed civic-tech", "head of product at public-benefit org", "growth lead at DTC health"). 2-4 entries max.
+
+Keep these three tracks DISTINCT. A "domain" is a vertical, a "work area" is a problem/flow, a "skill" is a craft. Do not mix them. If you can't fill one track confidently from their data, return [] for that track rather than padding.`;
+
+async function modeInsights(profile: unknown): Promise<unknown> {
+  const userText = `Parsed profile:\n${JSON.stringify(profile, null, 2)}`;
+  return await callClaudeJson(INSIGHTS_SYSTEM, userText, 2000);
+}
+
+// ---------- bundle: multi-doc context pass ----------
+//
+// Resume text is the primary "parse" input; everything else (cover letters,
+// writing samples, LLM transcripts, project descriptions, dream JDs) goes
+// through this pass which pulls voice, values signals, projects, and
+// dream-role tells without re-parsing structured history.
+
+const BUNDLE_SYSTEM = `You read a bundle of supporting documents a job-seeker has uploaded (cover letters, writing samples, LLM-generated career docs, project descriptions, dream job descriptions, notes-to-self). Return ONLY JSON:
+
+{
+  "voiceSample":     string,
+  "values":          [string],
+  "projects":        [{ "title": string, "summary": string, "metric": string|null }],
+  "dreamRoleSignals":[string],
+  "wins":            [{ "headline": string, "metric": string|null }]
+}
+
+Rules:
+- voiceSample: ≤ 200 words verbatim or lightly stitched from THEIR words — the cover-letter agent uses this for voice. Choose the most distinctive 2-3 sentences.
+- values: 3-6 short phrases capturing what they care about ("public benefit", "high-agency teams", "research-led product").
+- projects: anything they describe as a project/initiative they led. summary ≤ 25 words. metric null when no number stated.
+- dreamRoleSignals: if any dream JDs are present, pull 3-5 short phrases describing the shape of role they want.
+- wins: numbered accomplishments mentioned. Empty array if none.`;
+
+async function modeBundle(text: string): Promise<unknown> {
+  const trimmed = text.slice(0, MAX_INPUT_CHARS);
+  return await callClaudeJson(BUNDLE_SYSTEM, trimmed, 2500);
+}
+
 // ---------- extract: per-question tag extraction ----------
 
 interface QuestionSpec {
@@ -277,6 +336,16 @@ serve(async (req: Request) => {
         if (!body.text) return err('text required');
         const draft = await modeParse(body.text);
         return jsonResp({ draft });
+      }
+      case 'bundle': {
+        if (!body.text) return err('text required');
+        const bundle = await modeBundle(body.text);
+        return jsonResp({ bundle });
+      }
+      case 'insights': {
+        if (!body.profile) return err('profile required');
+        const insights = await modeInsights(body.profile);
+        return jsonResp({ insights });
       }
       case 'extract': {
         if (!body.questionId || !body.answer) return err('questionId + answer required');


### PR DESCRIPTION
## Summary

Rev of the onboarding flow per UX feedback. PRD updated: [`docs/strategy/prds/job-onboarding-flow.md`](docs/strategy/prds/job-onboarding-flow.md).

**Five stages now (was six):**
1. Welcome
2. **Upload** — multi-file dropzone (resume + cover letters + writing samples + LLM career docs + dream JDs). PDF extraction reused from `job-career.js`, promoted to shared `job/js/pdf-extract.js`.
3. **Insights** — celebration hero + three translation tracks (Domains / Work areas / Craft) + collapsible edit panel. Replaces form-field "Confirm".
4. **Questions** — chat UX (tryapt pattern, Wise tokens). Bottom-anchored composer, "We heard:" ack between turns.
5. **Tailor** — "How we'll tailor your search." Four grouped sections with "You said:" excerpts. Single commit CTA at the bottom; no separate preview.

**Debug:** the JSON dump survives behind `?debug=1` for QA. Never shown in the live flow.

**Edge function `onboard` v0.2.0** adds `bundle` (voice/values/projects from supporting docs) and `insights` (3-track translation card) modes. Deployed.

## Demo path

1. Sign in → `/job/settings/` → **Open onboarding (demo)**.
2. Drop in resume + any supporting docs (multi-select works).
3. Insight hero renders with hero paragraph + three distinct tracks.
4. Chat through five questions; each turn shows the prior turn's extracted tags.
5. Tailor groups prepopulated with "you said:" excerpts.
6. **Show me what we'd save** → demo preview inline.

Add `?debug=1` to any URL on the flow to see the live JSON state.

## Test plan

- [ ] `/job/settings/` → demo entry works.
- [ ] Multi-file upload: PDF + text resume together.
- [ ] Insights hero renders with three populated tracks (Domains, Work areas, Craft).
- [ ] Skipping upload routes to cold-start "Let's start with the basics".
- [ ] Chat UX: ⌘+Enter sends; Skip advances; previous extraction echo renders.
- [ ] Tailor groups show verbatim "You said:" excerpts.
- [ ] `?debug=1` shows JSON panel.
- [ ] Live commit (no `?demo=1`) routes to `/job/jobs/recommended/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)