### PR TITLE
job: chat takeover — full-screen, minimal, ChatGPT-style landing

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -4168,19 +4168,53 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
 /* Chat (Stage 3) */
 /* Chat surface — apt-inspired scrolling log. AI turns are plain inline
    text (no bubble). User turns are outlined cards, right-aligned. */
+/* Chat surface — full-screen, ChatGPT-inspired, minimal.
+   Two states:
+     .chat--landing  — empty log; composer + first question centered.
+     .chat--active   — log fills, composer pinned bottom.
+   Distinction between user and AI is alignment + subtle color shift only.
+   No bubble cards, no borders around messages, no surface cards. */
+
 .chat {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
-  height: calc(100vh - 240px);
-  min-height: 480px;
-}
-.chat__progress-bar {
+  flex: 1;
+  min-height: 0;
   width: 100%;
-  height: 3px;
-  background: var(--border);
-  border-radius: 999px;
-  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  padding-top: env(safe-area-inset-top);
+  gap: 0;
+}
+
+/* Full-bleed when the chat stage is active. */
+job-onboarding { display: contents; }
+.onboard:has(.chat) {
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  gap: 0;
+  flex: 1;
+  min-height: 100dvh;
+}
+.onboard:has(.chat) > .stepper,
+.onboard:has(.chat) > .onboard__demo-banner {
+  max-width: 720px;
+  margin: var(--space-3) auto 0;
+  padding: 0 var(--space-4);
+}
+.onboard:has(.chat) > .onboard__stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat__progress-bar {
+  flex: none;
+  width: 100%;
+  height: 2px;
+  background: transparent;
 }
 .chat__progress-bar > span {
   display: block;
@@ -4188,37 +4222,75 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   background: var(--accent-strong);
   transition: width 240ms ease-out;
 }
+
 .chat__log {
   flex: 1;
+  min-height: 0;
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
-  padding: var(--space-3) 0 var(--space-4);
+  gap: var(--space-6);
   scroll-behavior: smooth;
 }
+
+/* Landing state: log becomes a vertically centered hero with no scrolling. */
+.chat--landing .chat__log {
+  overflow: hidden;
+  justify-content: center;
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
+}
+
+.chat__hero {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: 0 var(--space-3);
+}
+.chat__hero-question {
+  font-size: var(--font-size-title-2);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: var(--lh-title);
+  color: var(--fg);
+  margin: 0;
+}
+
+/* AI + user turns — same body size, no containers. Distinction is
+   alignment + color. */
+.chat__ai,
+.chat__user {
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  font-weight: 400;
+  margin: 0;
+  max-width: 100%;
+}
 .chat__ai {
-  max-width: 720px;
+  align-self: flex-start;
+  color: var(--fg);
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  color: var(--fg);
-  line-height: var(--lh-body);
+}
+.chat__ai-reflection,
+.chat__ai-question {
+  margin: 0;
 }
 .chat__ai-reflection {
   color: var(--fg-muted);
-  margin: 0;
 }
 .chat__ai-question {
-  font-size: var(--font-size-title-3);
-  font-weight: 600;
-  line-height: var(--lh-title);
-  margin: 0;
   color: var(--fg);
+  font-weight: 500;
 }
 .chat__ai--thinking {
   color: var(--fg-muted);
-  font-size: var(--font-size-title-3);
   letter-spacing: 0.15em;
   animation: chat-thinking 1.2s ease-in-out infinite;
 }
@@ -4228,55 +4300,90 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
 }
 .chat__user {
   align-self: flex-end;
-  max-width: 70%;
-  border: 1px solid var(--border-strong);
-  border-radius: 24px;
-  padding: var(--space-3) var(--space-4);
-  background: var(--bg);
+  text-align: right;
   color: var(--fg);
-  line-height: var(--lh-body);
+  white-space: pre-wrap;
+}
+
+/* Composer — sticky to bottom in active, centered hero in landing. */
+.chat__composer-wrap {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background: var(--bg);
+  padding: var(--space-3) var(--space-4) calc(var(--space-3) + env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.chat--landing .chat__composer-wrap {
+  position: static;
+  padding-top: 0;
+}
+.chat__composer-wrap > * {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto;
 }
 
 .chat__composer {
-  position: sticky;
-  bottom: var(--space-3);
   display: grid;
-  grid-template-columns: 40px 1fr 40px;
+  grid-template-columns: 36px 1fr 36px;
   gap: var(--space-2);
   align-items: end;
   background: var(--bg);
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 6px 8px;
+}
+.chat__composer:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
 }
 .chat__attach {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
-  border: 1px solid var(--border);
+  width: 36px;
+  height: 36px;
   border-radius: 999px;
-  background: var(--bg);
+  background: transparent;
   color: var(--fg-muted);
   cursor: pointer;
   font-size: 22px;
   line-height: 1;
 }
-.chat__attach:hover { border-color: var(--border-strong); color: var(--fg); }
+.chat__attach:hover { color: var(--fg); }
 .chat__composer textarea {
   width: 100%;
-  min-height: 44px;
+  min-height: 36px;
   max-height: 200px;
-  padding: var(--space-3) var(--space-4);
-  border: 1px solid var(--border);
-  border-radius: 24px;
-  background: var(--bg);
+  padding: 8px 4px;
+  border: 0;
+  background: transparent;
   color: var(--fg);
   font: inherit;
+  font-size: var(--font-size-body);
   line-height: var(--lh-body);
-  resize: vertical;
+  resize: none;
+  outline: none;
 }
-.chat__composer textarea:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.chat__send {
+  appearance: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 0;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.chat__send:disabled { opacity: 0.35; cursor: default; }
 .chat__composer-row {
   display: flex;
   justify-content: space-between;
@@ -4290,15 +4397,14 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
 .chat__pill {
   appearance: none;
   background: transparent;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
-  padding: var(--space-2) var(--space-3);
+  border: 0;
+  padding: 4px var(--space-2);
   font: inherit;
-  font-size: var(--font-size-small);
+  font-size: var(--font-size-caption);
   color: var(--fg-muted);
   cursor: pointer;
 }
-.chat__pill:hover { border-color: var(--border-strong); color: var(--fg); }
+.chat__pill:hover { color: var(--fg); text-decoration: underline; }
 .btn--send {
   width: 40px;
   height: 40px;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.82.0";
-console.log(`[job] v${VERSION} - Chat rev: scrolling log, reflections, mid-flow attach (apt-inspired)`);
+const VERSION = "0.83.0";
+console.log(`[job] v${VERSION} - Chat takeover: full-screen, minimal, ChatGPT landing pattern, mobile-safe`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -162,6 +162,11 @@ setTimeout(() => {
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('signin-btn');
   if (btn) btn.addEventListener('click', () => window.CtrlAuth.openLoginModal());
+  // Onboarding is its own full-screen takeover and works pre-auth. Suppress
+  // the auto-open sign-in modal on those routes; the component opens auth
+  // explicitly at finalize time.
+  const onOnboardingRoute = location.pathname.startsWith('/job/onboarding');
+  if (onOnboardingRoute) return;
   setTimeout(() => {
     if (document.body.dataset.authState !== 'in') {
       window.CtrlAuth.openLoginModal();

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -618,40 +618,62 @@ export class JobOnboarding extends LitElement {
     `;
   }
 
-  // -------- Stage 3: chat (scrolling log, apt-style) --------
+  // -------- Stage 3: chat (minimal, ChatGPT-inspired) --------
+  //
+  // Two states:
+  //   - landing: no user turn yet → composer + first question centered
+  //     vertically (ChatGPT empty-state pattern).
+  //   - active:  any user turn exists → composer pinned bottom, log scrolls
+  //     above it.
 
   _renderChat() {
     this._ensureChatSeeded();
     const log = this.draft._meta.chatLog || [];
+    const hasUserTurn = log.some(t => t.role === 'user');
     const totalSlots = QUESTIONS.length;
     const answeredCount = Object.keys(this.draft._meta.answers || {}).length;
     const pct = Math.min(100, Math.round((answeredCount / totalSlots) * 100));
 
     return html`
-      <section class="onboard__stage chat">
-        <div class="chat__progress-bar"><span style="width:${pct}%"></span></div>
+      <section class="onboard__stage chat ${hasUserTurn ? 'chat--active' : 'chat--landing'}">
+        ${hasUserTurn ? html`<div class="chat__progress-bar"><span style="width:${pct}%"></span></div>` : nothing}
 
         <div class="chat__log">
-          ${log.map(turn => turn.role === 'ai' ? this._renderAiTurn(turn) : this._renderUserTurn(turn))}
-          ${this.busy ? html`<div class="chat__ai chat__ai--thinking">…</div>` : nothing}
+          ${hasUserTurn
+            ? log.map(turn => turn.role === 'ai' ? this._renderAiTurn(turn) : this._renderUserTurn(turn))
+            : this._renderLandingHero(log)}
+          ${this.busy && hasUserTurn ? html`<div class="chat__ai chat__ai--thinking">…</div>` : nothing}
         </div>
 
-        <div class="chat__composer">
-          <label for="chat-attach" class="chat__attach" title="Attach a resume or writing sample">+</label>
-          <input id="chat-attach" type="file" multiple accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
-                 style="display:none" @change=${(e) => this._handleAttach(e.target.files)}/>
-          <textarea id="chat-input" placeholder="Type your answer…"
-                    @keydown=${(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); this._submitAnswer(); } }}></textarea>
-          <button class="btn btn--primary btn--send" ?disabled=${this.busy} @click=${() => this._submitAnswer()}
-                  aria-label="Send">↑</button>
-        </div>
-        <div class="chat__composer-row">
-          <div class="chat__composer-pills">
-            <button class="chat__pill" @click=${() => this._submitAnswer({ skip: true })}>Skip</button>
+        <div class="chat__composer-wrap">
+          <div class="chat__composer">
+            <label for="chat-attach" class="chat__attach" title="Attach a resume or writing sample">+</label>
+            <input id="chat-attach" type="file" multiple accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+                   style="display:none" @change=${(e) => this._handleAttach(e.target.files)}/>
+            <textarea id="chat-input" rows="1" placeholder="Type your answer…"
+                      @input=${(e) => this._autoSize(e.target)}
+                      @keydown=${(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); this._submitAnswer(); } }}></textarea>
+            <button class="chat__send" ?disabled=${this.busy} @click=${() => this._submitAnswer()}
+                    aria-label="Send">↑</button>
           </div>
-          <div class="chat__composer-hint">⌘+Enter to send</div>
+          <div class="chat__composer-row">
+            <button class="chat__pill" @click=${() => this._submitAnswer({ skip: true })}>Skip</button>
+            <span class="chat__composer-hint">⌘+Enter to send</span>
+          </div>
         </div>
       </section>
+    `;
+  }
+
+  _renderLandingHero(log) {
+    // Pre-first-turn: render the seeded question centered as the hero.
+    const ai = log.find(t => t.role === 'ai');
+    if (!ai) return nothing;
+    return html`
+      <div class="chat__hero">
+        ${ai.reflection ? html`<p class="chat__ai-reflection">${ai.reflection}</p>` : nothing}
+        <p class="chat__hero-question">${ai.question || ''}</p>
+      </div>
     `;
   }
 
@@ -667,7 +689,27 @@ export class JobOnboarding extends LitElement {
     return html`<div class="chat__user">${turn.text}</div>`;
   }
 
-  updated() { this._afterRender(); }
+  _autoSize(ta) {
+    ta.style.height = 'auto';
+    ta.style.height = Math.min(200, ta.scrollHeight) + 'px';
+  }
+
+  updated() {
+    this._afterRender();
+    // Autofocus the input whenever the chat stage renders. Mobile-friendly:
+    // helps the keyboard come up immediately on first arrival.
+    if (this.draft._meta.stage === 3) {
+      const ta = this.querySelector('#chat-input');
+      if (ta && document.activeElement !== ta) {
+        // Only focus on first mount of the stage to avoid stealing focus on
+        // every re-render. Track via a data attr.
+        if (!ta.dataset.autofocused) {
+          ta.dataset.autofocused = '1';
+          ta.focus();
+        }
+      }
+    }
+  }
 
   // -------- Stage 4: tailor --------
 

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -2,13 +2,28 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Welcome to /job</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.83.0">
+  <style>
+    /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
+       component is the entire page. The auth gate only renders when we
+       explicitly need it (set body[data-need-auth=true] from app.js). */
+    html, body { height: 100%; }
+    body { margin: 0; background: var(--bg); color: var(--fg); }
+    .gate { display: none; }
+    body[data-need-auth="true"] .gate { display: flex; }
+    body[data-need-auth="true"] .onboard-host { display: none; }
+    .onboard-host {
+      min-height: 100dvh;
+      display: flex;
+      flex-direction: column;
+    }
+  </style>
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -17,19 +32,16 @@
   <section id="signin-gate" class="gate">
     <div class="gate__card">
       <h1>/job</h1>
-      <p>Your career operating system. Sign in to start.</p>
+      <p>Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
   </section>
 
-  <div class="app">
-    <job-rail></job-rail>
-    <main class="app__main">
-      <job-onboarding></job-onboarding>
-    </main>
+  <div class="onboard-host">
+    <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.82.0">
-  <script src="/job/js/theme.js?v=0.82.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.83.0">
+  <script src="/job/js/theme.js?v=0.83.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.82.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.83.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Pulls away from design-system cards. /job/onboarding becomes a full-viewport chat takeover with no rail, no bubble outlines. Landing state centers the first question + composer; sending slides composer to bottom. 100dvh + safe-area for mobile. Details in commit. v0.83.0.