### PR TITLE
job: chat polish — center hero+composer, hide stepper

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -4197,11 +4197,20 @@ job-onboarding { display: contents; }
   flex: 1;
   min-height: 100dvh;
 }
-.onboard:has(.chat) > .stepper,
+/* In chat mode the stepper feels like UI noise — hide it and let the
+   thin progress bar (active state) carry the role. The demo banner
+   stays so it's clear nothing commits. */
+.onboard:has(.chat) > .stepper { display: none; }
 .onboard:has(.chat) > .onboard__demo-banner {
   max-width: 720px;
   margin: var(--space-3) auto 0;
-  padding: 0 var(--space-4);
+  padding: var(--space-2) var(--space-4);
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: var(--fg-muted);
+  font-size: var(--font-size-caption);
+  text-align: center;
 }
 .onboard:has(.chat) > .onboard__stage {
   flex: 1;
@@ -4237,12 +4246,16 @@ job-onboarding { display: contents; }
   scroll-behavior: smooth;
 }
 
-/* Landing state: log becomes a vertically centered hero with no scrolling. */
-.chat--landing .chat__log {
-  overflow: hidden;
+/* Landing state: hero + composer centered as a unit (ChatGPT pattern). */
+.chat--landing {
   justify-content: center;
+  gap: var(--space-4);
+}
+.chat--landing .chat__log {
+  flex: 0 1 auto;
+  overflow: hidden;
   padding-top: var(--space-4);
-  padding-bottom: var(--space-4);
+  padding-bottom: 0;
 }
 
 .chat__hero {


### PR DESCRIPTION
Polish follow-up. Center hero + composer as a unit. Hide stepper while in chat. Soften demo banner.