### PR TITLE
job: chat — dot-step + N-of-M progress, tuned spacing rhythm

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -4219,22 +4219,33 @@ job-onboarding { display: contents; }
   flex-direction: column;
 }
 
-.chat__progress-bar {
+/* Progress meter — dot-step + "N of M" caption. Replaces the bar so the
+   user has both shape (where am I) and number (how much left) at a glance.
+   Sits flush top-center, captions-size, --fg-muted. */
+.chat__progress {
   flex: none;
-  width: 100%;
-  max-width: 720px;
-  margin: 0 auto;
-  height: 2px;
-  background: var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-4) 0;
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  letter-spacing: 0.01em;
+}
+.chat__progress-dots {
+  display: inline-flex;
+  gap: 6px;
+}
+.chat__progress-dots span {
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
-  overflow: hidden;
+  background: var(--border);
+  transition: background 240ms ease-out, transform 240ms ease-out;
 }
-.chat__progress-bar > span {
-  display: block;
-  height: 100%;
-  background: var(--accent-strong);
-  transition: width 240ms ease-out;
-}
+.chat__progress-dots span.is-done    { background: var(--accent-strong); }
+.chat__progress-dots span.is-current { background: var(--accent); transform: scale(1.15); }
 
 .chat__log {
   flex: 1;
@@ -4242,14 +4253,16 @@ job-onboarding { display: contents; }
   width: 100%;
   max-width: 720px;
   margin: 0 auto;
-  padding: var(--space-5) var(--space-4);
+  /* Vertical rhythm: more space at the bottom so the latest turn has
+     breathing room above the composer; horizontal padding keeps text
+     off the absolute viewport edge. */
+  padding: var(--space-5) var(--space-4) var(--space-6);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  /* Latest message hugs the composer (anchor to bottom). When content
-     exceeds the log height, older messages scroll up. */
+  /* Latest turn hugs the composer; older turns scroll up off the top. */
   justify-content: flex-end;
-  gap: var(--space-4);
+  gap: var(--space-5);
   scroll-behavior: smooth;
 }
 
@@ -4296,7 +4309,7 @@ job-onboarding { display: contents; }
   color: var(--fg);
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: var(--space-3);
 }
 .chat__ai-reflection,
 .chat__ai-question {
@@ -4379,7 +4392,7 @@ job-onboarding { display: contents; }
   flex: none;
   width: 100%;
   background: var(--bg);
-  padding: var(--space-3) var(--space-4) calc(var(--space-3) + env(safe-area-inset-bottom));
+  padding: var(--space-4) var(--space-4) calc(var(--space-4) + env(safe-area-inset-bottom));
   display: flex;
   flex-direction: column;
   gap: var(--space-2);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.84.1";
-console.log(`[job] v${VERSION} - Chat polish: emphasis markdown, tighter gaps, constrained progress, no autocomplete`);
+const VERSION = "0.85.0";
+console.log(`[job] v${VERSION} - Chat: dot-step + N-of-M progress, better spacing rhythm`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -703,11 +703,23 @@ export class JobOnboarding extends LitElement {
     const hasUserTurn = log.some(t => t.role === 'user');
     const totalSlots = QUESTIONS.length;
     const answeredCount = Object.keys(this.draft._meta.answers || {}).length;
-    const pct = Math.min(100, Math.round((answeredCount / totalSlots) * 100));
+    // Current is the next unanswered slot (0-indexed). On the landing
+    // state nothing is answered yet so current=0 ("1 of 5").
+    const current = Math.min(totalSlots - 1, answeredCount);
+    const dots = Array.from({ length: totalSlots }, (_, i) => {
+      if (i < answeredCount) return 'is-done';
+      if (i === current)     return 'is-current';
+      return '';
+    });
 
     return html`
       <section class="onboard__stage chat ${hasUserTurn ? 'chat--active' : 'chat--landing'}">
-        ${hasUserTurn ? html`<div class="chat__progress-bar"><span style="width:${pct}%"></span></div>` : nothing}
+        <div class="chat__progress" aria-label="Question ${current + 1} of ${totalSlots}">
+          <span class="chat__progress-dots">
+            ${dots.map(cls => html`<span class=${cls}></span>`)}
+          </span>
+          <span>${current + 1} of ${totalSlots}</span>
+        </div>
 
         <div class="chat__log">
           ${hasUserTurn

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.84.1">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.85.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.84.1">
-  <script src="/job/js/theme.js?v=0.84.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.85.0">
+  <script src="/job/js/theme.js?v=0.85.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.84.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.85.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Drops the thin progress bar for a dot-step meter + N-of-M caption (visible in both landing and active states). Tightens turn-to-turn rhythm per Claude.ai/ChatGPT references. v0.85.0.