### PR TITLE
job: mobile pass — drawer fix + app-bar + bottom tabbar + segmented subnav + list-row + sticky action bar

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,13 +1,22 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.45.0");
-@import url("./tokens-generic-dark.css?v=0.45.0");
-@import url("./tokens-ctrl-light.css?v=0.45.0");
-@import url("./tokens-ctrl-dark.css?v=0.45.0");
-@import url("./components.css?v=0.45.0");
+@import url("./tokens-generic-light.css?v=0.46.0");
+@import url("./tokens-generic-dark.css?v=0.46.0");
+@import url("./tokens-ctrl-light.css?v=0.46.0");
+@import url("./tokens-ctrl-dark.css?v=0.46.0");
+@import url("./components.css?v=0.46.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
+
+/* Named breakpoints. Use as `@media (max-width: 720px)` etc. in CSS — the
+   custom properties exist so JS can read them via getComputedStyle(:root). */
+:root {
+  --bp-xs: 480px;
+  --bp-sm: 720px;
+  --bp-md: 960px;
+  --bp-lg: 1240px;
+}
 
 * { box-sizing: border-box; }
 
@@ -107,24 +116,7 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
   color: var(--fg-muted);
 }
 
-@media (max-width: 720px) {
-  .app {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "rail"
-      "main"
-      "footer";
-  }
-  .app__rail {
-    position: static;
-    height: auto;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-  }
-  .app__main { padding: var(--space-5); }
-  .rail-foot { margin-top: 0; flex-direction: row; gap: var(--space-3); }
-  .app__footer { padding: var(--space-3) var(--space-4); }
-}
+/* Mobile responsive rules for .app, .app__rail (drawer), .mobile-bar, and
+   the bottom .app-tabbar live in components.css. base.css used to redefine
+   them here, which silently won the cascade (base @imports components, then
+   its own rules run last) and neutralized the drawer. */

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -90,9 +90,17 @@
   margin: 0;
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
-  font-size: var(--font-size-title-1);
+  /* Scales from 24px on phones to 36px on desktop. The static token
+     --font-size-title-1 is 36px; the clamp keeps that as the ceiling so
+     desktop is unchanged. */
+  font-size: clamp(24px, 5.5vw, var(--font-size-title-1));
   line-height: var(--lh-title);
   letter-spacing: -0.02em;
+}
+/* On mobile the page H1 is duplicated by the .mobile-bar title — hide the
+   .page-header to keep the layout tight and avoid double titling. */
+@media (max-width: 720px) {
+  .page-header { display: none; }
 }
 .page-header p {
   margin: var(--space-2) 0 0;
@@ -1399,6 +1407,41 @@
 }
 .role-header__actions { flex-shrink: 0; padding-top: var(--space-2); }
 
+/* --- Mobile sticky action bar ---
+   On mobile, .role-header__actions detaches from the header and pins to the
+   bottom of the viewport (above the .app-tabbar) so the primary CTA stays
+   reachable while the user scrolls a long role page. */
+@media (max-width: 720px) {
+  .role-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-3);
+  }
+  .role-header__actions {
+    position: fixed;
+    left: 0;
+    right: 0;
+    /* Sits just above the bottom tabbar (≈64px + safe-area). */
+    bottom: calc(64px + env(safe-area-inset-bottom));
+    z-index: 28;
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-surface);
+    border-top: 1px solid var(--border);
+    display: flex;
+    gap: var(--space-3);
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.04);
+  }
+  .role-header__actions > * {
+    flex: 1 1 0;
+    min-height: 48px;
+    justify-content: center;
+  }
+  /* Make sure the bottom of the page content isn't hidden behind the bar. */
+  .app__main:has(.role-header__actions) {
+    padding-bottom: calc(72px + 64px + env(safe-area-inset-bottom));
+  }
+}
+
 .role-meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -2278,8 +2321,8 @@
   scroll-snap-align: start;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-5);
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
@@ -3397,9 +3440,15 @@
   overflow: hidden;
 }
 
-/* --- Mobile / narrow (< 820px): stack each row as a card.
-   Was 720px but the table cumulative min-width of ~600px plus padding
-   meant 720-820px viewports got a cramped horizontal scroll. */
+/* --- Mobile / narrow (< 820px): render each row as a Wise List Item ---
+   Layout per row:
+     [fit-pill 44px] [role-title + company + meta line]  [menu 44px]
+   Status moves into the meta line as a tiny chip beside the sector chips.
+   Sector chips are capped to a single line via flex+nowrap so the row keeps
+   the same height for every entry (predictable rhythm at scroll).
+
+   Cards sit on a transparent background with only a hairline divider, more
+   inline with native list-item patterns than the v1 outlined cards. */
 @media (max-width: 820px) {
   .pipeline-table-wrap {
     border: 0;
@@ -3414,43 +3463,114 @@
   .pipeline-table tbody {
     display: flex;
     flex-direction: column;
-    gap: var(--space-3);
+    gap: 0;
   }
   .pipeline-table tr {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     grid-template-areas:
       "fit role menu"
-      "status sector sector";
-    gap: var(--space-2) var(--space-3);
+      "fit meta menu";
+    column-gap: var(--space-3);
+    row-gap: 2px;
     align-items: center;
-    padding: var(--space-4);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    background: var(--bg-elevated);
+    padding: var(--space-3) var(--space-2);
+    border: 0;
+    border-bottom: 1px solid var(--border);
+    border-radius: 0;
+    background: transparent;
+    min-height: 64px;
   }
+  .pipeline-table tr:last-child { border-bottom: 0; }
   .pipeline-table tr:hover td { background: transparent; }
   .pipeline-table td {
     border-bottom: 0;
     padding: 0;
+    min-width: 0;
   }
-  .pipeline-table .col-fit    { grid-area: fit;    width: auto; }
-  .pipeline-table .col-status { grid-area: status; width: auto; }
-  .pipeline-table .col-role   { grid-area: role;   max-width: none; min-width: 0; }
-  .pipeline-table .col-sector { grid-area: sector; width: auto; }
-  .pipeline-table .col-menu   { grid-area: menu;   width: auto; text-align: right; }
-  .pipeline-table .col-sector .tag-chips { max-height: none; }
-  /* Recs table extras — show as a meta line below the role on mobile. */
+  .pipeline-table .col-fit {
+    grid-area: fit;
+    width: 44px;
+    align-self: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .pipeline-table .col-fit .fit-pill {
+    font-size: var(--font-size-small);
+    padding: 8px 0;
+    min-width: 44px;
+    text-align: center;
+  }
+  .pipeline-table .col-role {
+    grid-area: role;
+    max-width: none;
+    min-width: 0;
+    align-self: end;
+  }
+  /* Status + sector chips share a single meta line beneath the role title.
+     status is rendered into the same cell using a pseudo-area below; if the
+     row only has the status column, it sits alone. */
+  .pipeline-table .col-status {
+    grid-area: meta;
+    width: auto;
+    align-self: start;
+    font-size: var(--font-size-caption);
+    color: var(--fg-muted);
+  }
+  .pipeline-table .col-sector {
+    grid-area: meta;
+    width: auto;
+    align-self: start;
+    overflow: hidden;
+    max-height: 22px;
+  }
+  .pipeline-table .col-sector .tag-chips {
+    flex-wrap: nowrap;
+    overflow: hidden;
+    max-height: 22px;
+  }
+  /* When both status + sector cells exist on the same row they'd both claim
+     grid-area: meta and overlap. Hide sector in favor of status on the
+     pipeline rows (status is the higher-information cell). */
+  .pipeline-table tr:has(.col-status) .col-sector { display: none; }
+  .pipeline-table .col-menu {
+    grid-area: menu;
+    width: auto;
+    text-align: right;
+    align-self: center;
+  }
+  .pipeline-table .col-menu button {
+    width: 44px;
+    height: 44px;
+    border-radius: var(--radius-pill);
+  }
+
+  /* Recs table extras — collapse location / source / added into the meta line. */
   .pipeline-table tr:has(.col-location) {
     grid-template-areas:
-      "fit  role     menu"
-      "loc  source   added";
+      "fit role     menu"
+      "fit metarec  menu";
   }
-  .pipeline-table .col-location { grid-area: loc;    width: auto; }
-  .pipeline-table .col-added    { grid-area: added;  width: auto; text-align: right; }
+  .pipeline-table .col-location,
+  .pipeline-table .col-source,
+  .pipeline-table .col-added {
+    grid-area: metarec;
+    width: auto;
+    font-size: var(--font-size-caption);
+    color: var(--fg-muted);
+  }
+  /* When all three are present, stack them inline with separators via gap. */
+  .pipeline-table tr:has(.col-location) .col-location { justify-self: start; }
+  .pipeline-table tr:has(.col-location) .col-source   { display: none; } /* keep info dense */
+  .pipeline-table tr:has(.col-location) .col-added    { justify-self: end; }
 }
 
-/* --- Mobile top app bar (hamburger → drawer) --- */
+/* --- Mobile top app bar (title + contextual action; menu opens drawer) ---
+   Layout: [menu 44px] [title — page H1 text] [action slot, optional].
+   The menu is only the "more / nav drawer" affordance — primary nav lives
+   in the bottom .app-tabbar so the user never has to open the drawer to
+   switch top-level routes. */
 .mobile-bar {
   display: none;
   position: sticky;
@@ -3459,33 +3579,149 @@
   background: var(--bg-surface);
   border-bottom: 1px solid var(--border);
   padding: var(--space-3) var(--space-4);
+  padding-top: max(var(--space-3), env(safe-area-inset-top));
   align-items: center;
   gap: var(--space-3);
 }
-.mobile-bar__menu {
+.mobile-bar__menu,
+.mobile-bar__action {
   display: inline-grid;
   place-items: center;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-elevated);
   color: var(--fg);
   font-size: 18px;
   cursor: pointer;
+  flex-shrink: 0;
 }
-.mobile-bar__menu:hover { background: var(--bg-surface); }
-.mobile-bar__brand {
+.mobile-bar__menu:hover,
+.mobile-bar__action:hover { background: var(--bg-surface); }
+.mobile-bar__title {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.015em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mobile-bar__action-slot {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.mobile-bar__brand,
+.mobile-bar__sub { /* legacy — kept so older injected markup still renders */
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
   font-size: var(--font-size-body-lg);
   letter-spacing: -0.015em;
 }
-.mobile-bar__sub {
-  margin-left: var(--space-2);
+
+/* --- Mobile segmented sub-nav ---
+   Sticky horizontal pill group under the mobile-bar. Used on /job/jobs/ to
+   switch buckets (For You / Saved / Active / Archive) without opening the
+   drawer. Scrolls horizontally if items overflow the viewport. */
+.subnav-bar {
+  display: none;
+  position: sticky;
+  top: 65px; /* sits directly under mobile-bar */
+  z-index: 29;
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.subnav-bar::-webkit-scrollbar { display: none; }
+.subnav-bar__row {
+  display: inline-flex;
+  gap: 6px;
+  padding: 2px;
+  background: var(--bg-surface);
+  border-radius: var(--radius-pill);
+}
+.subnav-bar__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px var(--space-4);
   font-size: var(--font-size-small);
-  color: var(--fg-subtle);
   font-weight: var(--fw-medium);
+  color: var(--fg-muted);
+  border-radius: var(--radius-pill);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.subnav-bar__item:hover { text-decoration: none; color: var(--fg); }
+.subnav-bar__item[aria-current="page"] {
+  background: var(--accent-strong);
+  color: var(--accent-strong-fg);
+}
+.subnav-bar__item .nav-count {
+  font-size: 11px;
+  font-weight: var(--fw-semibold);
+  padding: 0 6px;
+  min-width: 18px;
+  height: 16px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  background: rgba(0,0,0,0.10);
+}
+.subnav-bar__item[aria-current="page"] .nav-count { background: rgba(0,0,0,0.15); }
+
+/* --- Mobile bottom tab bar ---
+   Fixed at the bottom of the viewport, 4 items. The active route's icon and
+   label use --accent-strong (Bright Green) per the brand rule. Respects
+   iOS safe-area so the bar doesn't collide with the home indicator. */
+.app-tabbar {
+  display: none;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 35;
+  background: var(--bg-surface);
+  border-top: 1px solid var(--border);
+  padding: 4px var(--space-2);
+  padding-bottom: max(4px, env(safe-area-inset-bottom));
+  justify-content: space-around;
+  align-items: stretch;
+}
+.app-tabbar__item {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  flex: 1 1 0;
+  min-height: 56px;
+  padding: 6px var(--space-2);
+  font-size: 11px;
+  font-weight: var(--fw-medium);
+  color: var(--fg-muted);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+}
+.app-tabbar__item:hover { text-decoration: none; }
+.app-tabbar__icon {
+  width: 24px;
+  height: 24px;
+  display: inline-grid;
+  place-items: center;
+  font-size: 18px;
+  line-height: 1;
+}
+.app-tabbar__item[aria-current="page"] {
+  color: var(--accent-strong-fg);
+  background: var(--accent-strong);
 }
 
 /* Drawer scrim + sliding panel for rail nav. */
@@ -3503,6 +3739,8 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
 
 @media (max-width: 720px) {
   .mobile-bar { display: flex; }
+  .app-tabbar  { display: flex; }
+  .subnav-bar[data-has-items="true"] { display: block; }
   .app__rail {
     position: fixed;
     inset: 0 auto 0 0;
@@ -3515,6 +3753,8 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
     flex-wrap: nowrap;
     box-shadow: var(--shadow-lg);
     padding: var(--space-5) var(--space-4);
+    padding-top: max(var(--space-5), env(safe-area-inset-top));
+    padding-bottom: max(var(--space-5), env(safe-area-inset-bottom));
     gap: var(--space-5);
   }
   body.rail-open .app__rail { transform: translateX(0); }
@@ -3528,7 +3768,15 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   }
   /* Rail no longer occupies layout flow on mobile — reclaim the column. */
   .app > .app__rail { grid-area: rail; }
-  .app__main { padding: var(--space-4); }
+  .app__main {
+    padding: var(--space-4);
+    /* Leave room for the fixed bottom tabbar + safe-area inset so the last
+       row isn't hidden behind it. 64px ≈ tabbar height incl. padding. */
+    padding-bottom: calc(72px + env(safe-area-inset-bottom));
+  }
+  /* Footer (theme toggle + version) lives in Settings on mobile; hiding the
+     desktop footer prevents it from sitting between content and the tabbar. */
+  .app__footer { display: none; }
 }
 
 /* ── Phase 2.0 — application-tracker UI ─────────────────────────── */

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.86.0";
-console.log(`[job] v${VERSION} - Chat: conversational questions + single combined ack+question block`);
+const VERSION = "0.87.0";
+console.log(`[job] v${VERSION} - Mobile: drawer fix + app-bar + bottom tabbar + segmented subnav + list-row + sticky action bar`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -69,6 +69,8 @@ async function applySignedInState(email) {
   document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
   injectFooter();
   injectMobileBar();
+  injectSubnavBar();
+  injectTabbar();
 }
 
 // Inject the global footer (theme toggle + version + links) into the .app
@@ -81,21 +83,31 @@ function injectFooter() {
   app.appendChild(el);
 }
 
-// Inject a mobile top app bar (hamburger + brand) at the start of every
-// page's <main>. CSS hides it on >720px screens. Tapping the menu button
-// flips body.rail-open which slides the rail in as a drawer.
+// Inject a mobile top app bar (menu + page title + optional action slot) at
+// the start of every page's <main>. CSS hides it on >720px screens. Tapping
+// the menu button flips body.rail-open which slides the rail in as a drawer.
+//
+// The title text is sourced from the page's .page-header h1 so each route
+// shows its own name. Pages can populate the trailing action slot by
+// appending elements to <header class="mobile-bar"> .mobile-bar__action-slot
+// (used by the pipeline page for Filter / Search).
 function injectMobileBar() {
   if (document.querySelector('.mobile-bar')) return;
   const main = document.querySelector('.app__main');
   const app = document.querySelector('.app');
   if (!main || !app) return;
 
+  const title = document.querySelector('.page-header h1')?.textContent?.trim()
+    || document.title.replace(/\s*[—|]\s*\/?job.*$/i, '').trim()
+    || 'ctrl.rodeo';
+
   const bar = document.createElement('header');
   bar.className = 'mobile-bar';
   bar.innerHTML = `
     <button type="button" class="mobile-bar__menu" aria-label="Open navigation"
             aria-controls="job-rail" aria-expanded="false">☰</button>
-    <span class="mobile-bar__brand">ctrl.rodeo<span class="mobile-bar__sub">/ job</span></span>
+    <span class="mobile-bar__title">${title}</span>
+    <span class="mobile-bar__action-slot"></span>
   `;
   main.prepend(bar);
 
@@ -129,6 +141,105 @@ function injectMobileBar() {
   // If the viewport grows past the breakpoint, drop the open state.
   const mq = window.matchMedia('(min-width: 721px)');
   mq.addEventListener?.('change', (e) => { if (e.matches) close(); });
+}
+
+// Inject the mobile segmented sub-nav (sticky under mobile-bar). Only
+// populated on /job/jobs/ today; data-has-items toggles visibility so
+// CSS only shows it when there's something to switch between. Counts are
+// kept in sync by listening to the same 'job:pipeline:refresh' that the
+// rail uses to refresh its count badges.
+function injectSubnavBar() {
+  if (document.querySelector('.subnav-bar')) return;
+  const main = document.querySelector('.app__main');
+  if (!main) return;
+
+  const bar = document.createElement('nav');
+  bar.className = 'subnav-bar';
+  bar.setAttribute('aria-label', 'Sub-navigation');
+  bar.dataset.hasItems = 'false';
+  bar.innerHTML = `<div class="subnav-bar__row"></div>`;
+  // Place directly after the mobile-bar (which has been prepended already).
+  const mb = main.querySelector('.mobile-bar');
+  (mb || main).after(bar);
+
+  const row = bar.querySelector('.subnav-bar__row');
+  const here = location.pathname;
+  const isJobs = /^\/job\/jobs\/?/.test(here);
+
+  if (!isJobs) {
+    bar.dataset.hasItems = 'false';
+    return;
+  }
+
+  // Keep in sync with ROUTES[0].sub in components/job-rail.js.
+  const ITEMS = [
+    { href: '/job/jobs/recommended/',    label: 'For You', path: '/job/jobs/recommended/', countKey: 'recommended' },
+    { href: '/job/jobs/?bucket=leads',   label: 'Saved',   bucket: 'leads',                countKey: 'leads' },
+    { href: '/job/jobs/?bucket=active',  label: 'Active',  bucket: 'active',               countKey: 'active' },
+    { href: '/job/jobs/?bucket=archive', label: 'Archive', bucket: 'archive' },
+  ];
+  const bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
+  const onSubPath = ITEMS.some(i => i.path && here.startsWith(i.path));
+  row.innerHTML = ITEMS.map(i => {
+    const active = i.path
+      ? here.startsWith(i.path)
+      : (!onSubPath && bucket === i.bucket);
+    return `<a class="subnav-bar__item" href="${i.href}" aria-current="${active ? 'page' : 'false'}"
+              data-count-key="${i.countKey || ''}">
+              <span class="subnav-bar__label">${i.label}</span>
+              ${i.countKey ? `<span class="nav-count" data-count="${i.countKey}" hidden></span>` : ''}
+            </a>`;
+  }).join('');
+  bar.dataset.hasItems = 'true';
+
+  const applyCounts = (counts) => {
+    if (!counts) return;
+    for (const el of bar.querySelectorAll('[data-count]')) {
+      const k = el.getAttribute('data-count');
+      const n = counts[k];
+      if (n == null) { el.hidden = true; continue; }
+      el.hidden = false;
+      el.textContent = String(n);
+    }
+  };
+
+  // The rail component already fetches and stores counts on itself; ask it
+  // for the current value, then listen for refresh signals.
+  const askRail = () => {
+    const rail = document.querySelector('job-rail');
+    if (rail?.counts) applyCounts(rail.counts);
+  };
+  askRail();
+  document.addEventListener('job:pipeline:refresh', () => setTimeout(askRail, 200));
+  document.addEventListener('job:auth:ready', () => setTimeout(askRail, 400));
+  // Poll once shortly after mount in case the rail hasn't fetched yet.
+  setTimeout(askRail, 600);
+}
+
+// Inject the bottom tab bar (4 top-level routes). CSS shows it only at
+// ≤720px. The active route gets aria-current="page" and styles with
+// --accent-strong. Sourcing from the rail's ROUTES list is overkill for
+// 4 items, so we declare them inline here. Keep in sync with job-rail.js.
+function injectTabbar() {
+  if (document.querySelector('.app-tabbar')) return;
+  const TABS = [
+    { href: '/job/jobs/',     label: 'Jobs',   icon: '◧', match: /^\/job\/jobs\/?/      },
+    { href: '/job/history/',  label: 'Career', icon: '◯', match: /^\/job\/history\/?/  },
+    { href: '/job/vision/',   label: 'Plan',   icon: '◇', match: /^\/job\/vision\/?/   },
+    { href: '/job/settings/', label: 'You',    icon: '◉', match: /^\/job\/settings\/?/ },
+  ];
+  const here = location.pathname;
+  const nav = document.createElement('nav');
+  nav.className = 'app-tabbar';
+  nav.setAttribute('aria-label', 'Primary');
+  nav.innerHTML = TABS.map(t => `
+    <a class="app-tabbar__item" href="${t.href}"
+       aria-current="${t.match.test(here) ? 'page' : 'false'}">
+      <span class="app-tabbar__icon" aria-hidden="true">${t.icon}</span>
+      <span class="app-tabbar__label">${t.label}</span>
+    </a>
+  `).join('');
+  document.body.appendChild(nav);
 }
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.45.0">
-  <script src="/job/js/theme.js?v=0.45.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.86.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.86.0">
-  <script src="/job/js/theme.js?v=0.86.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
+  <script src="/job/js/theme.js?v=0.87.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.86.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

PR0–PR5 bundled — makes `/job` feel like a mobile app at ≤720px while keeping desktop unchanged.

- **PR0 drawer cascade fix** — `base.css` was silently neutralizing the drawer in `components.css` (cascade order: base @imports components, then base's own `position: static` rule wins). Drawer now actually slides.
- **PR1 tokens + radius** — `--bp-{xs,sm,md,lg}` breakpoint vars added; `.rec-card` bumped to `--radius-lg` (30px) per Wise hard rule.
- **PR2 app-bar v2 + bottom tabbar** — top bar carries the page title + a 44px menu + action slot, padded with `env(safe-area-inset-top)`. New `.app-tabbar` is fixed-bottom 4-item nav (Jobs · Career · Plan · You) with `env(safe-area-inset-bottom)` and `--accent-strong` (Bright Green) active state. Desktop footer hides on mobile so it doesn't sit between content and tabbar.
- **PR3 segmented sub-nav** — sticky horizontal pill group under the app-bar for `/job/jobs/` bucket switching (For You / Saved / Active / Archive) with live count badges sourced from the rail's existing fetches.
- **PR4 list-row** — replaces the v1 table-as-card. Each row is a Wise List Item: 44px fit pill · two-line role + status/meta · 44px menu. Rows separated by hairline dividers, predictable 64px min-height.
- **PR5 sticky action bar + H1 down-shift** — `.page-header h1` is now `clamp(24px, 5.5vw, 36px)`. Page-header is hidden on mobile (the title is in the app-bar). `.role-header__actions` detaches into a fixed bar above the tabbar so the primary CTA stays reachable through long role pages.

Cache busted v0.86.0 → v0.87.0; CSS internal `@import` busters v0.45.0 → v0.46.0.

## Test plan
- [ ] /job/jobs/ at iPhone width: bottom tabbar visible; Jobs tab active; segmented subnav under the bar with For You/Saved/Active/Archive and live counts.
- [ ] Tap hamburger → rail slides in from the left as a drawer over a scrim; tapping a nav link or scrim closes it.
- [ ] Pipeline rows render as list-rows (fit pill leading, role + status meta, menu trailing) — no horizontal scroll.
- [ ] /job/jobs/recommended/ shows location/added inline in the meta line; subnav highlights "For You".
- [ ] /job/jobs/drill/ — primary actions pin to a sticky bar above the tabbar.
- [ ] Desktop ≥1024px — unchanged layout, drawer/tabbar hidden, page-header H1 stays at 36px.
- [ ] iOS Safari — safe-area insets respected on top bar and bottom tabbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)