### PR TITLE
job: mobile follow-ups — rail cascade fix + subnav counts wiring

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.46.0");
-@import url("./tokens-generic-dark.css?v=0.46.0");
-@import url("./tokens-ctrl-light.css?v=0.46.0");
-@import url("./tokens-ctrl-dark.css?v=0.46.0");
-@import url("./components.css?v=0.46.0");
+@import url("./tokens-generic-light.css?v=0.46.1");
+@import url("./tokens-generic-dark.css?v=0.46.1");
+@import url("./tokens-ctrl-light.css?v=0.46.1");
+@import url("./tokens-ctrl-dark.css?v=0.46.1");
+@import url("./components.css?v=0.46.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -3741,7 +3741,12 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   .mobile-bar { display: flex; }
   .app-tabbar  { display: flex; }
   .subnav-bar[data-has-items="true"] { display: block; }
-  .app__rail {
+  /* Higher specificity (.app .app__rail) than base.css's unconditional
+     `.app__rail { position: sticky }` rule, so the drawer's `fixed`
+     positioning wins regardless of CSS load order. base.css @imports
+     components.css then declares its own rules, so a flat `.app__rail`
+     selector here would otherwise lose the cascade. */
+  .app .app__rail {
     position: fixed;
     inset: 0 auto 0 0;
     width: min(280px, 86vw);
@@ -3757,7 +3762,7 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
     padding-bottom: max(var(--space-5), env(safe-area-inset-bottom));
     gap: var(--space-5);
   }
-  body.rail-open .app__rail { transform: translateX(0); }
+  body.rail-open .app .app__rail { transform: translateX(0); }
   .rail-foot { margin-top: auto; flex-direction: column; align-items: flex-start; }
   .app {
     grid-template-columns: 1fr;

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.87.0";
-console.log(`[job] v${VERSION} - Mobile: drawer fix + app-bar + bottom tabbar + segmented subnav + list-row + sticky action bar`);
+const VERSION = "0.87.1";
+console.log(`[job] v${VERSION} - Mobile: rail position cascade + subnav counts event`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -203,17 +203,15 @@ function injectSubnavBar() {
     }
   };
 
-  // The rail component already fetches and stores counts on itself; ask it
-  // for the current value, then listen for refresh signals.
+  // The rail component already fetches and stores counts on itself; listen
+  // for its broadcast event and apply.
   const askRail = () => {
     const rail = document.querySelector('job-rail');
     if (rail?.counts) applyCounts(rail.counts);
   };
-  askRail();
+  document.addEventListener('job:rail:counts', (e) => applyCounts(e.detail));
   document.addEventListener('job:pipeline:refresh', () => setTimeout(askRail, 200));
-  document.addEventListener('job:auth:ready', () => setTimeout(askRail, 400));
-  // Poll once shortly after mount in case the rail hasn't fetched yet.
-  setTimeout(askRail, 600);
+  askRail();
 }
 
 // Inject the bottom tab bar (4 top-level routes). CSS shows it only at

--- a/job/js/components/job-rail.js
+++ b/job/js/components/job-rail.js
@@ -104,6 +104,9 @@ export class JobRail extends LitElement {
       const active = roles.filter(r => bucketFor(r) === 'active').length;
       const recommended = recs?.count ?? (recs?.recommendations?.length ?? 0);
       this.counts = { leads, active, recommended };
+      // Broadcast so other mobile chrome (the segmented .subnav-bar in
+      // app.js) can pull the same counts without re-fetching.
+      document.dispatchEvent(new CustomEvent('job:rail:counts', { detail: this.counts }));
     } finally {
       this._loading = false;
     }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.1">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.0">
-  <script src="/job/js/theme.js?v=0.87.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
+  <script src="/job/js/theme.js?v=0.87.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #828.

## Summary
- Rail mobile drawer now reports `position: fixed` as spec'd. Was reporting `sticky` because base.css's unconditional `.app__rail { position: sticky }` outranked components.css's mobile `@media` rule (same specificity, base loads after its own @import). Bumped selector to `.app .app__rail` in the mobile block.
- Segmented subnav count badges (For You 383 / Saved 32 / Active 2) actually appear now. `job-rail` dispatches `job:rail:counts` when its fetch settles; the subnav listens.

## Test plan
- [ ] /job/jobs/ at iPhone width: For You badge shows ~383, Saved shows 32, Active shows 2.
- [ ] Hamburger opens drawer with `position: fixed` (DevTools elements panel).
🤖 Generated with [Claude Code](https://claude.com/claude-code)