### PR TITLE
job: mobile — fix .app grid cascade + remove hamburger border

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.46.1");
-@import url("./tokens-generic-dark.css?v=0.46.1");
-@import url("./tokens-ctrl-light.css?v=0.46.1");
-@import url("./tokens-ctrl-dark.css?v=0.46.1");
-@import url("./components.css?v=0.46.1");
+@import url("./tokens-generic-light.css?v=0.46.2");
+@import url("./tokens-generic-dark.css?v=0.46.2");
+@import url("./tokens-ctrl-light.css?v=0.46.2");
+@import url("./tokens-ctrl-dark.css?v=0.46.2");
+@import url("./components.css?v=0.46.2");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -3589,16 +3589,18 @@
   place-items: center;
   width: 44px;
   height: 44px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
+  border-radius: var(--radius-pill);
+  border: 0;
+  background: transparent;
   color: var(--fg);
-  font-size: 18px;
+  font-size: 20px;
   cursor: pointer;
   flex-shrink: 0;
 }
 .mobile-bar__menu:hover,
-.mobile-bar__action:hover { background: var(--bg-surface); }
+.mobile-bar__action:hover { background: var(--bg-elevated); }
+.mobile-bar__menu:active,
+.mobile-bar__action:active { background: var(--bg-surface); }
 .mobile-bar__title {
   flex: 1;
   min-width: 0;
@@ -3764,24 +3766,26 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
   }
   body.rail-open .app .app__rail { transform: translateX(0); }
   .rail-foot { margin-top: auto; flex-direction: column; align-items: flex-start; }
-  .app {
+  /* Higher-specificity selector (body .app) to outrank the unconditional
+     base.css `.app { grid-template-columns: 280px 1fr }` rule — same
+     cascade trap as the rail. Mobile collapses to a single column; the
+     rail is fixed-positioned and lives outside grid flow. */
+  body .app {
     grid-template-columns: 1fr;
     grid-template-areas:
-      "rail"
-      "main"
-      "footer";
+      "main";
   }
-  /* Rail no longer occupies layout flow on mobile — reclaim the column. */
-  .app > .app__rail { grid-area: rail; }
-  .app__main {
+  body .app > .app__main {
+    grid-area: main;
     padding: var(--space-4);
+    max-width: none;
     /* Leave room for the fixed bottom tabbar + safe-area inset so the last
        row isn't hidden behind it. 64px ≈ tabbar height incl. padding. */
     padding-bottom: calc(72px + env(safe-area-inset-bottom));
   }
   /* Footer (theme toggle + version) lives in Settings on mobile; hiding the
      desktop footer prevents it from sitting between content and the tabbar. */
-  .app__footer { display: none; }
+  body .app__footer { display: none; }
 }
 
 /* ── Phase 2.0 — application-tracker UI ─────────────────────────── */

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.87.1";
-console.log(`[job] v${VERSION} - Mobile: rail position cascade + subnav counts event`);
+const VERSION = "0.87.2";
+console.log(`[job] v${VERSION} - Mobile: .app grid cascade fix + hamburger borderless`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.1">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.2">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.1">
-  <script src="/job/js/theme.js?v=0.87.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
+  <script src="/job/js/theme.js?v=0.87.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.1"></script>
+  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
 </body>
 </html>


### PR DESCRIPTION
User screenshot showed content squeezed into the right side of the screen — main was reserving 280px for the (off-screen) rail at mobile widths.

## Summary
- `body .app` selector in the mobile @media block to win the cascade against base.css's unconditional `.app { grid-template-columns: 280px 1fr }`. Mobile is now a true single column.
- Same `body .app__footer { display: none }` so the desktop footer doesn't sit between the content and the bottom tabbar.
- Hamburger + trailing action are now borderless circular icon buttons (transparent bg, pill radius). Cleaner app-feel.

## Test plan
- [ ] /job/ on iPhone — content fills full width, no horizontal scroll, hamburger sits flush left of the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)