### PR TITLE
job: mobile — viewport overflow firewall + type-size pass

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.46.2");
-@import url("./tokens-generic-dark.css?v=0.46.2");
-@import url("./tokens-ctrl-light.css?v=0.46.2");
-@import url("./tokens-ctrl-dark.css?v=0.46.2");
-@import url("./components.css?v=0.46.2");
+@import url("./tokens-generic-light.css?v=0.47.0");
+@import url("./tokens-generic-dark.css?v=0.47.0");
+@import url("./tokens-ctrl-light.css?v=0.47.0");
+@import url("./tokens-ctrl-dark.css?v=0.47.0");
+@import url("./components.css?v=0.47.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2367,7 +2367,7 @@
 }
 .rec-card__meta {
   margin: 2px 0 0;
-  font-size: var(--font-size-caption);
+  font-size: 13px;
   color: var(--fg-muted);
   line-height: var(--lh-tight);
 }
@@ -3474,7 +3474,7 @@
     column-gap: var(--space-3);
     row-gap: 2px;
     align-items: center;
-    padding: var(--space-3) var(--space-2);
+    padding: var(--space-3) var(--space-4);
     border: 0;
     border-bottom: 1px solid var(--border);
     border-radius: 0;
@@ -3497,10 +3497,14 @@
     justify-content: center;
   }
   .pipeline-table .col-fit .fit-pill {
+    /* Badge type — keep at small (14px); the 16px default body size was
+       too large for a 44px-wide pill. */
     font-size: var(--font-size-small);
-    padding: 8px 0;
+    font-weight: var(--fw-semibold);
+    padding: 6px 0;
     min-width: 44px;
     text-align: center;
+    line-height: 1.2;
   }
   .pipeline-table .col-role {
     grid-area: role;
@@ -3606,9 +3610,10 @@
   min-width: 0;
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
-  font-size: var(--font-size-title-3);
+  /* iOS compact-title baseline (17pt). Title-3 (22) felt large for a top bar. */
+  font-size: var(--font-size-title-4);
   line-height: var(--lh-tight);
-  letter-spacing: -0.015em;
+  letter-spacing: -0.01em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3667,11 +3672,11 @@
   color: var(--accent-strong-fg);
 }
 .subnav-bar__item .nav-count {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: var(--fw-semibold);
   padding: 0 6px;
   min-width: 18px;
-  height: 16px;
+  height: 18px;
   display: inline-grid;
   place-items: center;
   border-radius: var(--radius-pill);
@@ -3775,14 +3780,30 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
     grid-template-areas:
       "main";
   }
+  /* Anti-overflow firewall.
+     Grid items default to min-width: auto (= min-content), so a wide child
+     (e.g. the 1800px .rec-row carousel) stretches the grid track and pushes
+     the page wider than the device viewport, which iOS Safari then exposes
+     as horizontal scroll. Forcing min-width: 0 + max-width: 100% on the
+     grid item AND its children caps the cascade. body { overflow-x: hidden }
+     is the belt to the suspender. */
+  body { overflow-x: hidden; }
   body .app > .app__main {
     grid-area: main;
+    min-width: 0;
+    max-width: 100%;
     padding: var(--space-4);
-    max-width: none;
     /* Leave room for the fixed bottom tabbar + safe-area inset so the last
        row isn't hidden behind it. 64px ≈ tabbar height incl. padding. */
     padding-bottom: calc(72px + env(safe-area-inset-bottom));
   }
+  body .app > .app__main > * { min-width: 0; max-width: 100%; }
+  /* Horizontal carousels: keep them inside the viewport. They scroll
+     internally via their own overflow-x: auto. */
+  .rec-row { min-width: 0; max-width: 100%; }
+  /* Recommendation cards on phones: 360px is too wide for a 400px screen.
+     Scale to fit while staying readable. */
+  .rec-card { width: min(82vw, 320px); flex: 0 0 auto; }
   /* Footer (theme toggle + version) lives in Settings on mobile; hiding the
      desktop footer prevents it from sitting between content and the tabbar. */
   body .app__footer { display: none; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.87.2";
-console.log(`[job] v${VERSION} - Mobile: .app grid cascade fix + hamburger borderless`);
+const VERSION = "0.88.0";
+console.log(`[job] v${VERSION} - Mobile: viewport overflow firewall + type-size pass`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.2">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.88.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.87.2">
-  <script src="/job/js/theme.js?v=0.87.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
+  <script src="/job/js/theme.js?v=0.88.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.87.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Root cause (viewport)

Page rendered with `body.scrollWidth = 1896` on a 400px device. The For You carousel (`.rec-row`) has `grid-template-columns: 360px × 5 = 1800px` of fixed intrinsic content. Grid items default to `min-width: auto` (= min-content), so 1800px propagated up through `.app__main` and stretched the `.app` grid track, which iOS Safari then exposed as horizontal scroll.

## Fixes
- `body { overflow-x: hidden }` mobile-only
- `min-width: 0; max-width: 100%` on `.app__main` and direct children
- `.rec-row { min-width: 0; max-width: 100% }` — carousel scrolls internally now
- `.rec-card { width: min(82vw, 320px) }` so a card fits a phone

## Type pass (granular)
| Element | Before | After | Why |
|-|-|-|-|
| `.mobile-bar__title` | 22 SemiBold | 18 SemiBold | Compact top-bar baseline (iOS 17pt) |
| `.subnav-bar .nav-count` | 11 | 12 | Caption baseline |
| `.rec-card__meta` | 12 | 13 | Read under 16px title |
| `.fit-pill` (in row) | 16 SemiBold | 14 SemiBold + lh 1.2 | Badge type — 16 was crushing a 44px pill |
| pipeline row padding | 12/8 | 12/16 | Thumb hit comfort |

## Test plan
- [ ] /job/jobs/ on iPhone — no horizontal scroll, content fills the viewport
- [ ] /job/jobs/recommended/ — carousel scrolls within its own row, page doesn't scroll sideways
- [ ] Top bar title shows at 18px (Jobs / For You / etc.)
- [ ] Fit pill scores look balanced inside the 44px circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)