### PR TITLE
job: mobile — drop bottom tabbar, edge-to-edge bars, stage-tabs scroll, fix row overlap

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.47.0");
-@import url("./tokens-generic-dark.css?v=0.47.0");
-@import url("./tokens-ctrl-light.css?v=0.47.0");
-@import url("./tokens-ctrl-dark.css?v=0.47.0");
-@import url("./components.css?v=0.47.0");
+@import url("./tokens-generic-light.css?v=0.48.0");
+@import url("./tokens-generic-dark.css?v=0.48.0");
+@import url("./tokens-ctrl-light.css?v=0.48.0");
+@import url("./tokens-ctrl-dark.css?v=0.48.0");
+@import url("./components.css?v=0.48.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -1421,10 +1421,10 @@
     position: fixed;
     left: 0;
     right: 0;
-    /* Sits just above the bottom tabbar (≈64px + safe-area). */
-    bottom: calc(64px + env(safe-area-inset-bottom));
+    bottom: 0;
     z-index: 28;
     padding: var(--space-3) var(--space-4);
+    padding-bottom: max(var(--space-3), env(safe-area-inset-bottom));
     background: var(--bg-surface);
     border-top: 1px solid var(--border);
     display: flex;
@@ -1436,9 +1436,10 @@
     min-height: 48px;
     justify-content: center;
   }
-  /* Make sure the bottom of the page content isn't hidden behind the bar. */
+  /* Reserve room below content for the sticky action bar so the last
+     paragraph isn't hidden by it. */
   .app__main:has(.role-header__actions) {
-    padding-bottom: calc(72px + 64px + env(safe-area-inset-bottom));
+    padding-bottom: calc(80px + env(safe-area-inset-bottom));
   }
 }
 
@@ -3273,6 +3274,33 @@
   margin-bottom: var(--space-4);
   flex-wrap: wrap;
 }
+/* On phones, the 5 stage chips can't fit on one line in 360–400px. Drop
+   the pill container so the row can scroll horizontally without an ugly
+   wrapping pill. The chips themselves keep their pill styling. */
+@media (max-width: 720px) {
+  .stage-tabs {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    border-radius: 0;
+    max-width: 100%;
+    gap: var(--space-2);
+  }
+  .stage-tabs::-webkit-scrollbar { display: none; }
+  .stage-tabs__tab {
+    flex-shrink: 0;
+    border: 1px solid var(--border);
+    background: var(--bg-surface);
+  }
+  .stage-tabs__tab.is-active {
+    border-color: var(--accent);
+  }
+}
 .stage-tabs__tab {
   appearance: none;
   background: transparent;
@@ -3467,19 +3495,19 @@
   }
   .pipeline-table tr {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-columns: 48px minmax(0, 1fr) 44px;
     grid-template-areas:
       "fit role menu"
       "fit meta menu";
-    column-gap: var(--space-3);
-    row-gap: 2px;
+    column-gap: var(--space-4);
+    row-gap: var(--space-2);
     align-items: center;
-    padding: var(--space-3) var(--space-4);
+    padding: var(--space-4) 0;
     border: 0;
     border-bottom: 1px solid var(--border);
     border-radius: 0;
     background: transparent;
-    min-height: 64px;
+    min-height: 72px;
   }
   .pipeline-table tr:last-child { border-bottom: 0; }
   .pipeline-table tr:hover td { background: transparent; }
@@ -3490,19 +3518,28 @@
   }
   .pipeline-table .col-fit {
     grid-area: fit;
-    width: 44px;
+    width: 48px;
     align-self: center;
     display: flex;
     align-items: center;
     justify-content: center;
+    overflow: visible;
   }
+  /* Score-pair on desktop shows both fit + candidate-strength side-by-side
+     in 93px. On phones that overflows a 48px column and bleeds into the
+     role title. Drop the secondary score on mobile — fit is the primary
+     signal; the breakdown lives one tap away in the role detail. */
+  .pipeline-table .col-fit .score-pair {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .pipeline-table .col-fit .score-pair__cand { display: none; }
   .pipeline-table .col-fit .fit-pill {
-    /* Badge type — keep at small (14px); the 16px default body size was
-       too large for a 44px-wide pill. */
     font-size: var(--font-size-small);
     font-weight: var(--fw-semibold);
     padding: 6px 0;
-    min-width: 44px;
+    min-width: 48px;
     text-align: center;
     line-height: 1.2;
   }
@@ -3538,6 +3575,8 @@
      grid-area: meta and overlap. Hide sector in favor of status on the
      pipeline rows (status is the higher-information cell). */
   .pipeline-table tr:has(.col-status) .col-sector { display: none; }
+  /* col-signal has no grid-area assigned — let auto-flow ignore it. */
+  .pipeline-table .col-signal { display: none; }
   .pipeline-table .col-menu {
     grid-area: menu;
     width: auto;
@@ -3638,21 +3677,24 @@
 .subnav-bar {
   display: none;
   position: sticky;
-  top: 65px; /* sits directly under mobile-bar */
+  /* Sticks just below the mobile-bar. The mobile-bar is the previous
+     body-level sibling and reports ~60–68px including safe-area inset. */
+  top: 60px;
   z-index: 29;
-  padding: var(--space-2) var(--space-4);
+  padding: var(--space-3) var(--space-4);
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
+  white-space: nowrap;
 }
 .subnav-bar::-webkit-scrollbar { display: none; }
 .subnav-bar__row {
   display: inline-flex;
-  gap: 6px;
-  padding: 2px;
-  background: var(--bg-surface);
-  border-radius: var(--radius-pill);
+  gap: var(--space-2);
+  padding: 0;
+  background: transparent;
 }
 .subnav-bar__item {
   display: inline-flex;
@@ -3684,52 +3726,8 @@
 }
 .subnav-bar__item[aria-current="page"] .nav-count { background: rgba(0,0,0,0.15); }
 
-/* --- Mobile bottom tab bar ---
-   Fixed at the bottom of the viewport, 4 items. The active route's icon and
-   label use --accent-strong (Bright Green) per the brand rule. Respects
-   iOS safe-area so the bar doesn't collide with the home indicator. */
-.app-tabbar {
-  display: none;
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 35;
-  background: var(--bg-surface);
-  border-top: 1px solid var(--border);
-  padding: 4px var(--space-2);
-  padding-bottom: max(4px, env(safe-area-inset-bottom));
-  justify-content: space-around;
-  align-items: stretch;
-}
-.app-tabbar__item {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 2px;
-  flex: 1 1 0;
-  min-height: 56px;
-  padding: 6px var(--space-2);
-  font-size: 11px;
-  font-weight: var(--fw-medium);
-  color: var(--fg-muted);
-  text-decoration: none;
-  border-radius: var(--radius-sm);
-}
-.app-tabbar__item:hover { text-decoration: none; }
-.app-tabbar__icon {
-  width: 24px;
-  height: 24px;
-  display: inline-grid;
-  place-items: center;
-  font-size: 18px;
-  line-height: 1;
-}
-.app-tabbar__item[aria-current="page"] {
-  color: var(--accent-strong-fg);
-  background: var(--accent-strong);
-}
+/* Bottom tab bar was removed: drawer (hamburger → rail) is the only mobile
+   nav. The .app-tabbar class is intentionally absent now. */
 
 /* Drawer scrim + sliding panel for rail nav. */
 .rail-scrim {
@@ -3746,7 +3744,6 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
 
 @media (max-width: 720px) {
   .mobile-bar { display: flex; }
-  .app-tabbar  { display: flex; }
   .subnav-bar[data-has-items="true"] { display: block; }
   /* Higher specificity (.app .app__rail) than base.css's unconditional
      `.app__rail { position: sticky }` rule, so the drawer's `fixed`
@@ -3792,10 +3789,8 @@ body.rail-open .rail-scrim { display: block; opacity: 1; }
     grid-area: main;
     min-width: 0;
     max-width: 100%;
-    padding: var(--space-4);
-    /* Leave room for the fixed bottom tabbar + safe-area inset so the last
-       row isn't hidden behind it. 64px ≈ tabbar height incl. padding. */
-    padding-bottom: calc(72px + env(safe-area-inset-bottom));
+    padding: var(--space-5) var(--space-4);
+    padding-bottom: max(var(--space-7), env(safe-area-inset-bottom));
   }
   body .app > .app__main > * { min-width: 0; max-width: 100%; }
   /* Horizontal carousels: keep them inside the viewport. They scroll

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.88.0";
-console.log(`[job] v${VERSION} - Mobile: viewport overflow firewall + type-size pass`);
+const VERSION = "0.89.0";
+console.log(`[job] v${VERSION} - Mobile: drop bottom tabbar, edge-to-edge bars, stage-tabs scroll, fix row overlap, breathing room`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -70,7 +70,6 @@ async function applySignedInState(email) {
   injectFooter();
   injectMobileBar();
   injectSubnavBar();
-  injectTabbar();
 }
 
 // Inject the global footer (theme toggle + version + links) into the .app
@@ -109,7 +108,10 @@ function injectMobileBar() {
     <span class="mobile-bar__title">${title}</span>
     <span class="mobile-bar__action-slot"></span>
   `;
-  main.prepend(bar);
+  // Sit OUTSIDE .app__main so the bar can be edge-to-edge while main keeps
+  // its own horizontal padding. Inserting before .app makes the sticky bar
+  // stick to the viewport top, not to a padded container.
+  document.body.insertBefore(bar, app);
 
   // Scrim sits between rail and the rest of the page; tapping it closes.
   let scrim = document.querySelector('.rail-scrim');
@@ -150,17 +152,18 @@ function injectMobileBar() {
 // rail uses to refresh its count badges.
 function injectSubnavBar() {
   if (document.querySelector('.subnav-bar')) return;
-  const main = document.querySelector('.app__main');
-  if (!main) return;
+  const app = document.querySelector('.app');
+  if (!app) return;
 
   const bar = document.createElement('nav');
   bar.className = 'subnav-bar';
   bar.setAttribute('aria-label', 'Sub-navigation');
   bar.dataset.hasItems = 'false';
   bar.innerHTML = `<div class="subnav-bar__row"></div>`;
-  // Place directly after the mobile-bar (which has been prepended already).
-  const mb = main.querySelector('.mobile-bar');
-  (mb || main).after(bar);
+  // Place directly after the mobile-bar (which has been inserted before .app).
+  const mb = document.querySelector('.mobile-bar');
+  if (mb) mb.after(bar);
+  else document.body.insertBefore(bar, app);
 
   const row = bar.querySelector('.subnav-bar__row');
   const here = location.pathname;
@@ -214,31 +217,7 @@ function injectSubnavBar() {
   askRail();
 }
 
-// Inject the bottom tab bar (4 top-level routes). CSS shows it only at
-// ≤720px. The active route gets aria-current="page" and styles with
-// --accent-strong. Sourcing from the rail's ROUTES list is overkill for
-// 4 items, so we declare them inline here. Keep in sync with job-rail.js.
-function injectTabbar() {
-  if (document.querySelector('.app-tabbar')) return;
-  const TABS = [
-    { href: '/job/jobs/',     label: 'Jobs',   icon: '◧', match: /^\/job\/jobs\/?/      },
-    { href: '/job/history/',  label: 'Career', icon: '◯', match: /^\/job\/history\/?/  },
-    { href: '/job/vision/',   label: 'Plan',   icon: '◇', match: /^\/job\/vision\/?/   },
-    { href: '/job/settings/', label: 'You',    icon: '◉', match: /^\/job\/settings\/?/ },
-  ];
-  const here = location.pathname;
-  const nav = document.createElement('nav');
-  nav.className = 'app-tabbar';
-  nav.setAttribute('aria-label', 'Primary');
-  nav.innerHTML = TABS.map(t => `
-    <a class="app-tabbar__item" href="${t.href}"
-       aria-current="${t.match.test(here) ? 'page' : 'false'}">
-      <span class="app-tabbar__icon" aria-hidden="true">${t.icon}</span>
-      <span class="app-tabbar__label">${t.label}</span>
-    </a>
-  `).join('');
-  document.body.appendChild(nav);
-}
+// (Bottom tab bar removed — drawer is the only mobile nav now.)
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when
 // it restores an existing session, so we must already be subscribed.

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.88.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.89.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.88.0">
-  <script src="/job/js/theme.js?v=0.88.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
+  <script src="/job/js/theme.js?v=0.89.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.88.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Iteration on user-reported mobile issues from screenshots.

## Fixes
1. **Bottom tabbar removed.** Felt cheesy. Drawer is the only mobile nav now (hamburger → rail).
2. **Top bar + subnav edge-to-edge.** They were prepended into `.app__main` which has horizontal padding, creating visible side gutters. Moved them OUT of main into body-level siblings (before `.app`), so they span full viewport while main keeps its own padding.
3. **Stage-tabs scroll horizontally on mobile.** The 5 stage chips wrapped to two rows in 360–400px. Mobile @media now drops the pill container, sets `flex-wrap: nowrap; overflow-x: auto`. Each tab keeps its individual pill border + active state.
4. **Pipeline row overlap fixed.** Root cause: `.score-pair` (fit + candidate-strength chips) is 93px wide inside a 44px `col-fit` and bled into the role title. On mobile: stack the pair vertically, hide `.score-pair__cand` entirely (fit is primary; breakdown is one tap into role detail). Bumped `col-fit` width to 48px.
5. **col-signal hidden.** It had no grid-area, so auto-flow placed it inside the row and contributed to the visual mess.
6. **Breathing room.** Pipeline row padding 12/8 → 16/0 internal with `space-4` gaps, min-height 72px. Main padding bumped to space-5/space-4.
7. **Subnav simplified.** Removed the pill container backdrop (was a card-in-a-card visual). Items flow as plain tabs.
8. **Sticky action bar** moved to `bottom: 0` (no tabbar to reserve space above).

## Test plan
- [ ] /job/jobs/?bucket=active on iPhone — no row overlap, only fit pill visible in leading slot, status pill on its own line
- [ ] Stage tabs scroll horizontally, don't wrap
- [ ] Top bar + subnav span full viewport width (no side gutters)
- [ ] No bottom tabbar
- [ ] More vertical space between rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)