### PR TITLE
job: mobile — home dashboard at /job/ + back caret + fix For You row + ✓ icon

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.48.0");
-@import url("./tokens-generic-dark.css?v=0.48.0");
-@import url("./tokens-ctrl-light.css?v=0.48.0");
-@import url("./tokens-ctrl-dark.css?v=0.48.0");
-@import url("./components.css?v=0.48.0");
+@import url("./tokens-generic-light.css?v=0.49.0");
+@import url("./tokens-generic-dark.css?v=0.49.0");
+@import url("./tokens-ctrl-light.css?v=0.49.0");
+@import url("./tokens-ctrl-dark.css?v=0.49.0");
+@import url("./components.css?v=0.49.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -3589,24 +3589,55 @@
     border-radius: var(--radius-pill);
   }
 
-  /* Recs table extras — collapse location / source / added into the meta line. */
+  /* Recs table extras — collapse location / source / added into the meta line.
+     col-menu on rec rows holds the Save + Dismiss actions (rec-actions ~96px
+     wide), so widen the menu column there. col-sector (which carries the
+     "source" string for recs, NOT a sector chip cluster) is hidden because
+     the company name already appears in col-role. */
   .pipeline-table tr:has(.col-location) {
+    grid-template-columns: 48px minmax(0, 1fr) auto;
     grid-template-areas:
       "fit role     menu"
       "fit metarec  menu";
+    column-gap: var(--space-3);
   }
+  .pipeline-table tr:has(.col-location) .col-sector { display: none; }
+  .pipeline-table tr:has(.col-location) .col-source { display: none; }
   .pipeline-table .col-location,
-  .pipeline-table .col-source,
   .pipeline-table .col-added {
     grid-area: metarec;
     width: auto;
     font-size: var(--font-size-caption);
     color: var(--fg-muted);
+    align-self: start;
   }
-  /* When all three are present, stack them inline with separators via gap. */
-  .pipeline-table tr:has(.col-location) .col-location { justify-self: start; }
-  .pipeline-table tr:has(.col-location) .col-source   { display: none; } /* keep info dense */
-  .pipeline-table tr:has(.col-location) .col-added    { justify-self: end; }
+  .pipeline-table tr:has(.col-location) .col-location { justify-self: start; white-space: nowrap; }
+  .pipeline-table tr:has(.col-location) .col-added    { justify-self: end;   white-space: nowrap; }
+  .pipeline-table tr:has(.col-location) .col-menu {
+    width: auto;
+    min-width: 96px;
+    align-self: center;
+  }
+  .pipeline-table .col-menu .rec-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+  /* Save button → checkmark icon on mobile. The label span is hidden, the
+     icon span (added in the Lit template) shows. Visually a 36px round
+     accent button — cleaner than a "Save" text pill at this width. */
+  .pipeline-table .col-menu .rec-actions .btn--accent {
+    width: 40px;
+    min-width: 40px;
+    height: 40px;
+    padding: 0;
+    border-radius: var(--radius-pill);
+  }
+  .pipeline-table .col-menu .rec-actions .btn--accent .btn-label { display: none; }
+  .pipeline-table .col-menu .rec-actions .btn-dismiss {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 /* --- Mobile top app bar (title + contextual action; menu opens drawer) ---
@@ -3626,6 +3657,7 @@
   align-items: center;
   gap: var(--space-3);
 }
+.mobile-bar__back,
 .mobile-bar__menu,
 .mobile-bar__action {
   display: inline-grid;
@@ -3636,14 +3668,17 @@
   border: 0;
   background: transparent;
   color: var(--fg);
-  font-size: 20px;
+  font-size: 28px;
+  line-height: 1;
   cursor: pointer;
   flex-shrink: 0;
+  text-decoration: none;
 }
+.mobile-bar__back:hover,
 .mobile-bar__menu:hover,
-.mobile-bar__action:hover { background: var(--bg-elevated); }
-.mobile-bar__menu:active,
-.mobile-bar__action:active { background: var(--bg-surface); }
+.mobile-bar__action:hover { background: var(--bg-elevated); text-decoration: none; }
+.mobile-bar__back { font-weight: var(--fw-semibold); padding-bottom: 4px; }
+.mobile-bar__spacer { width: 44px; height: 44px; flex-shrink: 0; }
 .mobile-bar__title {
   flex: 1;
   min-width: 0;
@@ -3662,12 +3697,157 @@
   align-items: center;
   gap: var(--space-2);
 }
+/* The For You carousel inside the Saved Jobs page (rendered by
+   <job-pipeline> when bucket=leads) is pulled forward to the home dashboard
+   on mobile, so hide it on the list view to avoid duplication and a long
+   above-the-fold scroll before the user reaches their saved roles. */
+@media (max-width: 720px) {
+  job-pipeline > job-recommendations { display: none; }
+}
+
 .mobile-bar__brand,
 .mobile-bar__sub { /* legacy — kept so older injected markup still renders */
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
   font-size: var(--font-size-body-lg);
   letter-spacing: -0.015em;
+}
+
+/* --- Mobile home dashboard (rendered by <job-home>) ---
+   Full-page hub at /job/ on mobile. Stacks four entry cards (Jobs, Career,
+   Plan, Settings); the Jobs card shows live counts plus a preview list of
+   For You roles so the carousel data is "pulled forward" into the hub. */
+.home {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+.home__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: clamp(28px, 7vw, 36px);
+  letter-spacing: -0.02em;
+  line-height: var(--lh-title);
+}
+.home__sub {
+  margin: 0 0 var(--space-2);
+  color: var(--fg-muted);
+  font-size: var(--font-size-body);
+}
+.home-card {
+  display: block;
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  text-decoration: none;
+  transition: border-color 80ms ease, transform 80ms ease;
+}
+.home-card:hover { border-color: var(--border-strong); text-decoration: none; }
+.home-card:active { transform: translateY(1px); }
+.home-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+.home-card__head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.015em;
+  line-height: var(--lh-tight);
+}
+.home-card__arrow {
+  color: var(--fg-subtle);
+  font-size: 22px;
+  line-height: 1;
+}
+.home-card__hint {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  line-height: var(--lh-tight);
+}
+.home-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+}
+.home-card__metrics strong {
+  color: var(--fg);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-4);
+  margin-right: 4px;
+}
+.home-card__list {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-3);
+}
+.home-rec {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  color: var(--fg);
+  text-decoration: none;
+}
+.home-rec:hover { text-decoration: none; }
+.home-rec__logo {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+.home-rec__body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.3;
+}
+.home-rec__title {
+  font-size: var(--font-size-body);
+  font-weight: var(--fw-medium);
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-rec__sub {
+  font-size: 13px;
+  color: var(--fg-subtle);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-rec__fit {
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-small);
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-strong);
+  color: var(--accent-strong-fg);
+  min-width: 36px;
+  text-align: center;
 }
 
 /* --- Mobile segmented sub-nav ---
@@ -3729,45 +3909,15 @@
 /* Bottom tab bar was removed: drawer (hamburger → rail) is the only mobile
    nav. The .app-tabbar class is intentionally absent now. */
 
-/* Drawer scrim + sliding panel for rail nav. */
-.rail-scrim {
-  display: none;
-  position: fixed;
-  inset: 0;
-  background: rgba(14,15,12,0.45);
-  z-index: 40;
-  opacity: 0;
-  transition: opacity 160ms ease;
-}
-body.rail-open .rail-scrim { display: block; opacity: 1; }
-[data-theme$="-dark"] .rail-scrim { background: rgba(0,0,0,0.55); }
+/* Drawer pattern was retired on mobile; .rail-scrim CSS was here. */
 
 @media (max-width: 720px) {
   .mobile-bar { display: flex; }
   .subnav-bar[data-has-items="true"] { display: block; }
-  /* Higher specificity (.app .app__rail) than base.css's unconditional
-     `.app__rail { position: sticky }` rule, so the drawer's `fixed`
-     positioning wins regardless of CSS load order. base.css @imports
-     components.css then declares its own rules, so a flat `.app__rail`
-     selector here would otherwise lose the cascade. */
-  .app .app__rail {
-    position: fixed;
-    inset: 0 auto 0 0;
-    width: min(280px, 86vw);
-    height: 100dvh;
-    transform: translateX(-100%);
-    transition: transform 220ms cubic-bezier(0.2, 0.0, 0.0, 1.0);
-    z-index: 50;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    box-shadow: var(--shadow-lg);
-    padding: var(--space-5) var(--space-4);
-    padding-top: max(var(--space-5), env(safe-area-inset-top));
-    padding-bottom: max(var(--space-5), env(safe-area-inset-bottom));
-    gap: var(--space-5);
-  }
-  body.rail-open .app .app__rail { transform: translateX(0); }
-  .rail-foot { margin-top: auto; flex-direction: column; align-items: flex-start; }
+  /* Drawer pattern is retired on mobile — the home dashboard at /job/ is
+     the nav surface. Hide the rail entirely on phones; the rail stays for
+     desktop. */
+  .app .app__rail { display: none; }
   /* Higher-specificity selector (body .app) to outrank the unconditional
      base.css `.app { grid-template-columns: 280px 1fr }` rule — same
      cascade trap as the rail. Mobile collapses to a single column; the

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -2,14 +2,40 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <title>/job — ctrl.rodeo</title>
-  <meta http-equiv="refresh" content="0; url=/job/jobs/">
-  <link rel="canonical" href="/job/jobs/">
   <meta name="robots" content="noindex">
-  <style>body{font-family:system-ui;padding:40px;color:#666}</style>
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
+  <script src="/auth/ctrl-auth.js"></script>
+  <script>
+    // Desktop falls through to the Jobs list view — the rail nav is more
+    // information-dense there, so the dashboard home is mobile-only.
+    if (window.matchMedia('(min-width: 721px)').matches) {
+      location.replace('/job/jobs/');
+    }
+  </script>
 </head>
-<body>
-  <p>Redirecting to <a href="/job/jobs/">/job/jobs/</a>…</p>
-  <script>location.replace('/job/jobs/');</script>
+<body data-auth-state="loading">
+
+  <section id="signin-gate" class="gate">
+    <div class="gate__card">
+      <h1>/job</h1>
+      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <button class="btn btn--primary" id="signin-btn">Sign in</button>
+      <div id="ctrl-auth-root"></div>
+    </div>
+  </section>
+
+  <div class="app">
+    <job-rail></job-rail>
+    <main class="app__main">
+      <job-home></job-home>
+    </main>
+  </div>
+
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.89.0";
-console.log(`[job] v${VERSION} - Mobile: drop bottom tabbar, edge-to-edge bars, stage-tabs scroll, fix row overlap, breathing room`);
+const VERSION = "0.90.0";
+console.log(`[job] v${VERSION} - Mobile: home dashboard at /job/, back caret, drop drawer, fix For You row, ✓ icon`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -39,6 +39,11 @@ if (location.pathname.startsWith('/job/onboarding')) {
 }
 if (location.pathname.startsWith('/job/settings')) {
   import('./components/job-settings.js' + V);
+}
+// Mobile dashboard at /job/ (root). Desktop gets redirected to /jobs/ by
+// inline script in index.html before this module runs.
+if (location.pathname === '/job/' || location.pathname === '/job') {
+  import('./components/job-home.js' + V);
 }
 
 async function applySignedInState(email) {
@@ -82,67 +87,35 @@ function injectFooter() {
   app.appendChild(el);
 }
 
-// Inject a mobile top app bar (menu + page title + optional action slot) at
-// the start of every page's <main>. CSS hides it on >720px screens. Tapping
-// the menu button flips body.rail-open which slides the rail in as a drawer.
-//
-// The title text is sourced from the page's .page-header h1 so each route
-// shows its own name. Pages can populate the trailing action slot by
-// appending elements to <header class="mobile-bar"> .mobile-bar__action-slot
-// (used by the pipeline page for Filter / Search).
+// Inject a mobile top app bar at the start of <body>. CSS hides it on
+// >720px screens. The leading button is a back caret on every page except
+// the home dashboard at /job/, where it's omitted. Title comes from the
+// page's .page-header h1.
 function injectMobileBar() {
   if (document.querySelector('.mobile-bar')) return;
-  const main = document.querySelector('.app__main');
   const app = document.querySelector('.app');
-  if (!main || !app) return;
+  if (!app) return;
 
-  const title = document.querySelector('.page-header h1')?.textContent?.trim()
-    || document.title.replace(/\s*[—|]\s*\/?job.*$/i, '').trim()
-    || 'ctrl.rodeo';
+  const isHome = location.pathname === '/job/' || location.pathname === '/job';
+  const title = isHome
+    ? '/ job'
+    : (document.querySelector('.page-header h1')?.textContent?.trim()
+       || document.title.replace(/\s*[—|]\s*\/?job.*$/i, '').trim()
+       || 'ctrl.rodeo');
 
   const bar = document.createElement('header');
   bar.className = 'mobile-bar';
+  bar.dataset.home = isHome ? 'true' : 'false';
   bar.innerHTML = `
-    <button type="button" class="mobile-bar__menu" aria-label="Open navigation"
-            aria-controls="job-rail" aria-expanded="false">☰</button>
+    ${isHome
+      ? `<span class="mobile-bar__spacer" aria-hidden="true"></span>`
+      : `<a class="mobile-bar__back" href="/job/" aria-label="Back to home">‹</a>`}
     <span class="mobile-bar__title">${title}</span>
     <span class="mobile-bar__action-slot"></span>
   `;
   // Sit OUTSIDE .app__main so the bar can be edge-to-edge while main keeps
-  // its own horizontal padding. Inserting before .app makes the sticky bar
-  // stick to the viewport top, not to a padded container.
+  // its own horizontal padding.
   document.body.insertBefore(bar, app);
-
-  // Scrim sits between rail and the rest of the page; tapping it closes.
-  let scrim = document.querySelector('.rail-scrim');
-  if (!scrim) {
-    scrim = document.createElement('div');
-    scrim.className = 'rail-scrim';
-    scrim.setAttribute('aria-hidden', 'true');
-    document.body.appendChild(scrim);
-  }
-
-  const close = () => {
-    document.body.classList.remove('rail-open');
-    bar.querySelector('.mobile-bar__menu').setAttribute('aria-expanded', 'false');
-  };
-  const open = () => {
-    document.body.classList.add('rail-open');
-    bar.querySelector('.mobile-bar__menu').setAttribute('aria-expanded', 'true');
-  };
-
-  bar.querySelector('.mobile-bar__menu').addEventListener('click', () => {
-    document.body.classList.contains('rail-open') ? close() : open();
-  });
-  scrim.addEventListener('click', close);
-  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
-  // Tapping a nav link inside the rail should close the drawer.
-  document.querySelector('.app__rail')?.addEventListener('click', (e) => {
-    if (e.target.closest('a[href]')) close();
-  });
-  // If the viewport grows past the breakpoint, drop the open state.
-  const mq = window.matchMedia('(min-width: 721px)');
-  mq.addEventListener?.('change', (e) => { if (e.matches) close(); });
 }
 
 // Inject the mobile segmented sub-nav (sticky under mobile-bar). Only

--- a/job/js/components/job-home.js
+++ b/job/js/components/job-home.js
@@ -1,0 +1,139 @@
+// job-home — mobile-only hub page. Renders at /job/ (root) and gives the
+// user a directory of the app: Jobs (with For You carousel + counts),
+// Career, Search plan, Settings. Replaces the drawer pattern on phones —
+// instead of opening a slide-out nav, the user navigates by tapping a
+// big section card. Desktop is unaffected; app.js redirects /job/ → /jobs/
+// for non-mobile viewports.
+
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+const V = (new URL(import.meta.url)).search;
+const [{ fetchPipeline, fetchRecommendations }] = await Promise.all([
+  import('../pipeline.js' + V),
+]);
+
+function isVisibleRole(r) {
+  if (!r.url) return false;
+  const company = (r.company || '').toLowerCase();
+  if (company === 'strava') return false;
+  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
+  return true;
+}
+function bucketOf(r) {
+  if (r.status === 'Active') return 'active';
+  if (r.status === 'Archive') return 'archive';
+  return 'leads';
+}
+
+export class JobHome extends LitElement {
+  createRenderRoot() { return this; }
+  static properties = {
+    counts: { state: true },
+    topRecs: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.counts = null;
+    this.topRecs = null;
+    this._onAuth = () => this._loadAll();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+    if (document.body.dataset.authState === 'in') this._loadAll();
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _loadAll() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this._loading) return;
+    this._loading = true;
+    try {
+      const [pipe, recs] = await Promise.all([
+        fetchPipeline().catch(() => null),
+        fetchRecommendations({ view: 'top' }).catch(() => null),
+      ]);
+      const roles = (pipe?.roles || []).filter(isVisibleRole);
+      const leads  = roles.filter(r => bucketOf(r) === 'leads').length;
+      const active = roles.filter(r => bucketOf(r) === 'active').length;
+      const recommended = recs?.count ?? (recs?.recommendations?.length ?? 0);
+      this.counts = { leads, active, recommended };
+      this.topRecs = (recs?.recommendations || []).slice(0, 5);
+    } finally {
+      this._loading = false;
+    }
+  }
+
+  _renderRecCard(rec) {
+    const initial = (rec.company || '·').slice(0, 1).toUpperCase();
+    return html`
+      <a class="home-rec" href="/job/jobs/recommended/">
+        <div class="home-rec__logo" aria-hidden="true">${initial}</div>
+        <div class="home-rec__body">
+          <span class="home-rec__title">${rec.title || 'Untitled role'}</span>
+          <span class="home-rec__sub">${rec.company || ''}${rec.location ? ` · ${rec.location}` : ''}</span>
+        </div>
+        <span class="home-rec__fit">${Number.isFinite(rec.fit) ? rec.fit : ''}</span>
+      </a>
+    `;
+  }
+
+  render() {
+    const c = this.counts || { leads: '—', active: '—', recommended: '—' };
+    return html`
+      <section class="home">
+        <h1 class="home__title">/ job</h1>
+        <p class="home__sub">Ian's career knowledge base.</p>
+
+        <a class="home-card home-card--jobs" href="/job/jobs/">
+          <div class="home-card__head">
+            <h2>Jobs</h2>
+            <span class="home-card__arrow" aria-hidden="true">→</span>
+          </div>
+          <div class="home-card__metrics">
+            <span><strong>${c.recommended}</strong> for you</span>
+            <span><strong>${c.leads}</strong> saved</span>
+            <span><strong>${c.active}</strong> active</span>
+          </div>
+          ${this.topRecs && this.topRecs.length ? html`
+            <div class="home-card__list">
+              ${this.topRecs.map(r => this._renderRecCard(r))}
+            </div>
+          ` : nothing}
+        </a>
+
+        <a class="home-card" href="/job/history/">
+          <div class="home-card__head">
+            <h2>Your career</h2>
+            <span class="home-card__arrow" aria-hidden="true">→</span>
+          </div>
+          <p class="home-card__hint">Companies, roles, and the narratives that go in your résumé.</p>
+        </a>
+
+        <a class="home-card" href="/job/vision/">
+          <div class="home-card__head">
+            <h2>Search plan</h2>
+            <span class="home-card__arrow" aria-hidden="true">→</span>
+          </div>
+          <p class="home-card__hint">Goals and intents that shape the recommendations.</p>
+        </a>
+
+        <a class="home-card" href="/job/settings/">
+          <div class="home-card__head">
+            <h2>Settings</h2>
+            <span class="home-card__arrow" aria-hidden="true">→</span>
+          </div>
+          <p class="home-card__hint">Theme, profile, onboarding.</p>
+        </a>
+      </section>
+    `;
+  }
+}
+
+customElements.define('job-home', JobHome);

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -300,9 +300,12 @@ export class JobRecommendationsTable extends LitElement {
         <td class="col col-menu">
           <div class="rec-actions">
             <button class="btn btn--sm btn--accent"
+                    aria-label=${this.addingId === r.id ? 'Saving' : 'Save role'}
+                    title=${this.addingId === r.id ? 'Saving…' : 'Save role'}
                     ?disabled=${this.addingId === r.id}
                     @click=${() => this._onAdd(r)}>
-              ${this.addingId === r.id ? 'Saving…' : 'Save'}
+              <span class="btn-icon" aria-hidden="true">${this.addingId === r.id ? '…' : '✓'}</span>
+              <span class="btn-label">${this.addingId === r.id ? 'Saving…' : 'Save'}</span>
             </button>
             <button class="btn-dismiss" aria-label="Dismiss recommendation"
                     title="Dismiss"

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.89.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.90.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.89.0">
-  <script src="/job/js/theme.js?v=0.89.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
+  <script src="/job/js/theme.js?v=0.90.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.89.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Replaces the drawer pattern on phones with a full-page home dashboard, fixes the For You list row overlap, swaps the Save button text for a checkmark icon, and removes the duplicate For You carousel from the Saved Jobs page.

## Mobile home dashboard
- `/job/` no longer redirects on mobile. Renders a new `<job-home>` Lit component with 4 entry cards (Jobs / Career / Plan / Settings).
- Jobs card pulls the For You carousel data forward as a 5-item preview list and shows live counts: `383 for you · 32 saved · 2 active`.
- Desktop still redirects to `/jobs/` via inline script (the rail nav owns navigation there).

## Drawer retired on mobile
- `<job-rail>` hides at ≤720px. The home is the nav surface now.
- `.mobile-bar` leads with a back caret on every page except `/job/`, which gets an inset spacer to keep the title centered.

## For You row overlap (the screenshot pain)
- Root cause: `tr:has(.col-location)` had no `grid-template-columns` rule, so `col-sector` and `col-source` fell into auto-flow and stole the role column's width (rendered 30.7px wide).
- Fix: explicit 48px / 1fr / auto template. `col-sector` and `col-source` hidden on mobile (the company already appears in the role cell).
- `col-menu` widened to fit Save + Dismiss without clipping.

## ✓ icon instead of "Save" text
- Lit template now renders `.btn-icon` (✓) + `.btn-label` (text) spans. CSS hides the label inside `.rec-actions` on mobile and rounds the button to 40px.

## Saved Jobs page
- `job-pipeline > job-recommendations { display: none }` on mobile. The For You carousel is already showcased on the home page; duplicating it buried the saved list.

## Test plan
- [ ] `/job/` on iPhone — shows home dashboard with 4 cards, top section shows top 5 For You roles with fit pills
- [ ] Tap "Jobs" card → /job/jobs/, back caret returns to home
- [ ] /job/jobs/recommended/ — rows are clean, Save shown as ✓ button
- [ ] /job/jobs/?bucket=leads — no For You carousel above the saved table
- [ ] Desktop unchanged (rail nav, no home, ≥721px redirects /job/ → /jobs/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)