### PR TITLE
job: fix sign-in gate flash + always show 'For You' on recs page

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.49.0");
-@import url("./tokens-generic-dark.css?v=0.49.0");
-@import url("./tokens-ctrl-light.css?v=0.49.0");
-@import url("./tokens-ctrl-dark.css?v=0.49.0");
-@import url("./components.css?v=0.49.0");
+@import url("./tokens-generic-light.css?v=0.49.1");
+@import url("./tokens-generic-dark.css?v=0.49.1");
+@import url("./tokens-ctrl-light.css?v=0.49.1");
+@import url("./tokens-ctrl-dark.css?v=0.49.1");
+@import url("./components.css?v=0.49.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 
@@ -40,9 +40,15 @@ button { font: inherit; cursor: pointer; }
 
 ::selection { background: var(--accent-muted); color: var(--fg); }
 
-/* Auth gating: signin card visible until allowlisted user is signed in. */
+/* Auth gating: gate visible only when auth definitely resolved to signed-out.
+   During the loading window (initial paint → session restored from cookie)
+   we hide both the gate and the app so neither flashes briefly during page
+   navigations. Once ctrl-auth dispatches signedin/signedout, the matching
+   surface fades in. */
+body[data-auth-state="loading"] #signin-gate,
+body[data-auth-state="loading"] .app { visibility: hidden; }
 body[data-auth-state="in"] #signin-gate { display: none; }
-body:not([data-auth-state="in"]) .app { display: none; }
+body[data-auth-state="out"] .app { display: none; }
 
 /* Hide the floating CtrlAuth bar while signed-out (own gate has the CTA). */
 body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -6,8 +6,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.90.0";
-console.log(`[job] v${VERSION} - Mobile: home dashboard at /job/, back caret, drop drawer, fix For You row, ✓ icon`);
+const VERSION = "0.90.1";
+console.log(`[job] v${VERSION} - Auth: no gate flash during loading; rec-table H1 always "For You"`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -345,7 +345,7 @@ export class JobRecommendationsTable extends LitElement {
     const rows = this._sorted();
     return html`
       <header class="recs-page__head">
-        <h1>Recommended for you</h1>
+        <h1>For You</h1>
         <span class="muted">${rows.length} ${rows.length === 1 ? 'role' : 'roles'}</span>
         <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
                 title="Scan Gmail for new role alerts and application updates"

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.90.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.90.1">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.0">
-  <script src="/job/js/theme.js?v=0.90.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.90.1">
+  <script src="/job/js/theme.js?v=0.90.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.90.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Two user-reported bugs:

1. **Sign-in gate flashes between page navigations.** `body` starts with `data-auth-state=\"loading\"` and CSS only hid the gate when state was `\"in\"`, so the gate paint was visible for the milliseconds before ctrl-auth restored the session.

   Fix: hide both the gate and the app while state is loading (`visibility: hidden` preserves layout, no flash on resolve).

2. **For You page H1 swap.** Loading rendered \"For You\" then loaded swapped to \"Recommended for you\". Made both states render \"For You\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)