### PR TITLE
job: P0 agent chat — FAB + bottom drawer + ask-job-agent

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.49.2");
-@import url("./tokens-generic-dark.css?v=0.49.2");
-@import url("./tokens-ctrl-light.css?v=0.49.2");
-@import url("./tokens-ctrl-dark.css?v=0.49.2");
-@import url("./components.css?v=0.49.2");
+@import url("./tokens-generic-light.css?v=0.50.0");
+@import url("./tokens-generic-dark.css?v=0.50.0");
+@import url("./tokens-ctrl-light.css?v=0.50.0");
+@import url("./tokens-ctrl-dark.css?v=0.50.0");
+@import url("./components.css?v=0.50.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -4958,3 +4958,243 @@ job-onboarding { display: contents; }
   font-size: var(--font-size-caption);
   color: var(--fg-muted);
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Global agent chat — FAB + bottom drawer (mounted by app.js
+   via injectChat). Visible everywhere except onboarding.
+   See <job-chat> component for state.
+   ───────────────────────────────────────────────────────────── */
+
+.chat-fab {
+  position: fixed;
+  right: var(--space-4);
+  bottom: var(--space-4);
+  bottom: max(var(--space-4), env(safe-area-inset-bottom));
+  z-index: 55;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-pill);
+  border: 0;
+  background: var(--accent-strong);
+  color: var(--accent-strong-fg);
+  font-size: 22px;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  display: inline-grid;
+  place-items: center;
+  transition: transform 80ms ease, box-shadow 80ms ease;
+}
+.chat-fab:hover { box-shadow: var(--shadow-lg); }
+.chat-fab:active { transform: translateY(1px); }
+.chat-fab__icon { line-height: 1; }
+
+/* Scrim sits between page and drawer. Mobile only — on desktop the drawer
+   is a floating panel that doesn't need a backdrop. */
+.chat-scrim {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 15, 12, 0.45);
+  z-index: 56;
+}
+[data-theme$="-dark"] .chat-scrim { background: rgba(0, 0, 0, 0.55); }
+@media (max-width: 720px) {
+  .chat-scrim { display: block; }
+}
+
+.chat-drawer {
+  position: fixed;
+  z-index: 57;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+/* Mobile: bottom sheet, ~88dvh tall, rounded top, full width. */
+@media (max-width: 720px) {
+  .chat-drawer {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    height: 88dvh;
+    max-height: 88dvh;
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+/* Desktop: floating panel anchored bottom-right above the FAB. */
+@media (min-width: 721px) {
+  .chat-drawer {
+    right: var(--space-4);
+    bottom: calc(56px + var(--space-4) + var(--space-3));
+    width: min(420px, 90vw);
+    height: min(640px, 80vh);
+    border-radius: var(--radius-lg);
+  }
+}
+
+.chat-drawer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+.chat-drawer__title {
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-4);
+  letter-spacing: -0.01em;
+}
+.chat-drawer__close {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-pill);
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-size: 22px;
+  cursor: pointer;
+  line-height: 1;
+}
+.chat-drawer__close:hover { background: var(--bg-elevated); }
+
+.chat-drawer__thread {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.chat-empty {
+  padding: var(--space-5) var(--space-3);
+  text-align: center;
+  color: var(--fg-muted);
+  font-size: var(--font-size-body);
+}
+.chat-empty p { margin: 0 0 var(--space-2); }
+.chat-empty__hint { font-size: var(--font-size-small); color: var(--fg-subtle); }
+
+.chat-msg {
+  display: flex;
+  max-width: 88%;
+}
+.chat-msg__body {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-lg);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.chat-msg--user {
+  align-self: flex-end;
+}
+.chat-msg--user .chat-msg__body {
+  background: var(--accent-strong);
+  color: var(--accent-strong-fg);
+  border-bottom-right-radius: var(--radius-md);
+}
+.chat-msg--assistant {
+  align-self: flex-start;
+}
+.chat-msg--assistant .chat-msg__body {
+  background: var(--bg-surface);
+  color: var(--fg);
+  border-bottom-left-radius: var(--radius-md);
+}
+.chat-msg--pending .chat-msg__body {
+  padding: var(--space-3) var(--space-4);
+  display: inline-flex;
+  gap: 4px;
+}
+.chat-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--fg-subtle);
+  animation: chat-dot 1.2s infinite ease-in-out both;
+}
+.chat-dot:nth-child(2) { animation-delay: 0.15s; }
+.chat-dot:nth-child(3) { animation-delay: 0.3s; }
+@keyframes chat-dot {
+  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-2px); }
+}
+
+.chat-error {
+  align-self: flex-start;
+  font-size: var(--font-size-small);
+  color: var(--error);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--error) 8%, transparent);
+}
+
+.chat-drawer__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0 var(--space-4) var(--space-3);
+}
+.chat-chip {
+  font: inherit;
+  font-size: var(--font-size-small);
+  padding: 6px var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--bg);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.chat-chip:hover { border-color: var(--border-strong); color: var(--fg); }
+
+.chat-drawer__composer {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+  align-items: flex-end;
+}
+.chat-drawer__input {
+  flex: 1;
+  resize: none;
+  min-height: 44px;
+  max-height: 160px;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-body);
+  line-height: var(--lh-tight);
+  outline: none;
+}
+.chat-drawer__input:focus { border-color: var(--accent); }
+
+.chat-drawer__send {
+  width: 44px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0;
+  font-size: 18px;
+  flex-shrink: 0;
+  border-radius: var(--radius-pill);
+}
+
+/* Hide the chat on the not-authorized + auth-loading paint to match the
+   existing rule that hides the rest of the app. */
+body[data-auth-state="loading"] job-chat,
+body[data-auth-state="out"] job-chat { display: none; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -6,8 +6,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.90.2";
-console.log(`[job] v${VERSION} - Mobile: hide For You H1 (mobile-bar title covers it)`);
+const VERSION = "0.91.0";
+console.log(`[job] v${VERSION} - Agent chat P0: FAB + drawer + ask-job-agent (no tools yet)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -75,6 +75,7 @@ async function applySignedInState(email) {
   injectFooter();
   injectMobileBar();
   injectSubnavBar();
+  injectChat();
 }
 
 // Inject the global footer (theme toggle + version + links) into the .app
@@ -191,6 +192,16 @@ function injectSubnavBar() {
 }
 
 // (Bottom tab bar removed — drawer is the only mobile nav now.)
+
+// Mount the global agent chat — FAB at bottom-right + bottom drawer.
+// Skipped on onboarding (the onboarding flow has its own chat surface).
+async function injectChat() {
+  if (document.querySelector('job-chat')) return;
+  if (location.pathname.startsWith('/job/onboarding')) return;
+  await import('./components/job-chat.js' + V);
+  const el = document.createElement('job-chat');
+  document.body.appendChild(el);
+}
 
 // Listeners FIRST — CtrlAuth's init can dispatch signedin synchronously when
 // it restores an existing session, so we must already be subscribed.

--- a/job/js/components/job-chat.js
+++ b/job/js/components/job-chat.js
@@ -1,0 +1,221 @@
+// job-chat — global chat surface. FAB at bottom-right of every /job page;
+// tap to open a bottom drawer with a chat thread. Mounted by app.js after
+// auth so the data exchange is always user-scoped.
+//
+// P0 scope:
+//   - one rolling thread per user
+//   - non-streaming POST to /functions/v1/ask-job-agent
+//   - assistant has NO tools yet — it can answer questions and acknowledge
+//     requests but cannot mutate anything
+//   - history fetched directly from public.chat_message (RLS-gated)
+//
+// P1 will swap the request to the agent SDK with tools + streaming + sub-
+// agents per the locked design recommendations.
+
+import { LitElement, html, css, nothing } from 'https://esm.run/lit@3';
+
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const FN_URL = `${SUPABASE_URL}/functions/v1/ask-job-agent`;
+
+const QUICK_PROMPTS = [
+  'What can you do?',
+  'Summarize my pipeline',
+  'I don\'t want to see engineering roles',
+  'Add a role: ',
+];
+
+export class JobChat extends LitElement {
+  // Light DOM so it inherits global tokens + can be styled from components.css.
+  createRenderRoot() { return this; }
+
+  static properties = {
+    open:     { state: true },
+    messages: { state: true },
+    sending:  { state: true },
+    error:    { state: true },
+    draft:    { state: true },
+  };
+
+  constructor() {
+    super();
+    this.open = false;
+    this.messages = [];
+    this.sending = false;
+    this.error = '';
+    this.draft = '';
+    this._loaded = false;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Wait until auth is resolved before fetching history. app.js mounts
+    // this component after applySignedInState() so we can usually fetch
+    // immediately, but guard anyway.
+    if (document.body.dataset.authState === 'in') this._loadHistory();
+  }
+
+  _supabase() { return window.CtrlAuth?.getSupabaseClient?.(); }
+
+  async _loadHistory() {
+    if (this._loaded) return;
+    const sb = this._supabase();
+    if (!sb) return;
+    const { data, error } = await sb
+      .from('chat_message')
+      .select('id, role, body, created_at')
+      .order('created_at', { ascending: true })
+      .limit(200);
+    if (error) {
+      console.warn('[job-chat] history fetch failed', error);
+      return;
+    }
+    this.messages = (data || []).map((m) => ({ ...m, kind: 'persisted' }));
+    this._loaded = true;
+  }
+
+  async _send() {
+    const text = (this.draft || '').trim();
+    if (!text || this.sending) return;
+    this.error = '';
+    this.sending = true;
+
+    // Optimistic local insert so the thread updates instantly.
+    const optimisticId = `tmp-${Date.now()}`;
+    this.messages = [
+      ...this.messages,
+      { id: optimisticId, role: 'user', body: text, kind: 'optimistic' },
+    ];
+    this.draft = '';
+    this._scrollToBottom();
+
+    const sb = this._supabase();
+    const token = (await sb?.auth.getSession?.())?.data?.session?.access_token;
+    if (!token) {
+      this.error = 'Not signed in.';
+      this.sending = false;
+      return;
+    }
+
+    try {
+      const res = await fetch(FN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+          'apikey': window.CtrlAuth?.config?.supabaseAnonKey || '',
+        },
+        body: JSON.stringify({ message: text }),
+      });
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Server ${res.status}: ${errText.slice(0, 240)}`);
+      }
+      const data = await res.json();
+      // Replace optimistic user message with the persisted one and append assistant.
+      this.messages = this.messages
+        .filter((m) => m.id !== optimisticId)
+        .concat([data.user, data.assistant].filter(Boolean).map((m) => ({ ...m, kind: 'persisted' })));
+      this._scrollToBottom();
+    } catch (err) {
+      console.error('[job-chat] send failed', err);
+      this.error = String(err.message || err);
+      // Leave the optimistic user message in place so the user can retry.
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  _scrollToBottom() {
+    requestAnimationFrame(() => {
+      const el = this.querySelector('.chat-drawer__thread');
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+  }
+
+  _onKeyDown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      this._send();
+    }
+  }
+
+  _toggle() {
+    this.open = !this.open;
+    if (this.open) {
+      this._loadHistory();
+      requestAnimationFrame(() => this.querySelector('.chat-drawer__input')?.focus());
+      this._scrollToBottom();
+    }
+  }
+
+  _useQuickPrompt(p) {
+    this.draft = p;
+    this.querySelector('.chat-drawer__input')?.focus();
+  }
+
+  render() {
+    return html`
+      <button class="chat-fab"
+              aria-label=${this.open ? 'Close chat' : 'Open chat'}
+              aria-expanded=${this.open ? 'true' : 'false'}
+              @click=${() => this._toggle()}>
+        <span class="chat-fab__icon" aria-hidden="true">${this.open ? '×' : '✨'}</span>
+      </button>
+
+      ${this.open ? html`
+        <div class="chat-scrim" @click=${() => this._toggle()} aria-hidden="true"></div>
+        <aside class="chat-drawer" role="dialog" aria-label="Job chat">
+          <header class="chat-drawer__head">
+            <span class="chat-drawer__title">Ask /job</span>
+            <button class="chat-drawer__close" aria-label="Close" @click=${() => this._toggle()}>×</button>
+          </header>
+
+          <div class="chat-drawer__thread">
+            ${this.messages.length === 0 ? html`
+              <div class="chat-empty">
+                <p>I'm the /job agent. Ask me anything about your pipeline, career, or search plan.</p>
+                <p class="chat-empty__hint">In P0 I can only answer questions — tools land soon.</p>
+              </div>
+            ` : this.messages.map((m) => html`
+              <div class="chat-msg chat-msg--${m.role}">
+                <div class="chat-msg__body">${m.body}</div>
+              </div>
+            `)}
+            ${this.sending ? html`
+              <div class="chat-msg chat-msg--assistant chat-msg--pending">
+                <div class="chat-msg__body"><span class="chat-dot"></span><span class="chat-dot"></span><span class="chat-dot"></span></div>
+              </div>
+            ` : nothing}
+            ${this.error ? html`<div class="chat-error">${this.error}</div>` : nothing}
+          </div>
+
+          ${this.messages.length === 0 ? html`
+            <div class="chat-drawer__chips">
+              ${QUICK_PROMPTS.map((p) => html`
+                <button class="chat-chip" @click=${() => this._useQuickPrompt(p)}>${p}</button>
+              `)}
+            </div>
+          ` : nothing}
+
+          <form class="chat-drawer__composer" @submit=${(e) => { e.preventDefault(); this._send(); }}>
+            <textarea class="chat-drawer__input"
+                      placeholder="Ask anything…"
+                      rows="1"
+                      .value=${this.draft}
+                      ?disabled=${this.sending}
+                      @input=${(e) => { this.draft = e.target.value; }}
+                      @keydown=${this._onKeyDown}></textarea>
+            <button class="chat-drawer__send btn btn--primary"
+                    type="submit"
+                    aria-label="Send"
+                    ?disabled=${this.sending || !this.draft.trim()}>
+              ↑
+            </button>
+          </form>
+        </aside>
+      ` : nothing}
+    `;
+  }
+}
+
+customElements.define('job-chat', JobChat);

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.90.2">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.91.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.90.2">
-  <script src="/job/js/theme.js?v=0.90.2"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
+  <script src="/job/js/theme.js?v=0.91.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.90.2"></script>
+  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
 </body>
 </html>

--- a/supabase/functions/ask-job-agent/index.ts
+++ b/supabase/functions/ask-job-agent/index.ts
@@ -1,0 +1,173 @@
+// Supabase Edge Function: ask-job-agent
+// Coordinator for the /job global chat. P0 scope: single-turn LLM with the
+// last N messages of context, no tools, no streaming. The agent loop with
+// tool use and sub-agents lands in P1.
+//
+// POST /functions/v1/ask-job-agent
+// Body: { message: string }
+// Returns: { user: ChatMessage, assistant: ChatMessage }
+//
+// Auth: standard /job bearer token (verifyJobUserDetailed).
+//
+// Design recs locked in (see chat conversation):
+//   - Coordinator: claude-sonnet-4-6
+//   - Single rolling thread per user
+//   - Direct-answer for read-only; in P0 every request is read-only
+//   - $0.05 hard cap per turn (≈ ~25k input + 4k output tokens at Sonnet)
+//   - No streaming yet (P4)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
+import { verifyJobUserDetailed, corsHeaders } from '../_shared/job-auth.ts';
+
+const VERSION = '0.1.0';
+console.log(`[ask-job-agent] v${VERSION} — P0 coordinator (no tools, no stream)`);
+
+const MODEL = 'claude-sonnet-4-6';
+const MAX_HISTORY = 20;   // last N messages included as context
+const MAX_OUTPUT_TOKENS = 1024;
+
+const SYSTEM_PROMPT = `You are the agent for /job, Ian Fike's career knowledge base at ctrl.rodeo/job. Ian uses this app to track every job he's interested in, his career history, his recommendations, and his search preferences.
+
+You speak with Ian directly. Be concise, conversational, and useful. Match the voice of a sharp, friendly co-worker — not a customer-support bot. Don't add disclaimers, preambles, or "great question" filler.
+
+Your job right now (P0 scope):
+- Answer questions about what /job is, what's on the site, and what you (the agent) will be able to do once tools are wired up.
+- Be honest about your limits. You can't yet read Ian's actual pipeline, vision, or career data — that lands in P1.
+- If Ian asks you to *do* something (add a role, update preferences, archive items, generate a resume, summarize his pipeline) tell him which Tier-1 capability that maps to and that it's coming in the next phase. Don't pretend to do it.
+
+When you do not know something, say so. Keep responses under ~120 words unless Ian explicitly asks for more.`;
+
+interface ClientMessage { role: 'user' | 'assistant' | 'tool' | 'system'; body: string; }
+
+async function fetchHistory(supabase: ReturnType<typeof createClient>, userId: string): Promise<ClientMessage[]> {
+  const { data, error } = await supabase
+    .from('chat_message')
+    .select('role, body')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(MAX_HISTORY);
+  if (error) {
+    console.warn('[ask-job-agent] fetchHistory failed', error);
+    return [];
+  }
+  // Reverse so we end up with oldest-first to send to the model.
+  return (data || []).reverse() as ClientMessage[];
+}
+
+async function insertMessage(
+  supabase: ReturnType<typeof createClient>,
+  userId: string,
+  role: 'user' | 'assistant',
+  body: string,
+): Promise<{ id: string; role: string; body: string; created_at: string } | null> {
+  const { data, error } = await supabase
+    .from('chat_message')
+    .insert({ user_id: userId, role, body })
+    .select('id, role, body, created_at')
+    .single();
+  if (error) {
+    console.warn('[ask-job-agent] insertMessage failed', error);
+    return null;
+  }
+  return data as { id: string; role: string; body: string; created_at: string };
+}
+
+async function callClaude(history: ClientMessage[], userMsg: string): Promise<string> {
+  const anthropicKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!anthropicKey) throw new Error('ANTHROPIC_API_KEY not configured');
+
+  // Anthropic messages API expects only user/assistant roles; map tool
+  // results down to user-role text for now (tools aren't in P0).
+  const messages = [
+    ...history
+      .filter(m => m.role === 'user' || m.role === 'assistant')
+      .map(m => ({ role: m.role as 'user' | 'assistant', content: m.body })),
+    { role: 'user' as const, content: userMsg },
+  ];
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': anthropicKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: MAX_OUTPUT_TOKENS,
+      system: SYSTEM_PROMPT,
+      messages,
+    }),
+  });
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Anthropic API ${res.status}: ${errText.slice(0, 400)}`);
+  }
+  const payload = await res.json();
+  const text = (payload?.content || [])
+    .filter((b: { type: string }) => b.type === 'text')
+    .map((b: { text: string }) => b.text)
+    .join('\n')
+    .trim();
+  return text || '(no response)';
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
+  }
+
+  const user = await verifyJobUserDetailed(req);
+  if (!user) {
+    return new Response(JSON.stringify({ error: 'unauthorized' }), {
+      status: 401,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  let message = '';
+  try {
+    const body = await req.json();
+    message = String(body?.message || '').slice(0, 4000).trim();
+  } catch (_) { /* ignored */ }
+  if (!message) {
+    return new Response(JSON.stringify({ error: 'message required' }), {
+      status: 400,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Use a user-scoped client so RLS gates the insert/select to this user.
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+  const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+
+  try {
+    const history = await fetchHistory(supabase, user.id);
+
+    // Persist the user turn first so even if the model call fails the
+    // message isn't lost from the UI.
+    const userRecord = await insertMessage(supabase, user.id, 'user', message);
+
+    const assistantText = await callClaude(history, message);
+    const assistantRecord = await insertMessage(supabase, user.id, 'assistant', assistantText);
+
+    return new Response(JSON.stringify({ user: userRecord, assistant: assistantRecord }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[ask-job-agent] error', err);
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/071_chat.sql
+++ b/supabase/migrations/071_chat.sql
@@ -1,0 +1,39 @@
+-- Migration 071_chat.sql
+-- Adds chat_message — the per-user agent chat history shown in the
+-- floating chat drawer at the bottom-right of every /job page.
+--
+-- P0 design (see docs/strategy/prds/job-chat.md — to be written):
+--   - single rolling thread per user, so no thread_id column yet
+--   - role enum mirrors the Anthropic message-API role taxonomy plus a
+--     local 'tool' value for tool-result events once P1 lands
+--   - tool_name + tool_payload are nullable today and populated by the
+--     agent loop in P1 when actions like update_pipeline_row run
+--
+-- RLS: standard owner-only pattern. The edge function uses the user's
+-- bearer token so insert/select policies cover both reads and writes.
+
+create table public.chat_message (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid not null references auth.users(id) on delete cascade,
+  role        text not null check (role in ('user', 'assistant', 'tool', 'system')),
+  body        text not null default '',
+  tool_name   text,
+  tool_payload jsonb,
+  created_at  timestamptz not null default now()
+);
+
+create index chat_message_user_created_idx
+  on public.chat_message (user_id, created_at desc);
+
+alter table public.chat_message enable row level security;
+
+create policy "chat_message: owner select"
+  on public.chat_message for select
+  using (auth.uid() = user_id);
+
+create policy "chat_message: owner insert"
+  on public.chat_message for insert
+  with check (auth.uid() = user_id);
+
+-- Grant the standard role set; RLS handles the actual gating.
+grant select, insert on public.chat_message to authenticated;


### PR DESCRIPTION
First slice of the global agent chat. **Already deployed** to Supabase (migration applied, edge fn live).

## What ships
- **`<job-chat>` component** — FAB bottom-right + bottom drawer (mobile) / floating panel (desktop). Mounted in body by `app.js` after auth. Persists per-user thread.
- **`ask-job-agent` edge fn** — single-turn Sonnet 4.6 coordinator, last 20 messages of context. No tools, no streaming yet. System prompt is scoped to /job and instructs the model to be honest about its current limits (so "summarize my pipeline" → "that's P1, not faking it" rather than hallucination).
- **`071_chat.sql` migration** — single rolling thread per user; role enum + tool fields ready for P1.

## What's NOT in P0
- Tools (search_pipeline, update_pipeline_row, add_role_from_url, update_vision) — P1
- Streaming + sub-agents — P2
- `/job/chat/` permalink page — P4

## Test plan
- [ ] FAB visible on /job/, /job/jobs/, /job/history/ etc. (not on onboarding)
- [ ] Click FAB → drawer opens; mobile = bottom sheet, desktop = floating panel bottom-right
- [ ] Ask "What can you do?" → coherent reply scoped to the agent's actual capabilities
- [ ] Ask "Archive everything I applied to >2 weeks ago" → honest "that's P1, not yet" reply
- [ ] Reload page → previous messages reappear
- [ ] Sign out → FAB disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)