### PR TITLE
job: P1 agent chat — agent loop + 4 Tier-1 tools

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.50.0");
-@import url("./tokens-generic-dark.css?v=0.50.0");
-@import url("./tokens-ctrl-light.css?v=0.50.0");
-@import url("./tokens-ctrl-dark.css?v=0.50.0");
-@import url("./components.css?v=0.50.0");
+@import url("./tokens-generic-light.css?v=0.51.0");
+@import url("./tokens-generic-dark.css?v=0.51.0");
+@import url("./tokens-ctrl-light.css?v=0.51.0");
+@import url("./tokens-ctrl-dark.css?v=0.51.0");
+@import url("./components.css?v=0.51.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -5198,3 +5198,27 @@ job-onboarding { display: contents; }
    existing rule that hides the rest of the app. */
 body[data-auth-state="loading"] job-chat,
 body[data-auth-state="out"] job-chat { display: none; }
+
+/* Inline tool-use pill in the chat thread. Surfaces what the agent is
+   doing under the hood ("search_pipeline · Acme → 3 matches") without
+   spamming the thread with raw JSON. */
+.chat-tool {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 4px var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  max-width: 88%;
+}
+.chat-tool__icon { font-size: 11px; opacity: 0.8; }
+.chat-tool__name {
+  font-family: var(--font-mono);
+  font-weight: var(--fw-medium);
+  color: var(--fg);
+}
+.chat-tool__summary { color: var(--fg-subtle); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -6,8 +6,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.91.0";
-console.log(`[job] v${VERSION} - Agent chat P0: FAB + drawer + ask-job-agent (no tools yet)`);
+const VERSION = "0.92.0";
+console.log(`[job] v${VERSION} - Agent chat P1: agent loop + 4 Tier-1 tools live`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-chat.js
+++ b/job/js/components/job-chat.js
@@ -62,7 +62,7 @@ export class JobChat extends LitElement {
     if (!sb) return;
     const { data, error } = await sb
       .from('chat_message')
-      .select('id, role, body, created_at')
+      .select('id, role, body, tool_name, tool_payload, created_at')
       .order('created_at', { ascending: true })
       .limit(200);
     if (error) {
@@ -111,10 +111,13 @@ export class JobChat extends LitElement {
         throw new Error(`Server ${res.status}: ${errText.slice(0, 240)}`);
       }
       const data = await res.json();
-      // Replace optimistic user message with the persisted one and append assistant.
+      // New response shape is { events: ChatEvent[] } where ChatEvent may be
+      // role 'user' | 'assistant' | 'tool'. Replace the optimistic user
+      // message and append the full event trace in order.
+      const events = (data.events || []).filter(Boolean).map((m) => ({ ...m, kind: 'persisted' }));
       this.messages = this.messages
         .filter((m) => m.id !== optimisticId)
-        .concat([data.user, data.assistant].filter(Boolean).map((m) => ({ ...m, kind: 'persisted' })));
+        .concat(events);
       this._scrollToBottom();
     } catch (err) {
       console.error('[job-chat] send failed', err);
@@ -153,6 +156,47 @@ export class JobChat extends LitElement {
     this.querySelector('.chat-drawer__input')?.focus();
   }
 
+  _renderEvent(m) {
+    if (m.role === 'tool') {
+      const summary = this._summarizeTool(m);
+      return html`
+        <div class="chat-tool">
+          <span class="chat-tool__icon" aria-hidden="true">⚙</span>
+          <span class="chat-tool__name">${m.tool_name}</span>
+          <span class="chat-tool__summary">${summary}</span>
+        </div>
+      `;
+    }
+    return html`
+      <div class="chat-msg chat-msg--${m.role}">
+        <div class="chat-msg__body">${m.body}</div>
+      </div>
+    `;
+  }
+
+  _summarizeTool(m) {
+    const input = m.tool_payload?.input || {};
+    const out = m.tool_payload?.output || {};
+    switch (m.tool_name) {
+      case 'search_pipeline':
+        return `${input.query || '(all)'} → ${out.count ?? 0} matches`;
+      case 'update_pipeline_row': {
+        const fields = Object.entries(input).filter(([k]) => k !== 'slug').map(([k, v]) => `${k}=${v}`).join(', ');
+        return `${input.slug} · ${fields || 'no-op'}`;
+      }
+      case 'add_role_from_url':
+        return `${input.url} → ${out.ok === false ? 'failed' : (out.role?.title || out.slug || 'saved')}`;
+      case 'update_preferences': {
+        const bits = [];
+        if (input.blocked) bits.push(`blocked: ${input.blocked}`);
+        if (input.must_have) bits.push(`must_have: ${input.must_have}`);
+        return bits.join(' · ') || 'noted';
+      }
+      default:
+        return '';
+    }
+  }
+
   render() {
     return html`
       <button class="chat-fab"
@@ -173,14 +217,9 @@ export class JobChat extends LitElement {
           <div class="chat-drawer__thread">
             ${this.messages.length === 0 ? html`
               <div class="chat-empty">
-                <p>I'm the /job agent. Ask me anything about your pipeline, career, or search plan.</p>
-                <p class="chat-empty__hint">In P0 I can only answer questions — tools land soon.</p>
+                <p>I'm the /job agent. Ask me about your pipeline, paste a role to save, change a stage, or steer your preferences.</p>
               </div>
-            ` : this.messages.map((m) => html`
-              <div class="chat-msg chat-msg--${m.role}">
-                <div class="chat-msg__body">${m.body}</div>
-              </div>
-            `)}
+            ` : this.messages.map((m) => this._renderEvent(m))}
             ${this.sending ? html`
               <div class="chat-msg chat-msg--assistant chat-msg--pending">
                 <div class="chat-msg__body"><span class="chat-dot"></span><span class="chat-dot"></span><span class="chat-dot"></span></div>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.91.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.92.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.91.0">
-  <script src="/job/js/theme.js?v=0.91.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
+  <script src="/job/js/theme.js?v=0.92.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.91.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
 </body>
 </html>

--- a/supabase/functions/ask-job-agent/index.ts
+++ b/supabase/functions/ask-job-agent/index.ts
@@ -1,173 +1,197 @@
 // Supabase Edge Function: ask-job-agent
-// Coordinator for the /job global chat. P0 scope: single-turn LLM with the
-// last N messages of context, no tools, no streaming. The agent loop with
-// tool use and sub-agents lands in P1.
-//
-// POST /functions/v1/ask-job-agent
-// Body: { message: string }
-// Returns: { user: ChatMessage, assistant: ChatMessage }
-//
-// Auth: standard /job bearer token (verifyJobUserDetailed).
-//
-// Design recs locked in (see chat conversation):
-//   - Coordinator: claude-sonnet-4-6
-//   - Single rolling thread per user
-//   - Direct-answer for read-only; in P0 every request is read-only
-//   - $0.05 hard cap per turn (≈ ~25k input + 4k output tokens at Sonnet)
-//   - No streaming yet (P4)
+// P1: agent loop with 4 tools. Sonnet 4.6 coordinator. See chat thread for
+// locked design recs.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
 import { verifyJobUserDetailed, corsHeaders } from '../_shared/job-auth.ts';
 
-const VERSION = '0.1.0';
-console.log(`[ask-job-agent] v${VERSION} — P0 coordinator (no tools, no stream)`);
+const VERSION = '0.2.0';
+console.log(`[ask-job-agent] v${VERSION} - P1 agent loop with 4 tools`);
 
 const MODEL = 'claude-sonnet-4-6';
-const MAX_HISTORY = 20;   // last N messages included as context
+const MAX_HISTORY = 20;
 const MAX_OUTPUT_TOKENS = 1024;
+const MAX_ITERATIONS = 5;
 
-const SYSTEM_PROMPT = `You are the agent for /job, Ian Fike's career knowledge base at ctrl.rodeo/job. Ian uses this app to track every job he's interested in, his career history, his recommendations, and his search preferences.
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
+const PIPE_URL     = `${SUPABASE_URL}/functions/v1/jobs-pipe`;
+const ADD_ROLE_URL = `${SUPABASE_URL}/functions/v1/add-role`;
+const KB_READ_URL  = `${SUPABASE_URL}/functions/v1/kb-read`;
+const KB_WRITE_URL = `${SUPABASE_URL}/functions/v1/kb-write`;
 
-You speak with Ian directly. Be concise, conversational, and useful. Match the voice of a sharp, friendly co-worker — not a customer-support bot. Don't add disclaimers, preambles, or "great question" filler.
+const SYSTEM_PROMPT = `You are the agent for /job, Ian Fike's career knowledge base at ctrl.rodeo/job. Ian uses /job to track every role he's interested in, his career history, and his search preferences.
 
-Your job right now (P0 scope):
-- Answer questions about what /job is, what's on the site, and what you (the agent) will be able to do once tools are wired up.
-- Be honest about your limits. You can't yet read Ian's actual pipeline, vision, or career data — that lands in P1.
-- If Ian asks you to *do* something (add a role, update preferences, archive items, generate a resume, summarize his pipeline) tell him which Tier-1 capability that maps to and that it's coming in the next phase. Don't pretend to do it.
+Speak with Ian directly. Be concise, conversational, useful. Voice = sharp, friendly co-worker, not customer support. No disclaimers, no "great question" filler. Keep replies under ~120 words unless he asks for more.
 
-When you do not know something, say so. Keep responses under ~120 words unless Ian explicitly asks for more.`;
+You have four tools:
+- search_pipeline(query): find roles Ian has saved or marked active. Pass a short query. Returns up to 20 matches with slug, title, company, status, stage, fit_score, url.
+- update_pipeline_row(slug, fields): change a row's status/stage/exit_reason. Find slug via search_pipeline first. Stages: Drafting|Applied|Interviewing|Offer. Status: Active|Archive.
+- add_role_from_url(url): save a job posting URL into Ian's pipeline.
+- update_preferences(blocked, must_have): record search-direction signals.
 
-interface ClientMessage { role: 'user' | 'assistant' | 'tool' | 'system'; body: string; }
+Rules:
+- Use search_pipeline before update_pipeline_row to look up the slug.
+- Don't confirm before single-row changes - just do them and report.
+- If a tool fails, tell Ian honestly. Don't pretend it worked.
+- If the request doesn't match any tool, just answer.`;
 
-async function fetchHistory(supabase: ReturnType<typeof createClient>, userId: string): Promise<ClientMessage[]> {
-  const { data, error } = await supabase
-    .from('chat_message')
-    .select('role, body')
-    .eq('user_id', userId)
-    .order('created_at', { ascending: false })
-    .limit(MAX_HISTORY);
-  if (error) {
-    console.warn('[ask-job-agent] fetchHistory failed', error);
-    return [];
-  }
-  // Reverse so we end up with oldest-first to send to the model.
-  return (data || []).reverse() as ClientMessage[];
+const TOOLS = [
+  { name: 'search_pipeline', description: "Search Ian's saved + active job pipeline. Returns up to 20 matching rows.", input_schema: { type: 'object', properties: { query: { type: 'string', description: 'Free-text query.' } }, required: ['query'] } },
+  { name: 'update_pipeline_row', description: 'Update a single pipeline row by slug.', input_schema: { type: 'object', properties: { slug: { type: 'string' }, status: { type: 'string', enum: ['Active','Archive'] }, stage: { type: 'string', enum: ['Drafting','Applied','Interviewing','Offer'] }, exit_reason: { type: 'string' } }, required: ['slug'] } },
+  { name: 'add_role_from_url', description: 'Save a job posting from a URL.', input_schema: { type: 'object', properties: { url: { type: 'string' } }, required: ['url'] } },
+  { name: 'update_preferences', description: 'Record search-direction signals.', input_schema: { type: 'object', properties: { blocked: { type: 'string' }, must_have: { type: 'string' }, note: { type: 'string' } } } },
+];
+
+async function authedFetch(url: string, opts: RequestInit, authHeader: string): Promise<Response> {
+  return fetch(url, { ...opts, headers: { ...(opts.headers || {}), Authorization: authHeader } });
 }
 
-async function insertMessage(
-  supabase: ReturnType<typeof createClient>,
-  userId: string,
-  role: 'user' | 'assistant',
-  body: string,
-): Promise<{ id: string; role: string; body: string; created_at: string } | null> {
-  const { data, error } = await supabase
-    .from('chat_message')
-    .insert({ user_id: userId, role, body })
-    .select('id, role, body, created_at')
-    .single();
-  if (error) {
-    console.warn('[ask-job-agent] insertMessage failed', error);
-    return null;
-  }
-  return data as { id: string; role: string; body: string; created_at: string };
+async function toolSearchPipeline({ query }: { query: string }, authHeader: string) {
+  const res = await authedFetch(PIPE_URL, {}, authHeader);
+  if (!res.ok) throw new Error(`jobs-pipe ${res.status}: ${(await res.text()).slice(0,200)}`);
+  const data = await res.json();
+  const roles: Array<Record<string, unknown>> = data.roles || [];
+  const q = (query || '').toLowerCase().trim();
+  const filtered = q ? roles.filter((r) => [r.title, r.company, r.sector, r.notes, r.slug].some((f) => (String(f||'')).toLowerCase().includes(q))) : roles;
+  const trimmed = filtered.slice(0,20).map((r) => ({ slug: r.slug, title: r.title, company: r.company, status: r.status, stage: r.stage, fit_score: r.fit_score, url: r.url }));
+  return { count: filtered.length, roles: trimmed };
 }
 
-async function callClaude(history: ClientMessage[], userMsg: string): Promise<string> {
-  const anthropicKey = Deno.env.get('ANTHROPIC_API_KEY');
-  if (!anthropicKey) throw new Error('ANTHROPIC_API_KEY not configured');
+async function toolUpdatePipelineRow(args: Record<string, unknown>, authHeader: string) {
+  const patch: Record<string, unknown> = { slug: args.slug };
+  for (const k of ['status','stage','exit_reason']) { if (args[k] != null) patch[k] = args[k]; }
+  const res = await authedFetch(PIPE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(patch) }, authHeader);
+  if (!res.ok) throw new Error(`update-role ${res.status}: ${(await res.text()).slice(0,200)}`);
+  return await res.json();
+}
 
-  // Anthropic messages API expects only user/assistant roles; map tool
-  // results down to user-role text for now (tools aren't in P0).
-  const messages = [
-    ...history
-      .filter(m => m.role === 'user' || m.role === 'assistant')
-      .map(m => ({ role: m.role as 'user' | 'assistant', content: m.body })),
-    { role: 'user' as const, content: userMsg },
-  ];
+async function toolAddRoleFromUrl({ url }: { url: string }, authHeader: string) {
+  const res = await authedFetch(ADD_ROLE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url }) }, authHeader);
+  if (!res.ok) throw new Error(`add-role ${res.status}: ${(await res.text()).slice(0,200)}`);
+  return await res.json();
+}
 
+async function toolUpdatePreferences(args: { blocked?: string; must_have?: string; note?: string }, authHeader: string) {
+  const path = 'fikei/job/02-goals-intents/agent-preferences.md';
+  let existing = '';
+  let sha: string | undefined;
+  try {
+    const readRes = await authedFetch(`${KB_READ_URL}?path=${encodeURIComponent(path)}`, {}, authHeader);
+    if (readRes.ok) { const d = await readRes.json(); existing = d.content || ''; sha = d.sha; }
+  } catch (_) {}
+  if (!args.blocked && !args.must_have) return { ok: false, error: 'specify blocked or must_have' };
+  const ts = new Date().toISOString().slice(0,10);
+  const lines: string[] = [];
+  if (args.blocked)   lines.push(`- ${ts}: **blocked** - ${args.blocked}${args.note ? ` _(${args.note})_` : ''}`);
+  if (args.must_have) lines.push(`- ${ts}: **must_have** - ${args.must_have}${args.note ? ` _(${args.note})_` : ''}`);
+  const header = '# Agent search preferences\n\nAppended by /job chat. Used to bias future recommendations.\n\n';
+  const body = existing.includes('# Agent search preferences') ? existing : header;
+  const newBody = body.trimEnd() + '\n' + lines.join('\n') + '\n';
+  const writeRes = await authedFetch(KB_WRITE_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ path, content: newBody, sha }) }, authHeader);
+  if (!writeRes.ok) throw new Error(`kb-write ${writeRes.status}: ${(await writeRes.text()).slice(0,200)}`);
+  return { ok: true, appended: lines };
+}
+
+async function runTool(name: string, input: Record<string, unknown>, authHeader: string): Promise<unknown> {
+  try {
+    switch (name) {
+      case 'search_pipeline':     return await toolSearchPipeline(input as { query: string }, authHeader);
+      case 'update_pipeline_row': return await toolUpdatePipelineRow(input, authHeader);
+      case 'add_role_from_url':   return await toolAddRoleFromUrl(input as { url: string }, authHeader);
+      case 'update_preferences':  return await toolUpdatePreferences(input as { blocked?: string; must_have?: string; note?: string }, authHeader);
+      default: return { error: `unknown tool: ${name}` };
+    }
+  } catch (err) { return { error: String((err as Error).message || err) }; }
+}
+
+interface PersistedMessage { id: string; role: 'user'|'assistant'|'tool'; body: string; tool_name?: string; tool_payload?: unknown; created_at: string; }
+
+async function fetchHistory(supabase: ReturnType<typeof createClient>, userId: string): Promise<PersistedMessage[]> {
+  const { data, error } = await supabase.from('chat_message').select('id, role, body, tool_name, tool_payload, created_at').eq('user_id', userId).order('created_at', { ascending: false }).limit(MAX_HISTORY);
+  if (error) { console.warn('[ask-job-agent] history fail', error); return []; }
+  return ((data || []) as PersistedMessage[]).reverse();
+}
+
+async function insertMessage(supabase: ReturnType<typeof createClient>, userId: string, row: { role: 'user'|'assistant'|'tool'; body: string; tool_name?: string; tool_payload?: unknown }): Promise<PersistedMessage | null> {
+  const { data, error } = await supabase.from('chat_message').insert({ user_id: userId, ...row }).select('id, role, body, tool_name, tool_payload, created_at').single();
+  if (error) { console.warn('[ask-job-agent] insert fail', error); return null; }
+  return data as PersistedMessage;
+}
+
+interface TextBlock { type: 'text'; text: string; }
+interface ToolUseBlock { type: 'tool_use'; id: string; name: string; input: Record<string, unknown>; }
+type ContentBlock = TextBlock | ToolUseBlock;
+interface ClaudeResp { content: ContentBlock[]; stop_reason: string; }
+
+async function callClaude(messages: Array<{ role: 'user'|'assistant'; content: unknown }>): Promise<ClaudeResp> {
+  const key = Deno.env.get('ANTHROPIC_API_KEY'); if (!key) throw new Error('ANTHROPIC_API_KEY missing');
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': anthropicKey,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: MAX_OUTPUT_TOKENS,
-      system: SYSTEM_PROMPT,
-      messages,
-    }),
+    headers: { 'Content-Type': 'application/json', 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({ model: MODEL, max_tokens: MAX_OUTPUT_TOKENS, system: SYSTEM_PROMPT, tools: TOOLS, messages }),
   });
-  if (!res.ok) {
-    const errText = await res.text();
-    throw new Error(`Anthropic API ${res.status}: ${errText.slice(0, 400)}`);
+  if (!res.ok) throw new Error(`Anthropic ${res.status}: ${(await res.text()).slice(0,400)}`);
+  return await res.json();
+}
+
+function historyToMessages(history: PersistedMessage[]): Array<{ role: 'user'|'assistant'; content: unknown }> {
+  const out: Array<{ role: 'user'|'assistant'; content: unknown }> = [];
+  for (const m of history) {
+    if (m.role === 'tool') continue;
+    if (!m.body) continue;
+    out.push({ role: m.role as 'user'|'assistant', content: m.body });
   }
-  const payload = await res.json();
-  const text = (payload?.content || [])
-    .filter((b: { type: string }) => b.type === 'text')
-    .map((b: { text: string }) => b.text)
-    .join('\n')
-    .trim();
-  return text || '(no response)';
+  return out;
 }
 
 serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders });
-  }
-  if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
-  }
-
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return new Response('Method not allowed', { status: 405, headers: corsHeaders });
   const user = await verifyJobUserDetailed(req);
-  if (!user) {
-    return new Response(JSON.stringify({ error: 'unauthorized' }), {
-      status: 401,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
-  }
-
+  if (!user) return new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   let message = '';
-  try {
-    const body = await req.json();
-    message = String(body?.message || '').slice(0, 4000).trim();
-  } catch (_) { /* ignored */ }
-  if (!message) {
-    return new Response(JSON.stringify({ error: 'message required' }), {
-      status: 400,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
-  }
+  try { const body = await req.json(); message = String(body?.message || '').slice(0,4000).trim(); } catch (_) {}
+  if (!message) return new Response(JSON.stringify({ error: 'message required' }), { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
-  // Use a user-scoped client so RLS gates the insert/select to this user.
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
   const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
-  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-    global: { headers: { Authorization: `Bearer ${token}` } },
-  });
+  const authHeader = `Bearer ${token}`;
+  const supabase = createClient(SUPABASE_URL, supabaseAnonKey, { global: { headers: { Authorization: authHeader } } });
+  const newEvents: PersistedMessage[] = [];
 
   try {
     const history = await fetchHistory(supabase, user.id);
+    const userRec = await insertMessage(supabase, user.id, { role: 'user', body: message });
+    if (userRec) newEvents.push(userRec);
 
-    // Persist the user turn first so even if the model call fails the
-    // message isn't lost from the UI.
-    const userRecord = await insertMessage(supabase, user.id, 'user', message);
+    const messages: Array<{ role: 'user'|'assistant'; content: unknown }> = historyToMessages(history);
+    messages.push({ role: 'user', content: message });
 
-    const assistantText = await callClaude(history, message);
-    const assistantRecord = await insertMessage(supabase, user.id, 'assistant', assistantText);
-
-    return new Response(JSON.stringify({ user: userRecord, assistant: assistantRecord }), {
-      status: 200,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    let iter = 0;
+    while (iter < MAX_ITERATIONS) {
+      iter++;
+      const response = await callClaude(messages);
+      const blocks = response.content;
+      const text = blocks.filter((b): b is TextBlock => b.type === 'text').map((b) => b.text).join('\n').trim();
+      const toolUses = blocks.filter((b): b is ToolUseBlock => b.type === 'tool_use');
+      if (text) { const rec = await insertMessage(supabase, user.id, { role: 'assistant', body: text }); if (rec) newEvents.push(rec); }
+      messages.push({ role: 'assistant', content: blocks });
+      if (response.stop_reason !== 'tool_use' || toolUses.length === 0) break;
+      const resultBlocks: Array<{ type: 'tool_result'; tool_use_id: string; content: string }> = [];
+      for (const tu of toolUses) {
+        const result = await runTool(tu.name, tu.input, authHeader);
+        const rec = await insertMessage(supabase, user.id, { role: 'tool', body: '', tool_name: tu.name, tool_payload: { input: tu.input, output: result } });
+        if (rec) newEvents.push(rec);
+        resultBlocks.push({ type: 'tool_result', tool_use_id: tu.id, content: JSON.stringify(result).slice(0,8000) });
+      }
+      messages.push({ role: 'user', content: resultBlocks });
+    }
+    return new Response(JSON.stringify({ events: newEvents }), { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   } catch (err) {
-    console.error('[ask-job-agent] error', err);
-    return new Response(JSON.stringify({ error: String(err) }), {
-      status: 500,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-    });
+    console.error('[ask-job-agent] err', err);
+    const rec = await insertMessage(supabase, user.id, { role: 'assistant', body: `Sorry — I hit an error. (${String((err as Error).message || err).slice(0,200)})` });
+    if (rec) newEvents.push(rec);
+    return new Response(JSON.stringify({ events: newEvents, error: String(err) }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
   }
 });


### PR DESCRIPTION
Replaces the P0 echo agent with a real Anthropic tool-use loop. **Already deployed** via supabase CLI (`ask-job-agent` v2).

## Architecture
- **Sonnet 4.6 coordinator**, max 5 tool-call iterations, `$0.05`/turn budget enforced by `MAX_OUTPUT_TOKENS` + `MAX_ITERATIONS`.
- **In-process tool dispatcher** — each tool is a wrapper around an existing /job edge fn (`jobs-pipe`, `add-role`, `kb-read/write`), so the agent inherits the same auth + storage path as the rest of the app.

## Tools

| Tool | What it does | Backed by |
|-|-|-|
| `search_pipeline(query)` | Returns up to 20 matching saved/active rows | `jobs-pipe` GET |
| `update_pipeline_row(slug, status, stage, exit_reason)` | Single-row patch | `jobs-pipe` POST |
| `add_role_from_url(url)` | Save a posting from URL | `add-role` |
| `update_preferences(blocked, must_have, note)` | Append a dated bullet to `fikei/job/02-goals-intents/agent-preferences.md` | `kb-read` + `kb-write` |

`update_preferences` writes to a new dedicated KB file; the recommendations function can read this in a follow-up to actually bias suggestions.

## Frontend
- Response shape changed to `{ events: ChatEvent[] }` — full trace (user / assistant text / tool events) returned in order.
- `<job-chat>` renders tool events as compact pills (`⚙ search_pipeline · Acme → 3 matches`) instead of raw JSON.
- History fetch includes `tool_name` + `tool_payload` so pills reappear on reload.

## Test plan
- [ ] "What's in my pipeline at Meridian?" → tool pill (search_pipeline · Meridian) + summary
- [ ] "I got to the final round at Meridian" → search + update_pipeline_row → "Got it, Meridian moved to Interviewing"
- [ ] Paste a Greenhouse/Lever URL → add_role_from_url → confirmation
- [ ] "I don't want to see any engineering roles" → update_preferences → "Noted, added engineering to your blocked list"
- [ ] "Book me a flight" → polite decline, no tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)