### PR TITLE
job: chat agent — fix tool-call amnesia across turns

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.51.0");
-@import url("./tokens-generic-dark.css?v=0.51.0");
-@import url("./tokens-ctrl-light.css?v=0.51.0");
-@import url("./tokens-ctrl-dark.css?v=0.51.0");
-@import url("./components.css?v=0.51.0");
+@import url("./tokens-generic-light.css?v=0.51.1");
+@import url("./tokens-generic-dark.css?v=0.51.1");
+@import url("./tokens-ctrl-light.css?v=0.51.1");
+@import url("./tokens-ctrl-dark.css?v=0.51.1");
+@import url("./components.css?v=0.51.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -6,8 +6,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.92.0";
-console.log(`[job] v${VERSION} - Agent chat P1: agent loop + 4 Tier-1 tools live`);
+const VERSION = "0.92.1";
+console.log(`[job] v${VERSION} - Agent chat: tool-call memory across turns (history replay fix)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.92.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.92.1">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.92.0">
-  <script src="/job/js/theme.js?v=0.92.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.92.1">
+  <script src="/job/js/theme.js?v=0.92.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.92.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.92.1"></script>
 </body>
 </html>

--- a/supabase/functions/ask-job-agent/index.ts
+++ b/supabase/functions/ask-job-agent/index.ts
@@ -135,13 +135,50 @@ async function callClaude(messages: Array<{ role: 'user'|'assistant'; content: u
   return await res.json();
 }
 
+// Reconstruct prior turns for the model. We can't replay the original
+// tool_use/tool_result blocks (we don't persist Anthropic's tool_use_id),
+// so tool runs become a compact assistant-side breadcrumb:
+//   "[I called update_preferences with {...} → {ok: true, appended: [...]}]"
+// That keeps the model's memory of what it actually did, so on the next
+// turn it doesn't claim it never ran the tool. Without this, the agent
+// gets amnesia about its own actions across turns.
 function historyToMessages(history: PersistedMessage[]): Array<{ role: 'user'|'assistant'; content: unknown }> {
   const out: Array<{ role: 'user'|'assistant'; content: unknown }> = [];
+  // Group consecutive tool events with the assistant turn they belong to.
+  let pendingBreadcrumbs: string[] = [];
+
+  const flushBreadcrumbs = () => {
+    if (!pendingBreadcrumbs.length) return;
+    // Attach to the most recent assistant message, OR push as a standalone
+    // assistant note if the assistant turn hasn't been emitted yet.
+    const lastIdx = out.length - 1;
+    if (lastIdx >= 0 && out[lastIdx].role === 'assistant') {
+      out[lastIdx] = { role: 'assistant', content: `${out[lastIdx].content as string}\n\n${pendingBreadcrumbs.join('\n')}` };
+    } else {
+      out.push({ role: 'assistant', content: pendingBreadcrumbs.join('\n') });
+    }
+    pendingBreadcrumbs = [];
+  };
+
   for (const m of history) {
-    if (m.role === 'tool') continue;
-    if (!m.body) continue;
-    out.push({ role: m.role as 'user'|'assistant', content: m.body });
+    if (m.role === 'tool') {
+      const payload = (m.tool_payload || {}) as { input?: unknown; output?: unknown };
+      const inputStr = JSON.stringify(payload.input ?? {}).slice(0, 400);
+      const outputStr = JSON.stringify(payload.output ?? {}).slice(0, 600);
+      pendingBreadcrumbs.push(`[Ran ${m.tool_name} with ${inputStr} → ${outputStr}]`);
+      continue;
+    }
+    if (m.role === 'user') {
+      flushBreadcrumbs();
+      if (m.body) out.push({ role: 'user', content: m.body });
+      continue;
+    }
+    if (m.role === 'assistant') {
+      flushBreadcrumbs();
+      if (m.body) out.push({ role: 'assistant', content: m.body });
+    }
   }
+  flushBreadcrumbs();
   return out;
 }
 


### PR DESCRIPTION
User report: agent ran a tool successfully, then on the next turn claimed it never ran the tool and re-ran it, twice. Three duplicate entries ended up in the prefs file. Root cause: `historyToMessages` was dropping tool events before sending context to Claude. Fixed by replaying tool runs as compact breadcrumbs in the assistant's apparent context. Already deployed via supabase CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)