### PR TITLE
job: Move A — /job/vision reads from job.vision_field (KB-backed UI retired)

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=0.54.0");
-@import url("./tokens-generic-dark.css?v=0.54.0");
-@import url("./tokens-ctrl-light.css?v=0.54.0");
-@import url("./tokens-ctrl-dark.css?v=0.54.0");
-@import url("./components.css?v=0.54.0");
+@import url("./tokens-generic-light.css?v=0.55.0");
+@import url("./tokens-generic-dark.css?v=0.55.0");
+@import url("./tokens-ctrl-light.css?v=0.55.0");
+@import url("./tokens-ctrl-dark.css?v=0.55.0");
+@import url("./components.css?v=0.55.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -5222,3 +5222,159 @@ body[data-auth-state="out"] job-chat { display: none; }
   color: var(--fg);
 }
 .chat-tool__summary { color: var(--fg-subtle); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+
+/* ─────────────────────────────────────────────────────────────
+   Structured vision editor — replaces the legacy KB-backed
+   file-per-concept tree. One section per category, one card per
+   job.vision_field row. Each card carries its updated_at + source.
+   ───────────────────────────────────────────────────────────── */
+
+.vf { display: flex; flex-direction: column; gap: var(--space-7); max-width: 920px; }
+
+.vf-section__title {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.015em;
+}
+.vf-section__grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 1fr;
+}
+
+.vf-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  padding: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.vf-card__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+.vf-card__title-wrap {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.vf-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-4);
+  letter-spacing: -0.01em;
+}
+.vf-card__name {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+}
+.vf-card__meta {
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+}
+.vf-card__desc {
+  margin: 0;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+  line-height: var(--lh-tight);
+}
+.vf-card__editor { width: 100%; }
+
+.vf-card__foot {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+}
+.vf-saved { color: var(--success); font-size: var(--font-size-small); }
+.vf-error { color: var(--error);   font-size: var(--font-size-small); }
+
+/* ── Inputs ─────────────────────────────────────────────────── */
+.vf-input,
+.vf-textarea {
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  resize: vertical;
+}
+.vf-input:focus,
+.vf-textarea:focus,
+.vf-chip-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+.vf-textarea--mono { font-family: var(--font-mono); font-size: var(--font-size-small); }
+
+.vf-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-small);
+  cursor: pointer;
+}
+
+/* ── Chip editor for string_array ───────────────────────────── */
+.vf-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  min-height: 44px;
+  align-items: center;
+}
+.vf-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px var(--space-2) 4px var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-small);
+  color: var(--fg);
+}
+.vf-chip__x {
+  background: transparent;
+  border: 0;
+  color: var(--fg-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.vf-chip__x:hover { color: var(--fg); }
+.vf-chip-input {
+  flex: 1;
+  min-width: 120px;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-body);
+  padding: 4px var(--space-2);
+  outline: none;
+}
+
+.vf-empty { color: var(--fg-muted); font-style: italic; }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/index.html
+++ b/job/index.html
@@ -6,8 +6,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -36,6 +36,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -6,8 +6,8 @@
   <title>Role — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "0.95.0";
-console.log(`[job] v${VERSION} - vision_field normalization (phase 1): per-field row, source, timestamp`);
+const VERSION = "0.96.0";
+console.log(`[job] v${VERSION} - Move A: /job/vision reads from job.vision_field instead of KB`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-vision.js
+++ b/job/js/components/job-vision.js
@@ -1,214 +1,106 @@
-// job-vision — tabbed browser for fikei/job/02-goals-intents/.
+// job-vision — structured editor for job.vision_field. Each preference
+// is its own row in Postgres (see migration 074); this page is a typed
+// form over that table, replacing the old KB-backed tree-of-markdown-
+// files UI.
 //
-// Layout:
-//   [Narrative | Goals | Intents | Filters | Other]   ← only non-empty tabs
-//   Single-column list of cards (title · facts/bullets preview · "Open")
-//   Click a card  → expands inline to render structured fields + markdown
-//                   body, plus Edit/Save/Cancel. Edits commit via kb-write
-//                   with baseSha concurrency control.
+// Reads:  GET  /functions/v1/vision-field → { fields: { [name]: {...} } }
+// Writes: POST /functions/v1/vision-field { updates: [{name,value}] }
 //
-// Structure on disk: the same `**Label:** value` convention used elsewhere
-// in fikei/job (see migrate-job's parseDoc). Fields live between the H1 and
-// the first H2 / non-field line. We lift those into a "facts strip" so the
-// UI matches how /jobs already consumes the data, while editing stays raw
-// markdown — no schema lock-in.
+// Auth: standard /job bearer token. The edge fn marks every write as
+// `source: 'user'` so the agent-driven 'agent' edits are visually
+// distinguishable in the metadata footer of each field.
+
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
-import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
-const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { writeFile }] = await Promise.all([
-  import('../markdown.js' + V),
-  import('../kbwrite.js' + V),
-]);
 
-const VISION_DIR = '02-goals-intents';
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const FN_URL = `${SUPABASE_URL}/functions/v1/vision-field`;
 
-const CATEGORIES = [
-  { id: 'narrative', label: 'Narrative',
-    test: (n) => /^(narrative|voice|story|bio|about|arc)/.test(n) },
-  { id: 'goals',     label: 'Goals',
-    test: (n) => /^(goal|north|mission|vision|aim|ambition)/.test(n) },
-  { id: 'intents',   label: 'Intents',
-    test: (n) => /^(intent|target|seeking|looking|wants|preference|stage|sector|role|geo|comp|salary|location)/.test(n) },
-  { id: 'filters',   label: 'Filters',
-    test: (n) => /^(criteria|filter|dealbreaker|deal-breaker|anti|no-go|must|reject|exclud)/.test(n) },
-  { id: 'other',     label: 'Other', test: () => true },
+// Field grouping. Each section lists the canonical field names that
+// belong to it. Anything not listed below falls into 'Other'.
+const SECTIONS = [
+  { id: 'narrative', label: 'Narrative + voice',
+    names: ['narrative_arc', 'voice_rules_md'] },
+  { id: 'targets', label: 'Targets',
+    names: ['target_titles', 'target_stages', 'target_sectors', 'target_geographies'] },
+  { id: 'mission', label: 'Mission + culture',
+    names: ['mission_keywords', 'mission_required', 'anti_mission_terms', 'culture_keywords', 'interest_tags', 'impact_themes'] },
+  { id: 'comp', label: 'Compensation',
+    names: ['comp_floor_base', 'comp_floor_total'] },
+  { id: 'filters', label: 'Filters',
+    names: ['deal_breakers', 'blocked_titles', 'must_have_keywords'] },
+  { id: 'advanced', label: 'Advanced',
+    names: ['score_weights', 'raw_md'] },
 ];
 
-function categoryFor(name) {
-  const base = name.replace(/\.md$/, '').toLowerCase();
-  for (const c of CATEGORIES) if (c.test(base)) return c.id;
-  return 'other';
+function relTime(iso) {
+  if (!iso) return '';
+  const t = new Date(iso).getTime();
+  if (!t) return '';
+  const dt = Date.now() - t;
+  if (dt < 60_000) return 'just now';
+  if (dt < 3_600_000) return `${Math.floor(dt / 60_000)}m ago`;
+  if (dt < 86_400_000) return `${Math.floor(dt / 3_600_000)}h ago`;
+  if (dt < 30 * 86_400_000) return `${Math.floor(dt / 86_400_000)}d ago`;
+  return new Date(iso).toLocaleDateString();
 }
 
-function titleFromFile(name, content) {
-  const m = (content || '').match(/^#\s+(.+)$/m);
-  if (m) return m[1].trim();
-  return name.replace(/\.md$/, '').replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-}
-
-function wordCount(content) {
-  return (content || '').trim().split(/\s+/).filter(Boolean).length;
-}
-
-// Parse `**Label:** value` lines between the H1 and the first H2 / non-field
-// content. Mirrors migrate-job's parseDoc. Anything we couldn't pull out as a
-// field stays in the body for normal markdown rendering.
-function parseDoc(content) {
-  const out = { title: '', fields: [], body: '' };
-  const lines = (content || '').split(/\r?\n/);
-  let i = 0;
-  let inHeader = true;
-  const bodyStart = () => lines.slice(i).join('\n').trim();
-  for (; i < lines.length; i++) {
-    const line = lines[i];
-    if (!out.title) {
-      const h1 = line.match(/^#\s+(.+)$/);
-      if (h1) { out.title = h1[1].trim(); continue; }
-    }
-    if (inHeader) {
-      if (line.startsWith('## ')) { inHeader = false; break; }
-      const f = line.match(/^\*\*([^*:]+):\*\*\s*(.*)$/);
-      if (f) { out.fields.push({ label: f[1].trim(), value: f[2].trim() }); continue; }
-      if (!line.trim()) continue;
-      // First non-field, non-blank line ends the header section.
-      inHeader = false;
-      break;
-    }
-  }
-  out.body = bodyStart();
-  return out;
-}
-
-// A value is treated as a list if it has 2+ items separated by `,` or `;`
-// or ` / `. Returns null otherwise. We use this to pick chip vs. inline.
-function splitList(value) {
-  if (!value) return null;
-  const parts = value.split(/\s*(?:,|;| \/ )\s*/).map(s => s.trim()).filter(Boolean);
-  return parts.length >= 2 ? parts : null;
-}
-
-// Field labels that should render as money. Values are passed through —
-// we don't reformat (Ian might write "$180k base + 0.5% equity").
-const MONEY_LABELS = /^(base|base floor|salary|salary floor|cash|total comp|total comp target|fractional|fractional rate|day rate|hourly|equity|equity expectation|equity target|all-in|total)/i;
-
-function isMoney(label) { return MONEY_LABELS.test(label); }
-
-// Some KB files have a literal bullet glyph after the markdown marker
-// (e.g. `- • foo` from copy/paste). Both the marker AND the glyph render,
-// giving the appearance of "double bullets". Strip the leading glyph
-// (and other common variants) from the captured text. Also collapse any
-// remaining nested markdown bullet markers at the very start.
-const LEADING_BULLET_RE = /^[\s ]*[•·●○◦▪▫–—-][\s ]*/;
-
-function cleanBulletText(text) {
-  let out = (text || '').trim();
-  // Repeat in case the line is `· · foo` etc.
-  for (let i = 0; i < 3 && LEADING_BULLET_RE.test(out); i++) {
-    out = out.replace(LEADING_BULLET_RE, '');
-  }
-  return out.trim();
-}
-
-// Normalize the raw markdown body before marked sees it: when a list line
-// starts with `- • foo` (or any equivalent), drop the glyph so marked
-// renders only one bullet from the list marker. Leaves real content alone.
-function normalizeBulletGlyphs(md) {
-  if (!md) return md;
-  return md.replace(
-    /^([ \t]*)([-*+])([ \t]+)([•·●○◦▪▫–—-])([ \t]+|)/gm,
-    (_m, indent, marker, sp, _glyph, _tail) => `${indent}${marker}${sp}`
-  );
-}
-
-// First non-field, non-heading bullet line from the body — used as a card
-// preview when the file is bullet-heavy (deal-breakers, voice rules, etc.).
-function firstBullets(body, max = 3) {
-  if (!body) return [];
-  const out = [];
-  for (const line of body.split(/\r?\n/)) {
-    const m = line.match(/^\s*[-*+]\s+(.+?)\s*$/);
-    if (m) out.push(cleanBulletText(m[1]));
-    if (out.length >= max) break;
-  }
-  return out;
-}
-
-// Plain-text fallback preview if the file has no fields and no bullets.
-function prosePreview(body) {
-  return (body || '')
-    .replace(/```[\s\S]*?```/g, ' ')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_m, s, l) => (l || s))
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .replace(/^[#>*\-+\s]+/gm, '')
-    .replace(/\*\*?([^*]+)\*\*?/g, '$1')
-    .replace(/_+([^_]+)_+/g, '$1')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
+const SOURCE_LABEL = {
+  user: 'you',
+  agent: 'the chat agent',
+  'migrate-job': 'the initial KB import',
+  import: 'an import',
+};
 
 export class JobVision extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
-    state:    { state: true },
-    error:    { state: true },
-    files:    { state: true },
-    activeTab:{ state: true },
-    openPath: { state: true },
+    state:   { state: true },     // 'idle' | 'loading' | 'loaded' | 'error'
+    error:   { state: true },
+    fields:  { state: true },     // { [name]: row }
+    drafts:  { state: true },     // { [name]: draft value } — edit-in-progress
+    saving:  { state: true },     // Set<name>
+    flash:   { state: true },     // { [name]: 'saved' | 'error' }
   };
 
   constructor() {
     super();
     this.state = 'idle';
     this.error = '';
-    this.files = [];
-    const params = new URLSearchParams(location.search);
-    this.activeTab = params.get('tab') || 'all';
-    this.openPath = params.get('open') || '';
+    this.fields = {};
+    this.drafts = {};
+    this.saving = new Set();
+    this.flash = {};
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this._maybeLoad();
-    this._onAuth = () => this._maybeLoad();
-    document.addEventListener('ctrl:auth:signedin', this._onAuth);
-    document.addEventListener('job:auth:ready', this._onAuth);
+    this._authReady = () => this._load();
+    document.addEventListener('job:auth:ready', this._authReady);
+    if (document.body.dataset.authState === 'in') this._load();
   }
   disconnectedCallback() {
-    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
-    document.removeEventListener('job:auth:ready', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._authReady);
     super.disconnectedCallback();
   }
 
-  async _maybeLoad() {
-    if (document.body.dataset.authState !== 'in') return;
+  _supabase() { return window.CtrlAuth?.getSupabaseClient?.(); }
+
+  async _token() {
+    const sb = this._supabase();
+    return (await sb?.auth.getSession?.())?.data?.session?.access_token;
+  }
+
+  async _load() {
     if (this.state === 'loading' || this.state === 'loaded') return;
     this.state = 'loading';
+    this.error = '';
     try {
-      const { entries = [] } = await window.JobKB.listDir(VISION_DIR);
-      const mdEntries = entries
-        .filter(e => e.type === 'file' && e.name.endsWith('.md'))
-        .sort((a, b) => a.name.localeCompare(b.name));
-      const files = await Promise.all(mdEntries.map(async (e) => {
-        try {
-          const { content, sha } = await window.JobKB.readFile(e.path);
-          return {
-            path: e.path, name: e.name, content, sha,
-            category: categoryFor(e.name),
-            editing: false, draft: '', saving: false, saveError: '',
-          };
-        } catch (err) {
-          return {
-            path: e.path, name: e.name, content: '', sha: '',
-            category: categoryFor(e.name),
-            editing: false, draft: '', saving: false,
-            saveError: String(err?.message || err),
-          };
-        }
-      }));
-      this.files = files;
+      const token = await this._token();
+      const res = await fetch(FN_URL, { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) throw new Error(`Server ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = await res.json();
+      this.fields = data.fields || {};
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e?.message || e);
@@ -216,253 +108,240 @@ export class JobVision extends LitElement {
     }
   }
 
-  _writeUrl() {
-    const qs = new URLSearchParams();
-    if (this.activeTab && this.activeTab !== 'all') qs.set('tab', this.activeTab);
-    if (this.openPath) qs.set('open', this.openPath);
-    const search = qs.toString();
-    history.replaceState(null, '', '/job/vision/' + (search ? `?${search}` : ''));
+  _draftFor(name) {
+    if (Object.prototype.hasOwnProperty.call(this.drafts, name)) return this.drafts[name];
+    return this._currentValue(name);
   }
 
-  _switchTab(id) {
-    this.activeTab = id;
-    if (this.openPath) {
-      const open = this.files.find(f => f.path === this.openPath);
-      if (open && id !== 'all' && open.category !== id) this.openPath = '';
+  _currentValue(name) {
+    const v = this.fields[name]?.value;
+    if (v === undefined || v === null) {
+      const kind = this.fields[name]?.kind;
+      if (kind === 'string_array') return [];
+      if (kind === 'text_md')      return '';
+      if (kind === 'number')       return null;
+      if (kind === 'bool')         return false;
+      return null;
     }
-    this._writeUrl();
+    return v;
   }
 
-  _openCard(path) {
-    this.openPath = this.openPath === path ? '' : path;
-    if (!this.openPath) {
-      this._updateFile(path, { editing: false, draft: '', saveError: '' });
-    }
-    this._writeUrl();
+  _setDraft(name, value) {
+    this.drafts = { ...this.drafts, [name]: value };
   }
 
-  _updateFile(path, patch) {
-    this.files = this.files.map(f => f.path === path ? { ...f, ...patch } : f);
+  _hasChanges(name) {
+    if (!Object.prototype.hasOwnProperty.call(this.drafts, name)) return false;
+    const a = JSON.stringify(this.drafts[name]);
+    const b = JSON.stringify(this._currentValue(name));
+    return a !== b;
   }
 
-  _startEdit(path) {
-    const f = this.files.find(x => x.path === path);
-    if (!f) return;
-    this._updateFile(path, { editing: true, draft: f.content, saveError: '' });
-  }
-  _cancelEdit(path) {
-    this._updateFile(path, { editing: false, draft: '', saveError: '' });
-  }
-  _onDraftInput(path, value) {
-    this._updateFile(path, { draft: value });
+  _cancel(name) {
+    const { [name]: _, ...rest } = this.drafts;
+    this.drafts = rest;
+    const { [name]: _f, ...rf } = this.flash;
+    this.flash = rf;
   }
 
-  async _save(path) {
-    const f = this.files.find(x => x.path === path);
-    if (!f) return;
-    const next = (f.draft ?? '').trimEnd() + '\n';
-    if (next === (f.content ?? '')) {
-      this._updateFile(path, { editing: false, draft: '', saveError: '' });
-      return;
-    }
-    this._updateFile(path, { saving: true, saveError: '' });
+  async _save(name) {
+    if (!this._hasChanges(name) || this.saving.has(name)) return;
+    this.saving = new Set([...this.saving, name]);
+    this.flash = { ...this.flash, [name]: '' };
     try {
-      const res = await writeFile(path, next, f.sha);
-      this._updateFile(path, {
-        content: next,
-        sha: res?.sha || f.sha,
-        editing: false,
-        draft: '',
-        saving: false,
-        saveError: '',
+      const token = await this._token();
+      const value = this.drafts[name];
+      const res = await fetch(FN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ updates: [{ name, value }] }),
       });
+      if (!res.ok) throw new Error(`Server ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = await res.json();
+      if (data.errors?.length) throw new Error(data.errors[0].reason);
+      // Refresh just this field's metadata
+      const updated_at = data.updated?.[0]?.updated_at || new Date().toISOString();
+      this.fields = {
+        ...this.fields,
+        [name]: { ...this.fields[name], value, updated_at, source: 'user', source_detail: null },
+      };
+      const { [name]: _, ...rest } = this.drafts;
+      this.drafts = rest;
+      this.flash = { ...this.flash, [name]: 'saved' };
+      setTimeout(() => { const { [name]: _x, ...r } = this.flash; this.flash = r; }, 1800);
     } catch (e) {
-      this._updateFile(path, {
-        saving: false,
-        saveError: String(e?.message || e),
-      });
+      this.flash = { ...this.flash, [name]: `error: ${String(e.message || e).slice(0, 120)}` };
+    } finally {
+      const s = new Set(this.saving); s.delete(name); this.saving = s;
     }
   }
 
-  _visibleTabs() {
-    const counts = new Map([['all', this.files.length]]);
-    for (const f of this.files) counts.set(f.category, (counts.get(f.category) || 0) + 1);
-    const tabs = [{ id: 'all', label: 'All', count: counts.get('all') || 0 }];
-    for (const c of CATEGORIES) {
-      const n = counts.get(c.id) || 0;
-      if (n > 0) tabs.push({ id: c.id, label: c.label, count: n });
-    }
-    return tabs;
-  }
+  // ── Renderers per kind ───────────────────────────────────────────────
 
-  _filteredFiles() {
-    if (this.activeTab === 'all') return this.files;
-    return this.files.filter(f => f.category === this.activeTab);
-  }
-
-  _renderTabs(tabs) {
+  _renderStringArray(name) {
+    const value = this._draftFor(name) || [];
     return html`
-      <div class="asset-tabs">
-        ${tabs.map(t => html`
-          <button class="asset-tabs__tab ${this.activeTab === t.id ? 'is-active' : ''}"
-                  @click=${() => this._switchTab(t.id)}>
-            ${t.label} <span class="muted" style="font-weight:400;">${t.count}</span>
-          </button>
+      <div class="vf-chips">
+        ${value.map((v, i) => html`
+          <span class="vf-chip">
+            ${v}
+            <button class="vf-chip__x" aria-label="Remove"
+                    @click=${() => this._setDraft(name, value.filter((_, idx) => idx !== i))}>×</button>
+          </span>
         `)}
+        <input type="text" class="vf-chip-input" placeholder="Add term + Enter"
+               @keydown=${(e) => {
+                 if (e.key === 'Enter') {
+                   e.preventDefault();
+                   const t = e.target.value.trim();
+                   if (!t) return;
+                   if (value.includes(t)) { e.target.value = ''; return; }
+                   this._setDraft(name, [...value, t]);
+                   e.target.value = '';
+                 } else if (e.key === 'Backspace' && !e.target.value && value.length) {
+                   this._setDraft(name, value.slice(0, -1));
+                 }
+               }}>
       </div>
     `;
   }
 
-  // Render one field row. Lists become chips; money labels render as the
-  // value emphasized; everything else is plain text.
-  _renderField(field) {
-    const items = splitList(field.value);
-    const money = isMoney(field.label);
+  _renderTextMd(name) {
+    const value = this._draftFor(name) || '';
+    const rows = Math.min(20, Math.max(3, value.split('\n').length + 1));
     return html`
-      <div class="facts__row">
-        <dt class="facts__label">${field.label}</dt>
-        <dd class="facts__value ${money ? 'facts__value--money' : ''}">
-          ${items
-            ? html`<div class="chip-row">${items.map(x => html`<span class="tag-chip">${x}</span>`)}</div>`
-            : (field.value || html`<span class="muted">—</span>`)}
-        </dd>
-      </div>
+      <textarea class="vf-textarea" rows=${rows}
+                .value=${value}
+                @input=${(e) => this._setDraft(name, e.target.value)}></textarea>
     `;
   }
 
-  _renderFacts(doc, { compact = false } = {}) {
-    if (!doc.fields.length) return nothing;
-    const fields = compact ? doc.fields.slice(0, 4) : doc.fields;
+  _renderNumber(name) {
+    const value = this._draftFor(name);
     return html`
-      <dl class="facts ${compact ? 'facts--compact' : ''}">
-        ${fields.map(f => this._renderField(f))}
-      </dl>
+      <input type="number" class="vf-input" .value=${value == null ? '' : String(value)}
+             @input=${(e) => this._setDraft(name, e.target.value === '' ? null : Number(e.target.value))}>
     `;
   }
 
-  _renderCardPreview(doc) {
-    if (doc.fields.length) return this._renderFacts(doc, { compact: true });
-    const bullets = firstBullets(doc.body, 3);
-    if (bullets.length) {
-      return html`
-        <ul class="card-bullets">
-          ${bullets.map(b => html`<li>${b}</li>`)}
-        </ul>
-      `;
+  _renderBool(name) {
+    const value = !!this._draftFor(name);
+    return html`
+      <label class="vf-toggle">
+        <input type="checkbox" .checked=${value}
+               @change=${(e) => this._setDraft(name, e.target.checked)}>
+        <span>${value ? 'On' : 'Off'}</span>
+      </label>
+    `;
+  }
+
+  _renderJson(name) {
+    const raw = this._draftFor(name);
+    const value = raw == null ? '' : JSON.stringify(raw, null, 2);
+    return html`
+      <textarea class="vf-textarea vf-textarea--mono" rows="8" spellcheck="false"
+                .value=${value}
+                @input=${(e) => {
+                  const t = e.target.value;
+                  try { this._setDraft(name, t.trim() === '' ? null : JSON.parse(t)); }
+                  catch (_) { this._setDraft(name, t); /* leave as string until valid */ }
+                }}></textarea>
+    `;
+  }
+
+  _renderEditor(name) {
+    const kind = this.fields[name]?.kind;
+    switch (kind) {
+      case 'string_array': return this._renderStringArray(name);
+      case 'text_md':      return this._renderTextMd(name);
+      case 'number':       return this._renderNumber(name);
+      case 'bool':         return this._renderBool(name);
+      case 'json':         return this._renderJson(name);
+      default:             return html`<em class="vf-empty">Unknown kind: ${kind}</em>`;
     }
-    const prose = prosePreview(doc.body);
-    return html`<p class="vision-card__preview">${prose || html`<span class="muted">_(empty)_</span>`}</p>`;
   }
 
-  _renderCard(f) {
-    const doc = parseDoc(f.content);
-    const title = doc.title || titleFromFile(f.name, f.content);
-    const words = wordCount(f.content);
-    const isOpen = this.openPath === f.path;
-    if (isOpen) return this._renderDetail(f, doc, title);
+  _renderFieldCard(name) {
+    const f = this.fields[name];
+    if (!f) return nothing;
+    const dirty = this._hasChanges(name);
+    const saving = this.saving.has(name);
+    const flash = this.flash[name];
+    const updatedBy = SOURCE_LABEL[f.source] || f.source;
     return html`
-      <button type="button" class="vision-card" @click=${() => this._openCard(f.path)}>
-        <header class="vision-card__head">
-          <h3 class="vision-card__title">${title}</h3>
-          <span class="vision-card__cta">Open →</span>
+      <article class="vf-card" data-kind=${f.kind}>
+        <header class="vf-card__head">
+          <div class="vf-card__title-wrap">
+            <h3 class="vf-card__title">${f.display_name || name}</h3>
+            <span class="vf-card__name">${name}</span>
+          </div>
+          <div class="vf-card__meta">
+            <span class="vf-card__updated" title=${new Date(f.updated_at).toLocaleString()}>
+              Updated ${relTime(f.updated_at)} by ${updatedBy}
+            </span>
+          </div>
         </header>
-        <div class="vision-card__meta">
-          <span>${f.name}</span>
-          <span>·</span>
-          <span>${words} ${words === 1 ? 'word' : 'words'}</span>
-          ${doc.fields.length ? html`<span>·</span><span>${doc.fields.length} field${doc.fields.length === 1 ? '' : 's'}</span>` : nothing}
-        </div>
-        ${this._renderCardPreview(doc)}
-      </button>
+        ${f.description ? html`<p class="vf-card__desc">${f.description}</p>` : nothing}
+        <div class="vf-card__editor">${this._renderEditor(name)}</div>
+        ${dirty || flash ? html`
+          <footer class="vf-card__foot">
+            ${flash === 'saved'
+              ? html`<span class="vf-saved">✓ Saved</span>`
+              : flash
+                ? html`<span class="vf-error">${flash}</span>`
+                : nothing}
+            ${dirty ? html`
+              <button class="btn btn--sm" ?disabled=${saving}
+                      @click=${() => this._cancel(name)}>Cancel</button>
+              <button class="btn btn--sm btn--primary" ?disabled=${saving}
+                      @click=${() => this._save(name)}>
+                ${saving ? 'Saving…' : 'Save'}
+              </button>
+            ` : nothing}
+          </footer>
+        ` : nothing}
+      </article>
     `;
   }
 
-  _renderDetail(f, doc, title) {
+  _renderSection(section) {
+    const present = section.names.filter((n) => this.fields[n]);
+    if (!present.length) return nothing;
     return html`
-      <section class="vision-detail">
-        <header class="vision-detail__head">
-          <div>
-            <h2 class="vision-detail__title">${title}</h2>
-            <p class="muted" style="margin:0;font-size:var(--font-size-small);font-family:var(--font-mono);">${f.path}</p>
-          </div>
-          <div class="vision-detail__actions">
-            ${f.editing ? html`
-              <button class="btn btn--sm" ?disabled=${f.saving} @click=${() => this._cancelEdit(f.path)}>Cancel</button>
-              <button class="btn btn--sm btn--primary" ?disabled=${f.saving} @click=${() => this._save(f.path)}>
-                ${f.saving ? 'Saving…' : 'Save'}
-              </button>
-            ` : html`
-              <button class="btn btn--sm" @click=${() => this._startEdit(f.path)}>Edit</button>
-              <button class="btn btn--sm" @click=${() => this._openCard(f.path)}>Close</button>
-            `}
-          </div>
-        </header>
+      <section class="vf-section">
+        <h2 class="vf-section__title">${section.label}</h2>
+        <div class="vf-section__grid">
+          ${present.map((n) => this._renderFieldCard(n))}
+        </div>
+      </section>
+    `;
+  }
 
-        ${f.saveError ? html`
-          <p class="muted" style="color:var(--error);margin:0 0 var(--space-3);">${f.saveError}</p>
-        ` : nothing}
-
-        ${f.editing ? html`
-          <textarea class="asset-editor" style="min-height: 360px;"
-                    .value=${f.draft}
-                    @input=${(e) => this._onDraftInput(f.path, e.target.value)}></textarea>
-          <p class="muted" style="font-size:var(--font-size-small);margin:var(--space-3) 0 0;">
-            Tip: header fields use <code>**Label:** value</code>. Commas in a value become chips
-            (e.g. <code>**Primary sectors:** healthtech, edtech</code>). The /jobs skill reads
-            the same fields.
-          </p>
-        ` : html`
-          ${this._renderFacts(doc)}
-          ${doc.body ? html`
-            <article class="kb-doc asset-doc">${unsafeHTML(renderMarkdown(normalizeBulletGlyphs(doc.body)))}</article>
-          ` : (doc.fields.length ? nothing : html`<p class="muted">_(empty)_</p>`)}
-        `}
+  _renderOtherSection() {
+    const known = new Set(SECTIONS.flatMap((s) => s.names));
+    const others = Object.keys(this.fields).filter((n) => !known.has(n)).sort();
+    if (!others.length) return nothing;
+    return html`
+      <section class="vf-section">
+        <h2 class="vf-section__title">Other</h2>
+        <div class="vf-section__grid">
+          ${others.map((n) => this._renderFieldCard(n))}
+        </div>
       </section>
     `;
   }
 
   render() {
-    if (this.state === 'idle' || this.state === 'loading') {
-      return html`
-        <div class="vision-grid">
-          ${[0,1,2,3].map(() => html`
-            <div class="vision-card" style="cursor:default;">
-              <div class="skeleton" style="width:60%;height:18px;display:block;margin-bottom:8px;"></div>
-              <div class="skeleton" style="width:90%;height:12px;display:block;margin-bottom:6px;"></div>
-              <div class="skeleton" style="width:80%;height:12px;display:block;"></div>
-            </div>
-          `)}
-        </div>
-      `;
+    if (this.state === 'loading' || this.state === 'idle') {
+      return html`<p class="muted">Loading…</p>`;
     }
     if (this.state === 'error') {
-      return html`
-        <div class="placeholder" style="border-color:var(--error);color:var(--error);">
-          <h2>Couldn't load Search plan</h2>
-          <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
-        </div>`;
+      return html`<div class="placeholder"><h2>Couldn't load</h2><p>${this.error}</p></div>`;
     }
-    if (!this.files.length) {
-      return html`
-        <div class="vision-empty">
-          <h2 style="margin:0 0 var(--space-2);">No files yet</h2>
-          <p style="margin:0;">Add markdown files to <code>${VISION_DIR}/</code> in fikei/job to see them here.</p>
-        </div>`;
-    }
-    const tabs = this._visibleTabs();
-    const filtered = this._filteredFiles();
-    const totalFields = this.files.reduce((sum, f) => sum + parseDoc(f.content).fields.length, 0);
     return html`
-      ${this._renderTabs(tabs)}
-      <div class="vision-meta">
-        <span>${filtered.length} ${filtered.length === 1 ? 'file' : 'files'}</span>
-        <span>·</span>
-        <span>${totalFields} structured field${totalFields === 1 ? '' : 's'} across Search plan</span>
-      </div>
-      <div class="vision-grid">
-        ${filtered.length === 0
-          ? html`<div class="vision-empty" style="grid-column: 1 / -1;">Nothing in this category yet.</div>`
-          : filtered.map(f => this._renderCard(f))}
+      <div class="vf">
+        ${SECTIONS.map((s) => this._renderSection(s))}
+        ${this._renderOtherSection()}
       </div>
     `;
   }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.95.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.96.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=0.95.0">
-  <script src="/job/js/theme.js?v=0.95.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
+  <script src="/job/js/theme.js?v=0.96.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=0.95.0"></script>
+  <script type="module" src="/job/js/app.js?v=0.96.0"></script>
 </body>
 </html>

--- a/supabase/functions/vision-field/index.ts
+++ b/supabase/functions/vision-field/index.ts
@@ -1,0 +1,131 @@
+// Supabase Edge Function: vision-field
+// Read + write the user's job.vision_field rows. The /job/vision UI talks
+// here instead of kb-read/kb-write, so vision data lives in Postgres rather
+// than the fikei/job KB.
+//
+// GET  /functions/v1/vision-field
+//   → { fields: { [name]: { value, kind, display_name, description,
+//                           examples, updated_at, source, source_detail } } }
+//
+// POST /functions/v1/vision-field
+//   Body: { updates: [{ name, value }, ...] }
+//   → { updated: [{ name, updated_at, source }], errors: [...] }
+//
+// Validation: each update's `value` shape must match the field's `kind`.
+// Writes are 'source: user' (this is the UI editor). Agent-driven writes
+// continue to flow through ask-job-agent's update_preferences tool.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUserDetailed, corsHeaders, jsonResp, err } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[vision-field] v${VERSION}`);
+
+interface FieldRow {
+  name: string;
+  value: unknown;
+  kind: string;
+  display_name: string | null;
+  description: string | null;
+  examples: unknown;
+  updated_at: string;
+  created_at: string;
+  source: string;
+  source_detail: unknown;
+}
+
+function validateValue(kind: string, value: unknown): { ok: true } | { ok: false; reason: string } {
+  switch (kind) {
+    case 'string_array':
+      if (!Array.isArray(value)) return { ok: false, reason: 'expected array' };
+      if (!value.every((v) => typeof v === 'string')) return { ok: false, reason: 'expected array of strings' };
+      return { ok: true };
+    case 'text_md':
+      if (value !== null && typeof value !== 'string') return { ok: false, reason: 'expected string or null' };
+      return { ok: true };
+    case 'number':
+      if (value !== null && typeof value !== 'number') return { ok: false, reason: 'expected number or null' };
+      return { ok: true };
+    case 'bool':
+      if (typeof value !== 'boolean') return { ok: false, reason: 'expected boolean' };
+      return { ok: true };
+    case 'json':
+      // Anything jsonb-serializable. Null and primitives also count.
+      return { ok: true };
+    default:
+      return { ok: false, reason: `unknown kind: ${kind}` };
+  }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  const user = await verifyJobUserDetailed(req);
+  if (!user) return err('unauthorized', 401);
+  const sql = db();
+
+  // ── GET: return all fields for this user ────────────────────────────
+  if (req.method === 'GET') {
+    const rows = await sql<FieldRow[]>`
+      select name, value, kind, display_name, description, examples,
+             updated_at, created_at, source, source_detail
+        from job.vision_field
+       where user_id = ${user.id}
+       order by name
+    `;
+    const fields: Record<string, FieldRow> = {};
+    for (const r of rows) fields[r.name] = r;
+    return jsonResp({ fields });
+  }
+
+  // ── POST: partial diff update ───────────────────────────────────────
+  if (req.method === 'POST') {
+    let body: { updates?: Array<{ name?: string; value?: unknown }> };
+    try { body = await req.json(); } catch (_) { return err('invalid JSON body'); }
+    const updates = Array.isArray(body?.updates) ? body.updates : [];
+    if (updates.length === 0) return err('updates array required');
+    if (updates.length > 50) return err('too many updates (max 50)');
+
+    // Look up known fields for this user so we can validate against kind.
+    const known = await sql<{ name: string; kind: string }[]>`
+      select name, kind from job.vision_field where user_id = ${user.id}
+    `;
+    const kindByName = new Map(known.map((r) => [r.name, r.kind]));
+
+    const successes: Array<{ name: string; updated_at: string; source: string }> = [];
+    const errors: Array<{ name: string; reason: string }> = [];
+
+    for (const u of updates) {
+      const name = String(u?.name ?? '').trim();
+      if (!name) { errors.push({ name: '', reason: 'name required' }); continue; }
+      const kind = kindByName.get(name);
+      if (!kind) {
+        errors.push({ name, reason: 'unknown field — only existing fields are editable via this endpoint' });
+        continue;
+      }
+      const v = u.value;
+      const check = validateValue(kind, v);
+      if (!check.ok) { errors.push({ name, reason: check.reason }); continue; }
+
+      try {
+        const [updated] = await sql<{ updated_at: string }[]>`
+          update job.vision_field
+             set value = ${JSON.stringify(v)}::jsonb,
+                 source = 'user',
+                 source_detail = null
+           where user_id = ${user.id} and name = ${name}
+           returning updated_at
+        `;
+        if (updated) successes.push({ name, updated_at: updated.updated_at, source: 'user' });
+        else errors.push({ name, reason: 'row not found' });
+      } catch (e) {
+        errors.push({ name, reason: String((e as Error).message || e).slice(0, 200) });
+      }
+    }
+
+    return jsonResp({ updated: successes, errors });
+  }
+
+  return err('method not allowed', 405);
+});

--- a/supabase/migrations/074_vision_field_table 2.sql
+++ b/supabase/migrations/074_vision_field_table 2.sql
@@ -1,0 +1,151 @@
+-- 074_vision_field_table — Phase 1 of the vision data normalization.
+-- One row per vision concept in job.vision_field with its own kind /
+-- source / attribution / updated_at. Reads still come from job.vision in
+-- this phase; writes go to vision_field and mirror back to the matching
+-- job.vision column via the sync trigger so the existing reader chain
+-- (pull-recommendations, computeFit, etc.) keeps working unchanged.
+--
+-- Phase 2 migrates readers one-by-one; Phase 3 retires the sync trigger
+-- and the legacy columns become a view (or are dropped).
+
+create extension if not exists "pgcrypto";
+
+create table if not exists job.vision_field (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  name          text not null,
+  value         jsonb not null default 'null'::jsonb,
+  kind          text not null check (kind in (
+                   'string_array','text_md','number','bool','json'
+                 )),
+  display_name  text,
+  description   text,
+  examples      jsonb,
+  source        text not null default 'user'
+                check (source in ('user','agent','migrate-job','import')),
+  source_detail jsonb,
+  updated_at    timestamptz not null default now(),
+  created_at    timestamptz not null default now(),
+  unique (user_id, name)
+);
+
+create index if not exists vision_field_user_idx    on job.vision_field (user_id);
+create index if not exists vision_field_updated_idx on job.vision_field (updated_at desc);
+
+comment on table  job.vision_field is 'Normalized search-preference + vision data. One row per concept. Source of truth in Phase 2+; mirrored to job.vision columns by sync trigger in Phase 1.';
+comment on column job.vision_field.name is 'Canonical field name. Matches the legacy job.vision column name 1:1 during the migration.';
+comment on column job.vision_field.kind is 'Determines how `value` is interpreted and how the sync trigger casts it back to the legacy job.vision column.';
+comment on column job.vision_field.source is 'Who/what wrote this value. ''agent'' = ask-job-agent chat tool. ''migrate-job'' = batch seed. ''user'' = direct UI edit.';
+
+-- ── Sync trigger: vision_field → job.vision ────────────────────────────
+-- Writers update vision_field; this trigger keeps the legacy job.vision
+-- row in sync so unmigrated readers still see fresh data. Retired in
+-- Phase 3 once every reader has switched over.
+
+create or replace function job.vision_field_sync_to_legacy()
+returns trigger
+language plpgsql
+as $fn$
+declare
+  vid integer;
+  arr_value text[];
+  txt_value text;
+  num_value numeric;
+  bool_value boolean;
+begin
+  select id into vid from job.vision order by updated_at desc limit 1;
+  if vid is null then
+    insert into job.vision (id) values (1) returning id into vid;
+  end if;
+  if not exists (
+    select 1 from information_schema.columns
+     where table_schema = 'job' and table_name = 'vision' and column_name = new.name
+  ) then
+    return new;
+  end if;
+  case new.kind
+    when 'string_array' then
+      arr_value := coalesce(
+        (select array_agg(t) from jsonb_array_elements_text(new.value) as t),
+        '{}'::text[]
+      );
+      execute format('update job.vision set %I = $1, updated_at = now() where id = $2', new.name)
+        using arr_value, vid;
+    when 'text_md' then
+      txt_value := new.value #>> '{}';
+      execute format('update job.vision set %I = $1, updated_at = now() where id = $2', new.name)
+        using txt_value, vid;
+    when 'number' then
+      num_value := nullif(new.value #>> '{}', '')::numeric;
+      execute format('update job.vision set %I = $1, updated_at = now() where id = $2', new.name)
+        using num_value, vid;
+    when 'bool' then
+      bool_value := nullif(new.value #>> '{}', '')::boolean;
+      execute format('update job.vision set %I = $1, updated_at = now() where id = $2', new.name)
+        using bool_value, vid;
+    when 'json' then
+      execute format('update job.vision set %I = $1, updated_at = now() where id = $2', new.name)
+        using new.value, vid;
+    else
+      raise notice 'vision_field_sync_to_legacy: unknown kind %', new.kind;
+  end case;
+  return new;
+end
+$fn$;
+
+drop trigger if exists vision_field_sync on job.vision_field;
+create trigger vision_field_sync
+  after insert or update of value on job.vision_field
+  for each row
+  execute function job.vision_field_sync_to_legacy();
+
+-- ── Seed from job.vision into one row per known field ──────────────────
+do $$
+declare
+  uid uuid;
+  vrow job.vision%rowtype;
+  jnull jsonb := 'null'::jsonb;
+begin
+  select user_id into uid from public.user_profile order by onboarding_complete_at desc nulls last limit 1;
+  if uid is null then raise notice '074: no user_profile yet — skipping seed'; return; end if;
+  select * into vrow from job.vision order by updated_at desc limit 1;
+  if vrow.id is null then return; end if;
+
+  insert into job.vision_field (user_id, name, value, kind, display_name, description, source) values
+    (uid, 'target_titles',       coalesce(to_jsonb(vrow.target_titles),       jnull), 'string_array', 'Titles I''m targeting',          'Role-title phrases the recommender prefers.', 'migrate-job'),
+    (uid, 'target_stages',       coalesce(to_jsonb(vrow.target_stages),       jnull), 'string_array', 'Company stages',                  'Funding stages I''m considering.', 'migrate-job'),
+    (uid, 'target_sectors',      coalesce(to_jsonb(vrow.target_sectors),      jnull), 'string_array', 'Sectors',                          'Industries I''m interested in.', 'migrate-job'),
+    (uid, 'target_geographies',  coalesce(to_jsonb(vrow.target_geographies),  jnull), 'string_array', 'Geographies',                      'Locations / remote policies.', 'migrate-job'),
+    (uid, 'deal_breakers',       coalesce(to_jsonb(vrow.deal_breakers),       jnull), 'string_array', 'Deal-breakers',                    'Hard-stop conditions (consumed by Fit scoring).', 'migrate-job'),
+    (uid, 'impact_themes',       coalesce(to_jsonb(vrow.impact_themes),       jnull), 'string_array', 'Impact themes',                    'Mission themes the role should touch.', 'migrate-job'),
+    (uid, 'mission_keywords',    coalesce(to_jsonb(vrow.mission_keywords),    jnull), 'string_array', 'Mission keywords',                 'Words I want to see in the company mission.', 'migrate-job'),
+    (uid, 'anti_mission_terms',  coalesce(to_jsonb(vrow.anti_mission_terms),  jnull), 'string_array', 'Anti-mission terms',               'Mission signals that disqualify a role.', 'migrate-job'),
+    (uid, 'culture_keywords',    coalesce(to_jsonb(vrow.culture_keywords),    jnull), 'string_array', 'Culture keywords',                 'Cultural signals I''m drawn to.', 'migrate-job'),
+    (uid, 'interest_tags',       coalesce(to_jsonb(vrow.interest_tags),       jnull), 'string_array', 'Interests',                        'Personal interests that bias recommendations.', 'migrate-job'),
+    (uid, 'blocked_titles',      coalesce(to_jsonb(vrow.blocked_titles),      jnull), 'string_array', 'Blocked title patterns',           'Substring-match titles to exclude from recommendations. Written by the chat agent.', 'migrate-job'),
+    (uid, 'must_have_keywords',  coalesce(to_jsonb(vrow.must_have_keywords),  jnull), 'string_array', 'Required keywords',                'Phrases a posting must contain to be recommended.', 'migrate-job'),
+    (uid, 'narrative_arc',       coalesce(to_jsonb(vrow.narrative_arc),       jnull), 'text_md',      'Narrative arc',                    'The career story I''m telling.', 'migrate-job'),
+    (uid, 'voice_rules_md',      coalesce(to_jsonb(vrow.voice_rules_md),      jnull), 'text_md',      'Voice + cover-letter rules',       'How my cover letters should sound.', 'migrate-job'),
+    (uid, 'raw_md',              coalesce(to_jsonb(vrow.raw_md),              jnull), 'text_md',      'Raw KB seed (legacy)',             'Original concatenated markdown from the fikei/job KB.', 'migrate-job'),
+    (uid, 'comp_floor_base',     coalesce(to_jsonb(vrow.comp_floor_base),     jnull), 'number',       'Base salary floor',                'Minimum acceptable base salary in dollars.', 'migrate-job'),
+    (uid, 'comp_floor_total',    coalesce(to_jsonb(vrow.comp_floor_total),    jnull), 'number',       'Total comp floor',                 'Minimum acceptable total comp in dollars.', 'migrate-job'),
+    (uid, 'mission_required',    coalesce(to_jsonb(vrow.mission_required),    jnull), 'bool',         'Mission alignment required',       'If true, anti-mission terms hard-fail a role.', 'migrate-job'),
+    (uid, 'score_weights',       coalesce(vrow.score_weights,                 jnull), 'json',         'Fit score weights',                'Per-dimension weights for computeFit.', 'migrate-job')
+  on conflict (user_id, name) do nothing;
+end $$;
+
+alter table job.vision_field enable row level security;
+
+drop policy if exists "vision_field: owner select" on job.vision_field;
+create policy "vision_field: owner select" on job.vision_field
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "vision_field: owner insert" on job.vision_field;
+create policy "vision_field: owner insert" on job.vision_field
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "vision_field: owner update" on job.vision_field;
+create policy "vision_field: owner update" on job.vision_field
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+grant select, insert, update on job.vision_field to authenticated;

--- a/supabase/migrations/074a_vision_field_updated_at_trigger 2.sql
+++ b/supabase/migrations/074a_vision_field_updated_at_trigger 2.sql
@@ -1,0 +1,21 @@
+-- 074a — auto-bump vision_field.updated_at whenever value changes,
+-- regardless of writer. The agent tool sets updated_at explicitly today,
+-- but direct SQL / future writers shouldn't have to remember.
+
+create or replace function job.vision_field_bump_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  if old.value is distinct from new.value then
+    new.updated_at := now();
+  end if;
+  return new;
+end
+$$;
+
+drop trigger if exists vision_field_bump_updated_at on job.vision_field;
+create trigger vision_field_bump_updated_at
+  before update on job.vision_field
+  for each row
+  execute function job.vision_field_bump_updated_at();


### PR DESCRIPTION
Phase 2 reader migration. /job/vision is now a structured editor over the normalized job.vision_field table; the legacy 19-markdown-files-from-the-KB approach is gone from this page.

## What ships
- **New edge fn `vision-field`** — GET returns the full per-user field set; POST does partial diff with per-kind validation.
- **Rewritten `job-vision.js`** — sections (Narrative + voice / Targets / Mission + culture / Compensation / Filters / Advanced) with per-kind editors:
  - `string_array` → chip editor
  - `text_md` → auto-sized textarea
  - `number` → numeric input
  - `bool` → toggle
  - `json` → mono textarea
- **Per-card metadata footer**: "Updated 3d ago by the chat agent" reads `vision_field.updated_at` + `source` so it's visible WHEN + WHO last touched each preference.
- **Inline save**: dirty-detection, Cancel reverts, Save POSTs only the changed field, flash confirmation.
- All `JobKB.listDir` / `readFile` calls on this page are deleted.

## Still on KB
`job/js/components/job-detail.js` (the /job/history/drill page) still reads `01-job-history/{kind}/{slug}.md`. That's the next reader-migration target after Move B.

## Test plan
- [ ] /job/vision/ on desktop renders all sections from DB, no kb-read calls in Network tab
- [ ] Edit `target_titles` chip list → Save → metadata footer shows "Updated now by you"
- [ ] Edit then Cancel → reverts cleanly
- [ ] Use the chat to "block consultant roles" → /job/vision/ shows `blocked_titles` updated by the chat agent
- [ ] Number / bool / json editors work

Deployed via supabase CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)