### PR TITLE
job(gmail): 'Ladder' label on every sourced email + one-time backfill

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -14,11 +14,17 @@
 import { db } from './job-db.ts';
 import {
   type GmailMessage,
+  ensureAndApplyLabel,
   extractBody,
   getHeader,
   getMessage,
   getMessageIdHeader,
 } from './gmail.ts';
+
+// Every Gmail message we classify into an application event gets
+// stamped with this label so the user can audit what we've touched.
+// Mirrors the labeling in the gmail-jobs source plugin.
+const LADDER_LABEL = 'Ladder';
 import {
   classifyApplicationMessage,
   type ApplicationEventType,
@@ -84,6 +90,10 @@ export async function scanApplicationResponses(args: {
   const out: ApplicationScanResult = {
     classified: 0, inserted: 0, autoAdvanced: 0, needsReview: 0, skippedNoMatch: 0,
   };
+  // Gmail API ids of every message that produced at least one event row,
+  // collected so we can stamp the Ladder label in one batchModify call
+  // at end-of-scan.
+  const labelTargets: string[] = [];
 
   // Load active pipeline roles + best-known domain via hiring_companies cache.
   // company_name is the join key (case-insensitive). hiring_companies.name_norm
@@ -329,6 +339,7 @@ export async function scanApplicationResponses(args: {
     if (!inserted.length) continue;
     out.inserted++;
     if (needsReview) out.needsReview++;
+    labelTargets.push(msg.id);
 
     // Update role: last_activity_at always; gmail_thread_ids only at
     // THREAD_ASSOCIATION_FLOOR (poison-resistance); stage on auto-advance.
@@ -364,6 +375,19 @@ export async function scanApplicationResponses(args: {
     // signal. Source ranking: recruiter_email > jd_extract > inferred.
     // Backfill never writes inferred_from_events (per locked decision).
     await maybeUpdateProcessOutline(sql, matchedRole, classified, mode);
+  }
+
+  // Apply Ladder label to every message we classified into an event.
+  // Best-effort — failures (missing modify scope, transient errors) log
+  // but don't throw, since labeling is a side-effect of the scan.
+  if (labelTargets.length) {
+    try {
+      const res = await ensureAndApplyLabel(args.accessToken, labelTargets, LADDER_LABEL);
+      if (res.errors.length) console.warn(`[gmail-app-scan] label errors: ${res.errors.slice(0, 3).join(' | ')}`);
+      else console.log(`[gmail-app-scan] labeled ${res.labeled} message(s) with '${LADDER_LABEL}'`);
+    } catch (e) {
+      console.warn(`[gmail-app-scan] label apply failed: ${(e as Error).message}`);
+    }
   }
 
   return out;

--- a/supabase/functions/_shared/gmail.ts
+++ b/supabase/functions/_shared/gmail.ts
@@ -208,3 +208,107 @@ function stripHtml(html: string): string {
 function dedupe(arr: string[]): string[] {
   return [...new Set(arr)];
 }
+
+// ---------- Labels ----------
+//
+// Every Gmail message the pipeline touches gets stamped with a label so
+// the user can audit what we've used. Requires gmail.modify scope (a
+// strict superset of gmail.readonly).
+
+export interface GmailLabel {
+  id: string;
+  name: string;
+  type?: 'user' | 'system';
+}
+
+// Idempotent: returns the existing label id when present, otherwise
+// creates it. Cache the result per-process to avoid the list/create
+// round-trip on every batch.
+const _labelCache = new Map<string, string>();   // accessToken+name → labelId
+
+export async function ensureLabel(accessToken: string, name: string): Promise<string> {
+  const cacheKey = `${accessToken.slice(0, 24)}:${name}`;
+  const cached = _labelCache.get(cacheKey);
+  if (cached) return cached;
+
+  // List existing labels. labels.list returns user + system labels.
+  const listRes = await fetch(`${GMAIL_BASE}/labels`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!listRes.ok) throw new Error(`labels.list ${listRes.status}: ${(await listRes.text()).slice(0, 200)}`);
+  const list = await listRes.json() as { labels?: GmailLabel[] };
+  const existing = (list.labels || []).find(l => l.name === name);
+  if (existing) {
+    _labelCache.set(cacheKey, existing.id);
+    return existing.id;
+  }
+
+  // Create the label. labelListVisibility/messageListVisibility default
+  // to visible — the user wants to see emails the pipeline has touched.
+  const createRes = await fetch(`${GMAIL_BASE}/labels`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name,
+      labelListVisibility:    'labelShow',
+      messageListVisibility:  'show',
+    }),
+  });
+  if (!createRes.ok) throw new Error(`labels.create ${createRes.status}: ${(await createRes.text()).slice(0, 200)}`);
+  const created = await createRes.json() as GmailLabel;
+  _labelCache.set(cacheKey, created.id);
+  return created.id;
+}
+
+// Apply a label to many Gmail messages in one round-trip. Gmail's
+// batchModify accepts up to 1000 ids per call; we chunk just in case.
+// No-ops on empty input. Failures are caught + logged, never thrown —
+// labeling is a side-effect, not the critical path.
+export async function batchAddLabel(
+  accessToken: string,
+  messageIds: string[],
+  labelId: string,
+): Promise<{ labeled: number; chunks: number; errors: string[] }> {
+  const out = { labeled: 0, chunks: 0, errors: [] as string[] };
+  if (!messageIds.length) return out;
+  const unique = [...new Set(messageIds.filter(Boolean))];
+  const CHUNK = 900;
+  for (let i = 0; i < unique.length; i += CHUNK) {
+    const chunk = unique.slice(i, i + CHUNK);
+    try {
+      const r = await fetch(`${GMAIL_BASE}/messages/batchModify`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: chunk, addLabelIds: [labelId] }),
+      });
+      if (!r.ok) {
+        const errBody = (await r.text()).slice(0, 200);
+        out.errors.push(`batchModify ${r.status}: ${errBody}`);
+        continue;
+      }
+      out.labeled += chunk.length;
+      out.chunks++;
+    } catch (e) {
+      out.errors.push((e as Error).message);
+    }
+  }
+  return out;
+}
+
+// Convenience: ensure label + apply in one call. Used by the live
+// pipeline (gmail-jobs + application-scan) where we always want the
+// same Ladder label applied to every touched message.
+export async function ensureAndApplyLabel(
+  accessToken: string,
+  messageIds: string[],
+  labelName: string,
+): Promise<{ labelId: string | null; labeled: number; errors: string[] }> {
+  if (!messageIds.length) return { labelId: null, labeled: 0, errors: [] };
+  try {
+    const labelId = await ensureLabel(accessToken, labelName);
+    const res = await batchAddLabel(accessToken, messageIds, labelId);
+    return { labelId, labeled: res.labeled, errors: res.errors };
+  } catch (e) {
+    return { labelId: null, labeled: 0, errors: [(e as Error).message] };
+  }
+}

--- a/supabase/functions/_shared/google-tokens.ts
+++ b/supabase/functions/_shared/google-tokens.ts
@@ -181,5 +181,9 @@ export async function userIdForEmail(
 
 // Standard Gmail scope. Exported so every call site uses the same string.
 export const GMAIL_READONLY_SCOPE = 'https://www.googleapis.com/auth/gmail.readonly';
+// gmail.modify is a strict superset of gmail.readonly. Required to apply
+// labels (users.messages.modify / users.messages.batchModify). Added so
+// the pipeline can stamp a "Ladder" label on every email it sources from.
+export const GMAIL_MODIFY_SCOPE   = 'https://www.googleapis.com/auth/gmail.modify';
 export const CALENDAR_READONLY_SCOPE = 'https://www.googleapis.com/auth/calendar.readonly';
 export const CALENDAR_EVENTS_SCOPE = 'https://www.googleapis.com/auth/calendar.events';

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -29,6 +29,7 @@ import {
 import { db } from '../job-db.ts';
 import {
   type GmailMessage,
+  ensureAndApplyLabel,
   extractBody,
   getHeader,
   getMessage,
@@ -37,6 +38,11 @@ import {
   listSinceCursor,
 } from '../gmail.ts';
 import { scanApplicationResponses } from '../gmail-application-scan.ts';
+
+// Every email the pipeline sources from gets labeled in Gmail so the
+// user can audit what we've touched. The label is created on first use
+// and reused thereafter (see ensureLabel cache in _shared/gmail.ts).
+const LADDER_LABEL = 'Ladder';
 
 interface GmailJobsCfg {
   allowSenders?: string[];
@@ -162,6 +168,9 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidates from gmail (history=${!!state.history_id}, cap=${maxMessages})`);
 
     const out: RecommendedRoleInput[] = [];
+    // Track every Gmail API id that contributed at least one emit, so
+    // we can stamp the Ladder label at end-of-pull in one batch call.
+    const labelTargets: string[] = [];
 
     for (const id of ids) {
       if (newWork >= maxMessages) { cappedRun = true; break; }
@@ -337,6 +346,25 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
       // so we can audit — otherwise the message silently disappears.
       if (!emitted) {
         await logSkipped(sql, ctx.userEmail, msg, messageId, 'no_usable_roles', { extracted: jobs });
+      } else {
+        // At least one role was emitted from this message — stamp the
+        // Ladder label so the user can see which inbox items the
+        // pipeline has sourced from.
+        labelTargets.push(msg.id);
+      }
+    }
+
+    // Apply the Ladder label to every Gmail message that contributed at
+    // least one rec this tick. Best-effort: failures (missing modify
+    // scope, transient API errors) are logged but never throw, since
+    // labeling is a side-effect of the pipeline, not the critical path.
+    if (labelTargets.length) {
+      try {
+        const res = await ensureAndApplyLabel(accessToken, labelTargets, LADDER_LABEL);
+        if (res.errors.length) console.warn(`[gmail-jobs] label errors: ${res.errors.slice(0, 3).join(' | ')}`);
+        else console.log(`[gmail-jobs] labeled ${res.labeled} message(s) with '${LADDER_LABEL}'`);
+      } catch (e) {
+        console.warn(`[gmail-jobs] label apply failed: ${(e as Error).message}`);
       }
     }
 

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -26,13 +26,17 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import {
   getServiceClient,
   GMAIL_READONLY_SCOPE,
+  GMAIL_MODIFY_SCOPE,
   getAccessToken,
   userIdForEmail,
 } from '../_shared/google-tokens.ts';
 import { scanApplicationResponses } from '../_shared/gmail-application-scan.ts';
+import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
-const VERSION = '1.4.0';
-console.log(`[application-events] v${VERSION} - backfill skips user's own outbound messages`);
+const LADDER_LABEL = 'Ladder';
+
+const VERSION = '1.5.0';
+console.log(`[application-events] v${VERSION} - Gmail 'Ladder' label backfill action (needs gmail.modify scope)`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';
@@ -83,6 +87,9 @@ serve(async (req) => {
     }
     if (action === 'backfill') {
       return await runBackfill(body, userEmail);
+    }
+    if (action === 'backfill-labels') {
+      return await runBackfillLabels(body, userEmail);
     }
     return err(`unknown action: ${action}`);
   } catch (e) {
@@ -339,4 +346,63 @@ async function runBackfill(body: Record<string, unknown>, userEmail: string): Pr
   });
 
   return jsonResp({ version: VERSION, ...result });
+}
+
+
+// ---------- backfill-labels ----------
+//
+// One-time (re-runnable) sweep: stamp the Ladder label on every Gmail
+// message the pipeline has ever sourced. Walks two surfaces:
+//   - job.recommended_roles where source='gmail-jobs' (gmailApiId in payload)
+//   - job.application_events (gmail_api_id column)
+// Requires gmail.modify scope — if the user only has readonly, we
+// return a clear error asking for re-consent.
+
+async function runBackfillLabels(_body: Record<string, unknown>, userEmail: string): Promise<Response> {
+  const sb = getServiceClient();
+  const userId = await userIdForEmail(sb, userEmail);
+  if (!userId) return err('user not found', 400);
+  // Require the broader scope so batchModify is actually allowed.
+  const tokenRes = await getAccessToken(sb, userId, [GMAIL_MODIFY_SCOPE]);
+  if (!tokenRes) {
+    return jsonResp({
+      ok: false,
+      reason: 'needs_modify_scope',
+      message: 'Gmail labels require gmail.modify scope. Re-connect Gmail at /job/ to grant it.',
+    }, 400);
+  }
+
+  const sql = db();
+  // recommended_roles stores the Gmail API id under payload.gmailApiId
+  // when the row came from the gmail-jobs source. application_events
+  // stores it in its own column.
+  const recIds = await sql<{ gmail_api_id: string }[]>`
+    select distinct payload->>'gmailApiId' as gmail_api_id
+      from job.recommended_roles
+     where source = 'gmail-jobs'
+       and payload->>'gmailApiId' is not null
+  `;
+  const eventIds = await sql<{ gmail_api_id: string }[]>`
+    select distinct gmail_api_id
+      from job.application_events
+     where gmail_api_id is not null
+  `;
+
+  const all = [
+    ...recIds.map(r => r.gmail_api_id),
+    ...eventIds.map(r => r.gmail_api_id),
+  ].filter(Boolean);
+  const unique = [...new Set(all)];
+
+  const res = await ensureAndApplyLabel(tokenRes.accessToken, unique, LADDER_LABEL);
+  return jsonResp({
+    ok: true,
+    version: VERSION,
+    found:   unique.length,
+    fromRecs:   recIds.length,
+    fromEvents: eventIds.length,
+    labeled: res.labeled,
+    labelId: res.labelId,
+    errors:  res.errors,
+  });
 }

--- a/supabase/functions/gmail-auth/index.ts
+++ b/supabase/functions/gmail-auth/index.ts
@@ -13,8 +13,8 @@
 // don't need a new client registration. The redirect URI for gmail
 // connect points at /job/ — calendar-api keeps /calendar/.
 
-const VERSION = '0.1.0';
-console.log(`[gmail-auth] v${VERSION} - oauth for gmail.readonly`);
+const VERSION = '0.2.0';
+console.log(`[gmail-auth] v${VERSION} - oauth requests gmail.modify (superset of readonly) so pipeline can apply Ladder label`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -23,9 +23,16 @@ import {
   findTokenForScopes,
   getServiceClient,
   GMAIL_READONLY_SCOPE,
+  GMAIL_MODIFY_SCOPE,
   markRevoked,
   upsertToken,
 } from '../_shared/google-tokens.ts';
+
+// gmail.modify is a strict superset of gmail.readonly. We request both
+// so the scope_set on the token row covers callers that look up by
+// either scope. Existing readonly-only tokens still work for reading
+// until the user re-consents; labeling silently no-ops until then.
+const GMAIL_REQUESTED_SCOPES = [GMAIL_READONLY_SCOPE, GMAIL_MODIFY_SCOPE];
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -72,14 +79,13 @@ serve(async (req) => {
     if (!user) return json({ error: 'unauthorized' }, 401);
 
     const db = getServiceClient();
-    const scopeSet = canonicalScopeSet([GMAIL_READONLY_SCOPE]);
 
     if (action === 'auth-url') {
       const params = new URLSearchParams({
         client_id: GOOGLE_CLIENT_ID,
         redirect_uri: GMAIL_REDIRECT_URI,
         response_type: 'code',
-        scope: GMAIL_READONLY_SCOPE,
+        scope: GMAIL_REQUESTED_SCOPES.join(' '),
         access_type: 'offline',
         prompt: 'consent',
         // Including 'gmail' in state lets the /job/ JS distinguish this
@@ -119,11 +125,18 @@ serve(async (req) => {
         scope: string;
       };
 
-      // Verify Google actually granted gmail.readonly. include_granted_scopes
-      // means a previous calendar consent could come back without gmail.
+      // Verify Google actually granted the Gmail scopes we asked for.
+      // include_granted_scopes means a previous calendar consent could
+      // come back without gmail. We accept either readonly or modify —
+      // modify is a strict superset, so either path lets us read mail.
+      // Labeling requires modify specifically; if only readonly was
+      // granted, the row still stores OK and the pipeline degrades to
+      // read-only behavior.
       const grantedScopes = tokens.scope.split(/\s+/).filter(Boolean);
-      if (!grantedScopes.includes(GMAIL_READONLY_SCOPE)) {
-        return json({ error: 'gmail.readonly was not granted' }, 400);
+      const hasReadonly = grantedScopes.includes(GMAIL_READONLY_SCOPE);
+      const hasModify   = grantedScopes.includes(GMAIL_MODIFY_SCOPE);
+      if (!hasReadonly && !hasModify) {
+        return json({ error: 'gmail scopes not granted' }, 400);
       }
 
       // Resolve the Google account email so the user can confirm which
@@ -145,6 +158,16 @@ serve(async (req) => {
       if (!refresh) {
         return json({ error: 'no refresh_token; reconnect with prompt=consent' }, 400);
       }
+
+      // Store the Gmail scopes Google granted. gmail.modify is a strict
+      // superset of gmail.readonly — if modify was granted, advertise
+      // readonly too so existing callers (findTokenForScopes(...[GMAIL_READONLY_SCOPE])
+      // pattern) keep matching.
+      const gmailGranted = grantedScopes.filter(s => s.startsWith('https://www.googleapis.com/auth/gmail.'));
+      if (hasModify && !gmailGranted.includes(GMAIL_READONLY_SCOPE)) {
+        gmailGranted.push(GMAIL_READONLY_SCOPE);
+      }
+      const scopeSet = canonicalScopeSet(gmailGranted);
 
       const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
       await upsertToken(db, {


### PR DESCRIPTION
Stamps a Gmail label on every inbox message the pipeline sources from (gmail-jobs recs + Phase 2.0 application events) via users.messages.batchModify. Requires gmail.modify scope (superset of gmail.readonly) — gmail-auth now requests both, **one-time user re-consent needed at /job/ for labeling to start working**; reads keep functioning on the existing readonly token. New action: application-events { action: 'backfill-labels' } walks recommended_roles.payload->>'gmailApiId' + application_events.gmail_api_id, dedupes, batchModifies in one call. gmail-auth 0.2.0, application-events 1.5.0.