### PR TITLE
job: split upload — resume-first, then insight card prompts for more

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -5384,3 +5384,64 @@ body[data-auth-state="out"] job-chat { display: none; }
 }
 
 .vf-empty { color: var(--fg-muted); font-style: italic; }
+
+/* Supporting-docs invite card — sits at the bottom of the insight stage,
+   asks for the deeper read (cover letters, writing samples, etc.) after
+   the resume insight has rendered. */
+.insight-deepen {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+  padding: var(--space-5);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--bg-surface);
+}
+.insight-deepen__title {
+  font-size: var(--font-size-title-3);
+  font-weight: 600;
+  margin: 0;
+}
+.insight-deepen__lede {
+  color: var(--fg-muted);
+  line-height: var(--lh-body);
+  margin: 0;
+}
+.insight-deepen__examples {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-2) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.insight-deepen__examples li {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding-left: var(--space-3);
+  position: relative;
+  line-height: var(--lh-body);
+}
+.insight-deepen__examples li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.7em;
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--accent);
+}
+.insight-deepen__example-label {
+  color: var(--fg);
+  font-weight: 500;
+}
+.insight-deepen__example-use {
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+}
+.dropzone--compact {
+  padding: var(--space-4);
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
@@ -41,9 +41,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=0.96.0"></script>

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
@@ -44,9 +44,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=0.96.0"></script>

--- a/job/index.html
+++ b/job/index.html
@@ -9,15 +9,15 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=1.00.0">
@@ -72,12 +72,12 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=1.00.0"></script>

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
@@ -41,9 +41,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=0.96.0"></script>

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
@@ -44,9 +44,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=0.96.0"></script>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -8,11 +8,11 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 =======
-  <link rel="stylesheet" href="/job/css/base.css?v=1.2.0">
-  <script src="/job/js/theme.js?v=1.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
+  <script src="/job/js/theme.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <link rel="stylesheet" href="/job/css/base.css?v=0.96.0">
@@ -41,9 +41,9 @@
 
 <<<<<<< HEAD
 <<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 =======
-  <script type="module" src="/job/js/app.js?v=1.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
 >>>>>>> origin/master
 =======
   <script type="module" src="/job/js/app.js?v=0.96.0"></script>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "1.2.0";
-console.log(`[job] v${VERSION} - Apt voice + 4 follow-up Qs (intent/energy/aspiration/hardYes) + user bubble`);
+const VERSION = "1.3.0";
+console.log(`[job] v${VERSION} - Resume-first upload + insight card + supporting docs prompt`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -243,44 +243,34 @@ export class JobOnboarding extends LitElement {
     o[k] = [...cur];
   }
 
-  // -------- Stage 1: multi-file ingest --------
+  // -------- Stage 1: resume upload (single file) --------
+  //
+  // The resume is the bones — we always parse it first and generate insights
+  // from it alone. Supporting docs are layered on AFTER the insight card
+  // renders, via _handleSupportingUpload (called from Stage 2).
 
-  async _handleFiles(fileList) {
+  async _handleResumeUpload(fileList) {
     const files = Array.from(fileList || []);
     if (!files.length) return;
     this.error = '';
-    this.busy = true; this.busyLabel = `Reading ${files.length} file${files.length > 1 ? 's' : ''}…`;
+    this.busy = true; this.busyLabel = 'Reading your resume';
     try {
-      // Classify by filename: anything with "resume" or "cv" is the primary
-      // resume; everything else is bundle context. If no name match, the
-      // largest file (likely the resume) wins.
+      // Prefer the largest file as the resume if multiple were dropped;
+      // fallback to the only file. Anything else gets ignored here — the
+      // supporting-docs uploader on Stage 2 picks up additional files.
       const named = [];
       for (const f of files) {
         const text = await readFileAsText(f);
         named.push({ name: f.name, size: text.length, text });
       }
-      const resumeMatch = named.find(f => /(^|[\s_-])(resume|cv)/i.test(f.name));
-      const resume = resumeMatch || named.slice().sort((a, b) => b.size - a.size)[0];
-      const others = named.filter(f => f !== resume);
-
-      this.draft._meta.uploadedFiles = named.map(f => ({ name: f.name, size: f.size, isResume: f === resume }));
+      const resume = named.slice().sort((a, b) => b.size - a.size)[0];
+      this.draft._meta.uploadedFiles = [{ name: resume.name, size: resume.size, isResume: true }];
       this._commit();
 
-      // Two passes in parallel: parse resume → structured profile; bundle
-      // everything else (or the same resume if it's the only doc) → voice
-      // + values + projects + dream signals. Works pre-auth — callOnboard
-      // falls back to the anon key when there's no user session.
-      const bundleText = (others.length ? others : [resume]).map(f => `--- ${f.name} ---\n${f.text}`).join('\n\n');
-      this.busyLabel = 'Pulling out the bones (resume) and the voice (everything else)…';
-
-      const [parseRes, bundleRes] = await Promise.all([
-        callOnboard({ mode: 'parse',  text: resume.text }),
-        callOnboard({ mode: 'bundle', text: bundleText }),
-      ]);
+      this.busyLabel = 'Pulling out the bones';
+      const parseRes = await callOnboard({ mode: 'parse', text: resume.text });
       const draftIncoming = parseRes.draft || {};
-      const bundle = bundleRes.bundle || {};
 
-      // Merge parse output.
       this.draft.identity = { ...this.draft.identity, ...draftIncoming.identity };
       this.draft.location = { ...this.draft.location, ...draftIncoming.location };
       if (draftIncoming.capability) {
@@ -290,21 +280,12 @@ export class JobOnboarding extends LitElement {
         this.draft.capability.history     = draftIncoming.capability.history     || this.draft.capability.history;
       }
 
-      // Merge bundle output.
-      this.draft.bundle = bundle;
-      this._mergeArr('values_seed.cultureKeywords', bundle.values);
-      this._mergeArr('targeting.targetRoles', bundle.dreamRoleSignals);
-      if (Array.isArray(bundle.wins)) {
-        for (const w of bundle.wins) this.draft.wins.push(w);
-      }
-
-      // Now generate insights for Stage 2.
-      this.busyLabel = 'Mapping where this experience travels…';
+      // Generate insights from resume alone — the celebration card.
+      this.busyLabel = 'Mapping where this experience travels';
       const profileForInsights = {
         identity: this.draft.identity,
         location: this.draft.location,
         capability: this.draft.capability,
-        bundle: this.draft.bundle,
       };
       const insightsRes = await callOnboard({ mode: 'insights', profile: profileForInsights });
       this.draft.insights = insightsRes.insights || null;
@@ -317,8 +298,71 @@ export class JobOnboarding extends LitElement {
     }
   }
 
+  // -------- Stage 2: supporting-docs upload (optional, layered on top) --------
+  //
+  // Runs bundle on the new docs to extract voice + values + dream signals,
+  // merges into the existing draft, then regenerates the insight card so
+  // the user sees the depth grow.
+
+  async _handleSupportingUpload(fileList) {
+    const files = Array.from(fileList || []);
+    if (!files.length) return;
+    this.error = '';
+    this.busy = true; this.busyLabel = `Reading ${files.length} more file${files.length > 1 ? 's' : ''}`;
+    try {
+      const named = [];
+      for (const f of files) {
+        const text = await readFileAsText(f);
+        named.push({ name: f.name, size: text.length, text });
+      }
+      // Track these as additional uploaded files (resume stays flagged).
+      const meta = this.draft._meta.uploadedFiles || [];
+      this.draft._meta.uploadedFiles = [
+        ...meta,
+        ...named.map(f => ({ name: f.name, size: f.size, isResume: false })),
+      ];
+      this._commit();
+
+      this.busyLabel = 'Listening for the voice';
+      const bundleText = named.map(f => `--- ${f.name} ---\n${f.text}`).join('\n\n');
+      const bundleRes = await callOnboard({ mode: 'bundle', text: bundleText });
+      const bundle = bundleRes.bundle || {};
+
+      // Merge into draft.bundle (concat-merge for arrays).
+      const cur = this.draft.bundle || {};
+      this.draft.bundle = {
+        voiceSample: bundle.voiceSample || cur.voiceSample || '',
+        values:            [...new Set([...(cur.values || []),            ...(bundle.values || [])])],
+        projects:          [...(cur.projects || []), ...(bundle.projects || [])],
+        dreamRoleSignals:  [...new Set([...(cur.dreamRoleSignals || []),  ...(bundle.dreamRoleSignals || [])])],
+        wins:              [...(cur.wins || []),     ...(bundle.wins || [])],
+      };
+      this._mergeArr('values_seed.cultureKeywords', bundle.values);
+      this._mergeArr('targeting.targetRoles',        bundle.dreamRoleSignals);
+      if (Array.isArray(bundle.wins)) for (const w of bundle.wins) this.draft.wins.push(w);
+
+      // Regenerate insights with the deeper context — the celebration card
+      // grows as the user gives us more material.
+      this.busyLabel = 'Re-mapping with the deeper read';
+      const profileForInsights = {
+        identity: this.draft.identity,
+        location: this.draft.location,
+        capability: this.draft.capability,
+        bundle: this.draft.bundle,
+      };
+      const insightsRes = await callOnboard({ mode: 'insights', profile: profileForInsights });
+      if (insightsRes.insights) this.draft.insights = insightsRes.insights;
+      this._commit();
+    } catch (e) {
+      this.error = e.message;
+    } finally {
+      this.busy = false; this.busyLabel = '';
+    }
+  }
+
   async _skipUpload() {
-    // Manual start — no insights to show, but we still need an insights card.
+    // Manual start — no insights to show; the cold-start branch of
+    // _renderInsights handles the no-resume case.
     this.draft.insights = null;
     this._setStage(2);
   }
@@ -543,25 +587,20 @@ export class JobOnboarding extends LitElement {
     if (log) log.scrollTop = log.scrollHeight;
   }
 
-  // Mid-flow attach handler. Reuses upload path; routes back to chat
-  // afterwards with the same questionIdx so the user resumes where they were.
+  // Mid-flow attach handler — treats new files as supporting docs (resume
+  // is already parsed by now). Bundle pass + insights refresh; routes back
+  // to chat afterwards with the same questionIdx so the user resumes.
   async _handleAttach(fileList) {
     const idxBefore = this.draft._meta.questionIdx;
-    const stageBefore = this.draft._meta.stage;
-    await this._handleFiles(fileList);
-    // _handleFiles set stage=2. If they were in chat, route them back.
-    if (stageBefore === 3) {
-      this.draft._meta.stage = 3;
-      this.draft._meta.questionIdx = idxBefore;
-      // Inject a synthetic AI turn acknowledging the attach.
-      const resumeQ = QUESTIONS[idxBefore] || QUESTIONS[0];
-      this.draft._meta.chatLog.push({
-        role: 'ai',
-        qid: resumeQ.id,
-        content: `Thanks — I pulled what I could from that. Picking back up: **${resumeQ.label}**`,
-      });
-      this._commit();
-    }
+    await this._handleSupportingUpload(fileList);
+    // Stay on the chat stage; inject a soft AI ack of the attach.
+    const resumeQ = QUESTIONS[idxBefore] || QUESTIONS[0];
+    this.draft._meta.chatLog.push({
+      role: 'ai',
+      qid: resumeQ.id,
+      content: `Thanks — I pulled what I could from that. Picking back up: **${resumeQ.label}**`,
+    });
+    this._commit();
   }
 
   // -------- Stage 4: tailor --------
@@ -666,19 +705,19 @@ export class JobOnboarding extends LitElement {
     const files = this.draft._meta.uploadedFiles || [];
     return html`
       <section class="onboard__stage">
-        <h1>Drop in everything you've already got.</h1>
-        <p class="lede">Resume is the headline. Cover letters, writing samples, LLM career docs, project descriptions, dream JDs — anything you've already written that shows your shape. We'll pull the bones from the resume and the voice from the rest.</p>
+        <h1>Start with your resume.</h1>
+        <p class="lede">We'll pull the bones — companies, titles, skills, where you've been — and use them to ask better questions. You can layer in other docs next.</p>
         <label class="dropzone dropzone--multi" for="resume-file"
                @dragover=${(e) => { e.preventDefault(); e.currentTarget.classList.add('dropzone--active'); }}
                @dragleave=${(e) => e.currentTarget.classList.remove('dropzone--active')}
-               @drop=${(e) => { e.preventDefault(); e.currentTarget.classList.remove('dropzone--active'); this._handleFiles(e.dataTransfer.files); }}>
-          <div class="dropzone__title">Drag in PDFs, .md, or .txt — or click to choose</div>
-          <div class="dropzone__hint">Anything with "resume" or "cv" in the name is treated as the primary resume. The rest become voice/values context.</div>
-          <input id="resume-file" type="file" multiple accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
-                 style="display:none" @change=${(e) => this._handleFiles(e.target.files)}/>
+               @drop=${(e) => { e.preventDefault(); e.currentTarget.classList.remove('dropzone--active'); this._handleResumeUpload(e.dataTransfer.files); }}>
+          <div class="dropzone__title">Drop your resume — PDF, .md, or .txt</div>
+          <div class="dropzone__hint">Or click to choose. One file is plenty here.</div>
+          <input id="resume-file" type="file" accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+                 style="display:none" @change=${(e) => this._handleResumeUpload(e.target.files)}/>
           ${files.length ? html`
             <ul class="dropzone__files">
-              ${files.map(f => html`<li><strong>${f.name}</strong> ${f.isResume ? html`<span class="chip chip--on" style="font-size:var(--font-size-caption);">resume</span>` : ''}</li>`)}
+              ${files.map(f => html`<li><strong>${f.name}</strong></li>`)}
             </ul>` : nothing}
         </label>
         <div class="onboard__nav">
@@ -687,6 +726,19 @@ export class JobOnboarding extends LitElement {
         </div>
       </section>
     `;
+  }
+
+  // Bulleted list of high-value supporting-doc examples. Rendered inside
+  // the insight stage to invite a deeper read.
+  _supportingDocExamples() {
+    return [
+      { label: 'A past cover letter you liked',           uses: 'seeds the voice your cover-letter agent will write in' },
+      { label: 'Writing samples — Substack, internal memos, anything in your voice', uses: 'pulls voice + thinking patterns' },
+      { label: 'A performance review you held onto',      uses: 'third-party language about your strengths' },
+      { label: 'Project case studies or decks',           uses: 'depth on specific wins beyond resume bullets' },
+      { label: 'Dream JDs you\'ve bookmarked',            uses: 'reverse-engineers what you actually want' },
+      { label: 'A LinkedIn About blurb or short bio',     uses: 'how you already position yourself' },
+    ];
   }
 
   _renderInsights() {
@@ -720,12 +772,48 @@ export class JobOnboarding extends LitElement {
         ${this._renderTrack('Craft you bring', 'product / IC skills → role shapes this unlocks', ins.skills || [])}
 
         ${this._renderEditFooter()}
+        ${this._renderSupportingDocsCard()}
 
         <div class="onboard__nav">
           <button class="btn btn--ghost" @click=${() => this._setStage(1)}>Back</button>
           <button class="btn btn--primary" @click=${() => this._setStage(3)}>Looks right — keep going</button>
         </div>
       </section>
+    `;
+  }
+
+  // Supporting-docs card — invites the user to deepen the read after they've
+  // seen the resume-only insight. Bulleted examples make the ask concrete.
+  _renderSupportingDocsCard() {
+    const meta = this.draft._meta.uploadedFiles || [];
+    const supporting = meta.filter(f => !f.isResume);
+    return html`
+      <div class="insight-deepen">
+        <h2 class="insight-deepen__title">Want me to go deeper?</h2>
+        <p class="insight-deepen__lede">Resume tells me what you've done. Drop in anything else you've written and I can read for voice, taste, and the texture between the lines.</p>
+        <ul class="insight-deepen__examples">
+          ${this._supportingDocExamples().map(ex => html`
+            <li>
+              <span class="insight-deepen__example-label">${ex.label}</span>
+              <span class="insight-deepen__example-use">${ex.uses}</span>
+            </li>
+          `)}
+        </ul>
+        <label class="dropzone dropzone--multi dropzone--compact" for="supporting-files"
+               @dragover=${(e) => { e.preventDefault(); e.currentTarget.classList.add('dropzone--active'); }}
+               @dragleave=${(e) => e.currentTarget.classList.remove('dropzone--active')}
+               @drop=${(e) => { e.preventDefault(); e.currentTarget.classList.remove('dropzone--active'); this._handleSupportingUpload(e.dataTransfer.files); }}>
+          <div class="dropzone__title">Drop one or more — PDF, .md, .txt</div>
+          <div class="dropzone__hint">Or click to choose. I'll re-read everything and refresh the insight above.</div>
+          <input id="supporting-files" type="file" multiple accept=".pdf,.md,.txt,application/pdf,text/markdown,text/plain"
+                 style="display:none" @change=${(e) => this._handleSupportingUpload(e.target.files)}/>
+          ${supporting.length ? html`
+            <ul class="dropzone__files">
+              ${supporting.map(f => html`<li><strong>${f.name}</strong></li>`)}
+            </ul>` : nothing}
+        </label>
+        <p class="onboard__hint">Totally optional — keep going if you'd rather skip.</p>
+      </div>
     `;
   }
 


### PR DESCRIPTION
Stage 1 single-file resume → instant insights → Stage 2 prompts for supporting docs with a bulleted list of high-value examples (cover letters, writing samples, perf reviews, project decks, dream JDs, LinkedIn About). Adding supporting docs re-runs insights so the hero deepens. v1.3.0.