### PR TITLE
job: A2 — /job/history/drill reads from job.companies/projects/skills/wins via job-entity

### DIFF
--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=1.4.0");
-@import url("./tokens-generic-dark.css?v=1.4.0");
-@import url("./tokens-ctrl-light.css?v=1.4.0");
-@import url("./tokens-ctrl-dark.css?v=1.4.0");
-@import url("./components.css?v=1.4.0");
+@import url("./tokens-generic-light.css?v=1.5.0");
+@import url("./tokens-generic-dark.css?v=1.5.0");
+@import url("./tokens-ctrl-light.css?v=1.5.0");
+@import url("./tokens-ctrl-dark.css?v=1.5.0");
+@import url("./components.css?v=1.5.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
 
 
 
@@ -58,7 +58,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 
 
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "1.4.0";
-console.log(`[job] v${VERSION} - Resume-first upload + insight card + supporting docs prompt`);
+const VERSION = "1.5.0";
+console.log(`[job] v${VERSION} - history drill reads job.companies/projects/skills/wins via job-entity`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-detail.js
+++ b/job/js/components/job-detail.js
@@ -1,26 +1,23 @@
 // job-detail — generic drilldown view for /job/history/{kind}/{slug}/.
-// Reads ?kind= & ?slug= from the query, fetches the corresponding markdown
-// from fikei/job, renders with the wiki-link-aware renderer, and restores
-// the pretty URL via history.replaceState.
+// Reads ?kind= & ?slug= from the query, fetches the row from the
+// job-entity edge fn (which reads job.{companies,projects,skills,wins}
+// in Postgres), renders body_md with the wiki-link-aware renderer.
+//
+// Replaces the legacy KB read of /01-job-history/{kind}/{slug}.md so
+// the last live kb-read caller is gone.
 import { LitElement, html } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
 const { renderMarkdown } = await import('../markdown.js' + V);
 
-const KIND_DIR = {
-  companies: '01-job-history/companies',
-  projects:  '01-job-history/projects',
-  skills:    '01-job-history/skills',
-  wins:      '01-job-history/wins',
-  roles:     '01-job-history/roles',
-};
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const FN_URL = `${SUPABASE_URL}/functions/v1/job-entity`;
 
 const KIND_LABEL = {
   companies: 'Companies',
   projects:  'Projects',
   skills:    'Skills',
   wins:      'Wins',
-  roles:     'Roles',
 };
 
 export class JobDetail extends LitElement {
@@ -33,6 +30,8 @@ export class JobDetail extends LitElement {
     body:  { state: true },
     kind:  { state: true },
     slug:  { state: true },
+    updatedAt:   { state: true },
+    frontmatter: { state: true },
   };
 
   constructor() {
@@ -41,6 +40,8 @@ export class JobDetail extends LitElement {
     this.error = '';
     this.title = '';
     this.body = '';
+    this.updatedAt = '';
+    this.frontmatter = null;
     const params = new URLSearchParams(location.search);
     this.kind = (params.get('kind') || '').toLowerCase();
     this.slug = (params.get('slug') || '').toLowerCase();
@@ -68,27 +69,38 @@ export class JobDetail extends LitElement {
     super.disconnectedCallback();
   }
 
+  async _supabaseToken() {
+    const sb = window.CtrlAuth?.getSupabaseClient?.();
+    return (await sb?.auth.getSession?.())?.data?.session?.access_token;
+  }
+
   async _maybeLoad() {
     if (document.body.dataset.authState !== 'in') return;
     if (this.state === 'loading' || this.state === 'loaded') return;
-    if (!KIND_DIR[this.kind] || !this.slug) {
+    if (!KIND_LABEL[this.kind] || !this.slug) {
       this.state = 'error';
       this.error = `Unknown route. kind=${this.kind} slug=${this.slug}`;
       return;
     }
     this.state = 'loading';
     try {
-      const path = `${KIND_DIR[this.kind]}/${this.slug}.md`;
-      const { content } = await window.JobKB.readFile(path);
-      this.title = (content.match(/^#\s+(.+)$/m) || [, ''])[1].trim();
-      // Render the body without the leading H1 (we render that in our header).
+      const token = await this._supabaseToken();
+      const res = await fetch(`${FN_URL}?kind=${encodeURIComponent(this.kind)}&slug=${encodeURIComponent(this.slug)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error(`Server ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = await res.json();
+      const content = data.body_md || '';
+      this.title = data.title || this.slug;
+      this.frontmatter = data.frontmatter || null;
+      this.updatedAt = data.updated_at || '';
       const stripped = content.replace(/^#\s+.+\n+/, '');
       this.body = renderMarkdown(stripped);
       document.title = `${this.title} — /job`;
       this.state = 'loaded';
     } catch (e) {
       this.state = 'error';
-      this.error = String(e);
+      this.error = String(e?.message || e);
     }
   }
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=1.4.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=1.5.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <script src="/job/js/theme.js?v=1.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.4.0">
-  <script src="/job/js/theme.js?v=1.4.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.5.0">
+  <script src="/job/js/theme.js?v=1.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.4.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.5.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Replaces the last live KB reader. The history drill page now fetches each career-history row from Postgres via the new `job-entity` edge function. `kb-read` / `kb-write` left in the codebase for one more cycle so any caller I missed surfaces before we delete them.

Deployed via supabase CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)