### PR TITLE
job: hotfix — strip stale git conflict markers from onboarding HTML

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <script src="/job/js/theme.js?v=2.1.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -9,11 +9,6 @@
   <link rel="stylesheet" href="/job/css/base.css?v=1.5.1">
   <script src="/job/js/theme.js?v=1.5.1"></script>
 
-<<<<<<< HEAD
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
 
 
 
@@ -38,11 +33,7 @@
     </main>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -9,11 +9,6 @@
   <link rel="stylesheet" href="/job/css/base.css?v=1.5.1">
   <script src="/job/js/theme.js?v=1.5.1"></script>
 
-<<<<<<< HEAD
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
 
 
 
@@ -41,11 +36,7 @@
     </main>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,11 +9,6 @@
   <link rel="stylesheet" href="/job/css/base.css?v=1.5.1">
   <script src="/job/js/theme.js?v=1.5.1"></script>
 
-<<<<<<< HEAD
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
 
 
 
@@ -63,11 +58,7 @@
     </main>
   </div>
 
-<<<<<<< HEAD
   <script type="module" src="/job/js/app.js?v=1.5.1"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,13 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-<<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <script src="/job/js/theme.js?v=2.1.0"></script>
 
 
 
@@ -38,11 +33,7 @@
     </main>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 
 
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.0.0";
-console.log(`[job] v${VERSION} - Post-finalize deeper-story prompt before /jobs/recommended/`);
+const VERSION = "2.1.0";
+console.log(`[job] v${VERSION} - hotfix: strip stale conflict markers from onboarding HTML`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,13 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-<<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <script src="/job/js/theme.js?v=2.1.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,13 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-<<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.0.0">
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.0.0">
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.1.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -28,11 +23,7 @@
       flex-direction: column;
     }
   </style>
-<<<<<<< HEAD
-  <script src="/job/js/theme.js?v=2.0.0"></script>
-=======
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script src="/job/js/theme.js?v=2.1.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -51,10 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,15 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-<<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.1.0">
+  <script src="/job/js/theme.js?v=2.1.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -40,10 +34,6 @@
     </main>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,13 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-<<<<<<< HEAD
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
-=======
-  <link rel="stylesheet" href="/job/css/base.css?v=2.0.0">
-  <script src="/job/js/theme.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <link rel="stylesheet" href="/job/css/base.css?v=2.1.0">
+  <script src="/job/js/theme.js?v=2.1.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -38,10 +33,6 @@
     </main>
   </div>
 
-<<<<<<< HEAD
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
-=======
-  <script type="module" src="/job/js/app.js?v=2.0.0"></script>
->>>>>>> 60a64dfc (job: branching follow-ups — Haiku may go one level deeper per slot)
+  <script type="module" src="/job/js/app.js?v=2.1.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Onboarding HTML had literal <<<<<<< markers + duplicate script tags from a prior bad merge. That broke JS init (double customElements.define throws), which broke applySignedInState's redirect, which left authed users stuck on onboarding. Plus the markers rendered as visible text at the top of the page. v2.1.0.