### PR TITLE
job: MCP personal-access tokens (Path A) — long-lived auth for Claude Desktop/Code/Cursor

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <script src="/job/js/theme.js?v=1.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 </body>
 </html>

--- a/job/css/base.css
+++ b/job/css/base.css
@@ -1,11 +1,11 @@
 /* @import querystrings are bumped alongside JOB_VERSION in app.js so a
    release that only touches components.css/tokens busts the browser
    disk cache. The HTML cache-buster only refreshes base.css itself. */
-@import url("./tokens-generic-light.css?v=1.8.0");
-@import url("./tokens-generic-dark.css?v=1.8.0");
-@import url("./tokens-ctrl-light.css?v=1.8.0");
-@import url("./tokens-ctrl-dark.css?v=1.8.0");
-@import url("./components.css?v=1.8.0");
+@import url("./tokens-generic-light.css?v=1.9.0");
+@import url("./tokens-generic-dark.css?v=1.9.0");
+@import url("./tokens-ctrl-light.css?v=1.9.0");
+@import url("./tokens-ctrl-dark.css?v=1.9.0");
+@import url("./components.css?v=1.9.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -5537,3 +5537,88 @@ body[data-auth-state="out"] job-chat { display: none; }
   flex-direction: column;
   gap: var(--space-3);
 }
+
+/* ─────────────────────────────────────────────────────────────
+   MCP tokens section in /job/settings/. Personal access tokens
+   for the job-mcp endpoint.
+   ───────────────────────────────────────────────────────────── */
+
+.mcp-create {
+  display: flex;
+  gap: var(--space-3);
+  margin: var(--space-3) 0;
+}
+.mcp-create input {
+  flex: 1;
+  height: 44px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+}
+.mcp-create input:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+
+.mcp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-small);
+}
+.mcp-table th {
+  text-align: left;
+  font-weight: var(--fw-medium);
+  color: var(--fg-muted);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+}
+.mcp-table td {
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border);
+  color: var(--fg);
+}
+.mcp-table tr:last-child td { border-bottom: 0; }
+.mcp-table code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+}
+
+.mcp-fresh {
+  margin: var(--space-3) 0;
+  padding: var(--space-4);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  background: var(--accent-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.mcp-fresh__title { margin: 0; font-weight: var(--fw-semibold); }
+.mcp-fresh__warn { margin: 0; color: var(--warning); font-size: var(--font-size-small); }
+.mcp-fresh__value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-small);
+  word-break: break-all;
+  padding: var(--space-3);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  user-select: all;
+}
+.mcp-fresh__actions { display: flex; gap: var(--space-2); }
+.mcp-fresh__howto { margin-top: var(--space-2); }
+.mcp-fresh__howto summary {
+  cursor: pointer;
+  font-size: var(--font-size-small);
+  color: var(--fg-muted);
+}
+.mcp-fresh__howto pre {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-3);
+  background: var(--bg-surface);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-caption);
+  overflow-x: auto;
+  white-space: pre;
+}

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <script src="/job/js/theme.js?v=1.9.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 
 
 

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "1.8.0";
-console.log(`[job] v${VERSION} - chat permalink page at /job/chat/`);
+const VERSION = "1.9.0";
+console.log(`[job] v${VERSION} - MCP personal access tokens + settings UI`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-settings.js
+++ b/job/js/components/job-settings.js
@@ -10,6 +10,10 @@
 
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const MCP_TOKENS_URL = `${SUPABASE_URL}/functions/v1/job-mcp-tokens`;
+const MCP_ENDPOINT_URL = `${SUPABASE_URL}/functions/v1/job-mcp`;
+
 export class JobSettings extends LitElement {
   createRenderRoot() { return this; }
 
@@ -17,6 +21,11 @@ export class JobSettings extends LitElement {
     profile: { state: true },
     loading: { state: true },
     email:   { state: true },
+    mcpTokens:     { state: true },
+    mcpMinting:    { state: true },
+    mcpNewLabel:   { state: true },
+    mcpFreshToken: { state: true },   // raw token shown once after creation
+    mcpFreshLabel: { state: true },
   };
 
   constructor() {
@@ -24,6 +33,11 @@ export class JobSettings extends LitElement {
     this.profile = null;
     this.loading = true;
     this.email = '';
+    this.mcpTokens = [];
+    this.mcpMinting = false;
+    this.mcpNewLabel = '';
+    this.mcpFreshToken = '';
+    this.mcpFreshLabel = '';
   }
 
   connectedCallback() {
@@ -35,6 +49,11 @@ export class JobSettings extends LitElement {
   disconnectedCallback() {
     document.removeEventListener('job:auth:ready', this._onReady);
     super.disconnectedCallback();
+  }
+
+  async _token() {
+    const sb = window.CtrlAuth?.getSupabaseClient?.();
+    return (await sb?.auth.getSession?.())?.data?.session?.access_token;
   }
 
   async _load() {
@@ -50,9 +69,83 @@ export class JobSettings extends LitElement {
         .maybeSingle();
       if (error) { console.warn('[settings] profile fetch failed', error); }
       this.profile = data;
+      await this._loadMcpTokens();
     } finally {
       this.loading = false;
     }
+  }
+
+  async _loadMcpTokens() {
+    const token = await this._token();
+    if (!token) return;
+    try {
+      const res = await fetch(MCP_TOKENS_URL, { headers: { Authorization: `Bearer ${token}` } });
+      if (!res.ok) return;
+      const data = await res.json();
+      this.mcpTokens = data.tokens || [];
+    } catch (e) {
+      console.warn('[settings] mcp tokens fetch failed', e);
+    }
+  }
+
+  async _createMcpToken() {
+    const label = (this.mcpNewLabel || '').trim();
+    if (!label || this.mcpMinting) return;
+    this.mcpMinting = true;
+    try {
+      const token = await this._token();
+      const res = await fetch(MCP_TOKENS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ label }),
+      });
+      if (!res.ok) throw new Error(`Server ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = await res.json();
+      this.mcpFreshToken = data.token;
+      this.mcpFreshLabel = data.label;
+      this.mcpNewLabel = '';
+      await this._loadMcpTokens();
+    } catch (e) {
+      alert(`Couldn't create token: ${e.message || e}`);
+    } finally {
+      this.mcpMinting = false;
+    }
+  }
+
+  async _revokeMcpToken(id, label) {
+    if (!confirm(`Revoke MCP token "${label}"? Any client using this token will stop working immediately.`)) return;
+    try {
+      const token = await this._token();
+      const res = await fetch(MCP_TOKENS_URL, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ id }),
+      });
+      if (!res.ok) throw new Error(`Server ${res.status}`);
+      await this._loadMcpTokens();
+    } catch (e) {
+      alert(`Couldn't revoke: ${e.message || e}`);
+    }
+  }
+
+  _copyFreshToken() {
+    if (!this.mcpFreshToken) return;
+    navigator.clipboard?.writeText(this.mcpFreshToken).then(() => {}, () => {});
+  }
+
+  _dismissFreshToken() {
+    this.mcpFreshToken = '';
+    this.mcpFreshLabel = '';
+  }
+
+  _relTime(iso) {
+    if (!iso) return '—';
+    const dt = Date.now() - new Date(iso).getTime();
+    if (dt < 60_000) return 'just now';
+    if (dt < 3_600_000) return `${Math.floor(dt / 60_000)}m ago`;
+    if (dt < 86_400_000) return `${Math.floor(dt / 3_600_000)}h ago`;
+    if (dt < 30 * 86_400_000) return `${Math.floor(dt / 86_400_000)}d ago`;
+    return new Date(iso).toLocaleDateString();
   }
 
   async _restartOnboarding(demo = true) {
@@ -93,6 +186,78 @@ export class JobSettings extends LitElement {
             <button class="btn btn--primary" @click=${() => this._restartOnboarding(true)}>Open onboarding (demo)</button>
             <button class="btn" @click=${() => this._restartOnboarding(false)}>Re-run for real</button>
           </div>
+        </div>
+
+        <div class="onboard-card">
+          <h2 class="onboard-card__title">MCP tokens</h2>
+          <p class="onboard__hint">
+            Personal access tokens for the <a href="${MCP_ENDPOINT_URL}" target="_blank" rel="noopener">/job MCP endpoint</a>.
+            Use one in Claude Desktop / Cursor / Claude Code config so the agent can read your pipeline and update your preferences without you re-pasting a fresh JWT every hour.
+            Tokens don't expire — revoke from this page when you're done.
+          </p>
+
+          ${this.mcpFreshToken ? html`
+            <div class="mcp-fresh">
+              <p class="mcp-fresh__title">New token created: <strong>${this.mcpFreshLabel}</strong></p>
+              <p class="mcp-fresh__warn">Copy this now. It won't be shown again. If you lose it, mint another.</p>
+              <code class="mcp-fresh__value">${this.mcpFreshToken}</code>
+              <div class="mcp-fresh__actions">
+                <button class="btn btn--sm btn--primary" @click=${() => this._copyFreshToken()}>Copy</button>
+                <button class="btn btn--sm" @click=${() => this._dismissFreshToken()}>Done</button>
+              </div>
+              <details class="mcp-fresh__howto">
+                <summary>How to add this to Claude Desktop / Cursor / Claude Code</summary>
+                <pre>// Claude Desktop — claude_desktop_config.json
+{
+  "mcpServers": {
+    "ctrl-rodeo-job": {
+      "url": "${MCP_ENDPOINT_URL}",
+      "headers": { "Authorization": "Bearer ${this.mcpFreshToken}" }
+    }
+  }
+}
+
+// Claude Code
+claude mcp add ctrl-rodeo-job ${MCP_ENDPOINT_URL} \\
+  --transport http \\
+  --header "Authorization: Bearer ${this.mcpFreshToken}"
+</pre>
+              </details>
+            </div>
+          ` : nothing}
+
+          <form class="mcp-create" @submit=${(e) => { e.preventDefault(); this._createMcpToken(); }}>
+            <input type="text" placeholder="Label (e.g. Claude Desktop)" maxlength="80"
+                   .value=${this.mcpNewLabel}
+                   @input=${(e) => { this.mcpNewLabel = e.target.value; }}
+                   ?disabled=${this.mcpMinting}>
+            <button class="btn btn--primary" type="submit" ?disabled=${this.mcpMinting || !this.mcpNewLabel.trim()}>
+              ${this.mcpMinting ? 'Creating…' : '+ Create token'}
+            </button>
+          </form>
+
+          ${this.mcpTokens.length === 0 ? html`
+            <p class="onboard__hint" style="margin-top:var(--space-3);">No active tokens.</p>
+          ` : html`
+            <table class="mcp-table">
+              <thead>
+                <tr>
+                  <th>Label</th><th>Prefix</th><th>Created</th><th>Last used</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                ${this.mcpTokens.map((t) => html`
+                  <tr>
+                    <td><strong>${t.label}</strong></td>
+                    <td><code>mcp_${t.prefix}…</code></td>
+                    <td>${this._relTime(t.created_at)}</td>
+                    <td>${this._relTime(t.last_used_at)}</td>
+                    <td><button class="btn btn--sm" @click=${() => this._revokeMcpToken(t.id, t.label)}>Revoke</button></td>
+                  </tr>
+                `)}
+              </tbody>
+            </table>
+          `}
         </div>
 
         <div class="onboard-card">

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <script src="/job/js/theme.js?v=1.9.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -6,8 +6,8 @@
   <title>/job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=1.8.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=1.9.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
        component is the entire page. The auth gate only renders when we
@@ -23,7 +23,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <script src="/job/js/theme.js?v=1.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -42,6 +42,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=1.8.0">
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=1.9.0">
+  <script src="/job/js/theme.js?v=1.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.8.0">
-  <script src="/job/js/theme.js?v=1.8.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=1.9.0">
+  <script src="/job/js/theme.js?v=1.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.8.0"></script>
+  <script type="module" src="/job/js/app.js?v=1.9.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/job-auth.ts
+++ b/supabase/functions/_shared/job-auth.ts
@@ -39,9 +39,14 @@ export async function verifyJobUserDetailed(req: Request): Promise<JobUser | nul
   return { id: data.user.id, email: data.user.email.toLowerCase() };
 }
 
+// Returns the user's email when authenticated via a Supabase JWT, OR a
+// non-empty marker string ("mcp:<userid>") when authenticated via an
+// mcp_* personal-access token. Callers use this string only for a
+// truthiness gate today; data-routing key off user_id, not email.
 export async function verifyJobUser(req: Request): Promise<string | null> {
-  const u = await verifyJobUserDetailed(req);
-  return u?.email ?? null;
+  const u = await verifyJobUserAny(req);
+  if (!u) return null;
+  return u.email || `mcp:${u.id}`;
 }
 
 // Lighter auth check: returns the user when a valid signed-in session is
@@ -61,6 +66,54 @@ export async function verifySignedInUser(req: Request): Promise<JobUser | null> 
   const { data, error } = await supabase.auth.getUser(token);
   if (error || !data?.user?.id || !data?.user?.email) return null;
   return { id: data.user.id, email: data.user.email.toLowerCase() };
+}
+
+// ── MCP personal-access tokens ─────────────────────────────────────────
+// Format: "mcp_" + 32 base64url chars. The server stores sha256(raw)
+// in job.mcp_token.token_hash. Used as a long-lived alternative to
+// Supabase JWTs for MCP clients (Claude Desktop, Cursor, …).
+
+const MCP_TOKEN_RE = /^mcp_[A-Za-z0-9_-]{32,64}$/;
+
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+// Verify an `mcp_…` bearer. Returns the user_id + token row id on
+// success, null otherwise. Bumps last_used_at as a side effect.
+export async function verifyMcpToken(raw: string): Promise<{ user_id: string; token_id: string } | null> {
+  if (!MCP_TOKEN_RE.test(raw)) return null;
+  const supabaseUrl = Deno.env.get('SUPABASE_URL');
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY');
+  if (!supabaseUrl || !supabaseAnonKey) return null;
+  const hash = await sha256Hex(raw);
+  // Function lives in the `job` schema, not public.
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, { db: { schema: 'job' } });
+  const { data, error } = await supabase.rpc('mcp_token_verify', { p_hash: hash });
+  if (error || !data || !data.length) return null;
+  const row = (data as Array<{ user_id: string; token_id: string }>)[0];
+  // Bump last_used_at, fire-and-forget.
+  supabase.rpc('mcp_token_bump_used', { p_id: row.token_id }).then(() => {}, () => {});
+  return row;
+}
+
+// Accept EITHER a Supabase JWT or an mcp_* token. Used by the MCP
+// endpoints so a single client config can authenticate.
+export async function verifyJobUserAny(req: Request): Promise<JobUser | null> {
+  const auth = req.headers.get('Authorization') || '';
+  const token = auth.replace(/^Bearer\s+/i, '');
+  if (!token) return null;
+  if (token.startsWith('mcp_')) {
+    const mcp = await verifyMcpToken(token);
+    if (!mcp) return null;
+    // user_profile has no email column today; MCP-token callers don't
+    // need email (the tools use userId). Returning empty string keeps
+    // the JobUser shape stable.
+    return { id: mcp.user_id, email: '' };
+  }
+  return verifyJobUserDetailed(req);
 }
 
 export const corsHeaders = {

--- a/supabase/functions/job-mcp-tokens/index.ts
+++ b/supabase/functions/job-mcp-tokens/index.ts
@@ -1,0 +1,106 @@
+// Supabase Edge Function: job-mcp-tokens
+// CRUD for the user's MCP personal-access tokens. Powers the /job/settings/
+// "MCP tokens" section.
+//
+// GET    /functions/v1/job-mcp-tokens
+//   → { tokens: [{ id, label, prefix, created_at, last_used_at, expires_at }] }
+//   No raw token strings in this response — those are returned ONLY at
+//   creation. Lost tokens require minting a new one.
+//
+// POST   /functions/v1/job-mcp-tokens   { label }
+//   → { id, label, prefix, token, created_at }
+//   `token` is the raw `mcp_…` string. Show it once, then never again.
+//
+// DELETE /functions/v1/job-mcp-tokens   { id }
+//   → { revoked: true }
+//   Sets revoked_at; verifyMcpToken rejects revoked tokens.
+//
+// Auth: standard /job bearer JWT (verifyJobUserDetailed). MCP tokens
+// themselves cannot manage other MCP tokens — you must be signed in
+// with a real session to use this endpoint.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.97.0';
+import { verifyJobUserDetailed, corsHeaders, jsonResp, err } from '../_shared/job-auth.ts';
+
+const VERSION = '0.1.0';
+console.log(`[job-mcp-tokens] v${VERSION}`);
+
+const RAW_LEN = 32; // characters after the "mcp_" prefix
+
+function randomToken(): string {
+  const bytes = new Uint8Array(24); // 24 bytes → 32 base64url chars
+  crypto.getRandomValues(bytes);
+  const b64 = btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+    .slice(0, RAW_LEN);
+  return `mcp_${b64}`;
+}
+
+async function sha256Hex(s: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(s));
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  const user = await verifyJobUserDetailed(req);
+  if (!user) return err('unauthorized', 401);
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+  const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '');
+  // User-scoped client so RLS gates list/insert/update to this user.
+  const sb = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${token}` } },
+    db: { schema: 'job' },
+  });
+
+  if (req.method === 'GET') {
+    const { data, error } = await sb
+      .from('mcp_token')
+      .select('id, label, prefix, created_at, last_used_at, expires_at, revoked_at')
+      .is('revoked_at', null)
+      .order('created_at', { ascending: false });
+    if (error) return err(error.message, 500);
+    return jsonResp({ tokens: data || [] });
+  }
+
+  if (req.method === 'POST') {
+    let body: { label?: string };
+    try { body = await req.json(); } catch (_) { return err('invalid JSON body'); }
+    const label = String(body?.label || '').trim().slice(0, 80);
+    if (!label) return err('label required');
+
+    const raw = randomToken();                       // 'mcp_xxxx…'
+    const hash = await sha256Hex(raw);
+    const prefix = raw.slice(4, 12);                 // 8 chars after 'mcp_'
+
+    const { data, error } = await sb
+      .from('mcp_token')
+      .insert({ user_id: user.id, label, token_hash: hash, prefix })
+      .select('id, label, prefix, created_at')
+      .single();
+    if (error) return err(error.message, 500);
+
+    return jsonResp({ ...data, token: raw }, 201);
+  }
+
+  if (req.method === 'DELETE') {
+    let body: { id?: string };
+    try { body = await req.json(); } catch (_) { return err('invalid JSON body'); }
+    const id = String(body?.id || '').trim();
+    if (!id) return err('id required');
+    const { error } = await sb
+      .from('mcp_token')
+      .update({ revoked_at: new Date().toISOString() })
+      .eq('id', id);
+    if (error) return err(error.message, 500);
+    return jsonResp({ revoked: true });
+  }
+
+  return err('method not allowed', 405);
+});

--- a/supabase/functions/job-mcp/index.ts
+++ b/supabase/functions/job-mcp/index.ts
@@ -19,7 +19,7 @@
 // Auth: standard /job bearer token.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { verifyJobUserDetailed, corsHeaders } from '../_shared/job-auth.ts';
+import { verifyJobUserAny, corsHeaders } from '../_shared/job-auth.ts';
 import { TOOL_SCHEMAS, invokeTool, type ToolContext } from '../_shared/job-tools.ts';
 
 const VERSION = '0.1.0';
@@ -43,7 +43,7 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   if (req.method !== 'POST') return rpcError(null, -32600, 'POST required', 405);
 
-  const user = await verifyJobUserDetailed(req);
+  const user = await verifyJobUserAny(req);
   if (!user) return rpcError(null, -32001, 'unauthorized', 401);
 
   let body: JsonRpcReq;

--- a/supabase/migrations/078_mcp_token.sql
+++ b/supabase/migrations/078_mcp_token.sql
@@ -1,0 +1,70 @@
+-- 078 — Personal-access tokens for the /job MCP endpoint (job-mcp).
+-- Replaces the broken UX where users had to paste a 1-hour-expiring
+-- Supabase JWT into Claude Desktop / Cursor / Claude Code config.
+--
+-- Format: a raw token is "mcp_" + 32 random base64url chars (~192 bits
+-- of entropy). The server stores only sha256(token) in token_hash and
+-- a short prefix for display in the settings UI. The raw token is
+-- returned ONCE at creation; lost tokens require minting a new one.
+
+create table if not exists job.mcp_token (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  label         text not null,
+  token_hash    text not null unique,
+  prefix        text not null,
+  created_at    timestamptz not null default now(),
+  last_used_at  timestamptz,
+  expires_at    timestamptz,
+  revoked_at    timestamptz
+);
+create index if not exists mcp_token_user_idx       on job.mcp_token (user_id, created_at desc);
+create index if not exists mcp_token_hash_lookup_idx on job.mcp_token (token_hash) where revoked_at is null;
+
+comment on table  job.mcp_token is 'Personal-access tokens for the /job MCP endpoint. Raw tokens are returned only at creation; storage is hashed.';
+comment on column job.mcp_token.token_hash is 'hex sha256 of the raw "mcp_<32 chars>" token.';
+comment on column job.mcp_token.prefix is 'First 8 chars of the suffix portion (after "mcp_") shown in the settings UI so users can identify which token is which.';
+
+alter table job.mcp_token enable row level security;
+
+drop policy if exists "mcp_token: owner select" on job.mcp_token;
+create policy "mcp_token: owner select" on job.mcp_token
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "mcp_token: owner insert" on job.mcp_token;
+create policy "mcp_token: owner insert" on job.mcp_token
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "mcp_token: owner update" on job.mcp_token;
+create policy "mcp_token: owner update" on job.mcp_token
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+grant select, insert, update on job.mcp_token to authenticated;
+
+create or replace function job.mcp_token_verify(p_hash text)
+returns table (user_id uuid, token_id uuid)
+language sql
+security definer
+set search_path = public, job
+as $$
+  select user_id, id
+    from job.mcp_token
+   where token_hash = p_hash
+     and revoked_at is null
+     and (expires_at is null or expires_at > now())
+   limit 1
+$$;
+
+revoke all on function job.mcp_token_verify(text) from public;
+grant execute on function job.mcp_token_verify(text) to anon, authenticated;
+
+create or replace function job.mcp_token_bump_used(p_id uuid)
+returns void
+language sql
+security definer
+set search_path = public, job
+as $$
+  update job.mcp_token set last_used_at = now() where id = p_id
+$$;
+revoke all on function job.mcp_token_bump_used(uuid) from public;
+grant execute on function job.mcp_token_bump_used(uuid) to anon, authenticated;


### PR DESCRIPTION
Replaces the unusable 'paste a 1-hour JWT' UX with long-lived `mcp_…` tokens. Settings UI mints + revokes; auth layer accepts either Supabase JWT or mcp_ token transparently.

Migration 078 applied; job-mcp-tokens, job-mcp, jobs-pipe, add-role redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)