### PR TITLE
job: re-land pre-render auth check + prominent sign-in (lost in rebase)

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -5442,27 +5442,29 @@ body[data-auth-state="out"] job-chat { display: none; }
   padding: var(--space-4);
 }
 
-/* Welcome-stage sign-in shortcut. Sits in the top-right corner of the
-   pitch screen so returning users have an easy entry without walking
-   the onboarding flow. */
-.onboard__stage--welcome {
-  position: relative;
+/* Welcome-stage CTA row: Sign in (secondary, prominent) + Get started
+   (primary). Sign in sits beside the primary CTA so returning users
+   see it without scanning. */
+.onboard__nav--welcome {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
 }
-.onboard__signin {
-  position: absolute;
-  top: 0;
-  right: 0;
+.onboard__btn-signin {
   appearance: none;
-  background: transparent;
+  background: var(--bg-surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-pill);
-  padding: 6px var(--space-3);
+  padding: var(--space-3) var(--space-4);
   font: inherit;
-  font-size: var(--font-size-small);
-  color: var(--fg-muted);
+  font-size: var(--font-size-body);
+  color: var(--fg);
   cursor: pointer;
 }
-.onboard__signin:hover { color: var(--fg); border-color: var(--border-strong); }
+.onboard__btn-signin:hover { border-color: var(--border-strong); background: var(--bg); }
+.onboard__btn-signin strong { font-weight: 600; color: var(--fg); }
 
 /* ─────────────────────────────────────────────────────────────
    Chat permalink page (/job/chat/). Two-pane: thread list +

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -3,15 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="pragma" content="no-cache">
+  <meta http-equiv="expires" content="0">
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
-
-
-
-
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script>
@@ -58,7 +57,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,8 +7,8 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=1.3.0">
-  <script src="/job/js/theme.js?v=1.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=1.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.2.0";
-console.log(`[job] v${VERSION} - MCP personal access tokens + settings UI`);
+const VERSION = "2.4.0";
+console.log(`[job] v${VERSION} - Inline auth pre-check on /job/onboarding/ + completion cache`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -66,6 +66,13 @@ async function applySignedInState(email) {
     }
   }
   const completed = !!profile?.onboarding_complete_at;
+  // Cache completion flag so the next page load can pre-redirect without
+  // waiting for the user_profile query. Read by the inline script on
+  // /job/onboarding/index.html before any HTML renders.
+  try {
+    if (completed) localStorage.setItem('job:profile:completed', '1');
+    else           localStorage.removeItem('job:profile:completed');
+  } catch (e) { /* */ }
   // Returning user with completed onboarding lands on /job/onboarding —
   // bounce to recommended. They came back to sign in, not to walk the flow
   // again. (Existing users still get to /job/settings/?demo=1 to re-test.)
@@ -219,6 +226,7 @@ document.addEventListener('ctrl:auth:signedin', (e) => {
 });
 document.addEventListener('ctrl:auth:signedout', () => {
   document.body.dataset.authState = 'out';
+  try { localStorage.removeItem('job:profile:completed'); } catch (e) { /* */ }
 });
 
 // CtrlAuth mounts magic-link + Google sign-in into #ctrl-auth-root.

--- a/job/js/components/job-onboarding.js
+++ b/job/js/components/job-onboarding.js
@@ -814,14 +814,13 @@ export class JobOnboarding extends LitElement {
   _renderPitch() {
     return html`
       <section class="onboard__stage onboard__stage--welcome">
-        <button class="onboard__signin" @click=${() => this._openSignIn()}
-                title="Already have an account?">Sign in</button>
-
         <h1>Your career operating system.</h1>
         <p class="lede">Upload what you've already written, answer a few open questions, and we'll start pulling roles that match what you actually want — and draft the cover letters too.</p>
         <p class="onboard__hint">Takes about 8 minutes. You can leave and come back; we'll save where you left off.</p>
-        <div class="onboard__nav">
-          <span></span>
+        <div class="onboard__nav onboard__nav--welcome">
+          <button class="btn onboard__btn-signin" @click=${() => this._openSignIn()}>
+            Have an account? <strong>Sign in</strong>
+          </button>
           <button class="btn btn--primary" @click=${() => this._setStage(1)}>Get started</button>
         </div>
       </section>

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -3,45 +3,52 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta http-equiv="cache-control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="pragma" content="no-cache">
+  <meta http-equiv="expires" content="0">
   <title>/job</title>
   <meta name="robots" content="noindex">
+  <script>
+    // Pre-render auth check: an authed user with a completed profile who
+    // somehow lands on /job/onboarding/ (deep link, refresh, stale cache)
+    // gets bounced to /job/jobs/recommended/ BEFORE the onboarding HTML
+    // renders. The completion flag is written by app.js applySignedInState
+    // when it confirms a completed profile, so the check is sync.
+    (function () {
+      try {
+        if (localStorage.getItem('job:profile:completed') === '1') {
+          location.replace('/job/jobs/recommended/');
+        }
+      } catch (e) { /* fall through to render */ }
+    })();
+  </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.2.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.4.0">
   <style>
     /* Full-screen onboarding takeover. No rail, no chrome — the onboarding
-       component is the entire page. The auth gate only renders when we
-       explicitly need it (set body[data-need-auth=true] from app.js). */
+       component is the entire page. The auth modal mounts into
+       #ctrl-auth-root but is only opened by the component at finalize. */
     html, body { height: 100%; }
     body { margin: 0; background: var(--bg); color: var(--fg); }
-    .gate { display: none; }
-    body[data-need-auth="true"] .gate { display: flex; }
-    body[data-need-auth="true"] .onboard-host { display: none; }
     .onboard-host {
       min-height: 100dvh;
       display: flex;
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
 <body data-auth-state="loading">
 
-  <section id="signin-gate" class="gate">
-    <div class="gate__card">
-      <h1>/job</h1>
-      <p>Sign in to continue.</p>
-      <button class="btn btn--primary" id="signin-btn">Sign in</button>
-      <div id="ctrl-auth-root"></div>
-    </div>
-  </section>
+  <div id="ctrl-auth-root" style="display:none;"></div>
 
   <div class="onboard-host">
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.2.0">
-  <script src="/job/js/theme.js?v=2.2.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.4.0">
+  <script src="/job/js/theme.js?v=2.4.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.2.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.4.0"></script>
 </body>
 </html>


### PR DESCRIPTION
The earlier PR's changes were lost in a rebase squash. This re-lands the inline pre-redirect on /job/onboarding/ + completion-flag write + prominent Sign in CTA + no-cache metas. v2.4.0.