### PR TITLE
job: re-land inline pre-redirect on /job/onboarding/ (lost in #865 merge)

### DIFF
--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -8,6 +8,20 @@
   <meta http-equiv="expires" content="0">
   <title>/job</title>
   <meta name="robots" content="noindex">
+  <script>
+    // Pre-render auth check: an authed user with a completed profile who
+    // somehow lands on /job/onboarding/ (deep link, refresh, stale cache)
+    // gets bounced to /job/jobs/recommended/ BEFORE the onboarding HTML
+    // renders. The completion flag is written by app.js applySignedInState
+    // when it confirms a completed profile, so the check is sync.
+    (function () {
+      try {
+        if (localStorage.getItem('job:profile:completed') === '1') {
+          location.replace('/job/jobs/recommended/');
+        }
+      } catch (e) { /* fall through to render */ }
+    })();
+  </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
   <link rel="stylesheet" href="/job/css/components.css?v=2.3.0">


### PR DESCRIPTION
## Summary
- PR #865's merge to master kept the no-cache metas + sign-in CTA but the inline `localStorage['job:profile:completed']` pre-redirect script on `/job/onboarding/index.html` did not make it into master's tree. Production still flashes onboarding for completed users.
- This re-lands the inline `<script>` block so an authed user with a completed profile gets `location.replace('/job/jobs/recommended/')` BEFORE any onboarding HTML renders.
- Bumps cache-bust to v=2.4.0 across `job/` HTML so the new entry HTML actually reaches users.

## Test plan
- [ ] After Pages deploy, `curl https://ctrl.rodeo/job/onboarding/` contains the `job:profile:completed` inline check
- [ ] Authed user with completed profile hitting `/job/onboarding/` redirects to `/job/jobs/recommended/` with no onboarding flash
- [ ] New / signed-out user still sees Welcome stage