### PR TITLE
job: Apply takeover PR1 — shell, step nav, DB draft state

### DIFF
--- a/job/css/apply.css
+++ b/job/css/apply.css
@@ -1,0 +1,304 @@
+/* Apply-flow takeover — Wise-inspired surface that sits on top of the
+   /job dark theme. Distinct from the underlying chrome on purpose:
+   bright surface, generous whitespace, pill controls, big numbers.
+   Variables are scoped to .apply-takeover so they don't bleed. */
+
+.apply-takeover {
+  /* Wise-leaning palette */
+  --apply-bg: #f7f7f5;
+  --apply-surface: #ffffff;
+  --apply-ink: #0e0f0c;
+  --apply-ink-muted: #4d4f4c;
+  --apply-ink-subtle: #8a8c87;
+  --apply-accent: #163300;          /* wise deep green */
+  --apply-accent-fg: #ffffff;
+  --apply-accent-soft: #9fe870;     /* wise lime */
+  --apply-accent-soft-fg: #163300;
+  --apply-border: #e6e6e0;
+  --apply-border-strong: #c6c8c0;
+  --apply-success: #2f7d32;
+  --apply-warning: #b95d00;
+  --apply-error:   #c43a30;
+
+  --apply-radius-sm: 8px;
+  --apply-radius-md: 12px;
+  --apply-radius-lg: 20px;
+  --apply-radius-pill: 999px;
+
+  --apply-shadow-card: 0 1px 0 rgba(0,0,0,0.04), 0 8px 32px rgba(14,15,12,0.06);
+  --apply-shadow-pop:  0 12px 40px rgba(14,15,12,0.14);
+
+  --apply-font-display: "Inter", "Söhne", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --apply-font-body:    "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: var(--apply-bg);
+  color: var(--apply-ink);
+  font-family: var(--apply-font-body);
+  font-size: 16px;
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.apply-takeover * { box-sizing: border-box; }
+
+/* ----- Top bar ------------------------------------------------------- */
+.apply-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 28px;
+  background: var(--apply-surface);
+  border-bottom: 1px solid var(--apply-border);
+  flex-shrink: 0;
+}
+.apply-bar__brand {
+  display: flex; align-items: center; gap: 10px;
+  font-weight: 600; letter-spacing: -0.01em;
+}
+.apply-bar__role {
+  display: flex; flex-direction: column; gap: 2px; min-width: 0;
+}
+.apply-bar__role-title {
+  font-weight: 600; font-size: 15px; color: var(--apply-ink);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 360px;
+}
+.apply-bar__role-company {
+  font-size: 13px; color: var(--apply-ink-muted);
+}
+.apply-bar__spacer { flex: 1; }
+.apply-bar__close {
+  appearance: none; border: 1px solid var(--apply-border-strong);
+  background: transparent; color: var(--apply-ink);
+  border-radius: var(--apply-radius-pill);
+  padding: 8px 16px;
+  font: inherit; font-weight: 500; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.apply-bar__close:hover { background: var(--apply-bg); }
+
+/* ----- Step rail ----------------------------------------------------- */
+.apply-rail {
+  display: flex; align-items: center; gap: 0;
+  padding: 12px 28px;
+  background: var(--apply-surface);
+  border-bottom: 1px solid var(--apply-border);
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+.apply-rail__step {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 8px 16px 8px 8px;
+  border-radius: var(--apply-radius-pill);
+  color: var(--apply-ink-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  border: 1px solid transparent;
+  background: transparent;
+  font-family: inherit; font-size: 14px;
+}
+.apply-rail__step:hover { color: var(--apply-ink); }
+.apply-rail__step.is-active {
+  background: var(--apply-ink);
+  color: var(--apply-accent-fg);
+}
+.apply-rail__step.is-active .apply-rail__num {
+  background: var(--apply-accent-soft);
+  color: var(--apply-accent-soft-fg);
+}
+.apply-rail__step.is-done .apply-rail__num {
+  background: var(--apply-accent-soft);
+  color: var(--apply-accent-soft-fg);
+}
+.apply-rail__num {
+  width: 26px; height: 26px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--apply-bg);
+  border: 1px solid var(--apply-border-strong);
+  font-size: 12px; font-weight: 600;
+  flex-shrink: 0;
+}
+.apply-rail__sep {
+  width: 18px; height: 1px; background: var(--apply-border-strong);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* ----- Body ---------------------------------------------------------- */
+.apply-body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  justify-content: center;
+  padding: 48px 28px 120px;
+}
+.apply-step {
+  width: 100%;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.apply-step__head { display: flex; flex-direction: column; gap: 6px; }
+.apply-step__eyebrow {
+  font-size: 13px; color: var(--apply-ink-muted);
+  text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600;
+}
+.apply-step__title {
+  font-family: var(--apply-font-display);
+  font-size: 36px; line-height: 1.15; letter-spacing: -0.02em;
+  margin: 0; color: var(--apply-ink); font-weight: 600;
+}
+.apply-step__sub {
+  font-size: 16px; color: var(--apply-ink-muted); margin: 0;
+  max-width: 60ch;
+}
+
+.apply-card {
+  background: var(--apply-surface);
+  border: 1px solid var(--apply-border);
+  border-radius: var(--apply-radius-lg);
+  padding: 24px;
+  box-shadow: var(--apply-shadow-card);
+  display: flex; flex-direction: column; gap: 16px;
+}
+.apply-card__head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 16px;
+}
+.apply-card__title { font-size: 18px; font-weight: 600; margin: 0; }
+.apply-card__hint  { font-size: 13px; color: var(--apply-ink-muted); margin: 0; }
+
+/* ----- Form atoms ---------------------------------------------------- */
+.apply-field { display: flex; flex-direction: column; gap: 6px; }
+.apply-field__label {
+  font-size: 13px; font-weight: 600; color: var(--apply-ink);
+  display: flex; align-items: center; gap: 6px;
+}
+.apply-field__required { color: var(--apply-error); font-weight: 700; }
+.apply-field__hint { font-size: 12px; color: var(--apply-ink-subtle); }
+.apply-input,
+.apply-textarea,
+.apply-select {
+  appearance: none;
+  font-family: inherit; font-size: 15px;
+  padding: 12px 14px;
+  border: 1px solid var(--apply-border-strong);
+  background: var(--apply-surface);
+  color: var(--apply-ink);
+  border-radius: var(--apply-radius-md);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.apply-input:focus,
+.apply-textarea:focus,
+.apply-select:focus {
+  outline: none;
+  border-color: var(--apply-ink);
+  box-shadow: 0 0 0 3px rgba(159, 232, 112, 0.4);
+}
+.apply-textarea { min-height: 120px; resize: vertical; line-height: 1.55; }
+
+.apply-pill-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.apply-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: var(--apply-radius-pill);
+  background: var(--apply-bg);
+  border: 1px solid var(--apply-border);
+  font-size: 12px; color: var(--apply-ink-muted);
+}
+.apply-pill--ok      { background: #e8f5e2; color: var(--apply-success); border-color: transparent; }
+.apply-pill--warn    { background: #fff0e0; color: var(--apply-warning); border-color: transparent; }
+.apply-pill--info    { background: #eef3ff; color: #1f3a8a; border-color: transparent; }
+.apply-pill--accent  { background: var(--apply-accent-soft); color: var(--apply-accent-soft-fg); border-color: transparent; font-weight: 600; }
+
+/* ----- Buttons ------------------------------------------------------- */
+.apply-btn {
+  appearance: none; border: 1px solid transparent;
+  font-family: inherit; font-weight: 600; font-size: 15px;
+  padding: 12px 24px;
+  border-radius: var(--apply-radius-pill);
+  cursor: pointer;
+  transition: transform 80ms ease, background 120ms ease, color 120ms ease;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.apply-btn:active:not(:disabled) { transform: translateY(1px); }
+.apply-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+.apply-btn--primary {
+  background: var(--apply-accent-soft);
+  color: var(--apply-accent-soft-fg);
+}
+.apply-btn--primary:hover:not(:disabled) { background: #b9f08c; }
+.apply-btn--ghost {
+  background: transparent;
+  border-color: var(--apply-border-strong);
+  color: var(--apply-ink);
+}
+.apply-btn--ghost:hover:not(:disabled) { background: var(--apply-surface); }
+.apply-btn--dark {
+  background: var(--apply-ink);
+  color: var(--apply-accent-fg);
+}
+.apply-btn--dark:hover:not(:disabled) { background: #2a2c28; }
+.apply-btn--sm { padding: 8px 14px; font-size: 13px; }
+
+/* ----- Bottom action bar -------------------------------------------- */
+.apply-actions {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+  padding: 16px 28px;
+  background: rgba(247, 247, 245, 0.9);
+  backdrop-filter: saturate(140%) blur(8px);
+  border-top: 1px solid var(--apply-border);
+}
+.apply-actions__status {
+  font-size: 13px; color: var(--apply-ink-muted);
+}
+.apply-actions__group { display: flex; gap: 12px; }
+
+/* ----- Stuff used by later steps (declared early so PRs stack) ------ */
+.apply-empty {
+  border: 1px dashed var(--apply-border-strong);
+  background: var(--apply-surface);
+  border-radius: var(--apply-radius-md);
+  padding: 24px;
+  color: var(--apply-ink-muted);
+  text-align: center;
+  font-size: 14px;
+}
+.apply-loading {
+  display: inline-flex; align-items: center; gap: 8px;
+  color: var(--apply-ink-muted); font-size: 13px;
+}
+.apply-loading::before {
+  content: '';
+  width: 12px; height: 12px; border-radius: 50%;
+  border: 2px solid var(--apply-border-strong);
+  border-top-color: var(--apply-ink);
+  animation: apply-spin 0.8s linear infinite;
+}
+@keyframes apply-spin { to { transform: rotate(360deg); } }
+
+/* ----- Open-in-job button on the role detail page ------------------- */
+.apply-launch-btn {
+  background: var(--accent-soft, #9fe870);
+  color: #163300;
+  border: 1px solid transparent;
+  font-weight: 600;
+  border-radius: var(--radius-pill, 999px);
+}
+.apply-launch-btn:hover { filter: brightness(0.95); }
+
+@media (max-width: 720px) {
+  .apply-body { padding: 28px 16px 140px; }
+  .apply-bar  { padding: 12px 16px; }
+  .apply-rail { padding: 10px 16px; }
+  .apply-actions { padding: 12px 16px; }
+  .apply-step__title { font-size: 28px; }
+}

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
   <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
+  <link rel="stylesheet" href="/job/css/apply.css?v=0.1.0">
   <script src="/job/js/theme.js?v=2.3.0"></script>
 
 

--- a/job/js/apply.js
+++ b/job/js/apply.js
@@ -1,0 +1,64 @@
+// apply.js — client for the application-draft edge function, which
+// owns the Apply takeover state in job.application_draft.
+
+const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/application-draft';
+
+async function authHeader() {
+  const supabase = window.CtrlAuth?.getSupabaseClient?.();
+  if (!supabase) throw new Error('CtrlAuth not ready');
+  const { data } = await supabase.auth.getSession();
+  const token = data?.session?.access_token;
+  if (!token) throw new Error('not signed in');
+  return { Authorization: `Bearer ${token}` };
+}
+
+export async function readApplicationDraft(slug) {
+  const headers = await authHeader();
+  const res = await fetch(`${FN_URL}?slug=${encodeURIComponent(slug)}`, { headers });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`application-draft GET ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function upsertApplicationDraft(slug, patch) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug, ...patch }),
+  });
+  if (!res.ok) throw new Error(`application-draft POST ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function deleteApplicationDraft(slug) {
+  const headers = await authHeader();
+  const res = await fetch(FN_URL, {
+    method: 'DELETE',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ slug }),
+  });
+  if (!res.ok) throw new Error(`application-draft DELETE ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// Step ids — the takeover flow advances through these in order. Steps
+// can be hidden when the extracted application schema doesn't require
+// them (e.g. no cover letter requested, or no custom questions).
+export const STEPS = [
+  { id: 'general',   label: 'General info',  num: 1 },
+  { id: 'resume',    label: 'Resume',        num: 2 },
+  { id: 'cover',     label: 'Cover letter',  num: 3 },
+  { id: 'questions', label: 'Questions',     num: 4 },
+  { id: 'review',    label: 'Review',        num: 5 },
+];
+
+export function visibleSteps(fields) {
+  const reqCover = !!fields?.requires?.cover_letter;
+  const qs       = Array.isArray(fields?.custom_questions) ? fields.custom_questions : [];
+  return STEPS.filter(s => {
+    if (s.id === 'cover'     && !reqCover) return false;
+    if (s.id === 'questions' && qs.length === 0) return false;
+    return true;
+  });
+}

--- a/job/js/components/job-apply.js
+++ b/job/js/components/job-apply.js
@@ -1,0 +1,284 @@
+// job-apply — full-screen Apply takeover. Steps the user through the
+// application: general info → resume → cover letter (if required) →
+// custom questions (one per page) → review.
+//
+// PR1 scope: takeover shell, step nav, draft persistence, stub bodies
+// per step. Subsequent PRs:
+//   PR2 — extract-application-fields edge fn → populates fields/questions
+//   PR3 — General + Resume step bodies (reuse review tools)
+//   PR4 — Cover letter step (reuse annotation UI)
+//   PR5 — Custom questions step with AI annotated answers
+//   PR6 — Auto-submit handoff
+const VERSION = '0.1.0';
+console.log(`[job-apply] v${VERSION} - takeover shell`);
+
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+
+const V = (new URL(import.meta.url)).search;
+const [{ readApplicationDraft, upsertApplicationDraft, STEPS, visibleSteps }] = await Promise.all([
+  import('../apply.js' + V),
+]);
+
+export class JobApply extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    open:      { type: Boolean, reflect: true },
+    slug:      { type: String },
+    role:      { state: true },
+    draft:     { state: true },   // application_draft row
+    step:      { state: true },   // current step id
+    state:     { state: true },   // 'idle' | 'loading' | 'ready' | 'error'
+    error:     { state: true },
+    saving:    { state: true },
+  };
+
+  constructor() {
+    super();
+    this.open    = false;
+    this.slug    = '';
+    this.role    = null;
+    this.draft   = null;
+    this.step    = 'general';
+    this.state   = 'idle';
+    this.error   = '';
+    this.saving  = false;
+  }
+
+  // Public — called by the role detail page when the user clicks Apply.
+  async launch({ slug, role }) {
+    this.slug = slug;
+    this.role = role || null;
+    this.open = true;
+    document.documentElement.style.overflow = 'hidden';
+    this.state = 'loading';
+    try {
+      let d = await readApplicationDraft(slug);
+      if (!d) {
+        d = await upsertApplicationDraft(slug, {
+          apply_url: role?.url || null,
+          fields: {},
+          answers: {},
+          current_step: 'general',
+          status: 'draft',
+        });
+      }
+      this.draft = d;
+      this.step  = d.current_step || 'general';
+      this.state = 'ready';
+    } catch (e) {
+      this.error = e.message || String(e);
+      this.state = 'error';
+    }
+  }
+
+  close() {
+    this.open = false;
+    document.documentElement.style.overflow = '';
+    // Notify the host page so it can clean up routing.
+    this.dispatchEvent(new CustomEvent('apply:close', { bubbles: true, composed: true }));
+  }
+
+  // --- Step helpers --------------------------------------------------------
+  _steps() {
+    return visibleSteps(this.draft?.fields || {});
+  }
+  _stepIndex(id = this.step) {
+    return this._steps().findIndex(s => s.id === id);
+  }
+  _go(id) {
+    if (!id) return;
+    this.step = id;
+    this._persist({ current_step: id });
+  }
+  _next() {
+    const steps = this._steps();
+    const i = this._stepIndex();
+    if (i < 0 || i >= steps.length - 1) return;
+    this._go(steps[i + 1].id);
+  }
+  _prev() {
+    const steps = this._steps();
+    const i = this._stepIndex();
+    if (i <= 0) return;
+    this._go(steps[i - 1].id);
+  }
+
+  async _persist(patch) {
+    if (!this.slug) return;
+    this.saving = true;
+    try {
+      const updated = await upsertApplicationDraft(this.slug, patch);
+      this.draft = updated;
+    } catch (e) {
+      console.warn('[job-apply] persist failed', e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // --- Render --------------------------------------------------------------
+  render() {
+    if (!this.open) return nothing;
+    return html`
+      <div class="apply-takeover" role="dialog" aria-modal="true" aria-label="Apply">
+        ${this._renderBar()}
+        ${this._renderRail()}
+        <div class="apply-body">
+          ${this.state === 'loading' ? this._renderLoading()
+            : this.state === 'error' ? this._renderError()
+            : this._renderStep()}
+        </div>
+        ${this._renderActions()}
+      </div>
+    `;
+  }
+
+  _renderBar() {
+    const r = this.role || {};
+    return html`
+      <header class="apply-bar">
+        <div class="apply-bar__brand">/job ✨ <span style="color:var(--apply-ink-muted);font-weight:500;">Apply</span></div>
+        <div class="apply-bar__role">
+          <div class="apply-bar__role-title">${r.title || this.slug}</div>
+          <div class="apply-bar__role-company">${r.company || ''}</div>
+        </div>
+        <div class="apply-bar__spacer"></div>
+        ${r.url ? html`
+          <a class="apply-btn apply-btn--ghost apply-btn--sm" href=${r.url} target="_blank" rel="noopener noreferrer">
+            Open posting ↗
+          </a>` : nothing}
+        <button class="apply-bar__close" @click=${() => this.close()} aria-label="Close apply flow">
+          Close ✕
+        </button>
+      </header>
+    `;
+  }
+
+  _renderRail() {
+    const steps = this._steps();
+    const currentIdx = this._stepIndex();
+    return html`
+      <nav class="apply-rail" aria-label="Apply steps">
+        ${steps.map((s, i) => html`
+          ${i > 0 ? html`<span class="apply-rail__sep" aria-hidden="true"></span>` : nothing}
+          <button class="apply-rail__step ${this.step === s.id ? 'is-active' : ''} ${i < currentIdx ? 'is-done' : ''}"
+                  @click=${() => this._go(s.id)}>
+            <span class="apply-rail__num">${i < currentIdx ? '✓' : s.num}</span>
+            <span>${s.label}</span>
+          </button>
+        `)}
+      </nav>
+    `;
+  }
+
+  _renderLoading() {
+    return html`
+      <div class="apply-step">
+        <div class="apply-loading">Loading your draft…</div>
+      </div>
+    `;
+  }
+  _renderError() {
+    return html`
+      <div class="apply-step">
+        <h1 class="apply-step__title">Couldn't open this application</h1>
+        <p class="apply-step__sub">${this.error}</p>
+        <div><button class="apply-btn apply-btn--ghost" @click=${() => this.close()}>Close</button></div>
+      </div>
+    `;
+  }
+
+  _renderStep() {
+    switch (this.step) {
+      case 'general':   return this._renderGeneral();
+      case 'resume':    return this._renderResume();
+      case 'cover':     return this._renderCover();
+      case 'questions': return this._renderQuestions();
+      case 'review':    return this._renderReview();
+      default:          return this._renderGeneral();
+    }
+  }
+
+  _stepStub(eyebrow, title, sub, body) {
+    return html`
+      <section class="apply-step">
+        <div class="apply-step__head">
+          <div class="apply-step__eyebrow">${eyebrow}</div>
+          <h1 class="apply-step__title">${title}</h1>
+          ${sub ? html`<p class="apply-step__sub">${sub}</p>` : nothing}
+        </div>
+        ${body}
+      </section>
+    `;
+  }
+
+  _renderGeneral() {
+    return this._stepStub(
+      'Step 1',
+      'General information',
+      'We\'ll use what you already have. Skim and confirm — anything we don\'t know, you can fill in below.',
+      html`<div class="apply-card"><p class="apply-card__hint">General-info form arrives in the next PR — this step pulls name, email, location, work auth, and links from your /job profile and lets you confirm or override per application.</p></div>`,
+    );
+  }
+  _renderResume() {
+    return this._stepStub(
+      'Step 2',
+      'Resume',
+      'Tailored for this role, side-by-side with your base resume so you can see every change.',
+      html`<div class="apply-card"><p class="apply-card__hint">Resume review tools land in the next PR — same diff/highlight system as the Resume tab on the role page, embedded directly here.</p></div>`,
+    );
+  }
+  _renderCover() {
+    return this._stepStub(
+      'Step 3',
+      'Cover letter',
+      'Drafted, annotated with rationale, with one-click edits per highlight.',
+      html`<div class="apply-card"><p class="apply-card__hint">Cover-letter step arrives in PR4 — reuses the existing annotation UI (load-bearing phrases + opportunities) from the role page.</p></div>`,
+    );
+  }
+  _renderQuestions() {
+    return this._stepStub(
+      'Step 4',
+      'Custom questions',
+      'For each question on the application, we generate a draft with sourced stories and annotated rationale.',
+      html`<div class="apply-card"><p class="apply-card__hint">Custom-question pages arrive in PR5 — one page per question, with intent + standout-candidate profile + matched narratives + annotated draft.</p></div>`,
+    );
+  }
+  _renderReview() {
+    return this._stepStub(
+      'Final',
+      'Review and submit',
+      'One last pass. Submit goes through our autofill agent (handoff coming in PR6).',
+      html`<div class="apply-card"><p class="apply-card__hint">Review + auto-submit handoff arrives in PR6.</p></div>`,
+    );
+  }
+
+  _renderActions() {
+    const steps = this._steps();
+    const i = this._stepIndex();
+    const atStart = i <= 0;
+    const atEnd   = i >= steps.length - 1;
+    return html`
+      <div class="apply-actions">
+        <div class="apply-actions__status">
+          ${this.saving ? html`<span class="apply-loading">Saving…</span>` : html`<span>Draft saved · ${this._dirtyTag()}</span>`}
+        </div>
+        <div class="apply-actions__group">
+          <button class="apply-btn apply-btn--ghost" ?disabled=${atStart} @click=${() => this._prev()}>← Back</button>
+          ${atEnd
+            ? html`<button class="apply-btn apply-btn--primary" disabled title="Submit lands in PR6">Submit application</button>`
+            : html`<button class="apply-btn apply-btn--dark" @click=${() => this._next()}>Continue →</button>`}
+        </div>
+      </div>
+    `;
+  }
+  _dirtyTag() {
+    const ts = this.draft?.updated_at;
+    if (!ts) return 'new draft';
+    try { return `updated ${new Date(ts).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}`; }
+    catch { return 'saved'; }
+  }
+}
+
+customElements.define('job-apply', JobApply);

--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -50,6 +50,9 @@ const KIND_BY_TAB = {
 };
 
 const { listEvents, ackEvent: ackApplicationEvent, eventTypeLabel } = await import('../applicationEvents.js' + V);
+// Side-effect import — registers the <job-apply> custom element used by the
+// "Apply with /job" launch button below.
+await import('./job-apply.js' + V);
 
 function fmtDate(s) {
   if (!s) return '—';
@@ -1642,8 +1645,11 @@ export class JobRoleDetail extends LitElement {
                title="Open the originating email in Gmail">📧 Source email</a>
           ` : nothing}
           ${r.url ? html`
-            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
-               @click=${() => engageRole(this.slug)}>Apply ↗</a>
+            <button class="btn apply-launch-btn" @click=${() => this._launchApply()}>
+              Apply with /job ✨
+            </button>
+            <a class="btn btn--sm" href=${r.url} target="_blank" rel="noopener noreferrer"
+               @click=${() => engageRole(this.slug)} title="Open the posting in a new tab">Posting ↗</a>
           ` : nothing}
         </div>
       </header>
@@ -1755,9 +1761,12 @@ export class JobRoleDetail extends LitElement {
                title="Open the originating email in Gmail">📧 Source email</a>
           ` : nothing}
           ${r?.url ? html`
-            <a class="btn btn--accent" href=${r.url} target="_blank" rel="noopener noreferrer"
-               @click=${() => engageRole(this.slug)}>
-              Apply ↗
+            <button class="btn apply-launch-btn" @click=${() => this._launchApply()}>
+              Apply with /job ✨
+            </button>
+            <a class="btn btn--sm" href=${r.url} target="_blank" rel="noopener noreferrer"
+               @click=${() => engageRole(this.slug)} title="Open the posting in a new tab">
+              Posting ↗
             </a>
           ` : nothing}
         </div>
@@ -1779,7 +1788,35 @@ export class JobRoleDetail extends LitElement {
         : this.activeTab === 'activity' ? this._renderActivityTab()
         : this._renderAssetTab(this.activeTab)}
       </section>
+
+      <job-apply id="apply-takeover" @apply:close=${() => this._onApplyClose()}></job-apply>
     `;
+  }
+
+  _launchApply() {
+    // Engagement signal — same as the "Posting ↗" outbound click.
+    try { engageRole(this.slug); } catch { /* silent */ }
+    const el = this.renderRoot.querySelector('#apply-takeover');
+    if (!el) {
+      console.warn('[job-role-detail] apply takeover element missing');
+      return;
+    }
+    el.launch({ slug: this.slug, role: this.role });
+    // Reflect in URL so back-button closes the takeover instead of leaving the page.
+    try {
+      const u = new URL(location.href);
+      u.searchParams.set('apply', '1');
+      history.pushState({ apply: true }, '', u.toString());
+    } catch { /* ignore */ }
+  }
+  _onApplyClose() {
+    try {
+      const u = new URL(location.href);
+      if (u.searchParams.has('apply')) {
+        u.searchParams.delete('apply');
+        history.replaceState(null, '', u.toString());
+      }
+    } catch { /* ignore */ }
   }
 
   _renderProcessTracker() {

--- a/supabase/functions/application-draft/index.ts
+++ b/supabase/functions/application-draft/index.ts
@@ -1,0 +1,123 @@
+// application-draft — read + write the Apply-takeover state from
+// job.application_draft. One row per (user_id, role_slug).
+//
+//   GET  ?slug=                  → { ...draft } | 404
+//   POST { slug, ...patch }      → upserts and returns the row
+//   DELETE { slug }              → drops the draft (e.g. after submit)
+//
+// All access is RLS-gated by auth.uid(); we additionally narrow to the
+// authenticated user_id server-side as a belt-and-braces.
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[application-draft] v${VERSION} - apply takeover state`);
+
+const SLUG_RE = /^[a-z0-9_-]+$/;
+const STEP_RE = /^(general|resume|cover|questions|review)$/;
+const STATUS_RE = /^(draft|submitted|abandoned)$/;
+const ATS_RE = /^(greenhouse|lever|ashby|workday|smartrecruiters|other|unknown)$/;
+
+function pickJson(v: unknown, fallback: unknown = null) {
+  if (v === undefined) return undefined;
+  if (v === null) return null;
+  if (typeof v === 'object') return v;
+  return fallback;
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+
+  try {
+    const user = await verifyJobUserDetailed(req);
+    if (!user) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const slug = (new URL(req.url).searchParams.get('slug') || '').toLowerCase();
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+      const rows = await sql`
+        select id, role_slug, apply_url, ats, fields, answers,
+               current_step, status, extracted_at, submitted_at,
+               created_at, updated_at
+        from job.application_draft
+        where user_id = ${user.id} and role_slug = ${slug}
+        limit 1;
+      `;
+      if (rows.length === 0) return err('not found', 404);
+      return jsonResp(rows[0]);
+    }
+
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const slug = String(body.slug || '').toLowerCase();
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+
+      const patch: Record<string, unknown> = {};
+      if (body.apply_url    !== undefined) patch.apply_url    = body.apply_url ? String(body.apply_url) : null;
+      if (body.ats          !== undefined) {
+        const a = String(body.ats || '').toLowerCase();
+        if (a && !ATS_RE.test(a)) return err('invalid ats', 400);
+        patch.ats = a || null;
+      }
+      if (body.current_step !== undefined) {
+        const s = String(body.current_step || '').toLowerCase();
+        if (!STEP_RE.test(s)) return err('invalid current_step', 400);
+        patch.current_step = s;
+      }
+      if (body.status !== undefined) {
+        const s = String(body.status || '').toLowerCase();
+        if (!STATUS_RE.test(s)) return err('invalid status', 400);
+        patch.status = s;
+      }
+      if (body.fields  !== undefined) patch.fields  = pickJson(body.fields, {});
+      if (body.answers !== undefined) patch.answers = pickJson(body.answers, {});
+      if (body.extracted_at !== undefined) patch.extracted_at = body.extracted_at || null;
+      if (body.submitted_at !== undefined) patch.submitted_at = body.submitted_at || null;
+
+      const insertCols: string[] = ['user_id', 'role_slug'];
+      const insertVals: unknown[] = [user.id, slug];
+      const updateSetters: string[] = [];
+      for (const [k, v] of Object.entries(patch)) {
+        insertCols.push(k);
+        insertVals.push(v as never);
+        updateSetters.push(`${k} = excluded.${k}`);
+      }
+      // Build a typed insert query. postgres.js doesn't support
+      // dynamic column lists in tagged templates, so we use sql.unsafe
+      // with parameterized values.
+      const colList = insertCols.join(', ');
+      const placeholders = insertCols.map((_, i) => `$${i + 1}`).join(', ');
+      const updateClause = updateSetters.length
+        ? `do update set ${updateSetters.join(', ')}, updated_at = now()`
+        : `do nothing`;
+      const stmt = `
+        insert into job.application_draft (${colList})
+        values (${placeholders})
+        on conflict (user_id, role_slug) ${updateClause}
+        returning id, role_slug, apply_url, ats, fields, answers,
+                  current_step, status, extracted_at, submitted_at,
+                  created_at, updated_at;
+      `;
+      const rows = await sql.unsafe(stmt, insertVals as never);
+      return jsonResp(rows[0]);
+    }
+
+    if (req.method === 'DELETE') {
+      const body = await req.json().catch(() => ({}));
+      const slug = String(body.slug || '').toLowerCase();
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+      await sql`
+        delete from job.application_draft
+        where user_id = ${user.id} and role_slug = ${slug};
+      `;
+      return jsonResp({ ok: true });
+    }
+
+    return err('method not allowed', 405);
+  } catch (e) {
+    console.error('[application-draft] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/079_application_draft.sql
+++ b/supabase/migrations/079_application_draft.sql
@@ -1,0 +1,65 @@
+-- 079 — Application draft state for the /job Apply takeover flow.
+--
+-- One row per (user, role-slug). Stores the extracted field schema,
+-- the user's in-progress answers (AI drafts + edits + annotations),
+-- the current wizard step, and a status enum so we can later filter
+-- "drafts in flight" vs "submitted."
+--
+-- Pure JSONB blobs so the wizard schema can evolve without migrations.
+
+create table if not exists job.application_draft (
+  id            uuid primary key default gen_random_uuid(),
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  role_slug     text not null,
+  apply_url     text,
+  ats           text,
+  fields        jsonb not null default '{}'::jsonb,
+  answers       jsonb not null default '{}'::jsonb,
+  current_step  text not null default 'general',
+  status        text not null default 'draft',
+  extracted_at  timestamptz,
+  submitted_at  timestamptz,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  unique (user_id, role_slug)
+);
+
+create index if not exists application_draft_user_updated_idx
+  on job.application_draft (user_id, updated_at desc);
+
+comment on table  job.application_draft is 'In-progress Apply-flow state per (user, role). Survives reloads; one row per role-slug.';
+comment on column job.application_draft.fields  is 'Normalized extracted application schema (see extract-application-fields edge function): {general:[…], custom_questions:[…], requires:{resume,cover_letter}}';
+comment on column job.application_draft.answers is 'User-edited + AI-drafted answers keyed by field id, plus annotation state (rationale/opportunities) per question.';
+comment on column job.application_draft.ats    is 'Detected ATS provider (greenhouse|lever|ashby|workday|other|unknown).';
+
+create or replace function job.application_draft_touch()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at := now();
+  return new;
+end $$;
+
+drop trigger if exists application_draft_touch on job.application_draft;
+create trigger application_draft_touch
+  before update on job.application_draft
+  for each row execute function job.application_draft_touch();
+
+alter table job.application_draft enable row level security;
+
+drop policy if exists "application_draft: owner select" on job.application_draft;
+create policy "application_draft: owner select" on job.application_draft
+  for select using (auth.uid() = user_id);
+
+drop policy if exists "application_draft: owner insert" on job.application_draft;
+create policy "application_draft: owner insert" on job.application_draft
+  for insert with check (auth.uid() = user_id);
+
+drop policy if exists "application_draft: owner update" on job.application_draft;
+create policy "application_draft: owner update" on job.application_draft
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+drop policy if exists "application_draft: owner delete" on job.application_draft;
+create policy "application_draft: owner delete" on job.application_draft
+  for delete using (auth.uid() = user_id);
+
+grant select, insert, update, delete on job.application_draft to authenticated;


### PR DESCRIPTION
## Summary
First chunk of the multi-step **Apply with /job** flow on the role detail page. Adds an \"Apply with /job ✨\" button next to the existing posting link. Clicking it opens a full-screen, Wise-inspired takeover.

PR1 is intentionally the **shell only** — step bodies are stubs noting which subsequent PR fills each one. The shell is wired end-to-end so we can land PR2–PR6 without touching the routing or state plumbing.

- New table \`job.application_draft\` — one row per (user, role-slug), JSONB \`fields\` + \`answers\` so the wizard schema can evolve without migrations. RLS scoped to \`auth.uid()\`.
- New edge function \`application-draft\` — read/upsert/delete, same pattern as \`role-asset\`.
- New \`<job-apply>\` Lit element with: top bar, step rail (5 steps, 2 conditional), per-step renderer, action bar.
- Wise-inspired surface tokens scoped to \`.apply-takeover\` (bright bg, pill controls, lime accent).
- Launch button on \`job-role-detail\` next to a now-secondary \"Posting ↗\" link.

## Follow-ups (next PRs)
- **PR2** \`extract-application-fields\` edge function (Greenhouse/Lever/Ashby JSON APIs + HTML fallback)
- **PR3** General info + Resume step bodies (reuse review tools)
- **PR4** Cover letter step (reuse annotation UI)
- **PR5** Custom questions step with annotated AI answers
- **PR6** Auto-submit handoff (Chrome / extension)

## Test plan
- [ ] Open a role drill page → click \"Apply with /job ✨\" → takeover opens
- [ ] Step rail click navigates between General / Resume / Review (cover + questions hidden until PR2 populates \`fields\`)
- [ ] Continue / Back buttons advance + persist \`current_step\` server-side
- [ ] Close button + browser back both close cleanly and clear \`?apply=1\`
- [ ] Reload mid-flow → resumes on the same step

🤖 Generated with [Claude Code](https://claude.com/claude-code)