### PR TITLE
job: Apply takeover PR5 — Custom questions with annotated AI answers

### DIFF
--- a/job/css/apply.css
+++ b/job/css/apply.css
@@ -380,6 +380,60 @@
   .apply-cover-body { border-right: 0; border-bottom: 1px solid var(--apply-border); }
 }
 
+/* ----- Custom questions (pager + brief + draft) ---------------------- */
+.apply-qpager {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 12px 16px;
+  background: var(--apply-surface);
+  border: 1px solid var(--apply-border);
+  border-radius: var(--apply-radius-md);
+}
+.apply-qpager__dots { display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; }
+.apply-qpager__dot {
+  appearance: none;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--apply-bg);
+  border: 1px solid var(--apply-border-strong);
+  color: var(--apply-ink-muted);
+  font: inherit; font-size: 12px; font-weight: 600;
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+.apply-qpager__dot:hover    { color: var(--apply-ink); border-color: var(--apply-ink); }
+.apply-qpager__dot.is-done  { background: var(--apply-accent-soft); color: var(--apply-accent-soft-fg); border-color: transparent; }
+.apply-qpager__dot.is-active{ outline: 2px solid var(--apply-ink); outline-offset: 2px; }
+
+.apply-qbrief {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.apply-qbrief__col {
+  background: var(--apply-surface);
+  border: 1px solid var(--apply-border);
+  border-radius: var(--apply-radius-md);
+  padding: 14px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.apply-qbrief__eyebrow {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--apply-ink-muted); font-weight: 600;
+}
+.apply-qbrief__body { font-size: 13px; line-height: 1.5; color: var(--apply-ink); }
+.apply-qbrief__body p { margin: 0; }
+.apply-qbrief__stories { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.apply-qbrief__story-title { font-weight: 600; font-size: 13px; }
+.apply-qbrief__story-why   { font-size: 12px; color: var(--apply-ink-muted); }
+
+.apply-qdraft { min-height: 240px; }
+.apply-qdraft__preview { margin-top: 12px; font-size: 12px; color: var(--apply-ink-muted); }
+.apply-qdraft__preview summary { cursor: pointer; padding: 8px 0; user-select: none; }
+.apply-qdraft__preview[open] summary { color: var(--apply-ink); }
+
+@media (max-width: 900px) {
+  .apply-qbrief { grid-template-columns: 1fr; }
+}
+
 @media (max-width: 720px) {
   .apply-body { padding: 28px 16px 140px; }
   .apply-bar  { padding: 12px 16px; }

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
   <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <link rel="stylesheet" href="/job/css/apply.css?v=0.4.0">
+  <link rel="stylesheet" href="/job/css/apply.css?v=0.5.0">
   <script src="/job/js/theme.js?v=2.3.0"></script>
 
 

--- a/job/js/apply.js
+++ b/job/js/apply.js
@@ -3,6 +3,7 @@
 
 const FN_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/application-draft';
 const EXTRACT_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/extract-application-fields';
+const ANSWER_URL  = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/generate-question-answer';
 
 async function authHeader() {
   const supabase = window.CtrlAuth?.getSupabaseClient?.();
@@ -40,6 +41,24 @@ export async function extractApplicationFields(slug, url) {
     body: JSON.stringify({ slug, url }),
   });
   if (!res.ok) throw new Error(`extract-application-fields ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+export async function generateQuestionAnswer(slug, q) {
+  const headers = await authHeader();
+  const res = await fetch(ANSWER_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      slug,
+      question_id: q.id,
+      prompt: q.prompt,
+      type: q.type,
+      max_length: q.max_length || null,
+      options: q.options || null,
+    }),
+  });
+  if (!res.ok) throw new Error(`generate-question-answer ${res.status}: ${await res.text()}`);
   return res.json();
 }
 

--- a/job/js/components/job-apply.js
+++ b/job/js/components/job-apply.js
@@ -9,15 +9,15 @@
 //   PR4 — Cover letter step (reuse annotation UI)
 //   PR5 — Custom questions step with AI annotated answers
 //   PR6 — Auto-submit handoff
-const VERSION = '0.4.0';
-console.log(`[job-apply] v${VERSION} - + cover letter w/ annotations (PR4)`);
+const VERSION = '0.5.0';
+console.log(`[job-apply] v${VERSION} - + custom-question annotated drafts (PR5)`);
 
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 
 const V = (new URL(import.meta.url)).search;
 const [
-  { readApplicationDraft, upsertApplicationDraft, extractApplicationFields, STEPS, visibleSteps },
+  { readApplicationDraft, upsertApplicationDraft, extractApplicationFields, generateQuestionAnswer, STEPS, visibleSteps },
   { readRoleAsset },
   { renderMarkdown },
   { diffMarkdown, applyAIHighlights },
@@ -55,6 +55,9 @@ export class JobApply extends LitElement {
     analysisMd: { state: true },   // role analysis JSON (raw markdown blob)
     coverState: { state: true },   // 'idle'|'loading'|'ready'|'error'
     coverHi:    { state: true },   // { highlights, opportunities, loading, error }
+    qIdx:       { state: true },   // active custom-question index
+    qGen:       { state: true },   // { [qid]: 'idle'|'running'|'error' }
+    qErr:       { state: true },   // { [qid]: error message }
   };
 
   constructor() {
@@ -78,6 +81,9 @@ export class JobApply extends LitElement {
     this.analysisMd = '';
     this.coverState = 'idle';
     this.coverHi = { highlights: [], opportunities: [], loading: false, error: '' };
+    this.qIdx = 0;
+    this.qGen = {};
+    this.qErr = {};
     this._answerTimers = {};
   }
 
@@ -625,27 +631,198 @@ export class JobApply extends LitElement {
     }
     if (mark) mark.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }
+  // --- Custom questions ---------------------------------------------------
+  _qAnswer(qid) {
+    const a = this.draft?.answers?.[qid];
+    return (a && typeof a === 'object') ? a : null;
+  }
+  async _generateQuestion(q) {
+    this.qGen = { ...this.qGen, [q.id]: 'running' };
+    this.qErr = { ...this.qErr, [q.id]: '' };
+    try {
+      const result = await generateQuestionAnswer(this.slug, q);
+      // Preserve user edits if they already changed the draft.
+      const existing = this._qAnswer(q.id);
+      const draft = (existing?.user_edited_draft && existing?.user_edited_draft !== existing?.draft)
+        ? existing.user_edited_draft
+        : result.draft;
+      const answer = {
+        question_id: q.id,
+        intent: result.intent,
+        standout: result.standout,
+        stories: result.stories,
+        draft: result.draft,
+        user_edited_draft: draft,
+        highlights: result.highlights,
+        opportunities: result.opportunities,
+        generated_at: result.generated_at,
+      };
+      const answers = { ...(this.draft?.answers || {}), [q.id]: answer };
+      this.draft = { ...this.draft, answers };
+      await this._persist({ answers });
+      this.qGen = { ...this.qGen, [q.id]: 'idle' };
+    } catch (e) {
+      this.qGen = { ...this.qGen, [q.id]: 'error' };
+      this.qErr = { ...this.qErr, [q.id]: e.message || String(e) };
+    }
+  }
+  _setQuestionDraft(qid, value) {
+    const prev = this._qAnswer(qid) || {};
+    const next = { ...prev, question_id: qid, user_edited_draft: value };
+    const answers = { ...(this.draft?.answers || {}), [qid]: next };
+    this.draft = { ...this.draft, answers };
+    clearTimeout(this._answerTimers[qid]);
+    this._answerTimers[qid] = setTimeout(() => this._persist({ answers }), 500);
+  }
+
   _renderQuestions() {
     const qs = this.draft?.fields?.custom_questions || [];
-    return this._stepStub(
-      'Step 4',
-      `Custom questions${qs.length ? ` · ${qs.length}` : ''}`,
-      'For each question on the application, we generate a draft with sourced stories and annotated rationale.',
-      qs.length
-        ? html`
-            <ol class="apply-card" style="margin:0;padding:24px 24px 24px 44px;display:block;">
-              ${qs.map(q => html`
-                <li style="margin-bottom:14px;">
-                  <div style="font-weight:600;">${q.prompt}</div>
-                  <div style="font-size:12px;color:var(--apply-ink-subtle);">
-                    ${q.type}${q.required ? ' · required' : ''}${q.options?.length ? ` · ${q.options.length} options` : ''}
-                  </div>
-                </li>
-              `)}
-            </ol>
-            <p class="apply-card__hint" style="margin:0;">PR5 wraps each of these in its own page with AI intent + annotated draft answers.</p>`
-        : html`<div class="apply-card"><p class="apply-card__hint">No custom questions detected yet — extraction either hasn't run or this ATS has none.</p></div>`,
-    );
+    if (!qs.length) {
+      return this._stepStub(
+        'Step 4',
+        'Custom questions',
+        'For each question on the application, we generate a draft with sourced stories and annotated rationale.',
+        html`<div class="apply-card"><p class="apply-card__hint">No custom questions detected for this application.</p></div>`,
+      );
+    }
+    const idx = Math.max(0, Math.min(this.qIdx, qs.length - 1));
+    const q = qs[idx];
+    const ans = this._qAnswer(q.id);
+    const gen = this.qGen[q.id] || 'idle';
+    const err = this.qErr[q.id] || '';
+
+    const draftMd = ans?.user_edited_draft ?? ans?.draft ?? '';
+    const { html: marked, comments } = (draftMd && ans && (ans.highlights?.length || ans.opportunities?.length))
+      ? applyAIHighlights(draftMd, ans.highlights || [], ans.opportunities || [])
+      : { html: draftMd || '', comments: [] };
+    const renderedDraft = renderMarkdown(marked);
+    const charCount = (draftMd || '').length;
+    const overMax = q.max_length && charCount > q.max_length;
+    const completed = qs.filter(qq => {
+      const a = this._qAnswer(qq.id);
+      return !!(a?.user_edited_draft || a?.draft);
+    }).length;
+
+    return html`
+      <section class="apply-step" style="max-width:1080px;">
+        <div class="apply-step__head">
+          <div class="apply-step__eyebrow">Step 4 · Custom question ${idx + 1} of ${qs.length}</div>
+          <h1 class="apply-step__title">${q.prompt}</h1>
+          <div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-top:4px;">
+            <span class="apply-pill">${q.type}</span>
+            ${q.required ? html`<span class="apply-pill apply-pill--warn">required</span>` : nothing}
+            ${q.max_length ? html`<span class="apply-pill ${overMax ? 'apply-pill--warn' : ''}">${charCount}/${q.max_length} chars</span>` : nothing}
+            <span class="apply-pill apply-pill--info">${completed}/${qs.length} drafted</span>
+          </div>
+        </div>
+
+        <!-- Pager -->
+        <nav class="apply-qpager">
+          <button class="apply-btn apply-btn--ghost apply-btn--sm" ?disabled=${idx === 0} @click=${() => this.qIdx = idx - 1}>← Previous</button>
+          <div class="apply-qpager__dots">
+            ${qs.map((qq, i) => html`
+              <button class="apply-qpager__dot ${i === idx ? 'is-active' : ''} ${this._qAnswer(qq.id) ? 'is-done' : ''}"
+                      title=${qq.prompt}
+                      @click=${() => this.qIdx = i}>${i + 1}</button>
+            `)}
+          </div>
+          <button class="apply-btn apply-btn--ghost apply-btn--sm" ?disabled=${idx === qs.length - 1} @click=${() => this.qIdx = idx + 1}>Next →</button>
+        </nav>
+
+        <!-- Intent + standout + stories -->
+        <div class="apply-qbrief">
+          <div class="apply-qbrief__col">
+            <div class="apply-qbrief__eyebrow">What they're really asking</div>
+            <div class="apply-qbrief__body">
+              ${ans?.intent ? html`<p>${ans.intent}</p>`
+                : gen === 'running' ? html`<span class="apply-loading">Thinking…</span>`
+                : html`<p class="apply-card__hint">Generate a draft to see the intent breakdown.</p>`}
+            </div>
+          </div>
+          <div class="apply-qbrief__col">
+            <div class="apply-qbrief__eyebrow">A standout answer</div>
+            <div class="apply-qbrief__body">
+              ${ans?.standout ? html`<p>${ans.standout}</p>`
+                : gen === 'running' ? html`<span class="apply-loading">Thinking…</span>`
+                : html`<p class="apply-card__hint">—</p>`}
+            </div>
+          </div>
+          <div class="apply-qbrief__col">
+            <div class="apply-qbrief__eyebrow">Story matches</div>
+            <div class="apply-qbrief__body">
+              ${ans?.stories?.length ? html`
+                <ul class="apply-qbrief__stories">
+                  ${ans.stories.map(s => html`
+                    <li>
+                      <div class="apply-qbrief__story-title">${s.title}</div>
+                      <div class="apply-qbrief__story-why">${s.why}</div>
+                    </li>`)}
+                </ul>`
+                : gen === 'running' ? html`<span class="apply-loading">Sourcing…</span>`
+                : html`<p class="apply-card__hint">—</p>`}
+            </div>
+          </div>
+        </div>
+
+        <!-- Draft + annotations -->
+        <div class="apply-card apply-cover-card">
+          <div class="apply-card__head">
+            <h2 class="apply-card__title">Draft answer</h2>
+            <div style="display:flex;gap:8px;align-items:center;">
+              ${err ? html`<span class="apply-pill apply-pill--warn" title=${err}>Generation error</span>` : nothing}
+              <button class="apply-btn ${ans ? 'apply-btn--ghost' : 'apply-btn--primary'} apply-btn--sm"
+                      ?disabled=${gen === 'running'}
+                      @click=${() => this._generateQuestion(q)}>
+                ${gen === 'running' ? 'Generating…' : ans ? 'Regenerate' : 'Generate draft'}
+              </button>
+            </div>
+          </div>
+
+          ${!ans && gen !== 'running' ? html`
+            <div class="apply-empty">
+              Click <strong>Generate draft</strong> to source stories from your profile and write an annotated first pass.
+            </div>` : nothing}
+
+          ${ans ? html`
+            <div class="apply-cover-split">
+              <div style="display:flex;flex-direction:column;gap:0;">
+                <textarea class="apply-textarea apply-qdraft"
+                          .value=${ans?.user_edited_draft ?? ans?.draft ?? ''}
+                          @input=${(e) => this._setQuestionDraft(q.id, e.target.value)}></textarea>
+                <details class="apply-qdraft__preview">
+                  <summary>Preview with annotations</summary>
+                  <article class="apply-prose apply-cover-body" style="border-right:0;max-height:40vh;"
+                           @click=${(e) => this._onCoverPhraseClick(e)}>
+                    ${unsafeHTML(renderedDraft)}
+                  </article>
+                </details>
+              </div>
+              <aside class="apply-cover-rail">
+                <header class="apply-cover-rail__head">
+                  <h4>Annotations</h4>
+                  <span class="apply-cover-rail__count">${comments.length}</span>
+                </header>
+                ${comments.length === 0
+                  ? html`<p class="apply-cover-rail__empty">No annotations on this draft yet — try regenerating after edits.</p>`
+                  : html`<div class="apply-cover-rail__list">
+                      ${comments.map(c => html`
+                        <article class="apply-cover-comment ${c.kind === 'opportunity' ? 'is-op' : ''}"
+                                 data-rationale-id=${c.id}
+                                 @click=${() => this._scrollToPhrase(c.id)}>
+                          <header>
+                            <span class="apply-cover-comment__num">${c.kind === 'opportunity' ? '✦' : c.id}</span>
+                            <span class="apply-cover-comment__label">${c.label}</span>
+                          </header>
+                          <div class="apply-cover-comment__body">${unsafeHTML(renderMarkdown(c.text || ''))}</div>
+                          ${c.ask ? html`<p class="apply-cover-comment__ask">${c.ask}</p>` : nothing}
+                        </article>`)}
+                    </div>`}
+              </aside>
+            </div>
+          ` : nothing}
+        </div>
+      </section>
+    `;
   }
   _renderReview() {
     return this._stepStub(

--- a/supabase/functions/generate-question-answer/index.ts
+++ b/supabase/functions/generate-question-answer/index.ts
@@ -1,0 +1,183 @@
+// generate-question-answer — given an application's custom question,
+// the user's narratives, vision, and the role's analysis, return a
+// structured answer with sourced stories and annotated rationale.
+//
+//   POST {
+//     slug,            // role slug (used to load role analysis)
+//     question_id,
+//     prompt,          // the question itself
+//     type,            // long_text | short_text | select | …
+//     max_length?,
+//     options?,
+//   } →  {
+//     intent,                  // string — what the company is really asking
+//     standout,                // string — what a great answer would look like
+//     stories: [{ id, title, why }], // narratives sourced from job.narratives
+//     draft,                   // markdown draft answer in the user's voice
+//     highlights:    [{ phrase, label, rationale }],
+//     opportunities: [{ phrase, gap, ask }],
+//   }
+//
+// The frontend persists this into application_draft.answers[question_id]
+// and re-uses the rationale + opportunities the same way the cover letter
+// step does.
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+import Anthropic from 'https://esm.sh/@anthropic-ai/sdk@0.30.1?target=deno&deno-std=0.168.0';
+
+const VERSION = '0.1.0';
+console.log(`[generate-question-answer] v${VERSION} - per-question annotated drafts`);
+
+const MODEL = 'claude-haiku-4-5-20251001';
+
+const SYS = `You write application answers for a senior product / strategy operator (the user) and return them in a strict JSON shape that downstream UI consumes.
+
+Output ONLY valid JSON — no prose, no markdown fences. Schema:
+
+{
+  "intent":   string,    // 1-2 sentences — what the company is *really* asking. Distinguish surface ask from underlying signal.
+  "standout": string,    // 1-3 sentences — what a *standout* answer demonstrates. Be specific, not generic.
+  "stories":  Array<{ id: string, title: string, why: string }>,  // up to 3 narratives from the supplied list that best fit. why = 1 sentence linking narrative to question.
+  "draft":    string,    // The actual answer, in markdown, in the user's voice. Tight, specific, no clichés, no "I am passionate." Match the question's tone.
+  "highlights":    Array<{ phrase: string, label: string, rationale: string }>,  // verbatim substrings of "draft". label = short tag (≤4 words). rationale = why this phrase is load-bearing.
+  "opportunities": Array<{ phrase: string, gap: string, ask: string }>           // verbatim substrings of "draft" that are weakest. gap = what's missing. ask = one targeted question the user could answer to strengthen it.
+}
+
+Rules:
+- Voice: confident, plainspoken, concrete. No corporate filler ("synergies", "passionate", "thrilled"). No em-dashes unless the user's narratives use them.
+- Length: respect max_length when given (count characters, not tokens). For long_text aim for 120-220 words unless max_length forces shorter.
+- Stories: only cite stories from the supplied narrative list. Do not invent.
+- Highlights: 2-5 entries. Each phrase MUST be a verbatim substring of draft (case sensitive). Skip if you cannot identify load-bearing phrases.
+- Opportunities: 0-3. Each opportunity's phrase MUST be a verbatim substring of draft. If the user has clear evidence already, leave opportunities empty.`;
+
+async function loadContext(sql: ReturnType<typeof db>, userId: string, slug: string) {
+  const [narrRows, profileRows, analysisRows, narrAddRows, jdRows] = await Promise.all([
+    sql`select id, title, tags, linked_company_slug, content_md from job.narratives where user_id = ${userId}`,
+    sql`select identity, location, capability, values_seed, targeting from public.user_profile where user_id = ${userId} limit 1;`,
+    sql`select content_md from job.role_assets where role_slug = ${slug} and kind = 'analysis' limit 1;`,
+    sql`select content_md from job.global_assets where kind = 'narrative-additions' limit 1;`,
+    sql`select description_md from job.pipeline_roles where slug = ${slug} limit 1;`,
+  ]);
+  return {
+    narratives: narrRows,
+    profile: profileRows[0] || null,
+    analysisMd: analysisRows[0]?.content_md || '',
+    narrativeAdditionsMd: narrAddRows[0]?.content_md || '',
+    jdMd: jdRows[0]?.description_md || '',
+  };
+}
+
+function parseAnalysis(md: string): Record<string, unknown> | null {
+  if (!md) return null;
+  const fence = md.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const body = fence ? fence[1] : md;
+  try { return JSON.parse(body); } catch { return null; }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST')    return err('method not allowed', 405);
+
+  try {
+    const user = await verifyJobUserDetailed(req);
+    if (!user) return err('unauthorized', 401);
+
+    const body = await req.json().catch(() => ({}));
+    const slug = String(body.slug || '').toLowerCase();
+    const prompt = String(body.prompt || '').trim();
+    const qid = String(body.question_id || '').trim();
+    const type = String(body.type || 'long_text');
+    const maxLen = Number.isFinite(body.max_length) ? Number(body.max_length) : null;
+    const options = Array.isArray(body.options) ? body.options : null;
+    if (!/^[a-z0-9_-]+$/.test(slug)) return err('invalid slug', 400);
+    if (!prompt) return err('prompt required', 400);
+
+    const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+    if (!apiKey) return err('ANTHROPIC_API_KEY unset', 500);
+
+    const sql = db();
+    const ctx = await loadContext(sql, user.id, slug);
+    const analysis = parseAnalysis(ctx.analysisMd);
+    const role = analysis?.role || null;
+
+    const narrBlocks = (ctx.narratives || []).map((n: { id: string; title: string; tags: string[]; content_md: string }) =>
+      `## ${n.title}  (id: ${n.id})  tags: ${(n.tags || []).join(', ')}\n${(n.content_md || '').slice(0, 1400)}`
+    ).join('\n\n');
+
+    const identity = ctx.profile?.identity || {};
+    const values   = ctx.profile?.values_seed || {};
+    const targeting= ctx.profile?.targeting || {};
+    const profileBlock = JSON.stringify({ identity, values, targeting }, null, 2);
+
+    const lengthLine = maxLen ? `Hard maximum: ${maxLen} characters.` : 'No hard length limit.';
+    const typeLine = (type === 'short_text') ? 'Short answer (1-3 sentences).'
+                    : (type === 'long_text') ? 'Long answer (markdown, 1-3 short paragraphs).'
+                    : (type === 'yes_no')    ? 'Yes/No with a 1-2 sentence rationale.'
+                    : (type === 'select' || type === 'multiselect') ? `Selection from: ${(options || []).join(' | ')}. Draft a short justification too.`
+                    : 'Open response.';
+
+    const userMsg = `# Role
+${role ? JSON.stringify(role, null, 2) : '(see analysis below)'}
+
+# Analysis
+\`\`\`json
+${ctx.analysisMd.slice(0, 6000) || '(none)'}
+\`\`\`
+
+# JD excerpt
+${(ctx.jdMd || '').slice(0, 3000) || '(no JD on file)'}
+
+# User profile
+\`\`\`json
+${profileBlock}
+\`\`\`
+
+# Narratives (the only allowed story source)
+${narrBlocks || '(no narratives yet)'}
+
+# Extra narrative additions
+${(ctx.narrativeAdditionsMd || '').slice(0, 4000) || '(none)'}
+
+# The question
+${prompt}
+
+# Format
+${typeLine}
+${lengthLine}
+
+Produce the JSON object now. JSON only.`;
+
+    const client = new Anthropic({ apiKey });
+    const msg = await client.messages.create({
+      model: MODEL,
+      max_tokens: 3000,
+      system: SYS,
+      messages: [{ role: 'user', content: userMsg }],
+    });
+    const text = msg.content?.[0]?.type === 'text' ? msg.content[0].text : '';
+    const cleaned = text.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
+    let parsed: Record<string, unknown> = {};
+    try { parsed = JSON.parse(cleaned); }
+    catch (e) {
+      console.warn('[generate-question-answer] parse fail', e, cleaned.slice(0, 300));
+      return err('invalid model output', 500);
+    }
+    // Defensive coercion to the documented shape.
+    const out = {
+      question_id: qid,
+      intent:   typeof parsed.intent === 'string' ? parsed.intent : '',
+      standout: typeof parsed.standout === 'string' ? parsed.standout : '',
+      stories:  Array.isArray(parsed.stories) ? parsed.stories : [],
+      draft:    typeof parsed.draft === 'string' ? parsed.draft : '',
+      highlights:    Array.isArray(parsed.highlights)    ? parsed.highlights    : [],
+      opportunities: Array.isArray(parsed.opportunities) ? parsed.opportunities : [],
+      generated_at: new Date().toISOString(),
+      model: MODEL,
+    };
+    return jsonResp(out);
+  } catch (e) {
+    console.error('[generate-question-answer] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});


### PR DESCRIPTION
## Summary
Builds on #872. The Questions step is now a per-question pager. Each question gets its own page with an AI-generated brief (intent / standout / story matches) and an annotated draft answer.

**New edge function** \`generate-question-answer\` (Haiku 4.5)
- Loads role analysis + JD excerpt + user_profile + every narrative + narrative-additions, issues one structured JSON request.
- Strict output schema: \`intent\`, \`standout\`, \`stories[]\`, \`draft\`, \`highlights[]\`, \`opportunities[]\`. Highlight/opportunity phrases must be verbatim substrings of \`draft\` so \`applyAIHighlights()\` works without fuzzy matching.

**UI**
- Three-column brief: \"What they're really asking\" / \"A standout answer\" / \"Story matches\" (each story = title + 1-line why).
- Pager with numbered dots — done = lime fill, active = outline. Previous / Next pills.
- Editable textarea draft; debounced autosave to \`user_edited_draft\` (regenerate keeps the AI's \`draft\` AND your edits side by side).
- Collapsible annotation preview with the same comments rail / phrase-flash interactions as the cover-letter step.
- Char counter + \"N/total drafted\" status pill.

## Test plan
- [ ] Open a Greenhouse role with custom questions → Questions step shows numbered pager
- [ ] \"Generate draft\" populates intent / standout / stories / draft / annotations
- [ ] Edit draft → reload → edits persist (and don't get clobbered by Regenerate)
- [ ] Phrase ↔ comment scroll/flash works inside the preview accordion
- [ ] Pager dots show done state after generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)