### PR TITLE
job: fix blank pages — transition out of 'loading' when no session

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
 
 
 
@@ -67,7 +67,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <script src="/job/js/theme.js?v=2.3.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.0";
-console.log(`[job] v${VERSION} - Pre-render auth check + prominent sign-in + MCP tokens`);
+const VERSION = "2.3.1";
+console.log(`[job] v${VERSION} - Fix blank page: transition out of "loading" when no session`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -295,13 +295,27 @@ setTimeout(() => { _completePendingGmailOAuth(); }, 250);
 
 // Belt-and-braces: even with the listener attached early, some CtrlAuth code
 // paths can settle a restored session without dispatching to a fresh listener.
-// Reconcile from the canonical source after a tick.
+// Reconcile from the canonical source after a tick. If there's no user at
+// all, transition body off "loading" so the sign-in gate becomes visible —
+// CtrlAuth only fires `ctrl:auth:signedout` on a transition, not on initial
+// load with no session, so without this fallback an unauthed visitor sees a
+// permanently blank page (CSS hides everything while data-auth-state="loading").
+setTimeout(() => {
+  const u = window.CtrlAuth?.getUser?.();
+  if (u?.email) {
+    if (document.body.dataset.authState !== 'in') applySignedInState(u.email);
+  } else if (document.body.dataset.authState === 'loading') {
+    document.body.dataset.authState = 'out';
+  }
+}, 0);
+// Second pass after CtrlAuth's async fast-restore (fetchProfile) has had a
+// chance to land — if a user has arrived by then, promote to "in".
 setTimeout(() => {
   const u = window.CtrlAuth?.getUser?.();
   if (u?.email && document.body.dataset.authState !== 'in') {
     applySignedInState(u.email);
   }
-}, 0);
+}, 800);
 
 document.addEventListener('DOMContentLoaded', () => {
   const btn = document.getElementById('signin-btn');

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.0">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.0">
-  <script src="/job/js/theme.js?v=2.3.0"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <script src="/job/js/theme.js?v=2.3.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.0"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Unauthed visitors hitting /job/jobs/ or /job/jobs/recommended/ etc saw a permanently blank page. CSS hides everything while `body[data-auth-state='loading']`, and CtrlAuth only emits `ctrl:auth:signedout` on a transition — not on initial load with no session — so the body stayed in 'loading' forever.
- Fix: in app.js belt-and-braces reconcile, flip body to `data-auth-state='out'` when no user is present. Added a second 800ms pass for slow CtrlAuth fast-restores.
- Bumped VERSION 2.3.0 → 2.3.1 + synced all /job/*.html cache-bust strings.

## Test plan
- [ ] Hit https://ctrl.rodeo/job/jobs/recommended/ signed-out → see sign-in gate (not blank)
- [ ] Signed-in user with completed profile still sees the recommendations table
- [ ] Onboarding flow still works for new visitors