### PR TITLE
job: await getSession before user_profile query (stop bouncing authed users to onboarding)

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
 
 
 
@@ -67,7 +67,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <script src="/job/js/theme.js?v=2.3.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.1";
-console.log(`[job] v${VERSION} - Fix blank page: transition out of "loading" when no session`);
+const VERSION = "2.3.2";
+console.log(`[job] v${VERSION} - Await getSession + trust completion cache when RLS query fails`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -53,35 +53,50 @@ async function applySignedInState(email) {
   const sb = window.CtrlAuth?.getSupabaseClient?.();
   const onOnboarding = location.pathname.startsWith(ONBOARDING_PATH);
   let profile = null;
+  let queryOk = false;
   if (sb) {
     try {
+      // Wait for the supabase client to actually load the session from
+      // localStorage before issuing the user_profile query — otherwise the
+      // request can go out with just the anon key, RLS returns no rows, and
+      // we incorrectly conclude the user hasn't completed onboarding and
+      // bounce them back through it.
+      await sb.auth.getSession();
       const { data, error } = await sb
         .from('user_profile')
         .select('onboarding_complete_at')
         .maybeSingle();
       if (error) console.warn('[job] user_profile query failed', error);
+      else queryOk = true;
       profile = data;
     } catch (e) {
       console.warn('[job] user_profile query threw', e);
     }
   }
   const completed = !!profile?.onboarding_complete_at;
-  // Cache completion flag so the next page load can pre-redirect without
-  // waiting for the user_profile query. Read by the inline script on
-  // /job/ and /job/onboarding/index.html.
-  try {
-    if (completed) localStorage.setItem('job:profile:completed', '1');
-    else           localStorage.removeItem('job:profile:completed');
-  } catch (e) { /* */ }
+  // Only WRITE the completion cache on a successful query. A failed query
+  // (network/RLS hiccup) must not clear the flag and bounce a returning user
+  // back through onboarding.
+  if (queryOk) {
+    try {
+      if (completed) localStorage.setItem('job:profile:completed', '1');
+      else           localStorage.removeItem('job:profile:completed');
+    } catch (e) { /* */ }
+  }
+  // If the query failed but the cached flag says completed, trust the cache.
+  const effectiveCompleted = completed || (!queryOk && (() => {
+    try { return localStorage.getItem('job:profile:completed') === '1'; }
+    catch { return false; }
+  })());
   // Returning user with completed onboarding lands on /job/onboarding —
   // bounce to recommended. They came back to sign in, not to walk the flow
   // again. (Existing users still get to /job/settings/?demo=1 to re-test.)
-  if (onOnboarding && completed) {
+  if (onOnboarding && effectiveCompleted) {
     location.replace('/job/jobs/recommended/');
     return;
   }
   // Unauth or incomplete profile on a protected route → push into onboarding.
-  if (!onOnboarding && !completed) {
+  if (!onOnboarding && !effectiveCompleted) {
     location.replace(ONBOARDING_PATH + '/');
     return;
   }

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.1">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.1">
-  <script src="/job/js/theme.js?v=2.3.1"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.2">
+  <script src="/job/js/theme.js?v=2.3.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.1"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.2"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes 'every page redirects me to onboarding' for authed users. applySignedInState was firing the user_profile query before supabase loaded its session, RLS returned no rows, completed=false, bounce to onboarding. Now we await getSession() first, and only mutate the completion cache on successful queries (failed queries trust the cached flag).