### PR TITLE
job: Apply takeover hotfix — takeover element + raw-fetch Anthropic

### DIFF
--- a/job/js/components/job-role-detail.js
+++ b/job/js/components/job-role-detail.js
@@ -1701,6 +1701,11 @@ export class JobRoleDetail extends LitElement {
   }
 
   render() {
+    // <job-apply> always renders so the launch button on every state
+    // path can reach it. Lit reuses the element across re-renders so
+    // its internal state survives state transitions.
+    const takeover = html`<job-apply id="apply-takeover" @apply:close=${() => this._onApplyClose()}></job-apply>`;
+
     if (this.state === 'idle' || this.state === 'loading') {
       // If the user came from the pipeline we already have title/company/tags
       // in sessionStorage — paint that instantly with a shimmer body below.
@@ -1718,6 +1723,7 @@ export class JobRoleDetail extends LitElement {
           <section class="asset-panel">
             ${this._renderShimmerBody()}
           </section>
+          ${takeover}
         `;
       }
       return html`
@@ -1725,13 +1731,14 @@ export class JobRoleDetail extends LitElement {
         <div class="skeleton" style="width:60%;height:36px;margin-bottom:var(--space-2);display:block;"></div>
         <div class="skeleton" style="width:40%;height:18px;margin-bottom:var(--space-5);display:block;"></div>
         ${this._renderShimmerBody()}
+        ${takeover}
       `;
     }
     if (this.state === 'error') {
       return html`<div class="placeholder" style="border-color:var(--error);color:var(--error);">
         <h2>Couldn't load this role</h2>
         <p style="font-family:var(--font-mono);font-size:13px;">${this.error}</p>
-      </div>`;
+      </div>${takeover}`;
     }
     const r = this.role;
     return html`
@@ -1797,7 +1804,7 @@ export class JobRoleDetail extends LitElement {
         : this._renderAssetTab(this.activeTab)}
       </section>
 
-      <job-apply id="apply-takeover" @apply:close=${() => this._onApplyClose()}></job-apply>
+      ${takeover}
     `;
   }
 

--- a/supabase/functions/extract-application-fields/index.ts
+++ b/supabase/functions/extract-application-fields/index.ts
@@ -18,10 +18,37 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
-import Anthropic from 'https://esm.sh/@anthropic-ai/sdk@0.30.1?target=deno&deno-std=0.168.0';
 
-const VERSION = '0.1.0';
-console.log(`[extract-application-fields] v${VERSION} - greenhouse/lever/ashby + HTML fallback`);
+const VERSION = '0.2.0';
+console.log(`[extract-application-fields] v${VERSION} - raw-fetch Anthropic (no SDK)`);
+
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_MODEL = 'claude-haiku-4-5';
+
+async function callClaude(system: string, user: string, maxTokens = 4000): Promise<string> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`anthropic ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  return (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('\n').trim();
+}
 
 // ----- ATS detection -----------------------------------------------------
 type Ats =
@@ -326,7 +353,6 @@ async function extractHtmlFallback(sourceUrl: string, html: string, ats: string,
     .replace(/\s+/g, ' ')
     .slice(0, 40_000);
 
-  const client = new Anthropic({ apiKey });
   const sys = `You analyze a job application form's raw HTML and return a strict JSON schema describing the fields the applicant must fill out.
 
 Output ONLY valid JSON matching this TypeScript type — no prose, no markdown fences:
@@ -348,13 +374,7 @@ Rules:
 
   const user = `Application URL: ${sourceUrl}\nATS guess: ${ats}\n\nHTML (truncated):\n${trimmed}`;
 
-  const msg = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 4000,
-    system: sys,
-    messages: [{ role: 'user', content: user }],
-  });
-  const text = msg.content?.[0]?.type === 'text' ? msg.content[0].text : '';
+  const text = await callClaude(sys, user, 4000);
   let parsed: Partial<Schema> = {};
   try {
     const jsonStart = text.indexOf('{');

--- a/supabase/functions/generate-question-answer/index.ts
+++ b/supabase/functions/generate-question-answer/index.ts
@@ -24,12 +24,37 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
-import Anthropic from 'https://esm.sh/@anthropic-ai/sdk@0.30.1?target=deno&deno-std=0.168.0';
 
-const VERSION = '0.1.0';
-console.log(`[generate-question-answer] v${VERSION} - per-question annotated drafts`);
+const VERSION = '0.2.0';
+console.log(`[generate-question-answer] v${VERSION} - raw-fetch Anthropic (no SDK)`);
 
-const MODEL = 'claude-haiku-4-5-20251001';
+const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+const MODEL = 'claude-haiku-4-5';
+
+async function callClaude(system: string, user: string, maxTokens = 3000): Promise<string> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+  const res = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages: [{ role: 'user', content: user }],
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`anthropic ${res.status}: ${text.slice(0, 300)}`);
+  }
+  const data = await res.json() as { content: { type: string; text: string }[] };
+  return (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('\n').trim();
+}
 
 const SYS = `You write application answers for a senior product / strategy operator (the user) and return them in a strict JSON shape that downstream UI consumes.
 
@@ -93,9 +118,6 @@ serve(async (req) => {
     if (!/^[a-z0-9_-]+$/.test(slug)) return err('invalid slug', 400);
     if (!prompt) return err('prompt required', 400);
 
-    const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
-    if (!apiKey) return err('ANTHROPIC_API_KEY unset', 500);
-
     const sql = db();
     const ctx = await loadContext(sql, user.id, slug);
     const analysis = parseAnalysis(ctx.analysisMd);
@@ -148,14 +170,7 @@ ${lengthLine}
 
 Produce the JSON object now. JSON only.`;
 
-    const client = new Anthropic({ apiKey });
-    const msg = await client.messages.create({
-      model: MODEL,
-      max_tokens: 3000,
-      system: SYS,
-      messages: [{ role: 'user', content: userMsg }],
-    });
-    const text = msg.content?.[0]?.type === 'text' ? msg.content[0].text : '';
+    const text = await callClaude(SYS, userMsg, 3000);
     const cleaned = text.replace(/^```(?:json)?\s*|\s*```$/g, '').trim();
     let parsed: Record<string, unknown> = {};
     try { parsed = JSON.parse(cleaned); }


### PR DESCRIPTION
## Summary
Two live bugs caught from the Code for America posting test:

1. **\`apply takeover element missing\`** when clicking Apply while the role detail page is still in the loading/prefill state. \`<job-apply>\` was only rendered in the fully-loaded branch. Fix: render it once in every \`render()\` return.
2. **\`extract-application-fields\` 500** and **\`generate-question-answer\` would 500 too**. Root cause: the Anthropic SDK from \`esm.sh\` doesn't run cleanly in Supabase's Deno edge runtime. Replaced both with the same raw \`fetch\` to \`api.anthropic.com/v1/messages\` that \`gen-asset\` already uses. Bumped model id to \`claude-haiku-4-5\` (alias) for consistency.

No schema changes. Both edge functions redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)