### PR TITLE
job: harden Gmail→recs pipeline — loud source failures + health surfacing

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2533,6 +2533,22 @@
 .recs-page__refresh { align-self: center; }
 .recs-page__refresh-status { font-size: var(--font-size-caption); }
 
+/* Source-health banner — shown above the recs table when a source is
+   dead (e.g. Gmail token revoked). Distinguishes "no new recs" from
+   "we're blind". */
+.recs-health-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--error) 8%, transparent);
+}
+.recs-health-banner__msg { font-size: var(--font-size-body-sm); }
+
 /* Columns specific to the recs table — sizes mirror existing pipeline
    col-* declarations (around line 2500). */
 .pipeline-table .col-location { width: 14%; min-width: 120px; color: var(--text-muted); }

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -59,6 +59,8 @@ export class JobRecommendationsTable extends LitElement {
     selectedScoreWhich:  { state: true },
     _refreshing:         { state: true },
     _refreshFeedback:    { state: true },
+    _health:             { state: true },
+    _reconnecting:       { state: true },
   };
 
   constructor() {
@@ -73,6 +75,64 @@ export class JobRecommendationsTable extends LitElement {
     this.selectedRec = null;
     this._refreshing = false;
     this._refreshFeedback = '';
+    this._health = [];
+    this._reconnecting = false;
+  }
+
+  // ----- Source health banner ------------------------------------------
+  // The recommendations GET returns sourceHealth rows. Anything with
+  // needsReauth (dead Gmail token) or a lastError gets surfaced above the
+  // table — "no new recs" and "a source is blind" must look different.
+
+  _healthIssues() {
+    if (!Array.isArray(this._health)) return [];
+    return this._health.filter(s => s.enabled !== false && (s.needsReauth || s.lastError));
+  }
+
+  async _onReconnectGmail() {
+    if (this._reconnecting) return;
+    this._reconnecting = true;
+    try {
+      const supabase = window.CtrlAuth?.getSupabaseClient?.();
+      const { data } = await supabase.auth.getSession();
+      const token = data?.session?.access_token;
+      const r = await fetch('https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gmail-auth', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'auth-url' }),
+      });
+      const j = await r.json();
+      if (j.url) { window.location.assign(j.url); return; }
+      console.warn('[recs-table] reconnect: no auth url', j);
+    } catch (e) {
+      console.warn('[recs-table] reconnect failed', e);
+    } finally {
+      this._reconnecting = false;
+    }
+  }
+
+  _renderHealthBanner() {
+    const issues = this._healthIssues();
+    if (!issues.length) return nothing;
+    const gmailDead = issues.find(s => s.type === 'gmail-jobs' && s.needsReauth);
+    return html`
+      <div class="recs-health-banner" role="alert">
+        ${gmailDead ? html`
+          <span class="recs-health-banner__msg">
+            <strong>Gmail is disconnected</strong> — new job-alert emails aren't being scanned.
+          </span>
+          <button class="btn btn--sm btn--accent" ?disabled=${this._reconnecting}
+                  @click=${() => this._onReconnectGmail()}>
+            ${this._reconnecting ? 'Opening…' : 'Reconnect Gmail'}
+          </button>
+        ` : html`
+          <span class="recs-health-banner__msg">
+            <strong>Source issue:</strong>
+            ${issues.map(s => `${s.type}: ${s.lastError || 'needs attention'}`).join(' · ')}
+          </span>
+        `}
+      </div>
+    `;
   }
 
   async _onRefresh() {
@@ -141,6 +201,7 @@ export class JobRecommendationsTable extends LitElement {
     try {
       const data = await fetchRecommendations({ view: 'all' });
       this.items = data.recommendations || [];
+      this._health = Array.isArray(data.sourceHealth) ? data.sourceHealth : [];
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
@@ -354,6 +415,7 @@ export class JobRecommendationsTable extends LitElement {
         </button>
         ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
       </header>
+      ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`
         <div class="placeholder">
           <h2>No recommendations yet</h2>

--- a/supabase/functions/_shared/gmail.ts
+++ b/supabase/functions/_shared/gmail.ts
@@ -50,6 +50,11 @@ export interface ListResult {
   // the historyId we sent was too old (Gmail expires history after ~7
   // days). Caller catches this and re-runs with the timestamp fallback.
   historyExpired: boolean;
+  // True when the timestamp path hit its page cap and there were more
+  // results — the oldest messages in the window were silently dropped.
+  // Caller should log this so a long backfill is visible, not assumed
+  // complete.
+  truncated?: boolean;
 }
 
 // ---------- Listing ----------
@@ -89,8 +94,10 @@ export async function listSinceCursor(
   const q = [query || '', `after:${afterEpoch}`].filter(Boolean).join(' ');
   const ids: string[] = [];
   let pageToken: string | undefined;
+  let truncated = false;
   // Cap pages so a runaway query can't burn the whole tick.
-  for (let page = 0; page < 5; page++) {
+  const MAX_PAGES = 5;
+  for (let page = 0; page < MAX_PAGES; page++) {
     const url = new URL(`${GMAIL_BASE}/messages`);
     url.searchParams.set('q', q);
     url.searchParams.set('maxResults', '100');
@@ -101,11 +108,15 @@ export async function listSinceCursor(
     for (const m of (data.messages || [])) ids.push(m.id);
     if (!data.nextPageToken) break;
     pageToken = data.nextPageToken;
+    if (page === MAX_PAGES - 1) truncated = true;   // more pages remained
+  }
+  if (truncated) {
+    console.warn(`[gmail] messages.list hit ${MAX_PAGES}-page cap for q="${q.slice(0, 120)}" — oldest results dropped this tick`);
   }
   // messages.list doesn't return historyId; caller should ask
   // getProfileHistoryId after a successful timestamp scan to seed the
   // history cursor for the next tick.
-  return { messageIds: dedupe(ids), nextHistoryId: null, historyExpired: false };
+  return { messageIds: dedupe(ids), nextHistoryId: null, historyExpired: false, truncated };
 }
 
 // Fetch the user's profile to seed a historyId on first scan. Cheaper

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -101,16 +101,24 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     const sb = getServiceClient();
 
     // Resolve user_id for the email so we can look up the Google token.
+    // Missing user/token is NOT an empty inbox — it means the pipe is
+    // blind. Surface it loudly: stamp gmail_scan_state.last_error and
+    // throw so pull-recommendations writes user_sources.last_error and
+    // the run summary shows an error instead of a clean pulled:0.
     const userId = await userIdForEmail(sb, ctx.userEmail);
     if (!userId) {
-      console.warn(`[gmail-jobs] no user_id for ${ctx.userEmail}; not connected?`);
-      return [];
+      const err = `gmail not connected: no auth user for ${ctx.userEmail}`;
+      console.warn(`[gmail-jobs] ${err}`);
+      await markScanError(db(), ctx.userEmail, err);
+      throw new Error(err);
     }
 
     const tokenRes = await getAccessToken(sb, userId, [GMAIL_READONLY_SCOPE]);
     if (!tokenRes) {
-      console.warn(`[gmail-jobs] no gmail token for ${ctx.userEmail}; user has not consented`);
-      return [];
+      const err = 'gmail token missing or revoked — reauth required';
+      console.warn(`[gmail-jobs] ${err} (${ctx.userEmail})`);
+      await markScanError(db(), ctx.userEmail, err);
+      throw new Error(err);
     }
     const accessToken = tokenRes.accessToken;
 
@@ -165,7 +173,7 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     const ids = listRes.messageIds;
     let newWork = 0;
     let cappedRun = false;
-    console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidates from gmail (history=${!!state.history_id}, cap=${maxMessages})`);
+    console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidates from gmail (history=${!!state.history_id}, cap=${maxMessages}${listRes.truncated ? ', TRUNCATED — window larger than list cap' : ''})`);
 
     const out: RecommendedRoleInput[] = [];
     // Track every Gmail API id that contributed at least one emit, so
@@ -403,8 +411,13 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
       return out;
     }
 
+    // history.list returns the new cursor; the timestamp path (first run
+    // OR history-expired fallback) doesn't. Re-seed from the profile in
+    // BOTH cases — previously we only seeded when history_id was null,
+    // so an expired cursor stayed stale forever and every run re-ran the
+    // expensive timestamp query.
     let nextHistory: string | null = listRes.nextHistoryId;
-    if (!nextHistory && !state.history_id) {
+    if (!nextHistory) {
       nextHistory = await getProfileHistoryId(accessToken);
     }
     await sql`

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.15.0';
-console.log(`[pull-recommendations] v${VERSION} - surface all recs (no off-target/geo/min drops) + LinkedIn 'and more' digest detection`);
+const VERSION = '0.16.0';
+console.log(`[pull-recommendations] v${VERSION} - loud source failures (no silent no-token), durable run summaries in job.pull_runs`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -357,6 +357,20 @@ serve(async (req) => {
       await markRun(sql, src.id, { count: 0, dropped: 0, error: (e as Error).message });
       summary.push({ id: src.id, type: src.type, error: (e as Error).message });
     }
+  }
+
+  // Durable copy of the run summary — net._http_response gets pruned,
+  // job.pull_runs doesn't (30-day opportunistic retention). Never let
+  // bookkeeping fail the run.
+  try {
+    const hadError = summary.some(s => s.error != null);
+    const totalInserted = summary.reduce((n, s) => n + (typeof s.inserted === 'number' ? s.inserted : 0), 0);
+    await sql`
+      insert into job.pull_runs (version, sources, had_error, total_inserted)
+        values (${VERSION}, ${sql.json(summary)}, ${hadError}, ${totalInserted})`;
+    await sql`delete from job.pull_runs where ran_at < now() - interval '30 days'`;
+  } catch (e) {
+    console.warn(`[pull-recommendations] pull_runs bookkeeping failed: ${(e as Error).message}`);
   }
 
   return new Response(JSON.stringify({ ok: true, version: VERSION, ranAt: new Date().toISOString(), sources: summary }, null, 2), {

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.6.0';
-console.log(`[recommendations] v${VERSION} - return enrichment fields (status, retry, canonical_url)`);
+const VERSION = '0.7.0';
+console.log(`[recommendations] v${VERSION} - sourceHealth in GET (surface dead sources / gmail reauth)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -59,7 +59,33 @@ serve(async (req) => {
         order by r.fit_score desc nulls last, r.suggested_at desc
         limit ${isAll ? 500 : 60};
       `;
-      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows });
+      // Source health — lets the UI tell "no new recs" apart from "a
+      // source is dead". needs_reauth is true when the gmail-jobs source
+      // errored with a token problem OR the scan-state row carries one.
+      // Never fail the page over health bookkeeping.
+      let sourceHealth: unknown[] = [];
+      try {
+        sourceHealth = await sql`
+          select s.type,
+                 s.enabled,
+                 s.last_run_at   as "lastRunAt",
+                 s.last_run_count as "lastRunCount",
+                 s.last_error    as "lastError",
+                 case when s.type = 'gmail-jobs' and (
+                        coalesce(s.last_error, '')    ilike '%reauth%' or
+                        coalesce(s.last_error, '')    ilike '%not connected%' or
+                        coalesce(g.last_error, '')    ilike '%reauth%' or
+                        coalesce(g.last_error, '')    ilike '%not connected%'
+                      )
+                      then true else false end as "needsReauth"
+            from job.user_sources s
+            left join job.gmail_scan_state g on g.user_email = s.user_email
+           where s.user_email = ${email}
+           order by s.type`;
+      } catch (e) {
+        console.warn(`[recommendations] sourceHealth failed: ${(e as Error).message}`);
+      }
+      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows, sourceHealth });
     }
 
     if (req.method === 'POST') {

--- a/supabase/migrations/080_pull_runs.sql
+++ b/supabase/migrations/080_pull_runs.sql
@@ -1,0 +1,30 @@
+-- 080: job.pull_runs — durable per-run summaries for pull-recommendations.
+--
+-- Why: run summaries previously lived only in net._http_response (the
+-- pg_net response store), which gets pruned automatically. When the
+-- gmail-jobs source went silently dead for 26 days (revoked OAuth token,
+-- clean pulled:0 every run), there was no queryable history to spot the
+-- flatline. This table keeps one row per orchestrator run with the full
+-- per-source summary so health checks and humans can ask "when did this
+-- source last insert anything?"
+
+create table if not exists job.pull_runs (
+  id          bigint generated always as identity primary key,
+  ran_at      timestamptz not null default now(),
+  version     text not null,
+  -- The same summary array returned in the HTTP response:
+  -- [{ id, type, pulled, kept, droppedToPipeline, inserted, error?, skipped? }]
+  sources     jsonb not null,
+  -- Denormalized convenience flags for cheap health queries.
+  had_error   boolean not null default false,
+  total_inserted int not null default 0
+);
+
+create index if not exists pull_runs_ran_at_idx on job.pull_runs (ran_at desc);
+
+-- Retention: keep 30 days. Cheap delete piggybacked on insert volume
+-- (96 rows/day at 15-min cadence) — no separate cron needed; the edge
+-- function prunes opportunistically.
+
+comment on table job.pull_runs is
+  'Per-run summaries from pull-recommendations. Written by the edge function each run; pruned to ~30 days opportunistically.';


### PR DESCRIPTION
## Root cause

The `gmail-jobs` source went silently dead for ~26 days. The Google OAuth refresh token was **revoked** (the Cloud project is in *Testing* status, where Google expires refresh tokens after 7 days), so `getAccessToken` returned `null`, and the source returned `[]` with a clean `pulled:0` on every 15-min run. No error, no cursor movement, no surfaced signal — the only symptom was the *absence* of new recs.

The cursor (`gmail_scan_state.history_id`) was frozen at the 2026-05-17 value, and `last_run_count` was `0` every run while `last_error` stayed `null`.

## Fixes

**Loud failures (the core fix)**
- `gmail-jobs.ts`: missing `user_id` or token now stamps `gmail_scan_state.last_error` **and throws**, so `pull-recommendations` records `user_sources.last_error` and the run summary shows an `error` instead of a clean `pulled:0`.

**Cursor recovery**
- `gmail-jobs.ts`: re-seed `historyId` from the Gmail profile after a history-expired timestamp fallback. Previously we only seeded when `history_id` was null, so an expired cursor stayed stale forever and every run re-ran the expensive timestamp query.

**Truncation visibility**
- `gmail.ts`: `ListResult.truncated` flag + `console.warn` when `messages.list` hits its 5-page (500 msg) cap — a long backfill is now visible, not silently clipped. Surfaced in the gmail-jobs candidate log line too.

**Durable run history**
- `pull-recommendations` **v0.16.0**: persists each run summary to `job.pull_runs` (migration `080`). `net._http_response` gets pruned by pg_net; this table doesn't (30-day opportunistic retention). Makes "when did this source last insert anything?" a queryable question.

**Health surfacing**
- `recommendations` **v0.7.0**: GET returns `sourceHealth[]` per source (`lastRunAt`, `lastError`, `needsReauth`).
- Recs table: a source-health banner with a **Reconnect Gmail** CTA. "No new recs" and "we're blind" now look different.

## Also done out-of-band
- Paused the 3 `theirstack` sources (`enabled=false`) — out of API credits (402) for weeks.
- Migration `080_pull_runs` already applied to the Boards project.

## Follow-ups (not in this PR)
- Move the Google OAuth app **Testing → Production** to kill the 7-day refresh-token expiry that caused this. (Requires Console access — flagging for @fikei.)
- Encrypt refresh tokens at rest in `user_google_tokens`.
- Raw ingest ledger epic (replayable extraction) — proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)