### PR TITLE
job: clear Gmail disconnected banner immediately on reconnect

### DIFF
--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2533,6 +2533,22 @@
 .recs-page__refresh { align-self: center; }
 .recs-page__refresh-status { font-size: var(--font-size-caption); }
 
+/* Source-health banner — shown above the recs table when a source is
+   dead (e.g. Gmail token revoked). Distinguishes "no new recs" from
+   "we're blind". */
+.recs-health-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--error) 8%, transparent);
+}
+.recs-health-banner__msg { font-size: var(--font-size-body-sm); }
+
 /* Columns specific to the recs table — sizes mirror existing pipeline
    col-* declarations (around line 2500). */
 .pipeline-table .col-location { width: 14%; min-width: 120px; color: var(--text-muted); }

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -274,7 +274,32 @@ window.CtrlAuth.init({
   }
 })();
 
+// Single-flight guard so the event listener + timer + poller don't fire
+// three concurrent exchanges of the same single-use code.
+let _gmailConnectInFlight = false;
+
+// Wait for a Supabase session token, polling for up to ~timeoutMs. The
+// OAuth redirect lands before CtrlAuth has necessarily restored the
+// session, and ctrl:auth:signedin can fire before our listener attaches —
+// so a one-shot check raced and silently dropped the code. Poll instead.
+async function _waitForSessionToken(timeoutMs = 12000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const supabase = window.CtrlAuth?.getSupabaseClient?.();
+    if (supabase) {
+      try {
+        const { data } = await supabase.auth.getSession();
+        const token = data?.session?.access_token;
+        if (token) return token;
+      } catch { /* keep polling */ }
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  return null;
+}
+
 async function _completePendingGmailOAuth() {
+  if (_gmailConnectInFlight) return;
   let pending;
   try { pending = JSON.parse(sessionStorage.getItem('job:pendingGmailOAuth') || 'null'); } catch { return; }
   if (!pending?.code) return;
@@ -283,12 +308,15 @@ async function _completePendingGmailOAuth() {
     sessionStorage.removeItem('job:pendingGmailOAuth');
     return;
   }
-  const supabase = window.CtrlAuth?.getSupabaseClient?.();
-  if (!supabase) return;
-  const { data } = await supabase.auth.getSession();
-  const token = data?.session?.access_token;
-  if (!token) return;
+  _gmailConnectInFlight = true;
   try {
+    const token = await _waitForSessionToken();
+    if (!token) {
+      // Leave pending in place — a later signedin event or page load
+      // will retry while the code is still within its 10-min window.
+      console.warn('[job] gmail connect: no session yet, will retry');
+      return;
+    }
     const r = await fetch('https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gmail-auth', {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
@@ -298,11 +326,19 @@ async function _completePendingGmailOAuth() {
     if (r.ok) {
       console.log('[job] Gmail connected — token stored with gmail.modify scope');
       sessionStorage.removeItem('job:pendingGmailOAuth');
+      document.dispatchEvent(new CustomEvent('job:gmail:connected'));
     } else {
-      console.warn('[job] gmail-auth connect failed:', await r.text());
+      // The code is single-use; a failed exchange can't be retried with
+      // the same code. Drop it so we don't loop, and surface the error.
+      const body = await r.text();
+      console.warn('[job] gmail-auth connect failed:', r.status, body);
+      sessionStorage.removeItem('job:pendingGmailOAuth');
+      document.dispatchEvent(new CustomEvent('job:gmail:connect-failed', { detail: { status: r.status, body } }));
     }
   } catch (e) {
     console.warn('[job] gmail-auth connect error:', e.message);
+  } finally {
+    _gmailConnectInFlight = false;
   }
 }
 document.addEventListener('ctrl:auth:signedin', () => { _completePendingGmailOAuth(); });

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -187,10 +187,19 @@ export class JobRecommendationsTable extends LitElement {
     this._onAuth = () => this._maybeLoad();
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
     document.addEventListener('job:auth:ready', this._onAuth);
+    // Gmail just reconnected (app.js fires this after a successful token
+    // exchange) → hide the disconnected banner optimistically without
+    // waiting for the next scan to clear last_error server-side.
+    this._onGmailConnected = () => {
+      this._health = (this._health || []).filter(s => s.type !== 'gmail-jobs');
+      this.requestUpdate();
+    };
+    document.addEventListener('job:gmail:connected', this._onGmailConnected);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
+    document.removeEventListener('job:gmail:connected', this._onGmailConnected);
     super.disconnectedCallback();
   }
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -59,6 +59,8 @@ export class JobRecommendationsTable extends LitElement {
     selectedScoreWhich:  { state: true },
     _refreshing:         { state: true },
     _refreshFeedback:    { state: true },
+    _health:             { state: true },
+    _reconnecting:       { state: true },
   };
 
   constructor() {
@@ -73,6 +75,64 @@ export class JobRecommendationsTable extends LitElement {
     this.selectedRec = null;
     this._refreshing = false;
     this._refreshFeedback = '';
+    this._health = [];
+    this._reconnecting = false;
+  }
+
+  // ----- Source health banner ------------------------------------------
+  // The recommendations GET returns sourceHealth rows. Anything with
+  // needsReauth (dead Gmail token) or a lastError gets surfaced above the
+  // table — "no new recs" and "a source is blind" must look different.
+
+  _healthIssues() {
+    if (!Array.isArray(this._health)) return [];
+    return this._health.filter(s => s.enabled !== false && (s.needsReauth || s.lastError));
+  }
+
+  async _onReconnectGmail() {
+    if (this._reconnecting) return;
+    this._reconnecting = true;
+    try {
+      const supabase = window.CtrlAuth?.getSupabaseClient?.();
+      const { data } = await supabase.auth.getSession();
+      const token = data?.session?.access_token;
+      const r = await fetch('https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/gmail-auth', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'auth-url' }),
+      });
+      const j = await r.json();
+      if (j.url) { window.location.assign(j.url); return; }
+      console.warn('[recs-table] reconnect: no auth url', j);
+    } catch (e) {
+      console.warn('[recs-table] reconnect failed', e);
+    } finally {
+      this._reconnecting = false;
+    }
+  }
+
+  _renderHealthBanner() {
+    const issues = this._healthIssues();
+    if (!issues.length) return nothing;
+    const gmailDead = issues.find(s => s.type === 'gmail-jobs' && s.needsReauth);
+    return html`
+      <div class="recs-health-banner" role="alert">
+        ${gmailDead ? html`
+          <span class="recs-health-banner__msg">
+            <strong>Gmail is disconnected</strong> — new job-alert emails aren't being scanned.
+          </span>
+          <button class="btn btn--sm btn--accent" ?disabled=${this._reconnecting}
+                  @click=${() => this._onReconnectGmail()}>
+            ${this._reconnecting ? 'Opening…' : 'Reconnect Gmail'}
+          </button>
+        ` : html`
+          <span class="recs-health-banner__msg">
+            <strong>Source issue:</strong>
+            ${issues.map(s => `${s.type}: ${s.lastError || 'needs attention'}`).join(' · ')}
+          </span>
+        `}
+      </div>
+    `;
   }
 
   async _onRefresh() {
@@ -141,6 +201,7 @@ export class JobRecommendationsTable extends LitElement {
     try {
       const data = await fetchRecommendations({ view: 'all' });
       this.items = data.recommendations || [];
+      this._health = Array.isArray(data.sourceHealth) ? data.sourceHealth : [];
       this.state = 'loaded';
     } catch (e) {
       this.error = String(e);
@@ -354,6 +415,7 @@ export class JobRecommendationsTable extends LitElement {
         </button>
         ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
       </header>
+      ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`
         <div class="placeholder">
           <h2>No recommendations yet</h2>

--- a/supabase/functions/_shared/gmail.ts
+++ b/supabase/functions/_shared/gmail.ts
@@ -50,6 +50,11 @@ export interface ListResult {
   // the historyId we sent was too old (Gmail expires history after ~7
   // days). Caller catches this and re-runs with the timestamp fallback.
   historyExpired: boolean;
+  // True when the timestamp path hit its page cap and there were more
+  // results — the oldest messages in the window were silently dropped.
+  // Caller should log this so a long backfill is visible, not assumed
+  // complete.
+  truncated?: boolean;
 }
 
 // ---------- Listing ----------
@@ -89,8 +94,10 @@ export async function listSinceCursor(
   const q = [query || '', `after:${afterEpoch}`].filter(Boolean).join(' ');
   const ids: string[] = [];
   let pageToken: string | undefined;
+  let truncated = false;
   // Cap pages so a runaway query can't burn the whole tick.
-  for (let page = 0; page < 5; page++) {
+  const MAX_PAGES = 5;
+  for (let page = 0; page < MAX_PAGES; page++) {
     const url = new URL(`${GMAIL_BASE}/messages`);
     url.searchParams.set('q', q);
     url.searchParams.set('maxResults', '100');
@@ -101,11 +108,15 @@ export async function listSinceCursor(
     for (const m of (data.messages || [])) ids.push(m.id);
     if (!data.nextPageToken) break;
     pageToken = data.nextPageToken;
+    if (page === MAX_PAGES - 1) truncated = true;   // more pages remained
+  }
+  if (truncated) {
+    console.warn(`[gmail] messages.list hit ${MAX_PAGES}-page cap for q="${q.slice(0, 120)}" — oldest results dropped this tick`);
   }
   // messages.list doesn't return historyId; caller should ask
   // getProfileHistoryId after a successful timestamp scan to seed the
   // history cursor for the next tick.
-  return { messageIds: dedupe(ids), nextHistoryId: null, historyExpired: false };
+  return { messageIds: dedupe(ids), nextHistoryId: null, historyExpired: false, truncated };
 }
 
 // Fetch the user's profile to seed a historyId on first scan. Cheaper

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -101,16 +101,24 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     const sb = getServiceClient();
 
     // Resolve user_id for the email so we can look up the Google token.
+    // Missing user/token is NOT an empty inbox — it means the pipe is
+    // blind. Surface it loudly: stamp gmail_scan_state.last_error and
+    // throw so pull-recommendations writes user_sources.last_error and
+    // the run summary shows an error instead of a clean pulled:0.
     const userId = await userIdForEmail(sb, ctx.userEmail);
     if (!userId) {
-      console.warn(`[gmail-jobs] no user_id for ${ctx.userEmail}; not connected?`);
-      return [];
+      const err = `gmail not connected: no auth user for ${ctx.userEmail}`;
+      console.warn(`[gmail-jobs] ${err}`);
+      await markScanError(db(), ctx.userEmail, err);
+      throw new Error(err);
     }
 
     const tokenRes = await getAccessToken(sb, userId, [GMAIL_READONLY_SCOPE]);
     if (!tokenRes) {
-      console.warn(`[gmail-jobs] no gmail token for ${ctx.userEmail}; user has not consented`);
-      return [];
+      const err = 'gmail token missing or revoked — reauth required';
+      console.warn(`[gmail-jobs] ${err} (${ctx.userEmail})`);
+      await markScanError(db(), ctx.userEmail, err);
+      throw new Error(err);
     }
     const accessToken = tokenRes.accessToken;
 
@@ -165,7 +173,7 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     const ids = listRes.messageIds;
     let newWork = 0;
     let cappedRun = false;
-    console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidates from gmail (history=${!!state.history_id}, cap=${maxMessages})`);
+    console.log(`[gmail-jobs] ${ctx.userEmail} → ${ids.length} candidates from gmail (history=${!!state.history_id}, cap=${maxMessages}${listRes.truncated ? ', TRUNCATED — window larger than list cap' : ''})`);
 
     const out: RecommendedRoleInput[] = [];
     // Track every Gmail API id that contributed at least one emit, so
@@ -403,8 +411,13 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
       return out;
     }
 
+    // history.list returns the new cursor; the timestamp path (first run
+    // OR history-expired fallback) doesn't. Re-seed from the profile in
+    // BOTH cases — previously we only seeded when history_id was null,
+    // so an expired cursor stayed stale forever and every run re-ran the
+    // expensive timestamp query.
     let nextHistory: string | null = listRes.nextHistoryId;
-    if (!nextHistory && !state.history_id) {
+    if (!nextHistory) {
       nextHistory = await getProfileHistoryId(accessToken);
     }
     await sql`

--- a/supabase/functions/gmail-auth/index.ts
+++ b/supabase/functions/gmail-auth/index.ts
@@ -13,8 +13,8 @@
 // don't need a new client registration. The redirect URI for gmail
 // connect points at /job/ — calendar-api keeps /calendar/.
 
-const VERSION = '0.2.0';
-console.log(`[gmail-auth] v${VERSION} - oauth requests gmail.modify (superset of readonly) so pipeline can apply Ladder label`);
+const VERSION = '0.3.0';
+console.log(`[gmail-auth] v${VERSION} - clear stale last_error on connect so reconnect banner clears immediately`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -27,6 +27,7 @@ import {
   markRevoked,
   upsertToken,
 } from '../_shared/google-tokens.ts';
+import { db } from '../_shared/job-db.ts';
 
 // gmail.modify is a strict superset of gmail.readonly. We request both
 // so the scope_set on the token row covers callers that look up by
@@ -179,6 +180,20 @@ serve(async (req) => {
         google_email: profile.email ?? null,
         granted_for: 'gmail-jobs',
       });
+
+      // Clear the stale reauth error so the "Gmail disconnected" banner
+      // (driven by *_sources.last_error / gmail_scan_state.last_error)
+      // clears immediately on reconnect, instead of lingering until the
+      // next successful scan. Best-effort — never fail the connect over it.
+      try {
+        const sql = db();
+        await sql`update job.user_sources set last_error = null
+                   where user_email = ${user.email} and type = 'gmail-jobs'`;
+        await sql`update job.gmail_scan_state set last_error = null
+                   where user_email = ${user.email}`;
+      } catch (e) {
+        console.warn('[gmail-auth] clear last_error failed:', (e as Error).message);
+      }
 
       return json({ connected: true, email: profile.email ?? null });
     }

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.15.0';
-console.log(`[pull-recommendations] v${VERSION} - surface all recs (no off-target/geo/min drops) + LinkedIn 'and more' digest detection`);
+const VERSION = '0.16.0';
+console.log(`[pull-recommendations] v${VERSION} - loud source failures (no silent no-token), durable run summaries in job.pull_runs`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -357,6 +357,20 @@ serve(async (req) => {
       await markRun(sql, src.id, { count: 0, dropped: 0, error: (e as Error).message });
       summary.push({ id: src.id, type: src.type, error: (e as Error).message });
     }
+  }
+
+  // Durable copy of the run summary — net._http_response gets pruned,
+  // job.pull_runs doesn't (30-day opportunistic retention). Never let
+  // bookkeeping fail the run.
+  try {
+    const hadError = summary.some(s => s.error != null);
+    const totalInserted = summary.reduce((n, s) => n + (typeof s.inserted === 'number' ? s.inserted : 0), 0);
+    await sql`
+      insert into job.pull_runs (version, sources, had_error, total_inserted)
+        values (${VERSION}, ${sql.json(summary)}, ${hadError}, ${totalInserted})`;
+    await sql`delete from job.pull_runs where ran_at < now() - interval '30 days'`;
+  } catch (e) {
+    console.warn(`[pull-recommendations] pull_runs bookkeeping failed: ${(e as Error).message}`);
   }
 
   return new Response(JSON.stringify({ ok: true, version: VERSION, ranAt: new Date().toISOString(), sources: summary }, null, 2), {

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.6.0';
-console.log(`[recommendations] v${VERSION} - return enrichment fields (status, retry, canonical_url)`);
+const VERSION = '0.7.0';
+console.log(`[recommendations] v${VERSION} - sourceHealth in GET (surface dead sources / gmail reauth)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -59,7 +59,33 @@ serve(async (req) => {
         order by r.fit_score desc nulls last, r.suggested_at desc
         limit ${isAll ? 500 : 60};
       `;
-      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows });
+      // Source health — lets the UI tell "no new recs" apart from "a
+      // source is dead". needs_reauth is true when the gmail-jobs source
+      // errored with a token problem OR the scan-state row carries one.
+      // Never fail the page over health bookkeeping.
+      let sourceHealth: unknown[] = [];
+      try {
+        sourceHealth = await sql`
+          select s.type,
+                 s.enabled,
+                 s.last_run_at   as "lastRunAt",
+                 s.last_run_count as "lastRunCount",
+                 s.last_error    as "lastError",
+                 case when s.type = 'gmail-jobs' and (
+                        coalesce(s.last_error, '')    ilike '%reauth%' or
+                        coalesce(s.last_error, '')    ilike '%not connected%' or
+                        coalesce(g.last_error, '')    ilike '%reauth%' or
+                        coalesce(g.last_error, '')    ilike '%not connected%'
+                      )
+                      then true else false end as "needsReauth"
+            from job.user_sources s
+            left join job.gmail_scan_state g on g.user_email = s.user_email
+           where s.user_email = ${email}
+           order by s.type`;
+      } catch (e) {
+        console.warn(`[recommendations] sourceHealth failed: ${(e as Error).message}`);
+      }
+      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows, sourceHealth });
     }
 
     if (req.method === 'POST') {

--- a/supabase/migrations/080_pull_runs.sql
+++ b/supabase/migrations/080_pull_runs.sql
@@ -1,0 +1,30 @@
+-- 080: job.pull_runs — durable per-run summaries for pull-recommendations.
+--
+-- Why: run summaries previously lived only in net._http_response (the
+-- pg_net response store), which gets pruned automatically. When the
+-- gmail-jobs source went silently dead for 26 days (revoked OAuth token,
+-- clean pulled:0 every run), there was no queryable history to spot the
+-- flatline. This table keeps one row per orchestrator run with the full
+-- per-source summary so health checks and humans can ask "when did this
+-- source last insert anything?"
+
+create table if not exists job.pull_runs (
+  id          bigint generated always as identity primary key,
+  ran_at      timestamptz not null default now(),
+  version     text not null,
+  -- The same summary array returned in the HTTP response:
+  -- [{ id, type, pulled, kept, droppedToPipeline, inserted, error?, skipped? }]
+  sources     jsonb not null,
+  -- Denormalized convenience flags for cheap health queries.
+  had_error   boolean not null default false,
+  total_inserted int not null default 0
+);
+
+create index if not exists pull_runs_ran_at_idx on job.pull_runs (ran_at desc);
+
+-- Retention: keep 30 days. Cheap delete piggybacked on insert volume
+-- (96 rows/day at 15-min cadence) — no separate cron needed; the edge
+-- function prunes opportunistically.
+
+comment on table job.pull_runs is
+  'Per-run summaries from pull-recommendations. Written by the edge function each run; pruned to ~30 days opportunistically.';


### PR DESCRIPTION
## Problem

Second cause of "every refresh requires new auth": even after a *successful* reconnect, the banner kept showing **"Gmail disconnected."** It's driven by `user_sources.last_error` / `gmail_scan_state.last_error`, which only clear on the next *successful* gmail-jobs scan — so the stale error string lingered and the user clicked Reconnect again.

## Fix
- **gmail-auth v0.3.0**: on a successful `connect`, clear `last_error` on both `job.user_sources` (gmail-jobs) and `job.gmail_scan_state` (best-effort, never fails the connect).
- **recs table**: hide the gmail banner optimistically on the `job:gmail:connected` event (fired by app.js after a successful token exchange), without waiting for the server.

Companion to #915 (loud failures + banner) and #916 (callback race fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)