### PR TITLE
job: time-box gmail application-scan so a large pipeline can't 504 the run (v0.16.1)

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -81,11 +81,22 @@ export async function scanApplicationResponses(args: {
   windowDays?: number;
   // backfill optional role-slug filter (process one role at a time)
   roleSlug?: string;
+  // wall-clock budget in ms (default 40s) — caps the per-role Gmail
+  // searches + message processing so this side-effect can't time out the
+  // host run.
+  budgetMs?: number;
 }): Promise<ApplicationScanResult> {
   const sql = db();
   const mode = args.mode ?? 'live';
   const maxMessages = Math.max(1, Math.min(50, args.maxMessages ?? (mode === 'backfill' ? 5 : 30)));
   const windowDays = Math.max(1, args.windowDays ?? (mode === 'backfill' ? 30 : 7));
+  // Wall-clock budget. This scan runs inside gmail-jobs.pull() BEFORE the
+  // recs cursor write + insert, so if it overruns the 150s function limit
+  // the whole run 504s and NOTHING commits — no recs, no cursor advance.
+  // With a large pipeline (50+ roles × sequential Gmail searches) that was
+  // exactly the failure. Time-box it: when the budget is spent, stop and
+  // let the rest of the run finish. Side-effect, not critical path.
+  const deadline = Date.now() + Math.max(5_000, args.budgetMs ?? 40_000);
 
   const out: ApplicationScanResult = {
     classified: 0, inserted: 0, autoAdvanced: 0, needsReview: 0, skippedNoMatch: 0,
@@ -183,6 +194,10 @@ export async function scanApplicationResponses(args: {
   // first, then by most-recent engagement. If the pipeline ever grows
   // past this, the tail is silently skipped — bump or paginate.
   for (const role of roles.slice(0, 60)) {
+    if (Date.now() > deadline) {
+      console.warn(`[gmail-app-scan] name-search budget spent; scanned subset of ${roles.length} roles`);
+      break;
+    }
     // Build a candidate-name set per role. Start with company_name when
     // it looks real; add the title-derived company token when it
     // doesn't (rows added via /add-role sometimes land as
@@ -207,6 +222,10 @@ export async function scanApplicationResponses(args: {
   let processed = 0;
   for (const id of ids) {
     if (processed >= maxMessages) break;
+    if (Date.now() > deadline) {
+      console.warn(`[gmail-app-scan] processing budget spent after ${processed} msgs`);
+      break;
+    }
 
     let msg: GmailMessage;
     try {

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.16.0';
-console.log(`[pull-recommendations] v${VERSION} - loud source failures (no silent no-token), durable run summaries in job.pull_runs`);
+const VERSION = '0.16.1';
+console.log(`[pull-recommendations] v${VERSION} - time-box gmail application-scan (40s) so a large pipeline can't 504 the whole run`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Re-opened cleanly off current master (the prior #919 branch got tangled in squash-merge SHA conflicts and was closed).

## Root cause
After Gmail reconnected (token valid), the forced pull **504'd at 150s** and committed nothing. `scanApplicationResponses` runs **inside `gmail-jobs.pull()` before** the recs cursor write + insert, looping up to 60 pipeline roles with a **sequential Gmail search each** (57 roles here). Combined with the rec pull it blew the 150s edge limit → 504 → no recs inserted, cursor never advanced.

## Fix
Wall-clock budget (default 40s) on `scanApplicationResponses`; the per-role name-search loop and the message-processing loop both bail when it's spent. Side-effect, not the recs critical path. `pull-recommendations` → v0.16.1.

Already deployed to Supabase from local; this lands it on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)