### PR TITLE
job: paginated For You with infinite scroll — remove silent 500-row cap

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2549,6 +2549,17 @@
 }
 .recs-health-banner__msg { font-size: var(--font-size-body-sm); }
 
+/* Infinite-scroll footer for the For You table. The sentinel is an
+   invisible trip-wire the IntersectionObserver watches; the loadmore row
+   shows a status line while the next page is fetched. */
+.recs-sentinel { height: 1px; }
+.recs-loadmore {
+  text-align: center;
+  padding: var(--space-3);
+  font-size: var(--font-size-caption);
+  min-height: 1.5em;
+}
+
 /* Columns specific to the recs table — sizes mirror existing pipeline
    col-* declarations (around line 2500). */
 .pipeline-table .col-location { width: 14%; min-width: 120px; color: var(--text-muted); }

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <script src="/job/js/theme.js?v=2.3.4"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.3";
-console.log(`[job] v${VERSION} - Gmail OAuth callback no longer stripped by /job/ pre-route; robust token exchange`);
+const VERSION = "2.3.4";
+console.log(`[job] v${VERSION} - For You infinite scroll (server-side paginate + sort), no 500-row cap`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -25,6 +25,10 @@ const COLUMNS = [
   { id: 'menu',     label: '',         sortKey: null },
 ];
 
+// Page size for the infinite-scroll fetch. Server caps at 200; 100 keeps
+// each round-trip light while filling a tall viewport in one or two pages.
+const PAGE_SIZE = 100;
+
 function relTime(iso) {
   if (!iso) return '';
   const ms = Date.now() - Date.parse(iso);
@@ -61,6 +65,9 @@ export class JobRecommendationsTable extends LitElement {
     _refreshFeedback:    { state: true },
     _health:             { state: true },
     _reconnecting:       { state: true },
+    _total:              { state: true },
+    _loadingMore:        { state: true },
+    _hasMore:            { state: true },
   };
 
   constructor() {
@@ -77,6 +84,10 @@ export class JobRecommendationsTable extends LitElement {
     this._refreshFeedback = '';
     this._health = [];
     this._reconnecting = false;
+    this._total = 0;
+    this._offset = 0;
+    this._loadingMore = false;
+    this._hasMore = false;
   }
 
   // ----- Source health banner ------------------------------------------
@@ -145,13 +156,7 @@ export class JobRecommendationsTable extends LitElement {
         ? 'Recently refreshed — try again in a few minutes.'
         : 'Scanning Gmail for new roles…';
       setTimeout(async () => {
-        try {
-          const data = await fetchRecommendations({ view: 'all' });
-          // /functions/v1/recommendations returns { recommendations: [...] }
-          // — same shape _maybeLoad uses. Wrong field name made
-          // this.items become an object and _sorted() crash next render.
-          this.items = Array.isArray(data?.recommendations) ? data.recommendations : [];
-        } catch { /* keep stale */ }
+        await this._fetchPage({ reset: true });
         this.requestUpdate();
       }, 8000);
     } finally {
@@ -200,22 +205,63 @@ export class JobRecommendationsTable extends LitElement {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('job:gmail:connected', this._onGmailConnected);
+    if (this._io) { this._io.disconnect(); this._io = null; }
     super.disconnectedCallback();
+  }
+
+  // Observe the bottom sentinel — when it scrolls into view, pull the next
+  // page. rootMargin pre-fetches ~600px early so scrolling stays smooth.
+  updated() {
+    const sentinel = this.querySelector('.recs-sentinel');
+    if (!sentinel) return;
+    if (!this._io) {
+      this._io = new IntersectionObserver((entries) => {
+        if (entries.some(e => e.isIntersecting)) this._loadMore();
+      }, { rootMargin: '600px 0px' });
+    }
+    this._io.disconnect();
+    this._io.observe(sentinel);
   }
 
   async _maybeLoad() {
     if (document.body.dataset.authState !== 'in') return;
     if (this.state === 'loading' || this.state === 'loaded') return;
     this.state = 'loading';
+    await this._fetchPage({ reset: true });
+    if (this.state === 'loading') this.state = 'loaded';
+  }
+
+  // Fetch one page from the server (server-side sorted). reset=true starts
+  // a fresh list at offset 0 (initial load, sort change, refresh); otherwise
+  // appends the next page for infinite scroll.
+  async _fetchPage({ reset = false } = {}) {
+    if (reset) { this._offset = 0; this._hasMore = false; }
     try {
-      const data = await fetchRecommendations({ view: 'all' });
-      this.items = data.recommendations || [];
-      this._health = Array.isArray(data.sourceHealth) ? data.sourceHealth : [];
-      this.state = 'loaded';
+      const data = await fetchRecommendations({
+        view:   'all',
+        limit:  PAGE_SIZE,
+        offset: this._offset,
+        sort:   this.sortKey,
+        dir:    this.sortDir,
+      });
+      const page = Array.isArray(data?.recommendations) ? data.recommendations : [];
+      this.items   = reset ? page : [...this.items, ...page];
+      this._offset = this.items.length;
+      this._total  = Number.isFinite(data?.total) ? data.total : this.items.length;
+      this._hasMore = !!data?.hasMore;
+      if (reset && Array.isArray(data?.sourceHealth)) this._health = data.sourceHealth;
     } catch (e) {
-      this.error = String(e);
-      this.state = 'error';
+      if (reset) { this.error = String(e); this.state = 'error'; }
+      // append failures are non-fatal — keep what we have, allow retry
     }
+  }
+
+  async _loadMore() {
+    if (this._loadingMore || !this._hasMore) return;
+    this._loadingMore = true;
+    this.requestUpdate();
+    try { await this._fetchPage({ reset: false }); }
+    finally { this._loadingMore = false; this.requestUpdate(); }
   }
 
   _onSortClick(c) {
@@ -227,28 +273,15 @@ export class JobRecommendationsTable extends LitElement {
       // Numeric / date default to desc (highest/newest first), text asc.
       this.sortDir = (c.numeric || c.date) ? 'desc' : 'asc';
     }
+    // Sorting is server-side now (the full set is larger than one page),
+    // so a sort change re-fetches from offset 0 in the new order.
+    this._fetchPage({ reset: true });
   }
 
+  // Rows are returned already sorted by the server; this is just an
+  // array guard so a transient bad state can't crash render.
   _sorted() {
-    // Defensive: bad refresh response or transient state can leave
-    // this.items as something other than an array. Don't crash render.
-    if (!Array.isArray(this.items)) return [];
-    const col = COLUMNS.find(c => c.sortKey === this.sortKey);
-    if (!col) return this.items;
-    const dir = this.sortDir === 'asc' ? 1 : -1;
-    const get = (r) => {
-      const v = r[col.sortKey];
-      if (v == null) return col.numeric ? -Infinity : '';
-      if (col.numeric) return Number(v);
-      if (col.date) return Date.parse(v) || 0;
-      return String(v).toLowerCase();
-    };
-    return [...this.items].sort((a, b) => {
-      const va = get(a), vb = get(b);
-      if (va < vb) return -1 * dir;
-      if (va > vb) return  1 * dir;
-      return 0;
-    });
+    return Array.isArray(this.items) ? this.items : [];
   }
 
   async _onDismiss(rec) {
@@ -416,7 +449,9 @@ export class JobRecommendationsTable extends LitElement {
     return html`
       <header class="recs-page__head">
         <h1>For You</h1>
-        <span class="muted">${rows.length} ${rows.length === 1 ? 'role' : 'roles'}</span>
+        <span class="muted">${this._total > rows.length
+          ? `${rows.length} of ${this._total} roles`
+          : `${rows.length} ${rows.length === 1 ? 'role' : 'roles'}`}</span>
         <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
                 title="Scan Gmail for new role alerts and application updates"
                 @click=${() => this._onRefresh()}>
@@ -436,6 +471,10 @@ export class JobRecommendationsTable extends LitElement {
             <thead>${this._renderHeader()}</thead>
             <tbody>${rows.map(r => this._renderRow(r))}</tbody>
           </table>
+          ${this._hasMore ? html`
+            <div class="recs-sentinel" aria-hidden="true"></div>
+            <div class="recs-loadmore muted">${this._loadingMore ? 'Loading more…' : ''}</div>
+          ` : nothing}
         </div>
       `}
       ${renderScoreModal(this.selectedRec, () => this._closeFitModal(), this.selectedScoreWhich || 'fit')}

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -152,8 +152,17 @@ export async function addRole({ url, title, company, sector, source, fromRecomme
 export async function fetchRecommendations(opts = {}) {
   const headers = await authHeader();
   // opts.view === 'all' → full list (no fit-score floor) for the
-  // "Recommended for you" page. Default is the carousel/widget view.
-  const url = opts.view === 'all' ? `${REC_URL}?view=all` : REC_URL;
+  // "Recommended for you" page, paginated via limit/offset + server-side
+  // sort. Default is the carousel/widget view (single 60-row pull).
+  let url = REC_URL;
+  if (opts.view === 'all') {
+    const qs = new URLSearchParams({ view: 'all' });
+    if (opts.limit  != null) qs.set('limit',  String(opts.limit));
+    if (opts.offset != null) qs.set('offset', String(opts.offset));
+    if (opts.sort)           qs.set('sort',   opts.sort);
+    if (opts.dir)            qs.set('dir',    opts.dir);
+    url = `${REC_URL}?${qs}`;
+  }
   const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`recommendations ${res.status}: ${await res.text()}`);
   return res.json();

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.3">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.4">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.3">
-  <script src="/job/js/theme.js?v=2.3.3"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <script src="/job/js/theme.js?v=2.3.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.3"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.7.0';
-console.log(`[recommendations] v${VERSION} - sourceHealth in GET (surface dead sources / gmail reauth)`);
+const VERSION = '0.8.0';
+console.log(`[recommendations] v${VERSION} - paginated view=all (limit/offset/sort/dir + total) for infinite scroll`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -26,6 +26,43 @@ serve(async (req) => {
       const url = new URL(req.url);
       const view = url.searchParams.get('view') || 'default';
       const isAll = view === 'all';
+
+      // Pagination (view=all only). The default carousel view stays a
+      // single 60-row pull. limit caps at 200; the table loads pages via
+      // infinite scroll and reads `total` to show "X of Y".
+      const limit = isAll
+        ? Math.min(200, Math.max(1, parseInt(url.searchParams.get('limit') || '100', 10) || 100))
+        : 60;
+      const offset = isAll ? Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0) : 0;
+
+      // Server-side sort — whitelist of sortable columns mapped to the
+      // table's sortKeys. Anything else falls back to fit_score. dir is
+      // validated to asc/desc. Both are safe to splice via sql.unsafe
+      // because they only ever come from these fixed sets.
+      const SORT_COLS: Record<string, string> = {
+        fitScore:    'r.fit_score',
+        title:       'r.title',
+        location:    'r.location',
+        source:      'r.source',
+        suggestedAt: 'r.suggested_at',
+      };
+      const sortCol = SORT_COLS[url.searchParams.get('sort') || ''] || 'r.fit_score';
+      const sortDir = (url.searchParams.get('dir') || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc';
+
+      // Shared filter — reused by the page query and the count so "X of Y"
+      // counts exactly what the list would show.
+      const whereClause = sql`
+        where r.dismissed_at is null
+          and r.added_to_pipeline_slug is null
+          and (${isAll} or r.fit_score is null or r.fit_score >= 50)
+          and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
+          and not exists (
+            select 1
+              from job.pipeline_roles p
+             where lower(p.company_name) = lower(r.company)
+               and lower(p.title) = lower(r.title)
+          )`;
+
       const rows = await sql`
         select r.id, r.source, r.source_label as "sourceLabel", r.url, r.company, r.title, r.location,
                r.salary, r.logo_url as "logoUrl", r.posted_at as "postedAt",
@@ -46,19 +83,16 @@ serve(async (req) => {
                     then 'https://mail.google.com/mail/u/0/#inbox/' || (r.payload->>'gmailApiId')
                     else null end as "sourceEmailUrl"
         from job.recommended_roles r
-        where r.dismissed_at is null
-          and r.added_to_pipeline_slug is null
-          and (${isAll} or r.fit_score is null or r.fit_score >= 50)
-          and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
-          and not exists (
-            select 1
-              from job.pipeline_roles p
-             where lower(p.company_name) = lower(r.company)
-               and lower(p.title) = lower(r.title)
-          )
-        order by r.fit_score desc nulls last, r.suggested_at desc
-        limit ${isAll ? 500 : 60};
+        ${whereClause}
+        order by ${sql.unsafe(sortCol)} ${sql.unsafe(sortDir)} nulls last, r.suggested_at desc
+        limit ${limit} offset ${offset};
       `;
+      // Total matching count — only needed for the paginated view.
+      let total = rows.length;
+      if (isAll) {
+        const [{ n }] = await sql`select count(*)::int as n from job.recommended_roles r ${whereClause}`;
+        total = n;
+      }
       // Source health — lets the UI tell "no new recs" apart from "a
       // source is dead". needs_reauth is true when the gmail-jobs source
       // errored with a token problem OR the scan-state row carries one.
@@ -85,7 +119,13 @@ serve(async (req) => {
       } catch (e) {
         console.warn(`[recommendations] sourceHealth failed: ${(e as Error).message}`);
       }
-      return jsonResp({ ok: true, version: VERSION, view, count: rows.length, recommendations: rows, sourceHealth });
+      return jsonResp({
+        ok: true, version: VERSION, view,
+        count: rows.length, total,
+        offset, limit,
+        hasMore: isAll && offset + rows.length < total,
+        recommendations: rows, sourceHealth,
+      });
     }
 
     if (req.method === 'POST') {


### PR DESCRIPTION
## Problem
The "For You" page fetched `recommendations?view=all` with a hard `limit 500` and sorted client-side. Once active recs passed 500 (they just did — 57 fresh Gmail roles pushed it over), the tail was **silently dropped**.

## Change
Server-side pagination + sort:
- **recommendations v0.8.0**: `view=all` accepts `limit` (≤200) / `offset` / `sort` / `dir`, returns `total` + `hasMore`. Shared WHERE fragment so the count matches the list exactly. `sort` is whitelisted (`fitScore`/`title`/`location`/`source`/`suggestedAt`), `dir` validated to asc/desc.
- **recs table**: accumulates pages, an IntersectionObserver sentinel (600px pre-fetch) loads the next page on scroll, column-sort re-fetches from offset 0 server-side, header shows "X of Y roles".
- `/job` app → v2.3.4.

Sorting moved server-side because you can't correctly sort a partial page client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)