### PR TITLE
job: make For You infinite scroll reliable (scroll listener)

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <script src="/job/js/theme.js?v=2.3.5"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.4";
-console.log(`[job] v${VERSION} - For You infinite scroll (server-side paginate + sort), no 500-row cap`);
+const VERSION = "2.3.5";
+console.log(`[job] v${VERSION} - For You infinite scroll via scroll listener (reliable across layouts)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -200,27 +200,34 @@ export class JobRecommendationsTable extends LitElement {
       this.requestUpdate();
     };
     document.addEventListener('job:gmail:connected', this._onGmailConnected);
+    // Infinite scroll: when the viewport nears the bottom of the document,
+    // pull the next page. A plain scroll listener is more reliable across
+    // layouts than an IntersectionObserver on a 1px sentinel.
+    this._onScroll = () => {
+      if (!this._hasMore || this._loadingMore) return;
+      const nearBottom = window.innerHeight + window.scrollY >= document.body.scrollHeight - 900;
+      if (nearBottom) this._loadMore();
+    };
+    window.addEventListener('scroll', this._onScroll, { passive: true });
+    window.addEventListener('resize', this._onScroll, { passive: true });
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('job:gmail:connected', this._onGmailConnected);
-    if (this._io) { this._io.disconnect(); this._io = null; }
+    window.removeEventListener('scroll', this._onScroll);
+    window.removeEventListener('resize', this._onScroll);
     super.disconnectedCallback();
   }
 
-  // Observe the bottom sentinel — when it scrolls into view, pull the next
-  // page. rootMargin pre-fetches ~600px early so scrolling stays smooth.
+  // After each render, if the page isn't tall enough to scroll yet there
+  // are more rows, pull another page so a short first page can't strand
+  // the rest (no scroll event would ever fire).
   updated() {
-    const sentinel = this.querySelector('.recs-sentinel');
-    if (!sentinel) return;
-    if (!this._io) {
-      this._io = new IntersectionObserver((entries) => {
-        if (entries.some(e => e.isIntersecting)) this._loadMore();
-      }, { rootMargin: '600px 0px' });
+    if (this._hasMore && !this._loadingMore &&
+        document.body.scrollHeight <= window.innerHeight + 100) {
+      this._loadMore();
     }
-    this._io.disconnect();
-    this._io.observe(sentinel);
   }
 
   async _maybeLoad() {

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.4">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.5">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.4">
-  <script src="/job/js/theme.js?v=2.3.4"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <script src="/job/js/theme.js?v=2.3.5"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.4"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #921. The IntersectionObserver on the 1px sentinel didn't reliably trip on scroll (verified: manual `_loadMore()` grew the list 100→200, so the fetch/append logic is correct — only the trigger was broken). Replaced with a passive window scroll + resize listener (loads next page within 900px of the bottom) and an `updated()` guard that auto-loads when the page is too short to scroll. /job → v2.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)