### PR TITLE
job: best-match ranking + candidate floor on For You (follow-ups 1-3) + ATS investigation

### DIFF
--- a/docs/execution/job-recs-scoring-followups.md
+++ b/docs/execution/job-recs-scoring-followups.md
@@ -1,10 +1,15 @@
 # Job Recs — Scoring & Enrichment Follow-ups
 
-Status: open investigation items. Logged 2026-06-16 during the Gmail→recs pipeline recovery. Not yet scheduled into the plan — use `/plan` to break these into stories when prioritized.
+Status: items 1-3 addressed 2026-06-16 (score-based ranking + candidate floor). Items 4-5 open. Use `/plan` to schedule the open ones.
+
+**Shipped 2026-06-16 (recommendations v0.9.0 + /job v2.3.6) — addresses items 1, 2, 3:**
+- **#3 ranking:** For You now defaults to a "best overall match" sort — `candidate_score*0.6 + fit_score*0.4` for graded rows, `fit_score*0.8` for un-graded — so strong responsibilities-matches surface first and un-graded high-fit roles can't dominate the top. Clicking a column header still switches to that explicit sort.
+- **#2 candidate floor:** graded rows with `candidate_score < 30` are dropped from the list (un-graded "verifying" rows are never dropped on this basis).
+- **#1 leakage:** addressed *via* #2/#3 — this is the score-based approach the item itself called the target end-state. The Nava-PBC ops/proposals roles (high company-fit, low responsibilities-match) now sink or drop once graded, rather than being gated by brittle title strings. The substring title gate was intentionally removed by the earlier "surface all recs" change; we are NOT re-adding it — ranking on the candidate (responsibilities) grade is the durable fix. Revisit only if un-graded leakage proves persistent.
 
 ---
 
-## 1. Title-filter leakage on greenlit companies (Nava PBC)
+## 1. Title-filter leakage on greenlit companies (Nava PBC) — ADDRESSED via #2/#3
 
 **Observation.** Roles from greenlit companies (e.g. Nava PBC) are getting past the job-title rules — surfacing titles that the title filter (`blocked_titles` / `target_titles` in `pull-recommendations`) should screen out. Symptom: a lot of **High Fit, Low Candidate** combos, where the heuristic fit score is high (company/domain/values match) but the Haiku candidate grade (roles & responsibilities match) is low.
 
@@ -67,6 +72,27 @@ Context for the above: ~half of Gmail/LinkedIn-sourced roles stay `enrichment_st
 On failure it backs off with `nextRetryAt` capped at **7 days**, so unresolved roles linger as VERIFYING for up to a week (kept on their `linkedin.com/comm/jobs/view/<id>` URL with no JD).
 
 **Highest-leverage fix (proposed, not yet built):** when ATS resolution fails, fetch the JD directly from the LinkedIn job page (the alert URL already in `url`) so candidate scoring can proceed without a canonical ATS match. Secondary: broaden ATS detection (Workday, etc.) and shorten the first-retry backoff (7d is too long for a fresh miss).
+
+### ATS-gap investigation (2026-06-16): where do unresolved companies actually list?
+
+Researched 16 currently-unresolved companies (all hiring PMs) to answer "do they have a durable listing beyond LinkedIn, and on what platform?" **Answer: yes — nearly all have a durable ATS-backed careers page.** Our detector (`detectAts` in `enrich-job-source/index.ts`) only probes **Greenhouse, Lever, Ashby** and guesses the slug from a normalized company name.
+
+Two distinct gaps:
+
+**A. Slug-guessing fails for companies that ARE on a supported ATS (higher ROI).** 8 of 16 are on Greenhouse/Lever/Ashby — which we already probe — yet stay unresolved, because `probeSlug` guesses the wrong slug from the company name:
+- Ashby (already supported): Ambience Healthcare → `ambiencehealthcare`, Ascertain → `ascertain`, Baseten → `baseten`, Benepass → `benepass`, BetterUp → `betterup`, Brain Co. → `brainco`
+- Greenhouse: BetterHelp → `betterhelpcom`
+- Lever: Beam (Benefits) → `beam`
+- **Fix:** extract the real ATS slug/URL from the email body (LinkedIn alerts often include the apply link), and/or generate better slug candidates (drop "Inc/Co/Health/Healthcare" suffixes, try concatenated + hyphenated + `…com` variants). This alone would resolve ~half the misses with no new providers.
+
+**B. Missing ATS providers.** Companies on platforms we don't probe at all:
+- **Workday** — Alteryx (`alteryx.wd5.myworkdayjobs.com`), Availity (`availity.wd1…`), Bonterra (`bonterra.wd1…`). Public JSON: `POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs`. Highest-value add (enterprise/healthcare default).
+- **Workable** — Applause (`apply.workable.com/applause-4`). Public: `apply.workable.com/api/v3/accounts/{slug}/jobs`.
+- Low ROI / no public API: UltiPro (Baylor Genetics), Gem (BioRender, `jobs.gem.com`), Phenom (Actalent).
+
+**Staffing-agency caveat:** Actalent is a staffing agency — the "company" is the recruiter, not the employer. These are fundamentally unresolvable and should be flagged/down-weighted, not retried.
+
+**Recommended build order:** (1) extract apply-URL from email body + stronger slug candidates → fixes gap A; (2) add Workday detector (covers the enterprise tail) → biggest chunk of gap B; (3) add Workable; (4) LinkedIn-JD fallback for the genuinely-unresolvable remainder so they can still be candidate-scored.
 
 **Already shipped (2026-06-16):**
 - Batched grading drain: `pull-recommendations?rescore=1&ungraded=1&limit=N` (v0.16.2) — grades only ungraded rows that have a JD, newest first.

--- a/docs/execution/job-recs-scoring-followups.md
+++ b/docs/execution/job-recs-scoring-followups.md
@@ -37,6 +37,25 @@ Status: open investigation items. Logged 2026-06-16 during the Gmail→recs pipe
 
 ---
 
+## 4. Duplicate entries — make a best-effort dedup to keep the list clean
+
+**Observation.** The recs list has visible duplicates (e.g. OpenAI PM roles, plus many others). A scan of active recs (`group by lower(company), lower(title) having count(*) > 1`) shows three distinct duplication modes:
+
+1. **Same LinkedIn job, different tracking params (most common).** The same posting appears 3-5× because the dedup keys on the full `url`, but LinkedIn alert URLs carry per-email `?trackingId=…&refId=…&eid=…` query strings that differ every send. Examples: Talently SPM (`/jobs/view/4405461200`) ×4, Curana SPM (`/jobs/view/4378986845`) ×3, BioRender Product Lead (`/jobs/view/4377259538`) ×3 — **same `/jobs/view/<id>`**, different query string.
+   → **Fix:** normalize LinkedIn URLs to canonical `linkedin.com/jobs/view/<id>` (strip query) before any dedup/insert.
+
+2. **Cross-source duplicates.** The same role arrives from multiple sources and all land, because insert-time dedup only checks `pipeline_roles`, not existing `recommended_roles`. Examples: Heidi "PM, Integrations" from `gmail-jobs` + `tracked-ats`; Collectly SPM from `gmail-jobs` + `theirstack`.
+   → **Fix:** dedup new inserts against existing active `recommended_roles` on a normalized key (canonical_url when resolved, else `lower(company)|lower(title)`), merging source labels rather than inserting a second row.
+
+3. **Same canonical posting via different resolved URLs.** Once enrichment resolves `canonical_url`, two rows that resolve to the same ATS posting should collapse into one.
+   → **Fix:** dedup/merge on `canonical_url` after enrichment resolves.
+
+**Note:** not every same-company/same-title cluster is a dupe — Heidi legitimately has many distinct openings. Key dedup on normalized URL / canonical posting id, with `(company,title)` as a secondary signal, not the sole key. Goal is best-effort cleanliness, not aggressive collapsing that hides real distinct roles.
+
+**Where:** `supabase/functions/pull-recommendations/index.ts` (insert/dedup path — currently only the `pipeline_roles` NOT EXISTS check), `gmail-jobs.ts` (`hasMultipleJobLinks` already normalizes `/jobs/view/<id>` — reuse that normalization for dedup keys), `recommended_roles` (consider a normalized-url unique index or a merge-on-insert).
+
+---
+
 ## Investigation finding: enrichment-resolution gap (the "VERIFYING" ceiling)
 
 Context for the above: ~half of Gmail/LinkedIn-sourced roles stay `enrichment_status='unresolved'` ("VERIFYING") and therefore **cannot be candidate-scored** (Haiku grading needs a JD).

--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <script src="/job/js/theme.js?v=2.3.6"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.5";
-console.log(`[job] v${VERSION} - For You infinite scroll via scroll listener (reliable across layouts)`);
+const VERSION = "2.3.6";
+console.log(`[job] v${VERSION} - For You default ranks by best overall match (candidate+fit blend)`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -75,8 +75,10 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'idle';
     this.items = [];
     this.error = '';
-    // Default: same order as the widget (fit score desc).
-    this.sortKey = 'fitScore';
+    // Default: server-side "best overall match" ranking — a blend of the
+    // Haiku candidate grade and heuristic fit (see recommendations fn).
+    // Clicking a column header switches to that explicit server sort.
+    this.sortKey = 'best';
     this.sortDir = 'desc';
     this.addingId = null;
     this.selectedRec = null;

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.5">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.6">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.5">
-  <script src="/job/js/theme.js?v=2.3.5"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <script src="/job/js/theme.js?v=2.3.6"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.5"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.8.0';
-console.log(`[recommendations] v${VERSION} - paginated view=all (limit/offset/sort/dir + total) for infinite scroll`);
+const VERSION = '0.9.0';
+console.log(`[recommendations] v${VERSION} - default 'best' blended rank (candidate+fit) + candidate-score floor (drop graded <30)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -36,9 +36,8 @@ serve(async (req) => {
       const offset = isAll ? Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0) : 0;
 
       // Server-side sort — whitelist of sortable columns mapped to the
-      // table's sortKeys. Anything else falls back to fit_score. dir is
-      // validated to asc/desc. Both are safe to splice via sql.unsafe
-      // because they only ever come from these fixed sets.
+      // table's sortKeys. dir is validated to asc/desc. Both are safe to
+      // splice via sql.unsafe because they only come from these fixed sets.
       const SORT_COLS: Record<string, string> = {
         fitScore:    'r.fit_score',
         title:       'r.title',
@@ -46,8 +45,26 @@ serve(async (req) => {
         source:      'r.source',
         suggestedAt: 'r.suggested_at',
       };
-      const sortCol = SORT_COLS[url.searchParams.get('sort') || ''] || 'r.fit_score';
+      // Follow-up #3 — default "best overall match" ranking. Blend the
+      // Haiku candidate grade (responsibilities match — what the user
+      // actually cares about) with heuristic fit, weighted toward
+      // candidate. Ungraded rows fall back to fit with a 0.8 discount so a
+      // graded-strong role outranks an un-graded high-fit one (the
+      // Nava-PBC "high fit, no/low candidate" leakage). When the user
+      // clicks a column header the explicit column wins.
+      const BLENDED_RANK =
+        `(case when r.candidate_score is not null
+               then (r.candidate_score * 0.6 + coalesce(r.fit_score,0) * 0.4)
+               else coalesce(r.fit_score,0) * 0.8 end)`;
+      const sortParam = url.searchParams.get('sort') || 'best';
+      const sortExpr = SORT_COLS[sortParam] || BLENDED_RANK;
       const sortDir = (url.searchParams.get('dir') || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc';
+
+      // Follow-up #2 — candidate-score low-end threshold. Drop roles the
+      // Haiku grader scored as a clearly weak responsibilities match
+      // (< 30). Only applies to GRADED rows — un-graded (candidate_score
+      // null, still "verifying") rows are never dropped on this basis.
+      const CANDIDATE_FLOOR = 30;
 
       // Shared filter — reused by the page query and the count so "X of Y"
       // counts exactly what the list would show.
@@ -56,6 +73,7 @@ serve(async (req) => {
           and r.added_to_pipeline_slug is null
           and (${isAll} or r.fit_score is null or r.fit_score >= 50)
           and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
+          and not (r.candidate_score is not null and r.candidate_score < ${CANDIDATE_FLOOR})
           and not exists (
             select 1
               from job.pipeline_roles p
@@ -84,7 +102,7 @@ serve(async (req) => {
                     else null end as "sourceEmailUrl"
         from job.recommended_roles r
         ${whereClause}
-        order by ${sql.unsafe(sortCol)} ${sql.unsafe(sortDir)} nulls last, r.suggested_at desc
+        order by ${sql.unsafe(sortExpr)} ${sql.unsafe(sortDir)} nulls last, r.suggested_at desc
         limit ${limit} offset ${offset};
       `;
       // Total matching count — only needed for the paginated view.


### PR DESCRIPTION
Fixes the three scoring follow-ups and logs the ATS-gap investigation.

## Follow-ups 1-3 (shipped)
- **#3 ranking** — For You defaults to a blended *best overall match* sort: `candidate_score*0.6 + fit_score*0.4` (graded), `fit_score*0.8` (un-graded). Strong responsibilities-matches surface first; un-graded high-fit can't dominate the top. Column clicks still switch to explicit sorts. `recommendations` v0.9.0, `/job` v2.3.6.
- **#2 candidate floor** — drop graded rows with `candidate_score < 30` (un-graded "verifying" rows never dropped). Distribution showed a clean weak tail below 30.
- **#1 leakage** — addressed *via* #2/#3 (the score-based end-state the item itself called for). Nava-PBC ops/proposals roles (high company-fit, low responsibilities-match) now sink/drop once graded instead of being gated by brittle title strings.

## ATS-gap investigation (logged, not built)
Researched 16 unresolved companies. **Two gaps:**
- **(A, higher ROI)** slug-guessing fails for companies *already on* Greenhouse/Lever/Ashby (8 of 16 — Ambience, Baseten, Benepass, BetterUp, BetterHelp, Beam…). Fix: extract the apply-URL from the email body + stronger slug candidates.
- **(B)** missing providers — **Workday** (Alteryx/Availity/Bonterra) and **Workable** (Applause) have public APIs; UltiPro/Gem/Phenom don't. Actalent is a staffing agency (unresolvable).

Full detail + recommended build order in `docs/execution/job-recs-scoring-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)