### PR TITLE
job: pre-fetch dedup in gmail-jobs (cheap re-list/backfill)

### DIFF
--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -180,8 +180,32 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
     // we can stamp the Ladder label at end-of-pull in one batch call.
     const labelTargets: string[] = [];
 
+    // Pre-fetch dedup set — every Gmail API id we've already processed
+    // (emitted a rec for, or logged as skipped), loaded in TWO queries up
+    // front. The per-message dedup below keys on the Message-ID header,
+    // which needs a full getMessage first — so re-list/backfill runs over
+    // a window of mostly-processed mail used to re-download the whole
+    // window and time out before reaching new messages. Skipping on the
+    // raw id BEFORE getMessage makes those runs cheap and lets a backlog
+    // actually drain across successive ticks.
+    const processedIds = new Set<string>();
+    {
+      const recRows = await sql<{ gid: string | null }[]>`
+        select distinct payload->>'gmailApiId' as gid
+          from job.recommended_roles
+         where source = 'gmail-jobs' and payload ? 'gmailApiId'`;
+      for (const r of recRows) if (r.gid) processedIds.add(r.gid);
+      const skipRows = await sql<{ gmail_id: string | null }[]>`
+        select distinct gmail_id from job.gmail_skipped
+         where user_email = ${ctx.userEmail} and gmail_id is not null`;
+      for (const r of skipRows) if (r.gmail_id) processedIds.add(r.gmail_id);
+    }
+
     for (const id of ids) {
       if (newWork >= maxMessages) { cappedRun = true; break; }
+      // Cheap skip: already processed this Gmail message in a prior run.
+      // Avoids the getMessage body download + Haiku on re-list/backfill.
+      if (processedIds.has(id)) continue;
       let msg: GmailMessage;
       try {
         msg = await getMessage(accessToken, id, 'full');

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.16.2';
-console.log(`[pull-recommendations] v${VERSION} - targeted grading drain (?rescore=1&ungraded=1&limit=N) for batched candidate scoring`);
+const VERSION = '0.16.3';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs pre-fetch dedup on raw id (cheap re-list/backfill, no re-download)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Scan loop deduped on the Message-ID header (needs a full getMessage first), so re-list/backfill runs re-downloaded the whole window before reaching new mail and 504'd. Now preload processed Gmail API ids (2 queries) and skip on the raw id before fetching. Unblocks the 30-day backfill. v0.16.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)