### PR TITLE
job: dedup new recs vs existing (#4) + backlog items 6-7

### DIFF
--- a/docs/execution/job-recs-scoring-followups.md
+++ b/docs/execution/job-recs-scoring-followups.md
@@ -61,6 +61,41 @@ Status: items 1-3 addressed 2026-06-16 (score-based ranking + candidate floor). 
 
 ---
 
+## 6. Use the decline signal from "For You" (we log it; we don't use it)
+
+**Question raised:** are we logging all the roles I decline in For You? **Yes** — dismissing a rec sets `recommended_roles.dismissed_at = now()` and the row persists with full data (company, title, fit_score, candidate_score, breakdown). As of 2026-06-16 there are **243 dismissed roles** spanning 2026-05-09 → today. So the data exists and is queryable.
+
+**The gap:** we capture the dismissal *event* but (a) no **reason**, and (b) we don't **use** it. This is high-value negative-preference data — "what roles Ian doesn't like."
+
+**Proposed:**
+- Optional lightweight reason on dismiss (e.g. quick chips: wrong role / wrong domain / wrong seniority / comp / location / not interested). UI: `job-recommendations-table` dismiss button → small reason popover; store `dismissed_reason`.
+- A "what you decline" analysis (cluster dismissed roles by domain/title/seniority) to surface patterns.
+- Feed the signal back into scoring/preferences: recurring dismissed titles → suggest `vision.blocked_titles`; dismissed-domain skew → down-weight; or a learned negative-preference term in `fit.ts`. Closes the loop with follow-up #1 (move filtering toward responsibilities/preference signal, not title strings).
+
+**Where:** `recommendations/index.ts` (dismiss POST — add `dismissed_reason`), `job-recommendations-table.js` (reason UI), a new analysis surface (could live on `/job/vision` or a settings insight).
+
+---
+
+## 7. Capture Jack & Jill curated roles (high-value, not currently ingested)
+
+**What:** [Jack & Jill](https://www.jackandjill.ai/) is an AI recruiting platform (raised $20M seed, 2025). "Jack" is a candidate-side AI agent that interviews the user and emails **curated, comp-included, pre-matched roles** — i.e. a similar product to what /job is building, already doing the matching + scoring. Emails come from **`jack@jackandjill.ai`** (to `fikei@uw.edu`, same connected inbox). Example subjects: "Role details: Hinge Health, Roger, Sailor, Abridge, Everlywell, Luro + more"; "Following up: Healthtech roles and a new Director of Product lead"; "Deep dive: Paraform, Protagonist, Incredible Health".
+
+**Why high value:**
+- Human+AI-curated roles with **salary** ($232k–$320k base + equity), location, stage — richer than LinkedIn alerts.
+- Each digest has a **"TOP PICKS YOU'VE LIKED"** section = explicit *positive*-preference signal (pairs with item 6's negative signal).
+- These are already filtered to Ian's healthtech / zero-to-one sweet spot by a peer product.
+
+**Are we capturing them? No.** `DEFAULT_ALLOW_SENDERS` in `gmail-jobs.ts` covers linkedin/wellfound/otta/builtin/yc/hnhiring/workatastartup — **not `@jackandjill.ai`** — so these are silently skipped (out-of-allowlist).
+
+**Proposed:**
+- Add `@jackandjill.ai` to the allowlist.
+- The format is **conversational prose with multiple roles + comp**, not clean `/jobs/view/<id>` links — route to the Haiku multi-extractor (`extractJobsMulti`) with a prompt variant tuned for this digest shape (extract company, title, comp, location, and the like/recommended status per role).
+- Mine the "roles you've liked" as explicit positive-preference signal into vision/preferences and the candidate scorer.
+
+**Where:** `gmail-jobs.ts` (`DEFAULT_ALLOW_SENDERS`, `looksLikeDigest`/`hasMultipleJobLinks`, `extractJobsMulti` prompt), preference plumbing for the like-signal.
+
+---
+
 ## Investigation finding: enrichment-resolution gap (the "VERIFYING" ceiling)
 
 Context for the above: ~half of Gmail/LinkedIn-sourced roles stay `enrichment_status='unresolved'` ("VERIFYING") and therefore **cannot be candidate-scored** (Haiku grading needs a JD).

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.16.3';
-console.log(`[pull-recommendations] v${VERSION} - gmail-jobs pre-fetch dedup on raw id (cheap re-list/backfill, no re-download)`);
+const VERSION = '0.17.0';
+console.log(`[pull-recommendations] v${VERSION} - dedup new recs vs existing (normalized LinkedIn url / canonical / company|title)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -331,11 +331,46 @@ serve(async (req) => {
          where company_name is not null and title is not null
       `;
       const pipelineSet = new Set(pipelineKeys.map(r => r.key));
-      const filtered = kept.filter(r => {
+      const pipeFiltered = kept.filter(r => {
         const k = `${(r.input.company || '').toLowerCase()}|${(r.input.title || '').toLowerCase()}`;
         return !pipelineSet.has(k);
       });
-      const droppedToPipeline = kept.length - filtered.length;
+      const droppedToPipeline = kept.length - pipeFiltered.length;
+      // Follow-up #4 — dedup against EXISTING active recs (the on-conflict
+      // in insertNew only catches an identical source+source_id). Catches:
+      //   - same LinkedIn job re-sent with different ?trackingId (we key on
+      //     the normalized /jobs/view/<id>, not the raw url)
+      //   - the same canonical ATS posting (canonical_url)
+      //   - the same role arriving from a second source (company|title)
+      // Also dedups within this batch. Conservative: URL/canonical match is
+      // exact; company|title requires BOTH to match so Heidi's genuinely
+      // distinct openings (different titles) aren't collapsed.
+      const existing = await sql<{ url: string | null; canonical_url: string | null; company: string | null; title: string | null }[]>`
+        select url, canonical_url, company, title
+          from job.recommended_roles
+         where dismissed_at is null and added_to_pipeline_slug is null
+      `;
+      const seenKeys = new Set<string>();
+      const addKeys = (url: string | null, canonical: string | null, company: string | null, title: string | null) => {
+        const nu = normalizeJobUrl(canonical || url || '');
+        if (nu) seenKeys.add('u:' + nu);
+        if (company && title) seenKeys.add('ct:' + company.toLowerCase().trim() + '|' + title.toLowerCase().trim());
+      };
+      const hitsKey = (url: string | null, canonical: string | null, company: string | null, title: string | null) => {
+        const nu = normalizeJobUrl(canonical || url || '');
+        if (nu && seenKeys.has('u:' + nu)) return true;
+        if (company && title && seenKeys.has('ct:' + company.toLowerCase().trim() + '|' + title.toLowerCase().trim())) return true;
+        return false;
+      };
+      for (const e of existing) addKeys(e.url, e.canonical_url, e.company, e.title);
+      const filtered = pipeFiltered.filter(r => {
+        if (hitsKey(r.input.url, r.input.canonicalUrl ?? null, r.input.company ?? null, r.input.title ?? null)) return false;
+        // accept — register its keys so a later row in THIS batch dedups too
+        addKeys(r.input.url, r.input.canonicalUrl ?? null, r.input.company ?? null, r.input.title ?? null);
+        return true;
+      });
+      const droppedAsDup = pipeFiltered.length - filtered.length;
+      if (droppedAsDup > 0) console.log(`[pull-recommendations] dropped ${droppedAsDup} duplicate(s) vs existing/within-batch`);
       const inserted = await insertNew(sql, src, filtered);
       // Productize the v3 fit pipeline: every NEW recommendation gets a
       // JD fetch (if the plugin didn't provide one) + Haiku-graded role
@@ -623,6 +658,32 @@ function toRoleRow(r: RecommendedRoleInput): RoleRow {
 
 // ---------- Insert ----------
 
+// Normalize a job URL into a stable dedup key. LinkedIn alert URLs carry
+// per-email tracking params (?trackingId/refId/eid) that differ every send,
+// so the same posting otherwise looks unique — collapse to the canonical
+// /jobs/view/<id>. For other hosts, drop the query and trailing slash and
+// lowercase. Returns '' for empty input.
+function normalizeJobUrl(u: string): string {
+  if (!u) return '';
+  const li = u.match(/linkedin\.com\/(?:comm\/)?jobs\/view\/(\d+)/i);
+  if (li) return `linkedin.com/jobs/view/${li[1]}`;
+  try {
+    const url = new URL(u);
+    return (url.host + url.pathname).toLowerCase().replace(/\/+$/, '');
+  } catch {
+    return u.toLowerCase().trim();
+  }
+}
+
+// For storage: collapse a LinkedIn tracking URL to its clean canonical form
+// (still resolves, far shorter, dedup-stable). Non-LinkedIn URLs untouched
+// so apply links that depend on query params keep working.
+function cleanStoredUrl(u: string): string {
+  if (!u) return u;
+  const li = u.match(/linkedin\.com\/(?:comm\/)?jobs\/view\/(\d+)/i);
+  return li ? `https://www.linkedin.com/jobs/view/${li[1]}/` : u;
+}
+
 async function insertNew(
   sql: ReturnType<typeof db>,
   src: UserSourceRow,
@@ -635,7 +696,7 @@ async function insertNew(
     source:         r.input.source,
     source_id:      r.input.sourceId,
     source_label:   r.input.sourceLabel ?? null,
-    url:            r.input.url,
+    url:            cleanStoredUrl(r.input.url),
     company:        r.input.company ?? null,
     title:          r.input.title ?? null,
     location:       r.input.location ?? null,


### PR DESCRIPTION
## #4 Dedup
`insertNew` only deduped on identical `(source, source_id)`, so re-sent LinkedIn alerts (different `?trackingId`), the same canonical ATS posting, and the same role from a second source all landed as duplicates.

- `normalizeJobUrl()` — collapse LinkedIn URLs to canonical `/jobs/view/<id>`; host+path for others.
- Pull loop dedups new recs vs existing active recs + within batch, keyed on normalized url / canonical_url / exact company|title (conservative — both company AND title must match, so distinct openings aren't collapsed).
- `cleanStoredUrl()` stores LinkedIn recs as the clean canonical URL.
- (Existing duplicate rows cleaned up separately via SQL.)

## Backlog logged
- **#6** use the decline signal — we log `dismissed_at` (243 rows) but capture no reason and don't use it. Feed negative-preference back into scoring.
- **#7** capture **Jack & Jill** (`jack@jackandjill.ai`) curated roles — comp-included, pre-matched, with an explicit *roles you've liked* positive signal. Not ingested today (sender not allowlisted); needs the Haiku multi-extractor for the prose digest format.

v0.17.0. Full detail in `docs/execution/job-recs-scoring-followups.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)