### PR TITLE
job: tracked-ats captures the JD so its roles can be candidate-scored

### DIFF
--- a/supabase/functions/_shared/sources/tracked-ats.ts
+++ b/supabase/functions/_shared/sources/tracked-ats.ts
@@ -18,15 +18,34 @@ interface TrackedCompany {
   sector: string | null;
 }
 
+// Strip HTML to plain text for the JD body. Greenhouse/Ashby return the
+// description as HTML; Lever offers a plain variant we prefer when present.
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 // ---------- Per-ATS adapters ----------
 // Each returns the same RecommendedRoleInput shape so the worker
 // downstream is ATS-agnostic.
 
 async function pullGreenhouse(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
-  const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(c.ats_slug!)}/jobs`;
+  // ?content=true returns each posting's HTML body so we can store the JD —
+  // without it the role lands with no description and can never be graded.
+  const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(c.ats_slug!)}/jobs?content=true`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`greenhouse ${c.ats_slug} → ${res.status}`);
-  const data = await res.json() as { jobs: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string } }> };
+  const data = await res.json() as { jobs: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string }; content?: string }> };
   return (data.jobs || []).map(j => ({
     source:      'tracked-ats',
     sourceId:    `gh:${c.ats_slug}:${j.id}`,
@@ -35,6 +54,7 @@ async function pullGreenhouse(c: TrackedCompany): Promise<RecommendedRoleInput[]
     company:     c.name,
     title:       j.title,
     location:    j.location?.name,
+    description: stripHtml(j.content || '') || undefined,
     postedAt:    j.updated_at,
     payload:     { ats: 'Greenhouse', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));
@@ -44,7 +64,7 @@ async function pullLever(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
   const url = `https://api.lever.co/v0/postings/${encodeURIComponent(c.ats_slug!)}?mode=json`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`lever ${c.ats_slug} → ${res.status}`);
-  const data = await res.json() as Array<{ id: string; text: string; hostedUrl: string; createdAt: number; categories?: { location?: string } }>;
+  const data = await res.json() as Array<{ id: string; text: string; hostedUrl: string; createdAt: number; categories?: { location?: string }; descriptionPlain?: string; description?: string }>;
   return (data || []).map(j => ({
     source:      'tracked-ats',
     sourceId:    `lever:${c.ats_slug}:${j.id}`,
@@ -53,6 +73,7 @@ async function pullLever(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
     company:     c.name,
     title:       j.text,
     location:    j.categories?.location,
+    description: (j.descriptionPlain || stripHtml(j.description || '')) || undefined,
     postedAt:    j.createdAt ? new Date(j.createdAt).toISOString() : undefined,
     payload:     { ats: 'Lever', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));
@@ -62,7 +83,7 @@ async function pullAshby(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
   const url = `https://api.ashbyhq.com/posting-api/job-board/${encodeURIComponent(c.ats_slug!)}?includeCompensation=true`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`ashby ${c.ats_slug} → ${res.status}`);
-  const data = await res.json() as { jobs?: Array<{ id: string; title: string; jobUrl: string; publishedAt?: string; locationName?: string; compensationTierSummary?: string }> };
+  const data = await res.json() as { jobs?: Array<{ id: string; title: string; jobUrl: string; publishedAt?: string; locationName?: string; compensationTierSummary?: string; descriptionPlain?: string; descriptionHtml?: string }> };
   return (data.jobs || []).map(j => ({
     source:      'tracked-ats',
     sourceId:    `ashby:${c.ats_slug}:${j.id}`,
@@ -72,6 +93,7 @@ async function pullAshby(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
     title:       j.title,
     location:    j.locationName,
     salary:      j.compensationTierSummary,
+    description: (j.descriptionPlain || stripHtml(j.descriptionHtml || '')) || undefined,
     postedAt:    j.publishedAt,
     payload:     { ats: 'Ashby', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.18.0';
-console.log(`[pull-recommendations] v${VERSION} - ingest Jack & Jill curated roles (prose multi-extract, comp, no per-role url)`);
+const VERSION = '0.19.0';
+console.log(`[pull-recommendations] v${VERSION} - tracked-ats captures JD; backfill JD into existing JD-less rows on re-pull`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -371,7 +371,12 @@ serve(async (req) => {
       });
       const droppedAsDup = pipeFiltered.length - filtered.length;
       if (droppedAsDup > 0) console.log(`[pull-recommendations] dropped ${droppedAsDup} duplicate(s) vs existing/within-batch`);
-      const inserted = await insertNew(sql, src, filtered);
+      const upserted = await insertNew(sql, src, filtered);
+      // Only genuinely-new rows go through inline enrich+grade. Rows that
+      // were conflict-updated to backfill a missing JD are drained by the
+      // grade-ungraded cron instead — inline-grading a whole tracked-ats
+      // re-pull (hundreds of backfills) would time out the run.
+      const inserted = upserted.filter(r => r.isNew);
       // Productize the v3 fit pipeline: every NEW recommendation gets a
       // JD fetch (if the plugin didn't provide one) + Haiku-graded role
       // match + a v3 rescore using the structured fields. Cron pulls feed
@@ -688,7 +693,7 @@ async function insertNew(
   sql: ReturnType<typeof db>,
   src: UserSourceRow,
   rows: ScoredRow[],
-): Promise<Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null }>> {
+): Promise<Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null; isNew: boolean }>> {
   if (!rows.length) return [];
   const values = rows.map(r => ({
     user_email:     src.user_email,
@@ -715,12 +720,23 @@ async function insertNew(
     canonical_url:       r.input.canonicalUrl       ?? null,
     company_id:          r.input.companyId          ?? null,
   }));
+  // on conflict: backfill the JD (and salary) into an existing row that
+  // landed without one — e.g. tracked-ats roles created before the adapter
+  // captured descriptions. Only when the existing row lacks a real JD and
+  // the new pull has one, so we never overwrite good data. `xmax = 0`
+  // distinguishes a fresh insert from a backfill-update so the caller only
+  // inline-grades genuinely new rows (the grade-ungraded cron drains the
+  // backfilled ones — re-grading hundreds at once would time out the run).
   const inserted = await sql`
     insert into job.recommended_roles ${sql(values)}
-    on conflict (source, source_id) do nothing
-    returning id, company, title, url, fit_score as "fitScore", fit_breakdown as "breakdown", payload
+    on conflict (source, source_id) do update
+       set description = excluded.description,
+           salary      = coalesce(job.recommended_roles.salary, excluded.salary)
+     where coalesce(length(job.recommended_roles.description), 0) < 200
+       and coalesce(length(excluded.description), 0) >= 200
+    returning id, company, title, url, fit_score as "fitScore", fit_breakdown as "breakdown", payload, (xmax = 0) as "isNew"
   `;
-  return inserted as unknown as Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null }>;
+  return inserted as unknown as Array<{ id: string; company: string | null; title: string | null; url: string; fitScore: number; breakdown: Record<string, number>; payload: Record<string, unknown> | null; isNew: boolean }>;
 }
 
 // ---------- Bullet generation ----------


### PR DESCRIPTION
tracked-ats was the biggest candidate-score gap — **192 of 216** active roles landed with no description, so they could never be graded (`c —` forever). The ATS list endpoints already return the JD; we just weren't capturing it.

- Greenhouse adapter → `?content=true` + store stripped content; Lever/Ashby → `descriptionPlain`.
- `insertNew` on_conflict backfills description+salary into existing JD-less rows on re-pull (guarded: only when existing <200 and new ≥200 — never overwrites good data).
- `(xmax = 0)` inline-grades only genuinely-new rows; backfills drain via the grade-ungraded cron.

v0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)