### PR TITLE
job: fix tracked-ats OOM from JD capture (v0.19.1)

### DIFF
--- a/supabase/functions/_shared/sources/tracked-ats.ts
+++ b/supabase/functions/_shared/sources/tracked-ats.ts
@@ -40,12 +40,14 @@ function stripHtml(html: string): string {
 // downstream is ATS-agnostic.
 
 async function pullGreenhouse(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
-  // ?content=true returns each posting's HTML body so we can store the JD —
-  // without it the role lands with no description and can never be graded.
-  const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(c.ats_slug!)}/jobs?content=true`;
+  // NOTE: do NOT use ?content=true here — it returns the full HTML body for
+  // EVERY posting at EVERY tracked company, which blows the edge function's
+  // memory budget (WORKER_RESOURCE_LIMIT 546). Greenhouse roles get their JD
+  // lazily via enrichAndScoreNewRows/grading (per-role fetchJdText) instead.
+  const url = `https://boards-api.greenhouse.io/v1/boards/${encodeURIComponent(c.ats_slug!)}/jobs`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`greenhouse ${c.ats_slug} → ${res.status}`);
-  const data = await res.json() as { jobs: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string }; content?: string }> };
+  const data = await res.json() as { jobs: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string } }> };
   return (data.jobs || []).map(j => ({
     source:      'tracked-ats',
     sourceId:    `gh:${c.ats_slug}:${j.id}`,
@@ -54,10 +56,16 @@ async function pullGreenhouse(c: TrackedCompany): Promise<RecommendedRoleInput[]
     company:     c.name,
     title:       j.title,
     location:    j.location?.name,
-    description: stripHtml(j.content || '') || undefined,
     postedAt:    j.updated_at,
     payload:     { ats: 'Greenhouse', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));
+}
+
+// JD bodies can be many KB; cap so accumulating a few hundred roles across
+// all tracked companies stays well under the function memory limit.
+function capJd(s: string): string | undefined {
+  const t = (s || '').trim();
+  return t ? t.slice(0, 5000) : undefined;
 }
 
 async function pullLever(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
@@ -73,7 +81,7 @@ async function pullLever(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
     company:     c.name,
     title:       j.text,
     location:    j.categories?.location,
-    description: (j.descriptionPlain || stripHtml(j.description || '')) || undefined,
+    description: capJd(j.descriptionPlain || stripHtml(j.description || '')),
     postedAt:    j.createdAt ? new Date(j.createdAt).toISOString() : undefined,
     payload:     { ats: 'Lever', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));
@@ -93,7 +101,7 @@ async function pullAshby(c: TrackedCompany): Promise<RecommendedRoleInput[]> {
     title:       j.title,
     location:    j.locationName,
     salary:      j.compensationTierSummary,
-    description: (j.descriptionPlain || stripHtml(j.descriptionHtml || '')) || undefined,
+    description: capJd(j.descriptionPlain || stripHtml(j.descriptionHtml || '')),
     postedAt:    j.publishedAt,
     payload:     { ats: 'Ashby', companySlug: c.slug, atsSlug: c.ats_slug, jobId: j.id },
   }));

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.19.0';
-console.log(`[pull-recommendations] v${VERSION} - tracked-ats captures JD; backfill JD into existing JD-less rows on re-pull`);
+const VERSION = '0.19.1';
+console.log(`[pull-recommendations] v${VERSION} - tracked-ats JD capture w/o OOM (no greenhouse content=true; cap lever/ashby JD)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
v0.19.0's Greenhouse `?content=true` loaded the full HTML of every posting at every tracked company at once → HTTP 546 WORKER_RESOURCE_LIMIT, so the pull crashed and no JDs backfilled. Drop the heavy Greenhouse content fetch (those JDs come lazily via grading) and cap Lever/Ashby descriptions at 5k. v0.19.1.