### PR TITLE
job: For You UX — Fit/Strength columns, multi-level sort, hide-company

### DIFF
--- a/job/chat/index.html
+++ b/job/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/job/css/components.css
+++ b/job/css/components.css
@@ -2562,8 +2562,51 @@
 
 /* Columns specific to the recs table — sizes mirror existing pipeline
    col-* declarations (around line 2500). */
+.pipeline-table .col-fit      { width: 64px; white-space: nowrap; }
+.pipeline-table .col-strength { width: 78px; white-space: nowrap; }
 .pipeline-table .col-location { width: 14%; min-width: 120px; color: var(--text-muted); }
 .pipeline-table .col-added    { width: 88px;  white-space: nowrap; color: var(--text-muted); }
+
+/* Multi-level sort: small rank badge next to the arrow (1 = primary). */
+.th-sort__rank {
+  display: inline-block;
+  margin-left: 2px;
+  min-width: 13px;
+  padding: 0 3px;
+  font-size: 10px;
+  line-height: 13px;
+  text-align: center;
+  border-radius: 7px;
+  background: var(--accent);
+  color: var(--on-accent, #fff);
+}
+.recs-page__clearsort { align-self: center; font-size: var(--font-size-caption); }
+
+/* Row triple-dot menu ("Don't recommend this company" etc.). */
+.row-menu { position: relative; display: inline-flex; }
+.row-menu__trigger {
+  border: none; background: none; cursor: pointer;
+  color: var(--text-muted); font-size: 18px; line-height: 1;
+  padding: 2px 6px; border-radius: var(--radius-sm);
+}
+.row-menu__trigger:hover { color: var(--text); background: var(--surface-2, rgba(127,127,127,.12)); }
+.row-menu__pop {
+  position: absolute; top: 100%; right: 0; z-index: 30;
+  margin-top: 4px; min-width: 220px;
+  background: var(--surface, #fff);
+  border: 1px solid var(--border, rgba(127,127,127,.25));
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0,0,0,.18);
+  padding: 4px;
+}
+.row-menu__item {
+  display: block; width: 100%; text-align: left;
+  border: none; background: none; cursor: pointer;
+  padding: 8px 10px; border-radius: var(--radius-sm);
+  font-size: var(--font-size-body-sm); color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-menu__item:hover { background: var(--surface-2, rgba(127,127,127,.12)); }
 
 .rec-source {
   font-size: var(--font-size-body-sm);

--- a/job/history/drill/index.html
+++ b/job/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 
 
 

--- a/job/history/index.html
+++ b/job/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 
 
 

--- a/job/index.html
+++ b/job/index.html
@@ -9,8 +9,8 @@
   <title>/job — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 
 
 

--- a/job/jobs/drill/index.html
+++ b/job/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
   <link rel="stylesheet" href="/job/css/apply.css?v=0.6.0">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <script src="/job/js/theme.js?v=2.3.7"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 
 
 

--- a/job/jobs/index.html
+++ b/job/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/job/jobs/recommended/index.html
+++ b/job/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/job/js/app.js
+++ b/job/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /job/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.3.6";
-console.log(`[job] v${VERSION} - For You default ranks by best overall match (candidate+fit blend)`);
+const VERSION = "2.3.7";
+console.log(`[job] v${VERSION} - For You: Fit + Strength columns, multi-level sort, hide-company menu`);
 window.JOB_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/job/js/components/job-recommendations-table.js
+++ b/job/js/components/job-recommendations-table.js
@@ -8,7 +8,7 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./job-fit-modal.js' + V),
@@ -17,7 +17,8 @@ const [{ fetchRecommendations, dismissRecommendation, addRole, refreshSources },
 // Column shape mirrors job-pipeline's COLUMNS: id drives the col class,
 // sortKey gates sortability, label is what the header shows.
 const COLUMNS = [
-  { id: 'fit',      label: 'Fit',      sortKey: 'fitScore',    numeric: true },
+  { id: 'fit',      label: 'Fit',      sortKey: 'fitScore',       numeric: true },
+  { id: 'strength', label: 'Strength', sortKey: 'candidateScore', numeric: true },
   { id: 'role',     label: 'Role',     sortKey: 'title' },
   { id: 'location', label: 'Location', sortKey: 'location' },
   { id: 'sector',   label: 'Source',   sortKey: 'source' },
@@ -56,8 +57,8 @@ export class JobRecommendationsTable extends LitElement {
     state:    { state: true },
     items:    { state: true },
     error:    { state: true },
-    sortKey:  { state: true },
-    sortDir:  { state: true },
+    _sortLayers: { state: true },
+    _menuOpenId: { state: true },
     addingId: { state: true },
     selectedRec:         { state: true },
     selectedScoreWhich:  { state: true },
@@ -75,11 +76,12 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'idle';
     this.items = [];
     this.error = '';
-    // Default: server-side "best overall match" ranking — a blend of the
-    // Haiku candidate grade and heuristic fit (see recommendations fn).
-    // Clicking a column header switches to that explicit server sort.
-    this.sortKey = 'best';
-    this.sortDir = 'desc';
+    // Multi-level sort stack (Google-Sheets style): most-significant layer
+    // first. Empty → the server's "best overall match" blended ranking.
+    // Clicking a header pushes/toggles that column to the front; earlier
+    // layers become tiebreakers.
+    this._sortLayers = [];
+    this._menuOpenId = null;
     this.addingId = null;
     this.selectedRec = null;
     this._refreshing = false;
@@ -212,11 +214,15 @@ export class JobRecommendationsTable extends LitElement {
     };
     window.addEventListener('scroll', this._onScroll, { passive: true });
     window.addEventListener('resize', this._onScroll, { passive: true });
+    // Close any open row menu on an outside click.
+    this._onDocClick = () => { if (this._menuOpenId) this._menuOpenId = null; };
+    document.addEventListener('click', this._onDocClick);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('job:gmail:connected', this._onGmailConnected);
+    document.removeEventListener('click', this._onDocClick);
     window.removeEventListener('scroll', this._onScroll);
     window.removeEventListener('resize', this._onScroll);
     super.disconnectedCallback();
@@ -246,12 +252,15 @@ export class JobRecommendationsTable extends LitElement {
   async _fetchPage({ reset = false } = {}) {
     if (reset) { this._offset = 0; this._hasMore = false; }
     try {
+      const layers = this._sortLayers;
       const data = await fetchRecommendations({
         view:   'all',
         limit:  PAGE_SIZE,
         offset: this._offset,
-        sort:   this.sortKey,
-        dir:    this.sortDir,
+        // Multi-level: comma-joined keys + dirs, most-significant first.
+        // Empty stack → 'best' blended default on the server.
+        sort:   layers.length ? layers.map(l => l.key).join(',') : 'best',
+        dir:    layers.length ? layers.map(l => l.dir).join(',') : 'desc',
       });
       const page = Array.isArray(data?.recommendations) ? data.recommendations : [];
       this.items   = reset ? page : [...this.items, ...page];
@@ -273,17 +282,38 @@ export class JobRecommendationsTable extends LitElement {
     finally { this._loadingMore = false; this.requestUpdate(); }
   }
 
+  // Max sort layers kept. 3 is plenty (primary + two tiebreakers) and keeps
+  // the header indicators readable.
+  static SORT_DEPTH = 3;
+
+  _layerIndex(key) {
+    return this._sortLayers.findIndex(l => l.key === key);
+  }
+
   _onSortClick(c) {
     if (!c.sortKey) return;
-    if (this.sortKey === c.sortKey) {
-      this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
+    const key = c.sortKey;
+    const defaultDir = (c.numeric || c.date) ? 'desc' : 'asc';
+    const layers = [...this._sortLayers];
+    const idx = layers.findIndex(l => l.key === key);
+    if (idx === 0) {
+      // Re-clicking the current primary toggles its direction.
+      layers[0] = { key, dir: layers[0].dir === 'asc' ? 'desc' : 'asc' };
     } else {
-      this.sortKey = c.sortKey;
-      // Numeric / date default to desc (highest/newest first), text asc.
-      this.sortDir = (c.numeric || c.date) ? 'desc' : 'asc';
+      // Promote this column to primary; previous layers slide down as
+      // tiebreakers. Pull it from its old position first if present.
+      if (idx > 0) layers.splice(idx, 1);
+      layers.unshift({ key, dir: defaultDir });
     }
-    // Sorting is server-side now (the full set is larger than one page),
-    // so a sort change re-fetches from offset 0 in the new order.
+    this._sortLayers = layers.slice(0, JobRecommendationsTable.SORT_DEPTH);
+    // Server-side sort — re-fetch from offset 0 in the new (layered) order.
+    this._fetchPage({ reset: true });
+  }
+
+  // Shift-click (or the header's reset affordance) clears the stack back to
+  // the default "best" ranking.
+  _clearSort() {
+    this._sortLayers = [];
     this._fetchPage({ reset: true });
   }
 
@@ -341,19 +371,23 @@ export class JobRecommendationsTable extends LitElement {
   }
 
   _renderHeader() {
+    const multi = this._sortLayers.length > 1;
     return html`
       <tr>
         ${COLUMNS.map(c => {
           const cls = `col col-${c.id}`;
           if (!c.sortKey) return html`<th class=${cls}>${c.label}</th>`;
-          const active = this.sortKey === c.sortKey;
-          const arrow = active ? (this.sortDir === 'asc' ? '↑' : '↓') : '↕';
+          const idx = this._layerIndex(c.sortKey);
+          const layer = idx >= 0 ? this._sortLayers[idx] : null;
+          const arrow = layer ? (layer.dir === 'asc' ? '↑' : '↓') : '↕';
           return html`
             <th class=${cls}>
-              <button class=${'th-sort' + (active ? ' is-active' : '')}
+              <button class=${'th-sort' + (layer ? ' is-active' : '')}
+                      title=${layer ? `Sort layer ${idx + 1} — click to toggle / re-prioritize` : 'Click to sort; click another column to layer'}
                       @click=${() => this._onSortClick(c)}>
                 <span>${c.label}</span>
                 <span class="th-sort__arrow">${arrow}</span>
+                ${layer && multi ? html`<span class="th-sort__rank">${idx + 1}</span>` : nothing}
               </button>
             </th>
           `;
@@ -377,12 +411,10 @@ export class JobRecommendationsTable extends LitElement {
     return html`
       <tr class="pipeline-row" @click=${(e) => this._onRowClick(r, e)}>
         <td class="col col-fit" data-label="Fit">
-          ${renderScorePair(r, {
-            onFit:       (row) => this._openFitModal(row),
-            onCandidate: (row) => this._openCandidateModal(row),
-            fitClass,
-            candClass: fitClass,
-          })}
+          ${this._scorePill(r.fitScore, () => this._openFitModal(r), 'Fit score — tap for breakdown')}
+        </td>
+        <td class="col col-strength" data-label="Strength">
+          ${this._scorePill(r.candidateScore, () => this._openCandidateModal(r), 'Candidate strength — tap for breakdown')}
         </td>
         <td class="col col-role role-cell" data-label="Role">
           <div class="role-cell__inner">
@@ -422,10 +454,55 @@ export class JobRecommendationsTable extends LitElement {
             <button class="btn-dismiss" aria-label="Dismiss recommendation"
                     title="Dismiss"
                     @click=${() => this._onDismiss(r)}>×</button>
+            <div class="row-menu">
+              <button class="row-menu__trigger" aria-label="More actions" title="More"
+                      @click=${(e) => this._toggleMenu(r.id, e)}>⋯</button>
+              ${this._menuOpenId === r.id ? html`
+                <div class="row-menu__pop" @click=${(e) => e.stopPropagation()}>
+                  <button class="row-menu__item" @click=${() => this._onBlockCompany(r)}>
+                    Don't recommend ${r.company || 'this company'}
+                  </button>
+                  <button class="row-menu__item" @click=${() => { this._onDismiss(r); this._menuOpenId = null; }}>
+                    Dismiss this role
+                  </button>
+                </div>
+              ` : nothing}
+            </div>
           </div>
         </td>
       </tr>
     `;
+  }
+
+  // Single score pill (Fit or Strength). null score renders an em dash.
+  _scorePill(score, onClick, title) {
+    const cls = fitClass(score) + ' fit-pill--button';
+    return html`
+      <button class=${cls} title=${title}
+              @click=${(e) => { e.stopPropagation(); onClick(); }}>
+        ${score == null ? '—' : Math.round(score)}
+      </button>`;
+  }
+
+  _toggleMenu(id, e) {
+    e.stopPropagation();
+    this._menuOpenId = this._menuOpenId === id ? null : id;
+  }
+
+  async _onBlockCompany(r) {
+    const company = r.company;
+    this._menuOpenId = null;
+    if (!company) return;
+    // Optimistic: drop every loaded row from this company immediately.
+    const norm = company.toLowerCase().trim();
+    this.items = this.items.filter(x => (x.company || '').toLowerCase().trim() !== norm);
+    this.requestUpdate();
+    try {
+      await blockCompany(company);
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Won't recommend ${company} anymore` } }));
+    } catch (e) {
+      console.warn('[recs-table] blockCompany failed', e);
+    }
   }
 
   render() {
@@ -467,6 +544,12 @@ export class JobRecommendationsTable extends LitElement {
           ${this._refreshing ? 'Scanning…' : '↻ Refresh'}
         </button>
         ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
+        ${this._sortLayers.length ? html`
+          <button class="btn btn--sm recs-page__clearsort" title="Back to best-match order"
+                  @click=${() => this._clearSort()}>
+            Sorted by ${this._sortLayers.map(l => l.key === 'candidateScore' ? 'Strength' : l.key === 'fitScore' ? 'Fit' : l.key === 'suggestedAt' ? 'Date' : l.key).join(' › ')} · reset
+          </button>
+        ` : nothing}
       </header>
       ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`

--- a/job/js/pipeline.js
+++ b/job/js/pipeline.js
@@ -178,6 +178,19 @@ export async function dismissRecommendation(id) {
   return res.json();
 }
 
+// "Don't recommend this company" — blocks the company for this user and
+// dismisses its current recs server-side. Returns { dismissed: N }.
+export async function blockCompany(company) {
+  const headers = await authHeader();
+  const res = await fetch(REC_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ blockCompany: company }),
+  });
+  if (!res.ok) throw new Error(`block-company ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
 export async function checkLiveness({ slug } = {}) {
   const headers = await authHeader();
   const res = await fetch(LIVENESS_URL, {

--- a/job/not-authorized.html
+++ b/job/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /job</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
 </head>
 <body>
   <section class="gate">

--- a/job/onboarding/index.html
+++ b/job/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.6">
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.7">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <job-onboarding></job-onboarding>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/job/settings/index.html
+++ b/job/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <link rel="stylesheet" href="/job/css/components.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <link rel="stylesheet" href="/job/css/components.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/job/vision/index.html
+++ b/job/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /job</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/job/css/base.css?v=2.3.6">
-  <script src="/job/js/theme.js?v=2.3.6"></script>
+  <link rel="stylesheet" href="/job/css/base.css?v=2.3.7">
+  <script src="/job/js/theme.js?v=2.3.7"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/job/js/app.js?v=2.3.6"></script>
+  <script type="module" src="/job/js/app.js?v=2.3.7"></script>
 </body>
 </html>

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.20.0';
-console.log(`[pull-recommendations] v${VERSION} - role-universe gate on tracked-ats firehose (vision.target_titles or product default)`);
+const VERSION = '0.21.0';
+console.log(`[pull-recommendations] v${VERSION} - filter blocked companies at the source ("don't recommend this company")`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -305,6 +305,15 @@ serve(async (req) => {
         pulled = pulledRaw.filter(r => matchesRoleUniverse(r.title || '', universe));
         if (pulled.length !== before) console.log(`[pull-recommendations] tracked-ats role-universe: kept ${pulled.length}/${before}`);
       }
+      // "Don't recommend this company" — drop blocked companies at the
+      // source so they never re-accumulate (the recommendations read filter
+      // hides any that slip through). Applies to every source.
+      const blockedCos = await loadBlockedCompanies(sql, src.user_email);
+      if (blockedCos.size) {
+        const before = pulled.length;
+        pulled = pulled.filter(r => !blockedCos.has((r.company || '').toLowerCase().trim()));
+        if (pulled.length !== before) console.log(`[pull-recommendations] blocked-company filter: kept ${pulled.length}/${before}`);
+      }
       // Surface every rec — don't drop at off-target / off-geo / min_score.
       // The fit_score breakdown already factors sector/geo/experience
       // mismatch into the score itself, so a poor match just gets a low
@@ -496,6 +505,17 @@ function matchesRoleUniverse(title: string, universe: string[]): boolean {
   if (!universe.length) return true;          // no universe defined → keep all
   const t = title.toLowerCase();
   return universe.some(u => u && t.includes(u));
+}
+
+// Per-user "Don't recommend this company" set (normalized company names).
+async function loadBlockedCompanies(sql: ReturnType<typeof db>, userEmail: string): Promise<Set<string>> {
+  try {
+    const rows = await sql<{ company_norm: string }[]>`
+      select company_norm from job.blocked_companies where user_email = ${userEmail}`;
+    return new Set(rows.map(r => r.company_norm));
+  } catch {
+    return new Set();
+  }
 }
 
 // Geography filter — read vision.target_geographies; fall back to the

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.9.0';
-console.log(`[recommendations] v${VERSION} - default 'best' blended rank (candidate+fit) + candidate-score floor (drop graded <30)`);
+const VERSION = '0.10.0';
+console.log(`[recommendations] v${VERSION} - multi-level sort + candidateScore col + block-company filter/action`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -36,35 +36,50 @@ serve(async (req) => {
       const offset = isAll ? Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0) : 0;
 
       // Server-side sort — whitelist of sortable columns mapped to the
-      // table's sortKeys. dir is validated to asc/desc. Both are safe to
-      // splice via sql.unsafe because they only come from these fixed sets.
+      // table's sortKeys. Splicing via sql.unsafe is safe because keys and
+      // dirs only ever come from these fixed sets after validation.
       const SORT_COLS: Record<string, string> = {
-        fitScore:    'r.fit_score',
-        title:       'r.title',
-        location:    'r.location',
-        source:      'r.source',
-        suggestedAt: 'r.suggested_at',
+        fitScore:       'r.fit_score',
+        candidateScore: 'r.candidate_score',   // "Strength" column
+        title:          'r.title',
+        location:       'r.location',
+        source:         'r.source',
+        suggestedAt:    'r.suggested_at',
       };
-      // Follow-up #3 — default "best overall match" ranking. Blend the
-      // Haiku candidate grade (responsibilities match — what the user
-      // actually cares about) with heuristic fit, weighted toward
-      // candidate. Ungraded rows fall back to fit with a 0.8 discount so a
-      // graded-strong role outranks an un-graded high-fit one (the
-      // Nava-PBC "high fit, no/low candidate" leakage). When the user
-      // clicks a column header the explicit column wins.
+      // Default "best overall match" ranking — blend the Haiku candidate
+      // grade with heuristic fit, weighted toward candidate; ungraded rows
+      // fall back to fit with a 0.8 discount.
       const BLENDED_RANK =
         `(case when r.candidate_score is not null
                then (r.candidate_score * 0.6 + coalesce(r.fit_score,0) * 0.4)
                else coalesce(r.fit_score,0) * 0.8 end)`;
-      const sortParam = url.searchParams.get('sort') || 'best';
-      const sortExpr = SORT_COLS[sortParam] || BLENDED_RANK;
-      const sortDir = (url.searchParams.get('dir') || 'desc').toLowerCase() === 'asc' ? 'asc' : 'desc';
+      // Multi-level (Google-Sheets-style) sort: sort=k1,k2,… & dir=d1,d2,…
+      // most-significant first. Each layer must be a whitelisted column (or
+      // 'best'); unknown layers are dropped. A stable tiebreaker always
+      // trails so pagination stays deterministic.
+      const sortKeys = (url.searchParams.get('sort') || 'best').split(',').map(s => s.trim()).filter(Boolean);
+      const sortDirs = (url.searchParams.get('dir') || '').split(',').map(s => s.trim().toLowerCase());
+      const layers: string[] = [];
+      sortKeys.forEach((k, i) => {
+        const dir = sortDirs[i] === 'asc' ? 'asc' : 'desc';
+        if (k === 'best') layers.push(`${BLENDED_RANK} ${dir} nulls last`);
+        else if (SORT_COLS[k]) layers.push(`${SORT_COLS[k]} ${dir} nulls last`);
+      });
+      if (!layers.length) layers.push(`${BLENDED_RANK} desc nulls last`);
+      const orderBy = layers.join(', ') + ', r.suggested_at desc, r.id desc';
 
-      // Follow-up #2 — candidate-score low-end threshold. Drop roles the
-      // Haiku grader scored as a clearly weak responsibilities match
-      // (< 30). Only applies to GRADED rows — un-graded (candidate_score
-      // null, still "verifying") rows are never dropped on this basis.
+      // Candidate-score low-end threshold — drop clearly-weak graded roles
+      // (< 30). Un-graded rows are never dropped on this basis.
       const CANDIDATE_FLOOR = 30;
+
+      // Per-user blocked companies (the "Don't recommend this company"
+      // action). Filtered here so they vanish from For You immediately.
+      let blocked: string[] = [];
+      try {
+        const br = await sql<{ company_norm: string }[]>`
+          select company_norm from job.blocked_companies where user_email = ${email}`;
+        blocked = br.map(b => b.company_norm);
+      } catch { /* table absent / transient — don't fail the page */ }
 
       // Shared filter — reused by the page query and the count so "X of Y"
       // counts exactly what the list would show.
@@ -74,6 +89,7 @@ serve(async (req) => {
           and (${isAll} or r.fit_score is null or r.fit_score >= 50)
           and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
           and not (r.candidate_score is not null and r.candidate_score < ${CANDIDATE_FLOOR})
+          and (${blocked.length === 0} or lower(trim(r.company)) <> all(${blocked}::text[]))
           and not exists (
             select 1
               from job.pipeline_roles p
@@ -102,7 +118,7 @@ serve(async (req) => {
                     else null end as "sourceEmailUrl"
         from job.recommended_roles r
         ${whereClause}
-        order by ${sql.unsafe(sortExpr)} ${sql.unsafe(sortDir)} nulls last, r.suggested_at desc
+        order by ${sql.unsafe(orderBy)}
         limit ${limit} offset ${offset};
       `;
       // Total matching count — only needed for the paginated view.
@@ -148,6 +164,30 @@ serve(async (req) => {
 
     if (req.method === 'POST') {
       const body = await req.json().catch(() => ({}));
+
+      // "Don't recommend this company" — add to the per-user block list and
+      // dismiss its current recs in one shot. Future pulls also skip it.
+      if (body.blockCompany) {
+        const company = String(body.blockCompany).trim();
+        if (!company) return err('blockCompany required', 400);
+        const norm = company.toLowerCase();
+        await sql`insert into job.blocked_companies (user_email, company_norm)
+                    values (${email}, ${norm})
+                  on conflict (user_email, company_norm) do nothing`;
+        const dis = await sql`
+          update job.recommended_roles set dismissed_at = now()
+           where user_email = ${email} and dismissed_at is null
+             and lower(trim(company)) = ${norm}
+          returning id`;
+        return jsonResp({ ok: true, blockedCompany: company, dismissed: dis.length });
+      }
+      // Un-block (optional, for an undo affordance).
+      if (body.unblockCompany) {
+        const norm = String(body.unblockCompany).trim().toLowerCase();
+        await sql`delete from job.blocked_companies where user_email = ${email} and company_norm = ${norm}`;
+        return jsonResp({ ok: true, unblockedCompany: norm });
+      }
+
       const id = body.id ? String(body.id) : '';
       if (!id) return err('id required', 400);
       if (body.dismiss) {

--- a/supabase/migrations/081_blocked_companies.sql
+++ b/supabase/migrations/081_blocked_companies.sql
@@ -1,0 +1,16 @@
+-- 081: job.blocked_companies — per-user "don't recommend this company" list.
+--
+-- Driven by the For You row menu ("Don't recommend this company"). Recs from
+-- a blocked company are hidden at read time AND filtered at pull time so they
+-- don't re-accumulate. Keyed by user_email (same key recommended_roles uses)
+-- so the recommendations function can filter without resolving auth user ids.
+
+create table if not exists job.blocked_companies (
+  user_email   text not null,
+  company_norm text not null,          -- lower(trim(company))
+  created_at   timestamptz not null default now(),
+  primary key (user_email, company_norm)
+);
+
+comment on table job.blocked_companies is
+  'Per-user blocked companies — recs from these are hidden in For You and filtered at pull time.';


### PR DESCRIPTION
Three product changes to the For You table:

1. **Split Fit → Fit + Strength** columns, independently sortable (each its own score pill + breakdown modal).
2. **Multi-level sort** (Google-Sheets style): newest header click = primary, prior sorts = tiebreakers (rank badges, cap 3); empty = 'best' blend; reset chip. Server accepts `sort=k1,k2&dir=d1,d2`.
3. **Hide company**: per-row ⋯ menu → "Don't recommend <Company>" → `job.blocked_companies` (migration 081), dismisses current recs, filtered at read + pull.

recommendations v0.10.0, pull-recommendations v0.21.0, /job v2.3.7.