### PR TITLE
job: in-pipeline role-liveness detection (layers 1 & 2) — backlog #9

### DIFF
--- a/supabase/functions/enrich-job-source/index.ts
+++ b/supabase/functions/enrich-job-source/index.ts
@@ -18,8 +18,8 @@
 //           canonicalUrl?: string, jdText?: string,
 //           nextRetryAt?: ISO8601 }
 
-const VERSION = '0.4.0';
-console.log(`[enrich-job-source] v${VERSION} - Haiku semantic title→posting match when token overlap misses`);
+const VERSION = '0.5.0';
+console.log(`[enrich-job-source] v${VERSION} - layer-2 role-liveness: re-check ATS-resolved roles against the live board API`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
@@ -85,6 +85,15 @@ serve(async (req) => {
   // URL + status back. Lets the user drain after a Phase 1.5 cold-start.
   if (body.action === 'backfill') {
     return backfillBatch(Math.max(1, Math.min(15, body.limit ?? 8)));
+  }
+
+  // Liveness mode (backlog #9, layer 2) — re-check active ATS-resolved recs
+  // against the live board-API open-id set and close the ones whose posting
+  // is gone. Covers the Gmail/LinkedIn/theirstack roles that resolved to a
+  // Greenhouse/Lever/Ashby posting (tracked-ats is handled by layer 1 in
+  // pull-recommendations). Never closes on a board-fetch error.
+  if (body.action === 'liveness') {
+    return livenessBatch(Math.max(1, Math.min(100, body.limit ?? 40)));
   }
 
   const company = (body.company || '').trim();
@@ -235,6 +244,102 @@ async function backfillBatch(limit: number): Promise<Response> {
     resolved:  results.filter(x => x.resolved).length,
     results,
   };
+  return new Response(JSON.stringify(summary, null, 2), {
+    status: 200,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+// ---------- Liveness (layer 2) ----------
+//
+// Select up to `limit` active ATS-resolved recs, re-check each against its
+// board's live open-id set, and close the ones whose posting is gone. We
+// fetch each board's list ONCE per invocation (cached by provider:slug) so
+// N roles at one company cost a single API call. A board-fetch failure
+// SKIPS that slug — we only ever close on a definitive "id absent from a
+// successfully-fetched board", never on an error.
+
+interface AtsPosting { provider: 'Greenhouse' | 'Lever' | 'Ashby'; slug: string; jobId: string }
+
+// Parse (provider, slug, jobId) out of a canonical ATS posting URL.
+//   Greenhouse: (job-)boards.greenhouse.io/<slug>/jobs/<id>
+//   Lever:      jobs.lever.co/<slug>/<id>
+//   Ashby:      jobs.ashbyhq.com/<slug>/<id>
+function parseAtsPosting(u: string): AtsPosting | null {
+  try {
+    const url = new URL(u);
+    const host = url.hostname.toLowerCase();
+    const seg = url.pathname.split('/').filter(Boolean);
+    if (/(?:^|\.)(boards|job-boards)\.greenhouse\.io$/.test(host)) {
+      const jobsIdx = seg.indexOf('jobs');
+      if (jobsIdx >= 1 && seg[jobsIdx + 1]) return { provider: 'Greenhouse', slug: seg[0], jobId: seg[jobsIdx + 1] };
+    }
+    if (/(?:^|\.)jobs\.lever\.co$/.test(host) && seg.length >= 2) {
+      return { provider: 'Lever', slug: seg[0], jobId: seg[seg.length - 1] };
+    }
+    if (/(?:^|\.)jobs\.ashbyhq\.com$/.test(host) && seg.length >= 2) {
+      return { provider: 'Ashby', slug: seg[0], jobId: seg[seg.length - 1] };
+    }
+  } catch { /* not a URL */ }
+  return null;
+}
+
+// Fetch a board's open postings and return the set of open ids as strings
+// (Ashby ids are UUIDs, Greenhouse numbers, Lever strings — compare as
+// strings). Returns null on any fetch/parse failure so the caller skips
+// rather than closing on error.
+async function fetchOpenIds(provider: AtsPosting['provider'], slug: string): Promise<Set<string> | null> {
+  const url =
+    provider === 'Greenhouse' ? `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`
+    : provider === 'Lever'    ? `https://api.lever.co/v0/postings/${slug}?mode=json`
+    :                           `https://api.ashbyhq.com/posting-api/job-board/${slug}`;
+  try {
+    const r = await fetch(url, { headers: { 'User-Agent': UA }, signal: AbortSignal.timeout(10000) });
+    if (!r.ok) return null;
+    const data = await r.json();
+    const jobs: Array<{ id: unknown }> = Array.isArray(data) ? data : ((data?.jobs as Array<{ id: unknown }>) || []);
+    return new Set(jobs.map(j => String(j.id)));
+  } catch { return null; }
+}
+
+async function livenessBatch(limit: number): Promise<Response> {
+  const sql = db();
+  // Longest-unchecked first so the cron sweeps the whole pool over time.
+  const rows = await sql<Array<{ id: string; url: string | null; canonical_url: string | null }>>`
+    select id, url, canonical_url
+      from job.recommended_roles
+     where closed_at is null
+       and dismissed_at is null
+       and added_to_pipeline_slug is null
+       and coalesce(canonical_url, url) ~* '(greenhouse|lever|ashbyhq)'
+     order by last_seen_at asc nulls first, suggested_at asc
+     limit ${limit}
+  `;
+
+  const parsed = rows
+    .map(r => ({ id: r.id, p: parseAtsPosting(r.canonical_url || '') || parseAtsPosting(r.url || '') }))
+    .filter((x): x is { id: string; p: AtsPosting } => x.p !== null);
+
+  const boardCache = new Map<string, Set<string> | null>();
+  let checked = 0, open = 0, closed = 0, skipped = rows.length - parsed.length;
+
+  for (const { id, p } of parsed) {
+    const key = `${p.provider}:${p.slug}`;
+    if (!boardCache.has(key)) boardCache.set(key, await fetchOpenIds(p.provider, p.slug));
+    const ids = boardCache.get(key);
+    if (!ids) { skipped++; continue; }          // board fetch failed → never close
+    checked++;
+    if (ids.has(String(p.jobId))) {
+      open++;
+      await sql`update job.recommended_roles set last_seen_at = now(), closed_at = null, closure_reason = null where id = ${id}`;
+    } else {
+      closed++;
+      await sql`update job.recommended_roles set closed_at = now(), closure_reason = 'ats-delisted' where id = ${id}`;
+    }
+  }
+
+  const summary = { ok: true, version: VERSION, checked, open, closed, skipped };
+  console.log(`[enrich-job-source] liveness: checked=${checked} open=${open} closed=${closed} skipped=${skipped}`);
   return new Response(JSON.stringify(summary, null, 2), {
     status: 200,
     headers: { ...corsHeaders, 'Content-Type': 'application/json' },

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.21.0';
-console.log(`[pull-recommendations] v${VERSION} - filter blocked companies at the source ("don't recommend this company")`);
+const VERSION = '0.22.0';
+console.log(`[pull-recommendations] v${VERSION} - layer-1 role-liveness: close tracked-ats roles that disappeared since last pull`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -395,6 +395,17 @@ serve(async (req) => {
       const droppedAsDup = pipeFiltered.length - filtered.length;
       if (droppedAsDup > 0) console.log(`[pull-recommendations] dropped ${droppedAsDup} duplicate(s) vs existing/within-batch`);
       const upserted = await insertNew(sql, src, filtered);
+      // Layer 1 role-liveness (backlog #9) — tracked-ats re-pulls EVERY open
+      // posting from each tracked board every run, so a previously-seen
+      // source_id that's no longer in the pull = the posting was taken down.
+      // Use `pulledRaw` (the full board BEFORE the role-universe gate) so a
+      // still-open posting that's merely filtered out of recs isn't falsely
+      // closed. Only operate on slugs we actually fetched this run — a
+      // transient board-fetch failure yields zero rows for that slug, and we
+      // must never mass-close a company on an error.
+      if (src.type === 'tracked-ats') {
+        await trackedAtsLiveness(sql, pulledRaw);
+      }
       // Only genuinely-new rows go through inline enrich+grade. Rows that
       // were conflict-updated to backfill a missing JD are drained by the
       // grade-ungraded cron instead — inline-grading a whole tracked-ats
@@ -633,6 +644,48 @@ function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number, ctx?: Fi
   return { kept, dropped };
 }
 
+
+// ---------- Layer 1 role-liveness (tracked-ats disappeared-since-pull) ----------
+// Given the FULL board pull (pre-universe-gate), reopen/stamp every active
+// tracked-ats rec whose source_id is in the pull, and close every active
+// rec whose slug WAS fetched this run but whose source_id is NOT in the
+// pull. tracked-ats source_ids encode the board as `<provider>:<slug>:<id>`,
+// so the slug is the middle (split_part …, 2) segment.
+async function trackedAtsLiveness(
+  sql: ReturnType<typeof db>,
+  pulledRaw: RecommendedRoleInput[],
+): Promise<void> {
+  const pulledIds = [...new Set(pulledRaw.map(r => r.sourceId).filter(Boolean))] as string[];
+  // Slugs we successfully fetched this run = the middle segment of every
+  // pulled source_id. Only these slugs are eligible to close anything.
+  const fetchedSlugs = [...new Set(
+    pulledIds.map(sid => sid.split(':')[1]).filter(Boolean),
+  )] as string[];
+  if (!fetchedSlugs.length) return;   // nothing fetched → never close
+
+  // 1) Stamp last_seen + reopen every active rec present in this pull.
+  const seen = await sql`
+    update job.recommended_roles
+       set last_seen_at   = now(),
+           closed_at      = null,
+           closure_reason = null
+     where source = 'tracked-ats'
+       and dismissed_at is null
+       and source_id = any(${pulledIds}::text[])`;
+  // 2) Close every active rec whose slug we fetched but whose id vanished.
+  const closed = await sql`
+    update job.recommended_roles
+       set closed_at      = now(),
+           closure_reason = 'delisted'
+     where source = 'tracked-ats'
+       and closed_at is null
+       and dismissed_at is null
+       and split_part(source_id, ':', 2) = any(${fetchedSlugs}::text[])
+       and source_id <> all(${pulledIds}::text[])`;
+  const seenN   = (seen   as unknown as { count: number }).count;
+  const closedN = (closed as unknown as { count: number }).count;
+  console.log(`[pull-recommendations] tracked-ats liveness: closed ${closedN}, seen ${seenN}`);
+}
 
 // ---------- Productize: enrich + Haiku-grade + rescore new inserts ----------
 // Each new row from a cron pull walks the same pipeline as the manual

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.10.0';
-console.log(`[recommendations] v${VERSION} - multi-level sort + candidateScore col + block-company filter/action`);
+const VERSION = '0.11.0';
+console.log(`[recommendations] v${VERSION} - hide closed (delisted/filled) roles from For You (backlog #9)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -85,6 +85,7 @@ serve(async (req) => {
       // counts exactly what the list would show.
       const whereClause = sql`
         where r.dismissed_at is null
+          and r.closed_at is null
           and r.added_to_pipeline_slug is null
           and (${isAll} or r.fit_score is null or r.fit_score >= 50)
           and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)

--- a/supabase/migrations/082_role_liveness.sql
+++ b/supabase/migrations/082_role_liveness.sql
@@ -1,0 +1,24 @@
+-- 082_role_liveness.sql — in-pipeline role-liveness detection (backlog #9).
+--
+-- A recommended_roles row currently lives forever once created, so the
+-- For You list accumulates filled/expired postings. These columns let the
+-- two liveness layers retire stale roles using authoritative ATS data:
+--   * layer 1 (pull-recommendations): tracked-ats "disappeared since last
+--     pull" diff — a previously-seen source_id no longer returned by a
+--     successfully-fetched board = closed ('delisted').
+--   * layer 2 (enrich-job-source action=liveness): re-check ATS-resolved
+--     roles against the live board-API open-id set = closed ('ats-delisted').
+-- A closed role is filtered out of For You (like dismissed) but kept in the
+-- DB for history/analytics. last_seen_at tracks the last time we confirmed
+-- the posting was still open; both layers clear closed_at when an id
+-- reappears (reopen semantics).
+
+alter table job.recommended_roles
+  add column if not exists closed_at      timestamptz,
+  add column if not exists last_seen_at   timestamptz,
+  add column if not exists closure_reason text;   -- 'delisted' | 'ats-delisted'
+
+-- Hot path for the liveness layers + the read filter: active rows per source.
+create index if not exists recommended_roles_active_idx
+  on job.recommended_roles (source)
+  where closed_at is null and dismissed_at is null;


### PR DESCRIPTION
## What

Automatically detect and retire CLOSED/filled job recommendations in the `/job` pipeline using authoritative ATS data — no LinkedIn scraping, no subagent. Backlog item #9.

## Schema — `082_role_liveness.sql`
`job.recommended_roles` gains `closed_at`, `last_seen_at`, `closure_reason text` ('delisted' | 'ats-delisted') + a partial index `recommended_roles_active_idx` on active rows. Applied to the Boards project.

## Layer 1 — tracked-ats "disappeared since last pull" (`pull-recommendations` v0.22.0)
After each tracked-ats pull, diff the **full** board (`pulledRaw`, pre-universe-gate) against active recs:
- present in pull → stamp `last_seen_at`, clear `closed_at`/`closure_reason` (reopen)
- slug fetched this run but id **not** in pull → `closed_at = now()`, `closure_reason = 'delisted'`

Two set-based UPDATEs. Only operates on slugs actually fetched (derived from `pulledRaw` source_ids), so a transient board-fetch failure (zero rows for that slug) never mass-closes a company.

**Known v1 limitation:** a company that drops to ZERO open postings returns no rows, so its slug isn't in the fetched set and its last role isn't closed by layer 1 — layer 2 / age-out catches that tail.

## Layer 2 — ATS board-API re-check (`enrich-job-source` v0.5.0, `action: 'liveness'`)
Selects up to `limit` (default 40) active ATS-resolved roles ordered `last_seen_at nulls first, suggested_at asc`, parses (provider, slug, jobId) from `canonical_url`/`url`, fetches each board **once** (cached per provider:slug), and:
- id in open-id set → `last_seen_at = now()`, clear `closed_at`
- id absent → `closed_at = now()`, `closure_reason = 'ats-delisted'`
- board fetch fails → **skip** the slug (never close on error)

Ids compared as strings (Ashby UUID / Greenhouse number / Lever string). Returns `{checked, open, closed, skipped}`.

## Read filter (`recommendations` v0.11.0)
`and r.closed_at is null` added to the shared whereClause — closed roles vanish from For You + the widget but stay in the DB for history (treated like dismissed).

## Cron
`liveness-check-6h` (`0 */6 * * *`) POSTs `{action:'liveness', limit:40}` to `enrich-job-source` with the anon Bearer JWT (same pattern as `enrich-backfill-12min`). Registered post-merge.

## Verification (post-deploy)
- [ ] Migration applied; columns exist
- [ ] Force a tracked-ats pull → closed count sane, `last_seen_at` populated
- [ ] Trigger liveness a few times → spot-check 2 closes vs live board API; never closes on fetch error
- [ ] Closed roles absent from recommendations GET (view=all)
- [ ] Both crons registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)