### PR TITLE
job: dedup For You against pipeline by normalized URL (v0.12.0)

### DIFF
--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.11.0';
-console.log(`[recommendations] v${VERSION} - hide closed (delisted/filled) roles from For You (backlog #9)`);
+const VERSION = '0.12.0';
+console.log(`[recommendations] v${VERSION} - dedup For You against pipeline by normalized URL too (saved/applied/rejected reappearing fix)`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -81,8 +81,31 @@ serve(async (req) => {
         blocked = br.map(b => b.company_norm);
       } catch { /* table absent / transient — don't fail the page */ }
 
+      // URL normalizer — strips scheme, leading www., query string,
+      // fragment, and trailing slashes so the same posting matches across
+      // sources (e.g. a Gmail-sourced rec vs. the URL the user pasted when
+      // saving). Returns '' for nulls so empty never equals empty. Columns
+      // are fixed literals, so sql.unsafe is safe here.
+      const normUrl = (col: string) => `
+        regexp_replace(
+          regexp_replace(
+            regexp_replace(
+              regexp_replace(lower(trim(coalesce(${col}, ''))), '^https?://', ''),
+              '^www\\.', ''),
+            '[?#].*$', ''),
+          '/+$', '')`;
+
       // Shared filter — reused by the page query and the count so "X of Y"
       // counts exactly what the list would show.
+      //
+      // The `not exists` dedup keeps anything already in the pipeline out of
+      // For You — whether it's Saved, Applied, or Rejected, since all live in
+      // pipeline_roles and we don't filter on status. It matches two ways:
+      //   1. exact (company, title) — the original check.
+      //   2. normalized URL (rec.url OR rec.canonical_url == pipeline.url) —
+      //      catches the same posting when title/company text drifted between
+      //      the saved copy and a later re-ingested recommendation (the cause
+      //      of saved jobs reappearing in For You).
       const whereClause = sql`
         where r.dismissed_at is null
           and r.closed_at is null
@@ -94,8 +117,17 @@ serve(async (req) => {
           and not exists (
             select 1
               from job.pipeline_roles p
-             where lower(p.company_name) = lower(r.company)
-               and lower(p.title) = lower(r.title)
+             where (
+                     lower(p.company_name) = lower(r.company)
+                     and lower(p.title) = lower(r.title)
+                   )
+                or (
+                     ${sql.unsafe(normUrl('p.url'))} <> ''
+                     and ${sql.unsafe(normUrl('p.url'))} in (
+                           ${sql.unsafe(normUrl('r.url'))},
+                           ${sql.unsafe(normUrl('r.canonical_url'))}
+                         )
+                   )
           )`;
 
       const rows = await sql`


### PR DESCRIPTION
## Problem
Saving a job on /job didn't reliably keep it out of **For You**. When the same posting was re-ingested later (e.g. it reappears in your Gmail), it came back as a recommendation.

## Root cause
The recommendations query deduped `recommended_roles` against `pipeline_roles` using an **exact case-insensitive (company, title) string match** ([recommendations/index.ts](supabase/functions/recommendations/index.ts)). The re-ingested copy is a brand-new `recommended_roles` row (so `added_to_pipeline_slug` is null again), and any drift in title/company text between the saved copy and the email-sourced copy — `"Senior PM, Growth"` vs `"Senior Product Manager, Growth"`, `"Acme, Inc."` vs `"Acme"` — defeated the dedup. The posting URL was never used for matching.

## Fix
Add a **normalized-URL** match alongside the title match in the `not exists` dedup:
- Normalizer strips scheme, leading `www.`, query string, fragment, and trailing slashes.
- Compares the recommendation's `url` **and** `canonical_url` against the pipeline role's `url`.
- Matches **all pipeline statuses** (Saved, Applied, Rejected) — the subquery doesn't filter on status, so anything you've already engaged with stays out of For You.
- Runs live at query time, so deploying this also **retroactively hides** already-leaked duplicates that match by URL — no backfill needed.

Kept the original (company, title) match as a fallback for the case where the same role lives at different URLs (LinkedIn-Apply vs Phenom vs direct ATS).

Bumps `recommendations` to **v0.12.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)