### PR TITLE
Rework rail brand to Ladder wordmark + icon

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -100,17 +100,36 @@ body:not([data-auth-state="in"]) #ctrlAuthBar { display: none !important; }
 .app__footer .footer__controls { display: inline-flex; align-items: center; gap: var(--space-3); }
 
 .brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   font-family: var(--font-display);
   font-weight: var(--fw-semibold);
   font-size: 20px;
   letter-spacing: -0.015em;
+  color: var(--fg);
+  text-decoration: none;
+}
+.brand:hover { text-decoration: none; }
+.brand:hover .brand__text { color: var(--fg); }
+.brand__mark {
+  flex: none;
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  color: var(--fg);
+}
+.brand__mark svg { width: 100%; height: 100%; }
+.brand__text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
 }
 .brand__sub {
-  display: block;
   font-size: var(--font-size-small);
   font-weight: 400;
   color: var(--fg-subtle);
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
 .rail-foot {

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.4.0";
-console.log(`[ladder] v${VERSION} - renamed product /job → /ladder (frontend + branding)`);
+const VERSION = "2.4.1";
+console.log(`[ladder] v${VERSION} - rail brand reworked to Ladder + ladder icon`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -129,10 +129,10 @@ function injectMobileBar() {
 
   const isHome = location.pathname === '/ladder/' || location.pathname === '/ladder';
   const title = isHome
-    ? '/ job'
+    ? 'Ladder'
     : (document.querySelector('.page-header h1')?.textContent?.trim()
-       || document.title.replace(/\s*[—|]\s*\/?job.*$/i, '').trim()
-       || 'ctrl.rodeo');
+       || document.title.replace(/\s*[—|]\s*\/?(ladder|job).*$/i, '').trim()
+       || 'Ladder');
 
   const bar = document.createElement('header');
   bar.className = 'mobile-bar';

--- a/ladder/js/components/ladder-footer.js
+++ b/ladder/js/components/ladder-footer.js
@@ -37,7 +37,7 @@ export class JobFooter extends LitElement {
     return html`
       <footer class="app__footer">
         <div>
-          <span class="footer__brand">ctrl.rodeo / job</span>
+          <span class="footer__brand">Ladder · ctrl.rodeo</span>
           ${window.LADDER_VERSION ? html`<span class="footer__version" style="margin-left:var(--space-3);">${window.LADDER_VERSION}</span>` : ''}
         </div>
         <div class="footer__controls">

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -123,10 +123,21 @@ export class JobRail extends LitElement {
   render() {
     return html`
       <aside class="app__rail">
-        <div class="brand">
-          ctrl.rodeo
-          <span class="brand__sub">/ job</span>
-        </div>
+        <a class="brand" href="/ladder/">
+          <span class="brand__mark" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+              <line x1="6.5" y1="2.5" x2="6.5" y2="21.5"/>
+              <line x1="17.5" y1="2.5" x2="17.5" y2="21.5"/>
+              <line x1="6.5" y1="7" x2="17.5" y2="7"/>
+              <line x1="6.5" y1="12" x2="17.5" y2="12"/>
+              <line x1="6.5" y1="17" x2="17.5" y2="17"/>
+            </svg>
+          </span>
+          <span class="brand__text">
+            Ladder
+            <span class="brand__sub">ctrl.rodeo</span>
+          </span>
+        </a>
         <nav>
           <ul class="nav-list">
             ${ROUTES.map(r => {

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.0">
-  <script src="/ladder/js/theme.js?v=2.4.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <script src="/ladder/js/theme.js?v=2.4.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Reworks the top of the left nav from "ctrl.rodeo / job" to a **Ladder** wordmark with a ladder icon.

- Inline ladder SVG mark (two rails + three rungs) + **Ladder** wordmark, with **ctrl.rodeo** as the subtitle
- Brand is now a clickable link back to `/ladder/`
- Icon uses `currentColor` → adapts to light + dark themes (verified both in Chrome)
- Footer brand → "Ladder · ctrl.rodeo"; mobile-bar home title → "Ladder"
- `VERSION` 2.4.0 → 2.4.1, cache-bust refreshed across pages

## Note
Sign-in gate `<h1>` still reads `/ladder` (separate screen) — left as-is, easy follow-up if you want it to match the wordmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)