### PR TITLE
Ladder list views: accurate For You count, nested location, source favicon

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -2564,8 +2564,23 @@
    col-* declarations (around line 2500). */
 .pipeline-table .col-fit      { width: 64px; white-space: nowrap; }
 .pipeline-table .col-strength { width: 78px; white-space: nowrap; }
-.pipeline-table .col-location { width: 14%; min-width: 120px; color: var(--text-muted); }
+.pipeline-table .col-source   { width: 1%; min-width: 116px; white-space: nowrap; }
 .pipeline-table .col-added    { width: 88px;  white-space: nowrap; color: var(--text-muted); }
+
+/* Location nested under Role (company line) on every list view. Muted,
+   single-line, with a small pin. Multiple locations collapse to "+N". */
+.role-cell__loc {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 2px;
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle, var(--text-muted));
+  min-width: 0;
+}
+.role-cell__loc .loc-pin { flex: none; opacity: 0.7; }
+.role-cell__loc-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.role-cell__loc-more { flex: none; opacity: 0.8; }
 
 /* Multi-level sort: small rank badge next to the arrow (1 = primary). */
 .th-sort__rank {
@@ -2609,8 +2624,25 @@
 .row-menu__item:hover { background: var(--surface-2, rgba(127,127,127,.12)); }
 
 .rec-source {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   font-size: var(--font-size-body-sm);
   color: var(--text-muted);
+  min-width: 0;
+  vertical-align: middle;
+}
+.rec-source__icon {
+  flex: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  object-fit: contain;
+}
+.rec-source__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .rec-source-email {
   display: inline-block;
@@ -3658,31 +3690,22 @@
     border-radius: var(--radius-pill);
   }
 
-  /* Recs table extras — collapse location / source / added into the meta line.
-     col-menu on rec rows holds the Save + Dismiss actions (rec-actions ~96px
-     wide), so widen the menu column there. col-sector (which carries the
-     "source" string for recs, NOT a sector chip cluster) is hidden because
-     the company name already appears in col-role. */
-  .pipeline-table tr:has(.col-location) {
+  /* Recs (For You) table on mobile. Location now lives inside the Role cell
+     (title / company / location), so the row is the standard two-area card.
+     Strength, Source and Added columns are secondary — hidden on phones to
+     keep the row scannable; col-menu carries Save + Dismiss so it widens. */
+  .pipeline-table--recs tr {
     grid-template-columns: 48px minmax(0, 1fr) auto;
     grid-template-areas:
-      "fit role     menu"
-      "fit metarec  menu";
+      "fit role menu"
+      "fit role menu";
     column-gap: var(--space-3);
   }
-  .pipeline-table tr:has(.col-location) .col-sector { display: none; }
-  .pipeline-table tr:has(.col-location) .col-source { display: none; }
-  .pipeline-table .col-location,
-  .pipeline-table .col-added {
-    grid-area: metarec;
-    width: auto;
-    font-size: var(--font-size-caption);
-    color: var(--fg-muted);
-    align-self: start;
-  }
-  .pipeline-table tr:has(.col-location) .col-location { justify-self: start; white-space: nowrap; }
-  .pipeline-table tr:has(.col-location) .col-added    { justify-self: end;   white-space: nowrap; }
-  .pipeline-table tr:has(.col-location) .col-menu {
+  .pipeline-table--recs .col-role { align-self: center; }
+  .pipeline-table--recs .col-strength,
+  .pipeline-table--recs .col-source,
+  .pipeline-table--recs .col-added { display: none; }
+  .pipeline-table--recs .col-menu {
     width: auto;
     min-width: 96px;
     align-self: center;

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.4.1";
-console.log(`[ladder] v${VERSION} - rail brand reworked to Ladder + ladder icon`);
+const VERSION = "2.5.0";
+console.log(`[ladder] v${VERSION} - For You count=total; location nested under Role; source favicon+label`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -6,6 +6,7 @@ const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, ch
 const { logoSrc, logoInitial } = await import('../logo.js' + V);
 const { renderScoreModal, renderScorePair, scoreClass: sharedScoreClass } = await import('./ladder-fit-modal.js' + V);
 const { loadRoleSignals, chipClassForSignal, ackEvent } = await import('../applicationEvents.js' + V);
+const { renderLocation } = await import('../format.js' + V);
 // Mount the recommendations widget. It self-loads when the user is signed in.
 import('./ladder-recommendations.js' + V);
 
@@ -894,6 +895,7 @@ export class JobPipeline extends LitElement {
                   : nothing}
               </div>
               <div class="role-cell__company">${r.company || ''}</div>
+              ${renderLocation(r.location)}
             </div>
           </div>
         </td>

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -102,7 +102,9 @@ export class JobRail extends LitElement {
       const roles = (pipe?.roles || []).filter(isVisibleRole);
       const leads  = roles.filter(r => bucketFor(r) === 'leads').length;
       const active = roles.filter(r => bucketFor(r) === 'active').length;
-      const recommended = recs?.count ?? (recs?.recommendations?.length ?? 0);
+      // `total` is the true count of all matching recs; `count` is only the
+      // returned page size (caps at the server's page limit, e.g. 100).
+      const recommended = recs?.total ?? recs?.count ?? (recs?.recommendations?.length ?? 0);
       this.counts = { leads, active, recommended };
       // Broadcast so other mobile chrome (the segmented .subnav-bar in
       // app.js) can pull the same counts without re-fetching.

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -8,20 +8,21 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
+  import('../format.js' + V),
 ]);
 
 // Column shape mirrors job-pipeline's COLUMNS: id drives the col class,
 // sortKey gates sortability, label is what the header shows.
+// Location is nested under Role (no standalone column) — sort still offered.
 const COLUMNS = [
   { id: 'fit',      label: 'Fit',      sortKey: 'fitScore',       numeric: true },
   { id: 'strength', label: 'Strength', sortKey: 'candidateScore', numeric: true },
   { id: 'role',     label: 'Role',     sortKey: 'title' },
-  { id: 'location', label: 'Location', sortKey: 'location' },
-  { id: 'sector',   label: 'Source',   sortKey: 'source' },
+  { id: 'source',   label: 'Source',   sortKey: 'source' },
   { id: 'added',    label: 'Added',    sortKey: 'suggestedAt', date: true },
   { id: 'menu',     label: '',         sortKey: null },
 ];
@@ -49,6 +50,7 @@ function fitClass(s) {
   if (s >= 30) return 'fit-pill fit-pill--weak';
   return 'fit-pill fit-pill--poor';
 }
+
 
 export class JobRecommendationsTable extends LitElement {
   createRenderRoot() { return this; }
@@ -336,6 +338,7 @@ export class JobRecommendationsTable extends LitElement {
         url: rec.url,
         title: rec.title,
         company: rec.company,
+        location: rec.location,
         source: 'Network',
         fromRecommendationId: rec.id,
       });
@@ -422,14 +425,12 @@ export class JobRecommendationsTable extends LitElement {
             <div class="role-cell__text">
               <div class="role-cell__title">${r.title || '(untitled)'}</div>
               <div class="role-cell__company">${r.company || ''}</div>
+              ${renderLocation(r.location)}
             </div>
           </div>
         </td>
-        <td class="col col-location" data-label="Location">
-          ${r.location ? r.location : html`<span class="muted">—</span>`}
-        </td>
-        <td class="col col-sector" data-label="Source">
-          <span class="rec-source">${r.sourceLabel || r.source || ''}</span>
+        <td class="col col-source" data-label="Source">
+          ${renderSource(r)}
           ${r.enrichmentStatus === 'unresolved' ? html`
             <span class="enrichment-badge" title="Still resolving the canonical posting. Aggregator URL in the meantime.">verifying</span>
           ` : nothing}
@@ -512,7 +513,7 @@ export class JobRecommendationsTable extends LitElement {
           <h1>For You</h1>
         </header>
         <div class="pipeline-table-wrap">
-          <table class="pipeline-table">
+          <table class="pipeline-table pipeline-table--recs">
             <thead>${this._renderHeader()}</thead>
             <tbody>
               ${Array.from({ length: 6 }).map(() => html`
@@ -559,7 +560,7 @@ export class JobRecommendationsTable extends LitElement {
         </div>
       ` : html`
         <div class="pipeline-table-wrap">
-          <table class="pipeline-table">
+          <table class="pipeline-table pipeline-table--recs">
             <thead>${this._renderHeader()}</thead>
             <tbody>${rows.map(r => this._renderRow(r))}</tbody>
           </table>

--- a/ladder/js/format.js
+++ b/ladder/js/format.js
@@ -1,0 +1,99 @@
+// format.js — shared display formatters + tiny renderers for the job list
+// views. Imported by ladder-recommendations-table.js and ladder-pipeline.js so
+// Location + Source render identically everywhere (single source of truth).
+import { html, nothing } from 'https://esm.run/lit@3';
+
+// Normalize a free-text location into a compact, deduped display.
+//   "San Francisco, CA; New York, NY"  → { primary: "San Francisco, CA", extra: 1, all: [...] }
+//   "Remote - US"                       → { primary: "Remote", extra: 0, all: ["Remote"] }
+//   ""/null                             → null
+// NOTE: we split on multi-location separators (; | / • • newlines, " or ")
+// but NOT on commas — a comma is the city,state separator inside one location.
+export function formatLocation(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+  const stripped = raw.replace(/^\s*locations?\s*:\s*/i, '').trim();
+  if (!stripped) return null;
+
+  const parts = stripped
+    .split(/\s*(?:;|\||•|·|\/|\bor\b|\n)\s*/i)
+    .map(cleanOne)
+    .filter(Boolean);
+
+  const seen = new Set();
+  const all = [];
+  for (const p of parts) {
+    const key = p.toLowerCase();
+    if (!seen.has(key)) { seen.add(key); all.push(p); }
+  }
+  if (!all.length) return null;
+  return { primary: all[0], extra: all.length - 1, all };
+}
+
+function cleanOne(p) {
+  let s = String(p || '').replace(/\s+/g, ' ').trim();
+  if (!s) return '';
+  // Collapse remote spellings → "Remote" (drops "Remote - US", "Remote (Global)").
+  if (/^remote\b/i.test(s)) return 'Remote';
+  if (/^hybrid\b/i.test(s)) return s.replace(/\s*[-–(].*$/, '').trim() || 'Hybrid';
+  // Trim redundant US country suffixes; keep international ones.
+  s = s.replace(/,?\s*(united states(?:\s+of\s+america)?|usa|u\.s\.a?\.?)\s*$/i, '').trim();
+  return s;
+}
+
+// Favicon for a host via Google's s2 service (same source as logo.js).
+function favicon(host) {
+  return host ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=64` : null;
+}
+
+// Source-platform metadata for a recommendation row.
+//   → { iconUrl, label, title }   label is a tight platform name.
+// Favicon: Gmail for inbox-sourced rows; otherwise the posting URL's host
+// (which IS the platform for ATS/company-page/LinkedIn sources).
+export function sourceMeta(r) {
+  const rawLabel = String(r.sourceLabel || r.source || '').trim();
+  const src = String(r.source || '').toLowerCase();
+
+  if (src.includes('gmail') || r.sourceEmailUrl) {
+    return { iconUrl: favicon('mail.google.com'), label: 'Gmail', title: rawLabel || 'Gmail' };
+  }
+
+  // Platform = text before a "·"/"|" separator ("Greenhouse · Abridge" → "Greenhouse").
+  let label = rawLabel.split(/\s*[·|]\s*/)[0].trim();
+  const lower = label.toLowerCase();
+  if (/linkedin/.test(lower) || src.includes('linkedin')) label = 'LinkedIn';
+  else if (lower === 'from company pages' || src === 'tracked-ats') label = label && lower !== 'from company pages' ? label : 'Company site';
+  else if (lower === 'manual') label = 'Added';
+  else if (lower === 'rss' || src.includes('rss')) label = 'RSS';
+  if (!label) label = rawLabel || 'Source';
+
+  let iconUrl = null;
+  try {
+    if (r.url) iconUrl = favicon(new URL(r.url).hostname.replace(/^www\./, ''));
+  } catch { /* ignore */ }
+
+  return { iconUrl, label, title: rawLabel || label };
+}
+
+const LOC_PIN = html`<svg class="loc-pin" viewBox="0 0 24 24" width="11" height="11" aria-hidden="true"><path d="M12 2a7 7 0 0 0-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 0 0-7-7zm0 9.5A2.5 2.5 0 1 1 12 6.5a2.5 2.5 0 0 1 0 5z" fill="currentColor"/></svg>`;
+
+// Location nested under the Role cell — normalized + deduped. Multiple
+// locations collapse to "primary +N" with the full list on hover.
+export function renderLocation(raw) {
+  const loc = formatLocation(raw);
+  if (!loc) return nothing;
+  return html`
+    <div class="role-cell__loc" title=${loc.extra ? loc.all.join(' · ') : loc.primary}>
+      ${LOC_PIN}<span class="role-cell__loc-text">${loc.primary}</span>${loc.extra
+        ? html`<span class="role-cell__loc-more">+${loc.extra}</span>` : nothing}
+    </div>`;
+}
+
+// Source as favicon + tight platform label (For You list).
+export function renderSource(r) {
+  const sm = sourceMeta(r);
+  return html`<span class="rec-source">
+    ${sm.iconUrl ? html`<img class="rec-source__icon" src=${sm.iconUrl} alt="" loading="lazy"
+        referrerpolicy="no-referrer" @error=${(e) => { e.target.style.visibility = 'hidden'; }}>` : nothing}
+    <span class="rec-source__label" title=${sm.title}>${sm.label}</span>
+  </span>`;
+}

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -138,12 +138,12 @@ export async function deleteRole(slug) {
   return res.json();
 }
 
-export async function addRole({ url, title, company, sector, source, fromRecommendationId } = {}) {
+export async function addRole({ url, title, company, location, sector, source, fromRecommendationId } = {}) {
   const headers = await authHeader();
   const res = await fetch(ADD_ROLE_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ url, title, company, sector, source, fromRecommendationId }),
+    body: JSON.stringify({ url, title, company, location, sector, source, fromRecommendationId }),
   });
   if (!res.ok) throw new Error(`add-role ${res.status}: ${await res.text()}`);
   return res.json();

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.4.1">
-  <script src="/ladder/js/theme.js?v=2.4.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.0">
+  <script src="/ladder/js/theme.js?v=2.5.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.4.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.0"></script>
 </body>
 </html>

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -11,11 +11,11 @@ import { parseSectorTags } from '../_shared/sector-tags.ts';
 import { computeFit } from '../jobs-pipe/fit.ts';
 import { scoreOne } from '../_shared/job-fit-haiku.ts';
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 // Status default: 'Saved' (post-taxonomy collapse).
 // Source-email-link: stash payload.gmailApiId as a Gmail web URL when
 // the rec came from Gmail.
-console.log(`[add-role] v${VERSION} - v3 fit at insert time: inherit Haiku from source rec OR fetch+grade fresh URLs`);
+console.log(`[add-role] v${VERSION} - persist location (from source rec or JSON-LD jobLocation)`);
 
 const URL_RE = /^https?:\/\//i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
@@ -73,7 +73,7 @@ function decodeEntities(s: string): string {
 
 // Returns the structured JobPosting JSON-LD if the page ships one. Most
 // modern ATSes (careerspage.io, Greenhouse, Workable, Ashby) embed it.
-function parseJobPostingLd(html: string): { title?: string; company?: string; description?: string; salaryLow?: number; salaryHigh?: number; datePosted?: string } | null {
+function parseJobPostingLd(html: string): { title?: string; company?: string; description?: string; salaryLow?: number; salaryHigh?: number; datePosted?: string; location?: string } | null {
   const blocks = [...html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)];
   for (const m of blocks) {
     try {
@@ -98,6 +98,23 @@ function parseJobPostingLd(html: string): { title?: string; company?: string; de
           if (Number.isFinite(lo)) out.salaryLow = lo;
           if (Number.isFinite(hi)) out.salaryHigh = hi;
         }
+        // jobLocation → "City, Region"; multiple locations joined with "; ".
+        // Fully-remote postings advertise jobLocationType: TELECOMMUTE.
+        const fmtAddr = (loc: any): string | null => {
+          const ad = loc?.address || loc;
+          if (!ad || typeof ad !== 'object') return null;
+          const parts = [ad.addressLocality, ad.addressRegion].filter((x: unknown) => typeof x === 'string' && x);
+          if (parts.length) return parts.join(', ');
+          const country = ad.addressCountry?.name || ad.addressCountry;
+          return typeof country === 'string' ? country : null;
+        };
+        const jl = c.jobLocation;
+        if (jl) {
+          const arr = Array.isArray(jl) ? jl : [jl];
+          const locs = Array.from(new Set(arr.map(fmtAddr).filter(Boolean) as string[]));
+          if (locs.length) out.location = locs.join('; ');
+        }
+        if (!out.location && c.jobLocationType === 'TELECOMMUTE') out.location = 'Remote';
         if (out.title || out.company || out.description) return out;
       }
     } catch { /* malformed JSON-LD; try next block */ }
@@ -363,6 +380,10 @@ serve(async (req) => {
     const { source, sourceLabel } = detectSource(url);
     const finalSource = body.source ? String(body.source) : source;
 
+    // Location: caller-supplied (rec carry-over) wins, then JSON-LD jobLocation.
+    // The rec-link block below also backfills from the source rec when present.
+    const location = (String(body.location || '').trim() || meta.ld?.location || '') || null;
+
     const sql = db();
     const companySlug = slugify(company) || null;
 
@@ -381,16 +402,17 @@ serve(async (req) => {
           returning slug
         )
         insert into job.pipeline_roles (
-          slug, company_slug, company_name, title, url, source, status
+          slug, company_slug, company_name, title, url, location, source, status
         ) values (
           ${slug}, ${companySlug}, ${company}, ${title},
-          ${url}, ${finalSource}, 'Saved'
+          ${url}, ${location}, ${finalSource}, 'Saved'
         )
         on conflict (slug) do update set
           url = excluded.url,
           title = excluded.title,
           company_name = excluded.company_name,
           company_slug = excluded.company_slug,
+          location = coalesce(job.pipeline_roles.location, excluded.location),
           source = coalesce(job.pipeline_roles.source, excluded.source),
           deleted_at = null,
           archived_at = null,
@@ -400,16 +422,17 @@ serve(async (req) => {
       // No company slug — insert without the FK link.
       await sql`
         insert into job.pipeline_roles (
-          slug, company_slug, company_name, title, url, source, status
+          slug, company_slug, company_name, title, url, location, source, status
         ) values (
           ${slug}, null, ${company}, ${title},
-          ${url}, ${finalSource}, 'Saved'
+          ${url}, ${location}, ${finalSource}, 'Saved'
         )
         on conflict (slug) do update set
           url = excluded.url,
           title = excluded.title,
           company_name = excluded.company_name,
           company_slug = excluded.company_slug,
+          location = coalesce(job.pipeline_roles.location, excluded.location),
           source = coalesce(job.pipeline_roles.source, excluded.source),
           deleted_at = null,
           archived_at = null,
@@ -561,8 +584,8 @@ serve(async (req) => {
     // user can re-open the originating thread from the role detail.
     if (body.fromRecommendationId) {
       try {
-        const recRows = await sql<{ source: string; payload: Record<string, unknown> | null }[]>`
-          select source, payload from job.recommended_roles
+        const recRows = await sql<{ source: string; payload: Record<string, unknown> | null; location: string | null }[]>`
+          select source, payload, location from job.recommended_roles
            where id = ${body.fromRecommendationId} limit 1`;
         await sql`
           update job.recommended_roles
@@ -570,6 +593,14 @@ serve(async (req) => {
           where id = ${body.fromRecommendationId};
         `;
         const rec = recRows[0];
+        // Backfill location from the source rec when the page parse missed it.
+        if (rec?.location && String(rec.location).trim()) {
+          await sql`
+            update job.pipeline_roles
+               set location = coalesce(location, ${rec.location})
+             where slug = ${slug};
+          `;
+        }
         const gmailApiId = rec?.source === 'gmail-jobs'
           ? (rec.payload as Record<string, unknown> | null)?.gmailApiId
           : null;

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.10.2';
-console.log(`[jobs-pipe] v${VERSION} - return updatedAt so drill page can auto-regen stale assets`);
+const VERSION = '0.11.0';
+console.log(`[jobs-pipe] v${VERSION} - return location for Role-cell nesting on list views`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -42,7 +42,7 @@ async function listRoles() {
   const rows = await sql`
     select
       r.slug, r.source_row as "rowNumber",
-      r.company_name as company, r.title, r.url, r.source, r.status,
+      r.company_name as company, r.title, r.url, r.location, r.source, r.status,
       r.stage, r.exit_reason as "exitReason", r.exit_context as "exitContext",
       r.contact, r.salary_range as salary, r.salary_low, r.salary_high,
       r.sector, r.investors, r.fit_score as score, r.fit_breakdown as breakdown,

--- a/supabase/migrations/083_pipeline_location.sql
+++ b/supabase/migrations/083_pipeline_location.sql
@@ -1,0 +1,24 @@
+-- 083_pipeline_location.sql
+-- Add `location` to job.pipeline_roles so Saved/Active/Archive list rows can
+-- show location nested under Role — parity with job.recommended_roles, which
+-- already carries it. Additive + nullable: safe, no data loss.
+
+alter table job.pipeline_roles add column if not exists location text;
+
+-- Backfill existing pipeline rows from their originating recommendation.
+-- Preferred link: recommended_roles.added_to_pipeline_slug → pipeline_roles.slug.
+update job.pipeline_roles p
+set location = r.location
+from job.recommended_roles r
+where p.location is null
+  and r.location is not null and btrim(r.location) <> ''
+  and r.added_to_pipeline_slug = p.slug;
+
+-- Fallback: match on exact posting URL for rows saved before the link existed
+-- (e.g. manual pastes that also appeared as recs).
+update job.pipeline_roles p
+set location = r.location
+from job.recommended_roles r
+where p.location is null
+  and r.location is not null and btrim(r.location) <> ''
+  and r.url = p.url;


### PR DESCRIPTION
Three changes to the job list views (For You / Saved / Active / Archive) + mobile check.

## 1. For You counter now accurate
The rail badge read the server's `count` field (the returned **page size**, which caps at 100). It now reads `total` (the true matching count). The "100" was never the real number.

## 2. Location — normalized + nested under Role (all 4 views)
- **Normalization** (`ladder/js/format.js` → `formatLocation`): splits genuinely-multiple locations on `;  |  /  •  "or"` (NOT commas, which separate city,state), dedupes case-insensitively, collapses `Remote - US → Remote`, trims redundant US country suffixes, and renders `primary +N` with the full list on hover.
- **Nested under Role**: location now renders under the company line in the Role cell — pin icon + text — instead of its own column.
- **Saved/Active/Archive had no location data at all.** Added end-to-end:
  - migration `083` — nullable `job.pipeline_roles.location` + backfill from `recommended_roles` (by `added_to_pipeline_slug`, then `url`)
  - `add-role` v0.4.0 — persists location (source-rec carry-over, or JSON-LD `jobLocation`/`TELECOMMUTE`)
  - `jobs-pipe` v0.11.0 — returns `r.location`

## 3. Source column cleanup (For You) — favicon + tight label
Leads with the platform favicon (Gmail for inbox-sourced, posting-host otherwise) + a tight label (`Greenhouse · Abridge → Greenhouse`). Keeps the "verifying" badge and the email-thread icon.

## Mobile (checked at 390px)
- For You rows hide Strength / Source / Added and nest location in the Role cell.
- Pipeline rows nest location above the existing status/sector meta line.
- Verified desktop + mobile in Chrome.

Shared formatters live in `ladder/js/format.js` (one source of truth for both tables). `app.js` VERSION 2.4.1 → 2.5.0.

## Post-merge (I'll handle)
Deploy `jobs-pipe` + `add-role`; run migration `083`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)