### PR TITLE
Fix variable source icons (TheirStack et al.)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.5.1";
-console.log(`[ladder] v${VERSION} - drop ctrl.rodeo subtitle from rail brand`);
+const VERSION = "2.5.2";
+console.log(`[ladder] v${VERSION} - consistent source favicon per platform (TheirStack/WWR/etc)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/format.js
+++ b/ladder/js/format.js
@@ -49,21 +49,35 @@ function favicon(host) {
 //   → { iconUrl, label, title }   label is a tight platform name.
 // Favicon: Gmail for inbox-sourced rows; otherwise the posting URL's host
 // (which IS the platform for ATS/company-page/LinkedIn sources).
+// Syndicated/aggregator sources re-post jobs from many different hosts, so the
+// posting URL's host is NOT the source — pin one fixed favicon + label per
+// platform so the icon stays consistent (e.g. all TheirStack rows look alike,
+// not one icon per underlying company). Keyed on the stable `source` enum.
+const PLATFORM = {
+  'gmail-jobs':   { host: 'mail.google.com',      label: 'Gmail' },
+  'theirstack':   { host: 'theirstack.com',       label: 'TheirStack' },
+  'wwr':          { host: 'weworkremotely.com',   label: 'We Work Remotely' },
+  'remotive':     { host: 'remotive.com',         label: 'Remotive' },
+  'hn':           { host: 'news.ycombinator.com', label: 'Hacker News' },
+  'linkedin-rss': { host: 'linkedin.com',         label: 'LinkedIn' },
+};
+
 export function sourceMeta(r) {
   const rawLabel = String(r.sourceLabel || r.source || '').trim();
   const src = String(r.source || '').toLowerCase();
 
-  if (src.includes('gmail') || r.sourceEmailUrl) {
-    return { iconUrl: favicon('mail.google.com'), label: 'Gmail', title: rawLabel || 'Gmail' };
+  const platform = PLATFORM[src] || (r.sourceEmailUrl ? PLATFORM['gmail-jobs'] : null);
+  if (platform) {
+    return { iconUrl: favicon(platform.host), label: platform.label, title: rawLabel || platform.label };
   }
 
-  // Platform = text before a "·"/"|" separator ("Greenhouse · Abridge" → "Greenhouse").
+  // Direct sources (tracked-ats, company pages, manual): the posting host IS
+  // the source, so its favicon is meaningful and matches the label. Label is
+  // the platform name before a "·" separator ("Greenhouse · Abridge" → "Greenhouse").
   let label = rawLabel.split(/\s*[·|]\s*/)[0].trim();
   const lower = label.toLowerCase();
-  if (/linkedin/.test(lower) || src.includes('linkedin')) label = 'LinkedIn';
-  else if (lower === 'from company pages' || src === 'tracked-ats') label = label && lower !== 'from company pages' ? label : 'Company site';
+  if (lower === 'from company pages') label = 'Company site';
   else if (lower === 'manual') label = 'Added';
-  else if (lower === 'rss' || src.includes('rss')) label = 'RSS';
   if (!label) label = rawLabel || 'Source';
 
   let iconUrl = null;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.1">
-  <script src="/ladder/js/theme.js?v=2.5.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.5.2">
+  <script src="/ladder/js/theme.js?v=2.5.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.5.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.5.2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem
The Source favicon was derived from each rec's **posting URL host**. Aggregator sources re-post jobs from many different hosts, so the icon varied row-to-row while the label stayed fixed. TheirStack alone spanned **56 distinct hosts across 152 recs** → 56 different icons all labeled "TheirStack". Same latent issue for We Work Remotely, Remotive, HN.

## Fix
Pin one favicon + label per **syndicated** platform (`theirstack`, `wwr`, `remotive`, `hn`, `linkedin-rss`, `gmail-jobs`), keyed on the stable `source` enum, in `ladder/js/format.js`.

**Direct** sources (`tracked-ats`, company pages, manual) keep the posting-host favicon — there the host *is* the source and already matches the label (Ashby / Greenhouse / Lever).

Verified in Chrome against the real `sourceMeta`: all TheirStack rows now share one icon; WWR/Remotive/HN/Gmail each get their own; tracked-ats still shows the matching ATS icon. VERSION 2.5.1 → 2.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)