### PR TITLE
ladder: fix gmail-auth reconnect banner never clearing (var shadowing)

### DIFF
--- a/supabase/functions/gmail-auth/index.ts
+++ b/supabase/functions/gmail-auth/index.ts
@@ -13,8 +13,8 @@
 // don't need a new client registration. The redirect URI for gmail
 // connect points at /job/ — calendar-api keeps /calendar/.
 
-const VERSION = '0.3.0';
-console.log(`[gmail-auth] v${VERSION} - clear stale last_error on connect so reconnect banner clears immediately`);
+const VERSION = '0.3.1';
+console.log(`[gmail-auth] v${VERSION} - fix: imported db() shadowed by local SupabaseClient, so last_error clear silently threw; reconnect banner never cleared`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -27,7 +27,7 @@ import {
   markRevoked,
   upsertToken,
 } from '../_shared/google-tokens.ts';
-import { db } from '../_shared/job-db.ts';
+import { db as jobSql } from '../_shared/job-db.ts';
 
 // gmail.modify is a strict superset of gmail.readonly. We request both
 // so the scope_set on the token row covers callers that look up by
@@ -186,7 +186,7 @@ serve(async (req) => {
       // clears immediately on reconnect, instead of lingering until the
       // next successful scan. Best-effort — never fail the connect over it.
       try {
-        const sql = db();
+        const sql = jobSql();
         await sql`update job.user_sources set last_error = null
                    where user_email = ${user.email} and type = 'gmail-jobs'`;
         await sql`update job.gmail_scan_state set last_error = null


### PR DESCRIPTION
## Problem
Google/Gmail connection in Ladder kept appearing broken even right after a successful reconnect. Investigation showed the token itself was healthy (refresh working, not revoked) — the **banner was stale**.

## Root cause
`gmail-auth/index.ts` is meant to clear `last_error` on every reconnect (PR #917), but that code **never ran successfully** due to variable shadowing:
- Line 30 imports `db` (postgres helper, a callable)
- Line 82 declares `const db = getServiceClient()` (a SupabaseClient), shadowing the import
- Line 189 `const sql = db()` calls the SupabaseClient as a function → throws → swallowed by the catch

Net: the "clear stale `last_error` on reconnect" logic never executed. The `Reconnect Gmail` banner (driven by `job.user_sources.last_error` + `job.gmail_scan_state.last_error`) persisted until the next fully successful scan.

## Fix
Alias the import to `jobSql` so the clear actually runs. Bumped `v0.3.0` → `v0.3.1`.

Also manually nulled the two stale `last_error` rows for the affected user so the current banner clears now.

Note: separate from the underlying Google "Testing"-mode 7-day token expiry, which still needs the OAuth app published to Production in Cloud Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)