### PR TITLE
field: fix mobile layout (stack blocks + nav overflow)

### DIFF
--- a/design-system/display.css
+++ b/design-system/display.css
@@ -144,8 +144,19 @@
 .d-subnav__link:hover { color: var(--fg-muted, #8a8885); }
 .d-subnav__link--active { color: var(--fg, #e8e6e3); border-bottom-color: var(--fg, #e8e6e3); }
 
+@media (max-width: 768px) {
+  /* Let the nav wrap instead of overflowing off the right edge.
+     JS re-pins the subnav below the (now taller) nav on resize. */
+  .d-nav { flex-wrap: wrap; padding: 12px 20px; row-gap: 8px; }
+  .d-nav__links { flex-wrap: wrap; gap: 12px 16px; justify-content: flex-start; }
+  .d-nav__group { flex-wrap: wrap; row-gap: 8px; }
+  .d-nav__group--expanded { gap: 12px; }
+  .d-nav__group-items { gap: 16px; }
+  .d-nav__group--expanded .d-nav__group-items { padding-inline: 14px; }
+}
+
 @media (max-width: 600px) {
-  .d-nav__links { gap: 16px; }
+  .d-nav__links { gap: 12px; }
   .d-subnav { overflow-x: auto; -webkit-overflow-scrolling: touch; }
   .d-subnav__link { white-space: nowrap; }
 }
@@ -677,6 +688,72 @@
   padding: 48px 0;
   transition: opacity 0.3s ease;
   /* opacity set by JS based on distance from viewport center */
+}
+
+/* Stack the sticky phone above the scrolling text on mobile */
+@media (max-width: 768px) {
+  .d-sticky-scroll { flex-direction: column; gap: 0; }
+  .d-sticky-scroll__phone { width: 100%; }
+  .d-sticky-scroll__layers {
+    height: 52vh;
+    width: calc(100% + 2 * var(--gutter-page, clamp(20px, 5vw, 64px)));
+    margin-left: calc(-1 * var(--gutter-page, clamp(20px, 5vw, 64px)));
+    margin-right: calc(-1 * var(--gutter-page, clamp(20px, 5vw, 64px)));
+  }
+  .d-sticky-scroll__step { min-height: 80vh; padding: 32px 0; }
+}
+
+/* ── Case study hero (Field header) ── */
+
+.d-case-hero {
+  display: flex;
+  gap: 32px;
+  padding: 48px 0 0;
+  align-items: flex-start;
+}
+
+.d-case-hero__media {
+  width: 500px;
+  height: 500px;
+  flex-shrink: 0;
+  overflow: hidden;
+  background: #0A0A0A;
+}
+
+.d-case-hero__content { flex: 1; min-width: 0; }
+
+@media (max-width: 768px) {
+  .d-case-hero { flex-direction: column; gap: 24px; padding-top: 32px; }
+  .d-case-hero__media { width: 100%; height: auto; aspect-ratio: 1 / 1; }
+}
+
+/* ── Case study two-column layout (Design Systems) ── */
+
+.d-ds-layout {
+  display: flex;
+  gap: 48px;
+  align-items: flex-start;
+}
+
+.d-ds-layout__swatches {
+  width: 380px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.d-ds-layout__principles {
+  flex: 1;
+  min-width: 0;
+  position: sticky;
+  top: 140px;
+}
+
+@media (max-width: 768px) {
+  .d-ds-layout { flex-direction: column; gap: 32px; }
+  .d-ds-layout__swatches { width: 100%; order: 2; }
+  .d-ds-layout__principles { width: 100%; position: static; top: auto; order: 1; }
 }
 
 /* ── Utilities ── */

--- a/field/index.html
+++ b/field/index.html
@@ -7,7 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/design-system/tokens.css">
   <link rel="stylesheet" href="/design-system/components.css">
-  <link rel="stylesheet" href="/design-system/display.css?v=506">
+  <link rel="stylesheet" href="/design-system/display.css?v=507">
 </head>
 <body class="d-page">
 
@@ -40,13 +40,13 @@
 <div class="d-contain">
 
   <!-- Header — side by side -->
-  <div style="display: flex; gap: 32px; padding: 48px 0 0; align-items: flex-start;">
+  <div class="d-case-hero">
     <!-- Hero animation — 500×500 square -->
-    <div style="width: 500px; height: 500px; flex-shrink: 0; overflow: hidden; background: #0A0A0A;">
-      <iframe src="/animations/hero.html" style="width: 500px; height: 500px; border: none; pointer-events: none; display: block;" id="heroFrame"></iframe>
+    <div class="d-case-hero__media">
+      <iframe src="/animations/hero.html" style="width: 100%; height: 100%; border: none; pointer-events: none; display: block;" id="heroFrame"></iframe>
     </div>
     <!-- Content -->
-    <div style="flex: 1;">
+    <div class="d-case-hero__content">
       <span class="d-status d-status--dev">Beta</span>
       <p class="d-headline d-headline--xl" style="margin-top: 12px;">Field</p>
       <p class="d-body" style="margin-top: 12px;">Turning the voices of a complex on-scene interactions into structured medical notes - all offline.</p>
@@ -268,10 +268,10 @@
       <p class="d-headline d-headline--md" style="margin-top: 4px;">Design Systems</p>
     </div>
 
-    <div style="display: flex; gap: 48px; align-items: flex-start;">
+    <div class="d-ds-layout">
 
       <!-- Right: Token swatches (scrolls) -->
-      <div style="width: 380px; flex-shrink: 0; display: flex; flex-direction: column; gap: 32px;">
+      <div class="d-ds-layout__swatches">
 
         <!-- Background -->
         <div>
@@ -344,7 +344,7 @@
       </div>
 
       <!-- Left: Principles (sticky, fits single page height) -->
-      <div style="flex: 1; position: sticky; top: 140px;">
+      <div class="d-ds-layout__principles">
         <p class="d-mono d-text--subtle" style="font-size: 10px; letter-spacing: 0.05em; margin-bottom: 20px;">DESIGN PRINCIPLES</p>
         <div style="display: flex; flex-direction: column; gap: 24px;">
           <!-- Information -->
@@ -483,10 +483,9 @@
   var started = {}; // track which iframes have been triggered
   var activeStep = 0;
 
-  var PAD = 48; // padding around phone inside the black box
-
   // Size phones to fit their layer container minus padding
   function sizePhones() {
+    var PAD = window.innerWidth <= 768 ? 20 : 48; // tighter padding on mobile
     var phones = document.querySelectorAll('.d-anim-phone');
     for (var i = 0; i < phones.length; i++) {
       var layer = phones[i].parentElement;


### PR DESCRIPTION
## Problem
On mobile, the Field case study (`ctrl.rodeo/field`) rendered broken: blocks that should stack stayed side-by-side and overflowed, and the top navigation ran off the right edge / overlapped.

## Cause
The page used inline `display: flex` with **fixed pixel widths** and **no responsive breakpoints**:
- Header: 500px hero box + flex content
- Core Experience: 460px sticky phone column (`.d-sticky-scroll`)
- Design Systems: 380px swatch column + sticky principles column
- Nav: too many items for a phone width, no wrap

## Fix
- Extracted the inline header and Design-Systems layouts into reusable `.d-case-hero` and `.d-ds-layout` component classes (desktop behavior unchanged).
- Added `@media (max-width: 768px)` rules to stack the hero, the two-column design-system block, and the sticky-scroll section.
- Let `.d-nav` / `.d-nav__links` wrap instead of overflowing (JS already re-pins the subnav below the taller nav on resize).
- Sized the stacked sticky phone with tighter mobile padding so it stays legible.
- Bumped `display.css?v=506 → 507` on the Field page to bust cache.

## Verification
Served the worktree locally and confirmed via DOM inspection that the new classes are wired and all four `max-width:768px` rule groups load with correct `flex-direction: column` declarations. Desktop layout is unchanged.

Note: Invoy and Livongo share the same nav/structure and likely have the same mobile issue — happy to apply the same fix if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)