### PR TITLE
ladder: full connections sweep + high-quality 2nd-degree

### DIFF
--- a/docs/strategy/prds/linkedin-connection-mining.md
+++ b/docs/strategy/prds/linkedin-connection-mining.md
@@ -1,24 +1,36 @@
 # Brief: Productizing "Who do I know here?" (LinkedIn connection mining)
 
-**Status:** Pilot shipped (manual mining, 6 companies) · **Owner:** Ian · **Date:** 2026-06-30
+**Status:** Full manual sweep shipped (all leads, 1st + 2nd degree) · **Owner:** Ian · **Date:** 2026-06-30
 
-## 1. What shipped (the pilot)
+## 1. What shipped
 
-For every saved lead in `/ladder`, the app now shows Ian's 1st-degree LinkedIn
-connections who **currently work at that company**, so a warm intro or referral
-is one click away.
+For every saved lead in `/ladder`, the app now shows the LinkedIn people tied to
+that company, in two tiers:
 
-- **Detail page** (`/ladder/jobs/{slug}/`) — a "People you may know here" card:
-  avatar, name, current title, link to their LinkedIn profile.
+- **1st degree** — connections who **currently work there** → ask for a warm
+  intro / referral.
+- **2nd degree (high quality)** — senior/decision-maker profiles (CPO, CTO,
+  CEO, VP/Head/Director of Product, founders) reachable **through a mutual** →
+  worth a connection request. Ranked by mutual-connection count.
+
+Surfaces:
+
+- **Detail page** (`/ladder/jobs/{slug}/`) — a "People you may know here" card,
+  grouped into a "You're connected" (1st) section and a "Worth a connection
+  request" (2nd) section with mutual counts. Each row links to the profile.
 - **Leads table** (`?bucket=leads`) — a "Network" column with an
-  overlapping-avatar stack per row.
-- **Data** — `job.company_connections` (migration 085), keyed on
-  `company_slug`; joined into every role at that company by `jobs-pipe`
-  (`r.connections`).
+  overlapping-avatar stack; 1st-degree faces are solid, 2nd-degree get a dashed
+  ring.
+- **Data** — `job.company_connections` (migrations 085 + 086), keyed on
+  `company_slug` with a `degree` (1st/2nd) + `mutuals` count; joined into every
+  role at that company by `jobs-pipe` (`r.connections`, ordered 1st then 2nd).
 
-The pilot was mined **by hand** for 6 companies: Anthropic (3), Abridge (1),
-Mercury (1), OpenAI (1); Plaid and Code for America returned no current
-1st-degree connections. Result: 6 connections, all with photos.
+**Coverage:** all 40 unique lead companies swept. Result: **81 connections —
+12 first-degree, 69 high-quality second-degree — across 30 companies**, nearly
+all with photos. Mining used a single people-search per company filtered to
+1st+2nd degree (`network=["F","S"]`), splitting on each card's degree marker.
+The `linkedin` slug lead (an Oura role) was mined against Oura; the
+`maven-clinic`/`mavenclinic` duplicate slugs share one mined set.
 
 ## 2. How the pilot was actually done (and why it's not yet a product)
 

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.10.0");
+@import url("./components.css?v=1.11.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5735,3 +5735,37 @@ body[data-auth-state="out"] job-chat { display: none; }
 .conn-text { display: flex; flex-direction: column; line-height: 1.25; }
 .conn-name { font-weight: var(--fw-semibold); font-size: var(--font-size-small); }
 .conn-title { color: var(--fg-subtle); font-size: var(--font-size-small); max-width: 32ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* ── Connections: 1st vs 2nd degree ───────────────────────────────────── */
+.conn-group__label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+}
+.conn-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: var(--fw-semibold);
+  flex: none;
+}
+.conn-badge--1st { background: var(--accent-strong); color: var(--accent-strong-fg); }
+.conn-badge--2nd { background: transparent; color: var(--fg-subtle); border: 1px dashed var(--border-strong); }
+.conn-link--2nd .conn-avatar { border: 2px dashed var(--border-strong); }
+.conn-mutuals { color: var(--fg-subtle); font-size: var(--font-size-small); opacity: 0.85; }
+
+/* 2nd-degree avatars in the leads-table stack get a dashed ring so they read
+   as "reachable through a mutual" rather than "already connected". */
+.conn-stack__avatar--2nd {
+  border-style: dashed;
+  border-color: var(--border-strong);
+  opacity: 0.9;
+}

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.6.0";
-console.log(`[ladder] v${VERSION} - LinkedIn connections on lead detail + leads-table avatars`);
+const VERSION = "2.7.0";
+console.log(`[ladder] v${VERSION} - 1st + high-quality 2nd-degree LinkedIn connections on leads`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -934,29 +934,38 @@ export class JobPipeline extends LitElement {
     `;
   }
 
-  // Avatar stack of Ian's 1st-degree LinkedIn connections who currently work
-  // at this lead's company (r.connections, joined in by jobs-pipe). Shows up
-  // to 4 faces + an overflow count; empty cell when there are none. Clicking
-  // the row still navigates to the detail page where the full list + intro
-  // links live.
+  // Avatar stack of Ian's LinkedIn connections tied to this lead's company
+  // (r.connections, joined in by jobs-pipe; ordered 1st-degree then 2nd).
+  // 1st-degree faces are solid; high-quality 2nd-degree (worth an intro) get
+  // a dashed ring. Shows up to 4 faces + an overflow count. Clicking the row
+  // opens the detail page where the grouped list + intro hints live.
   _renderConnectionsCell(r) {
     const conns = r.connections || [];
     if (!conns.length) return nothing;
+    const firstN = conns.filter(c => c.degree !== '2nd').length;
     const shown = conns.slice(0, 4);
     const extra = conns.length - shown.length;
-    const title = conns.map(c => c.name + (c.title ? ` — ${c.title}` : '')).join('\n');
+    const title = conns
+      .map(c => `${c.degree === '2nd' ? '2nd' : '1st'} · ${c.name}${c.title ? ` — ${c.title}` : ''}${c.degree === '2nd' && c.mutuals ? ` (${c.mutuals} mutual)` : ''}`)
+      .join('\n');
+    const aria = firstN
+      ? `${firstN} direct, ${conns.length - firstN} second-degree connection(s) here`
+      : `${conns.length} second-degree connection(s) here`;
     return html`
-      <span class="conn-stack" title=${title} aria-label=${`${conns.length} connection${conns.length === 1 ? '' : 's'} here`}>
-        ${shown.map(c => c.photoUrl
-          ? html`<img class="conn-stack__avatar" src=${c.photoUrl} alt=${c.name}
-                   loading="lazy" decoding="async"
-                   @error=${(e) => {
-                     const span = document.createElement('span');
-                     span.className = 'conn-stack__avatar conn-stack__avatar--placeholder';
-                     span.textContent = (c.name || '?').trim().charAt(0).toUpperCase() || '?';
-                     e.target.replaceWith(span);
-                   }}/>`
-          : html`<span class="conn-stack__avatar conn-stack__avatar--placeholder">${(c.name || '?').trim().charAt(0).toUpperCase() || '?'}</span>`)}
+      <span class="conn-stack" title=${title} aria-label=${aria}>
+        ${shown.map(c => {
+          const cls = 'conn-stack__avatar' + (c.degree === '2nd' ? ' conn-stack__avatar--2nd' : '');
+          return c.photoUrl
+            ? html`<img class=${cls} src=${c.photoUrl} alt=${c.name}
+                     loading="lazy" decoding="async"
+                     @error=${(e) => {
+                       const span = document.createElement('span');
+                       span.className = cls + ' conn-stack__avatar--placeholder';
+                       span.textContent = (c.name || '?').trim().charAt(0).toUpperCase() || '?';
+                       e.target.replaceWith(span);
+                     }}/>`
+            : html`<span class=${cls + ' conn-stack__avatar--placeholder'}>${(c.name || '?').trim().charAt(0).toUpperCase() || '?'}</span>`;
+        })}
         ${extra > 0 ? html`<span class="conn-stack__more">+${extra}</span>` : nothing}
       </span>
     `;

--- a/ladder/js/components/ladder-role-detail.js
+++ b/ladder/js/components/ladder-role-detail.js
@@ -620,36 +620,59 @@ export class JobRoleDetail extends LitElement {
     `;
   }
 
-  // "People you may know here" — Ian's 1st-degree LinkedIn connections who
-  // currently work at this role's company, joined in by jobs-pipe on
-  // r.connections. Each chip links out to the person's LinkedIn profile so
-  // Ian can ask for a warm intro / referral. Hidden when there are none.
+  // "People you may know here" — Ian's LinkedIn connections tied to this
+  // role's company, joined in by jobs-pipe on r.connections. Split into
+  // 1st-degree ("you know them directly" → warm intro/referral) and
+  // high-quality 2nd-degree ("worth a connection request" → decision-makers
+  // reachable through a mutual). Hidden when there are none.
   _renderConnections() {
     const conns = this.role?.connections || [];
     if (!conns.length) return nothing;
+    const firsts  = conns.filter(c => c.degree !== '2nd');
+    const seconds = conns.filter(c => c.degree === '2nd');
     return html`
       <article class="role-card role-connections">
         <header class="role-card__head"><h3>People you may know here</h3></header>
         <div class="role-card__body">
-          <p class="muted role-connections__sub">${conns.length} 1st-degree LinkedIn connection${conns.length === 1 ? '' : 's'} at ${this.role.company || 'this company'} — worth a warm intro.</p>
-          <ul class="conn-list">
-            ${conns.map(c => html`
-              <li class="conn-item">
-                <a class="conn-link" href=${c.profileUrl || '#'} target="_blank" rel="noopener">
-                  ${c.photoUrl
-                    ? html`<img class="conn-avatar" src=${c.photoUrl} alt="" loading="lazy" decoding="async"
-                             @error=${(e) => { e.target.replaceWith(this._connInitialEl(c.name)); }}/>`
-                    : this._connInitial(c.name)}
-                  <span class="conn-text">
-                    <span class="conn-name">${c.name}</span>
-                    ${c.title ? html`<span class="conn-title">${c.title}</span>` : nothing}
-                  </span>
-                </a>
-              </li>
-            `)}
-          </ul>
+          ${firsts.length ? html`
+            <p class="conn-group__label">
+              <span class="conn-badge conn-badge--1st">1st</span>
+              You're connected — ${firsts.length} direct contact${firsts.length === 1 ? '' : 's'} at ${this.role.company || 'this company'}. Ask for a warm intro or referral.
+            </p>
+            <ul class="conn-list">
+              ${firsts.map(c => this._renderConnItem(c))}
+            </ul>
+          ` : nothing}
+          ${seconds.length ? html`
+            <p class="conn-group__label" style=${firsts.length ? 'margin-top:var(--space-4);' : ''}>
+              <span class="conn-badge conn-badge--2nd">2nd</span>
+              Worth a connection request — ${seconds.length} senior/decision-maker${seconds.length === 1 ? '' : 's'} reachable through a mutual.
+            </p>
+            <ul class="conn-list">
+              ${seconds.map(c => this._renderConnItem(c))}
+            </ul>
+          ` : nothing}
         </div>
       </article>
+    `;
+  }
+
+  _renderConnItem(c) {
+    const isSecond = c.degree === '2nd';
+    return html`
+      <li class="conn-item">
+        <a class="conn-link ${isSecond ? 'conn-link--2nd' : ''}" href=${c.profileUrl || '#'} target="_blank" rel="noopener">
+          ${c.photoUrl
+            ? html`<img class="conn-avatar" src=${c.photoUrl} alt="" loading="lazy" decoding="async"
+                     @error=${(e) => { e.target.replaceWith(this._connInitialEl(c.name)); }}/>`
+            : this._connInitial(c.name)}
+          <span class="conn-text">
+            <span class="conn-name">${c.name}</span>
+            ${c.title ? html`<span class="conn-title">${c.title}</span>` : nothing}
+            ${isSecond && c.mutuals ? html`<span class="conn-mutuals">${c.mutuals} mutual connection${c.mutuals === 1 ? '' : 's'}</span>` : nothing}
+          </span>
+        </a>
+      </li>
     `;
   }
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.6.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.7.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.6.0">
-  <script src="/ladder/js/theme.js?v=2.6.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <script src="/ladder/js/theme.js?v=2.7.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.6.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.12.0';
-console.log(`[jobs-pipe] v${VERSION} - include LinkedIn connections per company (company_connections join)`);
+const VERSION = '0.13.0';
+console.log(`[jobs-pipe] v${VERSION} - connections include degree (1st/2nd) + mutual count`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -76,8 +76,10 @@ async function listRoles() {
           'name', c.full_name,
           'title', coalesce(nullif(c.current_title, ''), c.headline),
           'profileUrl', c.profile_url,
-          'photoUrl', c.photo_url
-        ) order by c.full_name)
+          'photoUrl', c.photo_url,
+          'degree', c.degree,
+          'mutuals', c.mutuals
+        ) order by c.degree, c.mutuals desc nulls last, c.full_name)
         from job.company_connections c
         where c.company_slug = r.company_slug
       ), array[]::json[]) as "connections"

--- a/supabase/migrations/086_company_connections_degree.sql
+++ b/supabase/migrations/086_company_connections_degree.sql
@@ -1,0 +1,17 @@
+-- 086_company_connections_degree.sql
+-- Add connection degree (1st vs 2nd) + mutual-connection count to
+-- job.company_connections so the /ladder UI can distinguish direct contacts
+-- (warm intro / referral) from high-quality 2nd-degree people worth a
+-- connection request (decision-makers reachable through a mutual).
+
+alter table job.company_connections
+  add column if not exists degree  text not null default '1st',
+  add column if not exists mutuals integer;
+
+create index if not exists company_connections_company_degree_idx
+  on job.company_connections (company_slug, degree);
+
+comment on column job.company_connections.degree is
+  '1st = Ian is directly connected; 2nd = reachable through a mutual (worth a connection request).';
+comment on column job.company_connections.mutuals is
+  'Shared-connection count for 2nd-degree people (intro feasibility signal).';


### PR DESCRIPTION
Extends the connections feature (PR #965) from the 6-company pilot to **all 40 lead companies**, and adds a **2nd-degree tier**.

## Tiers
- **1st degree** — connections currently at the company → warm intro / referral.
- **2nd degree (high quality)** — CPO/CTO/CEO, VP/Head/Director of Product, founders reachable **through a mutual**, ranked by mutual count → worth a connection request.

## Data
**81 connections — 12 first-degree, 69 second-degree — across 30 companies.** Notable 2nd-degree hits: CPO @ Verily, VP Product @ Google DeepMind, Head of Product @ Rad AI, CEO/CPO @ Talkiatry, VP Product @ Cityblock, Head of Product @ Midi, founders @ Grow Therapy / Develop Health / NexHealth / Wonderschool.

## Changes
- Migration `086`: `degree` (1st/2nd) + `mutuals` on `job.company_connections`.
- `jobs-pipe` v0.13.0: connections carry degree + mutuals, ordered 1st then 2nd (deployed).
- Detail card: grouped **"You're connected"** vs **"Worth a connection request"** (with mutual counts).
- Leads table: 2nd-degree avatars get a dashed ring vs solid 1st-degree.
- ladder `2.6.0 → 2.7.0`; components.css `1.10.0 → 1.11.0`.

Brief updated: `docs/strategy/prds/linkedin-connection-mining.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)