### PR TITLE
ladder: swap Network/Sector columns + Network hover card

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.11.0");
+@import url("./components.css?v=1.12.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5769,3 +5769,42 @@ body[data-auth-state="out"] job-chat { display: none; }
   border-color: var(--border-strong);
   opacity: 0.9;
 }
+
+/* ── Network column hover card ────────────────────────────────────────── */
+.conn-tip {
+  position: fixed;
+  z-index: 1000;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.28);
+  padding: var(--space-3);
+  max-height: 60vh;
+  overflow-y: auto;
+  pointer-events: none;
+}
+.conn-tip__group + .conn-tip__group { margin-top: var(--space-3); padding-top: var(--space-3); border-top: 1px solid var(--border); }
+.conn-tip__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-caption);
+  color: var(--fg-subtle);
+  margin-bottom: var(--space-2);
+}
+.conn-tip__list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-2); }
+.conn-tip__item { display: flex; align-items: center; gap: var(--space-2); }
+.conn-tip__avatar {
+  width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none;
+  background: var(--bg-surface); border: 1px solid var(--border);
+}
+.conn-tip__avatar--2nd { border-style: dashed; border-color: var(--border-strong); }
+.conn-tip__avatar--ph {
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: var(--fw-semibold); color: var(--fg-subtle); text-transform: uppercase;
+}
+.conn-tip__text { display: flex; flex-direction: column; line-height: 1.25; min-width: 0; }
+.conn-tip__name { font-weight: var(--fw-semibold); font-size: var(--font-size-small); }
+.conn-tip__title { color: var(--fg-subtle); font-size: var(--font-size-caption); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 240px; }
+.conn-tip__mutuals { color: var(--fg-subtle); font-size: var(--font-size-caption); opacity: 0.85; }
+.conn-stack { cursor: default; }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.7.0";
-console.log(`[ladder] v${VERSION} - 1st + high-quality 2nd-degree LinkedIn connections on leads`);
+const VERSION = "2.8.0";
+console.log(`[ladder] v${VERSION} - Network column hover card + swap Network/Sector order`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -56,8 +56,8 @@ const COLUMNS = [
   { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
   { id: 'role',   label: 'Role',   sortKey: 'title',   type: 'text' },
   { id: 'signal', label: '',       sortKey: null },
-  { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
   { id: 'connections', label: 'Network', sortKey: null },
+  { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
   { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
   { id: 'menu',   label: '',       sortKey: null },
 ];
@@ -131,6 +131,8 @@ export class JobPipeline extends LitElement {
     // reply_pending / new_update / stale_14d). Keyed by role slug.
     roleSignals:     { state: true },
     liveBanners:     { state: true },
+    // Hover-card state for the Network column: { conns, x, y } | null.
+    hoverConns:      { state: true },
   };
 
   constructor() {
@@ -142,6 +144,7 @@ export class JobPipeline extends LitElement {
     this._dragSlug = null;
     this._dragOverSlug = null;
     this.selectedRow = null;
+    this.hoverConns = null;
     const params = new URLSearchParams(location.search);
     const b = params.get('bucket');
     this.bucket = (b === 'leads' || b === 'active' || b === 'archive') ? b : 'leads';
@@ -906,8 +909,8 @@ export class JobPipeline extends LitElement {
           </div>
         </td>
         <td class="col col-signal" data-label="">${this._renderSignalCell(r)}</td>
-        <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
         ${this.bucket === 'leads' ? html`<td class="col col-connections" data-label="Network">${this._renderConnectionsCell(r)}</td>` : nothing}
+        <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
         ${showStatus ? html`<td class="col col-status status-cell" data-label="Status">${this._renderStatusCell(r)}</td>` : nothing}
         <td class="col col-menu">${this._renderMenuCell(r)}</td>
       </tr>
@@ -945,14 +948,13 @@ export class JobPipeline extends LitElement {
     const firstN = conns.filter(c => c.degree !== '2nd').length;
     const shown = conns.slice(0, 4);
     const extra = conns.length - shown.length;
-    const title = conns
-      .map(c => `${c.degree === '2nd' ? '2nd' : '1st'} · ${c.name}${c.title ? ` — ${c.title}` : ''}${c.degree === '2nd' && c.mutuals ? ` (${c.mutuals} mutual)` : ''}`)
-      .join('\n');
     const aria = firstN
       ? `${firstN} direct, ${conns.length - firstN} second-degree connection(s) here`
       : `${conns.length} second-degree connection(s) here`;
     return html`
-      <span class="conn-stack" title=${title} aria-label=${aria}>
+      <span class="conn-stack" aria-label=${aria}
+            @mouseenter=${(e) => this._showConnTip(conns, e)}
+            @mouseleave=${() => this._hideConnTip()}>
         ${shown.map(c => {
           const cls = 'conn-stack__avatar' + (c.degree === '2nd' ? ' conn-stack__avatar--2nd' : '');
           return c.photoUrl
@@ -968,6 +970,59 @@ export class JobPipeline extends LitElement {
         })}
         ${extra > 0 ? html`<span class="conn-stack__more">+${extra}</span>` : nothing}
       </span>
+    `;
+  }
+
+  // Hover card for the Network column — anchored to the hovered avatar
+  // stack, shows the full connection list (grouped 1st / 2nd degree) so Ian
+  // can eyeball who's there without opening the detail page. Fixed-position
+  // so it escapes the table's horizontal scroll container.
+  _showConnTip(conns, e) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    this.hoverConns = { conns, x: rect.left, y: rect.bottom + 6 };
+  }
+  _hideConnTip() { this.hoverConns = null; }
+
+  _renderConnTip() {
+    const h = this.hoverConns;
+    if (!h) return nothing;
+    const conns = h.conns || [];
+    const firsts  = conns.filter(c => c.degree !== '2nd');
+    const seconds = conns.filter(c => c.degree === '2nd');
+    // Clamp to viewport so the card never spills off-screen.
+    const width = 300;
+    const left = Math.max(8, Math.min(window.innerWidth - width - 8, h.x));
+    const top = Math.min(window.innerHeight - 20, h.y);
+    const row = (c) => html`
+      <li class="conn-tip__item">
+        ${c.photoUrl
+          ? html`<img class="conn-tip__avatar ${c.degree === '2nd' ? 'conn-tip__avatar--2nd' : ''}" src=${c.photoUrl} alt="" loading="lazy"
+                   @error=${(e) => {
+                     const s = document.createElement('span');
+                     s.className = 'conn-tip__avatar conn-tip__avatar--ph';
+                     s.textContent = (c.name || '?').trim().charAt(0).toUpperCase();
+                     e.target.replaceWith(s);
+                   }}/>`
+          : html`<span class="conn-tip__avatar conn-tip__avatar--ph">${(c.name || '?').trim().charAt(0).toUpperCase()}</span>`}
+        <span class="conn-tip__text">
+          <span class="conn-tip__name">${c.name}</span>
+          ${c.title ? html`<span class="conn-tip__title">${c.title}</span>` : nothing}
+          ${c.degree === '2nd' && c.mutuals ? html`<span class="conn-tip__mutuals">${c.mutuals} mutual</span>` : nothing}
+        </span>
+      </li>`;
+    return html`
+      <div class="conn-tip" style=${`left:${left}px;top:${top}px;width:${width}px;`}>
+        ${firsts.length ? html`
+          <div class="conn-tip__group">
+            <div class="conn-tip__head"><span class="conn-badge conn-badge--1st">1st</span> You're connected</div>
+            <ul class="conn-tip__list">${firsts.map(row)}</ul>
+          </div>` : nothing}
+        ${seconds.length ? html`
+          <div class="conn-tip__group">
+            <div class="conn-tip__head"><span class="conn-badge conn-badge--2nd">2nd</span> Worth a connection request</div>
+            <ul class="conn-tip__list">${seconds.map(row)}</ul>
+          </div>` : nothing}
+      </div>
     `;
   }
 
@@ -1005,8 +1060,8 @@ export class JobPipeline extends LitElement {
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
         </td>
         <td class="col col-signal"></td>
-        <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
         ${this.bucket === 'leads' ? html`<td class="col col-connections"><span class="skeleton skeleton--pill" style="width:64px;height:28px;"></span></td>` : nothing}
+        <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
         ${showStatus ? html`<td class="col col-status"><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
         <td class="col col-menu"><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
       </tr>
@@ -1228,6 +1283,7 @@ export class JobPipeline extends LitElement {
           <tbody>${rows.map(r => this._renderRow(r))}</tbody>
         </table>
       </div>
+      ${this._renderConnTip()}
       ${this._renderArchiveModal()}
 
       ${rows.length === 0 ? html`

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.7.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.7.0">
-  <script src="/ladder/js/theme.js?v=2.7.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <script src="/ladder/js/theme.js?v=2.8.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.7.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
 </body>
 </html>


### PR DESCRIPTION
- **Column order:** Network now precedes Sector in the leads table.
- **Hover card:** hovering the Network avatar stack opens a card with the full connection list — grouped **1st degree** (You're connected) vs **2nd degree** (Worth a connection request), with titles and mutual counts. `position:fixed` so it escapes the table's horizontal scroll; clamped to the viewport.

ladder `2.7.0 → 2.8.0`; components.css `1.11.0 → 1.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)