### PR TITLE
ladder: green ring on 1st-degree avatars, none on 2nd+

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.12.0");
+@import url("./components.css?v=1.13.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5672,7 +5672,7 @@ body[data-auth-state="out"] job-chat { display: none; }
   height: 26px;
   border-radius: 50%;
   object-fit: cover;
-  border: 2px solid var(--bg-elevated);
+  border: 2px solid var(--success);   /* 1st-degree: green ring */
   margin-left: -8px;
   background: var(--bg-surface);
 }
@@ -5722,6 +5722,7 @@ body[data-auth-state="out"] job-chat { display: none; }
   object-fit: cover;
   flex: none;
   background: var(--bg-surface);
+  border: 2px solid var(--success);   /* 1st-degree: green ring */
 }
 .conn-avatar--placeholder {
   display: inline-flex;
@@ -5759,15 +5760,13 @@ body[data-auth-state="out"] job-chat { display: none; }
 }
 .conn-badge--1st { background: var(--accent-strong); color: var(--accent-strong-fg); }
 .conn-badge--2nd { background: transparent; color: var(--fg-subtle); border: 1px dashed var(--border-strong); }
-.conn-link--2nd .conn-avatar { border: 2px dashed var(--border-strong); }
+.conn-link--2nd .conn-avatar { border: none; }   /* 2nd+ degree: no ring */
 .conn-mutuals { color: var(--fg-subtle); font-size: var(--font-size-small); opacity: 0.85; }
 
-/* 2nd-degree avatars in the leads-table stack get a dashed ring so they read
-   as "reachable through a mutual" rather than "already connected". */
+/* 2nd-degree (or greater) avatars carry no ring — only direct (1st-degree)
+   connections get the green ring, so a green face = "you already know them". */
 .conn-stack__avatar--2nd {
-  border-style: dashed;
-  border-color: var(--border-strong);
-  opacity: 0.9;
+  border: none;
 }
 
 /* ── Network column hover card ────────────────────────────────────────── */
@@ -5796,9 +5795,9 @@ body[data-auth-state="out"] job-chat { display: none; }
 .conn-tip__item { display: flex; align-items: center; gap: var(--space-2); }
 .conn-tip__avatar {
   width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none;
-  background: var(--bg-surface); border: 1px solid var(--border);
+  background: var(--bg-surface); border: 2px solid var(--success);   /* 1st: green ring */
 }
-.conn-tip__avatar--2nd { border-style: dashed; border-color: var(--border-strong); }
+.conn-tip__avatar--2nd { border: none; }   /* 2nd+ degree: no ring */
 .conn-tip__avatar--ph {
   display: inline-flex; align-items: center; justify-content: center;
   font-size: 12px; font-weight: var(--fw-semibold); color: var(--fg-subtle); text-transform: uppercase;

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.8.0";
-console.log(`[ladder] v${VERSION} - Network column hover card + swap Network/Sector order`);
+const VERSION = "2.8.1";
+console.log(`[ladder] v${VERSION} - green ring on 1st-degree connection avatars, none on 2nd+`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.0">
-  <script src="/ladder/js/theme.js?v=2.8.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.1">
+  <script src="/ladder/js/theme.js?v=2.8.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.8.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Direct (1st-degree) connection avatars now get a **green ring** (`--success`); 2nd-degree (or greater) avatars have **no ring**. Applied consistently across the leads-table stack, the detail-page card, and the Network hover card. A green face = someone Ian already knows directly.

ladder `2.8.0 → 2.8.1`; components.css `1.12.0 → 1.13.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)