### PR TITLE
ladder: sortable Network column

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.8.2";
-console.log(`[ladder] v${VERSION} - bright-green ring on 1st-degree avatars, white border on 2nd+`);
+const VERSION = "2.9.0";
+console.log(`[ladder] v${VERSION} - sortable Network column (weighted: direct contacts first)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -56,7 +56,7 @@ const COLUMNS = [
   { id: 'fit',    label: 'Fit',    sortKey: 'score',   type: 'num',  defaultDir: 'desc' },
   { id: 'role',   label: 'Role',   sortKey: 'title',   type: 'text' },
   { id: 'signal', label: '',       sortKey: null },
-  { id: 'connections', label: 'Network', sortKey: null },
+  { id: 'connections', label: 'Network', sortKey: 'connections', type: 'num', defaultDir: 'desc' },
   { id: 'sector', label: 'Sector', sortKey: 'sector',  type: 'text' },
   { id: 'status', label: 'Status', sortKey: 'status',  type: 'text' },
   { id: 'menu',   label: '',       sortKey: null },
@@ -425,9 +425,10 @@ export class JobPipeline extends LitElement {
       });
       return arr;
     }
+    const valFor = (r) => key === 'connections' ? this._connScore(r) : r[key];
     arr.sort((a, b) => {
-      const av = a[key];
-      const bv = b[key];
+      const av = valFor(a);
+      const bv = valFor(b);
       // null/undefined always sorted to bottom regardless of direction.
       if (av == null && bv == null) return 0;
       if (av == null) return 1;
@@ -935,6 +936,17 @@ export class JobPipeline extends LitElement {
              e.target.replaceWith(span);
            }}/>
     `;
+  }
+
+  // Weighted "network strength" score for sorting the Network column. Direct
+  // (1st-degree) contacts dominate (×100) so a lead where Ian knows someone
+  // outranks one with only 2nd-degree; 2nd-degree adds 1 + its mutual count
+  // as a tiebreaker. 0 when there are no connections.
+  _connScore(r) {
+    const conns = r.connections || [];
+    let s = 0;
+    for (const c of conns) s += (c.degree === '2nd' ? 1 + (c.mutuals || 0) : 100);
+    return s;
   }
 
   // Avatar stack of Ian's LinkedIn connections tied to this lead's company

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.9.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.8.2">
-  <script src="/ladder/js/theme.js?v=2.8.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.0">
+  <script src="/ladder/js/theme.js?v=2.9.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.8.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.9.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Clicking the **Network** header now sorts leads by connection strength — 1st-degree (direct) contacts weighted ×100 so leads where Ian knows someone rise to the top; 2nd-degree adds 1 + mutual count as a tiebreaker. ladder `2.8.2 → 2.9.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)