### PR TITLE
ladder: editable company name on role detail header

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.14.0");
+@import url("./components.css?v=1.15.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5808,3 +5808,37 @@ body[data-auth-state="out"] job-chat { display: none; }
 .conn-tip__title { color: var(--fg-subtle); font-size: var(--font-size-caption); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 240px; }
 .conn-tip__mutuals { color: var(--fg-subtle); font-size: var(--font-size-caption); opacity: 0.85; }
 .conn-stack { cursor: default; }
+
+/* ── Editable company name (role detail header) ───────────────────────── */
+.company-edit-btn {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  margin: -1px -2px;
+  font: inherit;
+  color: inherit;
+  cursor: text;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 4px;
+}
+.company-edit-btn:hover { text-decoration: underline; text-underline-offset: 2px; }
+.company-edit-pencil {
+  font-size: 0.8em;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.company-edit-btn:hover .company-edit-pencil,
+.company-edit-btn:focus-visible .company-edit-pencil { opacity: 0.55; }
+.company-edit-input {
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  padding: 1px 6px;
+  min-width: 180px;
+  max-width: 360px;
+}
+.company-edit-input:focus { outline: none; border-color: var(--accent-strong); }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.9.1";
-console.log(`[ladder] v${VERSION} - default Saved sort is fit score, not manual order`);
+const VERSION = "2.10.0";
+console.log(`[ladder] v${VERSION} - editable company name on the role detail header`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-role-detail.js
+++ b/ladder/js/components/ladder-role-detail.js
@@ -24,7 +24,7 @@ async function getTurndown() {
   return td;
 }
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative, engageRole, rescoreRole }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }, { renderFitCardBody, renderCandidateCardBody }] = await Promise.all([
+const [{ renderMarkdown }, { generateAsset, fetchPipeline, readRolePrefill, fetchCoverRationale, applyCoverEdit, addNarrative, engageRole, rescoreRole, updateRole }, { readRoleAsset, writeRoleAsset }, { logoSrc, logoInitial }, { diffMarkdown, highlightPhrases, applyAIHighlights }, { renderFitCardBody, renderCandidateCardBody }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../roleAsset.js' + V),
@@ -95,6 +95,7 @@ export class JobRoleDetail extends LitElement {
     activityState:  { state: true },  // 'idle' | 'loading' | 'loaded' | 'error'
     activityEvents: { state: true },  // EventRow[]
     processOutline: { state: true },  // { rounds, expected_total_rounds, source, ... } | null
+    editingCompany: { state: true },  // inline company-name edit in the header
   };
 
   constructor() {
@@ -123,6 +124,7 @@ export class JobRoleDetail extends LitElement {
     this.activityState  = 'idle';
     this.activityEvents = [];
     this.processOutline = null;
+    this.editingCompany = false;
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/ladder\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -686,6 +688,56 @@ export class JobRoleDetail extends LitElement {
     span.setAttribute('aria-hidden', 'true');
     span.textContent = (name || '?').trim().charAt(0).toUpperCase() || '?';
     return span;
+  }
+
+  // --- Inline company-name edit (header subtitle) --------------------------
+  // The crawler sometimes stores a mis-parsed company (e.g. the legal entity
+  // "Care Delivery Systems" instead of the brand "Midi Health"). Clicking the
+  // company name in the header turns it into an input; Enter/blur saves via
+  // jobs-pipe (company_name only — company_slug is left intact so connections
+  // and KB linkage keep working).
+  _renderCompanyEditable(r) {
+    const company = r?.company || '';
+    if (this.editingCompany) {
+      return html`<input class="company-edit-input" .value=${company}
+                   placeholder="Company name" aria-label="Company name"
+                   @keydown=${(e) => this._onCompanyKeydown(e)}
+                   @blur=${(e) => this._saveCompany(e.target.value)}>`;
+    }
+    return html`<button class="company-edit-btn" title="Click to edit the company name"
+                  @click=${() => this._startEditCompany()}>
+                  <span class="company-edit-name">${company || 'Add company'}</span>
+                  <span class="company-edit-pencil" aria-hidden="true">✎</span>
+                </button>`;
+  }
+
+  _startEditCompany() {
+    this.editingCompany = true;
+    this.updateComplete.then(() => {
+      const el = this.querySelector('.company-edit-input');
+      if (el) { el.focus(); el.select(); }
+    });
+  }
+
+  _onCompanyKeydown(e) {
+    if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); }
+    else if (e.key === 'Escape') { e.preventDefault(); this._companyCancel = true; this.editingCompany = false; }
+  }
+
+  async _saveCompany(value) {
+    if (this._companyCancel) { this._companyCancel = false; this.editingCompany = false; return; }
+    const name = (value || '').trim();
+    this.editingCompany = false;
+    if (!name || name === (this.role?.company || '')) return;
+    const prev = this.role?.company;
+    this.role = { ...this.role, company: name };
+    document.title = `${name} — ${this.role?.title || this.slug} — /ladder`;
+    try {
+      await updateRole(this.slug, { company_name: name });
+    } catch (e) {
+      this.role = { ...this.role, company: prev };
+      console.warn('[role-detail] company save failed:', (e && e.message) || e);
+    }
   }
 
   _renderDetails() {
@@ -1713,7 +1765,7 @@ export class JobRoleDetail extends LitElement {
           })()}
           <div class="role-header__title">
             <h1>${r.title || this.slug}</h1>
-            <p class="role-header__sub">${r.company || ''}${r.sector ? ` · ${r.sector}` : ''}</p>
+            <p class="role-header__sub">${this._renderCompanyEditable(r)}${r.sector ? html`<span class="role-header__sub-sep"> · ${r.sector}</span>` : nothing}</p>
           </div>
         </div>
         <div class="role-header__actions">
@@ -1836,7 +1888,7 @@ export class JobRoleDetail extends LitElement {
           })()}
           <div class="role-header__title">
             <h1>${r?.title || this.slug}</h1>
-            <p class="role-header__sub">${r?.company || ''}${r?.sector ? ` · ${r.sector}` : ''}</p>
+            <p class="role-header__sub">${this._renderCompanyEditable(r)}${r?.sector ? html`<span class="role-header__sub-sep"> · ${r.sector}</span>` : nothing}</p>
           </div>
         </div>
         <div class="role-header__actions">

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.9.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.9.1">
-  <script src="/ladder/js/theme.js?v=2.9.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <script src="/ladder/js/theme.js?v=2.10.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.9.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.13.0';
-console.log(`[jobs-pipe] v${VERSION} - connections include degree (1st/2nd) + mutual count`);
+const VERSION = '0.14.0';
+console.log(`[jobs-pipe] v${VERSION} - editable company_name (inline rename from detail header)`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -150,6 +150,23 @@ serve(async (req) => {
           where slug = ${slug};
         `;
         return jsonResp({ ok: true, slug, deleted: true });
+      }
+
+      // Company-name edit — inline rename from the detail header (e.g. fixing
+      // a mis-parsed "Care Delivery Systems" → "Midi Health"). company_slug
+      // is deliberately left untouched: connections + KB linkage key off the
+      // slug, not the display name. updated_at bumps so stale-analysis
+      // detection re-runs on next open.
+      if (typeof body.company_name === 'string') {
+        const name = body.company_name.trim().slice(0, 200);
+        if (!name) return err('company_name cannot be empty', 400);
+        const upd = await sql`
+          update job.pipeline_roles
+             set company_name = ${name}, updated_at = now()
+           where slug = ${slug}
+          returning slug;`;
+        if (!upd[0]) return err('role not found', 404);
+        return jsonResp({ ok: true, slug, company_name: name });
       }
 
       // Status / stage / exit_reason writeback.


### PR DESCRIPTION
Fixes mis-parsed company names (e.g. "Care Delivery Systems" → "Midi Health"). Click the company name in the detail header to edit it inline; Enter or blur saves.

- `jobs-pipe` v0.14.0: `POST { slug, company_name }` update path (deployed). Leaves `company_slug` intact so connections + KB linkage keep working.
- Detail header: pencil affordance on hover, input on click, optimistic save with revert-on-error.
- ladder `2.9.1 → 2.10.0`; components.css `1.14.0 → 1.15.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)