### PR TITLE
ladder: company name click-to-edit (no pencil)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.15.0");
+@import url("./components.css?v=1.16.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5824,13 +5824,6 @@ body[data-auth-state="out"] job-chat { display: none; }
   border-radius: 4px;
 }
 .company-edit-btn:hover { text-decoration: underline; text-underline-offset: 2px; }
-.company-edit-pencil {
-  font-size: 0.8em;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.company-edit-btn:hover .company-edit-pencil,
-.company-edit-btn:focus-visible .company-edit-pencil { opacity: 0.55; }
 .company-edit-input {
   font: inherit;
   color: var(--fg);

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.10.0";
-console.log(`[ladder] v${VERSION} - editable company name on the role detail header`);
+const VERSION = "2.10.1";
+console.log(`[ladder] v${VERSION} - click-to-edit company name (no pencil icon)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-role-detail.js
+++ b/ladder/js/components/ladder-role-detail.js
@@ -707,7 +707,6 @@ export class JobRoleDetail extends LitElement {
     return html`<button class="company-edit-btn" title="Click to edit the company name"
                   @click=${() => this._startEditCompany()}>
                   <span class="company-edit-name">${company || 'Add company'}</span>
-                  <span class="company-edit-pencil" aria-hidden="true">✎</span>
                 </button>`;
   }
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.0">
-  <script src="/ladder/js/theme.js?v=2.10.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <script src="/ladder/js/theme.js?v=2.10.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Removes the pencil icon on the editable company name — click the text itself to edit. ladder `2.10.0 → 2.10.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)