### PR TITLE
ladder: remove For You carousel from Saved view

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.10.1";
-console.log(`[ladder] v${VERSION} - click-to-edit company name (no pencil icon)`);
+const VERSION = "2.10.2";
+console.log(`[ladder] v${VERSION} - remove For You carousel from Saved (leads) view`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -1211,8 +1211,6 @@ export class JobPipeline extends LitElement {
     const showAddedBanner = added.length > 0 && !this.addedBanner.dismissed;
 
     return html`
-      ${this.bucket === 'leads' ? html`<ladder-recommendations></ladder-recommendations>` : nothing}
-
       ${this.bucket === 'active' ? this._renderLiveBanners() : nothing}
       ${this.bucket === 'active' ? this._renderNeedsAttention() : nothing}
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.1">
-  <script src="/ladder/js/theme.js?v=2.10.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.10.2">
+  <script src="/ladder/js/theme.js?v=2.10.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.10.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.10.2"></script>
 </body>
 </html>


### PR DESCRIPTION
Removes the `<ladder-recommendations>` For You carousel from the Saved (leads) table view. The standalone For You page and its nav link are untouched. ladder `2.10.1 → 2.10.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)