### PR TITLE
ladder: fix Saved liveness cron auth (anon Bearer)

### DIFF
--- a/supabase/migrations/087_saved_liveness_cron.sql
+++ b/supabase/migrations/087_saved_liveness_cron.sql
@@ -28,8 +28,13 @@ select cron.schedule(
   $$
   select net.http_post(
     url     := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/check-liveness',
+    -- check-liveness has verify_jwt=true, so the platform gateway needs a
+    -- valid Authorization header (anon key satisfies it) BEFORE the request
+    -- reaches the function; the x-cron-secret then bypasses the function's
+    -- own per-user auth. Mirrors the liveness-check-6h / enrich-backfill crons.
     headers := jsonb_build_object(
       'Content-Type',  'application/json',
+      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI',
       'x-cron-secret', '850f11f7cf611308809c5ac44233cdc6e60f5abddf3e56b9a1e068d3efa18ca1'
     ),
     body    := '{}'::jsonb,


### PR DESCRIPTION
Follow-up to #977. The `087` Saved liveness cron only sent `x-cron-secret`, but `check-liveness` runs with `verify_jwt=true` — the platform gateway 401s before the function's secret-bypass executes, so the cron would never fire in production. Add the anon Bearer (same pattern as the working `liveness-check-6h` / enrich-backfill crons). Verified live: `check-liveness` now returns 200 and sweeps the pipeline. Re-applied to the live cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)