### PR TITLE
ladder: auto-recover gmail-jobs from Anthropic outages (stop tombstoning)

### DIFF
--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -281,6 +281,7 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
         try {
           jobs = await extractJobsMulti({ subject, sender, body });
         } catch (e) {
+          await abortRunIfAiUnavailable(sql, ctx.userEmail, e as Error);
           await logSkipped(sql, ctx.userEmail, msg, messageId, 'parse_error', { reason: (e as Error).message, digest: true });
           continue;
         }
@@ -296,6 +297,7 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
           try {
             job = await extractJob({ subject, sender, body });
           } catch (e) {
+            await abortRunIfAiUnavailable(sql, ctx.userEmail, e as Error);
             await logSkipped(sql, ctx.userEmail, msg, messageId, 'parse_error', { reason: (e as Error).message });
             continue;
           }
@@ -314,6 +316,7 @@ export const gmailJobsSource: Source<GmailJobsCfg> = {
           try {
             jobs = await extractJobsMulti({ subject, sender, body });
           } catch (e) {
+            await abortRunIfAiUnavailable(sql, ctx.userEmail, e as Error);
             await logSkipped(sql, ctx.userEmail, msg, messageId, 'parse_error', { reason: (e as Error).message, digestRetry: true });
             continue;
           }
@@ -617,6 +620,43 @@ async function markScanError(sql: ReturnType<typeof db>, userEmail: string, erro
       values (${userEmail}, ${error}, now())
     on conflict (user_email) do update
       set last_error = excluded.last_error, updated_at = now()`;
+}
+
+// ── Transient AI-outage handling ───────────────────────────────────────
+// A Haiku extraction failure caused by the Anthropic API being *unavailable*
+// (credit balance exhausted → 400, rate-limit → 429, overloaded/5xx) is
+// transient: every message this tick fails the same way. We must NOT
+// tombstone the message in job.gmail_skipped — a permanent skip row lands in
+// the dedup pre-check forever, so even after credits are topped up the
+// message is never re-extracted (this is exactly what silently dropped a
+// week of roles on 2026-06-27). Instead abort the whole run WITHOUT
+// advancing the scan cursor. Because the cursor stays put, the next
+// scheduled tick re-lists the same window and re-extracts it automatically
+// once the API is healthy again — no manual delete/rewind needed.
+class AiUnavailableError extends Error {}
+
+function isRetryableAiError(message: string): boolean {
+  const m = message.toLowerCase();
+  return m.includes('credit balance is too low')          // billing exhausted (400)
+    || m.includes('overloaded')                            // 529
+    || m.includes('rate limit') || m.includes('rate_limit')// 429
+    || /anthropic\s+(429|500|502|503|529)\b/.test(m);      // explicit 429/5xx
+}
+
+// Throws AiUnavailableError (aborting the run, cursor untouched) when `e` is
+// a transient Anthropic outage; otherwise returns so the caller logs a
+// normal terminal skip. Stamps gmail_scan_state.last_error on abort so the
+// outage surfaces in the reconnect/retry banner instead of failing silent.
+async function abortRunIfAiUnavailable(
+  sql: ReturnType<typeof db>,
+  userEmail: string,
+  e: Error,
+): Promise<void> {
+  if (!isRetryableAiError(e.message)) return;
+  const msg = `AI extraction temporarily unavailable — will retry (${e.message.slice(0, 120)})`;
+  console.warn(`[gmail-jobs] ${msg}`);
+  await markScanError(sql, userEmail, msg);
+  throw new AiUnavailableError(msg);
 }
 
 // ---------- Haiku extraction ----------

--- a/supabase/functions/gmail-auth/index.ts
+++ b/supabase/functions/gmail-auth/index.ts
@@ -13,8 +13,8 @@
 // don't need a new client registration. The redirect URI for gmail
 // connect points at /job/ — calendar-api keeps /calendar/.
 
-const VERSION = '0.3.0';
-console.log(`[gmail-auth] v${VERSION} - clear stale last_error on connect so reconnect banner clears immediately`);
+const VERSION = '0.3.1';
+console.log(`[gmail-auth] v${VERSION} - fix: imported db() shadowed by local SupabaseClient, so last_error clear silently threw; reconnect banner never cleared`);
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
@@ -27,7 +27,7 @@ import {
   markRevoked,
   upsertToken,
 } from '../_shared/google-tokens.ts';
-import { db } from '../_shared/job-db.ts';
+import { db as jobSql } from '../_shared/job-db.ts';
 
 // gmail.modify is a strict superset of gmail.readonly. We request both
 // so the scope_set on the token row covers callers that look up by
@@ -186,7 +186,7 @@ serve(async (req) => {
       // clears immediately on reconnect, instead of lingering until the
       // next successful scan. Best-effort — never fail the connect over it.
       try {
-        const sql = db();
+        const sql = jobSql();
         await sql`update job.user_sources set last_error = null
                    where user_email = ${user.email} and type = 'gmail-jobs'`;
         await sql`update job.gmail_scan_state set last_error = null

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.22.0';
-console.log(`[pull-recommendations] v${VERSION} - layer-1 role-liveness: close tracked-ats roles that disappeared since last pull`);
+const VERSION = '0.23.0';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: transient Anthropic outages (credits/429/5xx) abort the run instead of tombstoning messages, so the backlog auto-re-drains once the API recovers`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';

--- a/supabase/migrations/085_purge_ai_outage_tombstones.sql
+++ b/supabase/migrations/085_purge_ai_outage_tombstones.sql
@@ -1,0 +1,27 @@
+-- 085_purge_ai_outage_tombstones.sql
+--
+-- Self-healing cleanup for the gmail-jobs pipeline.
+--
+-- Before v0.23.0, a Haiku extraction failure caused by the Anthropic API
+-- being unavailable (credit balance exhausted, 429 rate-limit, 5xx/overload)
+-- was logged to job.gmail_skipped with reason='parse_error'. That skip row
+-- is a permanent dedup tombstone, so even after credits were topped up the
+-- affected job-alert emails were never re-extracted — a whole window of
+-- roles silently vanished (observed 2026-06-27 → 2026-07-01).
+--
+-- v0.23.0 stops creating these tombstones (transient AI outages now abort
+-- the run without advancing the cursor, so the next tick re-drains). This
+-- migration removes any tombstones the old code already wrote for an AI
+-- outage, so those messages fall back into the scan and get re-extracted.
+-- Genuine parse failures (bad JSON, empty body, etc.) are left intact.
+--
+-- Idempotent: safe to re-run; matches only outage-caused rows.
+delete from job.gmail_skipped
+ where reason = 'parse_error'
+   and (
+        details->>'reason' ilike '%credit balance is too low%'
+     or details->>'reason' ilike '%overloaded%'
+     or details->>'reason' ~* 'anthropic\s+(429|500|502|503|529)'
+     or details->>'reason' ilike '%rate limit%'
+     or details->>'reason' ilike '%rate_limit%'
+   );


### PR DESCRIPTION
## Problem
When `ANTHROPIC_API_KEY` runs out of credits (or Anthropic 429s/5xx), the gmail-jobs Haiku extractor throws. The old code logged each failed email to `job.gmail_skipped` as `reason='parse_error'` — a **permanent dedup tombstone**. So even after credits were topped up, those job-alert emails were never re-extracted. A full week of roles (OpenAI, Scale AI, 23andMe, Humana, Oura, Glean…) silently vanished between 2026-06-27 and 07-01, surfacing only as a misleading `pulled:0`.

## Fix
Classify transient Anthropic outages (credit-balance 400, 429 rate-limit, 5xx/overload) and **abort the run instead of tombstoning**:
- No `gmail_skipped` row is written for the affected messages.
- The scan cursor is **not** advanced (the abort throws before the cursor write at the end of `pull()`).
- Because the cursor stays put, the **next scheduled tick re-lists the same window and re-extracts it automatically** once the API recovers — no manual delete/rewind.
- The abort stamps `gmail_scan_state.last_error` → surfaces as its own banner. It deliberately avoids the words `reauth`/`not connected`, so it does **not** trip the "Reconnect Gmail" banner (which would point at the wrong fix).

Genuine parse failures (bad JSON, empty body, no company/title) still tombstone as before — only transient AI outages are treated as retryable.

### Migration 085
Purges any AI-outage tombstones the old code already wrote (matches on `details.reason`), so they fall back into the scan and re-drain. Idempotent; leaves real parse failures intact.

### Files
- `_shared/sources/gmail-jobs.ts` — `isRetryableAiError` + `abortRunIfAiUnavailable`, wired into the 3 extraction catch sites.
- `pull-recommendations/index.ts` — v0.22.0 → v0.23.0.
- `migrations/085_purge_ai_outage_tombstones.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)