### PR TITLE
ladder: editable role title on detail header

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.16.0");
+@import url("./components.css?v=1.17.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5835,3 +5835,30 @@ body[data-auth-state="out"] job-chat { display: none; }
   max-width: 360px;
 }
 .company-edit-input:focus { outline: none; border-color: var(--accent-strong); }
+
+/* Editable role title (h1) — same interaction as the company name, sized to
+   inherit the h1 typography. */
+.title-edit-btn {
+  background: none;
+  border: none;
+  padding: 0 2px;
+  margin: -1px -2px;
+  font: inherit;
+  color: inherit;
+  cursor: text;
+  text-align: left;
+  border-radius: 4px;
+}
+.title-edit-btn:hover { text-decoration: underline; text-underline-offset: 3px; }
+.title-edit-input {
+  font: inherit;
+  color: var(--fg);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 0 8px;
+  width: 100%;
+  max-width: 720px;
+  box-sizing: border-box;
+}
+.title-edit-input:focus { outline: none; border-color: var(--accent-strong); }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.11.0";
-console.log(`[ladder] v${VERSION} - split Saved table into separate Fit + Strength columns (match For You)`);
+const VERSION = "2.12.0";
+console.log(`[ladder] v${VERSION} - editable role title on the detail header (like company)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-role-detail.js
+++ b/ladder/js/components/ladder-role-detail.js
@@ -96,6 +96,7 @@ export class JobRoleDetail extends LitElement {
     activityEvents: { state: true },  // EventRow[]
     processOutline: { state: true },  // { rounds, expected_total_rounds, source, ... } | null
     editingCompany: { state: true },  // inline company-name edit in the header
+    editingTitle:   { state: true },  // inline role-title edit in the header
   };
 
   constructor() {
@@ -125,6 +126,7 @@ export class JobRoleDetail extends LitElement {
     this.activityEvents = [];
     this.processOutline = null;
     this.editingCompany = false;
+    this.editingTitle = false;
 
     const pretty = sessionStorage.getItem('job:prettyPath');
     if (pretty && /^\/ladder\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
@@ -736,6 +738,52 @@ export class JobRoleDetail extends LitElement {
     } catch (e) {
       this.role = { ...this.role, company: prev };
       console.warn('[role-detail] company save failed:', (e && e.message) || e);
+    }
+  }
+
+  // --- Inline role-title edit (header h1) ----------------------------------
+  // Same pattern as the company edit: click the title to turn it into an
+  // input; Enter/blur saves via jobs-pipe (title only).
+  _renderTitleEditable(r) {
+    const title = r?.title || '';
+    if (this.editingTitle) {
+      return html`<input class="title-edit-input" .value=${title}
+                   placeholder="Role title" aria-label="Role title"
+                   @keydown=${(e) => this._onTitleKeydown(e)}
+                   @blur=${(e) => this._saveTitle(e.target.value)}>`;
+    }
+    return html`<button class="title-edit-btn" title="Click to edit the role title"
+                  @click=${() => this._startEditTitle()}>
+                  <span class="title-edit-name">${title || this.slug}</span>
+                </button>`;
+  }
+
+  _startEditTitle() {
+    this.editingTitle = true;
+    this.updateComplete.then(() => {
+      const el = this.querySelector('.title-edit-input');
+      if (el) { el.focus(); el.select(); }
+    });
+  }
+
+  _onTitleKeydown(e) {
+    if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); }
+    else if (e.key === 'Escape') { e.preventDefault(); this._titleCancel = true; this.editingTitle = false; }
+  }
+
+  async _saveTitle(value) {
+    if (this._titleCancel) { this._titleCancel = false; this.editingTitle = false; return; }
+    const title = (value || '').trim();
+    this.editingTitle = false;
+    if (!title || title === (this.role?.title || '')) return;
+    const prev = this.role?.title;
+    this.role = { ...this.role, title };
+    document.title = `${this.role?.company || ''} — ${title} — /ladder`;
+    try {
+      await updateRole(this.slug, { title });
+    } catch (e) {
+      this.role = { ...this.role, title: prev };
+      console.warn('[role-detail] title save failed:', (e && e.message) || e);
     }
   }
 
@@ -1763,7 +1811,7 @@ export class JobRoleDetail extends LitElement {
               : html`<span class="company-logo company-logo--lg company-logo--placeholder" aria-hidden="true">${logoInitial(r.company)}</span>`;
           })()}
           <div class="role-header__title">
-            <h1>${r.title || this.slug}</h1>
+            <h1>${this._renderTitleEditable(r)}</h1>
             <p class="role-header__sub">${this._renderCompanyEditable(r)}${r.sector ? html`<span class="role-header__sub-sep"> · ${r.sector}</span>` : nothing}</p>
           </div>
         </div>
@@ -1886,7 +1934,7 @@ export class JobRoleDetail extends LitElement {
               : html`<span class="company-logo company-logo--lg company-logo--placeholder" aria-hidden="true">${logoInitial(r?.company)}</span>`;
           })()}
           <div class="role-header__title">
-            <h1>${r?.title || this.slug}</h1>
+            <h1>${this._renderTitleEditable(r)}</h1>
             <p class="role-header__sub">${this._renderCompanyEditable(r)}${r?.sector ? html`<span class="role-header__sub-sep"> · ${r.sector}</span>` : nothing}</p>
           </div>
         </div>

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.11.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.11.0">
-  <script src="/ladder/js/theme.js?v=2.11.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <script src="/ladder/js/theme.js?v=2.12.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.11.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.14.0';
-console.log(`[jobs-pipe] v${VERSION} - editable company_name (inline rename from detail header)`);
+const VERSION = '0.15.0';
+console.log(`[jobs-pipe] v${VERSION} - editable company_name + title (inline rename from detail header)`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -167,6 +167,21 @@ serve(async (req) => {
           returning slug;`;
         if (!upd[0]) return err('role not found', 404);
         return jsonResp({ ok: true, slug, company_name: name });
+      }
+
+      // Title edit — inline rename from the detail header (e.g. fixing a
+      // mis-parsed "ŌURA hiring Senior PM" → "Senior Product Manager").
+      // updated_at bumps so stale-analysis detection re-runs on next open.
+      if (typeof body.title === 'string') {
+        const title = body.title.trim().slice(0, 300);
+        if (!title) return err('title cannot be empty', 400);
+        const upd = await sql`
+          update job.pipeline_roles
+             set title = ${title}, updated_at = now()
+           where slug = ${slug}
+          returning slug;`;
+        if (!upd[0]) return err('role not found', 404);
+        return jsonResp({ ok: true, slug, title });
       }
 
       // Status / stage / exit_reason writeback.


### PR DESCRIPTION
Click the role title in the detail header to edit it inline (Enter/blur saves, Esc cancels) — same interaction as the company name. `jobs-pipe` v0.15.0 gains a `POST { slug, title }` path (deployed). ladder `2.11.0 → 2.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)