### PR TITLE
ladder: surface "N expired removed" in For You

### DIFF
--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -71,6 +71,7 @@ export class JobRecommendationsTable extends LitElement {
     _total:              { state: true },
     _loadingMore:        { state: true },
     _hasMore:            { state: true },
+    _recentlyExpired:    { state: true },
   };
 
   constructor() {
@@ -94,6 +95,7 @@ export class JobRecommendationsTable extends LitElement {
     this._offset = 0;
     this._loadingMore = false;
     this._hasMore = false;
+    this._recentlyExpired = 0;
   }
 
   // ----- Source health banner ------------------------------------------
@@ -270,6 +272,7 @@ export class JobRecommendationsTable extends LitElement {
       this._total  = Number.isFinite(data?.total) ? data.total : this.items.length;
       this._hasMore = !!data?.hasMore;
       if (reset && Array.isArray(data?.sourceHealth)) this._health = data.sourceHealth;
+      if (reset) this._recentlyExpired = Number.isFinite(data?.recentlyExpired) ? data.recentlyExpired : 0;
     } catch (e) {
       if (reset) { this.error = String(e); this.state = 'error'; }
       // append failures are non-fatal — keep what we have, allow retry
@@ -539,6 +542,12 @@ export class JobRecommendationsTable extends LitElement {
         <span class="muted">${this._total > rows.length
           ? `${rows.length} of ${this._total} roles`
           : `${rows.length} ${rows.length === 1 ? 'role' : 'roles'}`}</span>
+        ${this._recentlyExpired > 0 ? html`
+          <span class="muted recs-page__pruned"
+                title="Postings the liveness checks found expired and removed in the last 7 days">
+            · ${this._recentlyExpired} expired removed
+          </span>
+        ` : nothing}
         <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
                 title="Scan Gmail for new role alerts and application updates"
                 @click=${() => this._onRefresh()}>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.12.0';
-console.log(`[recommendations] v${VERSION} - dedup For You against pipeline by normalized URL too (saved/applied/rejected reappearing fix)`);
+const VERSION = '0.13.0';
+console.log(`[recommendations] v${VERSION} - return recentlyExpired (recs auto-retired by liveness in last 7d) so For You can show "N expired removed"`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -160,6 +160,21 @@ serve(async (req) => {
         const [{ n }] = await sql`select count(*)::int as n from job.recommended_roles r ${whereClause}`;
         total = n;
       }
+      // Count of recs the liveness layers auto-retired in the last 7 days.
+      // Lets For You reassure the user that expired postings are being pruned
+      // ("N expired removed") instead of silently vanishing. Never fail the
+      // page over this — it's a cosmetic count.
+      let recentlyExpired = 0;
+      try {
+        const [{ n }] = await sql`
+          select count(*)::int as n
+            from job.recommended_roles
+           where closed_at is not null
+             and closed_at > now() - interval '7 days'`;
+        recentlyExpired = n;
+      } catch (e) {
+        console.warn(`[recommendations] recentlyExpired count failed: ${(e as Error).message}`);
+      }
       // Source health — lets the UI tell "no new recs" apart from "a
       // source is dead". needs_reauth is true when the gmail-jobs source
       // errored with a token problem OR the scan-state row carries one.
@@ -188,7 +203,7 @@ serve(async (req) => {
       }
       return jsonResp({
         ok: true, version: VERSION, view,
-        count: rows.length, total,
+        count: rows.length, total, recentlyExpired,
         offset, limit,
         hasMore: isAll && offset + rows.length < total,
         recommendations: rows, sourceHealth,


### PR DESCRIPTION
Follow-up to #977/#978. Expired recs were removed from For You silently. The `recommendations` GET now returns `recentlyExpired` (count of recs the liveness layers auto-retired in the last 7 days) and the For You table header shows a subtle `· N expired removed` note — pruning is now visible, not invisible.

`recommendations` v0.12.0 → v0.13.0 (deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)