### PR TITLE
ladder: For You quality floors, Wildcards, pre-save detail page, Wellfound Gmail source

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.17.0");
+@import url("./components.css?v=1.18.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -2397,6 +2397,94 @@
 .rec-card__bullets p { display: inline; margin: 0; }
 .rec-card__desc { margin: 0; font-size: var(--font-size-body); color: var(--fg-muted); }
 
+/* Title link inside a rec card — opens the pre-save detail page. */
+.rec-card__title-link { color: inherit; text-decoration: none; }
+.rec-card__title-link:hover { text-decoration: underline; }
+
+/* --- Wildcards strip (For You) ---
+   High candidate-strength / low stated-criteria-fit roles. Dashed accent
+   border marks them as deliberate outliers, not more of the same list. */
+.rec-wildcards { margin-top: var(--space-6); }
+.rec-wildcards__head { margin-bottom: var(--space-3); }
+.rec-wildcards__head .muted { font-size: var(--font-size-caption); }
+.rec-card--wildcard { border: 1px dashed var(--accent); }
+.rec-card__wildcard-why {
+  margin: 6px 0 0;
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  font-style: italic;
+  line-height: var(--lh-tight);
+}
+
+/* --- Rec pre-save detail page (/ladder/jobs/<slug>/?rec=<id>) --- */
+.rec-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-width: 960px;
+}
+.rec-detail__head { display: flex; gap: var(--space-4); align-items: flex-start; }
+.rec-detail__logo {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+.rec-detail__logo--placeholder {
+  display: grid; place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  color: var(--fg-muted);
+}
+.rec-detail__title-block { min-width: 0; flex: 1; }
+.rec-detail__title-block h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: 24px;
+  line-height: var(--lh-tight);
+  letter-spacing: -0.01em;
+}
+.rec-detail__meta { margin: 4px 0 0; color: var(--fg-muted); }
+.rec-detail__source { margin: 4px 0 0; font-size: var(--font-size-caption); }
+.rec-detail__scores { display: flex; gap: var(--space-2); flex-shrink: 0; }
+.rec-detail__actions { display: flex; gap: var(--space-3); align-items: center; flex-wrap: wrap; }
+.rec-detail__wildcard {
+  border: 1px dashed var(--accent);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--bg-surface);
+  font-size: var(--font-size-body);
+}
+.rec-detail__wildcard ul { margin: var(--space-2) 0; padding-left: var(--space-5); }
+.rec-detail__cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+.rec-detail__bullets {
+  list-style: disc;
+  margin: 0;
+  padding: var(--space-4) var(--space-5);
+  display: flex; flex-direction: column; gap: var(--space-2);
+}
+.rec-detail__bullets li > * { display: inline; }
+.rec-detail__bullets p { display: inline; margin: 0; }
+.rec-detail__jd { padding: 0 var(--space-4) var(--space-4); }
+.rec-detail__banner {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  font-size: var(--font-size-body);
+}
+.rec-detail__banner--warn { color: var(--warning); }
+@media (max-width: 720px) {
+  .rec-detail__cards { grid-template-columns: 1fr; }
+  .rec-detail__head { flex-wrap: wrap; }
+}
+
 .rec-card__foot {
   margin-top: auto;
   display: flex;

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.12.0";
-console.log(`[ladder] v${VERSION} - editable role title on the detail header (like company)`);
+const VERSION = "2.13.0";
+console.log(`[ladder] v${VERSION} - For You: wildcards strip, pre-save rec detail page, clicks open in new tab`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -25,7 +25,17 @@ if (location.pathname.startsWith('/ladder/history/drill')) {
   import('./components/ladder-career.js' + V);
 }
 if (location.pathname.startsWith('/ladder/jobs/drill')) {
-  import('./components/ladder-role-detail.js' + V);
+  // ?rec=<id> → pre-save detail for a recommendation (not yet in the
+  // pipeline). Swap the static <ladder-role-detail> mount for the rec
+  // variant; the 404 rewrite preserves the query so pretty URLs like
+  // /ladder/jobs/<slug>/?rec=<id> land here with both params.
+  if (new URLSearchParams(location.search).get('rec')) {
+    import('./components/ladder-rec-detail.js' + V);
+    const mount = document.querySelector('ladder-role-detail');
+    if (mount) mount.replaceWith(document.createElement('ladder-rec-detail'));
+  } else {
+    import('./components/ladder-role-detail.js' + V);
+  }
 } else if (location.pathname.startsWith('/ladder/jobs/recommended')) {
   import('./components/ladder-recommendations-table.js' + V);
 } else if (location.pathname.startsWith('/ladder/jobs')) {

--- a/ladder/js/components/ladder-fit-modal.js
+++ b/ladder/js/components/ladder-fit-modal.js
@@ -28,6 +28,20 @@ export const CANDIDATE_DIM_LABELS = {
   comp:    { label: 'Compensation',        max: 1,  hint: 'No money-mismatch risk — range clears your floor.', binary: true },
 };
 
+// The 1-2 fit dimensions dragging a rec's score down, as
+// { key, label, pct, rationale } — used by the Wildcards strip and the
+// pre-save rec detail page to explain "why low fit". Tiebreaker dims
+// (stage/comp/geo, max < 10) are skipped; they never explain a low fit.
+export function weakestFitDims(row, n = 2) {
+  const breakdown = row?.breakdown || row?.fitBreakdown || {};
+  const rationales = row?.rationales || row?.fitRationales || {};
+  return Object.entries(DIM_LABELS)
+    .filter(([, meta]) => meta.max >= 10)
+    .map(([k, meta]) => ({ key: k, label: meta.label, pct: ((breakdown[k] || 0) / meta.max), rationale: rationales[k] || '' }))
+    .sort((a, b) => a.pct - b.pct)
+    .slice(0, n);
+}
+
 export function scoreClass(s) {
   if (s == null) return 'fit-pill fit-pill--poor';
   if (s >= 70) return 'fit-pill fit-pill--strong';

--- a/ladder/js/components/ladder-rec-detail.js
+++ b/ladder/js/components/ladder-rec-detail.js
@@ -1,0 +1,235 @@
+// ladder-rec-detail — pre-save detail page for a recommended role.
+// Reached from For You via /ladder/jobs/<slug>/?rec=<id> (the 404 rewrite
+// lands on /ladder/jobs/drill/?slug=…&rec=… and app.js mounts this instead
+// of <ladder-role-detail> when ?rec= is present). Shows everything we know
+// about the rec — fit + candidate-strength breakdowns, summaries, match
+// bullets, JD — so the save/skip decision happens before it enters the
+// pipeline. Saving hands off to the normal role detail page.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { fetchRecommendation, addRole, dismissRecommendation }, { logoSrc, logoInitial }, { renderFitCardBody, renderCandidateCardBody, scoreClass, weakestFitDims }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../pipeline.js' + V),
+  import('../logo.js' + V),
+  import('./ladder-fit-modal.js' + V),
+]);
+
+// Wildcard band — keep in sync with the recommendations function's
+// WILDCARD_MIN_STRENGTH / WILDCARD_MAX_FIT.
+export function isWildcardRec(rec) {
+  return rec?.candidateScore != null && rec.candidateScore >= 65
+    && rec.fitScore != null && rec.fitScore < 50;
+}
+
+export class LadderRecDetail extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    state:  { state: true },
+    error:  { state: true },
+    rec:    { state: true },
+    saving: { state: true },
+    dismissed: { state: true },
+  };
+
+  constructor() {
+    super();
+    this.state = 'idle';
+    this.error = '';
+    this.rec = null;
+    this.saving = false;
+    this.dismissed = false;
+    const params = new URLSearchParams(location.search);
+    this.recId = params.get('rec') || '';
+    this.slug = (params.get('slug') || '').toLowerCase();
+
+    // Restore the pretty path the 404 rewrite stashed, keeping ?rec so a
+    // reload routes back here instead of into the pipeline role detail.
+    const pretty = sessionStorage.getItem('job:prettyPath');
+    if (pretty && /^\/ladder\/jobs\/[a-z0-9-]+\/?$/.test(pretty)) {
+      sessionStorage.removeItem('job:prettyPath');
+      history.replaceState(null, '', pretty.replace(/\/?$/, '/') + `?rec=${this.recId}`);
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    super.disconnectedCallback();
+  }
+
+  async _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    if (!this.recId) { this.state = 'error'; this.error = 'Missing rec id'; return; }
+    this.state = 'loading';
+    try {
+      this.rec = await fetchRecommendation(this.recId);
+      this.dismissed = Boolean(this.rec?.dismissedAt);
+      this.state = 'loaded';
+      if (this.rec) document.title = `${this.rec.company} — ${this.rec.title} — /ladder`;
+    } catch (e) {
+      this.state = 'error';
+      this.error = String(e);
+    }
+  }
+
+  async _onSave() {
+    const rec = this.rec;
+    if (!rec || this.saving) return;
+    this.saving = true;
+    try {
+      const r = await addRole({
+        url: rec.url,
+        title: rec.title,
+        company: rec.company,
+        source: 'Network',
+        fromRecommendationId: rec.id,
+      });
+      // Hand off to the full pipeline detail page for the saved role.
+      window.location.assign(`/ladder/jobs/${r.slug}/`);
+    } catch (e) {
+      console.warn('[rec-detail] save failed', e);
+      this.error = `Save failed: ${e.message || e}`;
+      this.saving = false;
+    }
+  }
+
+  async _onDismiss() {
+    if (!this.rec) return;
+    this.dismissed = true;
+    try { await dismissRecommendation(this.rec.id); } catch {}
+  }
+
+  _renderBanner() {
+    const rec = this.rec;
+    if (rec.addedToPipelineSlug) {
+      return html`<div class="rec-detail__banner">
+        Already in your pipeline —
+        <a href=${`/ladder/jobs/${rec.addedToPipelineSlug}/`}>open the saved role →</a>
+      </div>`;
+    }
+    if (rec.closedAt) {
+      return html`<div class="rec-detail__banner rec-detail__banner--warn">
+        This posting looks closed (${rec.closureReason || 'expired'}). The link may no longer work.
+      </div>`;
+    }
+    if (this.dismissed) {
+      return html`<div class="rec-detail__banner">
+        Dismissed. <a href="/ladder/jobs/recommended/">Back to For You →</a>
+      </div>`;
+    }
+    return nothing;
+  }
+
+  _renderWildcardCallout() {
+    const rec = this.rec;
+    if (!isWildcardRec(rec)) return nothing;
+    const weak = weakestFitDims(rec);
+    return html`
+      <aside class="rec-detail__wildcard">
+        <strong>🃏 Wildcard</strong> — you'd likely be a standout candidate
+        (strength ${rec.candidateScore}), but it scores low on your stated
+        criteria (fit ${rec.fitScore}).
+        <ul>
+          ${weak.map(w => html`<li><strong>${w.label}:</strong> ${w.rationale || 'weak signal'}</li>`)}
+          ${(rec.hardFails || []).map(f => html`<li><strong>Hard fail:</strong> ${f}</li>`)}
+        </ul>
+        Worth asking whether the criteria or the role is wrong.
+      </aside>
+    `;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'loading') {
+      return html`<div class="rec-detail"><div class="skeleton" style="width:60%;height:28px;"></div></div>`;
+    }
+    if (this.state === 'error' || !this.rec) {
+      return html`<div class="rec-detail">
+        <p class="muted">Couldn't load this recommendation. ${this.error}</p>
+        <a href="/ladder/jobs/recommended/">Back to For You →</a>
+      </div>`;
+    }
+    const rec = this.rec;
+    const meta = [rec.company, rec.location, rec.salary].filter(Boolean).join('  •  ');
+    const posting = rec.canonicalUrl || rec.url;
+    const bullets = Array.isArray(rec.matchBullets) ? rec.matchBullets : [];
+    const logo = rec.logoUrl || logoSrc(rec);
+    return html`
+      <div class="rec-detail">
+        ${this._renderBanner()}
+        <header class="rec-detail__head">
+          ${logo
+            ? html`<img class="rec-detail__logo" src=${logo} alt="" loading="lazy"
+                        @error=${(e) => { e.target.style.display = 'none'; }}/>`
+            : html`<div class="rec-detail__logo rec-detail__logo--placeholder" aria-hidden="true">${logoInitial(rec.company)}</div>`}
+          <div class="rec-detail__title-block">
+            <h1>${rec.title || '(untitled)'}</h1>
+            ${meta ? html`<p class="rec-detail__meta">${meta}</p>` : nothing}
+            <p class="rec-detail__source muted">
+              ${rec.sourceLabel ? html`via ${rec.sourceLabel}` : nothing}
+              ${rec.sourceEmailUrl ? html` · <a href=${rec.sourceEmailUrl} target="_blank" rel="noopener">📧 source email</a>` : nothing}
+              ${rec.enrichmentStatus === 'unresolved' ? html` · <span class="enrichment-badge">verifying source</span>` : nothing}
+            </p>
+          </div>
+          <div class="rec-detail__scores">
+            <span class=${scoreClass(rec.fitScore)} title="Fit score">${rec.fitScore ?? '—'}</span>
+            <span class=${scoreClass(rec.candidateScore)} title="Candidate strength">${rec.candidateScore ?? '—'}</span>
+          </div>
+        </header>
+
+        <div class="rec-detail__actions">
+          <button class="btn btn--accent" ?disabled=${this.saving || Boolean(rec.addedToPipelineSlug)}
+                  @click=${() => this._onSave()}>
+            ${this.saving ? 'Saving…' : 'Save role'}
+          </button>
+          ${posting ? html`
+            <a class="btn" href=${posting} target="_blank" rel="noopener">Open posting ↗</a>
+          ` : nothing}
+          ${!this.dismissed && !rec.addedToPipelineSlug ? html`
+            <button class="link-subtle" @click=${() => this._onDismiss()}>Dismiss</button>
+          ` : nothing}
+        </div>
+
+        ${this._renderWildcardCallout()}
+
+        ${bullets.length ? html`
+          <article class="role-card">
+            <header class="role-card__head"><h3>Why it surfaced</h3></header>
+            <ul class="rec-detail__bullets">
+              ${bullets.map(b => html`<li>${unsafeHTML(renderMarkdown(String(b)))}</li>`)}
+            </ul>
+          </article>
+        ` : nothing}
+
+        <div class="rec-detail__cards">
+          <article class="role-card role-card--fit fit-modal">
+            <header class="role-card__head"><h3>Fit</h3></header>
+            ${renderFitCardBody(rec, { summary: rec.fitSummary || null })}
+          </article>
+          <article class="role-card role-card--fit fit-modal">
+            <header class="role-card__head"><h3>Candidate strength</h3></header>
+            ${renderCandidateCardBody(rec, { summary: rec.candidateSummary || null })}
+          </article>
+        </div>
+
+        ${rec.description ? html`
+          <article class="role-card">
+            <header class="role-card__head"><h3>Job description</h3></header>
+            <div class="kb-doc rec-detail__jd">${unsafeHTML(renderMarkdown(rec.description))}</div>
+          </article>
+        ` : nothing}
+      </div>
+    `;
+  }
+}
+
+customElements.define('ladder-rec-detail', LadderRecDetail);

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -8,11 +8,12 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }, { roleSlug }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
   import('../format.js' + V),
+  import('../slug.js' + V),
 ]);
 
 // Column shape mirrors job-pipeline's COLUMNS: id drives the col class,
@@ -404,13 +405,10 @@ export class JobRecommendationsTable extends LitElement {
 
   _onRowClick(r, e) {
     if (e.target.closest('button, a, .row-menu, .fit-pill--button')) return;
-    if (!r.url) return;
-    // Plain click → in-page; Cmd/Ctrl/middle → new tab (browser standard).
-    if (e.metaKey || e.ctrlKey || e.button === 1) {
-      window.open(r.url, '_blank', 'noopener');
-    } else {
-      window.location.assign(r.url);
-    }
+    // Row click → pre-save detail page, in a NEW tab so browsing the list
+    // is never hijacked. The external posting link lives on that page.
+    const detail = `/ladder/jobs/${roleSlug(r.company, r.title)}/?rec=${r.id}`;
+    window.open(detail, '_blank', 'noopener');
   }
 
   _renderRow(r) {

--- a/ladder/js/components/ladder-recommendations.js
+++ b/ladder/js/components/ladder-recommendations.js
@@ -5,12 +5,19 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendations, dismissRecommendation, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair, weakestFitDims }, { roleSlug }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
+  import('../slug.js' + V),
 ]);
+
+// Pre-save detail page for a rec. The pretty slug 404-rewrites into
+// /ladder/jobs/drill/?slug=…&rec=… where app.js mounts <ladder-rec-detail>.
+export function recDetailUrl(rec) {
+  return `/ladder/jobs/${roleSlug(rec.company, rec.title)}/?rec=${rec.id}`;
+}
 
 function relTime(iso) {
   if (!iso) return '';
@@ -30,6 +37,7 @@ export class JobRecommendations extends LitElement {
   static properties = {
     state: { state: true },
     items: { state: true },
+    wildcards: { state: true },
     error: { state: true },
     addingId: { state: true },
     selectedRec:        { state: true },
@@ -42,6 +50,7 @@ export class JobRecommendations extends LitElement {
     super();
     this.state = 'idle';
     this.items = [];
+    this.wildcards = [];
     this.error = '';
     this.addingId = null;
     this.selectedRec = null;
@@ -101,10 +110,17 @@ export class JobRecommendations extends LitElement {
       this.error = String(e);
       this.state = 'error';
     }
+    // Wildcards load after the main strip — never block or fail the
+    // carousel over them.
+    try {
+      const wc = await fetchRecommendations({ view: 'wildcard' });
+      this.wildcards = wc.recommendations || [];
+    } catch { this.wildcards = []; }
   }
 
   async _onDismiss(id) {
     this.items = this.items.filter(r => r.id !== id);
+    this.wildcards = this.wildcards.filter(r => r.id !== id);
     try { await dismissRecommendation(id); } catch {}
   }
 
@@ -120,8 +136,9 @@ export class JobRecommendations extends LitElement {
         source: 'Network',
         fromRecommendationId: rec.id,
       });
-      // Optimistic: pop from the carousel.
+      // Optimistic: pop from the carousel + wildcards strip.
       this.items = this.items.filter(x => x.id !== rec.id);
+      this.wildcards = this.wildcards.filter(x => x.id !== rec.id);
       // Invite the pipeline to refresh + surface the new row in the
       // "N new jobs added" banner instead of navigating.
       document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
@@ -182,7 +199,10 @@ export class JobRecommendations extends LitElement {
           })()}
           <div class="rec-card__title-block">
             <div class="rec-card__title-row">
-              <h3 class="rec-card__title">${rec.title || '(untitled)'}</h3>
+              <h3 class="rec-card__title">
+                <a class="rec-card__title-link" href=${recDetailUrl(rec)} target="_blank" rel="noopener"
+                   title="Open role details in a new tab">${rec.title || '(untitled)'}</a>
+              </h3>
               ${renderScorePair(rec, {
                 onFit:       (row) => this._openFitModal(row),
                 onCandidate: (row) => this._openCandidateModal(row),
@@ -220,6 +240,62 @@ export class JobRecommendations extends LitElement {
     `;
   }
 
+  // Wildcard card — high candidate strength, low stated-criteria fit.
+  // Deliberately leads with WHY the fit is low: the strip exists to
+  // pressure-test the search criteria, not just to list more roles.
+  _renderWildcardCard(rec) {
+    const weak = weakestFitDims(rec, 2);
+    const fails = rec.hardFails || [];
+    return html`
+      <article class="rec-card rec-card--wildcard" role="listitem">
+        <header class="rec-card__head">
+          <div class="rec-card__title-block">
+            <div class="rec-card__title-row">
+              <h3 class="rec-card__title">
+                <a class="rec-card__title-link" href=${recDetailUrl(rec)} target="_blank" rel="noopener"
+                   title="Open role details in a new tab">${rec.title || '(untitled)'}</a>
+              </h3>
+              ${renderScorePair(rec, {
+                onFit:       (row) => this._openFitModal(row),
+                onCandidate: (row) => this._openCandidateModal(row),
+                fitClass:    (s) => this._fitClass(s),
+                candClass:   (s) => this._fitClass(s),
+              })}
+            </div>
+            <p class="rec-card__meta">${[rec.company, rec.location].filter(Boolean).join('  •  ')}</p>
+            <p class="rec-card__wildcard-why">
+              Standout candidate — low fit because:
+              ${[...fails.map(f => `hard fail: ${f}`), ...weak.map(w => w.rationale || `weak ${w.label.toLowerCase()}`)]
+                .slice(0, 2).join(' · ')}
+            </p>
+          </div>
+        </header>
+        <footer class="rec-card__foot">
+          <button class="btn btn--sm btn--accent" ?disabled=${this.addingId === rec.id}
+                  @click=${() => this._onAdd(rec)}>
+            ${this.addingId === rec.id ? 'Saving…' : 'Save role'}
+          </button>
+          <button class="link-subtle" @click=${() => this._onDismiss(rec.id)}>Dismiss</button>
+        </footer>
+      </article>
+    `;
+  }
+
+  _renderWildcards() {
+    if (!this.wildcards.length) return nothing;
+    return html`
+      <div class="rec-wildcards">
+        <header class="rec-shell__head rec-wildcards__head">
+          <h2>🃏 Wildcards</h2>
+          <span class="muted">Roles where you'd likely be a standout candidate — but that flunk your stated criteria. A litmus test for the litmus.</span>
+        </header>
+        <div class="rec-row" role="list">
+          ${this.wildcards.map(r => this._renderWildcardCard(r))}
+        </div>
+      </div>
+    `;
+  }
+
   _renderEmpty() {
     return html`
       <div class="rec-empty">
@@ -250,7 +326,11 @@ export class JobRecommendations extends LitElement {
       `;
     }
     if (this.state === 'error' || !this.items.length) {
-      return html`<div class="rec-shell">${this._renderEmpty()}</div>`;
+      return html`<div class="rec-shell">
+        ${this._renderEmpty()}
+        ${this._renderWildcards()}
+        ${renderScoreModal(this.selectedRec, () => this._closeFitModal(), this.selectedScoreWhich || 'fit')}
+      </div>`;
     }
     // Show only the top 5 by fit score on the widget; full list lives
     // on /ladder/jobs/recommended/. Items already arrive sorted by
@@ -279,6 +359,7 @@ export class JobRecommendations extends LitElement {
             See all recommendations →
           </a>
         </footer>
+        ${this._renderWildcards()}
         ${renderScoreModal(this.selectedRec, () => this._closeFitModal(), this.selectedScoreWhich || 'fit')}
       </section>
     `;

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -151,9 +151,11 @@ export async function addRole({ url, title, company, location, sector, source, f
 
 export async function fetchRecommendations(opts = {}) {
   const headers = await authHeader();
-  // opts.view === 'all' → full list (no fit-score floor) for the
-  // "Recommended for you" page, paginated via limit/offset + server-side
-  // sort. Default is the carousel/widget view (single 60-row pull).
+  // opts.view === 'all'      → full list (no score floors) for the
+  //                            "Recommended for you" page, paginated via
+  //                            limit/offset + server-side sort.
+  // opts.view === 'wildcard' → short "standout candidate, low fit" strip.
+  // Default is the carousel/widget view (single 60-row pull).
   let url = REC_URL;
   if (opts.view === 'all') {
     const qs = new URLSearchParams({ view: 'all' });
@@ -162,11 +164,24 @@ export async function fetchRecommendations(opts = {}) {
     if (opts.sort)           qs.set('sort',   opts.sort);
     if (opts.dir)            qs.set('dir',    opts.dir);
     url = `${REC_URL}?${qs}`;
+  } else if (opts.view === 'wildcard') {
+    url = `${REC_URL}?view=wildcard`;
   }
   const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`recommendations ${res.status}: ${await res.text()}`);
   return res.json();
 }
+// Single recommendation by id — powers the pre-save detail page
+// (/ladder/jobs/<slug>/?rec=<id>). Returns the row regardless of score /
+// dismissed / closed state; the page renders those states itself.
+export async function fetchRecommendation(id) {
+  const headers = await authHeader();
+  const res = await fetch(`${REC_URL}?id=${encodeURIComponent(id)}`, { headers });
+  if (!res.ok) throw new Error(`recommendation ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  return data.recommendation || null;
+}
+
 export async function dismissRecommendation(id) {
   const headers = await authHeader();
   const res = await fetch(REC_URL, {

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -58,7 +58,9 @@ const DEFAULT_ALLOW_SENDERS = [
   'jobs-noreply@linkedin.com',
   'jobalerts-noreply@linkedin.com',
   '@linkedin.com',
-  '@wellfound.com',
+  // Domain-suffix (no @) — Wellfound digests come from team@hi.wellfound.com,
+  // which '@wellfound.com' never matches under the includes() check below.
+  'wellfound.com',
   '@otta.com',
   '@hellootta.com',
   '@hnhiring.com',
@@ -83,6 +85,7 @@ const DIGEST_HINTS = [
   'roundup',
   'job digest',
   'jobs digest',
+  'more matches',                  // Wellfound: "New job: X at Y, and 24 more matches"
 ];
 
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.23.0';
-console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: transient Anthropic outages (credits/429/5xx) abort the run instead of tombstoning messages, so the backlog auto-re-drains once the API recovers`);
+const VERSION = '0.23.1';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: Wellfound allowlist matches hi.wellfound.com subdomain sender; "more matches" subject counts as digest`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.13.0';
-console.log(`[recommendations] v${VERSION} - return recentlyExpired (recs auto-retired by liveness in last 7d) so For You can show "N expired removed"`);
+const VERSION = '0.14.0';
+console.log(`[recommendations] v${VERSION} - candidate floor 50 (ungraded=pending), view=wildcard (standout candidate / low fit), view=all now unfiltered`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -18,21 +18,63 @@ serve(async (req) => {
     const sql = db();
 
     if (req.method === 'GET') {
-      // ?view=all   → all active recs regardless of fit score (for the
-      //               "Recommended for you" full-list page). Still excludes
-      //               dismissed + already-in-pipeline; those are signal of
-      //               user intent, not just score thresholds.
-      // (default)   → score floor 50, max 60 rows (drives the carousel).
+      // ?view=all      → all active recs regardless of score (for the
+      //                  "Recommended for you" full-list page). Still excludes
+      //                  dismissed + already-in-pipeline; those are signal of
+      //                  user intent, not just score thresholds. No score
+      //                  floors at all — this is the inspection surface for
+      //                  everything the default view filters out.
+      // ?view=wildcard → "standout candidate, low fit" — roles where the
+      //                  Haiku grade says you'd beat most applicants but the
+      //                  heuristic fit flunks your stated criteria. Meant to
+      //                  pressure-test the litmus, so hard-fails are ALLOWED
+      //                  here (mega-cap / mission conflicts are exactly the
+      //                  cases worth a second look). Top rows by strength.
+      // (default)      → fit floor 50 + strength floor 50, max 60 rows
+      //                  (drives the carousel).
       const url = new URL(req.url);
+
+      // ?id=<uuid> → single-rec lookup for the pre-save detail page.
+      // Returns the row regardless of score/dismissed/closed state (the
+      // page renders those states itself), scoped to the caller's rows.
+      const recId = url.searchParams.get('id');
+      if (recId) {
+        const one = await sql`
+          select r.id, r.source, r.source_label as "sourceLabel", r.url, r.company, r.title, r.location,
+                 r.salary, r.logo_url as "logoUrl", r.posted_at as "postedAt",
+                 r.description, r.match_bullets as "matchBullets", r.suggested_at as "suggestedAt",
+                 r.fit_score as "fitScore", r.fit_breakdown as "breakdown",
+                 r.fit_rationales as "rationales", r.fit_summary as "fitSummary",
+                 r.candidate_score as "candidateScore", r.candidate_breakdown as "candidateBreakdown",
+                 r.candidate_rationales as "candidateRationales", r.candidate_summary as "candidateSummary",
+                 r.comp_acceptable as "compAcceptable",
+                 r.hard_fails as "hardFails", r.sector,
+                 r.enrichment_status as "enrichmentStatus",
+                 r.canonical_url as "canonicalUrl",
+                 r.dismissed_at as "dismissedAt", r.closed_at as "closedAt",
+                 r.closure_reason as "closureReason",
+                 r.added_to_pipeline_slug as "addedToPipelineSlug",
+                 case when r.source = 'gmail-jobs' and r.payload ? 'gmailApiId'
+                      then 'https://mail.google.com/mail/u/0/#inbox/' || (r.payload->>'gmailApiId')
+                      else null end as "sourceEmailUrl"
+            from job.recommended_roles r
+           where r.id = ${recId} and r.user_email = ${email}
+           limit 1`;
+        if (!one.length) return err('not found', 404);
+        return jsonResp({ ok: true, version: VERSION, recommendation: one[0] });
+      }
+
       const view = url.searchParams.get('view') || 'default';
       const isAll = view === 'all';
+      const isWildcard = view === 'wildcard';
 
       // Pagination (view=all only). The default carousel view stays a
-      // single 60-row pull. limit caps at 200; the table loads pages via
-      // infinite scroll and reads `total` to show "X of Y".
+      // single 60-row pull; wildcard is a short strip. limit caps at 200;
+      // the table loads pages via infinite scroll and reads `total` to
+      // show "X of Y".
       const limit = isAll
         ? Math.min(200, Math.max(1, parseInt(url.searchParams.get('limit') || '100', 10) || 100))
-        : 60;
+        : isWildcard ? 6 : 60;
       const offset = isAll ? Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0) : 0;
 
       // Server-side sort — whitelist of sortable columns mapped to the
@@ -66,11 +108,24 @@ serve(async (req) => {
         else if (SORT_COLS[k]) layers.push(`${SORT_COLS[k]} ${dir} nulls last`);
       });
       if (!layers.length) layers.push(`${BLENDED_RANK} desc nulls last`);
-      const orderBy = layers.join(', ') + ', r.suggested_at desc, r.id desc';
+      const orderBy = (isWildcard ? 'r.candidate_score desc nulls last' : layers.join(', '))
+        + ', r.suggested_at desc, r.id desc';
 
-      // Candidate-score low-end threshold — drop clearly-weak graded roles
-      // (< 30). Un-graded rows are never dropped on this basis.
-      const CANDIDATE_FLOOR = 30;
+      // Strength (candidate-score) floor for the default view. Raised from
+      // 30 → 50 (2026-07): live distribution has strength median 52 / max 78,
+      // so a floor of 30 only trimmed the bottom ~15% — roles that fit the
+      // criteria but where you'd be a weak applicant still showed. Ungraded
+      // rows are treated as PENDING (excluded) until enrichment grades them;
+      // they remain visible in view=all.
+      const CANDIDATE_FLOOR = 50;
+
+      // Wildcard band: strength high enough to be a standout (the Haiku
+      // rubric's "top 10-15%" band starts at 75 and nothing live scores
+      // above 78, so 65 is genuinely rare air), fit below the default
+      // view's floor. Percentile-anchored intent — revisit if the strength
+      // distribution shifts.
+      const WILDCARD_MIN_STRENGTH = 65;
+      const WILDCARD_MAX_FIT = 50;
 
       // Per-user blocked companies (the "Don't recommend this company"
       // action). Filtered here so they vanish from For You immediately.
@@ -110,9 +165,11 @@ serve(async (req) => {
         where r.dismissed_at is null
           and r.closed_at is null
           and r.added_to_pipeline_slug is null
-          and (${isAll} or r.fit_score is null or r.fit_score >= 50)
-          and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
-          and not (r.candidate_score is not null and r.candidate_score < ${CANDIDATE_FLOOR})
+          and (${isAll || isWildcard} or r.fit_score is null or r.fit_score >= 50)
+          and (${isAll || isWildcard} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
+          and (${isAll} or (r.candidate_score is not null and r.candidate_score >= ${CANDIDATE_FLOOR}))
+          and (${!isWildcard} or (r.candidate_score >= ${WILDCARD_MIN_STRENGTH}
+                                  and coalesce(r.fit_score, 100) < ${WILDCARD_MAX_FIT}))
           and (${blocked.length === 0} or lower(trim(r.company)) <> all(${blocked}::text[]))
           and not exists (
             select 1


### PR DESCRIPTION
## What

Four For You upgrades in one pass:

1. **Score floors** — `recommendations` v0.14.0 raises the strength (candidate_score) floor from 30 → 50 on the default view; ungraded rows are now *pending* (hidden until enrichment grades them) instead of passing. Applies to all current rows instantly since it's a read-time filter (127 of 346 active recs survive). `view=all` is now truly unfiltered as the inspection surface.
2. **Wildcards** — new `view=wildcard` (strength ≥ 65, fit < 50, hard-fails allowed) + a 🃏 strip under the carousel that leads with *why* fit is low (weakest fit dimensions / hard fails). Exists to pressure-test the search criteria.
3. **New tab + pre-save detail page** — new `ladder-rec-detail` component at `/ladder/jobs/<slug>/?rec=<id>` showing fit + strength breakdowns, summaries, match bullets, and the JD before saving. For You clicks (carousel titles + table rows) open it in a new tab; the external posting link lives on that page.
4. **Wellfound Gmail source** — root-cause fix: Wellfound sends from `team@hi.wellfound.com`, which the `@wellfound.com` allowlist entry never matched under `sender.includes()`. Zero Wellfound recs had ever ingested. Now domain-suffix matched + "…more matches" subjects count as digests. (`pull-recommendations` v0.23.1)

## Versions
- ladder 2.12.0 → 2.13.0 (+ components.css 1.17.0 → 1.18.0, HTML pins)
- recommendations 0.13.0 → 0.14.0
- pull-recommendations 0.23.0 → 0.23.1

## Post-merge
- Deploy `recommendations` + `pull-recommendations`
- Re-enrich the 9 ungraded active recs
- Drain the Wellfound backlog (background agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)