### PR TITLE
feat(events): DB source registry, cross-source dedup, pipeline maintenance

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1613,8 +1613,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.10.0';
-  console.log(`[events] v${VERSION} - SFMOMA HTML scraper, multi-day events, exhibitions rail`);
+  const VERSION = '1.11.0';
+  console.log(`[events] v${VERSION} - DB source registry + cross-source event merge`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2088,16 +2088,40 @@ body {
         .order('date', { ascending: true });
       if (error) { log('L2 cache: query error — ' + error.message); return null; }
       if (!data || data.length === 0) { log('L2 cache: empty'); return null; }
-      const events = data.map(row => ({
-        date: row.date, time: row.time || '', name: row.name, venue: row.venue,
-        address: row.address || '', city: row.city || '', genre: row.genre || '',
-        price: row.price || '', ages: row.ages || '', promoter: row.promoter || '',
-        url: row.url, source: row.source_id,
-        contentType: row.content_type || getSourceCategory(row.source_id),
-        description: row.description || '', imageUrl: row.image_url || '',
-        enrichedTags: row.tags || [],
-      }));
-      log(`L2 cache: loaded ${events.length} events`);
+      // Merge rows that are the same physical event scraped from different
+      // sources (shared canonical_key). One row is shown with all source
+      // tokens; richer fields win regardless of which source supplied them.
+      const byCanonical = new Map();
+      let mergedCount = 0;
+      for (const row of data) {
+        const key = row.canonical_key || row.event_key || (row.source_id + '|' + row.url);
+        const ev = {
+          date: row.date, time: row.time || '', name: row.name, venue: row.venue,
+          address: row.address || '', city: row.city || '', genre: row.genre || '',
+          price: row.price || '', ages: row.ages || '', promoter: row.promoter || '',
+          url: row.url, source: row.source_id,
+          contentType: row.content_type || getSourceCategory(row.source_id),
+          description: row.description || '', imageUrl: row.image_url || '',
+          enrichedTags: row.tags || [],
+        };
+        const existing = byCanonical.get(key);
+        if (!existing) {
+          ev.sources = [ev.source];
+          byCanonical.set(key, ev);
+        } else {
+          mergedCount++;
+          if (!existing.sources.includes(ev.source)) existing.sources.push(ev.source);
+          if (!existing.time && ev.time) existing.time = ev.time;
+          if (!existing.genre && ev.genre) existing.genre = ev.genre;
+          if (!existing.price && ev.price) existing.price = ev.price;
+          if (!existing.ages && ev.ages) existing.ages = ev.ages;
+          if (!existing.description && ev.description) existing.description = ev.description;
+          if (!existing.imageUrl && ev.imageUrl) existing.imageUrl = ev.imageUrl;
+          if (existing.enrichedTags.length === 0 && ev.enrichedTags.length > 0) existing.enrichedTags = ev.enrichedTags;
+        }
+      }
+      const events = Array.from(byCanonical.values());
+      log(`L2 cache: loaded ${events.length} events` + (mergedCount ? ` (${mergedCount} cross-source duplicates merged)` : ''));
       return events;
     } catch (e) { log('L2 cache: error — ' + e.message); return null; }
   }
@@ -3970,7 +3994,29 @@ body {
   }
 
   // --- Init ---
+  // Refresh the stock source catalog from the event_sources registry table.
+  // The hardcoded STOCK_SOURCES array is the fallback if the table is
+  // unreachable; the array is mutated in place so all existing references
+  // (onboarding pickers, category lookups) see the DB-backed list.
+  async function loadSourceRegistry() {
+    if (!supabaseClient) return;
+    try {
+      const { data, error } = await supabaseClient
+        .from('event_sources')
+        .select('id, name, category, type, url, region, description')
+        .eq('enabled', true);
+      if (error || !data || data.length === 0) {
+        log('Source registry: unavailable, using built-in list' + (error ? ' — ' + error.message : ''));
+        return;
+      }
+      STOCK_SOURCES.length = 0;
+      data.forEach(r => STOCK_SOURCES.push(r));
+      log(`Source registry: ${data.length} sources loaded from DB`);
+    } catch (e) { log('Source registry: ' + e.message); }
+  }
+
   async function init() {
+    await loadSourceRegistry();
     loadSettings();
     loadSources();
     bindEvents();

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.3.2'
-console.log(`[cache-events] v${VERSION} - fix status recovery: consecutive_failures=0 should never be broken`)
+const VERSION = '1.4.0'
+console.log(`[cache-events] v${VERSION} - canonical_key cross-source dedup + decaying peak for count-drop detection`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -29,6 +29,28 @@ function jsonResponse(body: Record<string, unknown>, status = 200) {
 // Generate SHA-256 event key matching the DB helper function
 async function generateEventKey(source: string, date: string, name: string, venue: string): Promise<string> {
   const normalized = `${source}|${date}|${name.trim().toLowerCase()}|${venue.trim().toLowerCase()}`
+  const data = new TextEncoder().encode(normalized)
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+// Source-agnostic key so the same event scraped from two sources can be
+// merged in the UI. Strips diacritics (Café → cafe) and collapses whitespace;
+// SQL backfill in migration 088 matches this except diacritics (converges on
+// next scrape since updates rewrite the key).
+function normalizeForKey(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+async function generateCanonicalKey(date: string, name: string, venue: string): Promise<string> {
+  const normalized = `${date}|${normalizeForKey(name)}|${normalizeForKey(venue)}`
   const data = new TextEncoder().encode(normalized)
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   return Array.from(new Uint8Array(hashBuffer))
@@ -108,10 +130,14 @@ async function upsertSourceHealth(
     const outcomesSeen = existing.outcomes_seen || {}
     outcomesSeen[outcomeKey] = (outcomesSeen[outcomeKey] || 0) + 1
 
-    // Track peak event count (stored in JSONB to avoid migration)
+    // Track peak event count (stored in JSONB to avoid migration).
+    // The peak decays 0.5% per successful scrape (~34%/week at 12 scrapes/day)
+    // so a listing-volume high from months ago doesn't flag the source as
+    // degraded forever — count_drop should mean "recent drop", not
+    // "smaller than the all-time record".
     const previousPeak = outcomesSeen.peak_event_count || 0
-    if (isSuccess && outcome.eventCount > previousPeak) {
-      outcomesSeen.peak_event_count = outcome.eventCount
+    if (isSuccess) {
+      outcomesSeen.peak_event_count = Math.round(Math.max(outcome.eventCount, previousPeak * 0.995) * 10) / 10
     }
     const peakCount = outcomesSeen.peak_event_count || 0
 
@@ -231,8 +257,10 @@ serve(async (req: Request) => {
     const rows = await Promise.all(events.map(async (ev) => {
       if (!ev.source || !ev.date || !ev.name || !ev.venue || !ev.url) return null
       const eventKey = await generateEventKey(ev.source, ev.date, ev.name, ev.venue)
+      const canonicalKey = await generateCanonicalKey(ev.date, ev.name, ev.venue)
       return {
         event_key: eventKey,
+        canonical_key: canonicalKey,
         source_id: ev.source,
         date: ev.date,
         time: ev.time || null,
@@ -311,7 +339,7 @@ serve(async (req: Request) => {
     // if newly available — parsers that didn't used to emit it may now).
     if (toUpdate.length > 0) {
       for (const row of toUpdate) {
-        const patch: Record<string, unknown> = { scraped_at: row.scraped_at }
+        const patch: Record<string, unknown> = { scraped_at: row.scraped_at, canonical_key: row.canonical_key }
         if (row.description) patch.description = row.description
         const { error: updateErr } = await supabase
           .from('events')

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.2.0'
-console.log(`[scrape-events] v${VERSION} - server-side event scraper`)
+const VERSION = '1.3.0'
+console.log(`[scrape-events] v${VERSION} - DB source registry, maintenance RPC, discord trigger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -60,6 +60,29 @@ function createSemaphore(limit: number) {
   }
 }
 
+// --- Source registry ---
+// Sources live in the event_sources table so adding one of an existing
+// parser type is an INSERT, not a deploy. STOCK_SOURCES remains as the
+// fallback if the table is unreachable or empty.
+
+async function loadSources(supabase: ReturnType<typeof createClient>): Promise<EventSource[]> {
+  try {
+    const { data, error } = await supabase
+      .from('event_sources')
+      .select('id, name, category, type, url, region, description')
+      .eq('enabled', true)
+
+    if (error || !data || data.length === 0) {
+      console.log(`[scrape-events] Registry unavailable (${error?.message || 'empty'}), falling back to STOCK_SOURCES`)
+      return STOCK_SOURCES
+    }
+    return data as EventSource[]
+  } catch (e) {
+    console.log(`[scrape-events] Registry load failed (${(e as Error).message}), falling back to STOCK_SOURCES`)
+    return STOCK_SOURCES
+  }
+}
+
 // --- Parser dispatch ---
 
 async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
@@ -95,6 +118,17 @@ interface SourceOutcome {
   durationMs?: number
 }
 
+// The Supabase edge platform validates Authorization: Bearer <token> at the
+// gateway and requires a valid JWT. Env service/anon keys may be in the new
+// non-JWT "sb_secret_" format, so we fall back to the public anon JWT for
+// internal function-to-function calls (overridable via INTERNAL_ANON_JWT).
+// Callee functions use their own service role for DB writes, so no
+// permission escalation is possible with this token.
+function internalJwt(): string {
+  return Deno.env.get('INTERNAL_ANON_JWT')
+    || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI'
+}
+
 // --- Push events to cache-events ---
 
 async function pushToCache(
@@ -103,12 +137,7 @@ async function pushToCache(
   supabaseUrl: string,
   _serviceKey: string,
 ): Promise<{ cached: number; updated: number; enrichQueued: number }> {
-  // The Supabase edge platform validates Authorization: Bearer <token> at the
-  // gateway and requires a valid JWT. Env service/anon keys may be in the new
-  // non-JWT "sb_secret_" format, so we hardcode the public anon JWT for
-  // internal function-to-function calls. cache-events uses its own service
-  // role for DB writes, so no permission escalation is needed.
-  const serviceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI'
+  const serviceKey = internalJwt()
   void _serviceKey
   // Format events to match ScrapedEvent interface expected by cache-events
   const formatted = events.map(ev => ({
@@ -128,12 +157,16 @@ async function pushToCache(
     description: ev.description || undefined,
   }))
 
-  // Send in batches of 400 (cache-events limit is 500)
+  // Send in batches of 400 (cache-events limit is 500). Source outcomes ride
+  // with the first batch; if that request fails they're retried as a
+  // health-only push at the end so a single failed batch can't lose a whole
+  // run's health tracking.
   let totalCached = 0, totalUpdated = 0, totalEnrichQueued = 0
+  let outcomesDelivered = false
 
   for (let i = 0; i < formatted.length; i += 400) {
     const batch = formatted.slice(i, i + 400)
-    const isLastBatch = i + 400 >= formatted.length
+    const attachOutcomes = !outcomesDelivered && sourceOutcomes.length > 0
 
     try {
       const resp = await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
@@ -144,8 +177,7 @@ async function pushToCache(
         },
         body: JSON.stringify({
           events: batch,
-          // Only send sourceOutcomes with the last batch
-          sourceOutcomes: isLastBatch ? sourceOutcomes : undefined,
+          sourceOutcomes: attachOutcomes ? sourceOutcomes : undefined,
         }),
       })
 
@@ -154,6 +186,7 @@ async function pushToCache(
         totalCached += result.cached || 0
         totalUpdated += result.updated || 0
         totalEnrichQueued += result.enrichQueued || 0
+        if (attachOutcomes) outcomesDelivered = true
       } else {
         const errText = await resp.text()
         console.error(`[scrape-events] cache-events batch failed: ${resp.status} ${errText}`)
@@ -163,8 +196,8 @@ async function pushToCache(
     }
   }
 
-  // If no events but we have outcomes, still send outcomes
-  if (formatted.length === 0 && sourceOutcomes.length > 0) {
+  // Health-only push if outcomes never made it (no events, or first batch failed)
+  if (!outcomesDelivered && sourceOutcomes.length > 0) {
     try {
       await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
         method: 'POST',
@@ -238,6 +271,7 @@ async function scrapeAll(triggeredBy: string): Promise<Record<string, unknown>> 
   const supabase = createClient(supabaseUrl, serviceKey)
 
   const runId = await createRun(supabase, triggeredBy)
+  const sources = await loadSources(supabase)
   const semaphore = createSemaphore(5)
 
   const allEvents: ScrapedEvent[] = []
@@ -246,10 +280,10 @@ async function scrapeAll(triggeredBy: string): Promise<Record<string, unknown>> 
   let sourcesSucceeded = 0
   let sourcesFailed = 0
 
-  console.log(`[scrape-events] Starting refresh-all: ${STOCK_SOURCES.length} sources, concurrency=5`)
+  console.log(`[scrape-events] Starting refresh-all: ${sources.length} sources, concurrency=5`)
 
   const results = await Promise.allSettled(
-    STOCK_SOURCES.map(source =>
+    sources.map(source =>
       semaphore(async () => {
         const start = Date.now()
         try {
@@ -317,7 +351,7 @@ async function scrapeAll(triggeredBy: string): Promise<Record<string, unknown>> 
   // Complete run tracking
   if (runId) {
     await completeRun(supabase, runId, {
-      sourcesAttempted: STOCK_SOURCES.length,
+      sourcesAttempted: sources.length,
       sourcesSucceeded,
       sourcesFailed,
       eventsTotal: allEvents.length,
@@ -327,27 +361,60 @@ async function scrapeAll(triggeredBy: string): Promise<Record<string, unknown>> 
     })
   }
 
+  // Post-run housekeeping: purge stale events/caches/runs (the cleanup
+  // functions existed since migrations 009/010/039 but nothing invoked them).
+  let maintenance: unknown = null
+  try {
+    const { data, error } = await supabase.rpc('run_events_maintenance')
+    if (error) {
+      console.error(`[scrape-events] Maintenance failed: ${error.message}`)
+    } else {
+      maintenance = data
+      console.log(`[scrape-events] Maintenance: ${JSON.stringify(data)}`)
+    }
+  } catch (e) {
+    console.error(`[scrape-events] Maintenance error: ${(e as Error).message}`)
+  }
+
+  // Kick the Discord scraper (it has no cron of its own; its 4h cache TTL
+  // makes an every-2h kick a no-op half the time). Fire-and-forget.
+  try {
+    fetch(`${supabaseUrl}/functions/v1/scrape-discord-events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${internalJwt()}`,
+      },
+      body: JSON.stringify({ action: 'refresh-all' }),
+    }).catch(err => console.error(`[scrape-events] Discord trigger failed: ${err.message}`))
+  } catch (e) {
+    console.error(`[scrape-events] Discord trigger error: ${(e as Error).message}`)
+  }
+
   return {
-    sourcesAttempted: STOCK_SOURCES.length,
+    sourcesAttempted: sources.length,
     sourcesSucceeded,
     sourcesFailed,
     eventsTotal: allEvents.length,
     eventsNew: cacheResult.cached,
     eventsUpdated: cacheResult.updated,
     enrichQueued: cacheResult.enrichQueued,
+    maintenance,
     errorLog: errorLog.length > 0 ? errorLog : undefined,
     runId,
   }
 }
 
 async function scrapeSingle(sourceId: string): Promise<Record<string, unknown>> {
-  const source = STOCK_SOURCES.find(s => s.id === sourceId)
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  const supabase = createClient(supabaseUrl, serviceKey)
+
+  const sources = await loadSources(supabase)
+  const source = sources.find(s => s.id === sourceId)
   if (!source) {
     return { error: `Source not found: ${sourceId}` }
   }
-
-  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
 
   const start = Date.now()
   try {
@@ -409,7 +476,8 @@ async function getStatus(): Promise<Record<string, unknown>> {
     .order('started_at', { ascending: false })
     .limit(5)
 
-  return { runs: data || [], totalSources: STOCK_SOURCES.length }
+  const sources = await loadSources(supabase)
+  return { runs: data || [], totalSources: sources.length }
 }
 
 function classifyError(msg: string): string {

--- a/supabase/migrations/088_event_sources_registry.sql
+++ b/supabase/migrations/088_event_sources_registry.sql
@@ -1,0 +1,118 @@
+-- ============================================
+-- Event Sources Registry + Cross-Source Dedup + Maintenance
+-- Migration 088
+--
+-- 1. event_sources: DB registry of scrape sources (replaces hardcoded
+--    STOCK_SOURCES in scrape-events/sources.ts and events/index.html —
+--    both keep a hardcoded fallback). Adding a source of an existing
+--    parser type becomes an INSERT, no deploy.
+-- 2. events.canonical_key: source-agnostic dedup key so the same event
+--    scraped from two sources can be merged in the UI.
+-- 3. run_events_maintenance(): single RPC bundling the cleanup functions
+--    that existed but were never invoked (called by scrape-events at the
+--    end of every run).
+-- ============================================
+
+-- 1. Source registry
+CREATE TABLE IF NOT EXISTS event_sources (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL,        -- music|film|tech|social|art|...
+  type TEXT NOT NULL,            -- parser type: html|ra|screenslate|garysguide|ical|json|rss|...
+  url TEXT NOT NULL,
+  region TEXT NOT NULL,          -- bay-area|los-angeles|new-york|seattle|...
+  description TEXT NOT NULL DEFAULT '',
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  notes TEXT,                    -- e.g. reason a source is disabled
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE event_sources ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read access"
+  ON event_sources FOR SELECT
+  USING (true);
+
+CREATE POLICY "Service role full access"
+  ON event_sources FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE OR REPLACE FUNCTION update_event_sources_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER event_sources_updated_at
+  BEFORE UPDATE ON event_sources
+  FOR EACH ROW EXECUTE FUNCTION update_event_sources_timestamp();
+
+-- Seed: the 9 live stock sources
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled) VALUES
+  ('19hz-bayarea', '19hz', 'music', 'html', 'https://19hz.info/eventlisting_BayArea.php', 'bay-area', 'Electronic music & nightlife', true),
+  ('ra-bayarea', 'Resident Advisor SF', 'music', 'ra', 'https://ra.co/events/us/sanfrancisco', 'bay-area', 'Electronic music events', true),
+  ('screenslate-sf', 'Screen Slate', 'film', 'screenslate', 'https://www.screenslate.com/listings', 'bay-area', 'Repertory & arthouse cinema', true),
+  ('19hz-losangeles', '19hz Los Angeles', 'music', 'html', 'https://19hz.info/eventlisting_LosAngeles.php', 'los-angeles', 'Electronic music & nightlife', true),
+  ('screenslate-nyc', 'Screen Slate', 'film', 'screenslate', 'https://www.screenslate.com/listings', 'new-york', 'Repertory & arthouse cinema', true),
+  ('19hz-seattle', '19hz Seattle', 'music', 'html', 'https://19hz.info/eventlisting_Seattle.php', 'seattle', 'Electronic music & nightlife', true),
+  ('garysguide-sf', 'Gary''s Guide SF', 'tech', 'garysguide', 'https://www.garysguide.com/events?region=sf', 'bay-area', 'Tech & startup events', true),
+  ('luma-sf', 'Luma SF', 'social', 'ical', 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', 'bay-area', 'What''s happening in San Francisco', true),
+  ('garysguide-nyc', 'Gary''s Guide NYC', 'tech', 'garysguide', 'https://www.garysguide.com/events?region=nyc', 'new-york', 'Tech & startup events', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Seed: removed sources, kept disabled so the removal reason is data, not a code comment
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, notes) VALUES
+  ('19hz-newyork', '19hz New York', 'music', 'html', 'https://19hz.info/eventlisting_NewYork.php', 'new-york', 'Electronic music & nightlife', false, '404 — page does not exist'),
+  ('sf-punchline', 'Punch Line SF', 'comedy', 'html', 'https://www.punchlinecomedyclub.com/shows', 'bay-area', 'Comedy club', false, 'Next.js SPA, event data in RSC JSON hydration — needs headless browser'),
+  ('cobbs-sf', 'Cobb''s Comedy Club', 'comedy', 'html', 'https://www.cobbscomedy.com/shows', 'bay-area', 'Comedy club', false, 'Next.js SPA, same as Punch Line — needs headless browser'),
+  ('citylights-sf', 'City Lights', 'literary', 'html', 'https://citylights.com/events/', 'bay-area', 'Bookstore events', false, 'Sucuri WAF JS challenge blocks server-side fetch'),
+  ('audium-sf', 'Audium', 'music', 'html', 'https://www.audium.org/', 'bay-area', 'Sound theater', false, 'WordPress ai1ec calendar plugin, JS-rendered — needs headless browser'),
+  ('sfdesignweek', 'SF Design Week', 'design', 'html', 'https://sfdesignweek.org/events/', 'bay-area', 'Design events', false, 'No events until April 2026; Tribe Events plugin when live')
+ON CONFLICT (id) DO NOTHING;
+
+-- 2. Cross-source dedup key: SHA256(date|name|venue), source-agnostic.
+-- Normalization must match cache-events generateCanonicalKey(): lowercase,
+-- trim, collapse whitespace. (JS additionally strips diacritics; accented
+-- rows converge on the next scrape when cache-events rewrites the key.)
+ALTER TABLE events ADD COLUMN IF NOT EXISTS canonical_key TEXT;
+CREATE INDEX IF NOT EXISTS idx_events_canonical ON events(canonical_key);
+
+UPDATE events SET canonical_key = encode(sha256(convert_to(
+  date::text || '|' ||
+  lower(regexp_replace(trim(name), '\s+', ' ', 'g')) || '|' ||
+  lower(regexp_replace(trim(venue), '\s+', ' ', 'g')),
+'UTF8')), 'hex')
+WHERE canonical_key IS NULL;
+
+-- 3. Maintenance RPC: bundles the never-invoked cleanup functions.
+-- Called by scrape-events at the end of each run (every 2h).
+CREATE OR REPLACE FUNCTION run_events_maintenance()
+RETURNS JSONB AS $$
+DECLARE
+  stale_events INTEGER;
+  stale_discord INTEGER;
+  old_runs INTEGER;
+BEGIN
+  DELETE FROM events WHERE date < CURRENT_DATE - INTERVAL '7 days';
+  GET DIAGNOSTICS stale_events = ROW_COUNT;
+
+  DELETE FROM discord_event_cache WHERE expires_at < NOW() - INTERVAL '7 days';
+  GET DIAGNOSTICS stale_discord = ROW_COUNT;
+
+  DELETE FROM scrape_runs WHERE started_at < NOW() - INTERVAL '90 days';
+  GET DIAGNOSTICS old_runs = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'stale_events', stale_events,
+    'stale_discord', stale_discord,
+    'old_runs', old_runs
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- One-time cleanup: source_health rows for sources no longer in the registry
+DELETE FROM source_health
+WHERE source_id NOT IN (SELECT id FROM event_sources);


### PR DESCRIPTION
## Summary
Implements the /events audit improvement plan (sources, dedup, stability):

- **Source registry → DB** (`event_sources` table, migration 088): adding a source of an existing parser type is now an INSERT, not a deploy. Seeded with the 9 live sources plus the 6 removed ones (disabled, with removal reason as data). `scrape-events` and the frontend both read the registry with a hardcoded fallback.
- **Cross-source dedup**: new `events.canonical_key` (SHA256 of date|name|venue, source-agnostic, diacritics stripped) written by `cache-events` and backfilled; frontend merges rows sharing a key into one event with multiple source tokens (`ev.sources` rendering already existed).
- **Maintenance actually runs**: `run_events_maintenance()` RPC bundles `cleanup_stale_events` + discord cache purge + 90-day scrape_runs cleanup — none of which had ever been invoked — and is called at the end of every scrape run.
- **Discord scraper wired**: `scrape-discord-events` had no cron; `scrape-events` now kicks its `refresh-all` after each run (4h cache TTL makes this cheap).
- **Health tracking fixes**: sourceOutcomes ship with the first cache batch (health-only retry if it fails) instead of only the last; `peak_event_count` now decays 0.5%/successful scrape so count-drop degradation means a *recent* drop — fixes Gary's Guide ×2 / Luma / Screen Slate SF being stuck 'degraded' vs months-old peaks.
- Versions: scrape-events 1.3.0, cache-events 1.4.0, events frontend 1.11.0.

## Post-merge
Apply migration 088 + deploy `scrape-events` and `cache-events` (will do after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)