### PR TITLE
ladder 2.13.1: Wildcards strip on the For You table page

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.13.0";
-console.log(`[ladder] v${VERSION} - For You: wildcards strip, pre-save rec detail page, clicks open in new tab`);
+const VERSION = "2.13.1";
+console.log(`[ladder] v${VERSION} - Wildcards strip moved to the For You table page (carousel is unmounted); bullet dedupe on rec detail`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-rec-detail.js
+++ b/ladder/js/components/ladder-rec-detail.js
@@ -205,7 +205,7 @@ export class LadderRecDetail extends LitElement {
           <article class="role-card">
             <header class="role-card__head"><h3>Why it surfaced</h3></header>
             <ul class="rec-detail__bullets">
-              ${bullets.map(b => html`<li>${unsafeHTML(renderMarkdown(String(b)))}</li>`)}
+              ${bullets.map(b => html`<li>${unsafeHTML(renderMarkdown(String(b).replace(/^\s*[•\-\*]\s*/, '')))}</li>`)}
             </ul>
           </article>
         ` : nothing}

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -8,7 +8,7 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }, { roleSlug }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair, weakestFitDims }, { renderLocation, renderSource }, { roleSlug }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
@@ -73,6 +73,7 @@ export class JobRecommendationsTable extends LitElement {
     _loadingMore:        { state: true },
     _hasMore:            { state: true },
     _recentlyExpired:    { state: true },
+    _wildcards:          { state: true },
   };
 
   constructor() {
@@ -97,6 +98,7 @@ export class JobRecommendationsTable extends LitElement {
     this._loadingMore = false;
     this._hasMore = false;
     this._recentlyExpired = 0;
+    this._wildcards = [];
   }
 
   // ----- Source health banner ------------------------------------------
@@ -249,6 +251,12 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'loading';
     await this._fetchPage({ reset: true });
     if (this.state === 'loading') this.state = 'loaded';
+    // Wildcards strip loads after the table — never block or fail the
+    // page over it.
+    try {
+      const wc = await fetchRecommendations({ view: 'wildcard' });
+      this._wildcards = Array.isArray(wc?.recommendations) ? wc.recommendations : [];
+    } catch { this._wildcards = []; }
   }
 
   // Fetch one page from the server (server-side sorted). reset=true starts
@@ -331,6 +339,7 @@ export class JobRecommendationsTable extends LitElement {
 
   async _onDismiss(rec) {
     this.items = this.items.filter(r => r.id !== rec.id);
+    this._wildcards = this._wildcards.filter(r => r.id !== rec.id);
     try { await dismissRecommendation(rec.id); } catch {}
   }
 
@@ -347,6 +356,7 @@ export class JobRecommendationsTable extends LitElement {
         fromRecommendationId: rec.id,
       });
       this.items = this.items.filter(x => x.id !== rec.id);
+      this._wildcards = this._wildcards.filter(x => x.id !== rec.id);
       document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
       document.dispatchEvent(new CustomEvent('job:pipeline:added', {
         detail: { role: { slug: r.slug, company: r.company || rec.company, title: r.title || rec.title } },
@@ -507,6 +517,65 @@ export class JobRecommendationsTable extends LitElement {
     }
   }
 
+  // --- Wildcards strip -------------------------------------------------
+  // High candidate-strength / low stated-criteria-fit roles (view=wildcard).
+  // Leads with WHY the fit is low — the strip exists to pressure-test the
+  // search criteria, not to list more of the same.
+  _wildcardDetailUrl(r) {
+    return `/ladder/jobs/${roleSlug(r.company, r.title)}/?rec=${r.id}`;
+  }
+
+  _renderWildcardCard(rec) {
+    const weak = weakestFitDims(rec, 2);
+    const fails = rec.hardFails || [];
+    const why = [...fails.map(f => `hard fail: ${f}`),
+                 ...weak.map(w => w.rationale || `weak ${w.label.toLowerCase()}`)].slice(0, 2).join(' · ');
+    return html`
+      <article class="rec-card rec-card--wildcard" role="listitem">
+        <header class="rec-card__head">
+          <div class="rec-card__title-block">
+            <div class="rec-card__title-row">
+              <h3 class="rec-card__title">
+                <a class="rec-card__title-link" href=${this._wildcardDetailUrl(rec)} target="_blank" rel="noopener"
+                   title="Open role details in a new tab">${rec.title || '(untitled)'}</a>
+              </h3>
+              ${renderScorePair(rec, {
+                onFit:       (row) => this._openFitModal(row),
+                onCandidate: (row) => this._openCandidateModal(row),
+                fitClass:    (s) => fitClass(s),
+                candClass:   (s) => fitClass(s),
+              })}
+            </div>
+            <p class="rec-card__meta">${[rec.company, rec.location].filter(Boolean).join('  •  ')}</p>
+            ${why ? html`<p class="rec-card__wildcard-why">Standout candidate — low fit because: ${why}</p>` : nothing}
+          </div>
+        </header>
+        <footer class="rec-card__foot">
+          <button class="btn btn--sm btn--accent" ?disabled=${this.addingId === rec.id}
+                  @click=${() => this._onAdd(rec)}>
+            ${this.addingId === rec.id ? 'Saving…' : 'Save role'}
+          </button>
+          <button class="link-subtle" @click=${() => this._onDismiss(rec)}>Dismiss</button>
+        </footer>
+      </article>
+    `;
+  }
+
+  _renderWildcards() {
+    if (!this._wildcards.length) return nothing;
+    return html`
+      <section class="rec-wildcards" aria-label="Wildcards">
+        <header class="rec-shell__head rec-wildcards__head">
+          <h2>🃏 Wildcards</h2>
+          <span class="muted">Roles where you'd likely be a standout candidate — but that flunk your stated criteria. A litmus test for the litmus.</span>
+        </header>
+        <div class="rec-row" role="list">
+          ${this._wildcards.map(r => this._renderWildcardCard(r))}
+        </div>
+      </section>
+    `;
+  }
+
   render() {
     if (this.state === 'idle' || this.state === 'loading') {
       return html`
@@ -560,6 +629,7 @@ export class JobRecommendationsTable extends LitElement {
         ` : nothing}
       </header>
       ${this._renderHealthBanner()}
+      ${this._renderWildcards()}
       ${rows.length === 0 ? html`
         <div class="placeholder">
           <h2>No recommendations yet</h2>

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
-  <script src="/ladder/js/theme.js?v=2.13.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <script src="/ladder/js/theme.js?v=2.13.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #984 — the carousel component the Wildcards strip was added to is defined but never mounted; the real For You surface is the recommendations table page. Renders the strip there (above the table), plus a bullet-dedupe fix on the rec detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)