### PR TITLE
ladder: Haiku-extracted location for pipeline roles

### DIFF
--- a/supabase/functions/_shared/job-fit-haiku.ts
+++ b/supabase/functions/_shared/job-fit-haiku.ts
@@ -21,6 +21,7 @@ export interface HaikuRoleMatch {
   seniority:  string;
   scope:      string;
   fitSummary: string;
+  location:   string | null;
   // Candidate-side: "are you a good candidate for this role?" Same Haiku
   // call returns both blocks so we don't pay twice.
   candidate?: {
@@ -121,6 +122,7 @@ Output JSON only:
   "seniority":  "below" | "equivalent" | "above" | "founding",
   "scope":      "ic" | "ic_player_coach" | "manager",
   "fitSummary": "<2-4 sentence prose, max 100 words. ONLY explain why this company / role is desirable for the candidate's needs — mission alignment, scope they want, kind of problem they care about, culture traits they care about. DO NOT describe why the candidate is a good fit for the company or what they bring to the role. Speak about the company in third person.>",
+  "location":   "<the role's location exactly as the posting states it, normalized to 'City, ST' / 'City, Country' / 'Remote' / 'Remote (US)' / 'Hybrid — City, ST'. Multiple offices: join with '; '. null if the posting never states one — do not guess from the company name>",
   "candidate": {
     "breakdown": {
       "skills":  <int 0-25>,
@@ -253,7 +255,7 @@ No prose outside the JSON.`;
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) return null;
     const parsed = JSON.parse(match[0]) as {
-      score?: number; rationale?: string; seniority?: string; scope?: string; fitSummary?: string;
+      score?: number; rationale?: string; seniority?: string; scope?: string; fitSummary?: string; location?: string | null;
       candidate?: {
         breakdown?: Partial<CandidateBreakdown>;
         rationales?: Partial<CandidateRationales>;
@@ -304,11 +306,15 @@ No prose outside the JSON.`;
       };
     }
 
+    const location = (typeof parsed.location === 'string' && parsed.location.trim() && parsed.location.trim().toLowerCase() !== 'null')
+      ? parsed.location.trim().slice(0, 200) : null;
+
     return {
       score: Math.max(0, Math.min(25, Math.round(parsed.score))),
       rationale: String(parsed.rationale || '').slice(0, 400),
       seniority, scope,
       fitSummary: String(parsed.fitSummary || '').slice(0, 1200),
+      location,
       candidate,
     };
   } catch (e) {
@@ -328,6 +334,7 @@ export async function scoreOne(r: RoleRow, sql: any): Promise<{
   seniority: string | null;
   scope: string | null;
   fitSummary: string | null;
+  location: string | null;
   description: string;
   candidate: HaikuRoleMatch['candidate'] | null;
 }> {
@@ -345,6 +352,7 @@ export async function scoreOne(r: RoleRow, sql: any): Promise<{
   let seniority: string | null = null;
   let scope: string | null = null;
   let fitSummary: string | null = null;
+  let location: string | null = null;
   let candidate: HaikuRoleMatch['candidate'] | null = null;
   if (description.length > 200) {
     const haiku = await haikuRoleMatch(enriched, ctx);
@@ -352,9 +360,10 @@ export async function scoreOne(r: RoleRow, sql: any): Promise<{
       roleScore = haiku.score; rationale = haiku.rationale;
       seniority = haiku.seniority; scope = haiku.scope;
       fitSummary = haiku.fitSummary || null;
+      location = haiku.location;
       candidate = haiku.candidate || null;
     }
   }
   const fit = computeFit(enriched, ctx, roleScore, seniority, rationale);
-  return { fit, roleScore, rationale, seniority, scope, fitSummary, description, candidate };
+  return { fit, roleScore, rationale, seniority, scope, fitSummary, location, description, candidate };
 }

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -11,11 +11,11 @@ import { parseSectorTags } from '../_shared/sector-tags.ts';
 import { computeFit } from '../jobs-pipe/fit.ts';
 import { scoreOne } from '../_shared/job-fit-haiku.ts';
 
-const VERSION = '0.4.0';
+const VERSION = '0.5.0';
 // Status default: 'Saved' (post-taxonomy collapse).
 // Source-email-link: stash payload.gmailApiId as a Gmail web URL when
 // the rec came from Gmail.
-console.log(`[add-role] v${VERSION} - persist location (from source rec or JSON-LD jobLocation)`);
+console.log(`[add-role] v${VERSION} - Haiku extracts location from JD when JSON-LD/rec have none`);
 
 const URL_RE = /^https?:\/\//i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
@@ -529,8 +529,8 @@ serve(async (req) => {
       type FitOut = Awaited<ReturnType<typeof scoreOne>>;
       let fitOut: FitOut;
       if (body.fromRecommendationId) {
-        const inherit = await sql<{ description: string | null; role_match_score: number | null; role_match_rationale: string | null; role_match_seniority: string | null; role_match_scope: string | null; fit_summary: string | null; candidate_score: number | null; candidate_breakdown: Record<string, number> | null; candidate_rationales: Record<string, string> | null; candidate_summary: string | null; comp_acceptable: boolean | null }[]>`
-          select description, role_match_score, role_match_rationale, role_match_seniority, role_match_scope, fit_summary,
+        const inherit = await sql<{ description: string | null; role_match_score: number | null; role_match_rationale: string | null; role_match_seniority: string | null; role_match_scope: string | null; fit_summary: string | null; location: string | null; candidate_score: number | null; candidate_breakdown: Record<string, number> | null; candidate_rationales: Record<string, string> | null; candidate_summary: string | null; comp_acceptable: boolean | null }[]>`
+          select description, role_match_score, role_match_rationale, role_match_seniority, role_match_scope, fit_summary, location,
                  candidate_score, candidate_breakdown, candidate_rationales, candidate_summary, comp_acceptable
             from job.recommended_roles where id = ${body.fromRecommendationId} limit 1`;
         const src = inherit[0];
@@ -541,7 +541,7 @@ serve(async (req) => {
           fitOut = {
             fit, roleScore: src.role_match_score, rationale: src.role_match_rationale,
             seniority: src.role_match_seniority, scope: src.role_match_scope,
-            fitSummary: src.fit_summary, description: src.description || '',
+            fitSummary: src.fit_summary, location: src.location, description: src.description || '',
             candidate: src.candidate_score != null ? {
               score: src.candidate_score,
               breakdown: src.candidate_breakdown as never,
@@ -570,6 +570,7 @@ serve(async (req) => {
                role_match_seniority = ${fitOut.seniority},
                role_match_scope     = ${fitOut.scope},
                fit_summary          = ${fitOut.fitSummary},
+               location             = coalesce(location, ${fitOut.location}),
                candidate_score      = ${fitOut.candidate?.score ?? null},
                candidate_breakdown  = ${fitOut.candidate ? JSON.stringify(fitOut.candidate.breakdown) : null}::jsonb,
                candidate_rationales = ${fitOut.candidate ? JSON.stringify(fitOut.candidate.rationales) : null}::jsonb,


### PR DESCRIPTION
## Problem
Roles in the Saved (`?bucket=leads`) and Active (`?bucket=active`) buckets showed location inconsistently — 52 of 82 pipeline roles had a null `location`. For You always shows it because `job.recommended_roles.location` is populated by its extraction pipelines. `add-role` only persisted location from JSON-LD `jobLocation` or an inherited recommendation, and LinkedIn/many ATS pages yield neither.

## Fix (forward)
- `_shared/job-fit-haiku.ts`: the Haiku scoring pass (which already reads the full JD) now also returns a normalized `location` (`City, ST` / `Remote` / `Hybrid — City, ST`; null when the posting never states one — no guessing).
- `add-role/index.ts` (0.4.0 → 0.5.0): persists that location via `coalesce(location, …)` so JSON-LD/rec-inherited values still win; the rec-inherit path also copies the rec's location directly.

## Backfill (data, no code)
One-off pass over existing rows: extract from the 34 stored JDs, re-fetch + parse the 7 URL-only rows; the 11 rows with no URL and no JD stay blank intentionally (blank beats guessed-wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)