### PR TITLE
ladder 2.13.2: compact, lighter Wildcards cards

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.18.0");
+@import url("./components.css?v=1.18.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -2403,18 +2403,55 @@
 
 /* --- Wildcards strip (For You) ---
    High candidate-strength / low stated-criteria-fit roles. Dashed accent
-   border marks them as deliberate outliers, not more of the same list. */
-.rec-wildcards { margin-top: var(--space-6); }
+   border marks them as deliberate outliers, not more of the same list.
+   Compact by design: narrower columns, quieter chrome, smaller type —
+   but airy inside (transparent bg, roomy line-height, real gaps) so the
+   strip reads as marginalia next to the main table, not a second table. */
+.rec-wildcards { margin: var(--space-6) 0 var(--space-5); }
 .rec-wildcards__head { margin-bottom: var(--space-3); }
 .rec-wildcards__head .muted { font-size: var(--font-size-caption); }
-.rec-card--wildcard { border: 1px dashed var(--accent); }
+.rec-row--wildcards {
+  grid-auto-columns: minmax(230px, 268px);
+  gap: var(--space-3);
+}
+.rec-card--wildcard {
+  border: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
+  background: transparent;
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  gap: var(--space-2);
+}
+.rec-card--wildcard:hover { border-color: var(--accent); }
+.rec-card--wildcard .rec-card__title {
+  font-size: 13px;
+  line-height: 1.35;
+}
+.rec-card--wildcard .rec-card__meta {
+  font-size: var(--font-size-caption);
+  margin-top: 1px;
+}
+.rec-card--wildcard .fit-pill {
+  min-width: 30px;
+  padding: 2px var(--space-2);
+  font-size: 11px;
+}
 .rec-card__wildcard-why {
-  margin: 6px 0 0;
+  margin: var(--space-2) 0 0;
   font-size: var(--font-size-caption);
   color: var(--fg-muted);
   font-style: italic;
-  line-height: var(--lh-tight);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
+.rec-card--wildcard .rec-card__foot { padding-top: var(--space-2); }
+.rec-card--wildcard .rec-card__foot .btn {
+  padding: 2px 10px;
+  font-size: var(--font-size-caption);
+}
+.rec-card--wildcard .rec-card__foot .link-subtle { font-size: var(--font-size-caption); }
 
 /* --- Rec pre-save detail page (/ladder/jobs/<slug>/?rec=<id>) --- */
 .rec-detail {

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.13.1";
-console.log(`[ladder] v${VERSION} - Wildcards strip moved to the For You table page (carousel is unmounted); bullet dedupe on rec detail`);
+const VERSION = "2.13.2";
+console.log(`[ladder] v${VERSION} - compact, lighter Wildcards cards`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -528,8 +528,11 @@ export class JobRecommendationsTable extends LitElement {
   _renderWildcardCard(rec) {
     const weak = weakestFitDims(rec, 2);
     const fails = rec.hardFails || [];
-    const why = [...fails.map(f => `hard fail: ${f}`),
-                 ...weak.map(w => w.rationale || `weak ${w.label.toLowerCase()}`)].slice(0, 2).join(' · ');
+    // Just the reasons — the strip header already explains the concept,
+    // so the card copy stays light. Lead with the weakest dimension label
+    // for scannability; the full rationale lives in the fit modal.
+    const why = [...fails.map(f => `Hard fail: ${f}`),
+                 ...weak.map(w => w.rationale || `Weak ${w.label.toLowerCase()}`)].slice(0, 2).join(' · ');
     return html`
       <article class="rec-card rec-card--wildcard" role="listitem">
         <header class="rec-card__head">
@@ -547,7 +550,7 @@ export class JobRecommendationsTable extends LitElement {
               })}
             </div>
             <p class="rec-card__meta">${[rec.company, rec.location].filter(Boolean).join('  •  ')}</p>
-            ${why ? html`<p class="rec-card__wildcard-why">Standout candidate — low fit because: ${why}</p>` : nothing}
+            ${why ? html`<p class="rec-card__wildcard-why">${why}</p>` : nothing}
           </div>
         </header>
         <footer class="rec-card__foot">
@@ -569,7 +572,7 @@ export class JobRecommendationsTable extends LitElement {
           <h2>🃏 Wildcards</h2>
           <span class="muted">Roles where you'd likely be a standout candidate — but that flunk your stated criteria. A litmus test for the litmus.</span>
         </header>
-        <div class="rec-row" role="list">
+        <div class="rec-row rec-row--wildcards" role="list">
           ${this._wildcards.map(r => this._renderWildcardCard(r))}
         </div>
       </section>

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.1">
-  <script src="/ladder/js/theme.js?v=2.13.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <script src="/ladder/js/theme.js?v=2.13.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
 </body>
 </html>


### PR DESCRIPTION
Design pass on the Wildcards strip: reduce card size while keeping whitespace — narrower columns, transparent bg + softened dashed border, smaller type/pills, clamped rationale with airy line-height, quieter footer. Drops the repeated card-copy prefix (the strip header explains the concept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)