### PR TITLE
Ladder: watched companies — direct careers-page sources with per-company filter modes

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.17.0");
+@import url("./components.css?v=1.18.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -5862,3 +5862,77 @@ body[data-auth-state="out"] job-chat { display: none; }
   box-sizing: border-box;
 }
 .title-edit-input:focus { outline: none; border-color: var(--accent-strong); }
+
+/* ---------- Watched companies strip (/ladder/jobs/recommended/) ----------
+   Green-lit direct company sources. Chips show company + active-rec count +
+   a per-company filter-mode select; the trailing form adds a new watch. */
+.watched-strip {
+  margin-bottom: var(--space-5);
+}
+.watched-strip__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+.watched-strip__head h2 {
+  margin: 0;
+  font-size: var(--font-size-title-3);
+}
+.watched-strip__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: stretch;
+}
+.watched-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+.watched-chip--off { opacity: 0.55; }
+.watched-chip__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.watched-chip__meta { font-size: var(--font-size-caption); white-space: nowrap; }
+.watched-chip__mode {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-caption);
+  padding: 2px var(--space-1);
+}
+.watched-chip__remove {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 var(--space-1);
+}
+.watched-chip__remove:hover { color: var(--fg); }
+.watched-add {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+.watched-add input {
+  background: var(--bg-surface);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
+  min-width: 180px;
+}
+.watched-strip__error {
+  color: var(--error, #e5484d);
+  font-size: var(--font-size-caption);
+  margin: var(--space-2) 0 0;
+}

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -25,10 +25,11 @@
   <div class="app">
     <ladder-rail></ladder-rail>
     <main class="app__main">
+      <ladder-watched-companies></ladder-watched-companies>
       <ladder-recommendations-table></ladder-recommendations-table>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.12.0";
-console.log(`[ladder] v${VERSION} - editable role title on the detail header (like company)`);
+const VERSION = "2.13.0";
+console.log(`[ladder] v${VERSION} - watched companies: direct careers-page sources with per-company filter modes on For You`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -28,6 +28,7 @@ if (location.pathname.startsWith('/ladder/jobs/drill')) {
   import('./components/ladder-role-detail.js' + V);
 } else if (location.pathname.startsWith('/ladder/jobs/recommended')) {
   import('./components/ladder-recommendations-table.js' + V);
+  import('./components/ladder-watched-companies.js' + V);
 } else if (location.pathname.startsWith('/ladder/jobs')) {
   import('./components/ladder-pipeline.js' + V);
 }

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -8,7 +8,7 @@
 // here; this view is the full audit trail.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, blockCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, watchCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair }, { renderLocation, renderSource }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
@@ -463,6 +463,9 @@ export class JobRecommendationsTable extends LitElement {
                       @click=${(e) => this._toggleMenu(r.id, e)}>⋯</button>
               ${this._menuOpenId === r.id ? html`
                 <div class="row-menu__pop" @click=${(e) => e.stopPropagation()}>
+                  <button class="row-menu__item" @click=${() => this._onWatchCompany(r)}>
+                    Watch ${r.company || 'this company'}
+                  </button>
                   <button class="row-menu__item" @click=${() => this._onBlockCompany(r)}>
                     Don't recommend ${r.company || 'this company'}
                   </button>
@@ -491,6 +494,23 @@ export class JobRecommendationsTable extends LitElement {
   _toggleMenu(id, e) {
     e.stopPropagation();
     this._menuOpenId = this._menuOpenId === id ? null : id;
+  }
+
+  // "Watch <company>" — green-light the company as a direct source. The
+  // server resolves the careers backend (major-tech registry or an ATS
+  // board probe); unsupported companies surface the server's message.
+  async _onWatchCompany(r) {
+    const company = r.company;
+    this._menuOpenId = null;
+    if (!company) return;
+    try {
+      await watchCompany({ company });
+      document.dispatchEvent(new CustomEvent('job:watch:added', { detail: { company } }));
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — its careers page feeds For You now` } }));
+    } catch (e) {
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: e.message || `Couldn't watch ${company}` } }));
+      console.warn('[recs-table] watchCompany failed', e);
+    }
   }
 
   async _onBlockCompany(r) {

--- a/ladder/js/components/ladder-watched-companies.js
+++ b/ladder/js/components/ladder-watched-companies.js
@@ -1,0 +1,162 @@
+// ladder-watched-companies — the green-lit watched company strip on the
+// For You page. Add a company by name (server resolves the careers
+// backend), pick how its roles surface via the per-company filter mode,
+// disable or remove a watch. Also listens for job:watch:added events so
+// the recs-table "Watch <company>" menu action refreshes the strip.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+const V = (new URL(import.meta.url)).search;
+const [{ fetchWatchedCompanies, watchCompany, updateWatchedCompany, unwatchCompany }] = await Promise.all([
+  import('../pipeline.js' + V),
+]);
+
+const FILTER_MODES = [
+  { value: 'all',         label: 'Any role',        hint: 'Every role the watch pulls, regardless of score' },
+  { value: 'role_level',  label: 'My role & level', hint: 'Roles that match your role and seniority — no fit-score floor' },
+  { value: 'good_fits',   label: 'Good fits',       hint: 'Standard For You gates (fit ≥50, strength ≥30)' },
+  { value: 'exceptional', label: 'Exceptional only', hint: 'Only roles graded 60+ candidate strength' },
+];
+
+export class LadderWatchedCompanies extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    watches:  { state: true },
+    state:    { state: true },
+    adding:   { state: true },
+    newName:  { state: true },
+    error:    { state: true },
+  };
+
+  constructor() {
+    super();
+    this.watches = [];
+    this.state = 'idle';
+    this.adding = false;
+    this.newName = '';
+    this.error = '';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._maybeLoad();
+    this._onAuth = () => this._maybeLoad();
+    this._onWatchAdded = () => this._load();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+    document.addEventListener('job:watch:added', this._onWatchAdded);
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    document.removeEventListener('job:watch:added', this._onWatchAdded);
+    super.disconnectedCallback();
+  }
+
+  _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this._load();
+  }
+
+  async _load() {
+    this.state = 'loading';
+    try {
+      this.watches = await fetchWatchedCompanies();
+      this.state = 'loaded';
+    } catch (e) {
+      console.warn('[watched-companies] load failed', e);
+      this.state = 'error';
+    }
+  }
+
+  async _onAdd(e) {
+    e.preventDefault();
+    const company = this.newName.trim();
+    if (!company || this.adding) return;
+    this.adding = true;
+    this.error = '';
+    try {
+      await watchCompany({ company });
+      this.newName = '';
+      await this._load();
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — roles land on the next pull` } }));
+    } catch (err) {
+      this.error = err.message || String(err);
+    } finally {
+      this.adding = false;
+    }
+  }
+
+  async _onModeChange(w, mode) {
+    const prev = w.filterMode;
+    w.filterMode = mode;
+    this.requestUpdate();
+    try {
+      await updateWatchedCompany(w.id, { filterMode: mode });
+    } catch (e) {
+      w.filterMode = prev;
+      this.requestUpdate();
+      console.warn('[watched-companies] mode update failed', e);
+    }
+  }
+
+  async _onRemove(w) {
+    if (!confirm(`Stop watching ${w.company}? Its active recommendations will be dismissed.`)) return;
+    this.watches = this.watches.filter(x => x.id !== w.id);
+    try { await unwatchCompany(w.id); } catch (e) { console.warn('[watched-companies] remove failed', e); this._load(); }
+  }
+
+  _relTime(iso) {
+    if (!iso) return 'never';
+    const m = Math.floor((Date.now() - Date.parse(iso)) / 60000);
+    if (m < 60) return `${Math.max(1, m)}m ago`;
+    const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+  }
+
+  render() {
+    if (this.state === 'idle' || this.state === 'error') return nothing;
+    return html`
+      <section class="watched-strip" aria-label="Watched companies">
+        <header class="watched-strip__head">
+          <h2>Watched companies</h2>
+          <span class="muted">Roles pulled straight from each company's careers page</span>
+        </header>
+        <div class="watched-strip__row">
+          ${this.watches.map(w => html`
+            <div class="watched-chip ${w.enabled ? '' : 'watched-chip--off'}">
+              <div class="watched-chip__main">
+                <strong>${w.company}</strong>
+                <span class="muted watched-chip__meta"
+                      title=${w.lastError ? `Last error: ${w.lastError}` : `Last pulled ${this._relTime(w.lastPulledAt)}`}>
+                  ${w.lastError ? '⚠︎' : ''} ${w.activeRecs ?? 0} active · ${this._relTime(w.lastPulledAt)}
+                </span>
+              </div>
+              <select class="watched-chip__mode" .value=${w.filterMode}
+                      title=${FILTER_MODES.find(m => m.value === w.filterMode)?.hint || ''}
+                      @change=${(e) => this._onModeChange(w, e.target.value)}>
+                ${FILTER_MODES.map(m => html`
+                  <option value=${m.value} ?selected=${m.value === w.filterMode} title=${m.hint}>${m.label}</option>
+                `)}
+              </select>
+              <button class="watched-chip__remove" aria-label=${`Stop watching ${w.company}`}
+                      title="Stop watching" @click=${() => this._onRemove(w)}>×</button>
+            </div>
+          `)}
+          <form class="watched-add" @submit=${(e) => this._onAdd(e)}>
+            <input type="text" placeholder="Watch a company…" maxlength="60"
+                   .value=${this.newName}
+                   @input=${(e) => { this.newName = e.target.value; this.error = ''; }}
+                   ?disabled=${this.adding}>
+            <button class="btn btn--sm" type="submit" ?disabled=${this.adding || !this.newName.trim()}>
+              ${this.adding ? 'Resolving…' : '+ Watch'}
+            </button>
+          </form>
+        </div>
+        ${this.error ? html`<p class="watched-strip__error">${this.error}</p>` : nothing}
+      </section>
+    `;
+  }
+}
+
+customElements.define('ladder-watched-companies', LadderWatchedCompanies);

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -191,6 +191,56 @@ export async function blockCompany(company) {
   return res.json();
 }
 
+// ----- Watched companies (job.watched_companies) ---------------------------
+// Green-lit companies pulled straight from their careers backends. Each has
+// a filter_mode gating how its roles surface in For You.
+const WATCHED_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/watched-companies';
+
+export async function fetchWatchedCompanies() {
+  const headers = await authHeader();
+  const res = await fetch(WATCHED_URL, { headers });
+  if (!res.ok) throw new Error(`watched-companies ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return Array.isArray(j.watches) ? j.watches : [];
+}
+
+// Add a watch. Server resolves the adapter (Google/Amazon/Workday/… or an
+// ATS board probe) when not provided. Throws with the server's message on
+// a 422 so the UI can tell the user the company isn't supported yet.
+export async function watchCompany({ company, adapter, config, filterMode, titleKeywords, locations } = {}) {
+  const headers = await authHeader();
+  const res = await fetch(WATCHED_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ company, adapter, config, filterMode, titleKeywords, locations }),
+  });
+  const j = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(j.error || `watch-company ${res.status}`);
+  return j.watch;
+}
+
+export async function updateWatchedCompany(id, patch) {
+  const headers = await authHeader();
+  const res = await fetch(WATCHED_URL, {
+    method: 'PATCH',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id, ...patch }),
+  });
+  if (!res.ok) throw new Error(`update-watch ${res.status}: ${await res.text()}`);
+  return (await res.json()).watch;
+}
+
+export async function unwatchCompany(id) {
+  const headers = await authHeader();
+  const res = await fetch(WATCHED_URL, {
+    method: 'DELETE',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id }),
+  });
+  if (!res.ok) throw new Error(`unwatch ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
 export async function checkLiveness({ slug } = {}) {
   const headers = await authHeader();
   const res = await fetch(LIVENESS_URL, {

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.12.0">
-  <script src="/ladder/js/theme.js?v=2.12.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.0">
+  <script src="/ladder/js/theme.js?v=2.13.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.12.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/sources/company-watch.ts
+++ b/supabase/functions/_shared/sources/company-watch.ts
@@ -1,0 +1,388 @@
+// company-watch — direct careers-page sources for watched companies.
+//
+// Reads job.watched_companies for the user and pulls open roles straight
+// from each company's careers backend. One plugin, six adapters:
+//
+//   google     — careers search page embeds job JSON (AF_initDataCallback
+//                ds:1); no public API since careers.google.com/api/v3 died.
+//   amazon     — amazon.jobs/en/search.json (full JD inline).
+//   workday    — POST /wday/cxs/{tenant}/{site}/jobs; JD via detail GET.
+//                Covers Nvidia, Salesforce, Adobe, and any Workday tenant.
+//   eightfold  — /api/apply/v2/jobs; JD via per-id detail GET. Netflix etc.
+//   apple      — jobs.apple.com search page embeds results in
+//                __staticRouterHydrationData (server-rendered).
+//   greenhouse / lever / ashby — public board APIs (same shape tracked-ats
+//                uses), for watched companies on a standard ATS.
+//
+// Config is empty on the user_sources row: the company list + per-company
+// adapter config live in job.watched_companies, so the watch list is a
+// first-class concept the UI can edit without touching user_sources.
+
+import type { Source, RecommendedRoleInput } from './types.ts';
+import { db } from '../job-db.ts';
+
+const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
+
+// Per-company caps so one giant board can't blow the function's memory or
+// wall-clock. Detail fetches (Workday/Eightfold JDs) are the expensive
+// part — new postings arrive incrementally after the first run, so a low
+// cap only slows the very first backfill.
+const MAX_ROLES_PER_COMPANY = 60;
+const MAX_DETAIL_FETCHES    = 12;
+const JD_CAP                = 5000;
+
+export interface WatchedCompanyRow {
+  id:             string;
+  company:        string;
+  company_norm:   string;
+  adapter:        string;
+  adapter_config: Record<string, unknown>;
+  title_keywords: string[];
+  locations:      string[];
+}
+
+function stripHtml(html: string): string {
+  return (html || '')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function capJd(s: string | undefined): string | undefined {
+  const t = (s || '').trim();
+  return t ? t.slice(0, JD_CAP) : undefined;
+}
+
+function slugify(s: string): string {
+  return (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: { 'user-agent': UA, accept: 'application/json', ...(init?.headers || {}) },
+  });
+  if (!res.ok) throw new Error(`${url.split('?')[0]} → ${res.status}`);
+  return await res.json() as T;
+}
+
+// ---------- Google (embedded AF_initDataCallback JSON) ----------
+// The careers search-results page server-renders the full result set as a
+// JSON blob. Entry shape (verified 2026-07): [0]=id, [1]=title, [2]=apply
+// url, [3]=[null, responsibilities html], [4]=[null, quals html],
+// [7]=company ("Google"/"YouTube"), [9]=locations, [10]=[null, about html],
+// [12]=[epochSec, nanos] posted.
+async function pullGoogle(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { searchUrl?: string; query?: string; location?: string };
+  let url = cfg.searchUrl;
+  if (!url) {
+    const p = new URLSearchParams();
+    p.set('q', cfg.query || 'product manager');
+    if (cfg.location) p.set('location', cfg.location);
+    p.set('employment_type', 'FULL_TIME');
+    url = `https://www.google.com/about/careers/applications/jobs/results?${p}`;
+  }
+  const res = await fetch(url, { headers: { 'user-agent': UA } });
+  if (!res.ok) throw new Error(`google careers → ${res.status}`);
+  const html = await res.text();
+  const m = html.match(/AF_initDataCallback\(\{key: 'ds:1'[\s\S]*?data:(\[[\s\S]*?\]), sideChannel/);
+  if (!m) throw new Error('google careers: ds:1 blob not found (page layout changed?)');
+  const data = JSON.parse(m[1]) as unknown[];
+  const jobs = (Array.isArray(data?.[0]) ? data[0] : []) as unknown[][];
+  return jobs.slice(0, MAX_ROLES_PER_COMPANY).map((j) => {
+    const id      = String(j[0] ?? '');
+    const title   = String(j[1] ?? '');
+    const brand   = typeof j[7] === 'string' && j[7] ? String(j[7]) : w.company;
+    const locs    = (Array.isArray(j[9]) ? j[9] as unknown[][] : [])
+      .map(l => String(l?.[0] ?? '')).filter(Boolean);
+    const aboutH  = (Array.isArray(j[10]) ? String(j[10][1] ?? '') : '');
+    const respH   = (Array.isArray(j[3])  ? String(j[3][1]  ?? '') : '');
+    const qualH   = (Array.isArray(j[4])  ? String(j[4][1]  ?? '') : '');
+    const posted  = (Array.isArray(j[12]) && typeof j[12][0] === 'number')
+      ? new Date((j[12][0] as number) * 1000).toISOString() : undefined;
+    if (!id || !title) return null;
+    return {
+      source:      'company-watch',
+      sourceId:    `cw:google:${id}`,
+      sourceLabel: `${brand} Careers`,
+      url:         `https://www.google.com/about/careers/applications/jobs/results/${id}-${slugify(title)}`,
+      company:     brand,
+      title,
+      location:    locs.slice(0, 3).join(' · ') || undefined,
+      description: capJd(stripHtml([aboutH, respH, qualH].filter(Boolean).join(' '))),
+      postedAt:    posted,
+      payload:     { adapter: 'google', watchedCompanyId: w.id, jobId: id },
+    } as RecommendedRoleInput;
+  }).filter(Boolean) as RecommendedRoleInput[];
+}
+
+// ---------- Amazon (amazon.jobs/en/search.json) ----------
+async function pullAmazon(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { query?: string; location?: string };
+  const p = new URLSearchParams();
+  p.set('base_query', cfg.query || 'product manager');
+  if (cfg.location) p.set('loc_query', cfg.location);
+  p.set('result_limit', String(MAX_ROLES_PER_COMPANY));
+  p.set('sort', 'recent');
+  const data = await fetchJson<{ jobs?: Array<Record<string, unknown>> }>(
+    `https://www.amazon.jobs/en/search.json?${p}`);
+  return (data.jobs || []).map(j => ({
+    source:      'company-watch',
+    sourceId:    `cw:amazon:${String(j.id_icims ?? j.id ?? '')}`,
+    sourceLabel: `Amazon Careers`,
+    url:         `https://www.amazon.jobs${String(j.job_path || '')}`,
+    company:     w.company,
+    title:       String(j.title || ''),
+    location:    String(j.normalized_location || j.location || '') || undefined,
+    description: capJd(stripHtml([j.description, j.basic_qualifications, j.preferred_qualifications]
+                   .filter(Boolean).map(String).join(' '))),
+    postedAt:    j.posted_date ? new Date(String(j.posted_date)).toISOString() : undefined,
+    payload:     { adapter: 'amazon', watchedCompanyId: w.id, jobId: String(j.id_icims ?? j.id ?? '') },
+  })).filter(r => r.title && r.sourceId !== 'cw:amazon:');
+}
+
+// ---------- Workday (CXS API — any tenant) ----------
+async function pullWorkday(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { host?: string; tenant?: string; site?: string; query?: string };
+  if (!cfg.host || !cfg.tenant || !cfg.site) throw new Error('workday config needs host/tenant/site');
+  const base = `https://${cfg.host}/wday/cxs/${cfg.tenant}/${cfg.site}`;
+  const data = await fetchJson<{ jobPostings?: Array<{ title?: string; externalPath?: string; locationsText?: string; postedOn?: string; bulletFields?: string[] }> }>(
+    `${base}/jobs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ searchText: cfg.query || 'product manager', limit: 20, offset: 0, appliedFacets: {} }),
+    });
+  const postings = (data.jobPostings || []).filter(j => j.externalPath).slice(0, MAX_ROLES_PER_COMPANY);
+  const out: RecommendedRoleInput[] = [];
+  let detailBudget = MAX_DETAIL_FETCHES;
+  for (const j of postings) {
+    const reqId = j.bulletFields?.[0] || j.externalPath!;
+    let description: string | undefined;
+    let posted: string | undefined;
+    if (detailBudget > 0) {
+      detailBudget--;
+      try {
+        const d = await fetchJson<{ jobPostingInfo?: { jobDescription?: string; startDate?: string } }>(
+          `${base}${j.externalPath}`);
+        description = capJd(stripHtml(d.jobPostingInfo?.jobDescription || ''));
+        posted = d.jobPostingInfo?.startDate ? new Date(d.jobPostingInfo.startDate).toISOString() : undefined;
+      } catch { /* JD is best-effort; the row still lands and grades later */ }
+    }
+    out.push({
+      source:      'company-watch',
+      sourceId:    `cw:workday:${cfg.tenant}:${reqId}`,
+      sourceLabel: `${w.company} Careers`,
+      url:         `https://${cfg.host}/en-US/${cfg.site}${j.externalPath}`,
+      company:     w.company,
+      title:       j.title || '',
+      location:    j.locationsText || undefined,
+      description,
+      postedAt:    posted,
+      payload:     { adapter: 'workday', watchedCompanyId: w.id, jobId: reqId },
+    });
+  }
+  return out.filter(r => r.title);
+}
+
+// ---------- Eightfold (explore.jobs.* — Netflix etc.) ----------
+async function pullEightfold(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { base?: string; domain?: string; query?: string };
+  if (!cfg.base || !cfg.domain) throw new Error('eightfold config needs base/domain');
+  const p = new URLSearchParams({ domain: cfg.domain, query: cfg.query || 'product manager', num: '50', start: '0' });
+  const data = await fetchJson<{ positions?: Array<{ id?: number; name?: string; location?: string; locations?: string[]; t_create?: number; canonicalPositionUrl?: string; job_description?: string }> }>(
+    `${cfg.base}/api/apply/v2/jobs?${p}`);
+  const positions = (data.positions || []).slice(0, MAX_ROLES_PER_COMPANY);
+  const out: RecommendedRoleInput[] = [];
+  let detailBudget = MAX_DETAIL_FETCHES;
+  for (const pos of positions) {
+    if (!pos.id || !pos.name) continue;
+    let description = capJd(stripHtml(pos.job_description || ''));
+    if (!description && detailBudget > 0) {
+      detailBudget--;
+      try {
+        const d = await fetchJson<{ job_description?: string }>(
+          `${cfg.base}/api/apply/v2/jobs/${pos.id}?domain=${encodeURIComponent(cfg.domain)}`);
+        description = capJd(stripHtml(d.job_description || ''));
+      } catch { /* best effort */ }
+    }
+    out.push({
+      source:      'company-watch',
+      sourceId:    `cw:eightfold:${cfg.domain}:${pos.id}`,
+      sourceLabel: `${w.company} Careers`,
+      url:         pos.canonicalPositionUrl || `${cfg.base}/careers/job/${pos.id}`,
+      company:     w.company,
+      title:       pos.name,
+      location:    (pos.locations || [pos.location]).filter(Boolean).slice(0, 3).join(' · ') || undefined,
+      description,
+      postedAt:    pos.t_create ? new Date(pos.t_create * 1000).toISOString() : undefined,
+      payload:     { adapter: 'eightfold', watchedCompanyId: w.id, jobId: String(pos.id) },
+    });
+  }
+  return out;
+}
+
+// ---------- Apple (server-rendered hydration JSON) ----------
+// The search page embeds results in window.__staticRouterHydrationData =
+// JSON.parse("<escaped json>"). We unescape via JSON.parse of the string
+// literal, then walk for the searchResults array.
+async function pullApple(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { query?: string; location?: string };
+  const p = new URLSearchParams({ search: cfg.query || 'product manager' });
+  if (cfg.location) p.set('location', cfg.location);
+  const res = await fetch(`https://jobs.apple.com/en-us/search?${p}`, { headers: { 'user-agent': UA } });
+  if (!res.ok) throw new Error(`apple careers → ${res.status}`);
+  const html = await res.text();
+  const m = html.match(/__staticRouterHydrationData\s*=\s*JSON\.parse\((".*?")\);/s);
+  if (!m) throw new Error('apple careers: hydration blob not found (page layout changed?)');
+  const state = JSON.parse(JSON.parse(m[1]) as string) as Record<string, unknown>;
+  // The job list lives somewhere under loaderData — find the first array
+  // whose entries look like postings (positionId + postingTitle).
+  let jobs: Array<Record<string, unknown>> = [];
+  const walk = (v: unknown) => {
+    if (jobs.length) return;
+    if (Array.isArray(v)) {
+      if (v.length && typeof v[0] === 'object' && v[0] !== null
+          && 'positionId' in (v[0] as Record<string, unknown>)
+          && 'postingTitle' in (v[0] as Record<string, unknown>)) {
+        jobs = v as Array<Record<string, unknown>>;
+        return;
+      }
+      for (const x of v) walk(x);
+    } else if (v && typeof v === 'object') {
+      for (const x of Object.values(v)) walk(x);
+    }
+  };
+  walk(state);
+  return jobs.slice(0, MAX_ROLES_PER_COMPANY).map(j => {
+    const id    = String(j.positionId || '');
+    const title = String(j.postingTitle || '');
+    if (!id || !title) return null;
+    const slug  = String(j.transformedPostingTitle || slugify(title));
+    const locs  = (Array.isArray(j.locations) ? j.locations as Array<Record<string, unknown>> : [])
+      .map(l => String(l.name || l.city || '')).filter(Boolean);
+    return {
+      source:      'company-watch',
+      sourceId:    `cw:apple:${id}`,
+      sourceLabel: 'Apple Careers',
+      url:         `https://jobs.apple.com/en-us/details/${id}/${slug}`,
+      company:     w.company,
+      title,
+      location:    locs.slice(0, 3).join(' · ') || undefined,
+      description: capJd(stripHtml(String(j.jobSummary || ''))),
+      postedAt:    j.postDateInGMT ? new Date(String(j.postDateInGMT)).toISOString() : undefined,
+      payload:     { adapter: 'apple', watchedCompanyId: w.id, jobId: id },
+    } as RecommendedRoleInput;
+  }).filter(Boolean) as RecommendedRoleInput[];
+}
+
+// ---------- Standard ATS boards (Greenhouse / Lever / Ashby) ----------
+// For watched companies that run a public board. Same endpoints as
+// tracked-ats but namespaced under company-watch so filter_mode applies.
+async function pullAtsBoard(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { slug?: string };
+  if (!cfg.slug) throw new Error(`${w.adapter} config needs slug`);
+  const slug = encodeURIComponent(cfg.slug);
+  if (w.adapter === 'greenhouse') {
+    const data = await fetchJson<{ jobs?: Array<{ id: number; title: string; absolute_url: string; updated_at: string; location?: { name: string } }> }>(
+      `https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`);
+    return (data.jobs || []).slice(0, MAX_ROLES_PER_COMPANY).map(j => ({
+      source: 'company-watch', sourceId: `cw:gh:${cfg.slug}:${j.id}`,
+      sourceLabel: `${w.company} Careers`, url: j.absolute_url,
+      company: w.company, title: j.title, location: j.location?.name,
+      postedAt: j.updated_at,
+      payload: { adapter: 'greenhouse', watchedCompanyId: w.id, jobId: String(j.id) },
+    }));
+  }
+  if (w.adapter === 'lever') {
+    const data = await fetchJson<Array<{ id: string; text: string; hostedUrl: string; createdAt: number; categories?: { location?: string }; descriptionPlain?: string }>>(
+      `https://api.lever.co/v0/postings/${slug}?mode=json`);
+    return (data || []).slice(0, MAX_ROLES_PER_COMPANY).map(j => ({
+      source: 'company-watch', sourceId: `cw:lever:${cfg.slug}:${j.id}`,
+      sourceLabel: `${w.company} Careers`, url: j.hostedUrl,
+      company: w.company, title: j.text, location: j.categories?.location,
+      description: capJd(j.descriptionPlain),
+      postedAt: j.createdAt ? new Date(j.createdAt).toISOString() : undefined,
+      payload: { adapter: 'lever', watchedCompanyId: w.id, jobId: j.id },
+    }));
+  }
+  if (w.adapter === 'ashby') {
+    const data = await fetchJson<{ jobs?: Array<{ id: string; title: string; jobUrl: string; publishedAt?: string; locationName?: string; compensationTierSummary?: string; descriptionPlain?: string }> }>(
+      `https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=true`);
+    return (data.jobs || []).slice(0, MAX_ROLES_PER_COMPANY).map(j => ({
+      source: 'company-watch', sourceId: `cw:ashby:${cfg.slug}:${j.id}`,
+      sourceLabel: `${w.company} Careers`, url: j.jobUrl,
+      company: w.company, title: j.title, location: j.locationName,
+      salary: j.compensationTierSummary, description: capJd(j.descriptionPlain),
+      postedAt: j.publishedAt,
+      payload: { adapter: 'ashby', watchedCompanyId: w.id, jobId: j.id },
+    }));
+  }
+  throw new Error(`unknown ats adapter: ${w.adapter}`);
+}
+
+const ADAPTERS: Record<string, (w: WatchedCompanyRow) => Promise<RecommendedRoleInput[]>> = {
+  google:     pullGoogle,
+  amazon:     pullAmazon,
+  workday:    pullWorkday,
+  eightfold:  pullEightfold,
+  apple:      pullApple,
+  greenhouse: pullAtsBoard,
+  lever:      pullAtsBoard,
+  ashby:      pullAtsBoard,
+};
+
+// Per-company include filters — cheap substring prefilters the user can
+// set on the watch (title keywords, locations). Empty lists = no-op.
+function passesWatchFilters(r: RecommendedRoleInput, w: WatchedCompanyRow): boolean {
+  if (w.title_keywords?.length) {
+    const t = (r.title || '').toLowerCase();
+    if (!w.title_keywords.some(k => k && t.includes(k.toLowerCase().trim()))) return false;
+  }
+  if (w.locations?.length) {
+    const l = (r.location || '').toLowerCase();
+    if (l && !w.locations.some(k => k && l.includes(k.toLowerCase().trim()))) return false;
+  }
+  return true;
+}
+
+export const companyWatchSource: Source = {
+  type: 'company-watch',
+  async pull(_cfg, ctx) {
+    const sql = db();
+    const watches = await sql<WatchedCompanyRow[]>`
+      select id, company, company_norm, adapter, adapter_config, title_keywords, locations
+        from job.watched_companies
+       where user_email = ${ctx.userEmail} and enabled = true`;
+    const out: RecommendedRoleInput[] = [];
+    for (const w of watches) {
+      const adapter = ADAPTERS[w.adapter];
+      if (!adapter) {
+        await sql`update job.watched_companies set last_error = ${'unknown adapter: ' + w.adapter} where id = ${w.id}`;
+        continue;
+      }
+      try {
+        const rows = (await adapter(w))
+          .filter(r => passesWatchFilters(r, w))
+          .map(r => ({ ...r, watchedCompanyId: w.id }));
+        out.push(...rows);
+        await sql`
+          update job.watched_companies
+             set last_pulled_at = now(), last_pull_count = ${rows.length}, last_error = null
+           where id = ${w.id}`;
+        console.log(`[company-watch] ${w.company} (${w.adapter}): ${rows.length} roles`);
+      } catch (e) {
+        await sql`update job.watched_companies set last_pulled_at = now(), last_error = ${(e as Error).message} where id = ${w.id}`;
+        console.warn(`[company-watch] ${w.company} (${w.adapter}): ${(e as Error).message}`);
+      }
+    }
+    return out;
+  },
+};

--- a/supabase/functions/_shared/sources/registry.ts
+++ b/supabase/functions/_shared/sources/registry.ts
@@ -7,8 +7,10 @@ import { linkedinRssSource } from './linkedin-rss.ts';
 import { rssSource } from './rss.ts';
 import { theirstackSource } from './theirstack.ts';
 import { gmailJobsSource } from './gmail-jobs.ts';
+import { companyWatchSource } from './company-watch.ts';
 
 export const SOURCES: Record<string, Source> = {
+  [companyWatchSource.type]: companyWatchSource,
   [fixtureSource.type]:     fixtureSource,
   [trackedAtsSource.type]:  trackedAtsSource,
   [linkedinRssSource.type]: linkedinRssSource as unknown as Source,

--- a/supabase/functions/_shared/sources/types.ts
+++ b/supabase/functions/_shared/sources/types.ts
@@ -33,6 +33,10 @@ export interface RecommendedRoleInput {
   enrichmentRetryAt?:   string;       // ISO8601
   canonicalUrl?:        string;       // canonical apply URL when resolved
   companyId?:           string;       // job.hiring_companies.id when known
+  // Set by the company-watch plugin: the job.watched_companies row that
+  // produced this posting. Drives per-company filter_mode at read time
+  // and suppresses the public/mega-cap hard-fail at scoring time.
+  watchedCompanyId?:    string;
 }
 
 // A Source<Cfg> is a pure function from config → array of postings. No

--- a/supabase/functions/jobs-pipe/fit.ts
+++ b/supabase/functions/jobs-pipe/fit.ts
@@ -379,9 +379,15 @@ function scoreArc(r: RoleRow, cap: number, ctx?: UserContext, seniorityHint?: st
 }
 
 // ---------- Stage (cap from weights.stage, default 4) ----------
-function scoreStage(r: RoleRow, cap: number): { v: number; reason: string; fail?: string } {
+function scoreStage(r: RoleRow, cap: number, watchedCompany?: boolean): { v: number; reason: string; fail?: string } {
   const i = (r.investors + ' ' + r.crunchbase).toLowerCase();
   if (/(?:^|\W)(google|meta|amazon|microsoft|apple|salesforce)(?:\W|$)/.test((r.company + ' ' + i).toLowerCase())) {
+    // A watched company is explicitly green-lit by the user, so being a
+    // mega-cap costs stage points but is NOT a hard fail (which would cap
+    // the whole score at 30 and keep every watched role out of For You).
+    if (watchedCompany) {
+      return { v: Math.round(cap * 0.25), reason: 'Public, mega-cap company — outside your usual stage band, but you\'re watching this company.' };
+    }
     return { v: Math.round(cap * 0.25), fail: 'public / mega-cap', reason: 'Public, mega-cap company — outside the company shape you\'re targeting.' };
   }
   if (/series d|series e|late stage/.test(i)) return { v: Math.round(cap * 0.5), reason: 'Later-stage company — past your sweet spot but workable.' };
@@ -415,14 +421,20 @@ function scoreGeo(_r: RoleRow, cap: number): { v: number; reason: string; fail?:
 }
 
 // ---------- Compose ----------
-export function computeFit(r: RoleRow, ctx?: UserContext, preComputedRole?: number | null, seniorityHint?: string | null, haikuRationale?: string | null): FitResult {
+export interface FitOptions {
+  // True when the posting came from a company the user explicitly watches
+  // (job.watched_companies). Suppresses the public/mega-cap hard fail.
+  watchedCompany?: boolean;
+}
+
+export function computeFit(r: RoleRow, ctx?: UserContext, preComputedRole?: number | null, seniorityHint?: string | null, haikuRationale?: string | null, opts?: FitOptions): FitResult {
   const w: FitWeights = { ...DEFAULT_WEIGHTS, ...(ctx?.weights || {}) };
   const values  = scoreValues(r, w.values, ctx);
   const culture = scoreCulture(r, w.culture, ctx);
   const role    = scoreRole(r, w.role, ctx, preComputedRole, haikuRationale);
   const domain  = scoreDomain(r, w.domain, ctx);
   const arc     = scoreArc(r, w.arc, ctx, seniorityHint);
-  const stage   = scoreStage(r, w.stage);
+  const stage   = scoreStage(r, w.stage, opts?.watchedCompany);
   const geo     = scoreGeo(r, w.geo);
   const comp    = scoreComp(r.salary, w.comp);
 

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.15.0';
-console.log(`[jobs-pipe] v${VERSION} - editable company_name + title (inline rename from detail header)`);
+const VERSION = '0.15.1';
+console.log(`[jobs-pipe] v${VERSION} - fit.ts: optional watchedCompany flag suppresses the public/mega-cap hard fail for watched-company roles`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -23,8 +23,8 @@ import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.23.0';
-console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: transient Anthropic outages (credits/429/5xx) abort the run instead of tombstoning messages, so the backlog auto-re-drains once the API recovers`);
+const VERSION = '0.24.0';
+console.log(`[pull-recommendations] v${VERSION} - company-watch source: direct careers-page pulls for watched companies (Google/Amazon/Workday/Eightfold/Apple/ATS), mega-cap hard-fail suppressed for watched rows`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -158,8 +158,8 @@ serve(async (req) => {
     // instead of one giant pass that times out before reaching anything.
     const ungradedOnly = qp.get('ungraded') === '1';
     const limitN = Math.max(0, Math.min(100, parseInt(qp.get('limit') || '0', 10) || 0));
-    const rows = await sql<Array<{ id: string; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null; role_match_score: number | null; role_match_rationale: string | null; role_match_seniority: string | null; role_match_scope: string | null; fit_summary: string | null; candidate_score: number | null }>>`
-      select id, title, company, description, sector, investors, salary, source,
+    const rows = await sql<Array<{ id: string; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null; role_match_score: number | null; role_match_rationale: string | null; role_match_seniority: string | null; role_match_scope: string | null; fit_summary: string | null; candidate_score: number | null; watched_company_id: string | null }>>`
+      select id, title, company, description, sector, investors, salary, source, watched_company_id,
              role_match_score, role_match_rationale, role_match_seniority, role_match_scope, fit_summary, candidate_score
         from job.recommended_roles
        where dismissed_at is null and added_to_pipeline_slug is null
@@ -194,7 +194,7 @@ serve(async (req) => {
           haikuCalls++;
         }
       }
-      const fit = computeFit(roleRow, ctx, roleScore, seniority, rationale);
+      const fit = computeFit(roleRow, ctx, roleScore, seniority, rationale, { watchedCompany: !!r.watched_company_id });
       await sql`
         update job.recommended_roles
            set fit_score            = ${fit.score},
@@ -405,6 +405,15 @@ serve(async (req) => {
       // must never mass-close a company on an error.
       if (src.type === 'tracked-ats') {
         await trackedAtsLiveness(sql, pulledRaw);
+      }
+      // Same disappeared-since-pull liveness for company-watch: each run
+      // re-pulls a company's full (query-scoped) result set, so an active
+      // rec from a watch we fetched this run whose source_id is absent =
+      // the posting was taken down. Keyed by watched_company_id so a
+      // transient adapter failure (no rows for that watch) never closes
+      // anything — failed watches don't appear in the fetched-id set.
+      if (src.type === 'company-watch') {
+        await companyWatchLiveness(sql, pulledRaw);
       }
       // Only genuinely-new rows go through inline enrich+grade. Rows that
       // were conflict-updated to backfill a missing JD are drained by the
@@ -634,7 +643,7 @@ function scoreAndFilter(rows: RecommendedRoleInput[], minScore: number, ctx?: Fi
   const kept: ScoredRow[] = [];
   let dropped = 0;
   for (const r of rows) {
-    const fit = computeFit(toRoleRow(r), ctx);
+    const fit = computeFit(toRoleRow(r), ctx, null, null, null, { watchedCompany: !!r.watchedCompanyId });
     // Surface-all-recs: only drop when min_score floor is set AND not met.
     // Hard-fails are kept with their flag so they show in the UI rather
     // than vanish silently.
@@ -687,6 +696,42 @@ async function trackedAtsLiveness(
   console.log(`[pull-recommendations] tracked-ats liveness: closed ${closedN}, seen ${seenN}`);
 }
 
+// ---------- company-watch disappeared-since-pull liveness ----------
+// Mirror of trackedAtsLiveness keyed on watched_company_id: only watches
+// whose ids appear in this pull are eligible to close rows, so a failed
+// adapter (zero rows for that watch) can never mass-close a company.
+// Caveat: tightening a watch's title/location filters removes rows from
+// the pull, which closes previously-surfaced recs as 'delisted' — that's
+// the intended UX (the watch no longer covers them).
+async function companyWatchLiveness(
+  sql: ReturnType<typeof db>,
+  pulledRaw: RecommendedRoleInput[],
+): Promise<void> {
+  const pulledIds = [...new Set(pulledRaw.map(r => r.sourceId).filter(Boolean))] as string[];
+  const fetchedWatchIds = [...new Set(pulledRaw.map(r => r.watchedCompanyId).filter(Boolean))] as string[];
+  if (!fetchedWatchIds.length) return;
+  const seen = await sql`
+    update job.recommended_roles
+       set last_seen_at   = now(),
+           closed_at      = null,
+           closure_reason = null
+     where source = 'company-watch'
+       and dismissed_at is null
+       and source_id = any(${pulledIds}::text[])`;
+  const closed = await sql`
+    update job.recommended_roles
+       set closed_at      = now(),
+           closure_reason = 'delisted'
+     where source = 'company-watch'
+       and closed_at is null
+       and dismissed_at is null
+       and watched_company_id = any(${fetchedWatchIds}::uuid[])
+       and source_id <> all(${pulledIds}::text[])`;
+  const seenN   = (seen   as unknown as { count: number }).count;
+  const closedN = (closed as unknown as { count: number }).count;
+  console.log(`[pull-recommendations] company-watch liveness: closed ${closedN}, seen ${seenN}`);
+}
+
 // ---------- Productize: enrich + Haiku-grade + rescore new inserts ----------
 // Each new row from a cron pull walks the same pipeline as the manual
 // /rescore endpoint, so cron-fed recommendations score the same as
@@ -698,8 +743,8 @@ async function enrichAndScoreNewRows(
   ctx: FitUserContext,
 ): Promise<void> {
   if (!ids.length) return;
-  const rows = await sql<Array<{ id: string; url: string | null; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null }>>`
-    select id, url, title, company, description, sector, investors, salary, source
+  const rows = await sql<Array<{ id: string; url: string | null; title: string | null; company: string | null; description: string | null; sector: string | null; investors: string[] | null; salary: string | null; source: string | null; watched_company_id: string | null }>>`
+    select id, url, title, company, description, sector, investors, salary, source, watched_company_id
       from job.recommended_roles
      where id = any(${ids}::uuid[])`;
   for (const r of rows) {
@@ -736,7 +781,7 @@ async function enrichAndScoreNewRows(
         candidate = haiku.candidate || null;
       }
     }
-    const fit = computeFit(roleRow, ctx, roleScore, seniority, rationale);
+    const fit = computeFit(roleRow, ctx, roleScore, seniority, rationale, { watchedCompany: !!r.watched_company_id });
     await sql`
       update job.recommended_roles
          set fit_score            = ${fit.score},
@@ -838,6 +883,7 @@ async function insertNew(
     enrichment_retry_at: r.input.enrichmentRetryAt  ?? null,
     canonical_url:       r.input.canonicalUrl       ?? null,
     company_id:          r.input.companyId          ?? null,
+    watched_company_id:  r.input.watchedCompanyId   ?? null,
   }));
   // on conflict: backfill the JD (and salary) into an existing row that
   // landed without one — e.g. tracked-ats roles created before the adapter

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.13.0';
-console.log(`[recommendations] v${VERSION} - return recentlyExpired (recs auto-retired by liveness in last 7d) so For You can show "N expired removed"`);
+const VERSION = '0.14.0';
+console.log(`[recommendations] v${VERSION} - watched-company filter modes: per-company surfacing gates (all / role_level / good_fits / exceptional) via job.watched_companies`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -106,13 +106,34 @@ serve(async (req) => {
       //      catches the same posting when title/company text drifted between
       //      the saved copy and a later re-ingested recommendation (the cause
       //      of saved jobs reappearing in For You).
+      // Watched-company filter modes (job.watched_companies.filter_mode)
+      // gate the carousel per company; unwatched rows keep the standard
+      // gates. The join is inside the fragment so the count query and the
+      // page query stay in lockstep.
+      //   'all'         → everything the watch pulls (even weak grades)
+      //   'role_level'  → role & level match: not below seniority, and
+      //                   Haiku role score ≥13/25 (ungraded rows pass —
+      //                   the watch query already scopes to the role)
+      //   'exceptional' → candidate_score ≥ 60 only
+      //   'good_fits' / unwatched → fit ≥50, no hard-fails, candidate ≥30
       const whereClause = sql`
+        left join job.watched_companies w on w.id = r.watched_company_id
         where r.dismissed_at is null
           and r.closed_at is null
           and r.added_to_pipeline_slug is null
-          and (${isAll} or r.fit_score is null or r.fit_score >= 50)
-          and (${isAll} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
-          and not (r.candidate_score is not null and r.candidate_score < ${CANDIDATE_FLOOR})
+          and (coalesce(w.filter_mode, '') = 'all'
+               or not (r.candidate_score is not null and r.candidate_score < ${CANDIDATE_FLOOR}))
+          and (${isAll} or
+            case coalesce(w.filter_mode, 'good_fits')
+              when 'all' then true
+              when 'role_level' then
+                (r.role_match_seniority is null or r.role_match_seniority <> 'below')
+                and coalesce(r.role_match_score, 13) >= 13
+              when 'exceptional' then coalesce(r.candidate_score, 0) >= 60
+              else
+                (r.fit_score is null or r.fit_score >= 50)
+                and coalesce(array_length(r.hard_fails, 1), 0) = 0
+            end)
           and (${blocked.length === 0} or lower(trim(r.company)) <> all(${blocked}::text[]))
           and not exists (
             select 1
@@ -143,6 +164,8 @@ serve(async (req) => {
                r.enrichment_status as "enrichmentStatus",
                r.enrichment_retry_at as "enrichmentRetryAt",
                r.canonical_url as "canonicalUrl",
+               r.watched_company_id as "watchedCompanyId",
+               w.filter_mode as "watchFilterMode",
                -- Source-email URL — derived from payload.gmailApiId for
                -- Gmail-sourced recs so the UI can render a "view source"
                -- link without parsing the JSON client-side.

--- a/supabase/functions/watched-companies/index.ts
+++ b/supabase/functions/watched-companies/index.ts
@@ -1,0 +1,202 @@
+// watched-companies — CRUD for the green-lit watched company list.
+//
+//   GET                → list this user's watched companies (+ active rec counts)
+//   POST { company, adapter?, config?, filterMode?, titleKeywords?, locations? }
+//                      → add a watch. When adapter/config are omitted the
+//                        server resolves them: known-major registry →
+//                        hiring_companies cache → ATS board probe.
+//   PATCH { id, ... }  → update filter_mode / keywords / locations / enabled / config
+//   DELETE { id }      → remove the watch and dismiss its active recs
+//
+// Adding the first watch also ensures a user_sources row of type
+// 'company-watch' exists (enabled, 6-hourly) so the pull-recommendations
+// cron starts ticking it without manual setup.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+
+const VERSION = '0.1.0';
+console.log(`[watched-companies] v${VERSION} - watched company list CRUD + adapter auto-resolution (google/amazon/workday/eightfold/apple/ats)`);
+
+const FILTER_MODES = new Set(['all', 'role_level', 'good_fits', 'exceptional']);
+
+// Known majors with custom careers backends. Config queries default to
+// 'product manager' — the UI lets the user edit per watch.
+const KNOWN_MAJORS: Record<string, { adapter: string; config: Record<string, unknown> }> = {
+  google:     { adapter: 'google',    config: { query: 'product manager' } },
+  youtube:    { adapter: 'google',    config: { query: 'product manager' } },
+  amazon:     { adapter: 'amazon',    config: { query: 'product manager' } },
+  apple:      { adapter: 'apple',     config: { query: 'product manager' } },
+  netflix:    { adapter: 'eightfold', config: { base: 'https://explore.jobs.netflix.net', domain: 'netflix.com', query: 'product manager' } },
+  nvidia:     { adapter: 'workday',   config: { host: 'nvidia.wd5.myworkdayjobs.com', tenant: 'nvidia', site: 'NVIDIAExternalCareerSite', query: 'product manager' } },
+  salesforce: { adapter: 'workday',   config: { host: 'salesforce.wd12.myworkdayjobs.com', tenant: 'salesforce', site: 'External_Career_Site', query: 'product manager' } },
+  adobe:      { adapter: 'workday',   config: { host: 'adobe.wd5.myworkdayjobs.com', tenant: 'adobe', site: 'external_experienced', query: 'product manager' } },
+};
+
+// ---------- ATS board probe (Greenhouse / Lever / Ashby) ----------
+// Same probe trio enrich-job-source uses, trimmed: try the company name as
+// a slug (spaces stripped / hyphenated) against each provider.
+function slugCandidates(name: string): string[] {
+  const base = name.toLowerCase().trim();
+  return [...new Set([
+    base.replace(/[^a-z0-9]+/g, ''),
+    base.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
+  ])].filter(Boolean);
+}
+
+async function probeAts(name: string): Promise<{ adapter: string; config: Record<string, unknown> } | null> {
+  const probes: Array<{ adapter: string; url: (s: string) => string; ok: (d: unknown) => boolean }> = [
+    { adapter: 'greenhouse', url: s => `https://boards-api.greenhouse.io/v1/boards/${s}/jobs`,
+      ok: d => Array.isArray((d as { jobs?: unknown[] })?.jobs) && ((d as { jobs: unknown[] }).jobs.length > 0) },
+    { adapter: 'lever',      url: s => `https://api.lever.co/v0/postings/${s}?mode=json&limit=1`,
+      ok: d => Array.isArray(d) && d.length > 0 },
+    { adapter: 'ashby',      url: s => `https://api.ashbyhq.com/posting-api/job-board/${s}`,
+      ok: d => Array.isArray((d as { jobs?: unknown[] })?.jobs) && ((d as { jobs: unknown[] }).jobs.length > 0) },
+  ];
+  for (const slug of slugCandidates(name)) {
+    const results = await Promise.allSettled(probes.map(async p => {
+      const res = await fetch(p.url(slug));
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+      if (!p.ok(data)) throw new Error('empty board');
+      return { adapter: p.adapter, config: { slug } };
+    }));
+    const hit = results.find(r => r.status === 'fulfilled');
+    if (hit && hit.status === 'fulfilled') return hit.value;
+  }
+  return null;
+}
+
+async function resolveAdapter(sql: ReturnType<typeof db>, company: string): Promise<{ adapter: string; config: Record<string, unknown> } | null> {
+  const norm = company.toLowerCase().trim();
+  if (KNOWN_MAJORS[norm]) return KNOWN_MAJORS[norm];
+  // hiring_companies cache — enrich-job-source has often already resolved
+  // this company's ATS provider + slug.
+  try {
+    const rows = await sql<{ ats_provider: string | null; ats_slug: string | null }[]>`
+      select ats_provider, ats_slug from job.hiring_companies
+       where name_norm = ${norm} and resolution_status = 'resolved'
+       limit 1`;
+    const c = rows[0];
+    if (c?.ats_provider && c?.ats_slug) {
+      const provider = c.ats_provider.toLowerCase();
+      if (['greenhouse', 'lever', 'ashby'].includes(provider)) {
+        return { adapter: provider, config: { slug: c.ats_slug } };
+      }
+    }
+  } catch { /* cache miss is fine */ }
+  return await probeAts(company);
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  try {
+    const email = await verifyJobUser(req);
+    if (!email) return err('unauthorized', 401);
+    const sql = db();
+
+    if (req.method === 'GET') {
+      const rows = await sql`
+        select w.id, w.company, w.adapter, w.adapter_config as "adapterConfig",
+               w.filter_mode as "filterMode", w.title_keywords as "titleKeywords",
+               w.locations, w.enabled, w.created_at as "createdAt",
+               w.last_pulled_at as "lastPulledAt", w.last_pull_count as "lastPullCount",
+               w.last_error as "lastError",
+               (select count(*)::int from job.recommended_roles r
+                 where r.watched_company_id = w.id
+                   and r.dismissed_at is null and r.closed_at is null
+                   and r.added_to_pipeline_slug is null) as "activeRecs"
+          from job.watched_companies w
+         where w.user_email = ${email}
+         order by w.company`;
+      return jsonResp({ ok: true, version: VERSION, watches: rows });
+    }
+
+    if (req.method === 'POST') {
+      const body = await req.json().catch(() => ({}));
+      const company = String(body.company || '').trim();
+      if (!company) return err('company required', 400);
+      const norm = company.toLowerCase();
+
+      let adapter = typeof body.adapter === 'string' ? body.adapter : '';
+      let config  = (body.config && typeof body.config === 'object') ? body.config as Record<string, unknown> : {};
+      if (!adapter) {
+        const resolved = await resolveAdapter(sql, company);
+        if (!resolved) {
+          return jsonResp({ ok: false, unresolved: true,
+            error: `Couldn't find a careers backend for "${company}". Supported: major tech (Google, Amazon, Apple, Netflix, Nvidia, Salesforce, Adobe) and any company on Greenhouse / Lever / Ashby.` }, 422);
+        }
+        adapter = resolved.adapter;
+        config  = { ...resolved.config, ...config };
+      }
+      const filterMode = FILTER_MODES.has(body.filterMode) ? body.filterMode : 'good_fits';
+      const titleKeywords = Array.isArray(body.titleKeywords) ? body.titleKeywords.map(String).filter(Boolean) : [];
+      const locations     = Array.isArray(body.locations)     ? body.locations.map(String).filter(Boolean)     : [];
+
+      const [watch] = await sql`
+        insert into job.watched_companies
+          (user_email, company, company_norm, adapter, adapter_config, filter_mode, title_keywords, locations)
+        values (${email}, ${company}, ${norm}, ${adapter}, ${sql.json(config)}, ${filterMode}, ${titleKeywords}, ${locations})
+        on conflict (user_email, company_norm) do update
+          set adapter = excluded.adapter,
+              adapter_config = excluded.adapter_config,
+              filter_mode = excluded.filter_mode,
+              enabled = true
+        returning id, company, adapter, adapter_config as "adapterConfig", filter_mode as "filterMode"`;
+
+      // Ensure the cron-driven source row exists for this user.
+      await sql`
+        insert into job.user_sources (user_email, type, config, enabled, schedule_cron, min_score)
+        select ${email}, 'company-watch', '{}'::jsonb, true, '0 */6 * * *', 0
+         where not exists (
+           select 1 from job.user_sources
+            where user_email = ${email} and type = 'company-watch')`;
+
+      return jsonResp({ ok: true, version: VERSION, watch });
+    }
+
+    if (req.method === 'PATCH') {
+      const body = await req.json().catch(() => ({}));
+      const id = String(body.id || '');
+      if (!id) return err('id required', 400);
+      if (body.filterMode !== undefined && !FILTER_MODES.has(body.filterMode)) {
+        return err(`filterMode must be one of: ${[...FILTER_MODES].join(', ')}`, 400);
+      }
+      const [row] = await sql`
+        update job.watched_companies
+           set filter_mode    = coalesce(${body.filterMode ?? null}, filter_mode),
+               title_keywords = coalesce(${Array.isArray(body.titleKeywords) ? body.titleKeywords.map(String) : null}, title_keywords),
+               locations      = coalesce(${Array.isArray(body.locations) ? body.locations.map(String) : null}, locations),
+               enabled        = coalesce(${typeof body.enabled === 'boolean' ? body.enabled : null}, enabled),
+               adapter_config = coalesce(${body.config && typeof body.config === 'object' ? sql.json(body.config) : null}, adapter_config)
+         where id = ${id} and user_email = ${email}
+         returning id, company, adapter, adapter_config as "adapterConfig",
+                   filter_mode as "filterMode", title_keywords as "titleKeywords",
+                   locations, enabled`;
+      if (!row) return err('not found', 404);
+      return jsonResp({ ok: true, version: VERSION, watch: row });
+    }
+
+    if (req.method === 'DELETE') {
+      const body = await req.json().catch(() => ({}));
+      const id = String(body.id || '');
+      if (!id) return err('id required', 400);
+      const dis = await sql`
+        update job.recommended_roles set dismissed_at = now()
+         where watched_company_id = ${id} and user_email = ${email} and dismissed_at is null
+         returning id`;
+      const del = await sql`
+        delete from job.watched_companies
+         where id = ${id} and user_email = ${email}
+         returning id`;
+      if (!del.length) return err('not found', 404);
+      return jsonResp({ ok: true, version: VERSION, deleted: id, dismissedRecs: dis.length });
+    }
+
+    return err('GET, POST, PATCH, or DELETE only', 405);
+  } catch (e) {
+    console.error('[watched-companies] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/088_watched_companies.sql
+++ b/supabase/migrations/088_watched_companies.sql
@@ -1,0 +1,49 @@
+-- 088: job.watched_companies — green-lit direct company sources.
+--
+-- Each row is a company the user explicitly watches. The company-watch
+-- source plugin pulls open roles straight from the company's careers
+-- backend (Google embedded JSON, Amazon search.json, Workday CXS,
+-- Eightfold, Apple hydration JSON, or a Greenhouse/Lever/Ashby board)
+-- and inserts them into job.recommended_roles like any other source.
+--
+-- filter_mode controls when the company's roles surface in the For You
+-- carousel (the full list always shows everything active):
+--   'all'         → every role the watch pulls
+--   'role_level'  → roles that match the user's role & level (Haiku
+--                   role-match ≥13/25 and not below seniority), no
+--                   fit/candidate floors
+--   'good_fits'   → the standard For You gates (default)
+--   'exceptional' → candidate_score ≥ 60 only ("really good fits")
+
+create table if not exists job.watched_companies (
+  id             uuid primary key default gen_random_uuid(),
+  user_email     text not null,
+  company        text not null,                  -- display name, e.g. "Google"
+  company_norm   text not null,                  -- lower(trim(company)) — dedup key
+  adapter        text not null,                  -- 'google' | 'amazon' | 'workday' | 'eightfold' | 'apple' | 'greenhouse' | 'lever' | 'ashby'
+  adapter_config jsonb not null default '{}',    -- per-adapter settings (query, host/tenant/site, slug, …)
+  filter_mode    text not null default 'good_fits'
+                 check (filter_mode in ('all', 'role_level', 'good_fits', 'exceptional')),
+  title_keywords text[] not null default '{}',   -- optional extra include filter (any-match, substring)
+  locations      text[] not null default '{}',   -- optional location filter (any-match, substring)
+  enabled        boolean not null default true,
+  created_at     timestamptz not null default now(),
+  last_pulled_at timestamptz,
+  last_pull_count integer,
+  last_error     text,
+  unique (user_email, company_norm)
+);
+
+comment on table job.watched_companies is
+  'Green-lit companies watched via direct careers-page sources. filter_mode gates For You surfacing per company.';
+
+alter table job.watched_companies enable row level security;
+
+-- Link recs back to the watch that produced them so the recommendations
+-- read path can apply the watch''s live filter_mode without re-pulling.
+alter table job.recommended_roles
+  add column if not exists watched_company_id uuid references job.watched_companies(id) on delete set null;
+
+create index if not exists recommended_roles_watched_idx
+  on job.recommended_roles (watched_company_id)
+  where watched_company_id is not null;


### PR DESCRIPTION
## What

Adds **watched companies** to Ladder: a green-lit list of companies whose careers pages are pulled directly (no aggregator), scored through the existing fit + candidate pipeline, and surfaced in For You according to a per-company filter mode.

### Direct source adapters (Tier 1 + 2, all verified live)
| Adapter | Companies | Mechanism |
|---|---|---|
| `google` | Google/YouTube | Careers search page embedded JSON (`AF_initDataCallback` ds:1) — old v3 API is dead |
| `amazon` | Amazon | `amazon.jobs/en/search.json` (full JD inline) |
| `workday` | Nvidia, Salesforce, Adobe, any Workday tenant | CXS API (`/wday/cxs/{tenant}/{site}/jobs` + detail GET for JD) |
| `eightfold` | Netflix (and other Eightfold cos) | `/api/apply/v2/jobs` + detail GET |
| `apple` | Apple | Search page `__staticRouterHydrationData` (server-rendered) |
| `greenhouse` / `lever` / `ashby` | Anyone on a standard board | Public board APIs |

Meta and Microsoft intentionally excluded.

### Watched company list
- `job.watched_companies` (migration 088) — one row per user+company with adapter config, per-watch title/location keyword filters, and a **filter mode**:
  - **Any role** — everything the watch pulls
  - **My role & level** — Haiku role-match ≥13/25 and not below seniority; no fit/candidate floors
  - **Good fits** (default) — the standard For You gates
  - **Exceptional only** — candidate score ≥ 60
- Mega-cap hard-fail is suppressed for watched rows (otherwise every Google/Amazon role would be capped at fit 30 and never surface).
- Disappeared-since-pull liveness closes watched recs whose posting vanished, keyed by watch id so a failed adapter can never mass-close.

### UX
- Watched-companies strip on `/ladder/jobs/recommended/`: add a company by name (server auto-resolves the backend), filter-mode dropdown per company, active counts, remove.
- **Watch \<company\>** action in the For You row menu.

### Versions
pull-recommendations 0.24.0 · recommendations 0.14.0 · watched-companies 0.1.0 (new) · jobs-pipe 0.15.1 · ladder 2.13.0

### Post-merge
- Run migration 088
- Deploy: `pull-recommendations`, `recommendations`, `watched-companies`, `jobs-pipe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)