### PR TITLE
For You table applies quality floors by default (fixes below-floor flood)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.18.1");
+@import url("./components.css?v=1.18.2");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -2656,6 +2656,17 @@
 }
 .recs-page__head > .muted { margin-right: auto; }
 .recs-page__refresh { align-self: center; }
+.recs-page__floor-toggle {
+  background: transparent;
+  border: 0;
+  align-self: center;
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  cursor: pointer;
+  text-decoration: underline dotted;
+  text-underline-offset: 3px;
+}
+.recs-page__floor-toggle:hover { color: var(--fg); }
 .recs-page__refresh-status { font-size: var(--font-size-caption); }
 
 /* Source-health banner — shown above the recs table when a source is

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.13.2";
-console.log(`[ladder] v${VERSION} - compact, lighter Wildcards cards`);
+const VERSION = "2.13.3";
+console.log(`[ladder] v${VERSION} - For You table applies quality floors by default with a show-all toggle`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -74,6 +74,7 @@ export class JobRecommendationsTable extends LitElement {
     _hasMore:            { state: true },
     _recentlyExpired:    { state: true },
     _wildcards:          { state: true },
+    _floorOn:            { state: true },
   };
 
   constructor() {
@@ -99,6 +100,9 @@ export class JobRecommendationsTable extends LitElement {
     this._hasMore = false;
     this._recentlyExpired = 0;
     this._wildcards = [];
+    // Quality floors (fit >= 50, strength >= 50, no hard fails) apply by
+    // default; the header toggle flips to the unfiltered audit view.
+    this._floorOn = true;
   }
 
   // ----- Source health banner ------------------------------------------
@@ -268,6 +272,7 @@ export class JobRecommendationsTable extends LitElement {
       const layers = this._sortLayers;
       const data = await fetchRecommendations({
         view:   'all',
+        floor:  this._floorOn,
         limit:  PAGE_SIZE,
         offset: this._offset,
         // Multi-level: comma-joined keys + dirs, most-significant first.
@@ -286,6 +291,14 @@ export class JobRecommendationsTable extends LitElement {
       if (reset) { this.error = String(e); this.state = 'error'; }
       // append failures are non-fatal — keep what we have, allow retry
     }
+  }
+
+  async _toggleFloor() {
+    this._floorOn = !this._floorOn;
+    this.state = 'loading';
+    this.requestUpdate();
+    await this._fetchPage({ reset: true });
+    this.state = 'loaded';
   }
 
   async _loadMore() {
@@ -618,6 +631,13 @@ export class JobRecommendationsTable extends LitElement {
             · ${this._recentlyExpired} expired removed
           </span>
         ` : nothing}
+        <button class="link-subtle recs-page__floor-toggle"
+                title=${this._floorOn
+                  ? 'Quality floors on: fit ≥ 50, strength ≥ 50, no hard fails, graded only. Click to see everything.'
+                  : 'Showing everything, including below-floor and ungraded roles. Click to re-apply the quality floors.'}
+                @click=${() => this._toggleFloor()}>
+          ${this._floorOn ? 'Below-floor hidden · show all' : 'Showing all · apply floors'}
+        </button>
         <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
                 title="Scan Gmail for new role alerts and application updates"
                 @click=${() => this._onRefresh()}>

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -163,6 +163,7 @@ export async function fetchRecommendations(opts = {}) {
     if (opts.offset != null) qs.set('offset', String(opts.offset));
     if (opts.sort)           qs.set('sort',   opts.sort);
     if (opts.dir)            qs.set('dir',    opts.dir);
+    if (opts.floor)          qs.set('floor',  '1');   // apply quality floors
     url = `${REC_URL}?${qs}`;
   } else if (opts.view === 'wildcard') {
     url = `${REC_URL}?view=wildcard`;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.3">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.2">
-  <script src="/ladder/js/theme.js?v=2.13.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.13.3">
+  <script src="/ladder/js/theme.js?v=2.13.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.13.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.13.3"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.14.0';
-console.log(`[recommendations] v${VERSION} - candidate floor 50 (ungraded=pending), view=wildcard (standout candidate / low fit), view=all now unfiltered`);
+const VERSION = '0.14.1';
+console.log(`[recommendations] v${VERSION} - view=all&floor=1 applies the quality floors with pagination; For You table sends it by default`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -67,6 +67,13 @@ serve(async (req) => {
       const view = url.searchParams.get('view') || 'default';
       const isAll = view === 'all';
       const isWildcard = view === 'wildcard';
+      // ?floor=1 (view=all only) → apply the default view's quality floors
+      // (fit >= 50, strength >= 50, no hard fails, ungraded = pending)
+      // while keeping pagination + sort. The For You table sends this by
+      // default; turning it off is the explicit "show below-floor" toggle.
+      const applyFloor = isAll && url.searchParams.get('floor') === '1';
+      // True when this view skips the quality floors entirely.
+      const unfloored = (isAll && !applyFloor) || isWildcard;
 
       // Pagination (view=all only). The default carousel view stays a
       // single 60-row pull; wildcard is a short strip. limit caps at 200;
@@ -165,9 +172,9 @@ serve(async (req) => {
         where r.dismissed_at is null
           and r.closed_at is null
           and r.added_to_pipeline_slug is null
-          and (${isAll || isWildcard} or r.fit_score is null or r.fit_score >= 50)
-          and (${isAll || isWildcard} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
-          and (${isAll} or (r.candidate_score is not null and r.candidate_score >= ${CANDIDATE_FLOOR}))
+          and (${unfloored} or r.fit_score is null or r.fit_score >= 50)
+          and (${unfloored} or coalesce(array_length(r.hard_fails, 1), 0) = 0)
+          and (${isAll && !applyFloor} or (r.candidate_score is not null and r.candidate_score >= ${CANDIDATE_FLOOR}))
           and (${!isWildcard} or (r.candidate_score >= ${WILDCARD_MIN_STRENGTH}
                                   and coalesce(r.fit_score, 100) < ${WILDCARD_MAX_FIT}))
           and (${blocked.length === 0} or lower(trim(r.company)) <> all(${blocked}::text[]))


### PR DESCRIPTION
The floors from #984 only applied to the unused 'default' view; the For You table fetches view=all which was intentionally unfiltered — so the page showed everything, including the freshly drained low-fit Wellfound roles. Now view=all&floor=1 applies fit ≥ 50 / strength ≥ 50 / no hard fails / graded-only with pagination intact, the table sends it by default, and a header toggle ('Below-floor hidden · show all') exposes the audit view on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)