### PR TITLE
Ladder: extract compensation from JD body text

### DIFF
--- a/supabase/functions/_shared/comp.ts
+++ b/supabase/functions/_shared/comp.ts
@@ -1,0 +1,57 @@
+// comp.ts — pull a compensation range out of JD body text.
+//
+// Most direct-source postings disclose pay inside the description rather
+// than a structured field ("US: $207000 - $301000 (USD) + bonus", "from
+// $136,100/year ... up to $235,200/year", "The base salary range is
+// 148,000 USD - 235,750 USD"). scoreComp only reads the salary column, so
+// without extraction these all grade as "compensation isn't disclosed".
+//
+// Approach: sentence-scoped keyword gating. Only dollar amounts in
+// sentences that talk about pay are collected — never bare figures like
+// "manage a $10M budget" — then min/max over what survives. Amounts must
+// land in a plausible annual-salary band (30k–2M).
+
+const COMP_KEYWORDS  = /(salar|compensat|\bpay\b|pay range|base pay|paid|on-target|OTE|remunerat|\bwage\b|bonus|equity|benefits|USD|\/year|per year|annum)/i;
+const NOT_COMP_WORDS = /(budget|revenue|\bARR\b|\bGMV\b|funding|raised|savings|valuation|cost savings|gift card|401\s?\(?k\)?)/i;
+
+const MIN_SALARY = 30_000;
+const MAX_SALARY = 2_000_000;
+
+// "$207,000", "$207000", "$185K", "148,000 USD", "148000 USD"
+const AMOUNT_RE = /(?:\$\s?(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?\s?[kK]\b|\d{5,7})|(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d{5,7})\s?USD\b)/g;
+
+function parseAmount(raw: string): number {
+  const t = raw.replace(/,/g, '').trim();
+  const k = /[kK]$/.test(t.replace(/\s/g, ''));
+  const n = parseFloat(t);
+  return k ? n * 1000 : n;
+}
+
+export function extractCompensation(text: string | null | undefined): string | null {
+  if (!text) return null;
+  const plain = text.replace(/ /g, ' ').replace(/\s+/g, ' ');
+  // Sentence-ish chunks. JD bodies are loose prose, so split on periods,
+  // semicolons, and bullet-ish breaks.
+  const chunks = plain.split(/(?<=[.;!?])\s+|\n+/);
+  const amounts: number[] = [];
+  // An explicit "$X - $Y" range is comp language on its own (Netflix's
+  // "the overall market range ... is typically $60,000 - $270,000" has no
+  // pay keyword in the sentence).
+  const RANGE_RE = /\$\s?[\d,\.]+\s?[kK]?\s*(?:-|–|—|to)\s*\$?\s?[\d,\.]+\s?[kK]?/;
+  for (const c of chunks) {
+    if (!COMP_KEYWORDS.test(c) && !RANGE_RE.test(c)) continue;
+    if (NOT_COMP_WORDS.test(c) && !/salar|compensat|pay range|base pay/i.test(c)) continue;
+    for (const m of c.matchAll(AMOUNT_RE)) {
+      const n = parseAmount(m[1] ?? m[2] ?? '');
+      if (Number.isFinite(n) && n >= MIN_SALARY && n <= MAX_SALARY) amounts.push(n);
+    }
+  }
+  if (!amounts.length) return null;
+  const min = Math.min(...amounts);
+  const max = Math.max(...amounts);
+  // A lone figure or a degenerate spread (>6x) reads as noise, not a range —
+  // still surface the single number case, drop the absurd-spread case.
+  if (min !== max && max / min > 6) return null;
+  const fmt = (n: number) => '$' + Math.round(n).toLocaleString('en-US');
+  return min === max ? fmt(min) : `${fmt(min)} – ${fmt(max)}`;
+}

--- a/supabase/functions/_shared/sources/company-watch.ts
+++ b/supabase/functions/_shared/sources/company-watch.ts
@@ -20,6 +20,7 @@
 
 import type { Source, RecommendedRoleInput } from './types.ts';
 import { db } from '../job-db.ts';
+import { extractCompensation } from '../comp.ts';
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
 
@@ -109,6 +110,10 @@ async function pullGoogle(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]>
     const posted  = (Array.isArray(j[12]) && typeof j[12][0] === 'number')
       ? new Date((j[12][0] as number) * 1000).toISOString() : undefined;
     if (!id || !title) return null;
+    // Extract comp from the UNCAPPED text — Google discloses pay in the
+    // closing paragraph of the about section ("US: $207000 - $301000 …"),
+    // which the 5k description cap can truncate away.
+    const fullText = stripHtml([aboutH, respH, qualH].filter(Boolean).join(' '));
     return {
       source:      'company-watch',
       sourceId:    `cw:google:${id}`,
@@ -117,7 +122,8 @@ async function pullGoogle(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]>
       company:     brand,
       title,
       location:    locs.slice(0, 3).join(' · ') || undefined,
-      description: capJd(stripHtml([aboutH, respH, qualH].filter(Boolean).join(' '))),
+      salary:      extractCompensation(fullText) ?? undefined,
+      description: capJd(fullText),
       postedAt:    posted,
       payload:     { adapter: 'google', watchedCompanyId: w.id, jobId: id },
     } as RecommendedRoleInput;
@@ -134,19 +140,23 @@ async function pullAmazon(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]>
   p.set('sort', 'recent');
   const data = await fetchJson<{ jobs?: Array<Record<string, unknown>> }>(
     `https://www.amazon.jobs/en/search.json?${p}`);
-  return (data.jobs || []).map(j => ({
-    source:      'company-watch',
-    sourceId:    `cw:amazon:${String(j.id_icims ?? j.id ?? '')}`,
-    sourceLabel: `Amazon Careers`,
-    url:         `https://www.amazon.jobs${String(j.job_path || '')}`,
-    company:     w.company,
-    title:       String(j.title || ''),
-    location:    String(j.normalized_location || j.location || '') || undefined,
-    description: capJd(stripHtml([j.description, j.basic_qualifications, j.preferred_qualifications]
-                   .filter(Boolean).map(String).join(' '))),
-    postedAt:    j.posted_date ? new Date(String(j.posted_date)).toISOString() : undefined,
-    payload:     { adapter: 'amazon', watchedCompanyId: w.id, jobId: String(j.id_icims ?? j.id ?? '') },
-  })).filter(r => r.title && r.sourceId !== 'cw:amazon:');
+  return (data.jobs || []).map(j => {
+    const fullText = stripHtml([j.description, j.basic_qualifications, j.preferred_qualifications]
+      .filter(Boolean).map(String).join(' '));
+    return {
+      source:      'company-watch',
+      sourceId:    `cw:amazon:${String(j.id_icims ?? j.id ?? '')}`,
+      sourceLabel: `Amazon Careers`,
+      url:         `https://www.amazon.jobs${String(j.job_path || '')}`,
+      company:     w.company,
+      title:       String(j.title || ''),
+      location:    String(j.normalized_location || j.location || '') || undefined,
+      salary:      extractCompensation(fullText) ?? undefined,
+      description: capJd(fullText),
+      postedAt:    j.posted_date ? new Date(String(j.posted_date)).toISOString() : undefined,
+      payload:     { adapter: 'amazon', watchedCompanyId: w.id, jobId: String(j.id_icims ?? j.id ?? '') },
+    };
+  }).filter(r => r.title && r.sourceId !== 'cw:amazon:');
 }
 
 // ---------- Workday (CXS API — any tenant) ----------
@@ -166,13 +176,16 @@ async function pullWorkday(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]
   for (const j of postings) {
     const reqId = j.bulletFields?.[0] || j.externalPath!;
     let description: string | undefined;
+    let salary: string | undefined;
     let posted: string | undefined;
     if (detailBudget > 0) {
       detailBudget--;
       try {
         const d = await fetchJson<{ jobPostingInfo?: { jobDescription?: string; startDate?: string } }>(
           `${base}${j.externalPath}`);
-        description = capJd(stripHtml(d.jobPostingInfo?.jobDescription || ''));
+        const fullJd = stripHtml(d.jobPostingInfo?.jobDescription || '');
+        description = capJd(fullJd);
+        salary = extractCompensation(fullJd) ?? undefined;
         posted = d.jobPostingInfo?.startDate ? new Date(d.jobPostingInfo.startDate).toISOString() : undefined;
       } catch { /* JD is best-effort; the row still lands and grades later */ }
     }
@@ -184,6 +197,7 @@ async function pullWorkday(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]
       company:     w.company,
       title:       j.title || '',
       location:    j.locationsText || undefined,
+      salary,
       description,
       postedAt:    posted,
       payload:     { adapter: 'workday', watchedCompanyId: w.id, jobId: reqId },
@@ -204,13 +218,13 @@ async function pullEightfold(w: WatchedCompanyRow): Promise<RecommendedRoleInput
   let detailBudget = MAX_DETAIL_FETCHES;
   for (const pos of positions) {
     if (!pos.id || !pos.name) continue;
-    let description = capJd(stripHtml(pos.job_description || ''));
-    if (!description && detailBudget > 0) {
+    let fullJd = stripHtml(pos.job_description || '');
+    if (!fullJd && detailBudget > 0) {
       detailBudget--;
       try {
         const d = await fetchJson<{ job_description?: string }>(
           `${cfg.base}/api/apply/v2/jobs/${pos.id}?domain=${encodeURIComponent(cfg.domain)}`);
-        description = capJd(stripHtml(d.job_description || ''));
+        fullJd = stripHtml(d.job_description || '');
       } catch { /* best effort */ }
     }
     out.push({
@@ -221,7 +235,8 @@ async function pullEightfold(w: WatchedCompanyRow): Promise<RecommendedRoleInput
       company:     w.company,
       title:       pos.name,
       location:    (pos.locations || [pos.location]).filter(Boolean).slice(0, 3).join(' · ') || undefined,
-      description,
+      salary:      extractCompensation(fullJd) ?? undefined,
+      description: capJd(fullJd),
       postedAt:    pos.t_create ? new Date(pos.t_create * 1000).toISOString() : undefined,
       payload:     { adapter: 'eightfold', watchedCompanyId: w.id, jobId: String(pos.id) },
     });
@@ -276,6 +291,7 @@ async function pullApple(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> 
       company:     w.company,
       title,
       location:    locs.slice(0, 3).join(' · ') || undefined,
+      salary:      extractCompensation(String(j.jobSummary || '')) ?? undefined,
       description: capJd(stripHtml(String(j.jobSummary || ''))),
       postedAt:    j.postDateInGMT ? new Date(String(j.postDateInGMT)).toISOString() : undefined,
       payload:     { adapter: 'apple', watchedCompanyId: w.id, jobId: id },
@@ -308,6 +324,7 @@ async function pullAtsBoard(w: WatchedCompanyRow): Promise<RecommendedRoleInput[
       source: 'company-watch', sourceId: `cw:lever:${cfg.slug}:${j.id}`,
       sourceLabel: `${w.company} Careers`, url: j.hostedUrl,
       company: w.company, title: j.text, location: j.categories?.location,
+      salary: extractCompensation(j.descriptionPlain) ?? undefined,
       description: capJd(j.descriptionPlain),
       postedAt: j.createdAt ? new Date(j.createdAt).toISOString() : undefined,
       payload: { adapter: 'lever', watchedCompanyId: w.id, jobId: j.id },
@@ -320,7 +337,8 @@ async function pullAtsBoard(w: WatchedCompanyRow): Promise<RecommendedRoleInput[
       source: 'company-watch', sourceId: `cw:ashby:${cfg.slug}:${j.id}`,
       sourceLabel: `${w.company} Careers`, url: j.jobUrl,
       company: w.company, title: j.title, location: j.locationName,
-      salary: j.compensationTierSummary, description: capJd(j.descriptionPlain),
+      salary: j.compensationTierSummary || extractCompensation(j.descriptionPlain) || undefined,
+      description: capJd(j.descriptionPlain),
       postedAt: j.publishedAt,
       payload: { adapter: 'ashby', watchedCompanyId: w.id, jobId: j.id },
     }));

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -20,11 +20,12 @@ import { computeFit, type RoleRow, type UserContext as FitUserContext } from '..
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-haiku.ts';
+import { extractCompensation } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.24.0';
-console.log(`[pull-recommendations] v${VERSION} - company-watch source: direct careers-page pulls for watched companies (Google/Amazon/Workday/Eightfold/Apple/ATS), mega-cap hard-fail suppressed for watched rows`);
+const VERSION = '0.25.0';
+console.log(`[pull-recommendations] v${VERSION} - comp extraction from JD body text (shared extractCompensation): adapters, pull fallback, enrich + rescore persistence`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -169,10 +170,13 @@ serve(async (req) => {
     `;
     let updated = 0, haikuCalls = 0;
     for (const r of rows) {
+      // Comp fallback so rescoring an old row picks up a pay range that
+      // only ever existed inside the JD body. Persisted below.
+      const extractedComp = r.salary ? null : extractCompensation(r.description);
       const roleRow: RoleRow = {
         status: '', rank: '',
         company: r.company || '', title: r.title || '', url: '',
-        source: r.source || '', contact: '', salary: r.salary || '',
+        source: r.source || '', contact: '', salary: r.salary || extractedComp || '',
         sector: r.sector || '', investors: (r.investors || []).join(', '),
         website: '', crunchbase: '', description: r.description || '',
       };
@@ -201,6 +205,7 @@ serve(async (req) => {
                fit_breakdown        = ${sql.json(fit.breakdown)},
                fit_rationales       = ${sql.json(fit.rationales)},
                hard_fails           = ${fit.hardFails},
+               salary               = coalesce(salary, ${extractedComp}),
                role_match_score     = ${roleScore},
                role_match_rationale = ${rationale},
                role_match_seniority = ${seniority},
@@ -221,10 +226,11 @@ serve(async (req) => {
         from job.pipeline_roles where deleted_at is null`;
     let pipeUpdated = 0;
     for (const r of pipeRows) {
+      const pipeExtractedComp = r.salary_range ? null : extractCompensation(r.description);
       const roleRow: RoleRow = {
         status: '', rank: '',
         company: r.company_name || '', title: r.title || '', url: '',
-        source: r.source || '', contact: '', salary: r.salary_range || '',
+        source: r.source || '', contact: '', salary: r.salary_range || pipeExtractedComp || '',
         sector: r.sector || '', investors: (r.investors || []).join(', '),
         website: '', crunchbase: '', description: r.description || '',
       };
@@ -253,6 +259,7 @@ serve(async (req) => {
                fit_breakdown        = ${sql.json(fit.breakdown)},
                fit_rationales       = ${sql.json(fit.rationales)},
                hard_fails           = ${fit.hardFails},
+               salary_range         = coalesce(salary_range, ${pipeExtractedComp}),
                role_match_score     = ${pipeRoleScore},
                role_match_rationale = ${pipeRationale},
                role_match_seniority = ${pipeSeniority},
@@ -344,7 +351,12 @@ serve(async (req) => {
         : stage1;
       const droppedByMust = beforeMust - filteredPull.length;
       if (droppedByMust > 0) console.log(`[pull-recommendations] dropped ${droppedByMust}/${beforeMust} by must_have_keywords`);
-      const { kept } = scoreAndFilter(filteredPull, /* minScore */ 0, fitCtx);
+      // Comp fallback for every source: most postings disclose pay inside
+      // the JD body, not a structured field — without this the comp bucket
+      // grades "not disclosed" while the description plainly states a range.
+      const compFilled = filteredPull.map(r =>
+        r.salary ? r : { ...r, salary: extractCompensation(r.description) ?? undefined });
+      const { kept } = scoreAndFilter(compFilled, /* minScore */ 0, fitCtx);
       // Drop anything the user already has in their pipeline (any state —
       // active, archived, deleted). Match on (lower(company), lower(title))
       // so a different ATS URL for the same posting still dedupes.
@@ -759,10 +771,20 @@ async function enrichAndScoreNewRows(
         }
       } catch { /* best effort */ }
     }
+    // Comp fallback — a freshly-fetched JD often carries the pay range the
+    // plugin's structured fields lacked. Persist so the UI shows it too.
+    let salary = r.salary || '';
+    if (!salary) {
+      const comp = extractCompensation(description);
+      if (comp) {
+        salary = comp;
+        await sql`update job.recommended_roles set salary = ${comp} where id = ${r.id}::uuid and salary is null`;
+      }
+    }
     const roleRow: RoleRow = {
       status: '', rank: '',
       company: r.company || '', title: r.title || '', url: r.url || '',
-      source: r.source || '', contact: '', salary: r.salary || '',
+      source: r.source || '', contact: '', salary,
       sector: r.sector || '', investors: (r.investors || []).join(', '),
       website: '', crunchbase: '', description,
     };


### PR DESCRIPTION
## What

Fixes recs graded "compensation isn't disclosed" while the JD plainly states a pay range. `scoreComp` only reads the salary column, and most direct sources disclose pay in the description body:

- Google: `US: $207000 - $301000 (USD) + 20% bonus target + equity`
- Amazon: `from $136,100/year ... up to $235,200/year`
- Workday: `The base salary range is 148,000 USD - 235,750 USD`
- Netflix: `the overall market range ... is typically $60,000 - $270,000`

## How

- **`_shared/comp.ts`** — `extractCompensation()`: sentence-scoped keyword gating (salary/pay/comp/bonus/USD or an explicit `$X – $Y` range), budget/revenue/401(k) blocklist, 30k–2M annual band, min/max → `"$207,000 – $301,000"`. Tested against all four real formats + negatives (budgets, hourly, 401(k), consumer price ranges).
- **company-watch adapters** extract from the *uncapped* JD text — Google's pay paragraph sits at the very end, past the 5k description cap.
- **pull loop**: comp fallback for every source (gmail, tracked-ats, etc.) before scoring.
- **enrich + rescore paths** persist the extracted range into `salary` / `salary_range` when empty, so existing rows backfill on the next rescore/grading pass.

pull-recommendations → v0.25.0

### Post-merge
- Deploy `pull-recommendations`
- Kick `POST /pull-recommendations?rescore=1&haiku=0` to backfill existing rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)