### PR TITLE
Truthful For You badge + dismissed roles stay dismissed

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,6 +30,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.14.1";
-console.log(`[ladder] v${VERSION} - remove the unmounted For You carousel component`);
+const VERSION = "2.14.2";
+console.log(`[ladder] v${VERSION} - For You rail badge counts the floored view`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -95,9 +95,10 @@ export class JobRail extends LitElement {
     try {
       const [pipe, recs] = await Promise.all([
         fetchPipeline().catch(() => null),
-        // view=all so the For You count reflects every candidate JD,
-        // not just the >=50-fit subset the carousel shows.
-        fetchRecommendations({ view: 'all' }).catch(() => null),
+        // floor=1 so the badge matches what the For You page actually
+        // shows by default (fit >= 50, strength >= 50, no hard fails).
+        // limit:1 — we only need `total`, not a page of rows.
+        fetchRecommendations({ view: 'all', floor: true, limit: 1 }).catch(() => null),
       ]);
       const roles = (pipe?.roles || []).filter(isVisibleRole);
       const leads  = roles.filter(r => bucketFor(r) === 'leads').length;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.1">
-  <script src="/ladder/js/theme.js?v=2.14.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <script src="/ladder/js/theme.js?v=2.14.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
 </body>
 </html>

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.25.0';
-console.log(`[pull-recommendations] v${VERSION} - comp extraction from JD body text (shared extractCompensation): adapters, pull fallback, enrich + rescore persistence`);
+const VERSION = '0.25.1';
+console.log(`[pull-recommendations] v${VERSION} - dedup against ALL recs incl. dismissed — a dismissed role must not resurrect from the next digest`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -380,10 +380,14 @@ serve(async (req) => {
       // Also dedups within this batch. Conservative: URL/canonical match is
       // exact; company|title requires BOTH to match so Heidi's genuinely
       // distinct openings (different titles) aren't collapsed.
+      //
+      // NO dismissed/added filter here: a dismissal is a user decision, and
+      // the next weekly digest re-sending the same posting (fresh source_id,
+      // so insertNew's on-conflict can't catch it) must not resurrect it as
+      // a new rec. Dedup against EVERY known rec, whatever its state.
       const existing = await sql<{ url: string | null; canonical_url: string | null; company: string | null; title: string | null }[]>`
         select url, canonical_url, company, title
           from job.recommended_roles
-         where dismissed_at is null and added_to_pipeline_slug is null
       `;
       const seenKeys = new Set<string>();
       const addKeys = (url: string | null, canonical: string | null, company: string | null, title: string | null) => {


### PR DESCRIPTION
Two user-reported issues:

1. **Sidebar counter mismatch** — the rail badge fetched unfloored view=all (400+) while the For You page shows the floored view (~135). The badge (and mobile subnav, which mirrors it) now counts with floor=1.
2. **Declined roles resurrecting** — dismissals are tracked (dismissed_at) and filtered at read time, but the ingest dedup only checked non-dismissed recs, so weekly digests re-sending the same posting under a new source_id recreated it. Dedup now runs against all known recs regardless of state; 24 resurrected rows were retroactively re-dismissed in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)