### PR TITLE
ladder 2.15.0: For You inbox + review flow (J&J-inspired simplification)

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -10,7 +10,7 @@ These are the Wise rules we follow strictly. Don't break them when adding compon
 2. **Inter for body, Inter SemiBold for display.** Wise Sans is Wise's display face but it's not freely distributable; we substitute Inter SemiBold and tighten letter-spacing on titles. If we ever ship Wise Sans we drop it into `--font-display`.
 3. **4px base spacing scale.** Use `var(--space-N)` only — 1=4, 2=8, 3=12, 4=16, 5=24, 6=32, 7=48, 8=64. No magic numbers.
 4. **Generous radius.** Wise's smallest desktop radius is 16px. Cards 30px, buttons pill (`--radius-pill: 999px`). Don't use `border-radius: 4px` anywhere — looks wrong.
-5. **Forest Green and Bright Green own the brand.** Light theme: Forest Green (`#163300`) is `--accent` (interactive primary); Bright Green (`#9FE870`) is `--accent-strong` (highlighted nav, accent CTAs, active fit pills). Dark theme inverts: Forest is the base, Bright is the accent everywhere.
+5. **Forest Green and Bright Green own the brand — but only for actions.** Light theme: Forest Green (`#163300`) is `--accent` (interactive primary); Bright Green (`#9FE870`) is `--accent-strong`. Green is reserved for **the primary action on each screen** (accent CTAs, active fit pills in score modals). Active nav, tabs, and selected states are **neutral** (`--bg-overlay` + semibold), never green fills — one accented moment per screen. Red appears only on destructive/error surfaces, never in browse lists. Dark theme inverts: Forest is the base, Bright is the accent.
 6. **Token contract.** Every component reads `var(--bg)`, `var(--fg)`, `var(--accent)`, etc. Never hardcode hex values. The CTRL alternate must expose the same custom-property names.
 7. **No emoji or decorative icons unless the user adds them.**
 
@@ -29,6 +29,19 @@ These are the Wise rules we follow strictly. Don't break them when adding compon
 | `--font-size-caption` | 12 | chips, captions |
 
 Line heights: `--lh-display: 1.1`, `--lh-title: 1.25`, `--lh-body: 1.55`, `--lh-tight: 1.35`.
+
+## Core patterns (v2.15)
+
+The For You surface follows a **triage, don't browse** model (inbox → review → decide):
+
+| Pattern | Classes | Rules |
+|-|-|-|
+| Inbox groups | `.inbox`, `.inbox-group`, `.inbox-card`, `.inbox-row` | New roles batch by arrival date ("Today · 3 roles"). One elevated card per day, hairline dividers between rows. Rows show logo + full wrapped title + `company · location` and exactly one affordance: **Review**. Never put scores, accept/reject buttons, or kebab menus on inbox rows. |
+| Review overlay | `.review`, `.review__dots`, `.review__foot` | Full-screen, one role at a time, progress dots (≤12) or an "n of N" counter. Sticky footer with exactly two decisions: "Not for me" (neutral) / "Save role" (accent). Company-level actions live behind the top-bar ⋯. |
+| Verdict cards | `.verdict-card`, `.verdict-chip` | Qualitative fit first: "Excellent / Solid / Borderline on <dimension>" + one-sentence rationale, issues sorted first. Numbers stay one tap away in the score modal — numeric pills don't appear in lists. |
+| Collapsed JD | `.jd-collapse` | Raw scraped posting text is never the reading surface; it collapses behind "Original posting text". Summaries and match bullets lead. |
+| Page ⋯ menu | `.page-menu` | Operational controls (refresh sources, quality-floor toggle, expiry info) live behind one ⋯ in the page header — machinery stays out of the reading flow. Sourcing config (watched companies) lives on /ladder/vision/. |
+| Chat launcher | `.chat-fab` | Fixed 44px bubble top-right on every page (neutral surface, chat glyph). Never a floating bottom FAB over list content. |
 
 ## Cache busting
 

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -24,9 +24,12 @@
   background: var(--bg-elevated);
   text-decoration: none;
 }
+/* Active nav is neutral — a filled surface, not a brand-green splash.
+   Bright Green is reserved for the primary action on each screen. */
 .nav-list a[aria-current="page"] {
-  background: var(--accent-strong);
-  color: var(--accent-strong-fg);
+  background: var(--bg-overlay);
+  color: var(--fg);
+  font-weight: var(--fw-semibold);
 }
 
 /* --- Theme toggle --- */
@@ -439,6 +442,15 @@
 
 .link-subtle { color: var(--fg-muted); }
 .link-subtle:hover { color: var(--fg); text-decoration: underline; }
+/* Used on <button> as well as <a> — strip native button chrome. */
+button.link-subtle {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
 
 /* --- Sortable column headers --- */
 .th-sort {
@@ -3363,8 +3375,9 @@
 }
 .nav-sublist a:hover { background: var(--bg-elevated); color: var(--fg); text-decoration: none; }
 .nav-sublist a[aria-current="page"] {
-  background: var(--accent-muted);
-  color: var(--accent);
+  background: var(--bg-overlay);
+  color: var(--fg);
+  font-weight: var(--fw-semibold);
 }
 .nav-sublist .nav-sub__label { min-width: 0; }
 
@@ -3404,8 +3417,8 @@
   font-variant-numeric: tabular-nums;
 }
 .nav-sublist a[aria-current="page"] .nav-count {
-  background: var(--accent);
-  color: var(--accent-fg, #fff);
+  background: var(--bg-elevated);
+  color: var(--fg);
 }
 
 /* --- Bucket tabs (in-page Leads / Active / Archive) --- */
@@ -3732,10 +3745,10 @@
   }
   .pipeline-table tr {
     display: grid;
-    grid-template-columns: 48px minmax(0, 1fr) 44px;
+    grid-template-columns: minmax(0, 1fr) 44px;
     grid-template-areas:
-      "fit role menu"
-      "fit meta menu";
+      "role menu"
+      "meta menu";
     column-gap: var(--space-4);
     row-gap: var(--space-2);
     align-items: center;
@@ -3753,33 +3766,11 @@
     padding: 0;
     min-width: 0;
   }
-  .pipeline-table .col-fit {
-    grid-area: fit;
-    width: 48px;
-    align-self: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    overflow: visible;
-  }
-  /* Score-pair on desktop shows both fit + candidate-strength side-by-side
-     in 93px. On phones that overflows a 48px column and bleeds into the
-     role title. Drop the secondary score on mobile — fit is the primary
-     signal; the breakdown lives one tap away in the role detail. */
-  .pipeline-table .col-fit .score-pair {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-  .pipeline-table .col-fit .score-pair__cand { display: none; }
-  .pipeline-table .col-fit .fit-pill {
-    font-size: var(--font-size-small);
-    font-weight: var(--fw-semibold);
-    padding: 6px 0;
-    min-width: 48px;
-    text-align: center;
-    line-height: 1.2;
-  }
+  /* Numeric scores stay out of mobile lists entirely — the qualitative
+     verdicts + breakdown live one tap away in the role detail. Hiding the
+     cell (not just the pill) keeps the grid to [role | menu]. */
+  .pipeline-table .col-fit,
+  .pipeline-table .col-strength { display: none; }
   .pipeline-table .col-role {
     grid-area: role;
     max-width: none;
@@ -4066,16 +4057,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.home-rec__fit {
-  font-family: var(--font-display);
-  font-weight: var(--fw-semibold);
-  font-size: var(--font-size-small);
-  padding: 4px 10px;
-  border-radius: var(--radius-pill);
-  background: var(--accent-strong);
-  color: var(--accent-strong-fg);
-  min-width: 36px;
-  text-align: center;
+.home-rec__arrow {
+  color: var(--fg-subtle);
+  font-size: var(--font-size-body);
+  flex-shrink: 0;
 }
 
 /* --- Mobile segmented sub-nav ---
@@ -4118,8 +4103,9 @@
 }
 .subnav-bar__item:hover { text-decoration: none; color: var(--fg); }
 .subnav-bar__item[aria-current="page"] {
-  background: var(--accent-strong);
-  color: var(--accent-strong-fg);
+  background: var(--bg-overlay);
+  color: var(--fg);
+  font-weight: var(--fw-semibold);
 }
 .subnav-bar__item .nav-count {
   font-size: var(--font-size-caption);
@@ -5196,28 +5182,30 @@ job-onboarding { display: contents; }
    See <ladder-chat> component for state.
    ───────────────────────────────────────────────────────────── */
 
+/* Chat launcher — a fixed bubble in the top-right corner (J&J-style),
+   never floating over list content. Neutral surface; the drawer it opens
+   is the accented moment, not the button. */
 .chat-fab {
   position: fixed;
   right: var(--space-4);
-  bottom: var(--space-4);
-  bottom: max(var(--space-4), env(safe-area-inset-bottom));
+  top: max(var(--space-3), env(safe-area-inset-top));
   z-index: 55;
-  width: 56px;
-  height: 56px;
+  width: 44px;
+  height: 44px;
   border-radius: var(--radius-pill);
-  border: 0;
-  background: var(--accent-strong);
-  color: var(--accent-strong-fg);
-  font-size: 22px;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  font-size: 20px;
   cursor: pointer;
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-sm);
   display: inline-grid;
   place-items: center;
   transition: transform 80ms ease, box-shadow 80ms ease;
 }
-.chat-fab:hover { box-shadow: var(--shadow-lg); }
+.chat-fab:hover { box-shadow: var(--shadow-md); }
 .chat-fab:active { transform: translateY(1px); }
-.chat-fab__icon { line-height: 1; }
+.chat-fab__icon { line-height: 1; display: inline-grid; place-items: center; }
 
 /* Scrim sits between page and drawer. Mobile only — on desktop the drawer
    is a floating panel that doesn't need a backdrop. */
@@ -5256,11 +5244,12 @@ job-onboarding { display: contents; }
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
-/* Desktop: floating panel anchored bottom-right above the FAB. */
+/* Desktop: floating panel anchored top-right below the launcher. */
 @media (min-width: 721px) {
   .chat-drawer {
     right: var(--space-4);
-    bottom: calc(56px + var(--space-4) + var(--space-3));
+    top: calc(44px + var(--space-3) + var(--space-3));
+    bottom: auto;
     width: min(420px, 90vw);
     height: min(640px, 80vh);
     border-radius: var(--radius-lg);
@@ -6071,4 +6060,337 @@ body[data-auth-state="out"] job-chat { display: none; }
   color: var(--error, #e5484d);
   font-size: var(--font-size-caption);
   margin: var(--space-2) 0 0;
+}
+
+/* ==========================================================================
+   Inbox (For You) — date-batched groups, one Review affordance per row.
+   Replaces the sortable table: a single elevated card per day with hairline
+   dividers between rows. No scores, no inline accept/reject.
+   ========================================================================== */
+.inbox { display: flex; flex-direction: column; gap: var(--space-5); }
+
+.inbox-group__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  margin: 0 0 var(--space-3);
+}
+.inbox-group__label {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  letter-spacing: -0.01em;
+}
+.inbox-group__count { font-size: var(--font-size-small); }
+
+.inbox-card {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.inbox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+.inbox-row:last-child { border-bottom: 0; }
+.inbox-row__main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+.inbox-row__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.inbox-row__title {
+  font-weight: var(--fw-medium);
+  font-size: var(--font-size-body);
+  color: var(--fg);
+  /* Full titles, wrapped — never truncated to "Senior Produ…". */
+  overflow-wrap: anywhere;
+}
+.inbox-row__sub {
+  font-size: var(--font-size-small);
+  color: var(--fg-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.inbox-row__review {
+  flex-shrink: 0;
+  height: 40px;
+  padding: 0 var(--space-4);
+  background: var(--bg-surface);
+  border: 0;
+}
+.inbox-row__review:hover { background: var(--bg-overlay); }
+.inbox-row--skeleton { gap: var(--space-3); }
+.inbox-row--skeleton .inbox-row__text { flex: 1; gap: 6px; }
+
+/* Header ⋯ menu holding the operational controls (refresh, floors). */
+.page-menu { margin-left: auto; align-self: center; }
+.page-menu .row-menu__trigger {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-pill);
+  display: inline-grid;
+  place-items: center;
+}
+.page-menu .row-menu__trigger:hover { background: var(--bg-overlay); }
+.row-menu__info {
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-caption);
+  border-top: 1px solid var(--border);
+  white-space: nowrap;
+}
+.recs-page__head .page-menu ~ * { margin-right: 0; }
+
+/* ==========================================================================
+   Review overlay — full-screen, one role at a time. Progress dots up top,
+   summarized card in the middle, exactly two decisions pinned at the bottom.
+   ========================================================================== */
+.review {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+}
+.review__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  padding-top: max(var(--space-3), env(safe-area-inset-top));
+  flex-shrink: 0;
+}
+.review__bar-actions { display: inline-flex; align-items: center; gap: var(--space-2); }
+.review__dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+}
+.review__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--bg-overlay);
+  flex-shrink: 0;
+  transition: width 160ms ease, background 160ms ease;
+}
+.review__dot.is-current { width: 24px; background: var(--fg); }
+.review__counter { font-size: var(--font-size-small); color: var(--fg-muted); }
+.review__close,
+.review__more {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-grid;
+  place-items: center;
+}
+.review__scroll {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 0 var(--space-4) var(--space-6);
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+}
+.review__card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+.review__head { display: flex; gap: var(--space-4); align-items: flex-start; }
+.review__logo {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-sm);
+  object-fit: contain;
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+.review__logo--placeholder {
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  color: var(--fg-muted);
+}
+.review__head-text { min-width: 0; }
+.review__title {
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-3);
+  line-height: var(--lh-tight);
+  letter-spacing: -0.01em;
+  overflow-wrap: anywhere;
+}
+.review__meta { margin: 0; color: var(--fg-muted); font-size: var(--font-size-body); }
+.review__salary { margin: var(--space-1) 0 0; font-weight: var(--fw-medium); font-size: var(--font-size-body); }
+.review__sub { margin: var(--space-2) 0 0; font-size: var(--font-size-small); }
+.review__section { margin-bottom: var(--space-5); }
+.review__section-title {
+  margin: 0 0 var(--space-3);
+  font-family: var(--font-display);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-title-4);
+}
+.review__bullets {
+  margin: 0;
+  padding-left: 1.2em;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+}
+.review__bullets li > *, .review__bullets p { display: inline; margin: 0; }
+.review__summary { margin: 0; font-size: var(--font-size-body); line-height: var(--lh-body); }
+.review__numbers { margin: var(--space-3) 0 0; font-size: var(--font-size-caption); }
+.review__numbers .link-subtle { font-size: inherit; }
+.review__done { text-align: center; padding: var(--space-8) var(--space-4); }
+.review__foot {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  padding-bottom: max(var(--space-3), env(safe-area-inset-bottom));
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated);
+  flex-shrink: 0;
+}
+.review__foot .review__btn { width: 100%; }
+.review__btn--dismiss { background: var(--bg-surface); border: 0; }
+.review__btn--dismiss:hover { background: var(--bg-overlay); }
+@media (min-width: 721px) {
+  .review__foot { justify-content: center; }
+  .review__foot .review__btn { max-width: 344px; justify-self: end; }
+  .review__foot .review__btn + .review__btn { justify-self: start; }
+}
+
+/* ==========================================================================
+   Verdict cards — qualitative fit dimensions ("Excellent on job-ready
+   skills", "Borderline on compensation"). The numeric bars stay in the
+   score modal; these are the first read.
+   ========================================================================== */
+.verdict-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.verdict-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+}
+.verdict-card__title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body);
+}
+.verdict-card__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+.verdict-card--strong .verdict-card__dot { background: var(--accent-strong); }
+.verdict-card--ok     .verdict-card__dot { background: color-mix(in srgb, var(--accent-strong) 45%, var(--bg-surface)); }
+.verdict-card--weak   .verdict-card__dot { background: var(--warning); }
+.verdict-card--fail   { border-color: color-mix(in srgb, var(--error) 40%, var(--border)); }
+.verdict-card--fail .verdict-card__title { color: var(--error); }
+.verdict-card__body {
+  margin: var(--space-2) 0 0;
+  color: var(--fg-muted);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+}
+/* Compact chip row variant for tight surfaces. */
+.verdict-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+.verdict-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption);
+  font-weight: var(--fw-medium);
+  background: var(--bg-surface);
+  color: var(--fg-muted);
+}
+.verdict-chip--strong { background: var(--accent-muted); color: var(--fg); }
+.verdict-chip--weak   { background: color-mix(in srgb, var(--warning) 18%, transparent); }
+.verdict-chip--fail   { background: color-mix(in srgb, var(--error) 10%, transparent); color: var(--error); }
+
+/* Raw scraped posting text stays available but collapsed — the AI summary
+   and verdicts are the reading surface, not aggregator boilerplate. */
+.jd-collapse {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  margin: var(--space-4) 0;
+}
+.jd-collapse > summary {
+  cursor: pointer;
+  padding: var(--space-4);
+  font-weight: var(--fw-medium);
+  color: var(--fg-muted);
+  list-style: none;
+}
+.jd-collapse > summary::-webkit-details-marker { display: none; }
+.jd-collapse > summary::after { content: ' +'; color: var(--fg-subtle); }
+.jd-collapse[open] > summary::after { content: ' –'; }
+.jd-collapse__body {
+  padding: 0 var(--space-4) var(--space-4);
+  color: var(--fg-muted);
+  font-size: var(--font-size-small);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+.rec-detail__summary {
+  margin: 0 0 var(--space-4);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
 }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Your career — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>For You — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -25,11 +25,10 @@
   <div class="app">
     <ladder-rail></ladder-rail>
     <main class="app__main">
-      <ladder-watched-companies></ladder-watched-companies>
       <ladder-recommendations-table></ladder-recommendations-table>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.14.2";
-console.log(`[ladder] v${VERSION} - For You rail badge counts the floored view`);
+const VERSION = "2.15.0";
+console.log(`[ladder] v${VERSION} - For You inbox + review flow; qualitative verdicts; machinery moved to Search plan`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -38,12 +38,14 @@ if (location.pathname.startsWith('/ladder/jobs/drill')) {
   }
 } else if (location.pathname.startsWith('/ladder/jobs/recommended')) {
   import('./components/ladder-recommendations-table.js' + V);
-  import('./components/ladder-watched-companies.js' + V);
 } else if (location.pathname.startsWith('/ladder/jobs')) {
   import('./components/ladder-pipeline.js' + V);
 }
 if (location.pathname.startsWith('/ladder/vision')) {
   import('./components/ladder-vision.js' + V);
+  // Watched companies — sourcing config lives with the rest of the search
+  // plan, not in the For You reading flow.
+  import('./components/ladder-watched-companies.js' + V);
 }
 if (location.pathname.startsWith('/ladder/onboarding')) {
   import('./components/ladder-onboarding.js' + V);

--- a/ladder/js/components/ladder-chat.js
+++ b/ladder/js/components/ladder-chat.js
@@ -210,7 +210,11 @@ export class JobChat extends LitElement {
               aria-label=${this.open ? 'Close chat' : 'Open chat'}
               aria-expanded=${this.open ? 'true' : 'false'}
               @click=${() => this._toggle()}>
-        <span class="chat-fab__icon" aria-hidden="true">${this.open ? '×' : '✨'}</span>
+        <span class="chat-fab__icon" aria-hidden="true">${this.open ? '×' : html`
+          <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor"
+               stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 11.5a8.4 8.4 0 0 1-8.5 8.3 8.9 8.9 0 0 1-3.2-.6L3 21l1.9-5.1a8 8 0 0 1-1.4-4.4A8.4 8.4 0 0 1 12 3.2a8.4 8.4 0 0 1 9 8.3z"/>
+          </svg>`}</span>
       </button>
 
       ${this.open ? html`

--- a/ladder/js/components/ladder-fit-modal.js
+++ b/ladder/js/components/ladder-fit-modal.js
@@ -42,6 +42,84 @@ export function weakestFitDims(row, n = 2) {
     .slice(0, n);
 }
 
+// --- Qualitative verdicts ------------------------------------------------
+// Translate the numeric fit/candidate breakdowns into J&J-style dimension
+// verdicts ("Excellent on job-ready skills", "Borderline on compensation").
+// Lists and review surfaces lead with these; the numeric bars stay one tap
+// away in the score modal.
+function verdictTier(pct) {
+  if (pct >= 0.7) return { word: 'Excellent',  tier: 'strong' };
+  if (pct >= 0.4) return { word: 'Solid',      tier: 'ok' };
+  return { word: 'Borderline', tier: 'weak' };
+}
+
+// Collect verdicts from both breakdowns. Major fit dims (max >= 10) plus the
+// two candidate dims a hiring manager weighs first. Ungraded recs (no
+// breakdown data at all) return [] so callers can fall back gracefully.
+export function recVerdicts(row, n = 5) {
+  if (!row) return [];
+  const out = [];
+  const fitB = row.breakdown || row.fitBreakdown || {};
+  const fitR = row.rationales || row.fitRationales || {};
+  const candB = row.candidateBreakdown || {};
+  const candR = row.candidateRationales || {};
+  const graded = Object.keys(fitB).length > 0 || Object.keys(candB).length > 0;
+  if (!graded) return [];
+  for (const k of ['skills', 'scope']) {
+    const meta = CANDIDATE_DIM_LABELS[k];
+    if (!(k in candB)) continue;
+    out.push({ key: `cand:${k}`, label: meta.label, pct: (candB[k] || 0) / meta.max, rationale: candR[k] || '' });
+  }
+  for (const [k, meta] of Object.entries(DIM_LABELS)) {
+    if (meta.max < 10) continue;
+    if (!(k in fitB)) continue;
+    out.push({ key: `fit:${k}`, label: meta.label, pct: (fitB[k] || 0) / meta.max, rationale: fitR[k] || '' });
+  }
+  // Issues first (lowest pct), then strengths — mirrors how a reviewer
+  // scans: what's the catch, then why it's still worth a look. Prefer
+  // dims that have a written rationale when trimming.
+  return out
+    .sort((a, b) => (Boolean(b.rationale) - Boolean(a.rationale)) || (a.pct - b.pct))
+    .slice(0, n)
+    .sort((a, b) => a.pct - b.pct)
+    .map(v => ({ ...v, ...verdictTier(v.pct) }));
+}
+
+// Verdict cards + hard-fail callouts for a rec. The compact variant is a
+// single-line chip row for tight surfaces.
+export function renderVerdicts(row, { compact = false } = {}) {
+  const list = recVerdicts(row);
+  const fails = row?.hardFails || [];
+  if (!list.length && !fails.length) return nothing;
+  if (compact) {
+    return html`
+      <div class="verdict-chips">
+        ${fails.map(f => html`<span class="verdict-chip verdict-chip--fail">${f}</span>`)}
+        ${list.map(v => html`<span class="verdict-chip verdict-chip--${v.tier}">${v.word} · ${v.label.toLowerCase()}</span>`)}
+      </div>
+    `;
+  }
+  return html`
+    <ul class="verdict-list">
+      ${fails.map(f => html`
+        <li class="verdict-card verdict-card--fail">
+          <p class="verdict-card__title">Doesn't clear your bar</p>
+          <p class="verdict-card__body">${f}</p>
+        </li>
+      `)}
+      ${list.map(v => html`
+        <li class="verdict-card verdict-card--${v.tier}">
+          <p class="verdict-card__title">
+            <span class="verdict-card__dot" aria-hidden="true"></span>
+            ${v.word} on ${v.label.toLowerCase()}
+          </p>
+          ${v.rationale ? html`<p class="verdict-card__body">${v.rationale}</p>` : nothing}
+        </li>
+      `)}
+    </ul>
+  `;
+}
+
 export function scoreClass(s) {
   if (s == null) return 'fit-pill fit-pill--poor';
   if (s >= 70) return 'fit-pill fit-pill--strong';

--- a/ladder/js/components/ladder-home.js
+++ b/ladder/js/components/ladder-home.js
@@ -79,7 +79,7 @@ export class JobHome extends LitElement {
           <span class="home-rec__title">${rec.title || 'Untitled role'}</span>
           <span class="home-rec__sub">${rec.company || ''}${rec.location ? ` · ${rec.location}` : ''}</span>
         </div>
-        <span class="home-rec__fit">${Number.isFinite(rec.fit) ? rec.fit : ''}</span>
+        <span class="home-rec__arrow" aria-hidden="true">→</span>
       </a>
     `;
   }

--- a/ladder/js/components/ladder-rec-detail.js
+++ b/ladder/js/components/ladder-rec-detail.js
@@ -8,7 +8,7 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ renderMarkdown }, { fetchRecommendation, addRole, dismissRecommendation }, { logoSrc, logoInitial }, { renderFitCardBody, renderCandidateCardBody, scoreClass, weakestFitDims }] = await Promise.all([
+const [{ renderMarkdown }, { fetchRecommendation, addRole, dismissRecommendation }, { logoSrc, logoInitial }, { renderVerdicts, renderScoreModal, weakestFitDims }] = await Promise.all([
   import('../markdown.js' + V),
   import('../pipeline.js' + V),
   import('../logo.js' + V),
@@ -31,6 +31,7 @@ export class LadderRecDetail extends LitElement {
     rec:    { state: true },
     saving: { state: true },
     dismissed: { state: true },
+    scoreOpen: { state: true },
   };
 
   constructor() {
@@ -40,6 +41,7 @@ export class LadderRecDetail extends LitElement {
     this.rec = null;
     this.saving = false;
     this.dismissed = false;
+    this.scoreOpen = null;
     const params = new URLSearchParams(location.search);
     this.recId = params.get('rec') || '';
     this.slug = (params.get('slug') || '').toLowerCase();
@@ -136,7 +138,7 @@ export class LadderRecDetail extends LitElement {
     const weak = weakestFitDims(rec);
     return html`
       <aside class="rec-detail__wildcard">
-        <strong>🃏 Wildcard</strong> — you'd likely be a standout candidate
+        <strong>Wildcard</strong> — you'd likely be a standout candidate
         (strength ${rec.candidateScore}), but it scores low on your stated
         criteria (fit ${rec.fitScore}).
         <ul>
@@ -180,10 +182,6 @@ export class LadderRecDetail extends LitElement {
               ${rec.enrichmentStatus === 'unresolved' ? html` · <span class="enrichment-badge">verifying source</span>` : nothing}
             </p>
           </div>
-          <div class="rec-detail__scores">
-            <span class=${scoreClass(rec.fitScore)} title="Fit score">${rec.fitScore ?? '—'}</span>
-            <span class=${scoreClass(rec.candidateScore)} title="Candidate strength">${rec.candidateScore ?? '—'}</span>
-          </div>
         </header>
 
         <div class="rec-detail__actions">
@@ -210,23 +208,25 @@ export class LadderRecDetail extends LitElement {
           </article>
         ` : nothing}
 
-        <div class="rec-detail__cards">
-          <article class="role-card role-card--fit fit-modal">
-            <header class="role-card__head"><h3>Fit</h3></header>
-            ${renderFitCardBody(rec, { summary: rec.fitSummary || null })}
-          </article>
-          <article class="role-card role-card--fit fit-modal">
-            <header class="role-card__head"><h3>Candidate strength</h3></header>
-            ${renderCandidateCardBody(rec, { summary: rec.candidateSummary || null })}
-          </article>
-        </div>
+        <article class="role-card">
+          <header class="role-card__head"><h3>How it stacks up</h3></header>
+          ${rec.fitSummary ? html`<p class="rec-detail__summary">${rec.fitSummary}</p>` : nothing}
+          ${renderVerdicts(rec)}
+          <p class="review__numbers muted">
+            <button class="link-subtle" @click=${() => { this.scoreOpen = 'fit'; }}>Fit ${rec.fitScore ?? '—'}</button>
+            ·
+            <button class="link-subtle" @click=${() => { this.scoreOpen = 'candidate'; }}>Strength ${rec.candidateScore ?? '—'}</button>
+            — tap for the full breakdown
+          </p>
+        </article>
 
         ${rec.description ? html`
-          <article class="role-card">
-            <header class="role-card__head"><h3>Job description</h3></header>
-            <div class="kb-doc rec-detail__jd">${unsafeHTML(renderMarkdown(rec.description))}</div>
-          </article>
+          <details class="jd-collapse">
+            <summary>Original posting text</summary>
+            <div class="kb-doc jd-collapse__body">${unsafeHTML(renderMarkdown(rec.description))}</div>
+          </details>
         ` : nothing}
+        ${this.scoreOpen ? renderScoreModal({ ...rec, score: rec.fitScore }, () => { this.scoreOpen = null; }, this.scoreOpen) : nothing}
       </div>
     `;
   }

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -1,48 +1,26 @@
-// job-recommendations-table — full sortable list for /ladder/jobs/recommended/.
-// Mirrors the pipeline-table look (col-fit / role-cell / company-logo /
-// th-sort) so this page reads as a peer of the pipeline view, not a
-// separate widget.
+// ladder-recommendations-table — the For You inbox at /ladder/jobs/recommended/.
+// New roles arrive in small date-stamped batches (Today / Yesterday / Jun 12),
+// one "Review" affordance per row, and every decision happens inside the
+// full-screen <ladder-review-overlay> — no inline accept/reject, no numeric
+// score chips, no sort machinery in the reading flow. Pipeline plumbing
+// (quality-floor toggle, source refresh) lives behind a single ⋯ menu;
+// watched-company config moved to /ladder/vision/ (Search plan).
 //
 // Pulls the ?view=all variant so it includes recs below the carousel's
-// fit-score floor. Records persist in the DB regardless of what shows
-// here; this view is the full audit trail.
+// fit-score floor. Records persist in the DB regardless of what shows here.
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchRecommendations, dismissRecommendation, blockCompany, watchCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair, weakestFitDims }, { renderLocation, renderSource }, { roleSlug }] = await Promise.all([
+const [{ fetchRecommendations, dismissRecommendation, blockCompany, watchCompany, addRole, refreshSources }, { logoSrc, logoInitial }, { renderScoreModal, renderScorePair, weakestFitDims }, { roleSlug }] = await Promise.all([
   import('../pipeline.js' + V),
   import('../logo.js' + V),
   import('./ladder-fit-modal.js' + V),
-  import('../format.js' + V),
   import('../slug.js' + V),
 ]);
-
-// Column shape mirrors job-pipeline's COLUMNS: id drives the col class,
-// sortKey gates sortability, label is what the header shows.
-// Location is nested under Role (no standalone column) — sort still offered.
-const COLUMNS = [
-  { id: 'fit',      label: 'Fit',      sortKey: 'fitScore',       numeric: true },
-  { id: 'strength', label: 'Strength', sortKey: 'candidateScore', numeric: true },
-  { id: 'role',     label: 'Role',     sortKey: 'title' },
-  { id: 'source',   label: 'Source',   sortKey: 'source' },
-  { id: 'added',    label: 'Added',    sortKey: 'suggestedAt', date: true },
-  { id: 'menu',     label: '',         sortKey: null },
-];
+import('./ladder-review-overlay.js' + V);
 
 // Page size for the infinite-scroll fetch. Server caps at 200; 100 keeps
 // each round-trip light while filling a tall viewport in one or two pages.
 const PAGE_SIZE = 100;
-
-function relTime(iso) {
-  if (!iso) return '';
-  const ms = Date.now() - Date.parse(iso);
-  const s = Math.max(1, Math.floor(ms / 1000));
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60); if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24); if (d < 7)  return `${d}d ago`;
-  const w = Math.floor(d / 7);  if (w < 5)  return `${w}w ago`;
-  const mo = Math.floor(d / 30); return mo < 12 ? `${mo}mo ago` : `${Math.floor(mo / 12)}y ago`;
-}
 
 function fitClass(s) {
   if (s == null) return 'fit-pill fit-pill--poor';
@@ -52,6 +30,20 @@ function fitClass(s) {
   return 'fit-pill fit-pill--poor';
 }
 
+// Group label for an ISO timestamp: Today / Yesterday / "Jun 12" (+ year
+// when it isn't the current one). Grouping is by local calendar day.
+function dayLabel(iso) {
+  if (!iso) return 'Earlier';
+  const d = new Date(iso);
+  const now = new Date();
+  const startOf = (x) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const days = Math.round((startOf(now) - startOf(d)) / 86400000);
+  if (days <= 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  const opts = { month: 'short', day: 'numeric' };
+  if (d.getFullYear() !== now.getFullYear()) opts.year = 'numeric';
+  return d.toLocaleDateString('en-US', opts);
+}
 
 export class JobRecommendationsTable extends LitElement {
   createRenderRoot() { return this; }
@@ -60,8 +52,7 @@ export class JobRecommendationsTable extends LitElement {
     state:    { state: true },
     items:    { state: true },
     error:    { state: true },
-    _sortLayers: { state: true },
-    _menuOpenId: { state: true },
+    _menuOpen:  { state: true },
     addingId: { state: true },
     selectedRec:         { state: true },
     selectedScoreWhich:  { state: true },
@@ -75,6 +66,7 @@ export class JobRecommendationsTable extends LitElement {
     _recentlyExpired:    { state: true },
     _wildcards:          { state: true },
     _floorOn:            { state: true },
+    _reviewIndex:        { state: true },
   };
 
   constructor() {
@@ -82,12 +74,7 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'idle';
     this.items = [];
     this.error = '';
-    // Multi-level sort stack (Google-Sheets style): most-significant layer
-    // first. Empty → the server's "best overall match" blended ranking.
-    // Clicking a header pushes/toggles that column to the front; earlier
-    // layers become tiebreakers.
-    this._sortLayers = [];
-    this._menuOpenId = null;
+    this._menuOpen = false;
     this.addingId = null;
     this.selectedRec = null;
     this._refreshing = false;
@@ -101,14 +88,16 @@ export class JobRecommendationsTable extends LitElement {
     this._recentlyExpired = 0;
     this._wildcards = [];
     // Quality floors (fit >= 50, strength >= 50, no hard fails) apply by
-    // default; the header toggle flips to the unfiltered audit view.
+    // default; the ⋯ menu toggle flips to the unfiltered audit view.
     this._floorOn = true;
+    // Index into items while the review overlay is open; null = closed.
+    this._reviewIndex = null;
   }
 
   // ----- Source health banner ------------------------------------------
   // The recommendations GET returns sourceHealth rows. Anything with
   // needsReauth (dead Gmail token) or a lastError gets surfaced above the
-  // table — "no new recs" and "a source is blind" must look different.
+  // list — "no new recs" and "a source is blind" must look different.
 
   _healthIssues() {
     if (!Array.isArray(this._health)) return [];
@@ -225,8 +214,8 @@ export class JobRecommendationsTable extends LitElement {
     };
     window.addEventListener('scroll', this._onScroll, { passive: true });
     window.addEventListener('resize', this._onScroll, { passive: true });
-    // Close any open row menu on an outside click.
-    this._onDocClick = () => { if (this._menuOpenId) this._menuOpenId = null; };
+    // Close the header ⋯ menu on an outside click.
+    this._onDocClick = () => { if (this._menuOpen) this._menuOpen = false; };
     document.addEventListener('click', this._onDocClick);
   }
   disconnectedCallback() {
@@ -255,7 +244,7 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'loading';
     await this._fetchPage({ reset: true });
     if (this.state === 'loading') this.state = 'loaded';
-    // Wildcards strip loads after the table — never block or fail the
+    // Wildcards strip loads after the list — never block or fail the
     // page over it.
     try {
       const wc = await fetchRecommendations({ view: 'wildcard' });
@@ -263,22 +252,19 @@ export class JobRecommendationsTable extends LitElement {
     } catch { this._wildcards = []; }
   }
 
-  // Fetch one page from the server (server-side sorted). reset=true starts
-  // a fresh list at offset 0 (initial load, sort change, refresh); otherwise
-  // appends the next page for infinite scroll.
+  // Fetch one page from the server. Inbox order: newest batch first —
+  // the server's date sort keeps groups contiguous. reset=true starts a
+  // fresh list at offset 0; otherwise appends for infinite scroll.
   async _fetchPage({ reset = false } = {}) {
     if (reset) { this._offset = 0; this._hasMore = false; }
     try {
-      const layers = this._sortLayers;
       const data = await fetchRecommendations({
         view:   'all',
         floor:  this._floorOn,
         limit:  PAGE_SIZE,
         offset: this._offset,
-        // Multi-level: comma-joined keys + dirs, most-significant first.
-        // Empty stack → 'best' blended default on the server.
-        sort:   layers.length ? layers.map(l => l.key).join(',') : 'best',
-        dir:    layers.length ? layers.map(l => l.dir).join(',') : 'desc',
+        sort:   'suggestedAt',
+        dir:    'desc',
       });
       const page = Array.isArray(data?.recommendations) ? data.recommendations : [];
       this.items   = reset ? page : [...this.items, ...page];
@@ -309,47 +295,6 @@ export class JobRecommendationsTable extends LitElement {
     finally { this._loadingMore = false; this.requestUpdate(); }
   }
 
-  // Max sort layers kept. 3 is plenty (primary + two tiebreakers) and keeps
-  // the header indicators readable.
-  static SORT_DEPTH = 3;
-
-  _layerIndex(key) {
-    return this._sortLayers.findIndex(l => l.key === key);
-  }
-
-  _onSortClick(c) {
-    if (!c.sortKey) return;
-    const key = c.sortKey;
-    const defaultDir = (c.numeric || c.date) ? 'desc' : 'asc';
-    const layers = [...this._sortLayers];
-    const idx = layers.findIndex(l => l.key === key);
-    if (idx === 0) {
-      // Re-clicking the current primary toggles its direction.
-      layers[0] = { key, dir: layers[0].dir === 'asc' ? 'desc' : 'asc' };
-    } else {
-      // Promote this column to primary; previous layers slide down as
-      // tiebreakers. Pull it from its old position first if present.
-      if (idx > 0) layers.splice(idx, 1);
-      layers.unshift({ key, dir: defaultDir });
-    }
-    this._sortLayers = layers.slice(0, JobRecommendationsTable.SORT_DEPTH);
-    // Server-side sort — re-fetch from offset 0 in the new (layered) order.
-    this._fetchPage({ reset: true });
-  }
-
-  // Shift-click (or the header's reset affordance) clears the stack back to
-  // the default "best" ranking.
-  _clearSort() {
-    this._sortLayers = [];
-    this._fetchPage({ reset: true });
-  }
-
-  // Rows are returned already sorted by the server; this is just an
-  // array guard so a transient bad state can't crash render.
-  _sorted() {
-    return Array.isArray(this.items) ? this.items : [];
-  }
-
   async _onDismiss(rec) {
     this.items = this.items.filter(r => r.id !== rec.id);
     this._wildcards = this._wildcards.filter(r => r.id !== rec.id);
@@ -359,6 +304,10 @@ export class JobRecommendationsTable extends LitElement {
   async _onAdd(rec) {
     if (this.addingId) return;
     this.addingId = rec.id;
+    // Optimistic removal — the review flow advances instantly; the server
+    // save completes in the background (failures are logged and toasted).
+    this.items = this.items.filter(x => x.id !== rec.id);
+    this._wildcards = this._wildcards.filter(x => x.id !== rec.id);
     try {
       const r = await addRole({
         url: rec.url,
@@ -368,17 +317,91 @@ export class JobRecommendationsTable extends LitElement {
         source: 'Network',
         fromRecommendationId: rec.id,
       });
-      this.items = this.items.filter(x => x.id !== rec.id);
-      this._wildcards = this._wildcards.filter(x => x.id !== rec.id);
       document.dispatchEvent(new CustomEvent('job:pipeline:refresh', { detail: { slug: r.slug } }));
       document.dispatchEvent(new CustomEvent('job:pipeline:added', {
         detail: { role: { slug: r.slug, company: r.company || rec.company, title: r.title || rec.title } },
       }));
     } catch (e) {
       console.warn('[recs-table] add failed', e);
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Couldn't save ${rec.title || 'role'} — try again from Show all` } }));
     } finally {
       this.addingId = null;
     }
+  }
+
+  // "Watch <company>" — green-light the company as a direct source. The
+  // server resolves the careers backend (major-tech registry or an ATS
+  // board probe); unsupported companies surface the server's message.
+  async _onWatchCompany(r) {
+    const company = r.company;
+    if (!company) return;
+    try {
+      await watchCompany({ company });
+      document.dispatchEvent(new CustomEvent('job:watch:added', { detail: { company } }));
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — its careers page feeds For You now` } }));
+    } catch (e) {
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: e.message || `Couldn't watch ${company}` } }));
+      console.warn('[recs-table] watchCompany failed', e);
+    }
+  }
+
+  async _onBlockCompany(r) {
+    const company = r.company;
+    if (!company) return;
+    // Optimistic: drop every loaded row from this company immediately.
+    const norm = company.toLowerCase().trim();
+    this.items = this.items.filter(x => (x.company || '').toLowerCase().trim() !== norm);
+    this.requestUpdate();
+    try {
+      await blockCompany(company);
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Won't recommend ${company} anymore` } }));
+    } catch (e) {
+      console.warn('[recs-table] blockCompany failed', e);
+    }
+  }
+
+  // ----- Review overlay --------------------------------------------------
+
+  _openReview(index) { this._reviewIndex = index; }
+  _closeReview()     { this._reviewIndex = null; }
+
+  _renderReview() {
+    if (this._reviewIndex == null) return nothing;
+    const rows = this._sorted();
+    // Items removed out from under the overlay (save/dismiss/block) shift
+    // the queue; clamp, and close when it's drained.
+    if (!rows.length) { return nothing; }
+    const index = Math.min(this._reviewIndex, rows.length - 1);
+    return html`
+      <ladder-review-overlay
+        .items=${rows}
+        .index=${index}
+        @review-close=${() => this._closeReview()}
+        @review-save=${(e) => this._onAdd(e.detail.rec)}
+        @review-dismiss=${(e) => this._onDismiss(e.detail.rec)}
+        @review-watch=${(e) => this._onWatchCompany(e.detail.rec)}
+        @review-block=${(e) => this._onBlockCompany(e.detail.rec)}
+      ></ladder-review-overlay>
+    `;
+  }
+
+  // ----- Inbox list --------------------------------------------------------
+
+  _sorted() {
+    return Array.isArray(this.items) ? this.items : [];
+  }
+
+  _groups() {
+    const rows = this._sorted();
+    const groups = [];
+    const byLabel = new Map();
+    rows.forEach((r, i) => {
+      const label = dayLabel(r.suggestedAt);
+      let g = byLabel.get(label);
+      if (!g) { g = { label, rows: [] }; byLabel.set(label, g); groups.push(g); }
+      g.rows.push({ rec: r, index: i });
+    });
+    return groups;
   }
 
   _renderLogo(r) {
@@ -400,154 +423,64 @@ export class JobRecommendationsTable extends LitElement {
     `;
   }
 
-  _renderHeader() {
-    const multi = this._sortLayers.length > 1;
+  _renderInboxRow({ rec, index }) {
+    const sub = [rec.company, rec.location].filter(Boolean).join(' · ');
     return html`
-      <tr>
-        ${COLUMNS.map(c => {
-          const cls = `col col-${c.id}`;
-          if (!c.sortKey) return html`<th class=${cls}>${c.label}</th>`;
-          const idx = this._layerIndex(c.sortKey);
-          const layer = idx >= 0 ? this._sortLayers[idx] : null;
-          const arrow = layer ? (layer.dir === 'asc' ? '↑' : '↓') : '↕';
-          return html`
-            <th class=${cls}>
-              <button class=${'th-sort' + (layer ? ' is-active' : '')}
-                      title=${layer ? `Sort layer ${idx + 1} — click to toggle / re-prioritize` : 'Click to sort; click another column to layer'}
-                      @click=${() => this._onSortClick(c)}>
-                <span>${c.label}</span>
-                <span class="th-sort__arrow">${arrow}</span>
-                ${layer && multi ? html`<span class="th-sort__rank">${idx + 1}</span>` : nothing}
-              </button>
-            </th>
-          `;
-        })}
-      </tr>
+      <li class="inbox-row" role="listitem">
+        <button class="inbox-row__main" @click=${() => this._openReview(index)}>
+          ${this._renderLogo(rec)}
+          <span class="inbox-row__text">
+            <span class="inbox-row__title">${rec.title || '(untitled)'}</span>
+            ${sub ? html`<span class="inbox-row__sub">${sub}</span>` : nothing}
+          </span>
+        </button>
+        <button class="btn btn--sm inbox-row__review" @click=${() => this._openReview(index)}>
+          Review <span aria-hidden="true">→</span>
+        </button>
+      </li>
     `;
   }
 
-  _onRowClick(r, e) {
-    if (e.target.closest('button, a, .row-menu, .fit-pill--button')) return;
-    // Row click → pre-save detail page, in a NEW tab so browsing the list
-    // is never hijacked. The external posting link lives on that page.
-    const detail = `/ladder/jobs/${roleSlug(r.company, r.title)}/?rec=${r.id}`;
-    window.open(detail, '_blank', 'noopener');
+  _renderGroups() {
+    const groups = this._groups();
+    return html`
+      ${groups.map(g => html`
+        <section class="inbox-group">
+          <header class="inbox-group__head">
+            <h2 class="inbox-group__label">${g.label}</h2>
+            <span class="inbox-group__count muted">${g.rows.length} ${g.rows.length === 1 ? 'role' : 'roles'}</span>
+          </header>
+          <ul class="inbox-card" role="list">
+            ${g.rows.map(row => this._renderInboxRow(row))}
+          </ul>
+        </section>
+      `)}
+    `;
   }
 
-  _renderRow(r) {
+  // Header ⋯ menu: the operational controls (refresh, floor toggle,
+  // expiry info) that used to crowd the page header.
+  _renderHeaderMenu() {
     return html`
-      <tr class="pipeline-row" @click=${(e) => this._onRowClick(r, e)}>
-        <td class="col col-fit" data-label="Fit">
-          ${this._scorePill(r.fitScore, () => this._openFitModal(r), 'Fit score — tap for breakdown')}
-        </td>
-        <td class="col col-strength" data-label="Strength">
-          ${this._scorePill(r.candidateScore, () => this._openCandidateModal(r), 'Candidate strength — tap for breakdown')}
-        </td>
-        <td class="col col-role role-cell" data-label="Role">
-          <div class="role-cell__inner">
-            ${this._renderLogo(r)}
-            <div class="role-cell__text">
-              <div class="role-cell__title">${r.title || '(untitled)'}</div>
-              <div class="role-cell__company">${r.company || ''}</div>
-              ${renderLocation(r.location)}
-            </div>
-          </div>
-        </td>
-        <td class="col col-source" data-label="Source">
-          ${renderSource(r)}
-          ${r.enrichmentStatus === 'unresolved' ? html`
-            <span class="enrichment-badge" title="Still resolving the canonical posting. Aggregator URL in the meantime.">verifying</span>
-          ` : nothing}
-          ${r.sourceEmailUrl ? html`
-            <a class="rec-source-email" href=${r.sourceEmailUrl} target="_blank" rel="noopener"
-               title="Open the originating email in Gmail" @click=${(e) => e.stopPropagation()}>📧</a>
-          ` : nothing}
-        </td>
-        <td class="col col-added" data-label="Added">
-          <span class="muted">${r.suggestedAt ? relTime(r.suggestedAt) : ''}</span>
-        </td>
-        <td class="col col-menu">
-          <div class="rec-actions">
-            <button class="btn btn--sm btn--accent"
-                    aria-label=${this.addingId === r.id ? 'Saving' : 'Save role'}
-                    title=${this.addingId === r.id ? 'Saving…' : 'Save role'}
-                    ?disabled=${this.addingId === r.id}
-                    @click=${() => this._onAdd(r)}>
-              <span class="btn-icon" aria-hidden="true">${this.addingId === r.id ? '…' : '✓'}</span>
-              <span class="btn-label">${this.addingId === r.id ? 'Saving…' : 'Save'}</span>
+      <div class="row-menu page-menu">
+        <button class="row-menu__trigger" aria-label="List options" title="List options"
+                @click=${(e) => { e.stopPropagation(); this._menuOpen = !this._menuOpen; }}>⋯</button>
+        ${this._menuOpen ? html`
+          <div class="row-menu__pop" @click=${(e) => e.stopPropagation()}>
+            <button class="row-menu__item" ?disabled=${this._refreshing}
+                    @click=${() => { this._menuOpen = false; this._onRefresh(); }}>
+              ${this._refreshing ? 'Scanning…' : 'Refresh sources'}
             </button>
-            <button class="btn-dismiss" aria-label="Dismiss recommendation"
-                    title="Dismiss"
-                    @click=${() => this._onDismiss(r)}>×</button>
-            <div class="row-menu">
-              <button class="row-menu__trigger" aria-label="More actions" title="More"
-                      @click=${(e) => this._toggleMenu(r.id, e)}>⋯</button>
-              ${this._menuOpenId === r.id ? html`
-                <div class="row-menu__pop" @click=${(e) => e.stopPropagation()}>
-                  <button class="row-menu__item" @click=${() => this._onWatchCompany(r)}>
-                    Watch ${r.company || 'this company'}
-                  </button>
-                  <button class="row-menu__item" @click=${() => this._onBlockCompany(r)}>
-                    Don't recommend ${r.company || 'this company'}
-                  </button>
-                  <button class="row-menu__item" @click=${() => { this._onDismiss(r); this._menuOpenId = null; }}>
-                    Dismiss this role
-                  </button>
-                </div>
-              ` : nothing}
-            </div>
+            <button class="row-menu__item" @click=${() => { this._menuOpen = false; this._toggleFloor(); }}>
+              ${this._floorOn ? 'Show below-floor roles' : 'Re-apply quality floors'}
+            </button>
+            ${this._recentlyExpired > 0 ? html`
+              <div class="row-menu__info muted">${this._recentlyExpired} expired removed this week</div>
+            ` : nothing}
           </div>
-        </td>
-      </tr>
+        ` : nothing}
+      </div>
     `;
-  }
-
-  // Single score pill (Fit or Strength). null score renders an em dash.
-  _scorePill(score, onClick, title) {
-    const cls = fitClass(score) + ' fit-pill--button';
-    return html`
-      <button class=${cls} title=${title}
-              @click=${(e) => { e.stopPropagation(); onClick(); }}>
-        ${score == null ? '—' : Math.round(score)}
-      </button>`;
-  }
-
-  _toggleMenu(id, e) {
-    e.stopPropagation();
-    this._menuOpenId = this._menuOpenId === id ? null : id;
-  }
-
-  // "Watch <company>" — green-light the company as a direct source. The
-  // server resolves the careers backend (major-tech registry or an ATS
-  // board probe); unsupported companies surface the server's message.
-  async _onWatchCompany(r) {
-    const company = r.company;
-    this._menuOpenId = null;
-    if (!company) return;
-    try {
-      await watchCompany({ company });
-      document.dispatchEvent(new CustomEvent('job:watch:added', { detail: { company } }));
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — its careers page feeds For You now` } }));
-    } catch (e) {
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: e.message || `Couldn't watch ${company}` } }));
-      console.warn('[recs-table] watchCompany failed', e);
-    }
-  }
-
-  async _onBlockCompany(r) {
-    const company = r.company;
-    this._menuOpenId = null;
-    if (!company) return;
-    // Optimistic: drop every loaded row from this company immediately.
-    const norm = company.toLowerCase().trim();
-    this.items = this.items.filter(x => (x.company || '').toLowerCase().trim() !== norm);
-    this.requestUpdate();
-    try {
-      await blockCompany(company);
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Won't recommend ${company} anymore` } }));
-    } catch (e) {
-      console.warn('[recs-table] blockCompany failed', e);
-    }
   }
 
   // --- Wildcards strip -------------------------------------------------
@@ -602,7 +535,7 @@ export class JobRecommendationsTable extends LitElement {
     return html`
       <section class="rec-wildcards" aria-label="Wildcards">
         <header class="rec-shell__head rec-wildcards__head">
-          <h2>🃏 Wildcards</h2>
+          <h2>Wildcards</h2>
           <span class="muted">Roles where you'd likely be a standout candidate — but that flunk your stated criteria. A litmus test for the litmus.</span>
         </header>
         <div class="rec-row rec-row--wildcards" role="list">
@@ -618,18 +551,22 @@ export class JobRecommendationsTable extends LitElement {
         <header class="recs-page__head">
           <h1>For You</h1>
         </header>
-        <div class="pipeline-table-wrap">
-          <table class="pipeline-table pipeline-table--recs">
-            <thead>${this._renderHeader()}</thead>
-            <tbody>
-              ${Array.from({ length: 6 }).map(() => html`
-                <tr class="skeleton-row">
-                  ${COLUMNS.map(c => html`<td class=${`col col-${c.id}`}><span class="skeleton" style="width:80%;height:14px;display:inline-block;"></span></td>`)}
-                </tr>
-              `)}
-            </tbody>
-          </table>
-        </div>
+        <section class="inbox-group" aria-hidden="true">
+          <header class="inbox-group__head">
+            <span class="skeleton" style="width:96px;height:20px;display:inline-block;"></span>
+          </header>
+          <ul class="inbox-card" role="list">
+            ${Array.from({ length: 5 }).map(() => html`
+              <li class="inbox-row inbox-row--skeleton">
+                <span class="skeleton" style="width:44px;height:44px;border-radius:12px;"></span>
+                <span class="inbox-row__text">
+                  <span class="skeleton" style="width:60%;height:16px;display:inline-block;"></span>
+                  <span class="skeleton" style="width:40%;height:12px;display:inline-block;"></span>
+                </span>
+              </li>
+            `)}
+          </ul>
+        </section>
       `;
     }
     if (this.state === 'error') {
@@ -645,51 +582,31 @@ export class JobRecommendationsTable extends LitElement {
         <span class="muted">${this._total > rows.length
           ? `${rows.length} of ${this._total} roles`
           : `${rows.length} ${rows.length === 1 ? 'role' : 'roles'}`}</span>
-        ${this._recentlyExpired > 0 ? html`
-          <span class="muted recs-page__pruned"
-                title="Postings the liveness checks found expired and removed in the last 7 days">
-            · ${this._recentlyExpired} expired removed
-          </span>
-        ` : nothing}
-        <button class="link-subtle recs-page__floor-toggle"
-                title=${this._floorOn
-                  ? 'Quality floors on: fit ≥ 50, strength ≥ 50, no hard fails, graded only. Click to see everything.'
-                  : 'Showing everything, including below-floor and ungraded roles. Click to re-apply the quality floors.'}
-                @click=${() => this._toggleFloor()}>
-          ${this._floorOn ? 'Below-floor hidden · show all' : 'Showing all · apply floors'}
-        </button>
-        <button class="btn btn--sm recs-page__refresh" ?disabled=${this._refreshing}
-                title="Scan Gmail for new role alerts and application updates"
-                @click=${() => this._onRefresh()}>
-          ${this._refreshing ? 'Scanning…' : '↻ Refresh'}
-        </button>
-        ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
-        ${this._sortLayers.length ? html`
-          <button class="btn btn--sm recs-page__clearsort" title="Back to best-match order"
-                  @click=${() => this._clearSort()}>
-            Sorted by ${this._sortLayers.map(l => l.key === 'candidateScore' ? 'Strength' : l.key === 'fitScore' ? 'Fit' : l.key === 'suggestedAt' ? 'Date' : l.key).join(' › ')} · reset
+        ${!this._floorOn ? html`
+          <button class="link-subtle recs-page__floor-toggle" @click=${() => this._toggleFloor()}>
+            Showing all · apply floors
           </button>
         ` : nothing}
+        ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
+        ${this._renderHeaderMenu()}
       </header>
       ${this._renderHealthBanner()}
-      ${this._renderWildcards()}
       ${rows.length === 0 ? html`
         <div class="placeholder">
-          <h2>No recommendations yet</h2>
-          <p>New ones land here as soon as the workers pull fresh roles.</p>
+          <h2>All caught up</h2>
+          <p>New roles land here as soon as the workers pull them.</p>
         </div>
       ` : html`
-        <div class="pipeline-table-wrap">
-          <table class="pipeline-table pipeline-table--recs">
-            <thead>${this._renderHeader()}</thead>
-            <tbody>${rows.map(r => this._renderRow(r))}</tbody>
-          </table>
+        <div class="inbox">
+          ${this._renderGroups()}
           ${this._hasMore ? html`
             <div class="recs-sentinel" aria-hidden="true"></div>
             <div class="recs-loadmore muted">${this._loadingMore ? 'Loading more…' : ''}</div>
           ` : nothing}
         </div>
       `}
+      ${this._renderWildcards()}
+      ${this._renderReview()}
       ${renderScoreModal(this.selectedRec, () => this._closeFitModal(), this.selectedScoreWhich || 'fit')}
     `;
   }

--- a/ladder/js/components/ladder-review-overlay.js
+++ b/ladder/js/components/ladder-review-overlay.js
@@ -1,0 +1,233 @@
+// ladder-review-overlay — full-screen, one-role-at-a-time review flow for
+// For You. The inbox list opens this instead of exposing accept/reject on
+// every row: progress dots across the queue, a summarized role card with
+// qualitative verdicts, and exactly two decisions — "Not for me" / "Save".
+//
+// The parent (<ladder-recommendations-table>) owns the queue. This component
+// dispatches review-save / review-dismiss / review-close / review-watch /
+// review-block events and lets the parent mutate `items`; when the current
+// item is removed the next one slides into `index` automatically.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
+const V = (new URL(import.meta.url)).search;
+const [{ renderMarkdown }, { fetchRecommendation }, { logoSrc, logoInitial }, { renderVerdicts, renderScoreModal }] = await Promise.all([
+  import('../markdown.js' + V),
+  import('../pipeline.js' + V),
+  import('../logo.js' + V),
+  import('./ladder-fit-modal.js' + V),
+]);
+
+function relTime(iso) {
+  if (!iso) return '';
+  const ms = Date.now() - Date.parse(iso);
+  const d = Math.floor(ms / 86400000);
+  if (d < 1) return 'today';
+  if (d === 1) return 'yesterday';
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7); if (w < 5) return `${w}w ago`;
+  return `${Math.floor(d / 30)}mo ago`;
+}
+
+export class LadderReviewOverlay extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    items:  { attribute: false },
+    index:  { attribute: false },
+    _full:      { state: true },
+    _scoreOpen: { state: true },
+    _menuOpen:  { state: true },
+  };
+
+  constructor() {
+    super();
+    this.items = [];
+    this.index = 0;
+    this._full = null;       // fetchRecommendation result for the current rec
+    this._fullFor = null;    // rec id the fetch belongs to
+    this._scoreOpen = null;  // 'fit' | 'candidate' | null
+    this._menuOpen = false;
+    this._onKey = (e) => {
+      if (e.key === 'Escape') this._close();
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener('keydown', this._onKey);
+    document.body.style.overflow = 'hidden';
+  }
+  disconnectedCallback() {
+    document.removeEventListener('keydown', this._onKey);
+    document.body.style.overflow = '';
+    super.disconnectedCallback();
+  }
+
+  get rec() { return this.items?.[this.index] || null; }
+
+  willUpdate() {
+    const rec = this.rec;
+    if (rec && this._fullFor !== rec.id) {
+      this._fullFor = rec.id;
+      this._full = null;
+      this._scoreOpen = null;
+      this._menuOpen = false;
+      fetchRecommendation(rec.id)
+        .then(full => { if (this._fullFor === rec.id) this._full = full; })
+        .catch(() => { /* base row data is enough to decide */ });
+      // New card — scroll its body back to the top.
+      requestAnimationFrame(() => { this.querySelector('.review__scroll')?.scrollTo(0, 0); });
+    }
+  }
+
+  _close()  { this.dispatchEvent(new CustomEvent('review-close', { bubbles: true })); }
+  _emit(type) {
+    const rec = this.rec;
+    if (!rec) return;
+    this.dispatchEvent(new CustomEvent(type, { detail: { rec }, bubbles: true }));
+  }
+
+  _renderDots() {
+    const n = this.items.length;
+    if (n <= 1) return nothing;
+    if (n > 12) {
+      return html`<span class="review__counter">${this.index + 1} of ${n}</span>`;
+    }
+    return html`
+      <div class="review__dots" aria-label=${`Role ${this.index + 1} of ${n}`}>
+        ${this.items.map((_, i) => html`
+          <span class=${'review__dot' + (i === this.index ? ' is-current' : '')}></span>
+        `)}
+      </div>
+    `;
+  }
+
+  _renderLogo(rec) {
+    const src = (this._full?.logoUrl) || logoSrc(rec);
+    if (!src) return html`<div class="review__logo review__logo--placeholder" aria-hidden="true">${logoInitial(rec.company)}</div>`;
+    return html`<img class="review__logo" src=${src} alt="" loading="lazy"
+                     @error=${(e) => {
+                       const d = document.createElement('div');
+                       d.className = 'review__logo review__logo--placeholder';
+                       d.textContent = logoInitial(rec.company);
+                       e.target.replaceWith(d);
+                     }}>`;
+  }
+
+  render() {
+    const rec = this.rec;
+    if (!rec) {
+      // Queue drained mid-review — brief done state.
+      return html`
+        <div class="review" role="dialog" aria-modal="true" aria-label="Review roles">
+          <header class="review__bar">
+            <span></span>
+            <button class="review__close" aria-label="Close" @click=${() => this._close()}>×</button>
+          </header>
+          <div class="review__scroll"><div class="review__done">
+            <h2>All caught up</h2>
+            <p class="muted">No more roles to review.</p>
+          </div></div>
+        </div>
+      `;
+    }
+    const full = this._full;
+    const meta = [rec.company, rec.location || full?.location].filter(Boolean).join(' • ');
+    const salary = full?.salary || rec.salary || '';
+    const posting = full?.canonicalUrl || full?.url || rec.url;
+    const bullets = Array.isArray(full?.matchBullets) ? full.matchBullets : [];
+    const summary = full?.fitSummary || '';
+    const description = full?.description || '';
+    const fit = rec.fitScore ?? null;
+    const cand = rec.candidateScore ?? null;
+    const scoreRow = { ...rec, ...(full || {}), score: fit };
+    return html`
+      <div class="review" role="dialog" aria-modal="true" aria-label="Review role">
+        <header class="review__bar">
+          ${this._renderDots()}
+          <div class="review__bar-actions">
+            <div class="row-menu">
+              <button class="row-menu__trigger review__more" aria-label="More actions"
+                      @click=${(e) => { e.stopPropagation(); this._menuOpen = !this._menuOpen; }}>⋯</button>
+              ${this._menuOpen ? html`
+                <div class="row-menu__pop" @click=${(e) => e.stopPropagation()}>
+                  <button class="row-menu__item" @click=${() => { this._menuOpen = false; this._emit('review-watch'); }}>
+                    Watch ${rec.company || 'this company'}
+                  </button>
+                  <button class="row-menu__item" @click=${() => { this._menuOpen = false; this._emit('review-block'); }}>
+                    Don't recommend ${rec.company || 'this company'}
+                  </button>
+                </div>
+              ` : nothing}
+            </div>
+            <button class="review__close" aria-label="Close" @click=${() => this._close()}>×</button>
+          </div>
+        </header>
+
+        <div class="review__scroll" @click=${() => { this._menuOpen = false; }}>
+          <section class="review__card">
+            <header class="review__head">
+              ${this._renderLogo(rec)}
+              <div class="review__head-text">
+                <h2 class="review__title">${rec.title || '(untitled)'}</h2>
+                ${meta ? html`<p class="review__meta">${meta}</p>` : nothing}
+                ${salary ? html`<p class="review__salary">${salary}</p>` : nothing}
+                <p class="review__sub muted">
+                  ${rec.suggestedAt ? `Surfaced ${relTime(rec.suggestedAt)}` : ''}
+                  ${full?.sourceLabel ? ` • via ${full.sourceLabel}` : ''}
+                  ${posting ? html` • <a href=${posting} target="_blank" rel="noopener">Open posting ↗</a>` : nothing}
+                </p>
+              </div>
+            </header>
+          </section>
+
+          ${bullets.length ? html`
+            <section class="review__section">
+              <h3 class="review__section-title">Why it surfaced</h3>
+              <ul class="review__bullets">
+                ${bullets.map(b => html`<li>${unsafeHTML(renderMarkdown(String(b).replace(/^\s*[•\-\*]\s*/, '')))}</li>`)}
+              </ul>
+            </section>
+          ` : summary ? html`
+            <section class="review__section">
+              <h3 class="review__section-title">The read</h3>
+              <p class="review__summary">${summary}</p>
+            </section>
+          ` : nothing}
+
+          <section class="review__section">
+            ${renderVerdicts(rec)}
+            ${fit != null || cand != null ? html`
+              <p class="review__numbers muted">
+                <button class="link-subtle" @click=${() => { this._scoreOpen = 'fit'; }}>Fit ${fit ?? '—'}</button>
+                ·
+                <button class="link-subtle" @click=${() => { this._scoreOpen = 'candidate'; }}>Strength ${cand ?? '—'}</button>
+                — tap for the full breakdown
+              </p>
+            ` : nothing}
+          </section>
+
+          ${description ? html`
+            <details class="jd-collapse">
+              <summary>Original posting text</summary>
+              <div class="kb-doc jd-collapse__body">${unsafeHTML(renderMarkdown(description))}</div>
+            </details>
+          ` : nothing}
+        </div>
+
+        <footer class="review__foot">
+          <button class="btn review__btn review__btn--dismiss" @click=${() => this._emit('review-dismiss')}>
+            Not for me
+          </button>
+          <button class="btn btn--accent review__btn" @click=${() => this._emit('review-save')}>
+            Save role
+          </button>
+        </footer>
+
+        ${this._scoreOpen ? renderScoreModal(scoreRow, () => { this._scoreOpen = null; }, this._scoreOpen) : nothing}
+      </div>
+    `;
+  }
+}
+
+customElements.define('ladder-review-overlay', LadderReviewOverlay);

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — /ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.15.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — /ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.14.2">
-  <script src="/ladder/js/theme.js?v=2.14.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.15.0">
+  <script src="/ladder/js/theme.js?v=2.15.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,9 +30,10 @@
         <p>Goals and intents that guide the search. Same source the /jobs skill reads for relevance.</p>
       </header>
       <ladder-vision></ladder-vision>
+      <ladder-watched-companies></ladder-watched-companies>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.14.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.15.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## What

Side-by-side comparison with Jack & Jill's dashboard led to a "triage, don't browse" realignment of Ladder's For You surface. The reading flow gets radically simpler; the machinery moves one layer deeper (nothing deleted).

### Changes
- **For You → inbox**: roles batch by arrival date (Today / Yesterday / Jun 12), one `Review →` affordance per row. No score chips, no inline ✓/✗, no sortable table.
- **New review overlay** (`ladder-review-overlay`): full-screen, one role at a time, progress dots, summarized card, two decisions — *Not for me* / *Save role*. Watch/block company behind the ⋯.
- **Qualitative verdicts**: "Excellent / Solid / Borderline on <dimension>" cards from the existing breakdowns; numbers stay one tap away in the score modal. Same cards on the rec detail page.
- **JD collapse**: raw scraped posting text (LinkedIn boilerplate) folds behind "Original posting text".
- **Machinery relocated**: refresh + quality-floor toggle behind a header ⋯; watched companies now on Search plan (`/ladder/vision/`).
- **Color discipline**: neutral active nav/tabs; Bright Green reserved for the primary action per screen; scores out of mobile lists and home card.
- **Chat launcher**: 44px neutral bubble fixed top-right (SVG chat glyph), drawer anchors below on desktop.
- **DESIGN.md**: documents the new patterns + amended green rule.

### Testing
- All modified JS modules pass ESM syntax check.
- Local fixture smoke test (Chrome): inbox grouping, review overlay open/advance/dots, verdict cards, wildcards strip all render and behave correctly.
- Post-merge: verify on prod (auth-gated flows: save/dismiss round-trip, score modal, Search plan watched-companies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)