### PR TITLE
feat(events): source architecture Phase 1+2 — visibility, dedup ladder, Agape canonical feed

### DIFF
--- a/docs/playground/events/strategy/prd-event-source-architecture.md
+++ b/docs/playground/events/strategy/prd-event-source-architecture.md
@@ -177,16 +177,19 @@ Explicitly **not** filters: ticket platform (attribute → outbound link icon), 
 
 ## 7. Scope & Phasing
 
-### Phase 1 — Foundation
-- [ ] Canonical event store with `sources[]`, `visibility`, `recommended_by`, `posted_by`, normalized `venue`
-- [ ] Visibility engine per §3 matrix + RLS fix
-- [ ] Dedup ladder (URL match + tiered fuzzy match) server-side in cache pipeline
-- [ ] Agape Discord feed → canonical store (replacing standalone `discord_event_cache` read path)
+### Phase 1 — Foundation ✅ Shipped (migration 089, cache-events v1.6.0, scrape-discord-events v1.3.0, scrape-events v1.4.0)
+- [x] Canonical event store extensions: `visibility`, `canonical_url`, `recommended_by`, `posted_by` on `events`; `source_class` + `demoted` on `event_sources`
+- [x] Visibility engine per §3 matrix + RLS fix (public read restricted to `visibility='public'`; anon write policies removed)
+- [x] Dedup ladder (URL-first canonical adoption + nightlife-tier fuzzy match) server-side in `cache-events`
+- [x] Agape Discord feed → canonical store: `scrape-discord-events` forwards extracted events (with per-message `posted_by` attribution and `recommended_by=['agape']`) into `cache-events`; kicked every 2h by `scrape-events`
 
-### Phase 2 — Coverage
-- [ ] Demoted-platform ingestion (Eventbrite/Bandsintown as enrichers, hidden by default)
-- [ ] Venue calendar Wave 2 (arts & institutional)
-- [ ] Coverage metric: % of externally-hosted Agape events corroborated by a public feed
+### Phase 2 — Coverage (partial)
+- [x] Demotion machinery: `demoted` flag + corroboration visibility upgrades (both directions) in `cache-events` — dormant until demoted feeds are registered
+- [ ] Demoted-platform parsers (Eventbrite location search, Bandsintown) — needs new parser types
+- [x] Venue calendar Wave 2/3 backlog registered in `event_sources` (14 rows, disabled pending feed verification; enable = verify feed → set type → flip `enabled`, no deploy)
+- [ ] Wave 2 feed verification & enablement (per-venue stories)
+- [x] Coverage metric: `agape_coverage` view (corroboration % of Agape events vs public feeds)
+- [x] Event-platform domains (Partiful, Luma, Tixr, etc.) added to `enrich-event` allowlist per §4.1
 
 ### Phase 3 — Curation surface
 - [ ] Authenticated view with "Recommended by Agape" filter + badges + `posted_by`

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.5.1'
-console.log(`[cache-events] v${VERSION} - chunked existence check + duplicate-proof inserts (unchunked .in() silently failed, killing batches)`)
+const VERSION = '1.6.0'
+console.log(`[cache-events] v${VERSION} - source classes, visibility, URL-first dedup ladder + tiered fuzzy match (PRD source-architecture)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -72,6 +72,227 @@ interface ScrapedEvent {
   promoter?: string
   url: string
   contentType?: string
+  description?: string
+  postedBy?: string
+  recommendedBy?: string[]
+}
+
+// --- Source classes & visibility (PRD event-source-architecture §2–3) ---
+
+interface SourceMeta { source_class: string; demoted: boolean }
+
+async function loadSourceClasses(supabase: ReturnType<typeof createClient>): Promise<Map<string, SourceMeta>> {
+  const map = new Map<string, SourceMeta>()
+  const { data } = await supabase.from('event_sources').select('id, source_class, demoted')
+  for (const row of data || []) {
+    map.set(row.id as string, { source_class: (row.source_class as string) || 'discovery', demoted: !!row.demoted })
+  }
+  return map
+}
+
+// Visibility by source class: curation (Agape) and private-ticketing rows are
+// always private; demoted discovery feeds are private until corroborated by
+// the Agape channel (upgrade handled in resolveCanonicalKeys); everything
+// else is public.
+function visibilityFor(sourceId: string, classes: Map<string, SourceMeta>): 'public' | 'private' {
+  const meta = classes.get(sourceId)
+  if (!meta) return 'public'
+  if (meta.source_class === 'curation' || meta.source_class === 'private-ticketing') return 'private'
+  if (meta.demoted) return 'private'
+  return 'public'
+}
+
+// --- Canonical URL (dedup ladder rung 1) ---
+// Only per-event pages on known platforms qualify — a canonical URL must
+// uniquely identify one event, so venue homepages and generic listings are
+// excluded to avoid welding unrelated events together.
+
+const EVENT_URL_PATTERNS: RegExp[] = [
+  /^https?:\/\/partiful\.com\/e\/[\w-]+$/,
+  /^https?:\/\/(?:[a-z]{2}\.)?ra\.co\/events\/\d+$/,
+  /^https?:\/\/lu\.ma\/[\w.-]+$/,
+  /^https?:\/\/eventbrite\.com\/e\/[\w-]+$/,
+  /^https?:\/\/dice\.fm\/(?:event|partner)\/[\w/-]+$/,
+  /^https?:\/\/shotgun\.live\/(?:[a-z]{2}\/)?events\/[\w-]+$/,
+  /^https?:\/\/tixr\.com\/groups\/[\w-]+\/events\/[\w-]+$/,
+  /^https?:\/\/[\w-]+\.secretparty\.io\/[\w-]+$/,
+  /^https?:\/\/(?:wl\.)?seetickets\.us\/event\/[\w/-]+$/,
+  /^https?:\/\/meetup\.com\/[\w-]+\/events\/\d+$/,
+]
+
+function canonicalizeEventUrl(raw: string | undefined | null): string | null {
+  if (!raw) return null
+  try {
+    const u = new URL(raw)
+    u.hash = ''
+    u.search = ''
+    let s = u.toString().toLowerCase().replace(/\/+$/, '')
+    s = s.replace('://www.', '://').replace('://luma.com/', '://lu.ma/')
+    return EVENT_URL_PATTERNS.some(p => p.test(s)) ? s : null
+  } catch {
+    return null
+  }
+}
+
+// --- Fuzzy venue+date+name match (dedup ladder rung 2) ---
+// Only runs for curation-class rows at known nightlife venues, where the
+// collision probability with 19hz/RA is high (PRD §4 conservative policy:
+// prefer duplicate cards over false merges everywhere else).
+
+const NIGHTLIFE_VENUES = [
+  'public works', 'the midway', 'midway', 'great northern', '1015 folsom',
+  'f8', '1192 folsom', 'audio', 'undergroundsf', 'underground sf', 'gray area',
+  'monarch', 'halcyon', 'dna lounge', 'the endup', 'temple', 'the foundry',
+  'el rio', 'rickshaw stop', 'brick and mortar', 'bottom of the hill',
+  'the chapel', 'the independent', 'bimbos 365', 'new parish', 'fox oakland',
+  'the knockout', 'make out room', 'public sf', 'phoenix hotel',
+]
+
+function isNightlifeVenue(venue: string): boolean {
+  const nv = normalizeForKey(venue).replace(/^the /, '')
+  if (!nv) return false
+  return NIGHTLIFE_VENUES.some(w => {
+    const wv = w.replace(/^the /, '')
+    if (nv === wv) return true
+    if (wv.length > 4 && (nv.includes(wv) || wv.includes(nv))) return true
+    return false
+  })
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  const m = a.length, n = b.length
+  if (m === 0) return n
+  if (n === 0) return m
+  let prev = Array.from({ length: n + 1 }, (_, i) => i)
+  for (let i = 1; i <= m; i++) {
+    const cur = [i]
+    for (let j = 1; j <= n; j++) {
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1))
+    }
+    prev = cur
+  }
+  return prev[n]
+}
+
+function fuzzyNameMatch(a: string, b: string): boolean {
+  const na = normalizeForKey(a).replace(/[^a-z0-9 ]/g, '')
+  const nb = normalizeForKey(b).replace(/[^a-z0-9 ]/g, '')
+  if (!na || !nb) return false
+  if (na === nb) return true
+  if (na.length >= 6 && nb.length >= 6 && (na.includes(nb) || nb.includes(na))) return true
+  return levenshtein(na, nb) <= 3
+}
+
+function fuzzyVenueMatch(a: string, b: string): boolean {
+  const na = normalizeForKey(a).replace(/^the /, '').replace(/[^a-z0-9 ]/g, '')
+  const nb = normalizeForKey(b).replace(/^the /, '').replace(/[^a-z0-9 ]/g, '')
+  if (!na || !nb) return false
+  if (na === nb) return true
+  if (na.length >= 5 && nb.length >= 5 && (na.includes(nb) || nb.includes(na))) return true
+  return levenshtein(na, nb) <= 2
+}
+
+// --- Dedup ladder (PRD §4): mutate rows in place to adopt canonical identity ---
+// Rung 1: canonical URL match against existing rows (any direction — a public
+//         listing arriving after a Discord post adopts the Discord row's key,
+//         and vice versa, so merges are stable regardless of timing).
+// Rung 2: curation rows at nightlife venues fuzzy-match venue+date+name.
+// Rung 3: corroboration upgrades — demoted-feed rows sharing identity with an
+//         Agape row become public (PRD §2.1); direction-agnostic.
+async function resolveCanonicalKeys(
+  supabase: ReturnType<typeof createClient>,
+  rows: Record<string, unknown>[],
+  classes: Map<string, SourceMeta>,
+): Promise<{ urlAdopted: number; fuzzyAdopted: number; upgraded: number }> {
+  let urlAdopted = 0, fuzzyAdopted = 0, upgraded = 0
+
+  // Rung 1: URL adoption
+  const urls = [...new Set(rows.map(r => r.canonical_url as string | null).filter(Boolean))] as string[]
+  const urlToKey = new Map<string, string>()
+  for (let i = 0; i < urls.length; i += 100) {
+    const chunk = urls.slice(i, i + 100)
+    const { data } = await supabase
+      .from('events')
+      .select('canonical_url, canonical_key')
+      .in('canonical_url', chunk)
+    for (const row of data || []) {
+      if (row.canonical_url && row.canonical_key) urlToKey.set(row.canonical_url as string, row.canonical_key as string)
+    }
+  }
+  for (const r of rows) {
+    const cu = r.canonical_url as string | null
+    if (cu && urlToKey.has(cu) && r.canonical_key !== urlToKey.get(cu)) {
+      r.canonical_key = urlToKey.get(cu)
+      urlAdopted++
+    }
+  }
+
+  // Rung 2: tiered fuzzy match for curation rows at nightlife venues
+  const fuzzyRows = rows.filter(r =>
+    classes.get(r.source_id as string)?.source_class === 'curation' &&
+    isNightlifeVenue((r.venue as string) || '')
+  )
+  if (fuzzyRows.length > 0) {
+    const dates = [...new Set(fuzzyRows.map(r => r.date as string))]
+    const { data: candidates } = await supabase
+      .from('events')
+      .select('date, name, venue, canonical_key, source_id')
+      .in('date', dates.slice(0, 50))
+      .neq('source_id', fuzzyRows[0].source_id as string)
+    for (const r of fuzzyRows) {
+      const match = (candidates || []).find(c =>
+        c.date === r.date &&
+        fuzzyVenueMatch(c.venue as string, r.venue as string) &&
+        fuzzyNameMatch(c.name as string, r.name as string)
+      )
+      if (match && match.canonical_key && r.canonical_key !== match.canonical_key) {
+        r.canonical_key = match.canonical_key
+        fuzzyAdopted++
+      }
+    }
+  }
+
+  // Rung 3: corroboration upgrades for demoted feeds
+  const demotedIds = [...classes.entries()].filter(([, m]) => m.demoted).map(([id]) => id)
+  if (demotedIds.length > 0) {
+    // 3a. Incoming demoted rows already corroborated by a stored Agape row → public
+    const demotedRows = rows.filter(r => demotedIds.includes(r.source_id as string))
+    if (demotedRows.length > 0) {
+      const keys = [...new Set(demotedRows.map(r => r.canonical_key as string))]
+      const corroborated = new Set<string>()
+      for (let i = 0; i < keys.length; i += 100) {
+        const { data } = await supabase
+          .from('events')
+          .select('canonical_key')
+          .in('canonical_key', keys.slice(i, i + 100))
+          .eq('source_id', 'discord-agape-events')
+        for (const row of data || []) corroborated.add(row.canonical_key as string)
+      }
+      for (const r of demotedRows) {
+        if (corroborated.has(r.canonical_key as string) && r.visibility !== 'public') {
+          r.visibility = 'public'
+          upgraded++
+        }
+      }
+    }
+    // 3b. Incoming Agape rows corroborate stored demoted rows → flip them public
+    const agapeKeys = [...new Set(rows
+      .filter(r => classes.get(r.source_id as string)?.source_class === 'curation')
+      .map(r => r.canonical_key as string))]
+    for (let i = 0; i < agapeKeys.length; i += 100) {
+      const { data } = await supabase
+        .from('events')
+        .update({ visibility: 'public' })
+        .in('canonical_key', agapeKeys.slice(i, i + 100))
+        .in('source_id', demotedIds)
+        .eq('visibility', 'private')
+        .select('id')
+      upgraded += data?.length || 0
+    }
+  }
+
+  return { urlAdopted, fuzzyAdopted, upgraded }
 }
 
 interface SourceOutcome {
@@ -253,6 +474,9 @@ serve(async (req: Request) => {
     const newEventIds: string[] = []
     const errors: string[] = []
 
+    // Source taxonomy: class + demoted flag drive visibility and the dedup ladder
+    const sourceClasses = await loadSourceClasses(supabase)
+
     // Build rows with event keys
     const rows = await Promise.all(events.map(async (ev) => {
       if (!ev.source || !ev.date || !ev.name || !ev.venue || !ev.url) return null
@@ -261,6 +485,8 @@ serve(async (req: Request) => {
       return {
         event_key: eventKey,
         canonical_key: canonicalKey,
+        canonical_url: canonicalizeEventUrl(ev.url),
+        visibility: visibilityFor(ev.source, sourceClasses),
         source_id: ev.source,
         date: ev.date,
         time: ev.time || null,
@@ -275,6 +501,8 @@ serve(async (req: Request) => {
         url: ev.url,
         content_type: ev.contentType || null,
         description: ev.description || null,
+        posted_by: ev.postedBy || null,
+        recommended_by: ev.recommendedBy && ev.recommendedBy.length > 0 ? ev.recommendedBy : null,
         scraped_at: new Date().toISOString(),
       }
     }))
@@ -283,6 +511,20 @@ serve(async (req: Request) => {
 
     if (validRows.length === 0) {
       return jsonResponse({ cached: 0, updated: 0, enrichQueued: 0, healthUpdated, errors: ['No valid events'] })
+    }
+
+    // Dedup ladder: adopt canonical identity from existing rows (URL first,
+    // then tiered fuzzy) and apply corroboration visibility upgrades.
+    let ladder = { urlAdopted: 0, fuzzyAdopted: 0, upgraded: 0 }
+    try {
+      ladder = await resolveCanonicalKeys(supabase, validRows, sourceClasses)
+      if (ladder.urlAdopted || ladder.fuzzyAdopted || ladder.upgraded) {
+        console.log(`[cache-events] Dedup ladder: urlAdopted=${ladder.urlAdopted} fuzzyAdopted=${ladder.fuzzyAdopted} upgraded=${ladder.upgraded}`)
+      }
+    } catch (err) {
+      // Non-fatal: rows keep their name/venue-derived canonical_key
+      console.error('[cache-events] Dedup ladder failed:', (err as Error).message)
+      errors.push(`Dedup ladder: ${(err as Error).message}`)
     }
 
     // Check which event_keys already exist. Chunked: .in() with 400 64-char
@@ -358,6 +600,8 @@ serve(async (req: Request) => {
       const patchRows = toUpdate.map(row => ({
         event_key: row.event_key,
         canonical_key: row.canonical_key,
+        canonical_url: row.canonical_url,
+        visibility: row.visibility,
         source_id: row.source_id,
         date: row.date,
         time: row.time,
@@ -369,6 +613,8 @@ serve(async (req: Request) => {
         ages: row.ages,
         promoter: row.promoter,
         url: row.url,
+        posted_by: row.posted_by,
+        recommended_by: row.recommended_by,
         scraped_at: row.scraped_at,
       }))
       const { data: upserted, error: upsertErr } = await supabase

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -6,8 +6,8 @@
 // Body: { eventIds: string[] }   (batch up to 10)
 // Returns: { processed, succeeded, failed, results }
 
-const VERSION = '1.1.0'
-console.log(`[enrich-event] v${VERSION} - event enrichment with stuck-state recovery`)
+const VERSION = '1.1.1'
+console.log(`[enrich-event] v${VERSION} - retired Haiku model replaced (claude-3-haiku -> haiku-4-5)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -48,6 +48,19 @@ const ALLOWED_DOMAINS = [
   'citylights.com',
   'sfpl.org',
   'commonwealthclub.org',
+  // Event platforms from the Agape curation feed (PRD source-architecture §4.1:
+  // platform pages are the canonical fact source for Discord-announced events)
+  'partiful.com',
+  'lu.ma',
+  'luma.com',
+  'shotgun.live',
+  'tixr.com',
+  'seetickets.us',
+  'meetup.com',
+  'grayarea.org',
+  'thelab.org',
+  'bottomofthehill.com',
+  'thechapelsf.com',
 ]
 
 function isDomainAllowed(url: string): boolean {
@@ -222,7 +235,7 @@ Respond with JSON only: {"genre": "...", "content_type": "..."}`
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-3-haiku-20240307',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 150,
         messages: [{ role: 'user', content: prompt }],
       }),

--- a/supabase/functions/scrape-discord-events/index.ts
+++ b/supabase/functions/scrape-discord-events/index.ts
@@ -14,8 +14,8 @@
 //
 // Returns: { events: [...], meta: { ... }, cached: boolean }
 
-const VERSION = '1.2.0'
-console.log(`[scrape-discord-events] v${VERSION} - inspect + raw export actions`)
+const VERSION = '1.3.0'
+console.log(`[scrape-discord-events] v${VERSION} - canonical store forwarding (posted_by, recommended_by, per-message attribution)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -240,6 +240,8 @@ interface ExtractedEvent {
   ages: string
   promoter: string
   url: string
+  msg?: number       // 1-based index of the source message within the batch
+  postedBy?: string  // Discord author of the source message
 }
 
 function buildExtractionPrompt(messages: Array<{ content: string; timestamp: string; authorIsBot: boolean }>, today: string): string {
@@ -262,6 +264,7 @@ Rules:
 
 Output ONLY a JSON array (no markdown, no explanation):
 [{
+  "msg": <number of the source message the event came from, e.g. 1>,
   "date": "YYYY-MM-DD",
   "time": "HH:MM" or "HH:MM-HH:MM" or "",
   "name": "event title",
@@ -308,7 +311,7 @@ async function extractEventsWithAI(
         'anthropic-version': '2023-06-01',
       },
       body: JSON.stringify({
-        model: 'claude-3-haiku-20240307',
+        model: 'claude-haiku-4-5-20251001',
         max_tokens: 2048,
         messages: [{ role: 'user', content: prompt }],
       }),
@@ -329,9 +332,17 @@ async function extractEventsWithAI(
 
       if (Array.isArray(parsed)) {
         for (const event of parsed) {
-          if (!event.url && batch[0]) {
-            event.url = messagePermalink(guildId, channelId, batch[0].id)
+          // Map the event back to its source message (1-based "msg" index)
+          // for author attribution and a permalink URL fallback.
+          const idx = typeof event.msg === 'number' ? event.msg - 1 : 0
+          const srcMsg = batch[idx] || batch[0]
+          if (srcMsg) {
+            event.postedBy = srcMsg.author?.username || ''
+            if (!event.url) {
+              event.url = messagePermalink(guildId, channelId, srcMsg.id)
+            }
           }
+          delete event.msg
           allEvents.push(event)
         }
       }
@@ -414,7 +425,68 @@ async function scrapeAndCache(
   const lastMessageId = messages.length > 0 ? messages[0].id : undefined
   await writeCache(guildId, channelId, events, meta, lastMessageId)
 
+  // Forward into the canonical event store (PRD event-source-architecture).
+  // cache-events computes visibility from the source's class ('curation' →
+  // private), runs the dedup ladder, and triggers enrichment.
+  try {
+    const forwarded = await forwardToCanonicalStore(events)
+    meta.canonicalStore = forwarded
+  } catch (err) {
+    console.error('Canonical store forward failed:', (err as Error).message)
+    meta.canonicalStore = { error: (err as Error).message }
+  }
+
   return { events, meta }
+}
+
+const AGAPE_SOURCE_ID = 'discord-agape-events'
+
+async function forwardToCanonicalStore(events: ExtractedEvent[]): Promise<Record<string, unknown>> {
+  if (events.length === 0) return { cached: 0, updated: 0 }
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+  const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+  const payload = events.map(ev => ({
+    source: AGAPE_SOURCE_ID,
+    date: ev.date,
+    time: ev.time || '',
+    name: ev.name,
+    venue: ev.venue || 'TBA',
+    address: ev.address || '',
+    city: ev.city || 'San Francisco',
+    genre: ev.genre || '',
+    price: ev.price || '',
+    ages: ev.ages || '',
+    promoter: ev.promoter || '',
+    url: ev.url,
+    postedBy: ev.postedBy || '',
+    recommendedBy: ['agape'],
+  }))
+
+  const resp = await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${serviceKey}`,
+    },
+    body: JSON.stringify({
+      events: payload,
+      sourceOutcomes: [{
+        sourceId: AGAPE_SOURCE_ID,
+        sourceName: 'Agape #events',
+        sourceUrl: 'discord://agape/#events',
+        sourceType: 'discord',
+        eventCount: events.length,
+        ok: true,
+      }],
+    }),
+  })
+  if (!resp.ok) {
+    throw new Error(`cache-events ${resp.status}: ${(await resp.text()).slice(0, 200)}`)
+  }
+  const result = await resp.json()
+  console.log(`Canonical store: cached=${result.cached} updated=${result.updated}`)
+  return { cached: result.cached, updated: result.updated, enrichQueued: result.enrichQueued }
 }
 
 // --- Main handler ---

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.3.1'
-console.log(`[scrape-events] v${VERSION} - record cache-events batch failures in scrape_runs error_log`)
+const VERSION = '1.4.0'
+console.log(`[scrape-events] v${VERSION} - registry-driven sources exclude discord type (handled by scrape-discord-events kick)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -71,6 +71,11 @@ async function loadSources(supabase: ReturnType<typeof createClient>): Promise<E
       .from('event_sources')
       .select('id, name, category, type, url, region, description')
       .eq('enabled', true)
+      // Curation feeds (type=discord) are scraped by scrape-discord-events,
+      // kicked at the end of this run — not by this dispatcher. Including
+      // them here would log a zero-result outcome every run and drive their
+      // source_health to 'broken'.
+      .neq('type', 'discord')
 
     if (error || !data || data.length === 0) {
       console.log(`[scrape-events] Registry unavailable (${error?.message || 'empty'}), falling back to STOCK_SOURCES`)

--- a/supabase/migrations/089_source_architecture.sql
+++ b/supabase/migrations/089_source_architecture.sql
@@ -1,0 +1,93 @@
+-- ============================================
+-- Source Architecture: classes, visibility, canonical URL, Agape curation
+-- Migration 089
+--
+-- Implements Phase 1 + 2 of docs/playground/events/strategy/prd-event-source-architecture.md:
+-- 1. event_sources.source_class + demoted: the 4-class source taxonomy
+-- 2. events.visibility: visibility-by-corroboration (private rows hidden from anon)
+-- 3. events.canonical_url / recommended_by / posted_by: URL-first dedup + curation fields
+-- 4. RLS: public read restricted to visibility='public'; anon write removed
+--    (the pipeline writes via service role; the client is read-only since v1.9)
+-- 5. Registry rows: discord-agape-events (curation) + Wave 2 venue backlog (disabled)
+-- 6. agape_coverage view: corroboration-rate metric
+-- ============================================
+
+-- 1. Source taxonomy
+ALTER TABLE event_sources
+  ADD COLUMN IF NOT EXISTS source_class TEXT NOT NULL DEFAULT 'discovery'
+    CHECK (source_class IN ('venue','community','discovery','public-ticketing','private-ticketing','curation')),
+  ADD COLUMN IF NOT EXISTS demoted BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE event_sources SET source_class = 'public-ticketing' WHERE id = 'ra-bayarea';
+UPDATE event_sources SET source_class = 'discovery'
+  WHERE id IN ('19hz-bayarea','19hz-losangeles','19hz-seattle','19hz-newyork',
+               'screenslate-sf','screenslate-nyc','garysguide-sf','garysguide-nyc','luma-sf');
+UPDATE event_sources SET source_class = 'venue'
+  WHERE id IN ('sf-punchline','cobbs-sf','citylights-sf','audium-sf');
+
+-- The Agape Discord channel: the curation layer. Its events are always private;
+-- its recommendation signal upgrades demoted-feed events to public (PRD §2.1/§3).
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class) VALUES
+  ('discord-agape-events', 'Agape #events', 'social', 'discord',
+   'discord://952961396121931838/952974850476085308', 'bay-area',
+   'Agape community #events channel (curation feed)', true, 'curation')
+ON CONFLICT (id) DO UPDATE SET source_class = 'curation', type = 'discord';
+
+-- 2. Event visibility + curation + canonical URL
+ALTER TABLE events
+  ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'public'
+    CHECK (visibility IN ('public','private')),
+  ADD COLUMN IF NOT EXISTS canonical_url TEXT,
+  ADD COLUMN IF NOT EXISTS recommended_by TEXT[],
+  ADD COLUMN IF NOT EXISTS posted_by TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_events_canonical_url ON events(canonical_url) WHERE canonical_url IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_visibility ON events(visibility) WHERE visibility = 'private';
+
+-- 3. RLS: anon/public sees only public rows; private rows (Agape-only events,
+-- demoted-feed events pending corroboration) require service role. Anon write
+-- policies are removed — only the service-role pipeline writes events.
+DROP POLICY IF EXISTS "Public read access" ON events;
+CREATE POLICY "Public read access" ON events FOR SELECT USING (visibility = 'public');
+DROP POLICY IF EXISTS "Anon insert access" ON events;
+DROP POLICY IF EXISTS "Anon update access" ON events;
+
+-- 4. Wave 2 venue-calendar backlog (PRD §5). Disabled pending feed verification;
+-- enabling one = verify feed type/URL, set type, flip enabled. No deploy needed.
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('grayarea-sf', 'Gray Area', 'art', 'html', 'https://grayarea.org/events/', 'bay-area', 'Art & technology events', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('internetarchive-sf', 'Internet Archive', 'tech', 'html', 'https://www.eventbrite.com/o/internet-archive-16483604818', 'bay-area', 'Internet Archive events (Eventbrite org page)', false, 'venue', 'Wave 2 backlog — Eventbrite org page (class venue per PRD §8.4)'),
+  ('thelab-sf', 'The Lab', 'art', 'html', 'https://www.thelab.org/upcoming', 'bay-area', 'Experimental art & performance', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('sfsymphony', 'SF Symphony', 'music', 'html', 'https://www.sfsymphony.org/Buy-Tickets/Calendar', 'bay-area', 'Symphony calendar', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('exploratorium-sf', 'Exploratorium After Dark', 'social', 'html', 'https://www.exploratorium.edu/visit/calendar', 'bay-area', 'After Dark & museum events', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('sfmoma-events', 'SFMOMA', 'art', 'sfmoma', 'https://www.sfmoma.org/events/', 'bay-area', 'Museum events', false, 'venue', 'Wave 2 backlog — sfmoma parser exists but disabled; re-verify'),
+  ('thechapel-sf', 'The Chapel', 'music', 'html', 'https://thechapelsf.com/music/', 'bay-area', 'Live music venue', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('thelostchurch-sf', 'The Lost Church', 'music', 'html', 'https://www.thelostchurch.com/', 'bay-area', 'Intimate live performance', false, 'venue', 'Wave 2 backlog — Salesforce-sites ticketing, may need headless'),
+  ('odc-sf', 'ODC Dance', 'theater', 'html', 'https://odc.dance/performances', 'bay-area', 'Dance performances', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('bottomofthehill-sf', 'Bottom of the Hill', 'music', 'html', 'https://www.bottomofthehill.com/calendar.html', 'bay-area', 'Live music venue', false, 'venue', 'Wave 2 backlog — static HTML calendar, good candidate'),
+  ('brickandmortar-sf', 'Brick & Mortar Music Hall', 'music', 'html', 'https://www.brickandmortarmusic.com/', 'bay-area', 'Live music venue', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('rickshawstop-sf', 'Rickshaw Stop', 'music', 'html', 'https://rickshawstop.com/', 'bay-area', 'Live music venue', false, 'venue', 'Wave 2 backlog — verify feed type'),
+  ('noisebridge-sf', 'Noisebridge', 'tech', 'ical', 'https://www.noisebridge.net/wiki/Category:Events', 'bay-area', 'Hackerspace events', false, 'community', 'Wave 3 — wiki calendar, verify iCal availability'),
+  ('frontiertower-sf', 'Frontier Tower', 'tech', 'ical', 'https://lu.ma/frontiertower', 'bay-area', 'Frontier Tower community events (Luma org)', false, 'community', 'Wave 3 — Luma org page, verify iCal entity id')
+ON CONFLICT (id) DO NOTHING;
+
+-- 5. Coverage metric (PRD Phase 2): corroboration rate of Agape events.
+-- security_invoker so anon callers see it through events RLS (i.e., not at all
+-- for private rows); intended consumer is the service role / dashboards.
+CREATE OR REPLACE VIEW agape_coverage WITH (security_invoker = on) AS
+SELECT
+  COUNT(*) AS agape_events,
+  COUNT(*) FILTER (WHERE corroborated) AS corroborated,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE corroborated) / NULLIF(COUNT(*), 0), 1) AS corroboration_pct
+FROM (
+  SELECT a.id,
+    EXISTS (
+      SELECT 1 FROM events p
+      WHERE p.source_id <> a.source_id
+        AND p.visibility = 'public'
+        AND (p.canonical_key = a.canonical_key
+             OR (p.canonical_url IS NOT NULL AND p.canonical_url = a.canonical_url))
+    ) AS corroborated
+  FROM events a
+  WHERE a.source_id = 'discord-agape-events'
+) sub;


### PR DESCRIPTION
Implements Phase 1 and most of Phase 2 of the [source architecture PRD](docs/playground/events/strategy/prd-event-source-architecture.md).

## Phase 1 — Foundation (complete)
- **Migration 089**: `source_class` (4-class taxonomy) + `demoted` on `event_sources`; `visibility`/`canonical_url`/`recommended_by`/`posted_by` on `events`; RLS public read restricted to `visibility='public'`, anon write removed; `discord-agape-events` registered as curation source
- **cache-events v1.6.0**: source-class-driven visibility; dedup ladder — URL-first canonical adoption (10 platform patterns), nightlife-venue-tier fuzzy matching, direction-agnostic corroboration upgrades
- **scrape-discord-events v1.3.0**: per-message attribution (`posted_by` + permalink fallback), forwards extracted events into the canonical store; ongoing ingestion runs via the existing 2h `scrape-events` kick
- **scrape-events v1.4.0**: registry loop excludes discord-type sources (prevents false 'broken' health)

## Phase 2 — Coverage (partial)
- Demotion machinery live (dormant until demoted feeds registered); demoted-platform parsers are follow-up stories
- Wave 2/3 venue backlog registered in `event_sources` (14 rows, disabled pending feed verification — enabling is an INSERT-level change, no deploy)
- `agape_coverage` view for the corroboration metric
- Fixed retired `claude-3-haiku-20240307` model in scrape-discord-events + enrich-event (silent extraction/enrichment failures); event-platform domains added to enrichment allowlist

## Verified live
- 8 Agape events ingested as private with `posted_by`/`recommended_by=['agape']`
- Anon key: 0 private rows visible, 2,312 public rows intact
- Enrichment classifying via Partiful/Luma pages (dj-set, live-music) with images

🤖 Generated with [Claude Code](https://claude.com/claude-code)