### PR TITLE
ladder 2.17.0: J&J visual system + naming (Inbox, Profile, In progress, nav drawer)

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -9,26 +9,40 @@ These are the Wise rules we follow strictly. Don't break them when adding compon
 1. **Sentence case only.** Never `text-transform: uppercase`. No tracked all-caps labels. Headings, button labels, navigation, table headers — all sentence case.
 2. **Inter for body, Inter SemiBold for display.** Wise Sans is Wise's display face but it's not freely distributable; we substitute Inter SemiBold and tighten letter-spacing on titles. If we ever ship Wise Sans we drop it into `--font-display`.
 3. **4px base spacing scale.** Use `var(--space-N)` only — 1=4, 2=8, 3=12, 4=16, 5=24, 6=32, 7=48, 8=64. No magic numbers.
-4. **Generous radius.** Wise's smallest desktop radius is 16px. Cards 30px, buttons pill (`--radius-pill: 999px`). Don't use `border-radius: 4px` anywhere — looks wrong.
+4. **Generous radius, two button shapes.** Smallest radius 16px; cards 20px (`--radius-lg`). Decision CTAs (`.btn--primary`, `.btn--accent`, review footer) are pills; every other button is a 16px rounded-rect. Circular (`--radius-pill`) is otherwise reserved for `.icon-btn` and chips. Don't use `border-radius: 4px` anywhere — looks wrong.
 5. **Forest Green and Bright Green own the brand — but only for actions.** Light theme: Forest Green (`#163300`) is `--accent` (interactive primary); Bright Green (`#9FE870`) is `--accent-strong`. Green is reserved for **the primary action on each screen** (accent CTAs, active fit pills in score modals). Active nav, tabs, and selected states are **neutral** (`--bg-overlay` + semibold), never green fills — one accented moment per screen. Red appears only on destructive/error surfaces, never in browse lists. Dark theme inverts: Forest is the base, Bright is the accent.
 6. **Token contract.** Every component reads `var(--bg)`, `var(--fg)`, `var(--accent)`, etc. Never hardcode hex values. The CTRL alternate must expose the same custom-property names.
-7. **No emoji or decorative icons unless the user adds them.**
+7. **No emoji or decorative icons unless the user adds them — with one scoped exception:** inline SVG line icons are permitted in **primary navigation only** (rail + mobile drawer; see `NAV_ICONS` in `ladder-rail.js`). Never in content, cards, lists, or buttons.
 
 ## Type scale (px)
 
 | Token | Size | Use |
 |-|-|-|
 | `--font-size-display` | 56 | landing headlines (none in /ladder yet) |
-| `--font-size-title-1` | 36 | page H1 |
-| `--font-size-title-2` | 28 | section H2, card titles |
+| `--font-size-title-1` | 28 | page H1 (bold, -0.02em) |
+| `--font-size-title-2` | 22 | section H2, card titles |
 | `--font-size-title-3` | 22 | sub-section H3 |
 | `--font-size-title-4` | 18 | small heading / strong label |
 | `--font-size-body-lg` | 18 | KB document body, lede |
 | `--font-size-body` | 16 | default body |
-| `--font-size-small` | 14 | meta, table cells |
+| `--font-size-small` | 15 | meta, table cells |
 | `--font-size-caption` | 12 | chips, captions |
 
 Line heights: `--lh-display: 1.1`, `--lh-title: 1.25`, `--lh-body: 1.55`, `--lh-tight: 1.35`.
+Weights: `--fw-medium: 500`, `--fw-semibold: 600`, `--fw-bold: 700` (page H1s + inbox group headers are bold).
+Light surfaces are warm-neutral: `--bg #FAFAF9`, `--bg-surface #F4F4F2` — no green tint; color comes from content and the single accent.
+
+## Naming (v2.17)
+
+Nav labels are one-word nouns in sentence case; URLs and DB status values never change when labels do.
+
+| Surface | Name | Notes |
+|-|-|-|
+| /ladder/jobs/recommended/ | **Inbox** | Top-level nav item (the daily loop), not under Jobs. Formerly "For You". |
+| /ladder/jobs/ buckets | **Saved · In progress · Archive** | Display labels; DB status values stay `Saved/Active/Archive` (`STATUS_LABELS` in ladder-pipeline.js). |
+| /ladder/history/ | **Profile** | Formerly "Your career". |
+| /ladder/vision/ | **Search plan** | Subpages: Targets · Signals · Rules · Sources. |
+| Page titles | `<Page> — Ladder` | No slash-prefix branding anywhere ("Ask Ladder", gate says "Ladder"). |
 
 ## Core patterns (v2.15)
 

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Chat — /ladder</title>
+  <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -15,7 +15,7 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
+      <h1>Ladder</h1>
       <p>Sign in to read your chat history.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -13,13 +13,26 @@
 }
 
 .nav-list a {
-  display: block;
-  padding: var(--space-3) var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 48px;
+  padding: 0 var(--space-4);
   border-radius: var(--radius-sm);
   color: var(--fg);
   font-weight: var(--fw-medium);
   font-size: var(--font-size-body);
 }
+.nav-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  color: inherit;
+}
+.nav-label { flex: 1; min-width: 0; }
+.nav-list a .nav-count { margin-left: auto; }
 .nav-list a:hover {
   background: var(--bg-elevated);
   text-decoration: none;
@@ -52,7 +65,9 @@
   outline: none;
 }
 
-/* --- Buttons --- */
+/* --- Buttons ---
+   Two shapes only (J&J): decision CTAs (accent/primary) are pills; every
+   other button is a 16px rounded-rect. */
 .btn {
   display: inline-flex;
   align-items: center;
@@ -60,7 +75,7 @@
   gap: var(--space-2);
   height: 48px;
   padding: 0 var(--space-5);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
   background: var(--bg-elevated);
   color: var(--fg);
@@ -75,6 +90,7 @@
   background: var(--accent);
   color: var(--accent-fg);
   border-color: var(--accent);
+  border-radius: var(--radius-pill);
 }
 .btn--primary:hover { background: var(--accent); filter: brightness(1.06); }
 
@@ -82,6 +98,7 @@
   background: var(--accent-strong);
   color: var(--accent-strong-fg);
   border-color: var(--accent-strong);
+  border-radius: var(--radius-pill);
 }
 .btn--accent:hover { filter: brightness(0.97); }
 
@@ -92,10 +109,8 @@
 .page-header h1 {
   margin: 0;
   font-family: var(--font-display);
-  font-weight: var(--fw-semibold);
-  /* Scales from 24px on phones to 36px on desktop. The static token
-     --font-size-title-1 is 36px; the clamp keeps that as the ceiling so
-     desktop is unchanged. */
+  font-weight: var(--fw-bold, 700);
+  /* Scales from 24px on phones to the title-1 token (28px) on desktop. */
   font-size: clamp(24px, 5.5vw, var(--font-size-title-1));
   line-height: var(--lh-title);
   letter-spacing: -0.02em;
@@ -5182,6 +5197,25 @@ job-onboarding { display: contents; }
    See <ladder-chat> component for state.
    ───────────────────────────────────────────────────────────── */
 
+/* Circular icon button — J&J's signature chrome. Hamburger, chat, close,
+   overflow all share this shape. */
+.icon-btn {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  flex-shrink: 0;
+  transition: box-shadow 80ms ease, transform 80ms ease;
+}
+.icon-btn:hover { box-shadow: var(--shadow-md); }
+.icon-btn:active { transform: translateY(1px); }
+
 /* Chat launcher — a fixed bubble in the top-right corner (J&J-style),
    never floating over list content. Neutral surface; the drawer it opens
    is the accented moment, not the button. */
@@ -6068,7 +6102,7 @@ body[data-auth-state="out"] job-chat { display: none; }
    dividers between rows. No scores, no inline accept/reject.
    ========================================================================== */
 /* Cap the reading column — J&J-style centered inbox, not a full-bleed table. */
-.inbox { display: flex; flex-direction: column; gap: var(--space-5); max-width: 760px; }
+.inbox { display: flex; flex-direction: column; gap: var(--space-6); max-width: 760px; }
 
 .inbox-group__head {
   display: flex;
@@ -6079,9 +6113,9 @@ body[data-auth-state="out"] job-chat { display: none; }
 .inbox-group__label {
   margin: 0;
   font-family: var(--font-display);
-  font-weight: var(--fw-semibold);
+  font-weight: var(--fw-bold, 700);
   font-size: var(--font-size-title-3);
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
 }
 .inbox-group__count { font-size: var(--font-size-small); }
 
@@ -6099,9 +6133,19 @@ body[data-auth-state="out"] job-chat { display: none; }
   align-items: center;
   gap: var(--space-3);
   padding: var(--space-3) 0;
+  position: relative;
+}
+/* Inset divider — starts after the logo column (J&J/iOS list pattern):
+   28px logo + 12px gap. */
+.inbox-row::after {
+  content: '';
+  position: absolute;
+  left: 40px;
+  right: 0;
+  bottom: 0;
   border-bottom: 1px solid var(--border);
 }
-.inbox-row:last-child { border-bottom: 0; }
+.inbox-row:last-child::after { display: none; }
 .inbox-row__main {
   display: flex;
   align-items: center;
@@ -6419,4 +6463,90 @@ body[data-auth-state="out"] job-chat { display: none; }
   margin: 0 0 var(--space-4);
   font-size: var(--font-size-body);
   line-height: var(--lh-body);
+}
+
+/* ==========================================================================
+   Mobile nav drawer — J&J-style left sheet opened by the .mobile-bar
+   hamburger. Same taxonomy as the desktop rail (see ladder-rail.js).
+   ========================================================================== */
+.nav-drawer__scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 15, 12, 0.45);
+  z-index: 70;
+}
+.nav-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: min(320px, 85vw);
+  z-index: 71;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-5) var(--space-4);
+  padding-top: max(var(--space-5), env(safe-area-inset-top));
+  padding-bottom: max(var(--space-5), env(safe-area-inset-bottom));
+  overflow-y: auto;
+}
+.nav-drawer[hidden], .nav-drawer__scrim[hidden] { display: none; }
+.nav-drawer__brand { margin-bottom: var(--space-6); }
+.nav-drawer__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  flex: 1;
+}
+.nav-drawer__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 48px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--fg);
+  font-weight: var(--fw-medium);
+  font-size: var(--font-size-body);
+  text-decoration: none;
+}
+.nav-drawer__item:hover { background: var(--bg-surface); text-decoration: none; }
+.nav-drawer__item[aria-current="page"] {
+  background: var(--bg-overlay);
+  font-weight: var(--fw-semibold);
+}
+.nav-drawer__item .nav-count { margin-left: auto; }
+.nav-drawer__user,
+.rail-user {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-5);
+  padding: var(--space-3) var(--space-3) 0;
+  border-top: 1px solid var(--border);
+  font-size: var(--font-size-caption);
+  color: var(--fg-muted);
+  min-width: 0;
+}
+.rail-user { margin-top: auto; }
+.rail-user__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent-strong);
+  flex-shrink: 0;
+}
+.rail-user__email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* Drawer is mobile chrome; never show it on desktop. */
+@media (min-width: 721px) {
+  .nav-drawer, .nav-drawer__scrim { display: none !important; }
 }

--- a/ladder/css/tokens-ctrl-dark.css
+++ b/ladder/css/tokens-ctrl-dark.css
@@ -51,6 +51,7 @@
 
   --fw-medium: 500;
   --fw-semibold: 600;
+  --fw-bold: 700;
 
   /* Radius */
   --radius-sm: 2px;

--- a/ladder/css/tokens-ctrl-light.css
+++ b/ladder/css/tokens-ctrl-light.css
@@ -52,6 +52,7 @@
 
   --fw-medium: 500;
   --fw-semibold: 600;
+  --fw-bold: 700;
 
   /* Radius — CTRL is hard-edged (no pill buttons, no 30px cards) */
   --radius-sm: 2px;

--- a/ladder/css/tokens-generic-dark.css
+++ b/ladder/css/tokens-generic-dark.css
@@ -36,13 +36,13 @@
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   --font-size-display: 56px;
-  --font-size-title-1: 36px;
-  --font-size-title-2: 28px;
+  --font-size-title-1: 28px;
+  --font-size-title-2: 22px;
   --font-size-title-3: 22px;
   --font-size-title-4: 18px;
   --font-size-body-lg: 18px;
   --font-size-body: 16px;
-  --font-size-small: 14px;
+  --font-size-small: 15px;
   --font-size-caption: 12px;
 
   --lh-display: 1.1;
@@ -52,11 +52,12 @@
 
   --fw-medium: 500;
   --fw-semibold: 600;
+  --fw-bold: 700;
 
   /* Radius */
   --radius-sm: 16px;
   --radius-md: 20px;
-  --radius-lg: 30px;
+  --radius-lg: 20px;
   --radius-xl: 40px;
   --radius-2xl: 60px;
   --radius-pill: 999px;

--- a/ladder/css/tokens-generic-light.css
+++ b/ladder/css/tokens-generic-light.css
@@ -3,8 +3,8 @@
    Wise Foundations color, spacing, and radius pages. */
 [data-theme="generic-light"] {
   /* Backgrounds */
-  --bg: #FFFFFF;                                   /* Background Screen */
-  --bg-surface: #F5F7F4;                           /* tinted neutral lift */
+  --bg: #FAFAF9;                                   /* warm off-white canvas (J&J) */
+  --bg-surface: #F4F4F2;                           /* neutral lift — no green tint */
   --bg-elevated: #FFFFFF;                          /* Background Elevated */
   --bg-overlay: rgba(22, 51, 0, 0.08);             /* Background Overlay */
 
@@ -36,13 +36,13 @@
   --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   --font-size-display: 56px;
-  --font-size-title-1: 36px;
-  --font-size-title-2: 28px;
+  --font-size-title-1: 28px;
+  --font-size-title-2: 22px;
   --font-size-title-3: 22px;
   --font-size-title-4: 18px;
   --font-size-body-lg: 18px;
   --font-size-body: 16px;
-  --font-size-small: 14px;
+  --font-size-small: 15px;
   --font-size-caption: 12px;
 
   --lh-display: 1.1;
@@ -52,11 +52,12 @@
 
   --fw-medium: 500;
   --fw-semibold: 600;
+  --fw-bold: 700;
 
   /* Radius — Wise desktop scale (rounded-by-default look) */
   --radius-sm: 16px;
   --radius-md: 20px;
-  --radius-lg: 30px;
+  --radius-lg: 20px;
   --radius-xl: 40px;
   --radius-2xl: 60px;
   --radius-pill: 999px;

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>History — /ladder</title>
+  <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
 
 
 
@@ -19,8 +19,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Your career — /ladder</title>
+  <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
 
 
 
@@ -19,8 +19,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -30,13 +30,13 @@
     <ladder-rail></ladder-rail>
     <main class="app__main">
       <header class="page-header">
-        <h1>Your career</h1>
+        <h1>Profile</h1>
       </header>
       <ladder-career></ladder-career>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
 
 
 
@@ -61,8 +61,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Role — /ladder</title>
+  <title>Role — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
 
 
 
@@ -20,8 +20,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Jobs — /ladder</title>
+  <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -15,8 +15,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>For You — /ladder</title>
+  <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -15,8 +15,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.16.0";
-console.log(`[ladder] v${VERSION} - header score pills + company description on review/detail; inbox max-width`);
+const VERSION = "2.17.0";
+console.log(`[ladder] v${VERSION} - J&J visual system: Inbox/Profile/In progress naming, nav icons + drawer, warm surfaces, bold titles, 20px cards`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -132,9 +132,9 @@ function injectFooter() {
 }
 
 // Inject a mobile top app bar at the start of <body>. CSS hides it on
-// >720px screens. The leading button is a back caret on every page except
-// the home dashboard at /ladder/, where it's omitted. Title comes from the
-// page's .page-header h1.
+// >720px screens. J&J-style: a circular hamburger opens the nav drawer on
+// every page (the drawer is the only mobile nav — no back caret). Title
+// comes from the page's .page-header h1.
 function injectMobileBar() {
   if (document.querySelector('.mobile-bar')) return;
   const app = document.querySelector('.app');
@@ -151,15 +151,92 @@ function injectMobileBar() {
   bar.className = 'mobile-bar';
   bar.dataset.home = isHome ? 'true' : 'false';
   bar.innerHTML = `
-    ${isHome
-      ? `<span class="mobile-bar__spacer" aria-hidden="true"></span>`
-      : `<a class="mobile-bar__back" href="/ladder/" aria-label="Back to home">‹</a>`}
+    <button class="icon-btn mobile-bar__menu-btn" aria-label="Open navigation" aria-expanded="false">
+      <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="17" x2="20" y2="17"/></svg>
+    </button>
     <span class="mobile-bar__title">${title}</span>
     <span class="mobile-bar__action-slot"></span>
   `;
   // Sit OUTSIDE .app__main so the bar can be edge-to-edge while main keeps
   // its own horizontal padding.
   document.body.insertBefore(bar, app);
+  bar.querySelector('.mobile-bar__menu-btn').addEventListener('click', () => toggleNavDrawer(true));
+  injectNavDrawer();
+}
+
+// Left-side nav drawer (mobile). Same taxonomy as the rail — keep the two
+// in sync by hand (see ROUTES in components/ladder-rail.js). Icons mirror
+// NAV_ICONS there; primary navigation is the only surface icons are
+// allowed on (DESIGN.md rule 7).
+const DRAWER_ITEMS = [
+  { href: '/ladder/jobs/recommended/', label: 'Inbox',       countKey: 'recommended', match: /^\/ladder\/jobs\/recommended\/?/,
+    icon: '<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>' },
+  { href: '/ladder/jobs/',             label: 'Jobs',        countKey: 'leads',       match: /^\/ladder\/jobs(?!\/recommended)\/?/,
+    icon: '<rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>' },
+  { href: '/ladder/history/',          label: 'Profile',     match: /^\/ladder\/history\/?/,
+    icon: '<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>' },
+  { href: '/ladder/vision/',           label: 'Search plan', match: /^\/ladder\/vision\/?/,
+    icon: '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/>' },
+  { href: '/ladder/settings/',         label: 'Settings',    match: /^\/ladder\/settings\/?/,
+    icon: '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>' },
+];
+
+function injectNavDrawer() {
+  if (document.querySelector('.nav-drawer')) return;
+  const here = location.pathname;
+  const drawer = document.createElement('div');
+  drawer.innerHTML = `
+    <div class="nav-drawer__scrim" hidden></div>
+    <nav class="nav-drawer" aria-label="Navigation" hidden>
+      <a class="brand nav-drawer__brand" href="/ladder/">
+        <span class="brand__mark" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6.5" y1="2.5" x2="6.5" y2="21.5"/><line x1="17.5" y1="2.5" x2="17.5" y2="21.5"/><line x1="6.5" y1="7" x2="17.5" y2="7"/><line x1="6.5" y1="12" x2="17.5" y2="12"/><line x1="6.5" y1="17" x2="17.5" y2="17"/></svg>
+        </span>
+        <span class="brand__text">Ladder</span>
+      </a>
+      <ul class="nav-drawer__list">
+        ${DRAWER_ITEMS.map(i => `
+          <li>
+            <a class="nav-drawer__item" href="${i.href}" aria-current="${i.match.test(here) ? 'page' : 'false'}">
+              <span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">${i.icon}</svg></span>
+              <span class="nav-label">${i.label}</span>
+              ${i.countKey ? `<span class="nav-count" data-count="${i.countKey}" hidden></span>` : ''}
+            </a>
+          </li>`).join('')}
+      </ul>
+      <div class="nav-drawer__user">
+        <span class="rail-user__dot" aria-hidden="true"></span>
+        <span class="rail-user__email"></span>
+      </div>
+    </nav>
+  `;
+  while (drawer.firstChild) document.body.appendChild(drawer.firstChild);
+  document.querySelector('.nav-drawer__scrim').addEventListener('click', () => toggleNavDrawer(false));
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') toggleNavDrawer(false); });
+  const email = window.CtrlAuth?.getUser?.()?.email || '';
+  const emailEl = document.querySelector('.nav-drawer__user .rail-user__email');
+  if (email) emailEl.textContent = email;
+  else document.querySelector('.nav-drawer__user').hidden = true;
+  // Counts arrive from the rail's broadcast.
+  document.addEventListener('job:rail:counts', (e) => {
+    for (const el of document.querySelectorAll('.nav-drawer [data-count]')) {
+      const n = e.detail?.[el.getAttribute('data-count')];
+      if (n == null) { el.hidden = true; continue; }
+      el.hidden = false;
+      el.textContent = String(n);
+    }
+  });
+}
+
+function toggleNavDrawer(open) {
+  const drawer = document.querySelector('.nav-drawer');
+  const scrim = document.querySelector('.nav-drawer__scrim');
+  const btn = document.querySelector('.mobile-bar__menu-btn');
+  if (!drawer || !scrim) return;
+  drawer.hidden = !open;
+  scrim.hidden = !open;
+  if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+  document.body.style.overflow = open ? 'hidden' : '';
 }
 
 // Inject the mobile segmented sub-nav (sticky under mobile-bar). Only
@@ -184,26 +261,24 @@ function injectSubnavBar() {
 
   const row = bar.querySelector('.subnav-bar__row');
   const here = location.pathname;
-  const isJobs = /^\/ladder\/jobs\/?/.test(here);
+  // Pipeline buckets only — the Inbox is its own top-level page now, so
+  // /ladder/jobs/recommended/ gets no segmented sub-nav.
+  const isJobs = /^\/ladder\/jobs(?!\/recommended)\/?/.test(here) && !/^\/ladder\/jobs\/drill/.test(here);
 
   if (!isJobs) {
     bar.dataset.hasItems = 'false';
     return;
   }
 
-  // Keep in sync with ROUTES[0].sub in components/ladder-rail.js.
+  // Keep in sync with the Jobs sub-items in components/ladder-rail.js.
   const ITEMS = [
-    { href: '/ladder/jobs/recommended/',    label: 'For You', path: '/ladder/jobs/recommended/', countKey: 'recommended' },
-    { href: '/ladder/jobs/?bucket=leads',   label: 'Saved',   bucket: 'leads',                countKey: 'leads' },
-    { href: '/ladder/jobs/?bucket=active',  label: 'Active',  bucket: 'active',               countKey: 'active' },
-    { href: '/ladder/jobs/?bucket=archive', label: 'Archive', bucket: 'archive' },
+    { href: '/ladder/jobs/?bucket=leads',   label: 'Saved',       bucket: 'leads',  countKey: 'leads' },
+    { href: '/ladder/jobs/?bucket=active',  label: 'In progress', bucket: 'active', countKey: 'active' },
+    { href: '/ladder/jobs/?bucket=archive', label: 'Archive',     bucket: 'archive' },
   ];
   const bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
-  const onSubPath = ITEMS.some(i => i.path && here.startsWith(i.path));
   row.innerHTML = ITEMS.map(i => {
-    const active = i.path
-      ? here.startsWith(i.path)
-      : (!onSubPath && bucket === i.bucket);
+    const active = bucket === i.bucket;
     return `<a class="subnav-bar__item" href="${i.href}" aria-current="${active ? 'page' : 'false'}"
               data-count-key="${i.countKey || ''}">
               <span class="subnav-bar__label">${i.label}</span>

--- a/ladder/js/components/ladder-chat.js
+++ b/ladder/js/components/ladder-chat.js
@@ -221,7 +221,7 @@ export class JobChat extends LitElement {
         <div class="chat-scrim" @click=${() => this._toggle()} aria-hidden="true"></div>
         <aside class="chat-drawer" role="dialog" aria-label="Job chat">
           <header class="chat-drawer__head">
-            <span class="chat-drawer__title">Ask /ladder</span>
+            <span class="chat-drawer__title">Ask Ladder</span>
             <button class="chat-drawer__close" aria-label="Close" @click=${() => this._toggle()}>×</button>
           </header>
 

--- a/ladder/js/components/ladder-home.js
+++ b/ladder/js/components/ladder-home.js
@@ -88,8 +88,8 @@ export class JobHome extends LitElement {
     const c = this.counts || { leads: '—', active: '—', recommended: '—' };
     return html`
       <section class="home">
-        <h1 class="home__title">/ job</h1>
-        <p class="home__sub">Ian's career knowledge base.</p>
+        <h1 class="home__title">Ladder</h1>
+        <p class="home__sub">Your career, one place.</p>
 
         <a class="home-card home-card--jobs" href="/ladder/jobs/">
           <div class="home-card__head">
@@ -97,9 +97,9 @@ export class JobHome extends LitElement {
             <span class="home-card__arrow" aria-hidden="true">→</span>
           </div>
           <div class="home-card__metrics">
-            <span><strong>${c.recommended}</strong> for you</span>
+            <span><strong>${c.recommended}</strong> inbox</span>
             <span><strong>${c.leads}</strong> saved</span>
-            <span><strong>${c.active}</strong> active</span>
+            <span><strong>${c.active}</strong> in progress</span>
           </div>
           ${this.topRecs && this.topRecs.length ? html`
             <div class="home-card__list">
@@ -110,7 +110,7 @@ export class JobHome extends LitElement {
 
         <a class="home-card" href="/ladder/history/">
           <div class="home-card__head">
-            <h2>Your career</h2>
+            <h2>Profile</h2>
             <span class="home-card__arrow" aria-hidden="true">→</span>
           </div>
           <p class="home-card__hint">Companies, roles, and the narratives that go in your résumé.</p>

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -13,6 +13,9 @@ const { renderLocation } = await import('../format.js' + V);
 //   active → 'Active'  (with sub-stage: drafting/applied/interviewing/offer)
 //   archive→ 'Archive' (with exit_reason)
 const STATUS_OPTIONS = ['Saved', 'Active', 'Archive'];
+// Display labels for status values — the DB keeps 'Active'; the UI says
+// 'In progress' (clearer state pair with Saved/Archive).
+const STATUS_LABELS = { Saved: 'Saved', Active: 'In progress', Archive: 'Archive' };
 
 const STAGES = [
   { id: 'drafting',     label: 'Drafting' },
@@ -646,12 +649,12 @@ export class JobPipeline extends LitElement {
                       class=${'row-menu__item row-menu__item--status' + (cur === s ? ' is-current' : '')}
                       @click=${() => this._changeStatusFromMenu(r, s)}>
                 <span class="row-menu__check" aria-hidden="true">${cur === s ? '✓' : ''}</span>
-                <span>${s}</span>
+                <span>${STATUS_LABELS[s] || s}</span>
               </button>
             `)}
             ${cur === 'Active' ? html`
               <div class="row-menu__divider" role="separator"></div>
-              <div class="row-menu__group-label">Active stage</div>
+              <div class="row-menu__group-label">Stage</div>
               ${STAGES.map(s => html`
                 <button role="menuitem"
                         class=${'row-menu__item row-menu__item--stage' + (curStage === s.id ? ' is-current' : '')}
@@ -1216,7 +1219,7 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._sorted();
-    const bucketLabel = { leads: 'Saved', active: 'Active', archive: 'Archive' }[this.bucket];
+    const bucketLabel = { leads: 'Saved', active: 'In progress', archive: 'Archive' }[this.bucket];
     const added = this.addedBanner?.roles || [];
     const showAddedBanner = added.length > 0 && !this.addedBanner.dismissed;
 

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -1,7 +1,9 @@
 // job-rail — left rail nav. Light DOM (uses global tokens/components.css).
-// Theme toggle now lives in <ladder-footer> at the bottom of the page.
+// J&J-style: line icons (primary nav only — DESIGN.md rule 7 amendment),
+// 48px rows, right-aligned count badges, user identity pinned at the bottom.
 // Pages compose: <div class="app"><ladder-rail></ladder-rail><main class="app__main">…</main><ladder-footer></ladder-footer></div>
-import { LitElement, html } from 'https://esm.run/lit@3';
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
 const [{ fetchPipeline, fetchRecommendations }] = await Promise.all([
   import('../pipeline.js' + V),
@@ -24,28 +26,39 @@ function isVisibleRole(r) {
   return true;
 }
 
-// Each Jobs sub-item is either a bucket-filter on /ladder/jobs/ (matched
-// by `bucket`) or a real sub-page (matched by `path` prefix). The
-// renderer below uses `path ? prefix-match : bucket-equality` to decide
-// aria-current — so when we're on a sub-page like /ladder/jobs/recommended/,
-// none of the bucket items light up.
-//
-// `countKey` says which count to show; Archive deliberately omits it.
+// Primary-nav line icons — 20px, 1.8 stroke, inherit currentColor.
+// The ONLY place icons are allowed (DESIGN.md rule 7). Keep in sync with
+// the mobile drawer copy in app.js.
+export const NAV_ICONS = {
+  inbox: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>`,
+  jobs: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
+  profile: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`,
+  plan: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>`,
+  settings: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
+};
+
+// Nav taxonomy: Inbox is top-level (the daily loop shouldn't hide under
+// Jobs); Jobs holds the pipeline buckets. Sub-items are either a
+// bucket-filter on /ladder/jobs/ (matched by `bucket`) or a real sub-page
+// (matched by `path` prefix). `countKey` says which count to show.
+// Bucket VALUES ('active') are the data model; labels are display-only.
 const ROUTES = [
+  { href: '/ladder/jobs/recommended/', label: 'Inbox', icon: 'inbox',
+    match: /^\/ladder\/jobs\/recommended\/?/, countKey: 'recommended' },
   {
     href: '/ladder/jobs/',
     label: 'Jobs',
-    match: /^\/ladder\/jobs\/?/,
+    icon: 'jobs',
+    match: /^\/ladder\/jobs(?!\/recommended)\/?/,
     sub: [
-      { href: '/ladder/jobs/recommended/',      label: 'For You',              path: '/ladder/jobs/recommended/', countKey: 'recommended' },
-      { href: '/ladder/jobs/?bucket=leads',     label: 'Saved',                bucket: 'leads',                countKey: 'leads' },
-      { href: '/ladder/jobs/?bucket=active',    label: 'Active',               bucket: 'active',               countKey: 'active' },
-      { href: '/ladder/jobs/?bucket=archive',   label: 'Archive',              bucket: 'archive' },
+      { href: '/ladder/jobs/?bucket=leads',     label: 'Saved',       bucket: 'leads',   countKey: 'leads' },
+      { href: '/ladder/jobs/?bucket=active',    label: 'In progress', bucket: 'active',  countKey: 'active' },
+      { href: '/ladder/jobs/?bucket=archive',   label: 'Archive',     bucket: 'archive' },
     ],
   },
-  { href: '/ladder/history/',  label: 'Your career', match: /^\/ladder\/history\/?/ },
-  { href: '/ladder/vision/',   label: 'Search plan', match: /^\/ladder\/vision\/?/ },
-  { href: '/ladder/settings/', label: 'Settings',    match: /^\/ladder\/settings\/?/ }
+  { href: '/ladder/history/',  label: 'Profile',     icon: 'profile',  match: /^\/ladder\/history\/?/ },
+  { href: '/ladder/vision/',   label: 'Search plan', icon: 'plan',     match: /^\/ladder\/vision\/?/ },
+  { href: '/ladder/settings/', label: 'Settings',    icon: 'settings', match: /^\/ladder\/settings\/?/ }
 ];
 
 export class JobRail extends LitElement {
@@ -55,6 +68,7 @@ export class JobRail extends LitElement {
     path:   { state: true },
     bucket: { state: true },
     counts: { state: true },        // { leads, active, recommended } or null
+    email:  { state: true },
   };
 
   constructor() {
@@ -62,8 +76,12 @@ export class JobRail extends LitElement {
     this.path = location.pathname;
     this.bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
     this.counts = null;
+    this.email = window.CtrlAuth?.getUser?.()?.email || '';
     this._onBucket = (e) => { this.bucket = e.detail.bucket; };
-    this._onAuth = () => this._loadCounts();
+    this._onAuth = (e) => {
+      this.email = e?.detail?.email || window.CtrlAuth?.getUser?.()?.email || this.email;
+      this._loadCounts();
+    };
     this._onRefresh = () => this._loadCounts({ force: true });
   }
 
@@ -73,7 +91,7 @@ export class JobRail extends LitElement {
     document.addEventListener('ctrl:auth:signedin', this._onAuth);
     document.addEventListener('job:auth:ready', this._onAuth);
     // Other components emit this after they add/dismiss a role; refresh
-    // our counts so the sub-nav numbers stay truthful.
+    // our counts so the nav numbers stay truthful.
     document.addEventListener('job:pipeline:refresh', this._onRefresh);
     if (document.body.dataset.authState === 'in') this._loadCounts();
   }
@@ -87,7 +105,7 @@ export class JobRail extends LitElement {
 
   // Fetch both pipeline + active recs in parallel. Cheap (already cached
   // server-side for the pages that use them); the result drives the
-  // count chips next to Saved / Active / Recommended for you.
+  // count chips next to Inbox / Saved / In progress.
   async _loadCounts({ force = false } = {}) {
     if (document.body.dataset.authState !== 'in') return;
     if (!force && this._loading) return;
@@ -95,8 +113,8 @@ export class JobRail extends LitElement {
     try {
       const [pipe, recs] = await Promise.all([
         fetchPipeline().catch(() => null),
-        // floor=1 so the badge matches what the For You page actually
-        // shows by default (fit >= 50, strength >= 50, no hard fails).
+        // floor=1 so the badge matches what the Inbox actually shows by
+        // default (fit >= 50, strength >= 50, no hard fails).
         // limit:1 — we only need `total`, not a page of rows.
         fetchRecommendations({ view: 'all', floor: true, limit: 1 }).catch(() => null),
       ]);
@@ -107,8 +125,8 @@ export class JobRail extends LitElement {
       // returned page size (caps at the server's page limit, e.g. 100).
       const recommended = recs?.total ?? recs?.count ?? (recs?.recommendations?.length ?? 0);
       this.counts = { leads, active, recommended };
-      // Broadcast so other mobile chrome (the segmented .subnav-bar in
-      // app.js) can pull the same counts without re-fetching.
+      // Broadcast so other mobile chrome (the drawer + segmented .subnav-bar
+      // in app.js) can pull the same counts without re-fetching.
       document.dispatchEvent(new CustomEvent('job:rail:counts', { detail: this.counts }));
     } finally {
       this._loading = false;
@@ -124,6 +142,9 @@ export class JobRail extends LitElement {
   }
 
   render() {
+    // A path-anchored top-level route (Inbox) wins over prefix routes
+    // (Jobs) so both never light up at once.
+    const inboxActive = ROUTES[0].match.test(this.path);
     return html`
       <aside class="app__rail">
         <a class="brand" href="/ladder/">
@@ -140,25 +161,20 @@ export class JobRail extends LitElement {
         </a>
         <nav>
           <ul class="nav-list">
-            ${ROUTES.map(r => {
-              const active = r.match.test(this.path);
+            ${ROUTES.map((r, i) => {
+              const active = r.match.test(this.path) && !(i > 0 && inboxActive);
               return html`
                 <li>
                   <a href=${r.href}
                      aria-current=${active ? 'page' : 'false'}>
-                    ${r.label}
+                    ${r.icon ? html`<span class="nav-icon" aria-hidden="true">${unsafeHTML(NAV_ICONS[r.icon])}</span>` : nothing}
+                    <span class="nav-label">${r.label}</span>
+                    ${this._renderCount(r.countKey)}
                   </a>
                   ${active && r.sub ? html`
                     <ul class="nav-sublist">
                       ${r.sub.map(s => {
-                        // Path-based sub-items (real sub-pages) win out
-                        // over bucket-based ones — when we're on
-                        // /ladder/jobs/recommended/, no bucket should look
-                        // active.
-                        const onSubPath = r.sub.some(x => x.path && this.path.startsWith(x.path));
-                        const subActive = s.path
-                          ? this.path.startsWith(s.path)
-                          : (!onSubPath && this.bucket === s.bucket);
+                        const subActive = this.bucket === s.bucket;
                         return html`
                           <li>
                             <a href=${s.href} aria-current=${subActive ? 'page' : 'false'}>
@@ -175,6 +191,12 @@ export class JobRail extends LitElement {
             })}
           </ul>
         </nav>
+        ${this.email ? html`
+          <div class="rail-user">
+            <span class="rail-user__dot" aria-hidden="true"></span>
+            <span class="rail-user__email">${this.email}</span>
+          </div>
+        ` : nothing}
       </aside>
     `;
   }

--- a/ladder/js/components/ladder-rec-detail.js
+++ b/ladder/js/components/ladder-rec-detail.js
@@ -126,7 +126,7 @@ export class LadderRecDetail extends LitElement {
     }
     if (this.dismissed) {
       return html`<div class="rec-detail__banner">
-        Dismissed. <a href="/ladder/jobs/recommended/">Back to For You →</a>
+        Dismissed. <a href="/ladder/jobs/recommended/">Back to Inbox →</a>
       </div>`;
     }
     return nothing;
@@ -157,7 +157,7 @@ export class LadderRecDetail extends LitElement {
     if (this.state === 'error' || !this.rec) {
       return html`<div class="rec-detail">
         <p class="muted">Couldn't load this recommendation. ${this.error}</p>
-        <a href="/ladder/jobs/recommended/">Back to For You →</a>
+        <a href="/ladder/jobs/recommended/">Back to Inbox →</a>
       </div>`;
     }
     const rec = this.rec;

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -1,4 +1,4 @@
-// ladder-recommendations-table — the For You inbox at /ladder/jobs/recommended/.
+// ladder-recommendations-table — the Inbox at /ladder/jobs/recommended/.
 // New roles arrive in small date-stamped batches (Today / Yesterday / Jun 12),
 // one "Review" affordance per row, and every decision happens inside the
 // full-screen <ladder-review-overlay> — no inline accept/reject, no numeric
@@ -338,7 +338,7 @@ export class JobRecommendationsTable extends LitElement {
     try {
       await watchCompany({ company });
       document.dispatchEvent(new CustomEvent('job:watch:added', { detail: { company } }));
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — its careers page feeds For You now` } }));
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — its careers page feeds your Inbox now` } }));
     } catch (e) {
       document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: e.message || `Couldn't watch ${company}` } }));
       console.warn('[recs-table] watchCompany failed', e);
@@ -549,7 +549,7 @@ export class JobRecommendationsTable extends LitElement {
     if (this.state === 'idle' || this.state === 'loading') {
       return html`
         <header class="recs-page__head">
-          <h1>For You</h1>
+          <h1>Inbox</h1>
         </header>
         <section class="inbox-group" aria-hidden="true">
           <header class="inbox-group__head">
@@ -578,7 +578,7 @@ export class JobRecommendationsTable extends LitElement {
     const rows = this._sorted();
     return html`
       <header class="recs-page__head">
-        <h1>For You</h1>
+        <h1>Inbox</h1>
         <span class="muted">${this._total > rows.length
           ? `${rows.length} of ${this._total} roles`
           : `${rows.length} ${rows.length === 1 ? 'role' : 'roles'}`}</span>

--- a/ladder/js/components/ladder-review-overlay.js
+++ b/ladder/js/components/ladder-review-overlay.js
@@ -226,7 +226,7 @@ export class LadderReviewOverlay extends LitElement {
             Not for me
           </button>
           <button class="btn btn--accent review__btn" @click=${() => this._emit('review-save')}>
-            Save role
+            Save
           </button>
         </footer>
 

--- a/ladder/js/components/ladder-watched-companies.js
+++ b/ladder/js/components/ladder-watched-companies.js
@@ -12,7 +12,7 @@ const [{ fetchWatchedCompanies, watchCompany, updateWatchedCompany, unwatchCompa
 const FILTER_MODES = [
   { value: 'all',         label: 'Any role',        hint: 'Every role the watch pulls, regardless of score' },
   { value: 'role_level',  label: 'My role & level', hint: 'Roles that match your role and seniority — no fit-score floor' },
-  { value: 'good_fits',   label: 'Good fits',       hint: 'Standard For You gates (fit ≥50, strength ≥30)' },
+  { value: 'good_fits',   label: 'Good fits',       hint: 'Standard Inbox gates (fit ≥50, strength ≥30)' },
   { value: 'exceptional', label: 'Exceptional only', hint: 'Only roles graded 60+ candidate strength' },
 ];
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Not authorized — /ladder</title>
+  <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.16.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.17.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Settings — /ladder</title>
+  <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -16,7 +16,7 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
+      <h1>Ladder</h1>
       <p>Sign in to view settings.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Search plan — /ladder</title>
+  <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.16.0">
-  <script src="/ladder/js/theme.js?v=2.16.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <script src="/ladder/js/theme.js?v=2.17.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -15,8 +15,8 @@
 
   <section id="signin-gate" class="gate">
     <div class="gate__card">
-      <h1>/ladder</h1>
-      <p>Ian's career knowledge base and pipeline. Sign in to continue.</p>
+      <h1>Ladder</h1>
+      <p>Your career, one place. Sign in to continue.</p>
       <button class="btn btn--primary" id="signin-btn">Sign in</button>
       <div id="ctrl-auth-root"></div>
     </div>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.16.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## What

Approved naming + visual-system pass to align Ladder with Jack & Jill:

**Naming** (labels only — URLs and DB status values untouched): For You → **Inbox** (now top-level nav), Active → **In progress** (display label), Your career → **Profile**, home/gate/page-title branding → **Ladder** (no slash-prefix), "Ask Ladder", review footer "Save".

**Visual system**: bold 28px page titles, 22px section titles, 15px meta; 20px cards; two button shapes (pill CTAs, 16px rounded-rect everything else); `.icon-btn` circular primitive; warm neutral canvas (#FAFAF9) with green tint removed from surfaces; line icons in primary nav only (DESIGN.md rule 7 amended, scoped); mobile hamburger **nav drawer** replaces the back caret; desktop rail restyled (icon rows, right-aligned counts, identity footer); inset inbox dividers.

## Testing
- All touched modules pass ESM syntax check.
- Fixture smoke (Chrome, mobile + desktop): inbox rendering, rail icons/counts/footer, bold headers, card radius, warm surfaces all verified.
- Post-merge: verify drawer + subnav on prod (auth-gated chrome), plus Saved bucket labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)