### PR TITLE
ladder 2.18.0: Search plan subpages (summary + Targets/Signals/Rules/Sources)

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -56,6 +56,7 @@ The For You surface follows a **triage, don't browse** model (inbox → review �
 | Collapsed JD | `.jd-collapse` | Raw scraped posting text is never the reading surface; it collapses behind "Original posting text". Summaries and match bullets lead. |
 | Page ⋯ menu | `.page-menu` | Operational controls (refresh sources, quality-floor toggle, expiry info) live behind one ⋯ in the page header — machinery stays out of the reading flow. Sourcing config (watched companies) lives on /ladder/vision/. |
 | Chat launcher | `.chat-fab` | Fixed 44px bubble top-right on every page (neutral surface, chat glyph). Never a floating bottom FAB over list content. |
+| Search plan | `.vf-tabs`, `.vf-summary` | Landing = summary view: plan-strength bar + one tappable digest row per section. Sections (Targets · Signals · Rules · Sources) switch via `?section=`. Advanced (score weights, raw plan, unknown fields) folds at the bottom of Signals; Story lives on Profile → Narratives. |
 
 ## Cache busting
 

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -6550,3 +6550,108 @@ body[data-auth-state="out"] job-chat { display: none; }
 @media (min-width: 721px) {
   .nav-drawer, .nav-drawer__scrim { display: none !important; }
 }
+
+/* ==========================================================================
+   Search plan (v2.18) — summary landing + Targets/Signals/Rules/Sources
+   tabs switched by ?section= (same pattern as Jobs ?bucket=).
+   ========================================================================== */
+.vf-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+.vf-tabs .subnav-bar__item {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-medium);
+}
+.vf-tabs .subnav-bar__item[aria-current="page"] {
+  background: var(--bg-overlay);
+  color: var(--fg);
+  font-weight: var(--fw-semibold);
+}
+.vf-summary { max-width: 760px; }
+.vf-summary__strength {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-5);
+}
+.vf-summary__label { font-size: var(--font-size-body); }
+.vf-summary__bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-overlay);
+  overflow: hidden;
+}
+.vf-summary__bar span {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent-strong);
+}
+.vf-summary__list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.vf-summary__list li { position: relative; }
+.vf-summary__list li::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-bottom: 1px solid var(--border);
+}
+.vf-summary__list li:last-child::after { display: none; }
+.vf-summary__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  min-height: 64px;
+  padding: var(--space-3) 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+}
+.vf-summary__row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.vf-summary__row-label {
+  font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body);
+}
+.vf-summary__row-digest {
+  color: var(--fg-subtle);
+  font-size: var(--font-size-small);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vf-summary__row-arrow { color: var(--fg-subtle); flex-shrink: 0; }
+.vf-section__hint { margin: 0 0 var(--space-4); font-size: var(--font-size-small); }
+.vf-advanced { margin-top: var(--space-5); }
+.vf-story-note { margin-top: var(--space-5); font-size: var(--font-size-small); }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.17.0";
-console.log(`[ladder] v${VERSION} - J&J visual system: Inbox/Profile/In progress naming, nav icons + drawer, warm surfaces, bold titles, 20px cards`);
+const VERSION = "2.18.0";
+console.log(`[ladder] v${VERSION} - Search plan subpages: summary landing + Targets/Signals/Rules/Sources; Story on Profile`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-vision.js
+++ b/ladder/js/components/ladder-vision.js
@@ -15,22 +15,33 @@ import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const FN_URL = `${SUPABASE_URL}/functions/v1/vision-field`;
 
-// Field grouping. Each section lists the canonical field names that
-// belong to it. Anything not listed below falls into 'Other'.
-const SECTIONS = [
-  { id: 'narrative', label: 'Narrative + voice',
-    names: ['narrative_arc', 'voice_rules_md'] },
+// Search-plan taxonomy (v2.18): four subpages switched by ?section=,
+// reusing the Jobs ?bucket= pattern. Landing (no param) is a summary view
+// with a plan-strength chip and one tappable digest row per section.
+//   Targets — what a good role looks like (facts)
+//   Signals — what the grader rewards (taste)
+//   Rules   — hard gates that auto-drop a role
+//   Sources — where roles come from (watched companies + Gmail)
+// Story fields (narrative_arc, voice_rules_md) live on Profile → Narratives,
+// not here; Advanced (score_weights, raw_md) collapses at the bottom of
+// Signals. Unknown fields fall into that same Advanced fold.
+const TABS = [
   { id: 'targets', label: 'Targets',
-    names: ['target_titles', 'target_stages', 'target_sectors', 'target_geographies'] },
-  { id: 'mission', label: 'Mission + culture',
+    hint: 'What a good role looks like — titles, stage, sector, geography, comp.',
+    names: ['target_titles', 'target_stages', 'target_sectors', 'target_geographies', 'comp_floor_base', 'comp_floor_total'] },
+  { id: 'signals', label: 'Signals',
+    hint: 'What the recommendation grader rewards — mission, culture, interests.',
     names: ['mission_keywords', 'mission_required', 'anti_mission_terms', 'culture_keywords', 'interest_tags', 'impact_themes'] },
-  { id: 'comp', label: 'Compensation',
-    names: ['comp_floor_base', 'comp_floor_total'] },
-  { id: 'filters', label: 'Filters',
+  { id: 'rules', label: 'Rules',
+    hint: 'Hard gates — anything here auto-drops a role.',
     names: ['deal_breakers', 'blocked_titles', 'must_have_keywords'] },
-  { id: 'advanced', label: 'Advanced',
-    names: ['score_weights', 'raw_md'] },
+  { id: 'sources', label: 'Sources',
+    hint: 'Where roles come from — watched companies and Gmail scanning.',
+    names: [] },
 ];
+const ADVANCED_FIELDS = ['score_weights', 'raw_md'];
+// Story lives on Profile — never render these here.
+const STORY_FIELDS = ['narrative_arc', 'voice_rules_md'];
 
 function relTime(iso) {
   if (!iso) return '';
@@ -61,6 +72,7 @@ export class JobVision extends LitElement {
     drafts:  { state: true },     // { [name]: draft value } — edit-in-progress
     saving:  { state: true },     // Set<name>
     flash:   { state: true },     // { [name]: 'saved' | 'error' }
+    section: { state: true },     // active tab id or null (summary landing)
   };
 
   constructor() {
@@ -71,6 +83,16 @@ export class JobVision extends LitElement {
     this.drafts = {};
     this.saving = new Set();
     this.flash = {};
+    const s = new URLSearchParams(location.search).get('section');
+    this.section = TABS.some(t => t.id === s) ? s : null;
+  }
+
+  _setSection(id) {
+    this.section = id;
+    const url = new URL(location.href);
+    if (id) url.searchParams.set('section', id);
+    else url.searchParams.delete('section');
+    history.replaceState(null, '', url.pathname + url.search);
   }
 
   connectedCallback() {
@@ -304,30 +326,139 @@ export class JobVision extends LitElement {
     `;
   }
 
-  _renderSection(section) {
-    const present = section.names.filter((n) => this.fields[n]);
-    if (!present.length) return nothing;
+  // ── Summary landing + tabs ───────────────────────────────────────────
+
+  _isFilled(name) {
+    const v = this.fields[name]?.value;
+    if (v == null) return false;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === 'string') return v.trim().length > 0;
+    if (typeof v === 'boolean') return true;
+    return true;
+  }
+
+  // Plan strength = completeness across the core (non-Sources) fields.
+  _strength() {
+    const core = TABS.flatMap(t => t.names).filter(n => this.fields[n] && this.fields[n].kind !== 'bool');
+    if (!core.length) return { label: 'Getting started', pct: 0 };
+    const filled = core.filter(n => this._isFilled(n)).length;
+    const pct = filled / core.length;
+    const label = pct >= 0.8 ? 'Strong' : pct >= 0.5 ? 'Good' : 'Getting started';
+    return { label, pct };
+  }
+
+  _arr(name) {
+    const v = this.fields[name]?.value;
+    return Array.isArray(v) ? v : [];
+  }
+
+  _digest(tab) {
+    if (tab.id === 'targets') {
+      const bits = [];
+      const titles = this._arr('target_titles');
+      if (titles.length) bits.push(titles.slice(0, 3).join(', ') + (titles.length > 3 ? ` +${titles.length - 3}` : ''));
+      const stages = this._arr('target_stages');
+      if (stages.length) bits.push(stages.slice(0, 3).join(' / '));
+      const floor = this.fields.comp_floor_base?.value;
+      if (floor) bits.push(`$${Math.round(floor / 1000)}k+ base`);
+      return bits.join(' · ') || tab.hint;
+    }
+    if (tab.id === 'signals') {
+      const bits = [];
+      const m = this._arr('mission_keywords').length;   if (m) bits.push(`${m} mission`);
+      const c = this._arr('culture_keywords').length;   if (c) bits.push(`${c} culture`);
+      const i = this._arr('interest_tags').length;      if (i) bits.push(`${i} interests`);
+      return bits.length ? bits.join(' · ') + ' keywords' : tab.hint;
+    }
+    if (tab.id === 'rules') {
+      const bits = [];
+      if (this._isFilled('deal_breakers')) bits.push('Deal-breakers set');
+      const b = this._arr('blocked_titles').length;     if (b) bits.push(`${b} blocked titles`);
+      const mh = this._arr('must_have_keywords').length; if (mh) bits.push(`${mh} must-haves`);
+      return bits.join(' · ') || tab.hint;
+    }
+    return tab.hint;
+  }
+
+  _renderSummary() {
+    const s = this._strength();
+    return html`
+      <div class="vf-summary">
+        <div class="vf-summary__strength">
+          <span class="vf-summary__label">Plan strength: <strong>${s.label}</strong></span>
+          <span class="vf-summary__bar"><span style=${`width:${Math.round(s.pct * 100)}%`}></span></span>
+        </div>
+        <ul class="vf-summary__list" role="list">
+          ${TABS.map(t => html`
+            <li>
+              <button class="vf-summary__row" @click=${() => this._setSection(t.id)}>
+                <span class="vf-summary__row-text">
+                  <span class="vf-summary__row-label">${t.label}</span>
+                  <span class="vf-summary__row-digest">${this._digest(t)}</span>
+                </span>
+                <span class="vf-summary__row-arrow" aria-hidden="true">→</span>
+              </button>
+            </li>
+          `)}
+        </ul>
+      </div>
+    `;
+  }
+
+  _renderTabs() {
+    return html`
+      <div class="vf-tabs" role="tablist" aria-label="Search plan sections">
+        <button class="subnav-bar__item" aria-current=${this.section == null ? 'page' : 'false'}
+                @click=${() => this._setSection(null)}>Overview</button>
+        ${TABS.map(t => html`
+          <button class="subnav-bar__item" aria-current=${this.section === t.id ? 'page' : 'false'}
+                  @click=${() => this._setSection(t.id)}>${t.label}</button>
+        `)}
+      </div>
+    `;
+  }
+
+  // Advanced fold — score weights, raw markdown, plus any field the
+  // taxonomy doesn't know about (so nothing silently disappears).
+  _advancedNames() {
+    const known = new Set([...TABS.flatMap((t) => t.names), ...STORY_FIELDS]);
+    const others = Object.keys(this.fields).filter((n) => !known.has(n) && !ADVANCED_FIELDS.includes(n)).sort();
+    return [...ADVANCED_FIELDS.filter((n) => this.fields[n]), ...others];
+  }
+
+  _renderTab(tab) {
+    if (tab.id === 'sources') {
+      return html`
+        <section class="vf-section">
+          <p class="vf-section__hint muted">${tab.hint}</p>
+          <ladder-watched-companies></ladder-watched-companies>
+        </section>
+      `;
+    }
+    const present = tab.names.filter((n) => this.fields[n]);
     return html`
       <section class="vf-section">
-        <h2 class="vf-section__title">${section.label}</h2>
+        <p class="vf-section__hint muted">${tab.hint}</p>
         <div class="vf-section__grid">
           ${present.map((n) => this._renderFieldCard(n))}
         </div>
+        ${tab.id === 'signals' ? this._renderAdvanced() : nothing}
       </section>
     `;
   }
 
-  _renderOtherSection() {
-    const known = new Set(SECTIONS.flatMap((s) => s.names));
-    const others = Object.keys(this.fields).filter((n) => !known.has(n)).sort();
-    if (!others.length) return nothing;
+  _renderAdvanced() {
+    const names = this._advancedNames();
+    if (!names.length) return nothing;
     return html`
-      <section class="vf-section">
-        <h2 class="vf-section__title">Other</h2>
-        <div class="vf-section__grid">
-          ${others.map((n) => this._renderFieldCard(n))}
+      <details class="jd-collapse vf-advanced">
+        <summary>Advanced — score weights & raw plan</summary>
+        <div class="jd-collapse__body">
+          <div class="vf-section__grid">
+            ${names.map((n) => this._renderFieldCard(n))}
+          </div>
         </div>
-      </section>
+      </details>
     `;
   }
 
@@ -338,10 +469,17 @@ export class JobVision extends LitElement {
     if (this.state === 'error') {
       return html`<div class="placeholder"><h2>Couldn't load</h2><p>${this.error}</p></div>`;
     }
+    const tab = TABS.find(t => t.id === this.section) || null;
     return html`
       <div class="vf">
-        ${SECTIONS.map((s) => this._renderSection(s))}
-        ${this._renderOtherSection()}
+        ${this._renderTabs()}
+        ${tab ? this._renderTab(tab) : this._renderSummary()}
+        ${!tab ? html`
+          <p class="vf-story-note muted">
+            Your story — narrative arc and voice rules — lives on
+            <a href="/ladder/history/?tab=narratives">Profile → Narratives</a>.
+          </p>
+        ` : nothing}
       </div>
     `;
   }

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.17.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.18.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.17.0">
-  <script src="/ladder/js/theme.js?v=2.17.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.18.0">
+  <script src="/ladder/js/theme.js?v=2.18.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -27,13 +27,12 @@
     <main class="app__main">
       <header class="page-header">
         <h1>Search plan</h1>
-        <p>Goals and intents that guide the search. Same source the /jobs skill reads for relevance.</p>
+        <p>What drives the recommendations — targets, signals, rules, and sources.</p>
       </header>
       <ladder-vision></ladder-vision>
-      <ladder-watched-companies></ladder-watched-companies>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.17.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.18.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Search plan taxonomy redesign per the approved proposal: summary landing with plan-strength + digests, ?section= tabs, Sources hosts watched companies, Advanced folded under Signals, Story pointed at Profile → Narratives.

Tested with fixtures in Chrome (overview digests, strength bar, tab switching + URL sync, Targets editors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)