### PR TITLE
feat(events): Agape + past-events filters, greenlit Eventbrite orgs, metrics dashboard (v1.15.0)

### DIFF
--- a/docs/playground/events/strategy/prd-event-source-architecture.md
+++ b/docs/playground/events/strategy/prd-event-source-architecture.md
@@ -191,10 +191,13 @@ Explicitly **not** filters: ticket platform (attribute → outbound link icon), 
 - [x] Coverage metric: `agape_coverage` view (corroboration % of Agape events vs public feeds)
 - [x] Event-platform domains (Partiful, Luma, Tixr, etc.) added to `enrich-event` allowlist per §4.1
 
-### Phase 3 — Curation surface
-- [ ] Authenticated view with "Recommended by Agape" filter + badges + `posted_by`
-- [ ] Private-event view (class-4 events) for members
-- [ ] Venue Waves 1 & 3 gap-fill
+### Phase 3 — Curation surface (partial)
+- [x] "★ Agape" filter + "Past events" toggle in the events app (v1.15.0); private rows visible to authenticated users (migration 091 — §8.1 resolved: any Supabase-authenticated user)
+- [x] Metrics dashboard at `/events/metrics.html` (agape_coverage, source health, scrape runs, enrichment queue)
+- [x] Greenlit Eventbrite orgs with Agape signal via `eventbrite-org` parser (§8.4 resolved: class per-source) — Public Works, Manny's, Hoodslam, The Center SF, Envelop, Flux Vertical Theatre (migration 090)
+- [ ] Agape badge + `posted_by` display on event cards
+- [ ] Private-event view polish (class-4 events) for members
+- [ ] Venue Waves 1 & 3 gap-fill; Internet Archive org id lookup
 
 ---
 

--- a/events/index.html
+++ b/events/index.html
@@ -1481,6 +1481,8 @@ body {
       </select>
       <input type="date" class="input input--date" id="filterDateFrom" title="From date">
       <input type="date" class="input input--date" id="filterDateTo" title="To date">
+      <button class="btn btn--sm btn--ghost" id="filterAgape" title="Only events recommended in the Agape #events channel">★ Agape</button>
+      <button class="btn btn--sm btn--ghost" id="filterPast" title="Include past events (last 60 days)">Past events</button>
       <button class="btn btn--ghost btn--sm" id="filterClear">Clear</button>
     </div>
 
@@ -1757,8 +1759,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.14.0';
-  console.log(`[events] v${VERSION} - mobile card hierarchy: time anchor, plain-text meta, ages, multi-day ranges, whole-card tap`);
+  const VERSION = '1.15.0';
+  console.log(`[events] v${VERSION} - Agape recommended + past-events filters; Agape curation source; eventbrite-org stock sources`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1792,6 +1794,15 @@ body {
     { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
     // Bay Area — Social (Luma discover feed)
     { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
+    // Bay Area — Agape curation feed (private rows: visible only when signed in)
+    { id: 'discord-agape-events', name: 'Agape #events', category: 'social', type: 'discord', url: null, region: 'bay-area', description: 'Agape community recommendations' },
+    // Bay Area — Eventbrite orgs with Agape signal (scraped server-side)
+    { id: 'eb-publicworks', name: 'Public Works', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/public-works-17405142071', region: 'bay-area', description: 'Public Works SF' },
+    { id: 'eb-mannys', name: "Manny's", category: 'social', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/mannys-15114280512', region: 'bay-area', description: "Manny's civic events" },
+    { id: 'eb-hoodslam', name: 'Hoodslam', category: 'theater', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/hoodslam-15110219281', region: 'bay-area', description: 'Hoodslam' },
+    { id: 'eb-thecentersf', name: 'The Center SF', category: 'wellness', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/the-center-sf-3493443113', region: 'bay-area', description: 'Community & wellness' },
+    { id: 'eb-envelop', name: 'Envelop SF', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/envelop-17478025710', region: 'bay-area', description: 'Spatial audio venue' },
+    { id: 'eb-fluxvertical', name: 'Flux Vertical Theatre', category: 'theater', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/16887986144', region: 'bay-area', description: 'Vertical theater & circus' },
     // New York — Tech & Networking
     { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
   ];
@@ -1903,7 +1914,7 @@ body {
     events: [],
     sources: [],
     sourceHealth: {},  // { sourceId: { status, consecutive_failures, success_rate, last_failure_reason, ... } }
-    filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '' },
+    filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, showPast: false },
     sort: { key: 'date', dir: 'asc' },
     view: 'table',
     calMonth: new Date().getMonth(),
@@ -1969,6 +1980,16 @@ body {
     if (state.sources.length === 0) {
       const def = STOCK_SOURCES.find(s => s.id === '19hz-bayarea');
       state.sources = [{ ...def, enabled: true }];
+    }
+
+    // One-time migration: existing users get the Agape curation feed
+    // (harmless when signed out — RLS returns no private rows for anon)
+    if (!localStorage.getItem('ctrl-rodeo-agape-source-added')) {
+      if (!state.sources.some(s => s.id === 'discord-agape-events')) {
+        const agape = STOCK_SOURCES.find(s => s.id === 'discord-agape-events');
+        if (agape) state.sources.push({ ...agape, enabled: true });
+      }
+      localStorage.setItem('ctrl-rodeo-agape-source-added', '1');
     }
 
     saveSources();
@@ -2206,6 +2227,7 @@ body {
       const age = Date.now() - (cache.timestamp || 0);
       // Check if cache is fresh and source IDs match
       const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id).sort().join(',');
+      if (!!cache.showPast !== !!state.filters.showPast) { log('Cache skip: past-events window changed'); return null; }
       if (age < CACHE_MAX_AGE && cache.sourceIds === enabledIds && Array.isArray(cache.events)) {
         log(`Cache hit: ${cache.events.length} events, ${Math.round(age / 1000)}s old`);
         return cache.events;
@@ -2218,7 +2240,7 @@ body {
   function saveEventCache() {
     try {
       const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id).sort().join(',');
-      const cache = { events: state.events, sourceIds: enabledIds, timestamp: Date.now() };
+      const cache = { events: state.events, sourceIds: enabledIds, showPast: !!state.filters.showPast, timestamp: Date.now() };
       localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
       log(`Cache saved: ${state.events.length} events`);
     } catch (e) { log('Cache save failed: ' + e.message); }
@@ -2231,13 +2253,20 @@ body {
       const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id);
       if (enabledIds.length === 0) return null;
       const today = new Date().toISOString().split('T')[0];
-      log(`L2 cache: querying ${enabledIds.length} source(s)`);
+      // "Past events" widens the window to the 60-day retention horizon
+      let fromDate = today;
+      if (state.filters.showPast) {
+        const past = new Date();
+        past.setDate(past.getDate() - 60);
+        fromDate = past.toISOString().split('T')[0];
+      }
+      log(`L2 cache: querying ${enabledIds.length} source(s) from ${fromDate}`);
       // 12s ceiling so a hung request can't leave the spinner up forever
       const query = supabaseClient
         .from('events')
         .select('*')
         .in('source_id', enabledIds)
-        .gte('date', today)
+        .gte('date', fromDate)
         .order('date', { ascending: true });
       const timeout = new Promise(resolve =>
         setTimeout(() => resolve({ data: null, error: { message: 'timed out after 12s' } }), 12000));
@@ -2259,6 +2288,7 @@ body {
           contentType: row.content_type || getSourceCategory(row.source_id),
           description: row.description || '', imageUrl: row.image_url || '',
           enrichedTags: row.tags || [],
+          recommendedBy: row.recommended_by || [], postedBy: row.posted_by || '',
         };
         const existing = byCanonical.get(key);
         if (!existing) {
@@ -2267,6 +2297,10 @@ body {
         } else {
           mergedCount++;
           if (!existing.sources.includes(ev.source)) existing.sources.push(ev.source);
+          for (const r of ev.recommendedBy) {
+            if (!existing.recommendedBy.includes(r)) existing.recommendedBy.push(r);
+          }
+          if (!existing.postedBy && ev.postedBy) existing.postedBy = ev.postedBy;
           if (!existing.time && ev.time) existing.time = ev.time;
           if (!existing.genre && ev.genre) existing.genre = ev.genre;
           if (!existing.price && ev.price) existing.price = ev.price;
@@ -3105,9 +3139,25 @@ body {
   }
 
   // --- Filtering ---
+  function updateFilterChips() {
+    const agapeBtn = document.getElementById('filterAgape');
+    const pastBtn = document.getElementById('filterPast');
+    if (agapeBtn) {
+      agapeBtn.style.background = state.filters.agape ? 'var(--fg)' : '';
+      agapeBtn.style.color = state.filters.agape ? 'var(--bg)' : '';
+      agapeBtn.setAttribute('aria-pressed', String(!!state.filters.agape));
+    }
+    if (pastBtn) {
+      pastBtn.style.background = state.filters.showPast ? 'var(--fg)' : '';
+      pastBtn.style.color = state.filters.showPast ? 'var(--bg)' : '';
+      pastBtn.setAttribute('aria-pressed', String(!!state.filters.showPast));
+    }
+  }
+
   function getFilteredEvents() {
     return state.events.filter(ev => {
-      const { search, city, source, dateFrom, dateTo, category, contentType } = state.filters;
+      const { search, city, source, dateFrom, dateTo, category, contentType, agape } = state.filters;
+      if (agape && !((ev.recommendedBy && ev.recommendedBy.includes('agape')) || (ev.sources && ev.sources.includes('discord-agape-events')))) return false;
       if (search) { const q = search.toLowerCase(); if (![ev.name, ev.venue, ev.city, ev.genre, ev.promoter || '', ev.ages || ''].join(' ').toLowerCase().includes(q)) return false; }
       if (city && ev.city !== city) return false;
       if (source && ev.source !== source && !(ev.sources && ev.sources.includes(source))) return false;
@@ -3122,7 +3172,10 @@ body {
   }
 
   function clearAllFilters() {
-    state.filters = { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '' };
+    const hadPast = state.filters.showPast;
+    state.filters = { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, showPast: false };
+    updateFilterChips();
+    if (hadPast) fetchAllSources(true);
     document.getElementById('filterSearch').value = '';
     document.getElementById('filterCity').value = '';
     const fs = document.getElementById('filterSource'); if (fs) fs.value = '';
@@ -3469,6 +3522,16 @@ body {
     document.getElementById('filterSource').addEventListener('change', (e) => { state.filters.source = e.target.value; render(); });
     document.getElementById('filterDateFrom').addEventListener('change', (e) => { state.filters.dateFrom = e.target.value; render(); });
     document.getElementById('filterDateTo').addEventListener('change', (e) => { state.filters.dateTo = e.target.value; render(); });
+    document.getElementById('filterAgape').addEventListener('click', () => {
+      state.filters.agape = !state.filters.agape;
+      updateFilterChips();
+      render();
+    });
+    document.getElementById('filterPast').addEventListener('click', () => {
+      state.filters.showPast = !state.filters.showPast;
+      updateFilterChips();
+      fetchAllSources(true); // window change requires a fresh L2 query
+    });
     document.getElementById('filterClear').addEventListener('click', () => {
       clearAllFilters();
       filterBar.style.display = 'none';

--- a/events/metrics.html
+++ b/events/metrics.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Events Metrics — ctrl.rodeo</title>
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
+  <style>
+    :root {
+      --bg: #0a0a0a; --bg-surface: #141414; --bg-subtle: #1c1c1c;
+      --fg: #e8e8e8; --fg-muted: #9a9a9a; --fg-subtle: #6a6a6a;
+      --border: #2a2a2a; --good: #4ade80; --warn: #fbbf24; --bad: #f87171;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--fg); font: 14px/1.5 ui-monospace, 'SF Mono', Menlo, monospace; padding: 24px; }
+    h1 { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
+    .sub { color: var(--fg-subtle); font-size: 12px; margin-bottom: 24px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; margin-bottom: 24px; }
+    .card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+    .card .label { color: var(--fg-muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 6px; }
+    .card .value { font-size: 26px; font-weight: 600; }
+    .card .hint { color: var(--fg-subtle); font-size: 11px; margin-top: 4px; }
+    h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg-muted); margin: 24px 0 8px; }
+    table { width: 100%; border-collapse: collapse; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    th, td { text-align: left; padding: 7px 12px; font-size: 12px; border-bottom: 1px solid var(--border); }
+    th { color: var(--fg-subtle); font-weight: 500; text-transform: uppercase; font-size: 10px; letter-spacing: 0.05em; }
+    tr:last-child td { border-bottom: none; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .status-healthy { color: var(--good); } .status-degraded { color: var(--warn); }
+    .status-broken { color: var(--bad); } .status-unknown { color: var(--fg-subtle); }
+    .pill { display: inline-block; padding: 1px 7px; border-radius: 99px; font-size: 10px; border: 1px solid var(--border); color: var(--fg-muted); }
+    .auth-note { background: var(--bg-subtle); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; font-size: 12px; color: var(--fg-muted); margin-bottom: 16px; }
+    a { color: var(--fg-muted); }
+    .wrap { max-width: 1100px; margin: 0 auto; }
+    .table-scroll { overflow-x: auto; }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Events — Metrics</h1>
+  <div class="sub">Canonical store, source health, and Agape coverage · <a href="/events/">back to events</a> · <span id="asOf"></span></div>
+  <div class="auth-note" id="authNote" style="display:none">Signed out — private-event metrics (Agape events, coverage) are hidden. Sign in on the <a href="/events/">events page</a> and reload.</div>
+
+  <div class="grid" id="cards"></div>
+
+  <h2>Agape Coverage</h2>
+  <div class="table-scroll"><table id="coverageTable"><thead><tr><th>Agape events (60d window)</th><th class="num">Corroborated by public feed</th><th class="num">Coverage %</th></tr></thead><tbody></tbody></table></div>
+
+  <h2>Sources</h2>
+  <div class="table-scroll"><table id="sourcesTable"><thead><tr>
+    <th>Source</th><th>Class</th><th>Status</th><th class="num">Events</th><th class="num">Success rate</th><th>Last success</th>
+  </tr></thead><tbody></tbody></table></div>
+
+  <h2>Recent Scrape Runs</h2>
+  <div class="table-scroll"><table id="runsTable"><thead><tr>
+    <th>Started</th><th>By</th><th class="num">Sources ok/failed</th><th class="num">Events total</th><th class="num">New</th><th class="num">Updated</th>
+  </tr></thead><tbody></tbody></table></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script src="/auth/ctrl-auth.js"></script>
+<script>
+(async function () {
+  const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  document.getElementById('asOf').textContent = new Date().toLocaleString();
+
+  CtrlAuth.init({
+    supabaseUrl: 'https://yfhudwakpgzswiylhfbh.supabase.co',
+    supabaseAnonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI',
+    redirectTo: window.location.origin + '/events/metrics.html',
+    adminEmails: ['fike101@gmail.com'],
+  });
+  const sb = CtrlAuth.getSupabaseClient();
+  if (!sb) { document.body.innerHTML += '<p>Supabase client unavailable.</p>'; return; }
+  const { data: sessionData } = await sb.auth.getSession();
+  const session = sessionData && sessionData.session;
+  if (!session) document.getElementById('authNote').style.display = 'block';
+
+  // Paged event fetch — PostgREST caps responses at 1000 rows, and the
+  // store holds several thousand; aggregate over ALL rows, not a sample.
+  async function fetchAllEvents() {
+    const all = [];
+    for (let page = 0; page < 10; page++) {
+      const { data, error } = await sb.from('events')
+        .select('source_id, visibility, date, enrichment_status, recommended_by')
+        .range(page * 1000, page * 1000 + 999);
+      if (error || !data) break;
+      all.push(...data);
+      if (data.length < 1000) break;
+    }
+    return { data: all };
+  }
+
+  // Parallel fetches
+  const [evRes, srcRes, healthRes, runsRes, covRes] = await Promise.all([
+    fetchAllEvents(),
+    sb.from('event_sources').select('id, name, source_class, enabled, demoted'),
+    sb.from('source_health').select('source_id, status, success_rate, last_success_at, last_success_event_count'),
+    sb.from('scrape_runs').select('started_at, triggered_by, sources_succeeded, sources_failed, events_total, events_new, events_updated').order('started_at', { ascending: false }).limit(8),
+    sb.from('agape_coverage').select('*'),
+  ]);
+
+  const events = evRes.data || [];
+  const sources = srcRes.data || [];
+  const health = new Map((healthRes.data || []).map(h => [h.source_id, h]));
+  const today = new Date().toISOString().split('T')[0];
+
+  // --- Summary cards ---
+  const upcoming = events.filter(e => e.date >= today);
+  const privateRows = events.filter(e => e.visibility === 'private');
+  const agapeRows = events.filter(e => (e.recommended_by || []).includes('agape'));
+  const pendingEnrich = events.filter(e => e.enrichment_status === 'pending' || e.enrichment_status === 'processing');
+  const failedEnrich = events.filter(e => e.enrichment_status === 'failed');
+  const enabledSources = sources.filter(s => s.enabled);
+  const broken = enabledSources.filter(s => (health.get(s.id) || {}).status === 'broken');
+
+  const cards = [
+    { label: 'Upcoming events', value: upcoming.length, hint: `${events.length} total in store` },
+    { label: 'Agape recommended', value: agapeRows.length, hint: session ? `${privateRows.length} private rows` : 'sign in to see' },
+    { label: 'Enabled sources', value: enabledSources.length, hint: `${sources.length} registered, ${broken.length} broken` },
+    { label: 'Enrichment queue', value: pendingEnrich.length, hint: `${failedEnrich.length} failed` },
+  ];
+  document.getElementById('cards').innerHTML = cards.map(c =>
+    `<div class="card"><div class="label">${esc(c.label)}</div><div class="value">${esc(c.value)}</div><div class="hint">${esc(c.hint)}</div></div>`
+  ).join('');
+
+  // --- Agape coverage ---
+  const cov = (covRes.data && covRes.data[0]) || { agape_events: session ? 0 : '—', corroborated: '—', corroboration_pct: '—' };
+  document.querySelector('#coverageTable tbody').innerHTML =
+    `<tr><td>${esc(cov.agape_events)}</td><td class="num">${esc(cov.corroborated)}</td><td class="num">${esc(cov.corroboration_pct ?? '—')}${cov.corroboration_pct != null ? '%' : ''}</td></tr>`;
+
+  // --- Sources table ---
+  const counts = {};
+  for (const e of events) counts[e.source_id] = (counts[e.source_id] || 0) + 1;
+  const rows = sources
+    .filter(s => s.enabled)
+    .sort((a, b) => (counts[b.id] || 0) - (counts[a.id] || 0))
+    .map(s => {
+      const h = health.get(s.id) || {};
+      const status = h.status || 'unknown';
+      const cls = s.source_class + (s.demoted ? ' · demoted' : '');
+      return `<tr>
+        <td>${esc(s.name)}</td>
+        <td><span class="pill">${esc(cls)}</span></td>
+        <td class="status-${esc(status)}">${esc(status)}</td>
+        <td class="num">${counts[s.id] || 0}</td>
+        <td class="num">${h.success_rate != null ? Math.round(h.success_rate * 100) + '%' : '—'}</td>
+        <td>${h.last_success_at ? new Date(h.last_success_at).toLocaleString() : '—'}</td>
+      </tr>`;
+    }).join('');
+  document.querySelector('#sourcesTable tbody').innerHTML = rows || '<tr><td colspan="6">No sources</td></tr>';
+
+  // --- Runs table ---
+  document.querySelector('#runsTable tbody').innerHTML = (runsRes.data || []).map(r => `<tr>
+    <td>${new Date(r.started_at).toLocaleString()}</td>
+    <td>${esc(r.triggered_by)}</td>
+    <td class="num">${r.sources_succeeded ?? 0}/${r.sources_failed ?? 0}</td>
+    <td class="num">${r.events_total ?? 0}</td>
+    <td class="num">${r.events_new ?? 0}</td>
+    <td class="num">${r.events_updated ?? 0}</td>
+  </tr>`).join('') || '<tr><td colspan="6">No runs recorded</td></tr>';
+})();
+</script>
+</body>
+</html>

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.4.0'
-console.log(`[scrape-events] v${VERSION} - registry-driven sources exclude discord type (handled by scrape-discord-events kick)`)
+const VERSION = '1.5.0'
+console.log(`[scrape-events] v${VERSION} - eventbrite-org parser (greenlit orgs with Agape signal)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -26,6 +26,7 @@ import { scrapeGarysGuide } from './parsers/garysguide.ts'
 import { scrapeBonobo } from './parsers/bonobo.ts'
 import { scrapeSFMOMA } from './parsers/sfmoma.ts'
 import { scrapeIcal } from './parsers/ical.ts'
+import { scrapeEventbriteOrg } from './parsers/eventbrite-org.ts'
 import { scrapeJson } from './parsers/json.ts'
 import { scrapeRss } from './parsers/rss.ts'
 import { scrapeFamsf } from './parsers/famsf.ts'
@@ -99,6 +100,7 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'bonobo': return scrapeBonobo(source)
     case 'sfmoma': return scrapeSFMOMA(source)
     case 'ical': return scrapeIcal(source)
+    case 'eventbrite-org': return scrapeEventbriteOrg(source)
     case 'json': return scrapeJson(source)
     case 'rss': return scrapeRss(source)
     case 'famsf': return scrapeFamsf(source)

--- a/supabase/functions/scrape-events/parsers/eventbrite-org.ts
+++ b/supabase/functions/scrape-events/parsers/eventbrite-org.ts
@@ -1,0 +1,72 @@
+// Eventbrite organizer-page parser.
+// Source URL is the org page (https://www.eventbrite.com/o/<slug>-<numeric-id>);
+// events come from the public showmore JSON endpoint, no auth required:
+//   GET https://www.eventbrite.com/org/{orgId}/showmore/?type=future&page_size=50&page=N
+//
+// Per PRD event-source-architecture §8.4 (resolved): class is assigned
+// per-source, not per-platform — org pages with community signal are class
+// 'venue'/'community' even though Eventbrite *search* is a demoted discovery
+// feed. Only orgs that appeared in the Agape #events channel get registered.
+
+import { type ScrapedEvent } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+interface EbEvent {
+  url?: string
+  is_free?: boolean
+  name?: { text?: string }
+  start?: { local?: string }
+  end?: { local?: string }
+  venue?: {
+    name?: string
+    address?: { city?: string; localized_address_display?: string }
+  }
+  ticket_availability?: {
+    minimum_ticket_price?: { major_value?: string; display?: string }
+  }
+}
+
+export async function scrapeEventbriteOrg(source: EventSource): Promise<ScrapedEvent[]> {
+  const idMatch = source.url.match(/(\d+)\/?$/)
+  if (!idMatch) throw new Error(`eventbrite-org source URL must end in the numeric org id: ${source.url}`)
+  const orgId = idMatch[1]
+
+  const events: ScrapedEvent[] = []
+  let page = 1
+  const MAX_PAGES = 3 // 150 future events is plenty for any single org
+
+  while (page <= MAX_PAGES) {
+    const resp = await fetch(
+      `https://www.eventbrite.com/org/${orgId}/showmore/?type=future&page_size=50&page=${page}`,
+      { headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' } },
+    )
+    if (!resp.ok) throw new Error(`Eventbrite org API ${resp.status} for org ${orgId}`)
+    const data = await resp.json()
+    const batch: EbEvent[] = data?.data?.events || []
+
+    for (const e of batch) {
+      const start = e.start?.local || ''
+      if (!start || !e.name?.text) continue
+      const price = e.is_free ? 'Free'
+        : (e.ticket_availability?.minimum_ticket_price?.display || '')
+      events.push({
+        source: source.id,
+        date: start.split('T')[0],
+        time: (start.split('T')[1] || '').slice(0, 5),
+        name: e.name.text,
+        venue: e.venue?.name || source.name,
+        address: e.venue?.address?.localized_address_display || '',
+        city: e.venue?.address?.city || '',
+        price,
+        promoter: source.name,
+        url: e.url || source.url,
+        contentType: source.category,
+      })
+    }
+
+    if (!data?.data?.has_next_page) break
+    page++
+  }
+
+  return events
+}

--- a/supabase/migrations/090_eventbrite_signal_orgs.sql
+++ b/supabase/migrations/090_eventbrite_signal_orgs.sql
@@ -1,0 +1,37 @@
+-- ============================================
+-- Greenlit Eventbrite organizers with Agape-channel signal
+-- Migration 090
+--
+-- PRD event-source-architecture §8.4 (resolved): source class is assigned
+-- per-source, not per-platform. Eventbrite *search* stays a demoted discovery
+-- feed, but organizer pages with community signal are class venue/community.
+-- Signal = appearances in the Agape #events history (2022-2026 analysis).
+-- Scraped via the eventbrite-org parser (scrape-events v1.5.0).
+-- ============================================
+
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('eb-publicworks', 'Public Works', 'music', 'eventbrite-org', 'https://www.eventbrite.com/o/public-works-17405142071', 'bay-area', 'Public Works SF (Eventbrite org)', true, 'venue', 'Agape signal: 6 events'),
+  ('eb-mannys', 'Manny''s', 'social', 'eventbrite-org', 'https://www.eventbrite.com/o/mannys-15114280512', 'bay-area', 'Manny''s civic events space (Eventbrite org)', true, 'venue', 'Agape signal: 3 events'),
+  ('eb-hoodslam', 'Hoodslam', 'theater', 'eventbrite-org', 'https://www.eventbrite.com/o/hoodslam-15110219281', 'bay-area', 'Hoodslam wrestling/theater (Eventbrite org)', true, 'community', 'Agape signal: 3 events + org link posted directly'),
+  ('eb-thecentersf', 'The Center SF', 'wellness', 'eventbrite-org', 'https://www.eventbrite.com/o/the-center-sf-3493443113', 'bay-area', 'The Center SF community & wellness (Eventbrite org)', true, 'community', 'Agape signal: 2 events'),
+  ('eb-envelop', 'Envelop SF', 'music', 'eventbrite-org', 'https://www.eventbrite.com/o/envelop-17478025710', 'bay-area', 'Envelop spatial audio venue (Eventbrite org)', true, 'venue', 'Agape signal: 2 events')
+ON CONFLICT (id) DO NOTHING;
+
+-- Internet Archive was in the Wave 2 backlog pointing at its Eventbrite org
+-- page with a placeholder 'html' type — the new parser handles it; enable.
+UPDATE event_sources
+SET type = 'eventbrite-org', enabled = true,
+    notes = 'Agape signal: 4 events — enabled via eventbrite-org parser'
+WHERE id = 'internetarchive-sf';
+
+-- Post-verification adjustments (live-tested):
+-- internetarchive-sf: guessed org id 404s — disabled pending real /o/ id lookup.
+UPDATE event_sources
+SET enabled = false,
+    notes = 'Eventbrite org id unknown (guessed id 404s) — find real /o/ id from an IA event page, then re-enable'
+WHERE id = 'internetarchive-sf';
+
+-- Flux Vertical Theatre: org page was posted directly in the Agape channel.
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('eb-fluxvertical', 'Flux Vertical Theatre', 'theater', 'eventbrite-org', 'https://www.eventbrite.com/o/16887986144', 'bay-area', 'Flux Vertical Theatre (Eventbrite org)', true, 'community', 'Agape signal: org page posted directly in channel')
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/091_private_read_and_retention.sql
+++ b/supabase/migrations/091_private_read_and_retention.sql
@@ -1,0 +1,37 @@
+-- ============================================
+-- Authenticated private-event read + 60-day retention
+-- Migration 091
+--
+-- 1. PRD event-source-architecture §8.1 (resolved): any Supabase-authenticated
+--    user sees private rows (Agape events, demoted-feed events); anon sees
+--    public only. Powers the client's "Agape recommended" filter.
+-- 2. Retention 7d -> 60d so the "past events" toggle has data and
+--    agape_coverage accumulates history.
+-- ============================================
+
+CREATE POLICY "Authenticated read all events" ON events
+  FOR SELECT TO authenticated USING (true);
+
+CREATE OR REPLACE FUNCTION run_events_maintenance()
+RETURNS JSONB AS $$
+DECLARE
+  stale_events INTEGER;
+  stale_discord INTEGER;
+  old_runs INTEGER;
+BEGIN
+  DELETE FROM events WHERE date < CURRENT_DATE - INTERVAL '60 days';
+  GET DIAGNOSTICS stale_events = ROW_COUNT;
+
+  DELETE FROM discord_event_cache WHERE expires_at < NOW() - INTERVAL '7 days';
+  GET DIAGNOSTICS stale_discord = ROW_COUNT;
+
+  DELETE FROM scrape_runs WHERE started_at < NOW() - INTERVAL '90 days';
+  GET DIAGNOSTICS old_runs = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'stale_events', stale_events,
+    'stale_discord', stale_discord,
+    'old_runs', old_runs
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Filters (events app v1.15.0)
- **★ Agape** chip — only events recommended in the Agape #events channel (requires sign-in; anon sees none via RLS)
- **Past events** chip — widens the query window to the 60-day retention horizon (retention raised from 7d in migration 091)

## Greenlit Eventbrite orgs (user decision: orgs with Agape signal)
New `eventbrite-org` parser (scrape-events v1.5.0) using Eventbrite's public org JSON endpoint. Registered + enabled: Public Works (6 signal events), Manny's (3), Hoodslam (3), The Center SF (2), Envelop (2), Flux Vertical Theatre (org page posted in channel). PRD §8.4 resolved: class per-source, not per-platform. Internet Archive pending real org id.

## Metrics dashboard — `/events/metrics.html`
agape_coverage, per-source event counts + health, recent scrape runs, enrichment queue. Auth-aware: signed-out hides private metrics.

## Auth model (PRD §8.1 resolved)
Migration 091: any Supabase-authenticated user reads private rows; anon remains public-only.

Browser-verified end-to-end (onboarding, both filters, dashboard aggregation past the PostgREST 1000-row cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)