### PR TITLE
ladder 2.20.0: Search plan subsection redesigns

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -6655,3 +6655,125 @@ body[data-auth-state="out"] job-chat { display: none; }
 .vf-section__hint { margin: 0 0 var(--space-4); font-size: var(--font-size-small); }
 .vf-advanced { margin-top: var(--space-5); }
 .vf-story-note { margin-top: var(--space-5); font-size: var(--font-size-small); }
+
+/* ==========================================================================
+   Search plan subsections (v2.20) — chip collapse, merged comp card,
+   structured rules, blocked companies, source health.
+   ========================================================================== */
+.vf-section__grid--cols {
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+}
+.vf-chip--more,
+.vf-chip--ghost {
+  cursor: pointer;
+  border: 1px dashed var(--border-strong);
+  background: transparent;
+  color: var(--fg-muted);
+  font: inherit;
+  font-size: var(--font-size-caption);
+}
+.vf-chip--more:hover,
+.vf-chip--ghost:hover { background: var(--bg-surface); color: var(--fg); }
+.vf-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+.vf-chip-tools {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+.vf-chip-filter {
+  flex: 1;
+  max-width: 260px;
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+/* Anti-mission terms repel — warn tint so attract vs repel reads at a glance. */
+.vf-card[data-name="anti_mission_terms"] .vf-chip {
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+}
+.vf-toggle--inline { display: inline-flex; align-items: center; gap: 6px; font-size: var(--font-size-small); }
+.vf-comp-grid {
+  display: flex;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+.vf-comp-field { display: flex; flex-direction: column; gap: var(--space-1); }
+.vf-comp-label { font-size: var(--font-size-caption); color: var(--fg-muted); font-weight: var(--fw-medium); }
+.vf-comp-input {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-muted);
+}
+.vf-comp-input .vf-input { width: 130px; }
+/* Structured deal-breakers */
+.vf-rules { display: flex; flex-direction: column; gap: var(--space-4); }
+.vf-rules__heading {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-size-small);
+  font-weight: var(--fw-semibold);
+}
+.vf-rules__note { margin: 0 0 var(--space-2); font-size: var(--font-size-caption); }
+.vf-rules__list { list-style: none; margin: 0; padding: 0; }
+.vf-rules__item {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--font-size-small);
+}
+.vf-rules__item:last-child { border-bottom: 0; }
+.vf-rules__text { flex: 1; min-width: 0; }
+.vf-rules__add {
+  margin-top: var(--space-2);
+  width: 100%;
+  height: 32px;
+  padding: 0 var(--space-3);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-size-small);
+}
+/* Blocked companies + source health rows */
+.vf-blocked, .vf-sources { list-style: none; margin: 0; padding: 0; }
+.vf-blocked__row, .vf-sources__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--font-size-small);
+}
+.vf-blocked__row:last-child, .vf-sources__row:last-child { border-bottom: 0; }
+.vf-blocked__name { flex: 1; min-width: 0; text-transform: capitalize; }
+.vf-sources__dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--accent-strong); flex-shrink: 0;
+}
+.vf-sources__dot--bad { background: var(--error); }
+.vf-sources__text { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.vf-sources__name { font-weight: var(--fw-medium); }
+.vf-sources__meta { font-size: var(--font-size-caption); }
+.vf-sources__expired { margin: var(--space-3) 0 0; font-size: var(--font-size-caption); }
+.vf-summary__row-meta {
+  font-weight: var(--fw-medium);
+  font-size: var(--font-size-caption);
+  margin-left: var(--space-2);
+}
+/* Watched companies read as list rows here, not floating chips. */
+.watched-strip__row { display: flex; flex-direction: column; gap: var(--space-2); }
+.watched-chip { width: 100%; }

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.19.0";
-console.log(`[ladder] v${VERSION} - density pass: type scale down a notch, spacing remap, 40px controls; Search plan sub-nav in rail`);
+const VERSION = "2.20.0";
+console.log(`[ladder] v${VERSION} - Search plan subsections: chip collapse, structured rules, blocked companies, source health, merged comp card`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-vision.js
+++ b/ladder/js/components/ladder-vision.js
@@ -11,9 +11,57 @@
 // distinguishable in the metadata footer of each field.
 
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+const V = (new URL(import.meta.url)).search;
+const [{ fetchRecommendations, fetchBlockedCompanies, unblockCompany, refreshSources }] = await Promise.all([
+  import('../pipeline.js' + V),
+]);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const FN_URL = `${SUPABASE_URL}/functions/v1/vision-field`;
+
+// Chip walls collapse past this many entries (62 mission keywords should
+// not dominate the page). Expanded lists get a filter box.
+const CHIP_COLLAPSE_AT = 12;
+const CHIP_SHOW = 10;
+
+// Quick-add suggestions for funding stages — free text still works.
+const STAGE_SUGGESTIONS = ['Pre-seed', 'Seed', 'Series A', 'Series B', 'Series C', 'Series D+', 'Public'];
+
+// Human labels for source-health rows (recommendations GET → sourceHealth).
+const SOURCE_LABELS = {
+  'gmail-jobs': 'Gmail job alerts',
+  'company-watch': 'Watched companies',
+  'tracked-ats': 'Tracked ATS boards',
+};
+
+// ── Deal-breakers structured editing ─────────────────────────────────────
+// The doc is markdown: optional preamble, '## ' section headings, '- ' rule
+// items, free-text notes. Parse into groups so rules render as rows with
+// add/delete; serialize back losslessly enough for this shape. Anything the
+// parser can't confidently rebuild still has the "Edit as text" escape hatch.
+function parseRuleDoc(md) {
+  const lines = String(md || '').split('\n');
+  const doc = { preamble: [], sections: [] };
+  let cur = null;
+  for (const line of lines) {
+    const h = line.match(/^##\s+(.*)/);
+    if (h) { cur = { heading: h[1].trim(), notes: [], items: [] }; doc.sections.push(cur); continue; }
+    if (!cur) { if (line.trim()) doc.preamble.push(line.trim()); continue; }
+    const it = line.match(/^\s*[-*]\s+(.*)/);
+    if (it) cur.items.push(it[1]);
+    else if (line.trim()) cur.notes.push(line.trim());
+  }
+  return doc;
+}
+function serializeRuleDoc(doc) {
+  const out = [...doc.preamble];
+  for (const s of doc.sections) {
+    out.push('', `## ${s.heading}`);
+    if (s.notes.length) out.push(...s.notes);
+    out.push(...s.items.map(i => `- ${i}`));
+  }
+  return out.join('\n').replace(/\n{3,}/g, '\n\n').trim() + '\n';
+}
 
 // Search-plan taxonomy (v2.18): four subpages switched by ?section=,
 // reusing the Jobs ?bucket= pattern. Landing (no param) is a summary view
@@ -73,6 +121,13 @@ export class JobVision extends LitElement {
     saving:  { state: true },     // Set<name>
     flash:   { state: true },     // { [name]: 'saved' | 'error' }
     section: { state: true },     // active tab id or null (summary landing)
+    _expanded:    { state: true },  // Set<name> — chip lists shown in full
+    _chipFilters: { state: true },  // { [name]: filter text }
+    _blocked:     { state: true },  // [{company, blockedAt}] | null (loading)
+    _health:      { state: true },  // sourceHealth rows | null
+    _recentlyExpired: { state: true },
+    _refreshing:  { state: true },
+    _textMode:    { state: true },  // Set<name> — structured fields being edited raw
   };
 
   constructor() {
@@ -85,6 +140,32 @@ export class JobVision extends LitElement {
     this.flash = {};
     const s = new URLSearchParams(location.search).get('section');
     this.section = TABS.some(t => t.id === s) ? s : null;
+    this._expanded = new Set();
+    this._chipFilters = {};
+    this._blocked = null;
+    this._health = null;
+    this._recentlyExpired = 0;
+    this._refreshing = false;
+    this._textMode = new Set();
+  }
+
+  // Lazy per-tab data: blocked companies (Rules) and source health
+  // (Sources) load the first time their tab is visible.
+  willUpdate() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.section === 'rules' && this._blocked === null && !this._blockedLoading) {
+      this._blockedLoading = true;
+      fetchBlockedCompanies().then(b => { this._blocked = b; }).catch(() => { this._blocked = []; });
+    }
+    if (this.section === 'sources' && this._health === null && !this._healthLoading) {
+      this._healthLoading = true;
+      fetchRecommendations({ view: 'all', floor: true, limit: 1 })
+        .then(d => {
+          this._health = Array.isArray(d?.sourceHealth) ? d.sourceHealth : [];
+          this._recentlyExpired = Number.isFinite(d?.recentlyExpired) ? d.recentlyExpired : 0;
+        })
+        .catch(() => { this._health = []; });
+    }
   }
 
   _setSection(id) {
@@ -204,15 +285,38 @@ export class JobVision extends LitElement {
 
   _renderStringArray(name) {
     const value = this._draftFor(name) || [];
+    const expanded = this._expanded.has(name);
+    const filter = (this._chipFilters[name] || '').toLowerCase();
+    const collapsible = value.length > CHIP_COLLAPSE_AT;
+    let shown = value;
+    if (filter) shown = value.filter(v => v.toLowerCase().includes(filter));
+    else if (collapsible && !expanded) shown = value.slice(0, CHIP_SHOW);
     return html`
+      ${collapsible && expanded ? html`
+        <div class="vf-chip-tools">
+          <input type="text" class="vf-chip-filter" placeholder=${`Filter ${value.length} terms…`}
+                 .value=${this._chipFilters[name] || ''}
+                 @input=${(e) => { this._chipFilters = { ...this._chipFilters, [name]: e.target.value }; }}>
+          <button class="link-subtle" @click=${() => {
+            const s = new Set(this._expanded); s.delete(name); this._expanded = s;
+            this._chipFilters = { ...this._chipFilters, [name]: '' };
+          }}>Collapse</button>
+        </div>
+      ` : nothing}
       <div class="vf-chips">
-        ${value.map((v, i) => html`
+        ${shown.map((v) => html`
           <span class="vf-chip">
             ${v}
             <button class="vf-chip__x" aria-label="Remove"
-                    @click=${() => this._setDraft(name, value.filter((_, idx) => idx !== i))}>×</button>
+                    @click=${() => this._setDraft(name, value.filter((x) => x !== v))}>×</button>
           </span>
         `)}
+        ${collapsible && !expanded && !filter ? html`
+          <button class="vf-chip vf-chip--more"
+                  @click=${() => { this._expanded = new Set([...this._expanded, name]); }}>
+            +${value.length - CHIP_SHOW} more
+          </button>
+        ` : nothing}
         <input type="text" class="vf-chip-input" placeholder="Add term + Enter"
                @keydown=${(e) => {
                  if (e.key === 'Enter') {
@@ -226,6 +330,22 @@ export class JobVision extends LitElement {
                    this._setDraft(name, value.slice(0, -1));
                  }
                }}>
+      </div>
+      ${name === 'target_stages' ? this._renderStageSuggestions(value) : nothing}
+    `;
+  }
+
+  // Quick-add ghosts for common funding stages not yet selected.
+  _renderStageSuggestions(value) {
+    const missing = STAGE_SUGGESTIONS.filter(s => !value.some(v => v.toLowerCase() === s.toLowerCase()));
+    if (!missing.length) return nothing;
+    return html`
+      <div class="vf-suggestions">
+        ${missing.map(s => html`
+          <button class="vf-chip vf-chip--ghost" @click=${() => this._setDraft('target_stages', [...value, s])}>
+            + ${s}
+          </button>
+        `)}
       </div>
     `;
   }
@@ -285,7 +405,7 @@ export class JobVision extends LitElement {
     }
   }
 
-  _renderFieldCard(name) {
+  _renderFieldCard(name, { headerExtra = null, editor = null } = {}) {
     const f = this.fields[name];
     if (!f) return nothing;
     const dirty = this._hasChanges(name);
@@ -293,20 +413,21 @@ export class JobVision extends LitElement {
     const flash = this.flash[name];
     const updatedBy = SOURCE_LABEL[f.source] || f.source;
     return html`
-      <article class="vf-card" data-kind=${f.kind}>
+      <article class="vf-card" data-kind=${f.kind} data-name=${name}>
         <header class="vf-card__head">
           <div class="vf-card__title-wrap">
             <h3 class="vf-card__title">${f.display_name || name}</h3>
             <span class="vf-card__name">${name}</span>
           </div>
           <div class="vf-card__meta">
+            ${headerExtra || nothing}
             <span class="vf-card__updated" title=${new Date(f.updated_at).toLocaleString()}>
               Updated ${relTime(f.updated_at)} by ${updatedBy}
             </span>
           </div>
         </header>
         ${f.description ? html`<p class="vf-card__desc">${f.description}</p>` : nothing}
-        <div class="vf-card__editor">${this._renderEditor(name)}</div>
+        <div class="vf-card__editor">${editor || this._renderEditor(name)}</div>
         ${dirty || flash ? html`
           <footer class="vf-card__foot">
             ${flash === 'saved'
@@ -391,17 +512,27 @@ export class JobVision extends LitElement {
           <span class="vf-summary__bar"><span style=${`width:${Math.round(s.pct * 100)}%`}></span></span>
         </div>
         <ul class="vf-summary__list" role="list">
-          ${TABS.map(t => html`
+          ${TABS.map(t => {
+            const names = t.names.filter((n) => this.fields[n] && this.fields[n].kind !== 'bool');
+            const missing = names.filter((n) => !this._isFilled(n)).length;
+            const latest = t.names.map((n) => this.fields[n]?.updated_at).filter(Boolean).sort().pop();
+            const meta = [
+              missing ? `${missing} ${missing === 1 ? 'field' : 'fields'} empty` : '',
+              latest ? `updated ${relTime(latest)}` : '',
+            ].filter(Boolean).join(' · ');
+            return html`
             <li>
               <button class="vf-summary__row" @click=${() => this._setSection(t.id)}>
                 <span class="vf-summary__row-text">
-                  <span class="vf-summary__row-label">${t.label}</span>
+                  <span class="vf-summary__row-label">${t.label}
+                    ${meta ? html`<span class="vf-summary__row-meta muted">${meta}</span>` : nothing}
+                  </span>
                   <span class="vf-summary__row-digest">${this._digest(t)}</span>
                 </span>
                 <span class="vf-summary__row-arrow" aria-hidden="true">→</span>
               </button>
             </li>
-          `)}
+          `;})}
         </ul>
       </div>
     `;
@@ -429,14 +560,10 @@ export class JobVision extends LitElement {
   }
 
   _renderTab(tab) {
-    if (tab.id === 'sources') {
-      return html`
-        <section class="vf-section">
-          <p class="vf-section__hint muted">${tab.hint}</p>
-          <ladder-watched-companies></ladder-watched-companies>
-        </section>
-      `;
-    }
+    if (tab.id === 'sources') return this._renderSourcesTab(tab);
+    if (tab.id === 'rules')   return this._renderRulesTab(tab);
+    if (tab.id === 'targets') return this._renderTargetsTab(tab);
+    if (tab.id === 'signals') return this._renderSignalsTab(tab);
     const present = tab.names.filter((n) => this.fields[n]);
     return html`
       <section class="vf-section">
@@ -444,7 +571,276 @@ export class JobVision extends LitElement {
         <div class="vf-section__grid">
           ${present.map((n) => this._renderFieldCard(n))}
         </div>
-        ${tab.id === 'signals' ? this._renderAdvanced() : nothing}
+      </section>
+    `;
+  }
+
+  // ── Targets: two-column grid, comp floors merged into one card ────────
+  _renderTargetsTab(tab) {
+    const gridNames = tab.names.filter((n) => this.fields[n] && !n.startsWith('comp_floor'));
+    return html`
+      <section class="vf-section">
+        <p class="vf-section__hint muted">${tab.hint}</p>
+        <div class="vf-section__grid vf-section__grid--cols">
+          ${gridNames.map((n) => this._renderFieldCard(n))}
+          ${this._renderCompCard()}
+        </div>
+      </section>
+    `;
+  }
+
+  _renderCompCard() {
+    const names = ['comp_floor_base', 'comp_floor_total'].filter((n) => this.fields[n]);
+    if (!names.length) return nothing;
+    const dirty = names.some((n) => this._hasChanges(n));
+    const saving = names.some((n) => this.saving.has(n));
+    const flash = names.map((n) => this.flash[n]).find(Boolean);
+    const latest = names.map((n) => this.fields[n].updated_at).sort().pop();
+    return html`
+      <article class="vf-card" data-name="compensation">
+        <header class="vf-card__head">
+          <div class="vf-card__title-wrap">
+            <h3 class="vf-card__title">Compensation floor</h3>
+            <span class="vf-card__name">comp_floor</span>
+          </div>
+          <div class="vf-card__meta">
+            <span class="vf-card__updated">Updated ${relTime(latest)}</span>
+          </div>
+        </header>
+        <p class="vf-card__desc">Roles below the base floor hard-fail for non-founding positions.</p>
+        <div class="vf-comp-grid">
+          ${names.map((n) => {
+            const v = this._draftFor(n);
+            return html`
+              <label class="vf-comp-field">
+                <span class="vf-comp-label">${n === 'comp_floor_base' ? 'Base' : 'Total'}</span>
+                <span class="vf-comp-input">
+                  <span aria-hidden="true">$</span>
+                  <input type="number" class="vf-input" step="5000" min="0"
+                         .value=${v == null ? '' : String(v)}
+                         @input=${(e) => this._setDraft(n, e.target.value === '' ? null : Number(e.target.value))}>
+                </span>
+              </label>
+            `;
+          })}
+        </div>
+        ${dirty || flash ? html`
+          <footer class="vf-card__foot">
+            ${flash === 'saved' ? html`<span class="vf-saved">✓ Saved</span>`
+              : flash ? html`<span class="vf-error">${flash}</span>` : nothing}
+            ${dirty ? html`
+              <button class="btn btn--sm" ?disabled=${saving}
+                      @click=${() => names.forEach((n) => this._cancel(n))}>Cancel</button>
+              <button class="btn btn--sm btn--primary" ?disabled=${saving}
+                      @click=${async () => { for (const n of names) if (this._hasChanges(n)) await this._save(n); }}>
+                ${saving ? 'Saving…' : 'Save'}
+              </button>
+            ` : nothing}
+          </footer>
+        ` : nothing}
+      </article>
+    `;
+  }
+
+  // ── Signals: mission-required toggle inline in the Mission card ───────
+  _renderSignalsTab(tab) {
+    const gridNames = tab.names.filter((n) => this.fields[n] && n !== 'mission_required' && n !== 'mission_keywords');
+    const missionToggle = this.fields.mission_required ? html`
+      <label class="vf-toggle vf-toggle--inline" title="When on, roles with no mission signal hard-fail.">
+        <input type="checkbox" .checked=${!!this._currentValue('mission_required')}
+               ?disabled=${this.saving.has('mission_required')}
+               @change=${(e) => { this._setDraft('mission_required', e.target.checked); this._save('mission_required'); }}>
+        <span>Required</span>
+      </label>
+    ` : null;
+    return html`
+      <section class="vf-section">
+        <p class="vf-section__hint muted">${tab.hint}</p>
+        <div class="vf-section__grid">
+          ${this.fields.mission_keywords ? this._renderFieldCard('mission_keywords', { headerExtra: missionToggle }) : nothing}
+          ${gridNames.map((n) => this._renderFieldCard(n))}
+        </div>
+        ${this._renderAdvanced()}
+      </section>
+    `;
+  }
+
+  // ── Rules: structured deal-breakers + blocked companies ───────────────
+  _renderRulesTab(tab) {
+    const rest = tab.names.filter((n) => this.fields[n] && n !== 'deal_breakers');
+    return html`
+      <section class="vf-section">
+        <p class="vf-section__hint muted">${tab.hint}</p>
+        <div class="vf-section__grid">
+          ${this.fields.deal_breakers ? this._renderFieldCard('deal_breakers', {
+            headerExtra: html`
+              <button class="link-subtle" @click=${() => {
+                const s = new Set(this._textMode);
+                s.has('deal_breakers') ? s.delete('deal_breakers') : s.add('deal_breakers');
+                this._textMode = s;
+              }}>${this._textMode.has('deal_breakers') ? 'Structured view' : 'Edit as text'}</button>`,
+            editor: this._textMode.has('deal_breakers') ? null : this._renderRuleDocEditor('deal_breakers'),
+          }) : nothing}
+          ${rest.map((n) => this._renderFieldCard(n))}
+          ${this._renderBlockedCard()}
+        </div>
+      </section>
+    `;
+  }
+
+  _renderRuleDocEditor(name) {
+    const doc = parseRuleDoc(this._draftFor(name) || '');
+    const commit = () => this._setDraft(name, serializeRuleDoc(doc));
+    if (!doc.sections.length) return this._renderTextMd(name);
+    return html`
+      <div class="vf-rules">
+        ${doc.sections.map((sec) => html`
+          <div class="vf-rules__group">
+            <h4 class="vf-rules__heading">${sec.heading}</h4>
+            ${sec.notes.length ? html`<p class="vf-rules__note muted">${sec.notes.join(' ')}</p>` : nothing}
+            <ul class="vf-rules__list" role="list">
+              ${sec.items.map((item, i) => html`
+                <li class="vf-rules__item">
+                  <span class="vf-rules__text">${item}</span>
+                  <button class="vf-chip__x" aria-label="Remove rule"
+                          @click=${() => { sec.items.splice(i, 1); commit(); }}>×</button>
+                </li>
+              `)}
+            </ul>
+            <input type="text" class="vf-rules__add" placeholder="Add rule + Enter"
+                   @keydown=${(e) => {
+                     if (e.key !== 'Enter') return;
+                     e.preventDefault();
+                     const t = e.target.value.trim();
+                     if (!t) return;
+                     sec.items.push(t);
+                     e.target.value = '';
+                     commit();
+                   }}>
+          </div>
+        `)}
+      </div>
+    `;
+  }
+
+  async _unblock(company) {
+    this._blocked = (this._blocked || []).filter((b) => b.company !== company);
+    try {
+      await unblockCompany(company);
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `${company} can be recommended again` } }));
+    } catch (e) {
+      console.warn('[vision] unblock failed', e);
+      this._blocked = null; this._blockedLoading = false; // reload on next render
+    }
+  }
+
+  _renderBlockedCard() {
+    return html`
+      <article class="vf-card" data-name="blocked_companies">
+        <header class="vf-card__head">
+          <div class="vf-card__title-wrap">
+            <h3 class="vf-card__title">Blocked companies</h3>
+            <span class="vf-card__name">blocked_companies</span>
+          </div>
+        </header>
+        <p class="vf-card__desc">"Don't recommend" — roles from these companies never enter the Inbox.</p>
+        ${this._blocked == null ? html`<p class="muted">Loading…</p>`
+          : this._blocked.length === 0 ? html`<p class="vf-empty">No companies blocked.</p>`
+          : html`
+            <ul class="vf-blocked" role="list">
+              ${this._blocked.map((b) => html`
+                <li class="vf-blocked__row">
+                  <span class="vf-blocked__name">${b.company}</span>
+                  <span class="vf-blocked__meta muted">${relTime(b.blockedAt)}</span>
+                  <button class="link-subtle" @click=${() => this._unblock(b.company)}>Unblock</button>
+                </li>
+              `)}
+            </ul>
+          `}
+      </article>
+    `;
+  }
+
+  // ── Sources: pipeline health + watched companies ───────────────────────
+  async _onRefreshSources() {
+    if (this._refreshing) return;
+    this._refreshing = true;
+    try {
+      const r = await refreshSources();
+      document.dispatchEvent(new CustomEvent('job:toast', {
+        detail: { msg: r.throttled ? 'Recently refreshed — try again in a few minutes.' : 'Scanning sources for new roles…' },
+      }));
+    } catch (e) {
+      console.warn('[vision] refresh failed', e);
+    } finally {
+      this._refreshing = false;
+    }
+  }
+
+  async _onReconnectGmail() {
+    try {
+      const sb = this._supabase();
+      const token = (await sb?.auth.getSession?.())?.data?.session?.access_token;
+      const r = await fetch(`${SUPABASE_URL}/functions/v1/gmail-auth`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'auth-url' }),
+      });
+      const j = await r.json();
+      if (j.url) window.location.assign(j.url);
+    } catch (e) {
+      console.warn('[vision] gmail reconnect failed', e);
+    }
+  }
+
+  _renderSourcesTab(tab) {
+    const health = this._health;
+    return html`
+      <section class="vf-section">
+        <p class="vf-section__hint muted">${tab.hint}</p>
+        <article class="vf-card" data-name="source_health">
+          <header class="vf-card__head">
+            <div class="vf-card__title-wrap">
+              <h3 class="vf-card__title">Pipeline health</h3>
+              <span class="vf-card__name">sources</span>
+            </div>
+            <div class="vf-card__meta">
+              <button class="btn btn--sm" ?disabled=${this._refreshing} @click=${() => this._onRefreshSources()}>
+                ${this._refreshing ? 'Scanning…' : 'Refresh sources'}
+              </button>
+            </div>
+          </header>
+          ${health == null ? html`<p class="muted">Loading…</p>`
+            : health.length === 0 ? html`<p class="vf-empty">No sources configured.</p>`
+            : html`
+              <ul class="vf-sources" role="list">
+                ${health.map((s) => {
+                  const bad = s.enabled !== false && (s.needsReauth || s.lastError);
+                  return html`
+                    <li class="vf-sources__row">
+                      <span class=${'vf-sources__dot' + (bad ? ' vf-sources__dot--bad' : '')} aria-hidden="true"></span>
+                      <span class="vf-sources__text">
+                        <span class="vf-sources__name">${SOURCE_LABELS[s.type] || s.type}</span>
+                        <span class="vf-sources__meta muted">
+                          ${s.enabled === false ? 'Disabled'
+                            : s.needsReauth ? 'Disconnected — needs re-auth'
+                            : s.lastError ? s.lastError
+                            : 'Healthy'}
+                        </span>
+                      </span>
+                      ${s.type === 'gmail-jobs' && s.needsReauth ? html`
+                        <button class="btn btn--sm btn--accent" @click=${() => this._onReconnectGmail()}>Reconnect</button>
+                      ` : nothing}
+                    </li>
+                  `;
+                })}
+              </ul>
+            `}
+          ${this._recentlyExpired > 0 ? html`
+            <p class="vf-sources__expired muted">${this._recentlyExpired} expired postings removed in the last 7 days.</p>
+          ` : nothing}
+        </article>
+        <ladder-watched-companies></ladder-watched-companies>
       </section>
     `;
   }

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -207,6 +207,26 @@ export async function blockCompany(company) {
   return res.json();
 }
 
+// The caller's "don't recommend" list — [{ company, blockedAt }].
+export async function fetchBlockedCompanies() {
+  const headers = await authHeader();
+  const res = await fetch(`${REC_URL}?view=blocked`, { headers });
+  if (!res.ok) throw new Error(`blocked-companies ${res.status}: ${await res.text()}`);
+  const j = await res.json();
+  return Array.isArray(j.blocked) ? j.blocked : [];
+}
+
+export async function unblockCompany(company) {
+  const headers = await authHeader();
+  const res = await fetch(REC_URL, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ unblockCompany: company }),
+  });
+  if (!res.ok) throw new Error(`unblock-company ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
 // ----- Watched companies (job.watched_companies) ---------------------------
 // Green-lit companies pulled straight from their careers backends. Each has
 // a filter_mode gating how its roles surface in For You.

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.19.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.19.0">
-  <script src="/ladder/js/theme.js?v=2.19.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <script src="/ladder/js/theme.js?v=2.20.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.19.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.16.0';
-console.log(`[recommendations] v${VERSION} - expose company_description on list + detail responses`);
+const VERSION = '0.17.0';
+console.log(`[recommendations] v${VERSION} - ?view=blocked lists the caller's don't-recommend companies`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -33,6 +33,17 @@ serve(async (req) => {
       // (default)      → fit floor 50 + strength floor 50, max 60 rows
       //                  (drives the carousel).
       const url = new URL(req.url);
+
+      // ?view=blocked → the caller's "don't recommend" company list, for
+      // the Search plan → Rules card. Unblock goes through the existing
+      // POST { unblockCompany } action.
+      if (url.searchParams.get('view') === 'blocked') {
+        const rows = await sql<{ company_norm: string; created_at: string }[]>`
+          select company_norm, created_at from job.blocked_companies
+           where user_email = ${email}
+           order by created_at desc`;
+        return jsonResp({ blocked: rows.map(r => ({ company: r.company_norm, blockedAt: r.created_at })) });
+      }
 
       // ?id=<uuid> → single-rec lookup for the pre-save detail page.
       // Returns the row regardless of score/dismissed/closed state (the


### PR DESCRIPTION
Per the approved plan — Signals chip collapse + inline mission toggle + anti-mission tint; structured deal-breakers editor + Blocked companies card (new ?view=blocked API); Sources pipeline-health card w/ Gmail reconnect + refresh; Targets 2-col + merged Compensation card + stage quick-adds; Overview completeness stamps.

Post-merge: deploy `recommendations` (0.17.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)