### PR TITLE
ladder 2.20.1: fix stale components.css cache-bust pin

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -61,4 +61,4 @@ The For You surface follows a **triage, don't browse** model (inbox → review �
 
 ## Cache busting
 
-Every PR that touches `/ladder/js` or `/ladder/css` bumps `VERSION` in `ladder/js/app.js`. The string is appended to `<link>`/`<script>` URLs and to dynamic `import(...)` calls so GH Pages' 10-minute `max-age` doesn't shadow new deploys.
+Every PR that touches `/ladder/js` or `/ladder/css` bumps `VERSION` in `ladder/js/app.js`, the `?v=` on every HTML `<link>`/`<script>`, **and the `@import url("./components.css?v=…")` inside `base.css`** — that import is the easy one to forget and it silently pins component styles to the 10-minute edge cache.

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=1.18.2");
+@import url("./components.css?v=2.20.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.20.0";
-console.log(`[ladder] v${VERSION} - Search plan subsections: chip collapse, structured rules, blocked companies, source health, merged comp card`);
+const VERSION = "2.20.1";
+console.log(`[ladder] v${VERSION} - fix stale components.css @import version in base.css (was pinned at 1.18.2)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.0">
-  <script src="/ladder/js/theme.js?v=2.20.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.20.1">
+  <script src="/ladder/js/theme.js?v=2.20.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.20.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.20.1"></script>
 </body>
 </html>


### PR DESCRIPTION
base.css's `@import components.css?v=1.18.2` was never bumped by releases, leaving component styles on the 10-minute edge cache. Bumped to track VERSION; documented in DESIGN.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)