### PR TITLE
events 1.16.0: Interested bookmarks + Google Calendar sync (ctrl.events)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -353,6 +353,27 @@ body {
 .data-table .col-promoter { display: none; }
 .data-table .col-source { width: 90px; }
 .data-table .col-source .token--source + .token--source { margin-left: 3px; }
+.data-table .col-bm { width: 28px; padding-left: var(--space-2); padding-right: 0; }
+
+/* Bookmark ("interested") toggle */
+.bm-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 4px);
+  transition: color var(--duration-fast) ease;
+}
+.bm-btn:hover { color: var(--fg); }
+.bm-btn svg { fill: none; stroke: currentColor; }
+.bm-btn--on { color: var(--fg); }
+.bm-btn--on svg { fill: currentColor; }
 
 /* Source token — color-coded, clickable */
 .token--source {
@@ -1261,12 +1282,13 @@ body {
   .data-table tbody tr {
     grid-template-columns: auto 1fr auto auto;
     grid-template-areas:
-      "date date date date"
+      "date date date bm"
       "time time ages price"
       "name name name name"
       "venue venue venue venue"
       "genre genre genre source";
   }
+  .data-table .col-bm { grid-area: bm; width: auto; padding: 0; text-align: right; }
   .data-table .col-date { grid-area: date; width: auto; font-size: var(--text-2xs); color: var(--fg-muted); }
   .data-table .col-time { grid-area: time; display: block; width: auto; max-width: none; font-size: var(--text-xs); color: var(--fg); }
   .col-time .mobile-date-range { display: inline; }
@@ -1464,6 +1486,10 @@ body {
       <div class="sources-bar__chips" id="sourceChips"></div>
       <button class="btn btn--sm btn--ghost" id="forceRefreshBtn" title="Force refresh all sources (Shift+R)" style="padding:4px 6px;font-size:14px;line-height:1;opacity:0.5;min-width:0;" onclick="window.__forceRefreshSources && window.__forceRefreshSources()">⟳</button>
       <button class="btn btn--sm btn--dashed" id="addSourceBtn">Manage Sources</button>
+      <button class="btn btn--sm btn--ghost" id="calSyncBtn" title="Sync interested + Agape events to Google Calendar">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+        Calendar
+      </button>
       <button class="btn btn--sm btn--ghost sources-bar__filter-btn" id="filterToggleBtn">
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="1" y1="3" x2="11" y2="3"/><line x1="3" y1="6" x2="9" y2="6"/><line x1="5" y1="9" x2="7" y2="9"/></svg>
         Filter
@@ -1482,6 +1508,7 @@ body {
       <input type="date" class="input input--date" id="filterDateFrom" title="From date">
       <input type="date" class="input input--date" id="filterDateTo" title="To date">
       <button class="btn btn--sm btn--ghost" id="filterAgape" title="Only events recommended in the Agape #events channel">★ Agape</button>
+      <button class="btn btn--sm btn--ghost" id="filterInterested" title="Only events you bookmarked as interested">🔖 Interested</button>
       <button class="btn btn--sm btn--ghost" id="filterPast" title="Include past events (last 60 days)">Past events</button>
       <button class="btn btn--ghost btn--sm" id="filterClear">Clear</button>
     </div>
@@ -1524,6 +1551,7 @@ body {
       <table class="data-table" id="eventsTable">
         <thead>
           <tr>
+            <th class="col-bm" title="Interested"></th>
             <th class="col-date" data-sort="date">Date <span class="data-table__sort">&#9650;</span></th>
             <th class="col-time" data-sort="time">Time <span class="data-table__sort">&#9650;</span></th>
             <th class="col-name" data-sort="name">Event <span class="data-table__sort">&#9650;</span></th>
@@ -1747,6 +1775,22 @@ body {
     </div>
   </div>
 
+  <!-- Google Calendar Sync modal -->
+  <div class="modal" id="calSyncModal">
+    <div class="modal__content">
+      <h2 class="modal__title">Google Calendar Sync</h2>
+      <p style="font-size: var(--text-xs); color: var(--fg-muted); margin-bottom: var(--space-4);">
+        Mirror events into a dedicated <strong>ctrl.events</strong> Google calendar.
+        <span style="color: hsl(200, 60%, 55%);">■</span> Interested (bookmarked) &nbsp;
+        <span style="color: hsl(270, 45%, 60%);">■</span> Agape recommended
+      </p>
+      <div id="calSyncBody"></div>
+      <div class="modal__actions">
+        <button class="btn" id="calSyncClose">Close</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Supabase JS + Shared Auth Module -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
   <script src="/auth/ctrl-auth.js"></script>
@@ -1759,8 +1803,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.15.0';
-  console.log(`[events] v${VERSION} - Agape recommended + past-events filters; Agape curation source; eventbrite-org stock sources`);
+  const VERSION = '1.16.0';
+  console.log(`[events] v${VERSION} - Interested bookmarks + Google Calendar sync (ctrl.events, bookmarked/agape color-coded)`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1882,6 +1926,8 @@ body {
     updateDebugLogVisibility();
     if (wasLoggedOut) {
       log('Logged in as ' + (currentUser.email || 'user'));
+      loadBookmarks();
+      loadCalendarSyncState();
       const cloudLoaded = await loadSourcesCloud();
       if (cloudLoaded) {
         log('Cloud sync: restored sources after login');
@@ -1899,6 +1945,9 @@ body {
   document.addEventListener('ctrl:auth:signedout', () => {
     currentUser = null;
     updateDebugLogVisibility();
+    state.bookmarks = new Map();
+    resetCalendarSyncState();
+    render();
     log('Logged out');
   });
 
@@ -1914,8 +1963,9 @@ body {
     events: [],
     sources: [],
     sourceHealth: {},  // { sourceId: { status, consecutive_failures, success_rate, last_failure_reason, ... } }
-    filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, showPast: false },
+    filters: { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, interested: false, showPast: false },
     sort: { key: 'date', dir: 'asc' },
+    bookmarks: new Map(),  // eventKey -> { id, gcal_event_id } (user_event_bookmarks rows)
     view: 'table',
     calMonth: new Date().getMonth(),
     calYear: new Date().getFullYear(),
@@ -2086,6 +2136,243 @@ body {
       log(`Cloud sync: loaded ${cloudSources.length} sources for ${currentUser.email}`);
       return true;
     } catch (e) { log('Cloud sync load failed: ' + e.message); return false; }
+  }
+
+  // --- Bookmarks ("interested" flag, Supabase user_event_bookmarks) ---
+  function eventKeyFor(ev) {
+    return ev.key || (ev.source + '|' + ev.url);
+  }
+
+  function isAgapeEvent(ev) {
+    return (ev.recommendedBy && ev.recommendedBy.includes('agape')) ||
+           (ev.sources && ev.sources.includes('discord-agape-events')) ||
+           ev.source === 'discord-agape-events';
+  }
+
+  async function loadBookmarks() {
+    if (!supabaseClient || !currentUser) return;
+    try {
+      const { data, error } = await supabaseClient
+        .from('user_event_bookmarks')
+        .select('id, event_key')
+        .eq('user_id', currentUser.id);
+      if (error) { log('Bookmarks load error: ' + error.message); return; }
+      state.bookmarks = new Map((data || []).map(r => [r.event_key, r]));
+      log(`Bookmarks loaded: ${state.bookmarks.size}`);
+      render();
+    } catch (e) { log('Bookmarks load failed: ' + e.message); }
+  }
+
+  async function toggleBookmark(key) {
+    if (!currentUser) {
+      // Bookmarking is an authenticated feature — route to sign-in
+      CtrlAuth.openLoginModal();
+      return;
+    }
+    const existing = state.bookmarks.get(key);
+    if (existing) {
+      state.bookmarks.delete(key);
+      render();
+      const { error } = await supabaseClient
+        .from('user_event_bookmarks')
+        .delete()
+        .eq('id', existing.id);
+      if (error) { log('Bookmark remove error: ' + error.message); state.bookmarks.set(key, existing); render(); }
+      else { log('Bookmark removed: ' + key); scheduleCalendarSync(); }
+    } else {
+      const ev = state.events.find(e => eventKeyFor(e) === key);
+      if (!ev) return;
+      // Optimistic UI; reconcile with the returned row id
+      state.bookmarks.set(key, { id: null });
+      render();
+      const snapshot = {
+        name: ev.name, date: ev.date, endDate: ev.endDate || null, time: ev.time || '',
+        venue: ev.venue || '', address: ev.address || '', city: ev.city || '',
+        url: ev.url || '', source: ev.source, contentType: ev.contentType || '',
+        description: ev.description || '', agape: isAgapeEvent(ev),
+      };
+      const { data, error } = await supabaseClient
+        .from('user_event_bookmarks')
+        .upsert({ user_id: currentUser.id, event_key: key, event: snapshot }, { onConflict: 'user_id,event_key' })
+        .select('id, event_key')
+        .single();
+      if (error || !data) { log('Bookmark save error: ' + (error?.message || 'no row')); state.bookmarks.delete(key); render(); }
+      else { state.bookmarks.set(key, data); log('Bookmark saved: ' + key); scheduleCalendarSync(); }
+    }
+  }
+
+  // --- Google Calendar Sync (ctrl.events calendar via gcal-sync edge function) ---
+  const GCAL_STATE_KEY = 'ctrl-rodeo-gcal-oauth-state';
+  const calSync = { loaded: false, connected: false, syncEnabled: false, syncBookmarked: true, syncAgape: true, lastSyncedAt: null, busy: false, statusMsg: '' };
+
+  function regionTimezone() {
+    const region = localStorage.getItem('ctrl-rodeo-events-region') || 'bay-area';
+    return { 'new-york': 'America/New_York' }[region] || 'America/Los_Angeles';
+  }
+
+  async function gcalSyncCall(action, payload = {}) {
+    const token = getAccessToken();
+    if (!token) throw new Error('Sign in first');
+    const res = await fetch(`${SUPABASE_URL}/functions/v1/gcal-sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}`, 'apikey': SUPABASE_ANON_KEY },
+      body: JSON.stringify({ action, ...payload }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || `gcal-sync ${res.status}`);
+    return data;
+  }
+
+  function applyCalSyncStatus(data) {
+    calSync.loaded = true;
+    calSync.connected = !!data.connected;
+    calSync.syncEnabled = !!data.syncEnabled;
+    calSync.syncBookmarked = data.syncBookmarked !== false;
+    calSync.syncAgape = data.syncAgape !== false;
+    calSync.lastSyncedAt = data.lastSyncedAt || null;
+    if (data.result) {
+      const r = data.result;
+      calSync.statusMsg = `Synced: ${r.pushed} added, ${r.updated} updated, ${r.deleted} removed` + (r.errors ? `, ${r.errors} errors` : '');
+    }
+  }
+
+  async function loadCalendarSyncState() {
+    if (!currentUser) return;
+    try {
+      applyCalSyncStatus(await gcalSyncCall('status'));
+      renderCalSyncModal();
+    } catch (e) { log('Calendar sync status failed: ' + e.message); }
+  }
+
+  function resetCalendarSyncState() {
+    calSync.loaded = false; calSync.connected = false; calSync.syncEnabled = false;
+    calSync.lastSyncedAt = null; calSync.statusMsg = '';
+  }
+
+  // Debounced background sync after bookmark changes
+  let _calSyncDebounce = null;
+  function scheduleCalendarSync() {
+    if (!currentUser || !calSync.connected || !calSync.syncEnabled) return;
+    clearTimeout(_calSyncDebounce);
+    _calSyncDebounce = setTimeout(async () => {
+      try {
+        const data = await gcalSyncCall('sync');
+        applyCalSyncStatus(data);
+        log('Calendar sync: ' + (calSync.statusMsg || 'ok'));
+        renderCalSyncModal();
+      } catch (e) { log('Calendar sync failed: ' + e.message); }
+    }, 3000);
+  }
+
+  async function startGoogleConnect() {
+    const nonce = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    localStorage.setItem(GCAL_STATE_KEY, nonce);
+    const redirectUri = window.location.origin + '/events/';
+    const { url } = await gcalSyncCall('connect-url', { redirectUri, state: nonce });
+    window.location.href = url;
+  }
+
+  // Handle the OAuth redirect back from Google (?code=...&state=...)
+  async function handleGoogleCallback() {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    const stateParam = params.get('state');
+    if (!code || !stateParam) return;
+    const expected = localStorage.getItem(GCAL_STATE_KEY);
+    history.replaceState(null, '', window.location.pathname); // clean URL either way
+    if (!expected || stateParam !== expected) { log('Google callback: state mismatch, ignoring'); return; }
+    localStorage.removeItem(GCAL_STATE_KEY);
+    if (!currentUser) { log('Google callback: not signed in, ignoring'); return; }
+    openCalSyncModal();
+    setCalSyncBodyMsg('Connecting Google Calendar…');
+    try {
+      const data = await gcalSyncCall('exchange', { code, redirectUri: window.location.origin + '/events/', timezone: regionTimezone() });
+      applyCalSyncStatus(data);
+      if (!calSync.statusMsg) calSync.statusMsg = 'Connected.';
+      log('Google Calendar connected');
+    } catch (e) {
+      calSync.statusMsg = 'Connection failed: ' + e.message;
+      log('Google Calendar connect failed: ' + e.message);
+    }
+    renderCalSyncModal();
+  }
+
+  function openCalSyncModal() {
+    document.getElementById('calSyncModal').classList.add('modal--visible');
+    renderCalSyncModal();
+    if (currentUser && !calSync.loaded) loadCalendarSyncState();
+  }
+
+  function setCalSyncBodyMsg(msg) {
+    document.getElementById('calSyncBody').innerHTML =
+      `<p style="font-size: var(--text-xs); color: var(--fg-muted);">${escHtml(msg)}</p>`;
+  }
+
+  function renderCalSyncModal() {
+    const body = document.getElementById('calSyncBody');
+    if (!body) return;
+
+    if (!currentUser) {
+      body.innerHTML = `
+        <p style="font-size: var(--text-xs); color: var(--fg-muted); margin-bottom: var(--space-3);">Sign in to sync events to Google Calendar.</p>
+        <button class="btn btn--filled" onclick="document.getElementById('calSyncModal').classList.remove('modal--visible'); CtrlAuth.openLoginModal()">Sign in</button>`;
+      return;
+    }
+
+    if (!calSync.connected) {
+      body.innerHTML = `
+        <p style="font-size: var(--text-xs); color: var(--fg-muted); margin-bottom: var(--space-3);">Connect your Google account to create the ctrl.events calendar.</p>
+        <button class="btn btn--filled" id="calSyncConnect">Connect Google Calendar</button>
+        ${calSync.statusMsg ? `<p style="font-size: var(--text-2xs); color: var(--fg-subtle); margin-top: var(--space-2);">${escHtml(calSync.statusMsg)}</p>` : ''}`;
+      document.getElementById('calSyncConnect')?.addEventListener('click', async () => {
+        setCalSyncBodyMsg('Redirecting to Google…');
+        try { await startGoogleConnect(); }
+        catch (e) { calSync.statusMsg = 'Could not start connection: ' + e.message; renderCalSyncModal(); }
+      });
+      return;
+    }
+
+    const lastSynced = calSync.lastSyncedAt ? new Date(calSync.lastSyncedAt).toLocaleString() : 'never';
+    const cb = (id, checked, label, hint) => `
+      <label style="display: flex; align-items: flex-start; gap: var(--space-2); cursor: pointer; margin-bottom: var(--space-2); font-size: var(--text-xs);">
+        <input type="checkbox" id="${id}" ${checked ? 'checked' : ''} ${calSync.busy ? 'disabled' : ''} style="margin-top: 2px;">
+        <span>${label}<br><span style="color: var(--fg-subtle); font-size: var(--text-2xs);">${hint}</span></span>
+      </label>`;
+    body.innerHTML = `
+      ${cb('calSyncEnabled', calSync.syncEnabled, '<strong>Sync to Google Calendar</strong>', 'Keeps the ctrl.events calendar up to date')}
+      <div style="margin: var(--space-2) 0 var(--space-3) var(--space-5); ${calSync.syncEnabled ? '' : 'opacity: 0.45; pointer-events: none;'}">
+        ${cb('calSyncBookmarked', calSync.syncBookmarked, 'Interested events', 'Events you bookmark — blue')}
+        ${cb('calSyncAgape', calSync.syncAgape, 'Agape recommended', 'Community picks from the Agape #events channel — purple')}
+      </div>
+      <div style="display: flex; align-items: center; gap: var(--space-3);">
+        <button class="btn btn--sm btn--ghost" id="calSyncNow" ${calSync.busy || !calSync.syncEnabled ? 'disabled' : ''}>Sync now</button>
+        <span style="font-size: var(--text-2xs); color: var(--fg-subtle);">Last synced: ${escHtml(lastSynced)}</span>
+      </div>
+      ${calSync.statusMsg ? `<p style="font-size: var(--text-2xs); color: var(--fg-subtle); margin-top: var(--space-2);">${escHtml(calSync.statusMsg)}</p>` : ''}
+      <p style="margin-top: var(--space-4);"><a href="#" id="calSyncDisconnect" style="font-size: var(--text-2xs); color: var(--fg-subtle);">Disconnect Google Calendar</a></p>`;
+
+    const applySettings = async (payload) => {
+      calSync.busy = true; renderCalSyncModal();
+      try { applyCalSyncStatus(await gcalSyncCall('settings', payload)); }
+      catch (e) { calSync.statusMsg = 'Error: ' + e.message; }
+      calSync.busy = false; renderCalSyncModal();
+    };
+    document.getElementById('calSyncEnabled')?.addEventListener('change', (e) => applySettings({ syncEnabled: e.target.checked }));
+    document.getElementById('calSyncBookmarked')?.addEventListener('change', (e) => applySettings({ syncBookmarked: e.target.checked }));
+    document.getElementById('calSyncAgape')?.addEventListener('change', (e) => applySettings({ syncAgape: e.target.checked }));
+    document.getElementById('calSyncNow')?.addEventListener('click', async () => {
+      calSync.busy = true; calSync.statusMsg = 'Syncing…'; renderCalSyncModal();
+      try { applyCalSyncStatus(await gcalSyncCall('sync')); }
+      catch (e) { calSync.statusMsg = 'Sync failed: ' + e.message; }
+      calSync.busy = false; renderCalSyncModal();
+    });
+    document.getElementById('calSyncDisconnect')?.addEventListener('click', async (e) => {
+      e.preventDefault();
+      if (!confirm('Disconnect Google Calendar? The ctrl.events calendar stays in Google, but syncing stops.')) return;
+      try { applyCalSyncStatus(await gcalSyncCall('disconnect')); calSync.statusMsg = 'Disconnected.'; }
+      catch (err) { calSync.statusMsg = 'Error: ' + err.message; }
+      renderCalSyncModal();
+    });
   }
 
   // Get category for a source
@@ -2281,6 +2568,7 @@ body {
       for (const row of data) {
         const key = row.canonical_key || row.event_key || (row.source_id + '|' + row.url);
         const ev = {
+          key,
           date: row.date, time: row.time || '', name: row.name, venue: row.venue,
           address: row.address || '', city: row.city || '', genre: row.genre || '',
           price: row.price || '', ages: row.ages || '', promoter: row.promoter || '',
@@ -2666,7 +2954,13 @@ body {
       const priceData = formatPriceDisplay(ev.price);
       const priceTitle = priceData.full ? ` title="${escHtml(priceData.full)}"` : '';
       const thumbHtml = ev.imageUrl ? `<img src="${escHtml(ev.imageUrl)}" class="event-thumb" alt="" loading="lazy">` : '';
+      const bmKey = eventKeyFor(ev);
+      const isBm = state.bookmarks.has(bmKey);
+      const bmCell = `<td class="col-bm"><button class="bm-btn${isBm ? ' bm-btn--on' : ''}" data-bm-key="${encodeURIComponent(bmKey)}" aria-pressed="${isBm}" title="${isBm ? 'Interested — click to remove' : 'Mark as interested'}">
+        <svg width="14" height="14" viewBox="0 0 24 24" stroke-width="2" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+      </button></td>`;
       return `<tr>
+        ${bmCell}
         <td class="col-date">${dateDisplay}</td>
         <td class="col-time"${timeTip}>${timeDisplay}${mobileRangeHtml}</td>
         <td class="col-name">${thumbHtml}${nameCell}</td>
@@ -2692,7 +2986,7 @@ body {
         lastDate = ev.date;
         const d = new Date(ev.date + 'T00:00:00');
         const label = isNaN(d) ? ev.date : d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-        html += `<tr class="date-group"><td colspan="10" class="date-group__label">${escHtml(label)}</td></tr>`;
+        html += `<tr class="date-group"><td colspan="11" class="date-group__label">${escHtml(label)}</td></tr>`;
       }
       html += rowHtml(ev);
     }
@@ -3141,7 +3435,13 @@ body {
   // --- Filtering ---
   function updateFilterChips() {
     const agapeBtn = document.getElementById('filterAgape');
+    const interestedBtn = document.getElementById('filterInterested');
     const pastBtn = document.getElementById('filterPast');
+    if (interestedBtn) {
+      interestedBtn.style.background = state.filters.interested ? 'var(--fg)' : '';
+      interestedBtn.style.color = state.filters.interested ? 'var(--bg)' : '';
+      interestedBtn.setAttribute('aria-pressed', String(!!state.filters.interested));
+    }
     if (agapeBtn) {
       agapeBtn.style.background = state.filters.agape ? 'var(--fg)' : '';
       agapeBtn.style.color = state.filters.agape ? 'var(--bg)' : '';
@@ -3156,8 +3456,9 @@ body {
 
   function getFilteredEvents() {
     return state.events.filter(ev => {
-      const { search, city, source, dateFrom, dateTo, category, contentType, agape } = state.filters;
+      const { search, city, source, dateFrom, dateTo, category, contentType, agape, interested } = state.filters;
       if (agape && !((ev.recommendedBy && ev.recommendedBy.includes('agape')) || (ev.sources && ev.sources.includes('discord-agape-events')))) return false;
+      if (interested && !state.bookmarks.has(eventKeyFor(ev))) return false;
       if (search) { const q = search.toLowerCase(); if (![ev.name, ev.venue, ev.city, ev.genre, ev.promoter || '', ev.ages || ''].join(' ').toLowerCase().includes(q)) return false; }
       if (city && ev.city !== city) return false;
       if (source && ev.source !== source && !(ev.sources && ev.sources.includes(source))) return false;
@@ -3173,7 +3474,7 @@ body {
 
   function clearAllFilters() {
     const hadPast = state.filters.showPast;
-    state.filters = { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, showPast: false };
+    state.filters = { search: '', city: '', source: '', dateFrom: '', dateTo: '', category: '', contentType: '', agape: false, interested: false, showPast: false };
     updateFilterChips();
     if (hadPast) fetchAllSources(true);
     document.getElementById('filterSearch').value = '';
@@ -3527,6 +3828,12 @@ body {
       updateFilterChips();
       render();
     });
+    document.getElementById('filterInterested').addEventListener('click', () => {
+      if (!currentUser && !state.filters.interested) { CtrlAuth.openLoginModal(); return; }
+      state.filters.interested = !state.filters.interested;
+      updateFilterChips();
+      render();
+    });
     document.getElementById('filterPast').addEventListener('click', () => {
       state.filters.showPast = !state.filters.showPast;
       updateFilterChips();
@@ -3538,6 +3845,20 @@ body {
       filterToggleBtn.classList.remove('active');
     });
     document.getElementById('emptyClear').addEventListener('click', clearAllFilters);
+
+    // Bookmark ("interested") toggle
+    document.getElementById('eventsBody').addEventListener('click', (e) => {
+      const btn = e.target.closest('.bm-btn');
+      if (!btn) return;
+      e.preventDefault();
+      toggleBookmark(decodeURIComponent(btn.dataset.bmKey));
+    });
+
+    // Calendar sync modal
+    document.getElementById('calSyncBtn').addEventListener('click', openCalSyncModal);
+    document.getElementById('calSyncClose').addEventListener('click', () => {
+      document.getElementById('calSyncModal').classList.remove('modal--visible');
+    });
 
     // Mobile cards: the whole card is the tap target, not just the title link
     document.getElementById('eventsBody').addEventListener('click', (e) => {
@@ -4156,7 +4477,7 @@ body {
           '<div class="rec-signin-prompt">' +
             '<p class="rec-signin-prompt__text">Sign in to get personalized event recommendations based on your Boards.</p>' +
             '<p class="rec-signin-prompt__how">Recommendations analyze your saved links — artists, genres, categories, and keywords — then use AI to match upcoming events to your taste profile.</p>' +
-            '<button class="rec-signin-prompt__btn" onclick="document.getElementById(\'authLoginBtn\').click()">Sign in</button>' +
+            '<button class="rec-signin-prompt__btn" onclick="CtrlAuth.openLoginModal()">Sign in</button>' +
           '</div>';
         section.style.display = '';
         return;
@@ -4290,7 +4611,12 @@ body {
     if (currentUser && supabaseClient) {
       const cloudLoaded = await loadSourcesCloud();
       if (cloudLoaded) log('Init: using cloud sources');
+      loadBookmarks();
+      loadCalendarSyncState();
     }
+
+    // Returning from Google OAuth consent (?code=&state=)
+    handleGoogleCallback().catch(e => log('Google callback error: ' + e.message));
 
     if (!state.onboarded && state.sources.length === 0) {
       showOnboarding();

--- a/supabase/functions/gcal-sync/index.ts
+++ b/supabase/functions/gcal-sync/index.ts
@@ -1,0 +1,506 @@
+// Supabase Edge Function: gcal-sync
+// Mirrors a user's bookmarked ("interested") events and Agape-recommended events
+// into a dedicated "ctrl.events" Google Calendar.
+//
+// Ported from the trainingplans repo Google Calendar integration:
+// - OAuth code exchange + refresh-token flow (offline access, prompt=consent)
+// - Dedicated calendar created idempotently (verify stored id, recreate on 404)
+// - Dedupe via extendedProperties.private.eventKey (linear scan of the calendar)
+// - Color coding: bookmarked = Peacock (7), Agape = Grape (3)
+//
+// POST /functions/v1/gcal-sync   (Authorization: Bearer <user JWT>)
+// Body: { action: 'connect-url' | 'exchange' | 'status' | 'settings' | 'sync' | 'disconnect', ... }
+
+const VERSION = '1.0.0'
+console.log(`[gcal-sync] v${VERSION} — ctrl.events Google Calendar sync (bookmarked + agape)`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+const AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+const TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const CALENDAR_API = 'https://www.googleapis.com/calendar/v3'
+// Broad scope required to create a dedicated calendar (calendars.insert)
+const SCOPES = 'https://www.googleapis.com/auth/calendar'
+
+const CALENDAR_NAME = 'ctrl.events'
+const COLOR_BOOKMARKED = '7' // Peacock blue
+const COLOR_AGAPE = '3'      // Grape purple
+const DEFAULT_DURATION_MIN = 180
+
+function getSupabase() {
+  const url = Deno.env.get('SUPABASE_URL')!
+  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  return createClient(url, key)
+}
+
+function googleClientId(): string {
+  return Deno.env.get('GOOGLE_CLIENT_ID') || ''
+}
+function googleClientSecret(): string {
+  return Deno.env.get('GOOGLE_CLIENT_SECRET') || ''
+}
+
+// --- Auth: resolve the calling user from their JWT ---
+async function getUser(req: Request) {
+  const authHeader = req.headers.get('Authorization') || ''
+  const token = authHeader.replace(/^Bearer\s+/i, '')
+  if (!token) return null
+  const db = getSupabase()
+  const { data, error } = await db.auth.getUser(token)
+  if (error || !data?.user) return null
+  return data.user
+}
+
+// --- Token management (per trainingplans /lib/google.ts) ---
+
+interface SyncRow {
+  user_id: string
+  google_access_token: string | null
+  google_refresh_token: string | null
+  google_expires_at: string | null
+  google_calendar_id: string | null
+  sync_enabled: boolean
+  sync_bookmarked: boolean
+  sync_agape: boolean
+  timezone: string | null
+  last_synced_at: string | null
+}
+
+async function getSyncRow(userId: string): Promise<SyncRow | null> {
+  const db = getSupabase()
+  const { data } = await db.from('user_calendar_sync').select('*').eq('user_id', userId).maybeSingle()
+  return data as SyncRow | null
+}
+
+async function exchangeCode(code: string, redirectUri: string) {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: googleClientId(),
+      client_secret: googleClientSecret(),
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+    }),
+  })
+  if (!res.ok) throw new Error(`Google token exchange failed: ${res.status} ${await res.text()}`)
+  const d = await res.json()
+  return {
+    access_token: d.access_token as string,
+    refresh_token: (d.refresh_token as string) || null,
+    expires_at: new Date(Date.now() + (d.expires_in || 3600) * 1000).toISOString(),
+  }
+}
+
+async function getValidAccessToken(row: SyncRow): Promise<string> {
+  if (!row.google_refresh_token) throw new Error('GOOGLE_NOT_CONNECTED')
+  const expiresAt = row.google_expires_at ? new Date(row.google_expires_at).getTime() : 0
+  // Refresh preemptively if the token expires within 5 minutes
+  if (row.google_access_token && expiresAt - Date.now() > 5 * 60 * 1000) {
+    return row.google_access_token
+  }
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: googleClientId(),
+      client_secret: googleClientSecret(),
+      refresh_token: row.google_refresh_token,
+      grant_type: 'refresh_token',
+    }),
+  })
+  if (!res.ok) throw new Error(`Google token refresh failed: ${res.status} ${await res.text()}`)
+  const d = await res.json()
+  const db = getSupabase()
+  await db.from('user_calendar_sync').update({
+    google_access_token: d.access_token,
+    google_expires_at: new Date(Date.now() + (d.expires_in || 3600) * 1000).toISOString(),
+  }).eq('user_id', row.user_id)
+  return d.access_token
+}
+
+// --- Calendar creation (idempotent, per trainingplans ensureTrainingCalendar) ---
+
+async function ensureCalendar(row: SyncRow, token: string): Promise<string> {
+  const db = getSupabase()
+  const tz = row.timezone || 'America/Los_Angeles'
+
+  if (row.google_calendar_id) {
+    const check = await fetch(`${CALENDAR_API}/calendars/${encodeURIComponent(row.google_calendar_id)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (check.ok) return row.google_calendar_id
+    // 404/410 → calendar was deleted; fall through and recreate
+  }
+
+  const res = await fetch(`${CALENDAR_API}/calendars`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ summary: CALENDAR_NAME, timeZone: tz }),
+  })
+  if (res.status === 401 || res.status === 403) {
+    const body = await res.text()
+    if (/accessNotConfigured|has not been used|is disabled/i.test(body)) throw new Error('GOOGLE_API_DISABLED')
+    throw new Error('GOOGLE_SCOPE_INSUFFICIENT')
+  }
+  if (!res.ok) throw new Error(`Calendar create failed: ${res.status} ${await res.text()}`)
+  const data = await res.json()
+  await db.from('user_calendar_sync').update({ google_calendar_id: data.id }).eq('user_id', row.user_id)
+  return data.id as string
+}
+
+// --- Desired items: bookmarked + agape events ---
+
+interface DesiredItem {
+  eventKey: string
+  kind: 'bookmarked' | 'agape'
+  name: string
+  date: string          // YYYY-MM-DD
+  endDate: string | null
+  time: string | null   // raw scraped time string, e.g. "8pm", "7:30PM - 2AM"
+  venue: string
+  address: string
+  city: string
+  url: string
+  description: string
+}
+
+function todayISO(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
+async function getDesiredItems(row: SyncRow): Promise<DesiredItem[]> {
+  const db = getSupabase()
+  const today = todayISO()
+  const byKey = new Map<string, DesiredItem>()
+
+  if (row.sync_agape) {
+    // Agape-recommended events: tagged rows + the Agape Discord feed
+    const { data: agapeRows } = await db
+      .from('events')
+      .select('event_key, canonical_key, source_id, url, name, date, time, venue, address, city, description, recommended_by')
+      .gte('date', today)
+      .or('recommended_by.cs.{agape},source_id.eq.discord-agape-events')
+      .limit(500)
+    for (const r of agapeRows || []) {
+      const key = r.canonical_key || r.event_key || `${r.source_id}|${r.url}`
+      if (byKey.has(key)) continue
+      byKey.set(key, {
+        eventKey: key, kind: 'agape',
+        name: r.name, date: r.date, endDate: null, time: r.time || null,
+        venue: r.venue || '', address: r.address || '', city: r.city || '',
+        url: r.url || '', description: r.description || '',
+      })
+    }
+  }
+
+  if (row.sync_bookmarked) {
+    const { data: bms } = await db
+      .from('user_event_bookmarks')
+      .select('event_key, event')
+      .eq('user_id', row.user_id)
+    for (const b of bms || []) {
+      const ev = (b.event || {}) as Record<string, string>
+      if (!ev.date || ev.date < today) continue
+      // Bookmarked wins when an event is both bookmarked and Agape-recommended:
+      // an explicit user flag is a stronger signal than a community recommendation
+      byKey.set(b.event_key, {
+        eventKey: b.event_key, kind: 'bookmarked',
+        name: ev.name || 'Event', date: ev.date, endDate: ev.endDate || null, time: ev.time || null,
+        venue: ev.venue || '', address: ev.address || '', city: ev.city || '',
+        url: ev.url || '', description: ev.description || '',
+      })
+    }
+  }
+
+  return [...byKey.values()]
+}
+
+// --- Event payload (per trainingplans buildGoogleEvent) ---
+
+// Parse a scraped time string ("8pm", "7:30PM - 2AM", "20:00") → { h, m } or null
+function parseStartTime(raw: string | null): { h: number; m: number } | null {
+  if (!raw) return null
+  const start = raw.split(/[-–]/)[0].trim()
+  const ampm = start.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i)
+  if (ampm) {
+    let h = parseInt(ampm[1], 10) % 12
+    if (/pm/i.test(ampm[3])) h += 12
+    return { h, m: ampm[2] ? parseInt(ampm[2], 10) : 0 }
+  }
+  const h24 = start.match(/^(\d{1,2}):(\d{2})$/)
+  if (h24) {
+    const h = parseInt(h24[1], 10)
+    if (h >= 0 && h <= 23) return { h, m: parseInt(h24[2], 10) }
+  }
+  return null
+}
+
+function pad(n: number): string { return String(n).padStart(2, '0') }
+
+function nextDay(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
+
+function buildGoogleEvent(item: DesiredItem, tz: string): Record<string, unknown> {
+  const location = [item.venue, item.address, item.city].filter(Boolean).join(', ')
+  const descParts = []
+  if (item.url) descParts.push(item.url)
+  if (item.description) descParts.push(item.description)
+  descParts.push(item.kind === 'agape' ? 'Recommended by Agape — via ctrl.rodeo/events' : 'Interested — via ctrl.rodeo/events')
+
+  const event: Record<string, unknown> = {
+    summary: item.name,
+    location,
+    description: descParts.join('\n\n'),
+    colorId: item.kind === 'agape' ? COLOR_AGAPE : COLOR_BOOKMARKED,
+    extendedProperties: { private: { eventKey: item.eventKey, kind: item.kind, app: 'ctrl-events' } },
+  }
+
+  const start = parseStartTime(item.time)
+  if (!start) {
+    // All-day (end date is exclusive)
+    event.start = { date: item.date }
+    event.end = { date: nextDay(item.endDate || item.date) }
+    return event
+  }
+
+  // Timed event: local wall-clock in the user's timezone; Google resolves the offset
+  const startLocal = `${item.date}T${pad(start.h)}:${pad(start.m)}:00`
+  const endMinutes = start.h * 60 + start.m + DEFAULT_DURATION_MIN
+  const endH = Math.floor(endMinutes / 60), endM = endMinutes % 60
+  const endDate = endH >= 24 ? nextDay(item.date) : item.date
+  const endLocal = `${endDate}T${pad(endH % 24)}:${pad(endM)}:00`
+  event.start = { dateTime: startLocal, timeZone: tz }
+  event.end = { dateTime: endLocal, timeZone: tz }
+  event.reminders = { useDefault: false, overrides: [{ method: 'popup', minutes: 120 }] }
+  return event
+}
+
+// --- Sync (push-only reconcile, per trainingplans syncAllForAthlete) ---
+
+async function runSync(row: SyncRow): Promise<Record<string, number>> {
+  const token = await getValidAccessToken(row)
+  const calendarId = await ensureCalendar(row, token)
+  const tz = row.timezone || 'America/Los_Angeles'
+  const db = getSupabase()
+
+  const desired = await getDesiredItems(row)
+  const desiredByKey = new Map(desired.map(d => [d.eventKey, d]))
+
+  // Scan the calendar for events we own (extendedProperties.private.app = ctrl-events)
+  const existingByKey = new Map<string, { id: string; kind: string; summary: string; startRaw: string }>()
+  let pageToken: string | null = null
+  do {
+    const params = new URLSearchParams({
+      singleEvents: 'true', showDeleted: 'false', maxResults: '2500',
+      timeMin: new Date(Date.now() - 7 * 86400000).toISOString(),
+      privateExtendedProperty: 'app=ctrl-events',
+    })
+    if (pageToken) params.set('pageToken', pageToken)
+    const res = await fetch(`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    if (!res.ok) throw new Error(`Calendar list failed: ${res.status} ${await res.text()}`)
+    const data = await res.json()
+    for (const ev of data.items || []) {
+      const key = ev?.extendedProperties?.private?.eventKey
+      if (key && ev.status !== 'cancelled') {
+        existingByKey.set(key, {
+          id: ev.id,
+          kind: ev.extendedProperties.private.kind || '',
+          summary: ev.summary || '',
+          startRaw: JSON.stringify(ev.start || {}),
+        })
+      }
+    }
+    pageToken = data.nextPageToken || null
+  } while (pageToken)
+
+  let pushed = 0, updated = 0, deleted = 0, unchanged = 0, errors = 0
+
+  // Insert / update
+  for (const item of desired) {
+    const payload = buildGoogleEvent(item, tz)
+    const existing = existingByKey.get(item.eventKey)
+    try {
+      if (!existing) {
+        const res = await fetch(`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!res.ok) throw new Error(`insert ${res.status}`)
+        pushed++
+      } else {
+        // Cheap change check: kind (color), name, start
+        const startNow = JSON.stringify((payload as { start: unknown }).start)
+        if (existing.kind === item.kind && existing.summary === payload.summary && existing.startRaw === startNow) {
+          unchanged++
+        } else {
+          const res = await fetch(`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${existing.id}`, {
+            method: 'PATCH',
+            headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          })
+          if (!res.ok) throw new Error(`patch ${res.status}`)
+          updated++
+        }
+      }
+    } catch (e) {
+      errors++
+      console.log(`[gcal-sync] ${item.eventKey}: ${(e as Error).message}`)
+    }
+  }
+
+  // Delete events we own that are no longer desired (unbookmarked / toggled off)
+  for (const [key, existing] of existingByKey) {
+    if (desiredByKey.has(key)) continue
+    try {
+      const res = await fetch(`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${existing.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok && res.status !== 404 && res.status !== 410) throw new Error(`delete ${res.status}`)
+      deleted++
+    } catch (e) {
+      errors++
+      console.log(`[gcal-sync] delete ${key}: ${(e as Error).message}`)
+    }
+  }
+
+  const result = { pushed, updated, deleted, unchanged, errors }
+  await db.from('user_calendar_sync').update({
+    last_synced_at: new Date().toISOString(),
+    last_sync_result: result,
+  }).eq('user_id', row.user_id)
+  console.log(`[gcal-sync] ${row.user_id}: ${JSON.stringify(result)}`)
+  return result
+}
+
+// --- Status payload (never includes tokens) ---
+function statusPayload(row: SyncRow | null) {
+  return {
+    connected: !!row?.google_refresh_token,
+    syncEnabled: !!row?.sync_enabled,
+    syncBookmarked: row?.sync_bookmarked ?? true,
+    syncAgape: row?.sync_agape ?? true,
+    lastSyncedAt: row?.last_synced_at || null,
+  }
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  if (req.method !== 'POST') return new Response(JSON.stringify({ error: 'POST only' }), { status: 405, headers: jsonHeaders })
+
+  const user = await getUser(req)
+  if (!user) return new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401, headers: jsonHeaders })
+
+  let body: Record<string, unknown> = {}
+  try { body = await req.json() } catch { /* empty body ok for some actions */ }
+  const action = body.action as string
+  const db = getSupabase()
+
+  try {
+    switch (action) {
+      case 'connect-url': {
+        // Client passes its own origin-based redirect (must be registered in Google Cloud Console)
+        const redirectUri = (body.redirectUri as string) || ''
+        if (!/^https:\/\/(ctrl\.rodeo|fikei\.github\.io)\/|^http:\/\/localhost[:/]/.test(redirectUri)) {
+          return new Response(JSON.stringify({ error: 'invalid redirectUri' }), { status: 400, headers: jsonHeaders })
+        }
+        const params = new URLSearchParams({
+          client_id: googleClientId(),
+          redirect_uri: redirectUri,
+          response_type: 'code',
+          scope: SCOPES,
+          access_type: 'offline',   // enables refresh token
+          prompt: 'consent',        // force refresh_token issuance + scope re-consent
+          state: (body.state as string) || '',
+        })
+        return new Response(JSON.stringify({ url: `${AUTH_URL}?${params}` }), { headers: jsonHeaders })
+      }
+
+      case 'exchange': {
+        const tokens = await exchangeCode(body.code as string, body.redirectUri as string)
+        const existing = await getSyncRow(user.id)
+        await db.from('user_calendar_sync').upsert({
+          user_id: user.id,
+          google_access_token: tokens.access_token,
+          // Google only returns refresh_token on first consent; keep the old one otherwise
+          google_refresh_token: tokens.refresh_token || existing?.google_refresh_token || null,
+          google_expires_at: tokens.expires_at,
+          sync_enabled: true,
+          timezone: (body.timezone as string) || existing?.timezone || 'America/Los_Angeles',
+        }, { onConflict: 'user_id' })
+        const row = await getSyncRow(user.id)
+        let result = null
+        if (row?.google_refresh_token) {
+          try { result = await runSync(row) } catch (e) { console.log('[gcal-sync] initial sync failed: ' + (e as Error).message) }
+        }
+        return new Response(JSON.stringify({ ...statusPayload(row), result }), { headers: jsonHeaders })
+      }
+
+      case 'status': {
+        const row = await getSyncRow(user.id)
+        return new Response(JSON.stringify(statusPayload(row)), { headers: jsonHeaders })
+      }
+
+      case 'settings': {
+        const row = await getSyncRow(user.id)
+        if (!row) return new Response(JSON.stringify({ error: 'not connected' }), { status: 400, headers: jsonHeaders })
+        const update: Record<string, unknown> = {}
+        if (typeof body.syncEnabled === 'boolean') update.sync_enabled = body.syncEnabled
+        if (typeof body.syncBookmarked === 'boolean') update.sync_bookmarked = body.syncBookmarked
+        if (typeof body.syncAgape === 'boolean') update.sync_agape = body.syncAgape
+        if (typeof body.timezone === 'string') update.timezone = body.timezone
+        if (Object.keys(update).length) await db.from('user_calendar_sync').update(update).eq('user_id', user.id)
+        const fresh = await getSyncRow(user.id)
+        let result = null
+        if (fresh?.sync_enabled && fresh.google_refresh_token) {
+          result = await runSync(fresh) // settings changes reconcile immediately (adds AND removes)
+        }
+        return new Response(JSON.stringify({ ...statusPayload(fresh), result }), { headers: jsonHeaders })
+      }
+
+      case 'sync': {
+        const row = await getSyncRow(user.id)
+        if (!row?.google_refresh_token) return new Response(JSON.stringify({ error: 'GOOGLE_NOT_CONNECTED' }), { status: 400, headers: jsonHeaders })
+        if (!row.sync_enabled) return new Response(JSON.stringify({ ...statusPayload(row), result: null }), { headers: jsonHeaders })
+        const result = await runSync(row)
+        return new Response(JSON.stringify({ ...statusPayload(await getSyncRow(user.id)), result }), { headers: jsonHeaders })
+      }
+
+      case 'disconnect': {
+        // Clear tokens + calendar pointer; the ctrl.events calendar itself is left in place
+        await db.from('user_calendar_sync').update({
+          google_access_token: null,
+          google_refresh_token: null,
+          google_expires_at: null,
+          google_calendar_id: null,
+          sync_enabled: false,
+        }).eq('user_id', user.id)
+        return new Response(JSON.stringify(statusPayload(await getSyncRow(user.id))), { headers: jsonHeaders })
+      }
+
+      default:
+        return new Response(JSON.stringify({ error: `unknown action: ${action}` }), { status: 400, headers: jsonHeaders })
+    }
+  } catch (e) {
+    const msg = (e as Error).message || 'error'
+    const known = ['GOOGLE_NOT_CONNECTED', 'GOOGLE_SCOPE_INSUFFICIENT', 'GOOGLE_API_DISABLED']
+    const status = known.includes(msg) ? 409 : 500
+    console.log(`[gcal-sync] error (${action}): ${msg}`)
+    return new Response(JSON.stringify({ error: msg }), { status, headers: jsonHeaders })
+  }
+})

--- a/supabase/migrations/092_user_event_bookmarks.sql
+++ b/supabase/migrations/092_user_event_bookmarks.sql
@@ -1,0 +1,36 @@
+-- Migration 092: User Event Bookmarks
+-- Lets a signed-in user flag an event as "interested" (bookmark icon in /events).
+-- Stores a snapshot of the event so bookmarks survive cache expiry / source removal.
+-- Google Calendar sync (ctrl.events) reads these rows; dedupe there uses
+-- extendedProperties.private.eventKey on the Google side, not stored ids.
+
+CREATE TABLE user_event_bookmarks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_key TEXT NOT NULL,                          -- canonical_key || event_key || source|url (client-computed)
+  event JSONB NOT NULL DEFAULT '{}'::jsonb,         -- snapshot {name, date, endDate, time, venue, address, city, url, source, ...}
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, event_key)
+);
+
+CREATE INDEX idx_user_event_bookmarks_user ON user_event_bookmarks(user_id);
+
+-- RLS: users can only read/write their own bookmarks
+ALTER TABLE user_event_bookmarks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own bookmarks"
+  ON user_event_bookmarks FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert own bookmarks"
+  ON user_event_bookmarks FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update own bookmarks"
+  ON user_event_bookmarks FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own bookmarks"
+  ON user_event_bookmarks FOR DELETE
+  USING (auth.uid() = user_id);

--- a/supabase/migrations/093_user_calendar_sync.sql
+++ b/supabase/migrations/093_user_calendar_sync.sql
@@ -1,0 +1,44 @@
+-- Migration 093: User Google Calendar Sync (ctrl.events)
+-- Per-user Google Calendar connection + sync settings for /events.
+-- Bookmarked and Agape-recommended events are mirrored into a dedicated
+-- "ctrl.events" Google calendar by the gcal-sync edge function.
+-- Token columns are written only by the edge function (service role);
+-- RLS lets users read their own sync status but never the token columns
+-- are exposed to the UI (client selects only non-token columns).
+
+CREATE TABLE user_calendar_sync (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  google_access_token TEXT,
+  google_refresh_token TEXT,
+  google_expires_at TIMESTAMPTZ,
+  google_calendar_id TEXT,                     -- id of the "ctrl.events" calendar once created
+  sync_enabled BOOLEAN NOT NULL DEFAULT false,
+  sync_bookmarked BOOLEAN NOT NULL DEFAULT true,   -- mirror bookmarked ("interested") events
+  sync_agape BOOLEAN NOT NULL DEFAULT true,        -- mirror Agape-recommended events
+  timezone TEXT DEFAULT 'America/Los_Angeles',
+  last_synced_at TIMESTAMPTZ,
+  last_sync_result JSONB,                      -- {pushed, updated, deleted, errors} from last run
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE OR REPLACE FUNCTION update_user_calendar_sync_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_user_calendar_sync_updated
+  BEFORE UPDATE ON user_calendar_sync
+  FOR EACH ROW EXECUTE FUNCTION update_user_calendar_sync_timestamp();
+
+-- RLS: owner can read own row (client reads status/settings columns only);
+-- all writes go through the gcal-sync edge function using the service role,
+-- so no INSERT/UPDATE policies for authenticated users — tokens stay server-managed.
+ALTER TABLE user_calendar_sync ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read own calendar sync"
+  ON user_calendar_sync FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
Two authenticated-user features for **/events**:

### 1. Bookmark an event as "interested" 🔖
- New bookmark icon column on every event row (desktop table + mobile cards)
- Persisted per user in new `user_event_bookmarks` table (RLS own-rows only, stores an event snapshot so bookmarks survive cache expiry)
- New **Interested** filter chip next to the Agape filter
- Signed-out clicks route to the sign-in modal (also fixes the pre-existing broken `authLoginBtn` sign-in button in the recommendations prompt)

### 2. Google Calendar sync → "ctrl.events" calendar 📅
Ported from the trainingplans repo implementation (OAuth offline flow, idempotent calendar creation, extendedProperties dedupe):
- New `gcal-sync` edge function v1.0.0: code exchange + token refresh, creates/verifies a dedicated **ctrl.events** calendar, push-reconciles (insert/update/delete)
- **Color coded:** bookmarked = Peacock blue (colorId 7), Agape recommended = Grape purple (colorId 3); bookmarked wins when both
- **Settings modal** (Calendar button in the toolbar): connect/disconnect Google, master sync toggle, per-category toggles (Interested / Agape), Sync now, last-synced timestamp
- Auto-sync (3s debounce) after bookmark changes
- New `user_calendar_sync` table — token columns written only by the service role; client reads status via the edge function

## Migrations
- `092_user_event_bookmarks.sql`
- `093_user_calendar_sync.sql`

## Post-merge setup required (not in this PR)
- Set `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` secrets on the Boards Supabase project (reuse the trainingplans Google Cloud OAuth app)
- Add `https://ctrl.rodeo/events/` as an authorized redirect URI in Google Cloud Console

## Testing
- Chrome smoke test on localhost: v1.16.0 boots clean, 470 rows render with bookmark buttons, Calendar modal opens with signed-out prompt, bookmark click while signed out opens the login modal
- JS syntax (node --check) and edge function TS (esbuild) both pass
- Signed-in bookmark toggle + live Google sync need post-deploy QA (requires migrations + secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)