### PR TITLE
gcal-sync 1.0.1: reuse existing GOOGLE_CALENDAR_* secrets

### DIFF
--- a/supabase/functions/gcal-sync/index.ts
+++ b/supabase/functions/gcal-sync/index.ts
@@ -11,7 +11,7 @@
 // POST /functions/v1/gcal-sync   (Authorization: Bearer <user JWT>)
 // Body: { action: 'connect-url' | 'exchange' | 'status' | 'settings' | 'sync' | 'disconnect', ... }
 
-const VERSION = '1.0.0'
+const VERSION = '1.0.1'
 console.log(`[gcal-sync] v${VERSION} — ctrl.events Google Calendar sync (bookmarked + agape)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -40,11 +40,13 @@ function getSupabase() {
   return createClient(url, key)
 }
 
+// Reuses the OAuth client already configured for the /calendar app
+// (same Google Cloud project; ctrl.rodeo/events/ must be an authorized redirect URI)
 function googleClientId(): string {
-  return Deno.env.get('GOOGLE_CLIENT_ID') || ''
+  return Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID') || ''
 }
 function googleClientSecret(): string {
-  return Deno.env.get('GOOGLE_CLIENT_SECRET') || ''
+  return Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET') || ''
 }
 
 // --- Auth: resolve the calling user from their JWT ---


### PR DESCRIPTION
Follow-up to #1017: the Boards Supabase project already has the /calendar app's Google OAuth client configured (`GOOGLE_CALENDAR_CLIENT_ID` / `GOOGLE_CALENDAR_CLIENT_SECRET`). Point gcal-sync at those secret names so **no new secrets are needed** — the only remaining setup is adding `https://ctrl.rodeo/events/` as an authorized redirect URI on that OAuth client in Google Cloud Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)