### PR TITLE
feat(events): one-off event submission by web link

### DIFF
--- a/docs/playground/events/strategy/prd-event-source-architecture.md
+++ b/docs/playground/events/strategy/prd-event-source-architecture.md
@@ -40,6 +40,8 @@ Every source belongs to exactly one class. Class determines default visibility, 
 | **3. Public Event Ticketing** | Ticketing platforms with public, discoverable event pages | RA, Luma, Dice, Shotgun, Tixr, SeeTickets | **Public** |
 | **4. Private Ticketing / Invites** | Invite-native platforms with no discovery surface | Partiful, secretparty.io, Google Forms, Discord text-only announcements | **Hidden (for now)** |
 
+**User-submitted one-off events** (`user-submitted` source, `add-event` function) follow the same per-URL rules: any signed-in user can paste an event link; public ticketing/venue pages become public rows, private-invite platforms (Partiful, secretparty, forms) stay private. The URL-first dedup ladder merges submissions that already exist in the store.
+
 **The Agape Discord channel is not a class-member — it is the curation layer.** It contributes the `recommended_by: agape` signal and `posted_by` attribution to events in any class. It is also the *only* ingestion path for class-4 events.
 
 ### 2.1 Demotion rule (long-tail discovery platforms)
@@ -195,6 +197,7 @@ Explicitly **not** filters: ticket platform (attribute → outbound link icon), 
 - [x] "★ Agape" filter + "Past events" toggle in the events app (v1.15.0); private rows visible to authenticated users (migration 091 — §8.1 resolved: any Supabase-authenticated user)
 - [x] Metrics dashboard at `/events/metrics.html` (agape_coverage, source health, scrape runs, enrichment queue)
 - [x] Greenlit Eventbrite orgs with Agape signal via `eventbrite-org` parser (§8.4 resolved: class per-source) — Public Works, Manny's, Hoodslam, The Center SF, Envelop, Flux Vertical Theatre (migration 090)
+- [x] One-off event submission by link (`add-event` v1.0.0 + client v1.16.0): JSON-LD → OG → Haiku extraction, per-URL visibility, auth-gated
 - [ ] Agape badge + `posted_by` display on event cards
 - [ ] Private-event view polish (class-4 events) for members
 - [ ] Venue Waves 1 & 3 gap-fill; Internet Archive org id lookup

--- a/events/index.html
+++ b/events/index.html
@@ -1639,6 +1639,16 @@ body {
         <div id="activeSourcesList" style="border: var(--border-thin) solid var(--border-subtle); max-height: 200px; overflow-y: auto;"></div>
       </div>
 
+      <!-- One-off event by link (add-event edge function) -->
+      <div class="form-group" id="oneOffGroup">
+        <label class="form-label">Add a one-off event by link</label>
+        <div style="display:flex; gap: var(--space-2);">
+          <input type="text" class="input" id="oneOffUrl" placeholder="Paste an event page URL (Partiful, Luma, Eventbrite, venue…)" style="flex:1;">
+          <button class="btn btn--sm" id="oneOffAddBtn">Add</button>
+        </div>
+        <span class="form-hint" id="oneOffStatus"></span>
+      </div>
+
       <div style="font-size: var(--text-2xs); color: var(--fg-subtle); text-align: center; text-transform: uppercase; letter-spacing: var(--tracking-wider); margin: var(--space-3) 0;">add more</div>
 
       <!-- Pin-based suggestions (logged-in users) -->
@@ -1759,8 +1769,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.15.0';
-  console.log(`[events] v${VERSION} - Agape recommended + past-events filters; Agape curation source; eventbrite-org stock sources`);
+  const VERSION = '1.16.0';
+  console.log(`[events] v${VERSION} - one-off event submission by link (add-event); Community adds source`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1796,6 +1806,8 @@ body {
     { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
     // Bay Area — Agape curation feed (private rows: visible only when signed in)
     { id: 'discord-agape-events', name: 'Agape #events', category: 'social', type: 'discord', url: null, region: 'bay-area', description: 'Agape community recommendations' },
+    // One-off events added by users via the add-event function
+    { id: 'user-submitted', name: 'Community adds', category: 'social', type: 'manual', url: null, region: 'bay-area', description: 'One-off events added by link' },
     // Bay Area — Eventbrite orgs with Agape signal (scraped server-side)
     { id: 'eb-publicworks', name: 'Public Works', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/public-works-17405142071', region: 'bay-area', description: 'Public Works SF' },
     { id: 'eb-mannys', name: "Manny's", category: 'social', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/mannys-15114280512', region: 'bay-area', description: "Manny's civic events" },
@@ -1990,6 +2002,14 @@ body {
         if (agape) state.sources.push({ ...agape, enabled: true });
       }
       localStorage.setItem('ctrl-rodeo-agape-source-added', '1');
+    }
+    // One-time migration: community-added one-off events source
+    if (!localStorage.getItem('ctrl-rodeo-user-submitted-added')) {
+      if (!state.sources.some(s => s.id === 'user-submitted')) {
+        const us = STOCK_SOURCES.find(s => s.id === 'user-submitted');
+        if (us) state.sources.push({ ...us, enabled: true });
+      }
+      localStorage.setItem('ctrl-rodeo-user-submitted-added', '1');
     }
 
     saveSources();
@@ -3526,6 +3546,34 @@ body {
       state.filters.agape = !state.filters.agape;
       updateFilterChips();
       render();
+    });
+    document.getElementById('oneOffAddBtn').addEventListener('click', async () => {
+      const input = document.getElementById('oneOffUrl');
+      const status = document.getElementById('oneOffStatus');
+      const btn = document.getElementById('oneOffAddBtn');
+      const url = input.value.trim();
+      if (!url) { status.textContent = 'Paste an event page URL first'; return; }
+      const token = getAccessToken();
+      if (!token) { status.textContent = 'Sign in to add events'; return; }
+      btn.disabled = true;
+      status.textContent = 'Extracting event…';
+      try {
+        const resp = await fetch(SUPABASE_URL + '/functions/v1/add-event', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+          body: JSON.stringify({ url }),
+        });
+        const data = await resp.json();
+        if (!resp.ok) { status.textContent = data.error || 'Failed to add event'; return; }
+        const vis = data.visibility === 'private' ? ' (private — visible to signed-in users)' : '';
+        status.textContent = 'Added: ' + data.event.name + ' on ' + data.event.date + vis;
+        input.value = '';
+        fetchAllSources(true);
+      } catch (e) {
+        status.textContent = 'Error: ' + e.message;
+      } finally {
+        btn.disabled = false;
+      }
     });
     document.getElementById('filterPast').addEventListener('click', () => {
       state.filters.showPast = !state.filters.showPast;

--- a/supabase/functions/add-event/index.ts
+++ b/supabase/functions/add-event/index.ts
@@ -1,0 +1,223 @@
+// Supabase Edge Function: add-event
+// Lets a signed-in user add a one-off event by pasting a web link.
+// Fetches the page, extracts structured event data (JSON-LD Event schema ->
+// OpenGraph tags -> Claude Haiku fallback), and forwards it into the
+// canonical store via cache-events under the 'user-submitted' source.
+//
+// Visibility follows the PRD source-architecture rules per URL, not per
+// source: links on private-invite platforms (Partiful, secretparty, forms)
+// stay private; public ticketing/venue pages are public. The URL-first dedup
+// ladder in cache-events auto-merges submissions that already exist.
+//
+// POST /functions/v1/add-event   (requires an authenticated user JWT)
+// Body: { url: string }
+// Returns: { event, visibility, merged: boolean }
+
+const VERSION = '1.0.0'
+console.log(`[add-event] v${VERSION} - one-off event submission by link`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function json(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+const SOURCE_ID = 'user-submitted'
+
+// Private-invite platforms: submissions from these stay private (PRD §2.2)
+const PRIVATE_HOSTS = ['partiful.com', 'secretparty.io', 'docs.google.com', 'forms.gle']
+
+interface Extracted {
+  date: string
+  time: string
+  name: string
+  venue: string
+  address: string
+  city: string
+  price: string
+  description: string
+  imageUrl: string
+}
+
+// --- JSON-LD extraction (schema.org Event) ---
+
+// deno-lint-ignore no-explicit-any
+function findEventNode(node: any): any | null {
+  if (!node || typeof node !== 'object') return null
+  if (Array.isArray(node)) {
+    for (const n of node) { const f = findEventNode(n); if (f) return f }
+    return null
+  }
+  const type = node['@type']
+  const types = Array.isArray(type) ? type : [type]
+  if (types.some(t => typeof t === 'string' && /Event$/i.test(t))) return node
+  if (node['@graph']) return findEventNode(node['@graph'])
+  return null
+}
+
+function extractJsonLd(html: string): Extracted | null {
+  const scripts = html.matchAll(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+  for (const m of scripts) {
+    try {
+      const ev = findEventNode(JSON.parse(m[1]))
+      if (!ev || !ev.name || !ev.startDate) continue
+      const start = String(ev.startDate)
+      const loc = ev.location && !Array.isArray(ev.location) ? ev.location : (ev.location?.[0] || {})
+      const addr = loc.address || {}
+      const offers = Array.isArray(ev.offers) ? ev.offers[0] : ev.offers
+      return {
+        date: start.split('T')[0],
+        time: (start.split('T')[1] || '').slice(0, 5),
+        name: String(ev.name).slice(0, 200),
+        venue: String(loc.name || '').slice(0, 120),
+        address: String(typeof addr === 'string' ? addr : addr.streetAddress || '').slice(0, 200),
+        city: String(typeof addr === 'object' ? addr.addressLocality || '' : '').slice(0, 80),
+        price: offers?.price ? `$${offers.price}` : '',
+        description: String(ev.description || '').slice(0, 500),
+        imageUrl: String(Array.isArray(ev.image) ? ev.image[0] : ev.image || ''),
+      }
+    } catch { /* malformed JSON-LD block — try the next one */ }
+  }
+  return null
+}
+
+// --- AI fallback (page text -> structured event) ---
+
+async function extractWithAI(html: string, url: string, apiKey: string): Promise<Extracted | null> {
+  const title = html.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1] || ''
+  const ogTitle = html.match(/property=["']og:title["'][^>]*content=["']([^"']*)/i)?.[1] || ''
+  const ogDesc = html.match(/property=["']og:description["'][^>]*content=["']([^"']*)/i)?.[1] || ''
+  const text = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .slice(0, 4000)
+
+  const today = new Date().toISOString().split('T')[0]
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 512,
+      messages: [{
+        role: 'user',
+        content: `Extract the single event described on this web page. Today is ${today}. URL: ${url}\nTitle: ${title}\nOG title: ${ogTitle}\nOG description: ${ogDesc}\nPage text: ${text}\n\nReturn ONLY a JSON object (no markdown): {"date":"YYYY-MM-DD","time":"HH:MM" or "","name":"...","venue":"..." or "","address":"" ,"city":"" ,"price":"" ,"description":"one sentence"} — or null if no event is identifiable.`,
+      }],
+    }),
+  })
+  if (!resp.ok) throw new Error(`Claude API ${resp.status}`)
+  const data = await resp.json()
+  const raw = (data.content?.[0]?.text || '').replace(/^```(?:json)?\s*/m, '').replace(/\s*```$/m, '').trim()
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || !parsed.date || !parsed.name) return null
+    return { imageUrl: '', ...parsed }
+  } catch { return null }
+}
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  if (req.method !== 'POST') return json({ error: 'POST required' }, 405)
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const anonKey = Deno.env.get('SUPABASE_ANON_KEY')!
+    const serviceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+    // Require a signed-in user (or the service role, for testing/automation)
+    const authHeader = req.headers.get('Authorization') || ''
+    let submittedBy = ''
+    try {
+      const payload = JSON.parse(atob(authHeader.replace(/^Bearer\s+/i, '').split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+      if (payload.role === 'service_role') {
+        submittedBy = 'service'
+      } else {
+        const authed = createClient(supabaseUrl, anonKey, { global: { headers: { Authorization: authHeader } } })
+        const { data: { user } } = await authed.auth.getUser()
+        if (!user) return json({ error: 'Sign in to add events' }, 401)
+        submittedBy = user.email?.split('@')[0] || user.id.slice(0, 8)
+      }
+    } catch {
+      return json({ error: 'Sign in to add events' }, 401)
+    }
+
+    const { url } = await req.json() as { url?: string }
+    if (!url || !/^https?:\/\//i.test(url)) return json({ error: 'A valid http(s) URL is required' }, 400)
+    const host = new URL(url).hostname.toLowerCase().replace(/^www\./, '')
+    // SSRF guard: public hostnames only
+    if (/^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|\[)/.test(host) || !host.includes('.')) {
+      return json({ error: 'URL host not allowed' }, 400)
+    }
+
+    // Fetch the page
+    const page = await fetch(url, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(12000),
+    })
+    if (!page.ok) return json({ error: `Could not fetch page (${page.status})` }, 422)
+    const html = (await page.text()).slice(0, 800_000)
+
+    // Extract: JSON-LD first, AI fallback
+    let extracted = extractJsonLd(html)
+    let method = 'json-ld'
+    if (!extracted) {
+      const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+      if (!apiKey) return json({ error: 'No structured event data found on page' }, 422)
+      extracted = await extractWithAI(html, url, apiKey)
+      method = 'ai'
+    }
+    if (!extracted || !extracted.date || !/^\d{4}-\d{2}-\d{2}$/.test(extracted.date)) {
+      return json({ error: 'No event could be extracted from that page' }, 422)
+    }
+
+    const visibility = PRIVATE_HOSTS.some(h => host === h || host.endsWith('.' + h)) ? 'private' : 'public'
+
+    // Forward into the canonical store (dedup ladder merges if it already exists)
+    const cacheResp = await fetch(`${supabaseUrl}/functions/v1/cache-events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${serviceKey}` },
+      body: JSON.stringify({
+        events: [{
+          source: SOURCE_ID,
+          date: extracted.date,
+          time: extracted.time || '',
+          name: extracted.name,
+          venue: extracted.venue || 'TBA',
+          address: extracted.address || '',
+          city: extracted.city || '',
+          price: extracted.price || '',
+          url,
+          description: extracted.description || '',
+          postedBy: submittedBy,
+          visibility,
+        }],
+      }),
+    })
+    const cacheResult = await cacheResp.json()
+    if (!cacheResp.ok) return json({ error: `Store write failed: ${JSON.stringify(cacheResult).slice(0, 200)}` }, 502)
+
+    console.log(`[add-event] ${submittedBy} added "${extracted.name}" (${extracted.date}) via ${method}, visibility=${visibility}, cached=${cacheResult.cached} updated=${cacheResult.updated}`)
+    return json({
+      event: extracted,
+      visibility,
+      merged: (cacheResult.cached === 0 && cacheResult.updated > 0),
+      extraction: method,
+    })
+  } catch (err) {
+    console.error('[add-event] Error:', err)
+    return json({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.6.0'
-console.log(`[cache-events] v${VERSION} - source classes, visibility, URL-first dedup ladder + tiered fuzzy match (PRD source-architecture)`)
+const VERSION = '1.6.1'
+console.log(`[cache-events] v${VERSION} - per-event visibility override for user-submitted events`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -75,6 +75,9 @@ interface ScrapedEvent {
   description?: string
   postedBy?: string
   recommendedBy?: string[]
+  // Per-event visibility override (used by add-event, where visibility
+  // depends on the submitted URL's platform, not the source's class)
+  visibility?: 'public' | 'private'
 }
 
 // --- Source classes & visibility (PRD event-source-architecture §2–3) ---
@@ -486,7 +489,9 @@ serve(async (req: Request) => {
         event_key: eventKey,
         canonical_key: canonicalKey,
         canonical_url: canonicalizeEventUrl(ev.url),
-        visibility: visibilityFor(ev.source, sourceClasses),
+        visibility: (ev.visibility === 'public' || ev.visibility === 'private')
+          ? ev.visibility
+          : visibilityFor(ev.source, sourceClasses),
         source_id: ev.source,
         date: ev.date,
         time: ev.time || null,

--- a/supabase/migrations/094_user_submitted_source.sql
+++ b/supabase/migrations/094_user_submitted_source.sql
@@ -1,0 +1,15 @@
+-- ============================================
+-- One-off user-submitted events source (add-event edge function)
+-- Migration 094
+--
+-- enabled=false: the scraper never dispatches it (type 'manual' has no
+-- parser); the client adds it to users' source lists so its rows render.
+-- Class 'curation' => private by default; add-event overrides per URL
+-- (public ticketing/venue pages => public, Partiful/secretparty/forms =>
+-- private), passed through cache-events' per-event visibility override.
+-- ============================================
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('user-submitted', 'Community adds', 'social', 'manual', 'manual://add-event', 'bay-area',
+   'One-off events added by users via web link', false, 'curation',
+   'Written by the add-event function; enabled=false keeps it out of the scrape loop')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Add events by link
Any signed-in user can paste an event page URL in Manage Sources → "Add a one-off event by link". A new `add-event` edge function fetches the page, extracts the event (JSON-LD Event schema → OpenGraph → Claude Haiku fallback), and writes it into the canonical store under the `user-submitted` source with `posted_by` attribution.

- **Visibility per URL** (PRD rules): Partiful/secretparty/Google-Forms links stay private; public ticketing & venue pages are public
- **Dedup for free**: the existing URL-first ladder merges submissions that already exist — verified live with an Eventbrite URL that linked across eb-publicworks + 19hz rows
- **Guards**: auth required (JWT verified), SSRF host checks, 12s fetch timeout
- Known limitation: ra.co blocks datacenter fetches (Cloudflare 403) — error surfaces cleanly to the user

Client v1.16.0, cache-events v1.6.1 (per-event visibility override), migration 094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)