### PR TITLE
feat(events): ATA source, Agape badge, Wave 2/3 feed verification + enablement

### DIFF
--- a/docs/playground/events/strategy/prd-event-source-architecture.md
+++ b/docs/playground/events/strategy/prd-event-source-architecture.md
@@ -189,7 +189,7 @@ Explicitly **not** filters: ticket platform (attribute → outbound link icon), 
 - [x] Demotion machinery: `demoted` flag + corroboration visibility upgrades (both directions) in `cache-events` — dormant until demoted feeds are registered
 - [ ] Demoted-platform parsers (Eventbrite location search, Bandsintown) — needs new parser types
 - [x] Venue calendar Wave 2/3 backlog registered in `event_sources` (14 rows, disabled pending feed verification; enable = verify feed → set type → flip `enabled`, no deploy)
-- [ ] Wave 2 feed verification & enablement (per-venue stories)
+- [x] Wave 2/3 feed verification complete (migration 096): **enabled** Bottom of the Hill (dedicated RSS parser), Frontier Tower (Luma iCal), ATA (dedicated calendar parser, migration 095). **11 venues are JS-only** (Gray Area, The Lab, SF Symphony, Exploratorium, SFMOMA, The Chapel, Lost Church, ODC, Brick & Mortar, Rickshaw Stop; Noisebridge unstructured) — they need a headless-browser scrape path, tracked as a future epic
 - [x] Coverage metric: `agape_coverage` view (corroboration % of Agape events vs public feeds)
 - [x] Event-platform domains (Partiful, Luma, Tixr, etc.) added to `enrich-event` allowlist per §4.1
 

--- a/events/index.html
+++ b/events/index.html
@@ -65,6 +65,11 @@ body {
   flex: 1;
 }
 
+.token--agape {
+  border: var(--border-thin) solid #e8c547;
+  color: #e8c547;
+}
+
 .source-chip__count {
   margin-left: var(--space-1);
   opacity: 0.6;
@@ -1813,8 +1818,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.17.0';
-  console.log(`[events] v${VERSION} - one-off event submission by link (add-event); Interested bookmarks + Google Calendar sync`);
+  const VERSION = '1.17.1';
+  console.log(`[events] v${VERSION} - Agape badge + posted_by on event rows; ATA stock source`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1852,6 +1857,7 @@ body {
     { id: 'discord-agape-events', name: 'Agape #events', category: 'social', type: 'discord', url: null, region: 'bay-area', description: 'Agape community recommendations' },
     // One-off events added by users via the add-event function
     { id: 'user-submitted', name: 'Community adds', category: 'social', type: 'manual', url: null, region: 'bay-area', description: 'One-off events added by link' },
+    { id: 'ata-sf', name: 'ATA', category: 'film', type: 'ata', url: 'https://www.atasite.org/calendar', region: 'bay-area', description: 'Underground film & experimental art' },
     // Bay Area — Eventbrite orgs with Agape signal (scraped server-side)
     { id: 'eb-publicworks', name: 'Public Works', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/public-works-17405142071', region: 'bay-area', description: 'Public Works SF' },
     { id: 'eb-mannys', name: "Manny's", category: 'social', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/mannys-15114280512', region: 'bay-area', description: "Manny's civic events" },
@@ -2937,11 +2943,15 @@ body {
     const tbody = document.getElementById('eventsBody');
     const rowHtml = ev => {
       const sourceIds = ev.sources || [ev.source];
-      const sourceTagsHtml = sourceIds.map(sid => {
+      let sourceTagsHtml = sourceIds.map(sid => {
         const sName = state.sources.find(s => s.id === sid)?.name || sid;
         const sColor = getSourceColor(sid);
         return `<span class="token token--source" data-source-id="${escHtml(sid)}" style="border-color: ${sColor}; color: ${sColor};">${escHtml(sName)}</span>`;
       }).join(' ');
+      if (ev.agape || isAgapeEvent(ev)) {
+        const byAttr = ev.postedBy ? ` title="Recommended by ${escHtml(ev.postedBy)} in Agape #events"` : ' title="Recommended in Agape #events"';
+        sourceTagsHtml = `<span class="token token--agape"${byAttr}>★ Agape${ev.postedBy ? ' · ' + escHtml(ev.postedBy) : ''}</span> ` + sourceTagsHtml;
+      }
       const titleAttr = ev.description ? ` title="${escHtml(ev.description)}"` : '';
       const displayName = stripVenueFromTitle(ev.name, ev.venue);
       const nameCell = ev.url && ev.url !== '#'

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.6.0'
-console.log(`[scrape-events] v${VERSION} - ata parser (Artists' Television Access calendar)`)
+const VERSION = '1.7.0'
+console.log(`[scrape-events] v${VERSION} - ata + bottomofthehill parsers (Wave 2 verification pass)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -28,6 +28,7 @@ import { scrapeSFMOMA } from './parsers/sfmoma.ts'
 import { scrapeIcal } from './parsers/ical.ts'
 import { scrapeEventbriteOrg } from './parsers/eventbrite-org.ts'
 import { scrapeAta } from './parsers/ata.ts'
+import { scrapeBottomOfTheHill } from './parsers/bottomofthehill.ts'
 import { scrapeJson } from './parsers/json.ts'
 import { scrapeRss } from './parsers/rss.ts'
 import { scrapeFamsf } from './parsers/famsf.ts'
@@ -103,6 +104,7 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'ical': return scrapeIcal(source)
     case 'eventbrite-org': return scrapeEventbriteOrg(source)
     case 'ata': return scrapeAta(source)
+    case 'bottomofthehill': return scrapeBottomOfTheHill(source)
     case 'json': return scrapeJson(source)
     case 'rss': return scrapeRss(source)
     case 'famsf': return scrapeFamsf(source)

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.5.0'
-console.log(`[scrape-events] v${VERSION} - eventbrite-org parser (greenlit orgs with Agape signal)`)
+const VERSION = '1.6.0'
+console.log(`[scrape-events] v${VERSION} - ata parser (Artists' Television Access calendar)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -27,6 +27,7 @@ import { scrapeBonobo } from './parsers/bonobo.ts'
 import { scrapeSFMOMA } from './parsers/sfmoma.ts'
 import { scrapeIcal } from './parsers/ical.ts'
 import { scrapeEventbriteOrg } from './parsers/eventbrite-org.ts'
+import { scrapeAta } from './parsers/ata.ts'
 import { scrapeJson } from './parsers/json.ts'
 import { scrapeRss } from './parsers/rss.ts'
 import { scrapeFamsf } from './parsers/famsf.ts'
@@ -101,6 +102,7 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'sfmoma': return scrapeSFMOMA(source)
     case 'ical': return scrapeIcal(source)
     case 'eventbrite-org': return scrapeEventbriteOrg(source)
+    case 'ata': return scrapeAta(source)
     case 'json': return scrapeJson(source)
     case 'rss': return scrapeRss(source)
     case 'famsf': return scrapeFamsf(source)

--- a/supabase/functions/scrape-events/parsers/ata.ts
+++ b/supabase/functions/scrape-events/parsers/ata.ts
@@ -1,0 +1,71 @@
+// Artists' Television Access (atasite.org/calendar) parser.
+// WordPress with a server-rendered month table: cells contain
+//   <strong>DAY</strong><br />8:00 pm <a class="calendarlink" href="...">Title</a>
+// Month navigation via ?mm=M&yy=YYYY. Fetches the current and next month.
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const MONTHS = ['january','february','march','april','may','june','july','august','september','october','november','december']
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2}):(\d{2})\s*(am|pm)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  const ampm = m[3].toLowerCase()
+  if (ampm === 'pm' && h !== 12) h += 12
+  if (ampm === 'am' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${m[2]}`
+}
+
+function parseMonthPage(html: string, source: EventSource): ScrapedEvent[] {
+  const events: ScrapedEvent[] = []
+
+  const header = html.match(/class="calendar-month"[^>]*>([A-Za-z]+)(?:&nbsp;|\s)+(\d{4})/)
+  if (!header) return events
+  const month = MONTHS.indexOf(header[1].toLowerCase()) + 1
+  const year = parseInt(header[2], 10)
+  if (month === 0 || !year) return events
+
+  const table = html.match(/<table class="calendar-block">([\s\S]*?)<\/table>/)
+  if (!table) return events
+
+  for (const cell of table[1].split(/<td[^>]*>/).slice(1)) {
+    const dayMatch = cell.match(/<strong>(\d{1,2})<\/strong>/)
+    if (!dayMatch) continue
+    const day = parseInt(dayMatch[1], 10)
+    const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+
+    const entryRe = /(\d{1,2}:\d{2}\s*(?:am|pm))\s*<a class="calendarlink" href="([^"]+)"[^>]*>([^<]+)<\/a>/gi
+    let m: RegExpExecArray | null
+    while ((m = entryRe.exec(cell)) !== null) {
+      events.push({
+        source: source.id,
+        date,
+        time: to24h(m[1]),
+        name: m[3].trim(),
+        venue: 'ATA',
+        address: '992 Valencia St',
+        city: 'San Francisco',
+        url: m[2],
+        contentType: source.category,
+      })
+    }
+  }
+  return events
+}
+
+export async function scrapeAta(source: EventSource): Promise<ScrapedEvent[]> {
+  const now = new Date()
+  const next = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+  const base = source.url.replace(/\/+$/, '')
+
+  const pages = await Promise.all([
+    fetchUrl(`${base}/`),
+    fetchUrl(`${base}/?mm=${next.getMonth() + 1}&yy=${next.getFullYear()}`),
+  ])
+
+  const all: ScrapedEvent[] = []
+  for (const html of pages) all.push(...parseMonthPage(html, source))
+  return all
+}

--- a/supabase/functions/scrape-events/parsers/bottomofthehill.ts
+++ b/supabase/functions/scrape-events/parsers/bottomofthehill.ts
@@ -1,0 +1,68 @@
+// Bottom of the Hill (bottomofthehill.com/RSS.xml) parser.
+// FeedForAll RSS where the event date lives in the item TITLE, not pubDate:
+//   <title>2026  10/18  :  heavens to betsy ~ TBA ~ TBA</title>
+//   <description><b>lineup</b><br />7:30PM doors -- music 8:30PM<br />$35<br /> (all ages)</description>
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"').replace(/&#0?39;/g, "'")
+}
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2})(?::(\d{2}))?\s*([AP]M)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  const ampm = m[3].toUpperCase()
+  if (ampm === 'PM' && h !== 12) h += 12
+  if (ampm === 'AM' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${m[2] || '00'}`
+}
+
+export async function scrapeBottomOfTheHill(source: EventSource): Promise<ScrapedEvent[]> {
+  const xml = await fetchUrl(source.url)
+  const events: ScrapedEvent[] = []
+
+  for (const item of xml.split('<item>').slice(1)) {
+    const title = item.match(/<title>([\s\S]*?)<\/title>/)?.[1] || ''
+    const desc = decodeEntities(item.match(/<description>([\s\S]*?)<\/description>/)?.[1] || '')
+    const link = item.match(/<link>([\s\S]*?)<\/link>/)?.[1]?.trim() || source.url
+
+    const dm = title.match(/(\d{4})\s+(\d{1,2})\/(\d{1,2})\s*:\s*([\s\S]+)/)
+    if (!dm) continue
+    const date = `${dm[1]}-${dm[2].padStart(2, '0')}-${dm[3].padStart(2, '0')}`
+
+    // The feed contains the venue's full archive (900+ items, years back) —
+    // only ingest recent/future events
+    const cutoff = new Date()
+    cutoff.setDate(cutoff.getDate() - 7)
+    if (date < cutoff.toISOString().split('T')[0]) continue
+
+    const name = dm[4].split('~').map(s => s.trim()).filter(s => s && s.toUpperCase() !== 'TBA').join(', ')
+    if (!name) continue
+
+    const descText = desc.replace(/<[^>]+>/g, ' ')
+    const time = to24h(descText.match(/music\s+(\d{1,2}(?::\d{2})?\s*[AP]M)/i)?.[1]
+      || descText.match(/(\d{1,2}(?::\d{2})?\s*[AP]M)\s*doors/i)?.[1] || '')
+    const price = descText.match(/\$\d+(?:\.\d{2})?/)?.[0] || ''
+    const ages = descText.match(/\((all ages|21\s*(?:and|\+|&) ?(?:over|up)?|18\s*(?:and|\+|&) ?(?:over|up)?)\)?/i)?.[1] || ''
+
+    events.push({
+      source: source.id,
+      date,
+      time,
+      name,
+      venue: 'Bottom of the Hill',
+      address: '1233 17th St',
+      city: 'San Francisco',
+      price,
+      ages: ages ? ages.replace(/\s+/g, ' ').trim() : '',
+      url: link,
+      contentType: source.category,
+    })
+  }
+  return events
+}

--- a/supabase/migrations/095_ata_source.sql
+++ b/supabase/migrations/095_ata_source.sql
@@ -1,0 +1,9 @@
+-- ============================================
+-- ATA (Artists' Television Access) venue source
+-- Migration 095
+-- User-requested; parsed by the 'ata' parser (scrape-events v1.6.0):
+-- server-rendered WordPress month calendar at atasite.org/calendar.
+-- ============================================
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('ata-sf', 'ATA', 'film', 'ata', 'https://www.atasite.org/calendar', 'bay-area', 'Artists'' Television Access — underground film & experimental art', true, 'venue', 'Agape signal: 1 event in channel history; user-requested')
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/096_wave2_verification.sql
+++ b/supabase/migrations/096_wave2_verification.sql
@@ -1,0 +1,30 @@
+-- ============================================
+-- Wave 2/3 feed-verification results (research pass, 2026-07-03)
+-- Migration 096
+--
+-- Verified all 13 disabled venue/community sources. Enabled the two with
+-- server-readable feeds; recorded JS-only findings on the rest so nobody
+-- re-verifies blind. 11 venues need a headless-browser scrape path (future).
+-- ============================================
+
+UPDATE event_sources SET
+  type = 'bottomofthehill', url = 'https://bottomofthehill.com/RSS.xml', enabled = true,
+  notes = 'Verified: FeedForAll RSS, date in item title — dedicated parser'
+WHERE id = 'bottomofthehill-sf';
+
+UPDATE event_sources SET
+  type = 'ical', url = 'https://api2.luma.com/ics/get?entity=calendar&id=cal-Sl7q1nHTRXQzjP2', enabled = true,
+  notes = 'Verified: Luma calendar iCal (cal-Sl7q1nHTRXQzjP2)'
+WHERE id = 'frontiertower-sf';
+
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (WordPress+Elementor) — needs headless' WHERE id = 'grayarea-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (Squarespace; /upcoming 404) — needs headless' WHERE id = 'thelab-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only — needs headless' WHERE id = 'sfsymphony';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (Drupal) — needs headless' WHERE id = 'exploratorium-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only, no JSON-LD in initial HTML — needs headless' WHERE id = 'sfmoma-events';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (SeeTickets plugin) — needs headless' WHERE id = 'thechapel-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only; events on thelostchurch.org ticketing — needs headless' WHERE id = 'thelostchurch-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only — needs headless' WHERE id = 'odc-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (Ticketweb tw-events plugin) — needs headless' WHERE id = 'brickandmortar-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: JS-only (SeeTickets plugin) — needs headless' WHERE id = 'rickshawstop-sf';
+UPDATE event_sources SET notes = 'Verified 2026-07-03: MediaWiki category page, unstructured dates — low value, skip' WHERE id = 'noisebridge-sf';


### PR DESCRIPTION
## ATA (user-requested)
New `ata` parser for atasite.org/calendar (server-rendered WordPress month table, current + next month). Live: 5 events (OpenScreening, Guy Debord series).

## Agape badge on event rows (client v1.17.1)
Recommended events show a gold **★ Agape · member** token with a tooltip — only visible to signed-in users since Agape rows are RLS-private.

## Wave 2/3 feed verification (completes the backlog)
Background agent verified all 13 disabled venue sources:
- **Enabled**: Bottom of the Hill (dedicated RSS parser — feed has date-in-title + full archive, parser skips past events) and Frontier Tower (Luma calendar iCal found in page data). Live: 188 + 49 events.
- **11 venues are JS-only** (Gray Area, The Lab, SF Symphony, Exploratorium, SFMOMA, The Chapel, Lost Church, ODC, Brick & Mortar, Rickshaw Stop, + Noisebridge unstructured) — findings recorded in source notes; headless-browser scraping is the future epic.

Migrations 095–096 applied; scrape-events v1.7.0 deployed; PRD updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)