### PR TITLE
feat(events): track tiat (art & technology Luma calendar)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1818,8 +1818,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.17.1';
-  console.log(`[events] v${VERSION} - Agape badge + posted_by on event rows; ATA stock source`);
+  const VERSION = '1.17.2';
+  console.log(`[events] v${VERSION} - tiat (art & technology Luma calendar) stock source`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1858,6 +1858,7 @@ body {
     // One-off events added by users via the add-event function
     { id: 'user-submitted', name: 'Community adds', category: 'social', type: 'manual', url: null, region: 'bay-area', description: 'One-off events added by link' },
     { id: 'ata-sf', name: 'ATA', category: 'film', type: 'ata', url: 'https://www.atasite.org/calendar', region: 'bay-area', description: 'Underground film & experimental art' },
+    { id: 'luma-tiat', name: 'tiat', category: 'art', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=calendar&id=cal-twiOosdGMMY66DI', region: 'bay-area', description: 'The intersection of art & technology' },
     // Bay Area — Eventbrite orgs with Agape signal (scraped server-side)
     { id: 'eb-publicworks', name: 'Public Works', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/public-works-17405142071', region: 'bay-area', description: 'Public Works SF' },
     { id: 'eb-mannys', name: "Manny's", category: 'social', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/mannys-15114280512', region: 'bay-area', description: "Manny's civic events" },

--- a/supabase/migrations/097_tiat_source.sql
+++ b/supabase/migrations/097_tiat_source.sql
@@ -1,0 +1,13 @@
+-- ============================================
+-- tiat (the intersection of art & technology) — Luma community calendar
+-- Migration 097
+-- User-requested explicit tracking (luma.com/tiat). Fills the art-category
+-- coverage gap the Agape historical analysis identified. iCal via the
+-- existing ical parser; calendar id cal-twiOosdGMMY66DI.
+-- ============================================
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('luma-tiat', 'tiat', 'art', 'ical',
+   'https://api2.luma.com/ics/get?entity=calendar&id=cal-twiOosdGMMY66DI', 'bay-area',
+   'tiat — the intersection of art & technology (Luma calendar)', true, 'community',
+   'User-requested; Luma calendar cal-twiOosdGMMY66DI (luma.com/tiat)')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Adds [luma.com/tiat](https://luma.com/tiat) — "the intersection of art & technology" — as an explicit source. Found its Luma calendar iCal (`cal-twiOosdGMMY66DI`); handled by the existing ical parser, no new code paths. Live with 23 upcoming events (31 in the 60-day window).

Notable: this directly addresses the art-coverage gap from the Agape historical analysis — art was the category with 95% zero-overlap against plannable feeds.

Migration 097 applied; client v1.17.2 adds it to stock sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)