### PR TITLE
fix(events): tiat events flagged as art — authoritative source categories

### DIFF
--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -6,8 +6,8 @@
 // Body: { eventIds: string[] }   (batch up to 10)
 // Returns: { processed, succeeded, failed, results }
 
-const VERSION = '1.1.1'
-console.log(`[enrich-event] v${VERSION} - retired Haiku model replaced (claude-3-haiku -> haiku-4-5)`)
+const VERSION = '1.2.0'
+console.log(`[enrich-event] v${VERSION} - authoritative source categories + full content-type taxonomy in AI prompt`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -215,7 +215,7 @@ async function classifyWithAI(event: {
 
 1. "genre" — the music/art genre (e.g. "Techno", "House", "Hip-Hop", "Jazz", "Rock", "Comedy", "Film", "Indie", "Drum & Bass"). Use the most specific genre that fits. If multiple genres apply, comma-separate up to 3. Return "" if truly unknown.
 
-2. "content_type" — one of: music, dj-set, live-music, festival, film, comedy, theater, other
+2. "content_type" — one of: music, dj-set, live-music, festival, film, comedy, theater, tech, social, art, design, literary, wellness, other
 
 Event name: ${event.name}
 Venue: ${event.venue}
@@ -276,6 +276,7 @@ async function enrichSingleEvent(
   eventVenue: string,
   eventGenre: string,
   eventContentType: string,
+  eventSourceId: string,
 ): Promise<EnrichResult> {
   await supabase
     .from('events')
@@ -324,6 +325,22 @@ async function enrichSingleEvent(
     return { eventId, success: true, description: null, imageUrl: null, tags: [] }
   }
 
+  // Venue/community sources have an authoritative category — a curated art
+  // calendar's events are art even when the AI reads them as "music" or
+  // "other". Curation feeds (Agape) span categories, so their rows keep AI
+  // classification; discovery/ticketing rows accept AI content_type too.
+  let authoritativeType: string | null = null
+  try {
+    const { data: src } = await supabase
+      .from('event_sources')
+      .select('category, source_class')
+      .eq('id', eventSourceId)
+      .single()
+    if (src && ['venue', 'community'].includes(src.source_class as string)) {
+      authoritativeType = (src.category as string) || null
+    }
+  } catch { /* registry lookup is best-effort */ }
+
   const { error } = await supabase
     .from('events')
     .update({
@@ -331,7 +348,9 @@ async function enrichSingleEvent(
       image_url: metadata.imageUrl,
       tags: metadata.tags.length > 0 ? metadata.tags : null,
       ...(aiResult?.genre ? { genre: aiResult.genre } : {}),
-      ...(aiResult?.content_type ? { content_type: aiResult.content_type } : {}),
+      ...(authoritativeType
+        ? { content_type: authoritativeType }
+        : (aiResult?.content_type ? { content_type: aiResult.content_type } : {})),
       enrichment_status: 'completed',
       enriched_at: new Date().toISOString(),
       enrichment_error: null,
@@ -393,7 +412,7 @@ serve(async (req: Request) => {
 
     const { data: events, error: fetchErr } = await supabase
       .from('events')
-      .select('id, url, name, venue, genre, content_type, enrichment_status')
+      .select('id, url, name, venue, genre, content_type, source_id, enrichment_status')
       .in('id', eventIds)
       .in('enrichment_status', ['pending', 'failed'])
 
@@ -417,6 +436,7 @@ serve(async (req: Request) => {
         supabase, event.id, event.url,
         event.name || '', event.venue || '',
         event.genre || '', event.content_type || '',
+        event.source_id || '',
       )
       results.push(result)
       if (result.success) succeeded++

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.7.0'
-console.log(`[scrape-events] v${VERSION} - ata + bottomofthehill parsers (Wave 2 verification pass)`)
+const VERSION = '1.7.1'
+console.log(`[scrape-events] v${VERSION} - ical parser carries source category as content_type`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/scrape-events/parsers/ical.ts
+++ b/supabase/functions/scrape-events/parsers/ical.ts
@@ -6,10 +6,10 @@ import type { EventSource } from '../sources.ts'
 
 export async function scrapeIcal(source: EventSource): Promise<ScrapedEvent[]> {
   const text = await fetchUrl(source.url)
-  return parseIcal(text, source.id)
+  return parseIcal(text, source.id, source.category)
 }
 
-function parseIcal(text: string, sourceId: string): ScrapedEvent[] {
+function parseIcal(text: string, sourceId: string, category?: string): ScrapedEvent[] {
   // RFC 5545 line-unfolding: CRLF + (SPACE|TAB) continues the previous line.
   const unfolded = text.replace(/\r?\n[ \t]/g, '')
 
@@ -51,6 +51,7 @@ function parseIcal(text: string, sourceId: string): ScrapedEvent[] {
       url: url || '',
       description,
       source: sourceId,
+      contentType: category,
     })
   }
 


### PR DESCRIPTION
All tiat rows are now `content_type='art'`. Root cause was three-layered:

1. The iCal parser never set contentType, so tiat/Frontier Tower/Luma rows were NULL
2. The enrichment AI's allowed type list was the legacy short set (no art/social/tech)
3. Nothing made a curated source's category authoritative

Fixes: iCal parser carries the source category; enrichment prompt uses the full taxonomy; venue/community-class sources force their registry category (a curated art calendar's events are art even if the AI reads them as music). Curation feeds (Agape) intentionally keep per-event AI classification since the channel spans categories. Existing rows backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)