### PR TITLE
ladder 2.22.0: banner lifecycle fixes (toast host, health snooze, persisted dismissals)

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -60,6 +60,7 @@ The For You surface follows a **triage, don't browse** model (inbox → review �
 | Collapsed JD | `.jd-collapse` | Raw scraped posting text is never the reading surface; it collapses behind "Original posting text". Summaries and match bullets lead. |
 | Page ⋯ menu | `.page-menu` | Operational controls (refresh sources, quality-floor toggle, expiry info) live behind one ⋯ in the page header — machinery stays out of the reading flow. Sourcing config (watched companies) lives on /ladder/vision/. |
 | Chat launcher | `.chat-fab` | Fixed 44px bubble top-right on every page (neutral surface, chat glyph). Never a floating bottom FAB over list content. |
+| Banners & toasts | `.toast-host`, `.recs-health-banner` | Every transient surface needs a defined lifecycle — at least two of: auto-timeout, explicit dismiss, state-driven refresh. Toasts (`job:toast`) render only through the global host in app.js (4.5s timeout, click-dismiss). Confirmation banners auto-expire (added 12s, liveness 20s). Persistent alerts (source health) get ✕ = 6h signature-keyed snooze + 5-min background revalidation, and clear when the server state clears. Dismissals that must survive reloads persist to localStorage (closed-banner watermark). |
 | Search plan | `.vf-tabs`, `.vf-summary` | Landing = summary view: plan-strength bar + one tappable digest row per section. Sections (Targets · Signals · Rules · Sources) switch via `?section=`. Advanced (score weights, raw plan, unknown fields) folds at the bottom of Signals; Story lives on Profile → Narratives. |
 
 ## Cache busting

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.21.1");
+@import url("./components.css?v=2.22.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -6777,3 +6777,53 @@ body[data-auth-state="out"] job-chat { display: none; }
 /* Watched companies read as list rows here, not floating chips. */
 .watched-strip__row { display: flex; flex-direction: column; gap: var(--space-2); }
 .watched-chip { width: 100%; }
+
+/* ==========================================================================
+   Toast host (v2.22) — the single renderer for job:toast events.
+   Auto-expires after 4.5s; click to dismiss; max 3 stacked.
+   ========================================================================== */
+.toast-host {
+  position: fixed;
+  left: 50%;
+  bottom: max(var(--space-5), env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  z-index: 95;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  pointer-events: none;
+  width: min(480px, calc(100vw - 32px));
+}
+.toast {
+  pointer-events: auto;
+  max-width: 100%;
+  padding: 10px var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--fg);
+  color: var(--bg);
+  font: inherit;
+  font-size: var(--font-size-small);
+  line-height: var(--lh-tight);
+  text-align: left;
+  cursor: pointer;
+  box-shadow: var(--shadow-md);
+  animation: toast-in 160ms ease;
+}
+.toast--leaving { opacity: 0; transition: opacity 200ms ease; }
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: none; }
+}
+.recs-health-banner__close {
+  margin-left: auto;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: var(--space-1) var(--space-2);
+  flex-shrink: 0;
+}

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.21.1";
-console.log(`[ladder] v${VERSION} - radius as a system: xs 6 / sm 8 / md 12 / lg 16 / xl 20; cards remapped lg→md; pill = token or decision`);
+const VERSION = "2.22.0";
+console.log(`[ladder] v${VERSION} - banner lifecycles: global toast host (job:toast finally renders), health-banner snooze + auto-revalidate, persisted closed-banner dismissal, auto-expiring confirmations`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -310,6 +310,37 @@ function injectSubnavBar() {
 }
 
 // (Bottom tab bar removed — drawer is the only mobile nav now.)
+
+// Global toast host. Components all over the app dispatch
+// `job:toast { detail: { msg } }` — this is the single renderer (there
+// previously was none, so toasts silently vanished). Every toast
+// auto-expires and is click-dismissable; max 3 stack.
+function injectToastHost() {
+  if (document.querySelector('.toast-host')) return;
+  const host = document.createElement('div');
+  host.className = 'toast-host';
+  host.setAttribute('role', 'status');
+  host.setAttribute('aria-live', 'polite');
+  document.body.appendChild(host);
+  document.addEventListener('job:toast', (e) => {
+    const msg = e.detail?.msg;
+    if (!msg) return;
+    const el = document.createElement('button');
+    el.className = 'toast';
+    el.type = 'button';
+    el.textContent = msg;
+    el.title = 'Dismiss';
+    const remove = () => {
+      el.classList.add('toast--leaving');
+      setTimeout(() => el.remove(), 200);
+    };
+    el.addEventListener('click', remove);
+    host.appendChild(el);
+    while (host.children.length > 3) host.firstChild.remove();
+    setTimeout(remove, 4500);
+  });
+}
+injectToastHost();
 
 // Mount the global agent chat — FAB at bottom-right + bottom drawer.
 // Skipped on onboarding (the onboarding flow has its own chat surface).

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -222,6 +222,12 @@ export class JobPipeline extends LitElement {
       const existing = new Map((this.addedBanner.roles || []).map(r => [r.slug, r]));
       for (const r of next) if (r?.slug) existing.set(r.slug, r);
       this.addedBanner = { roles: Array.from(existing.values()), dismissed: false };
+      // Confirmation info, not state — auto-dismiss; the roles are visible
+      // in the list itself. Timer resets while adds keep arriving.
+      clearTimeout(this._addedHideTimer);
+      this._addedHideTimer = setTimeout(() => {
+        this.addedBanner = { ...this.addedBanner, dismissed: true };
+      }, 12000);
     };
     document.addEventListener('job:pipeline:added', this._onAdded);
     this._onPopState = () => {
@@ -327,6 +333,13 @@ export class JobPipeline extends LitElement {
       if (closed.length) {
         this.livenessResult = { checked: res.checked || 0, closed };
         this.bannerDismissed = false;
+        // Auto-expire — the closed roles are already reflected in the list;
+        // the banner is a heads-up, not a permanent fixture.
+        clearTimeout(this._livenessHideTimer);
+        this._livenessHideTimer = setTimeout(() => {
+          this.livenessResultDismissed = true;
+          this.requestUpdate();
+        }, 20000);
       }
       try { localStorage.setItem('job:lastLivenessAt', String(Date.now())); } catch {}
     } catch (e) {
@@ -374,9 +387,22 @@ export class JobPipeline extends LitElement {
 
   _computeClosedSinceLastVisit() {
     const cutoff = this._lastVisitAt ? Date.parse(this._lastVisitAt) : 0;
+    // Dismissal watermark: closures the user has already acknowledged
+    // (closed-banner ×) never resurface, even when auto-liveness or a
+    // pipeline refresh recomputes this list mid-session or on reload.
+    let seenThrough = 0;
+    try { seenThrough = Number(localStorage.getItem('job:jobs:closedSeenThrough') || 0); } catch { /* */ }
     this.closedSinceLastVisit = this.roles.filter(r =>
-      r.closedDetectedAt && Date.parse(r.closedDetectedAt) > cutoff
+      r.closedDetectedAt
+      && Date.parse(r.closedDetectedAt) > cutoff
+      && Date.parse(r.closedDetectedAt) > seenThrough
     );
+  }
+
+  _dismissClosedBanner() {
+    this.bannerDismissed = true;
+    const latest = Math.max(0, ...this.closedSinceLastVisit.map(r => Date.parse(r.closedDetectedAt) || 0));
+    try { localStorage.setItem('job:jobs:closedSeenThrough', String(latest)); } catch { /* */ }
   }
 
   _onSortClick(col) {
@@ -1256,7 +1282,7 @@ export class JobPipeline extends LitElement {
             <span class="muted">${this.closedSinceLastVisit.slice(0, 4).map(r => r.company).join(', ')}${this.closedSinceLastVisit.length > 4 ? '…' : ''}</span>
           </div>
           <button class="row-menu__trigger" aria-label="Dismiss"
-                  @click=${() => { this.bannerDismissed = true; }}>×</button>
+                  @click=${() => this._dismissClosedBanner()}>×</button>
         </div>
       ` : nothing}
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -104,6 +104,30 @@ export class JobRecommendationsTable extends LitElement {
     return this._health.filter(s => s.enabled !== false && (s.needsReauth || s.lastError));
   }
 
+  // Banner lifecycle: dismiss snoozes THIS error signature for 6h (persisted).
+  // A new/different error resurfaces immediately; the same one comes back
+  // after the snooze if the server still reports it. The banner also clears
+  // naturally when a successful scan wipes last_error server-side.
+  static HEALTH_SNOOZE_MS = 6 * 60 * 60 * 1000;
+  _healthSignature(issues) {
+    return issues.map(s => `${s.type}:${s.needsReauth ? 'reauth' : (s.lastError || '').slice(0, 80)}`).sort().join('|');
+  }
+  _healthSnoozed(issues) {
+    try {
+      const raw = JSON.parse(localStorage.getItem('job:healthBannerSnooze') || 'null');
+      return raw && raw.sig === this._healthSignature(issues)
+        && (Date.now() - raw.at) < JobRecommendationsTable.HEALTH_SNOOZE_MS;
+    } catch { return false; }
+  }
+  _snoozeHealth() {
+    const issues = this._healthIssues();
+    try {
+      localStorage.setItem('job:healthBannerSnooze',
+        JSON.stringify({ sig: this._healthSignature(issues), at: Date.now() }));
+    } catch { /* */ }
+    this.requestUpdate();
+  }
+
   async _onReconnectGmail() {
     if (this._reconnecting) return;
     this._reconnecting = true;
@@ -129,6 +153,7 @@ export class JobRecommendationsTable extends LitElement {
   _renderHealthBanner() {
     const issues = this._healthIssues();
     if (!issues.length) return nothing;
+    if (this._healthSnoozed(issues)) return nothing;
     const gmailDead = issues.find(s => s.type === 'gmail-jobs' && s.needsReauth);
     return html`
       <div class="recs-health-banner" role="alert">
@@ -146,6 +171,9 @@ export class JobRecommendationsTable extends LitElement {
             ${issues.map(s => `${s.type}: ${s.lastError || 'needs attention'}`).join(' · ')}
           </span>
         `}
+        <button class="recs-health-banner__close" aria-label="Dismiss for now"
+                title="Dismiss — comes back if the issue is still present in 6 hours"
+                @click=${() => this._snoozeHealth()}>×</button>
       </div>
     `;
   }
@@ -204,6 +232,15 @@ export class JobRecommendationsTable extends LitElement {
       this.requestUpdate();
     };
     document.addEventListener('job:gmail:connected', this._onGmailConnected);
+    // While a health issue is showing, revalidate every 5 minutes so the
+    // banner clears itself once the source recovers — no reload needed.
+    this._healthTimer = setInterval(async () => {
+      if (!this._healthIssues().length) return;
+      try {
+        const d = await fetchRecommendations({ view: 'all', floor: true, limit: 1 });
+        if (Array.isArray(d?.sourceHealth)) this._health = d.sourceHealth;
+      } catch { /* keep the current banner */ }
+    }, 5 * 60 * 1000);
     // Infinite scroll: when the viewport nears the bottom of the document,
     // pull the next page. A plain scroll listener is more reliable across
     // layouts than an IntersectionObserver on a 1px sentinel.
@@ -222,6 +259,7 @@ export class JobRecommendationsTable extends LitElement {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('job:gmail:connected', this._onGmailConnected);
+    clearInterval(this._healthTimer);
     document.removeEventListener('click', this._onDocClick);
     window.removeEventListener('scroll', this._onScroll);
     window.removeEventListener('resize', this._onScroll);

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.21.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.22.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.21.1">
-  <script src="/ladder/js/theme.js?v=2.21.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.22.0">
+  <script src="/ladder/js/theme.js?v=2.22.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.21.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.22.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes the sticky-notification class of bugs: global toast renderer (job:toast previously had none), dismissible + self-clearing source-health banner (6h signature snooze + 5-min revalidation), persisted closed-banner dismissal watermark, auto-expiring confirmation banners, and a DESIGN.md lifecycle rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)