### PR TITLE
ladder 2.23.0: legible drawer chevron

### DIFF
--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -6848,5 +6848,5 @@ body[data-auth-state="out"] job-chat { display: none; }
   cursor: pointer;
 }
 .inbox-more__btn:hover { color: var(--fg); }
-.inbox-more__chevron { font-size: 10px; }
+.inbox-more__chevron { font-size: 12px; line-height: 1; }
 .inbox-row--below .inbox-row__title { color: var(--fg-muted); font-weight: var(--fw-medium); }


### PR DESCRIPTION
12px chevron on the below-your-bar drawer toggle (was rendering as a dot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)