### PR TITLE
feat(events): Epic 1 UI refinements — local-date fix, List/Month, day takeover, nav restructure

### DIFF
--- a/account/index.html
+++ b/account/index.html
@@ -424,6 +424,18 @@
       </div>
     </div>
 
+    <!-- Calendar sync (managed on the events page; session is shared) -->
+    <div class="account-card" id="calendarSection">
+      <div class="account-card__header">Calendar</div>
+      <div class="settings-row">
+        <div class="settings-row__label">
+          <span class="settings-row__title">Google Calendar Sync</span>
+          <span class="settings-row__description">Sync interested + Agape events to the ctrl.events calendar</span>
+        </div>
+        <a class="btn btn--sm" href="/events/#calendar-sync" style="text-decoration:none;">Manage</a>
+      </div>
+    </div>
+
     <!-- Connected Services -->
     <div class="account-card" id="ytSection">
       <div class="account-card__header">YouTube</div>

--- a/docs/playground/events/strategy/future-work.md
+++ b/docs/playground/events/strategy/future-work.md
@@ -6,7 +6,7 @@
 
 ---
 
-## Epic 1 — UI/UX refinements (user-reported, 2026-07-05)
+## Epic 1 — UI/UX refinements (user-reported, 2026-07-05) ✅ Shipped (client v1.19.0, 2026-07-06)
 
 | # | Item | Notes / diagnosis | Size |
 |---|---|---|---|

--- a/events/index.html
+++ b/events/index.html
@@ -76,7 +76,21 @@ body {
 }
 
 /* Date group headers — mobile-only section headers, hidden on desktop */
-.data-table tbody tr.date-group { display: none; }
+.day-detail__item--focus {
+  outline: var(--border-thin) solid var(--fg);
+  outline-offset: -1px;
+  background: var(--bg-subtle, rgba(255,255,255,0.04));
+}
+
+.data-table tbody tr.date-group td.date-group__label {
+  padding: var(--space-4) var(--space-2) var(--space-1);
+  font-size: var(--text-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  color: var(--fg-muted);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
+  background: var(--bg);
+}
 
 /* Multi-day range shown in the card's time slot — mobile only */
 .mobile-date-range { display: none; }
@@ -1398,8 +1412,11 @@ body {
         <span class="breadcrumb__current">Events</span>
       </nav>
       <div class="page-header__actions">
+        <!-- Pinned beside the fixed ctrl-auth bar -->
+        <button class="btn btn--sm btn--dashed" id="addSourceBtn"
+          style="position: fixed; top: calc(var(--safe-top, 0px) + var(--space-4) + 4px); right: calc(var(--safe-right, 0px) + 118px); z-index: 100;">Manage Sources</button>
         <div id="ctrl-auth-root"></div>
-        <!-- Theme toggle moved to /account/ settings -->
+        <!-- Theme toggle moved to /account/ settings; Calendar sync moved to /account/ -->
       </div>
     </div>
   </header>
@@ -1490,11 +1507,6 @@ body {
     <div class="sources-bar">
       <div class="sources-bar__chips" id="sourceChips"></div>
       <button class="btn btn--sm btn--ghost" id="forceRefreshBtn" title="Force refresh all sources (Shift+R)" style="padding:4px 6px;font-size:14px;line-height:1;opacity:0.5;min-width:0;" onclick="window.__forceRefreshSources && window.__forceRefreshSources()">⟳</button>
-      <button class="btn btn--sm btn--dashed" id="addSourceBtn">Manage Sources</button>
-      <button class="btn btn--sm btn--ghost" id="calSyncBtn" title="Sync interested + Agape events to Google Calendar">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-1px"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-        Calendar
-      </button>
       <button class="btn btn--sm btn--ghost sources-bar__filter-btn" id="filterToggleBtn">
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="1" y1="3" x2="11" y2="3"/><line x1="3" y1="6" x2="9" y2="6"/><line x1="5" y1="9" x2="7" y2="9"/></svg>
         Filter
@@ -1526,9 +1538,7 @@ body {
       <span id="statsText">0 events</span>
       <span id="statsFiltered"></span>
       <div class="view-toggle">
-        <button class="view-toggle__btn active" data-view="table">Table</button>
-        <button class="view-toggle__btn" data-view="day">Day</button>
-        <button class="view-toggle__btn" data-view="week">Week</button>
+        <button class="view-toggle__btn active" data-view="table">List</button>
         <button class="view-toggle__btn" data-view="calendar">Month</button>
       </div>
     </div>
@@ -1574,34 +1584,6 @@ body {
       </table>
     </div>
 
-    <!-- Day View -->
-    <div id="dayView" style="display: none;">
-      <div class="calendar__header">
-        <div class="calendar__nav">
-          <button class="btn btn--ghost btn--sm" id="dayPrev">&larr;</button>
-          <button class="btn btn--ghost btn--sm" id="dayToday">Today</button>
-          <button class="btn btn--ghost btn--sm" id="dayNext">&rarr;</button>
-        </div>
-        <span class="calendar__title" id="dayTitle"></span>
-        <span class="text-xs text-muted" id="dayStats"></span>
-      </div>
-      <div class="day-view" id="dayViewContent"></div>
-    </div>
-
-    <!-- Week View -->
-    <div id="weekView" style="display: none;">
-      <div class="calendar__header">
-        <div class="calendar__nav">
-          <button class="btn btn--ghost btn--sm" id="weekPrev">&larr;</button>
-          <button class="btn btn--ghost btn--sm" id="weekToday">Today</button>
-          <button class="btn btn--ghost btn--sm" id="weekNext">&rarr;</button>
-        </div>
-        <span class="calendar__title" id="weekTitle"></span>
-        <span class="text-xs text-muted" id="weekStats"></span>
-      </div>
-      <div class="week-view" id="weekViewContent"></div>
-    </div>
-
     <!-- Month/Calendar View -->
     <div id="calendarView" style="display: none;">
       <div class="calendar__header">
@@ -1620,7 +1602,7 @@ body {
             <span class="day-detail__title" id="dayDetailTitle"></span>
             <span class="day-detail__count" id="dayDetailCount"></span>
           </div>
-          <button class="day-detail__close" id="dayDetailClose">&times; Close</button>
+          <button class="day-detail__close" id="dayDetailClose">&larr; Back to month</button>
         </div>
         <ul class="day-detail__list" id="dayDetailList"></ul>
       </div>
@@ -1827,8 +1809,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.18.0';
-  console.log(`[events] v${VERSION} - beta setting: show/hide Recommended for you (default off)`);
+  const VERSION = '1.19.0';
+  console.log(`[events] v${VERSION} - Epic 1: local-date fix, List/Month views only, desktop date separators, month day-takeover, nav restructure`);
 
   // ============================================
   // Stock Sources Catalog
@@ -1984,6 +1966,13 @@ body {
     return session?.access_token || null;
   }
 
+  // Local-timezone date helpers. new Date().toISOString() is UTC — after
+  // 5pm PT that is tomorrow, which made the app open on the wrong day.
+  function localDateStr(d) {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  }
+  function localToday() { return localDateStr(new Date()); }
+
   // ============================================
   // State
   // ============================================
@@ -1997,7 +1986,7 @@ body {
     view: 'table',
     calMonth: new Date().getMonth(),
     calYear: new Date().getFullYear(),
-    calDate: new Date().toISOString().split('T')[0], // anchor date for day/week views
+    calDate: localToday(), // anchor date for day/week views
     selectedDate: null,
     onboarded: false,
   };
@@ -2104,7 +2093,7 @@ body {
       const saved = localStorage.getItem(SETTINGS_KEY);
       if (saved) {
         const settings = JSON.parse(saved);
-        if (settings.view) state.view = settings.view;
+        if (settings.view) state.view = (settings.view === 'day' || settings.view === 'week') ? 'table' : settings.view;
         if (settings.sort) state.sort = settings.sort;
         state.showRecommended = !!settings.showRecommended; // beta, default off
       }
@@ -2577,13 +2566,13 @@ body {
     try {
       const enabledIds = state.sources.filter(s => s.enabled).map(s => s.id);
       if (enabledIds.length === 0) return null;
-      const today = new Date().toISOString().split('T')[0];
+      const today = localToday();
       // "Past events" widens the window to the 60-day retention horizon
       let fromDate = today;
       if (state.filters.showPast) {
         const past = new Date();
         past.setDate(past.getDate() - 60);
-        fromDate = past.toISOString().split('T')[0];
+        fromDate = localDateStr(past);
       }
       log(`L2 cache: querying ${enabledIds.length} source(s) from ${fromDate}`);
       // 12s ceiling so a hung request can't leave the spinner up forever
@@ -2831,8 +2820,6 @@ body {
     const sorted = getSortedEvents(filtered);
     const tableWrap = document.querySelector('.data-table-wrap');
     const calView = document.getElementById('calendarView');
-    const dayViewEl = document.getElementById('dayView');
-    const weekViewEl = document.getElementById('weekView');
     const empty = document.getElementById('emptyState');
     const table = document.getElementById('eventsTable');
     const v = state.view;
@@ -2840,8 +2827,6 @@ body {
     // Hide all views first
     tableWrap.style.display = 'none';
     calView.style.display = 'none';
-    dayViewEl.style.display = 'none';
-    weekViewEl.style.display = 'none';
     empty.style.display = 'none';
 
     // Update empty state text based on context
@@ -2861,12 +2846,6 @@ body {
           closeDayDetail();
         }
       }
-    } else if (v === 'week') {
-      weekViewEl.style.display = '';
-      renderWeekView(filtered);
-    } else if (v === 'day') {
-      dayViewEl.style.display = '';
-      renderDayView(filtered);
     } else {
       // table view
       tableWrap.style.display = '';
@@ -2906,7 +2885,7 @@ body {
 
   function renderExhibitionsRail() {
     const rail = document.getElementById('exhibitionsRail');
-    const today = new Date().toISOString().split('T')[0];
+    const today = localToday();
 
     // Find ongoing exhibitions: contentType === 'exhibition' AND today is within date range
     const ongoing = state.events.filter(ev =>
@@ -3084,7 +3063,7 @@ body {
 
     const firstDay = new Date(year, month, 1).getDay(); // 0=Sun
     const daysInPrev = new Date(year, month, 0).getDate();
-    const today = new Date().toISOString().split('T')[0];
+    const today = localToday();
 
     const MAX_EVENTS_SHOWN = 4;
     let html = '';
@@ -3161,11 +3140,7 @@ body {
         // Time prefix if available
         const timeHtml = ev.time ? `<span class="calendar__event-time">${escHtml(ev.time.split('-')[0].split('(')[0].trim().substring(0, 7))}</span> ` : '';
 
-        if (ev.url && ev.url !== '#') {
-          inner += `<a href="${escHtml(ev.url)}" class="calendar__event" target="_blank" rel="noopener" title="${escHtml(tip)}">${timeHtml}${escHtml(ev.name)}</a>`;
-        } else {
-          inner += `<span class="calendar__event" title="${escHtml(tip)}">${timeHtml}${escHtml(ev.name)}</span>`;
-        }
+        inner += `<span class="calendar__event" data-focus="${escHtml(ev.name)}" title="${escHtml(tip)}">${timeHtml}${escHtml(ev.name)}</span>`;
       });
       if (events.length > maxShown) {
         inner += `<span class="calendar__more">+${events.length - maxShown} more</span>`;
@@ -3173,163 +3148,6 @@ body {
     }
 
     return `<div class="${cls.join(' ')}" data-date="${dateStr}" style="cursor: pointer;">${inner}</div>`;
-  }
-
-  // --- Day View ---
-  function renderDayView(events) {
-    const dateStr = state.calDate;
-    const d = new Date(dateStr + 'T00:00:00');
-    const container = document.getElementById('dayViewContent');
-    const title = document.getElementById('dayTitle');
-    const stats = document.getElementById('dayStats');
-
-    title.textContent = d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
-
-    const dayEvents = events.filter(ev => eventSpansDate(ev, dateStr));
-    // Mark spanning events (their start date isn't today)
-    dayEvents.forEach(ev => { ev._spansDay = ev.date !== dateStr; });
-    dayEvents.sort((a, b) => {
-      // Spanning events (exhibitions, multi-day) sort last
-      if (a._spansDay !== b._spansDay) return a._spansDay ? 1 : -1;
-      return (a.time || 'zzz').localeCompare(b.time || 'zzz');
-    });
-    stats.textContent = `${dayEvents.length} event${dayEvents.length !== 1 ? 's' : ''}`;
-
-    if (dayEvents.length === 0) {
-      container.innerHTML = '<div class="day-view__empty">No events on this day</div>';
-      return;
-    }
-
-    container.innerHTML = '<ul class="day-view__list">' + dayEvents.map(ev => {
-      const nameHtml = ev.url && ev.url !== '#'
-        ? `<a href="${escHtml(ev.url)}" target="_blank" rel="noopener">${escHtml(ev.name)}</a>`
-        : escHtml(ev.name);
-      const metaParts = [];
-      if (ev.venue) metaParts.push(`<span>${escHtml(ev.venue)}</span>`);
-      if (ev.city) metaParts.push(`<span>${escHtml(ev.city)}</span>`);
-      if (ev.price) metaParts.push(`<span>${escHtml(ev.price)}</span>`);
-      if (ev.ages) metaParts.push(`<span>${escHtml(ev.ages)}</span>`);
-      if (ev.promoter) metaParts.push(`<span>${escHtml(ev.promoter)}</span>`);
-      const genreHtml = ev.genre
-        ? ev.genre.split(/,\s*/).slice(0, 6).map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('')
-        : '';
-      const spanClass = ev._spansDay ? ' day-view__spanning' : '';
-      const spanLabel = ev._spansDay && ev.endDate ? `<div class="day-view__spanning-label">${formatDateRange(ev)}</div>` : '';
-      return `<li class="day-view__item${spanClass}">
-        <div class="day-view__time">${escHtml(ev.time || '\u2014')}</div>
-        <div class="day-view__info">
-          ${spanLabel}
-          <div class="day-view__name">${nameHtml}</div>
-          <div class="day-view__meta">${metaParts.join('')}</div>
-          ${genreHtml ? `<div class="day-view__tags">${genreHtml}</div>` : ''}
-        </div>
-      </li>`;
-    }).join('') + '</ul>';
-  }
-
-  // --- Week View ---
-  function getWeekStart(dateStr) {
-    const d = new Date(dateStr + 'T00:00:00');
-    const day = d.getDay(); // 0=Sun
-    d.setDate(d.getDate() - day);
-    return d.toISOString().split('T')[0];
-  }
-
-  function addDays(dateStr, n) {
-    const d = new Date(dateStr + 'T00:00:00');
-    d.setDate(d.getDate() + n);
-    return d.toISOString().split('T')[0];
-  }
-
-  function renderWeekView(events) {
-    const weekStart = getWeekStart(state.calDate);
-    const container = document.getElementById('weekViewContent');
-    const title = document.getElementById('weekTitle');
-    const stats = document.getElementById('weekStats');
-    const today = new Date().toISOString().split('T')[0];
-
-    // Build event map (expand multi-day events into each day)
-    const eventMap = {};
-    const weekEnd = addDays(weekStart, 6);
-    events.forEach(ev => {
-      if (!ev.date) return;
-      if (ev.endDate && ev.endDate > ev.date) {
-        // Multi-day: add to each day in the week it spans
-        for (let d = 0; d < 7; d++) {
-          const ds = addDays(weekStart, d);
-          if (eventSpansDate(ev, ds)) {
-            if (!eventMap[ds]) eventMap[ds] = [];
-            eventMap[ds].push({ ...ev, _spansDay: ev.date !== ds });
-          }
-        }
-      } else {
-        if (!eventMap[ev.date]) eventMap[ev.date] = [];
-        eventMap[ev.date].push(ev);
-      }
-    });
-
-    // Week date range for title
-    const startDate = new Date(weekStart + 'T00:00:00');
-    const endDate = new Date(weekEnd + 'T00:00:00');
-    const sameMonth = startDate.getMonth() === endDate.getMonth();
-    if (sameMonth) {
-      title.textContent = `${startDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric' })} \u2013 ${endDate.getDate()}, ${endDate.getFullYear()}`;
-    } else {
-      title.textContent = `${startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} \u2013 ${endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`;
-    }
-
-    // Count events this week
-    let weekEventCount = 0;
-    const MAX_SHOWN = 8;
-    let html = '<div class="week-view__grid">';
-
-    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-    for (let i = 0; i < 7; i++) {
-      const dateStr = addDays(weekStart, i);
-      const d = new Date(dateStr + 'T00:00:00');
-      const dayEvents = eventMap[dateStr] || [];
-      dayEvents.sort((a, b) => (a.time || 'zzz').localeCompare(b.time || 'zzz'));
-      weekEventCount += dayEvents.length;
-
-      const isToday = dateStr === today;
-      const isWeekend = (i === 0 || i === 6);
-      const cls = ['week-view__day'];
-      if (isToday) cls.push('week-view__day--today');
-      if (isWeekend) cls.push('week-view__day--weekend');
-
-      html += `<div class="${cls.join(' ')}" data-date="${dateStr}">`;
-      html += `<div class="week-view__day-header" data-date="${dateStr}">`;
-      html += `<span>${dayNames[i]}</span>`;
-      html += `<span class="week-view__day-num">${d.getDate()}</span>`;
-      if (dayEvents.length > 0) html += ` <span style="font-size:9px;color:var(--fg-subtle);">(${dayEvents.length})</span>`;
-      html += '</div>';
-      html += '<div class="week-view__day-events">';
-
-      const shown = dayEvents.slice(0, MAX_SHOWN);
-      shown.forEach(ev => {
-        const tip = [ev.name, ev.venue ? '@ ' + ev.venue : '', ev.time].filter(Boolean).join(' \u2014 ');
-        const timeHtml = ev.time && !ev._spansDay ? `<span class="week-view__event-time">${escHtml(ev.time.split('-')[0].split('(')[0].trim().substring(0, 7))}</span> ` : '';
-        const spanCls = ev._spansDay ? ' week-view__event--spanning' : '';
-        if (ev.url && ev.url !== '#') {
-          html += `<a href="${escHtml(ev.url)}" class="week-view__event${spanCls}" target="_blank" rel="noopener" title="${escHtml(tip)}">${timeHtml}${escHtml(ev.name)}</a>`;
-        } else {
-          html += `<span class="week-view__event${spanCls}" title="${escHtml(tip)}">${timeHtml}${escHtml(ev.name)}</span>`;
-        }
-      });
-      if (dayEvents.length > MAX_SHOWN) {
-        html += `<span class="week-view__more">+${dayEvents.length - MAX_SHOWN} more</span>`;
-      }
-      if (dayEvents.length === 0) {
-        html += '<div style="padding:var(--space-2);color:var(--fg-subtle);font-size:var(--text-2xs);text-align:center;">\u2014</div>';
-      }
-
-      html += '</div></div>';
-    }
-
-    html += '</div>';
-    container.innerHTML = html;
-    stats.textContent = `${weekEventCount} event${weekEventCount !== 1 ? 's' : ''} this week`;
   }
 
   // Auto-navigate calendar to the month with the most events
@@ -3347,7 +3165,7 @@ body {
       state.calYear = y;
       state.calMonth = m - 1;
       // Also set calDate to today if it's in the best month, otherwise first of that month
-      const today = new Date().toISOString().split('T')[0];
+      const today = localToday();
       if (today.startsWith(best[0])) {
         state.calDate = today;
       } else {
@@ -3357,8 +3175,10 @@ body {
   }
 
   // --- Day Detail View ---
-  function openDayDetail(dateStr) {
+  function openDayDetail(dateStr, focusName) {
     state.selectedDate = dateStr;
+    // Takeover: the day breakdown replaces the month grid
+    document.getElementById('calendarGrid').style.display = 'none';
     const filtered = getFilteredEvents();
     const dayEvents = filtered.filter(ev => eventSpansDate(ev, dateStr));
     const panel = document.getElementById('dayDetail');
@@ -3399,7 +3219,7 @@ body {
         const genreHtml = allTags.map(g => `<span class="genre-tag">${escHtml(g)}</span>`).join('');
         const descHtml = ev.description ? `<div class="day-detail__desc">${escHtml(ev.description)}</div>` : '';
         const imgHtml = ev.imageUrl ? `<img src="${escHtml(ev.imageUrl)}" class="day-detail__img" alt="" loading="lazy">` : '';
-        return `<li class="day-detail__item">
+        return `<li class="day-detail__item" data-name="${escHtml(ev.name)}">
           ${imgHtml}
           <div class="day-detail__time">${escHtml(ev.time || '\u2014')}</div>
           <div class="day-detail__info">
@@ -3413,17 +3233,23 @@ body {
     }
 
     panel.classList.add('day-detail--visible');
-    // Highlight selected cell
-    document.querySelectorAll('.calendar__cell--selected').forEach(c => c.classList.remove('calendar__cell--selected'));
-    document.querySelectorAll('.calendar__cell').forEach(cell => {
-      if (cell.dataset.date === dateStr) cell.classList.add('calendar__cell--selected');
-    });
-    // Scroll panel into view
+    // Focus a specific event if one was tapped in the month cell
+    list.querySelectorAll('.day-detail__item--focus').forEach(li => li.classList.remove('day-detail__item--focus'));
+    if (focusName) {
+      const target = [...list.querySelectorAll('.day-detail__item')].find(li => li.dataset.name === focusName);
+      if (target) {
+        target.classList.add('day-detail__item--focus');
+        setTimeout(() => target.scrollIntoView({ behavior: 'smooth', block: 'center' }), 50);
+        panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        return;
+      }
+    }
     panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
 
   function closeDayDetail() {
     state.selectedDate = null;
+    document.getElementById('calendarGrid').style.display = '';
     document.getElementById('dayDetail').classList.remove('day-detail--visible');
     document.querySelectorAll('.calendar__cell--selected').forEach(c => c.classList.remove('calendar__cell--selected'));
   }
@@ -3938,7 +3764,7 @@ body {
     });
 
     // Calendar sync modal
-    document.getElementById('calSyncBtn').addEventListener('click', openCalSyncModal);
+    document.getElementById('calSyncBtn')?.addEventListener('click', openCalSyncModal);
     document.getElementById('calSyncClose').addEventListener('click', () => {
       document.getElementById('calSyncModal').classList.remove('modal--visible');
     });
@@ -4078,25 +3904,7 @@ body {
     // View toggle — sync dates across views when switching
     document.querySelectorAll('.view-toggle__btn').forEach(btn => {
       btn.addEventListener('click', () => {
-        const newView = btn.dataset.view;
-        const oldView = state.view;
-        // Sync calDate from month view context
-        if (oldView === 'calendar' && (newView === 'day' || newView === 'week')) {
-          // If a day was selected in month view, use that date
-          if (state.selectedDate) {
-            state.calDate = state.selectedDate;
-          } else {
-            // Default to 1st of current month
-            state.calDate = `${state.calYear}-${String(state.calMonth + 1).padStart(2, '0')}-01`;
-          }
-        }
-        // Sync month view from calDate
-        if ((oldView === 'day' || oldView === 'week') && newView === 'calendar') {
-          const d = new Date(state.calDate + 'T00:00:00');
-          state.calYear = d.getFullYear();
-          state.calMonth = d.getMonth();
-        }
-        state.view = newView;
+        state.view = btn.dataset.view;
         saveSettings();
         render();
       });
@@ -4123,54 +3931,12 @@ body {
     document.getElementById('calendarGrid').addEventListener('click', (e) => {
       const cell = e.target.closest('.calendar__cell');
       if (!cell || !cell.dataset.date) return;
-      if (e.target.tagName === 'A') return;
-      openDayDetail(cell.dataset.date);
+      const chip = e.target.closest('.calendar__event');
+      openDayDetail(cell.dataset.date, chip ? chip.dataset.focus : null);
     });
 
     // Day detail close
     document.getElementById('dayDetailClose').addEventListener('click', closeDayDetail);
-
-    // Day view navigation
-    document.getElementById('dayPrev').addEventListener('click', () => {
-      state.calDate = addDays(state.calDate, -1);
-      render();
-    });
-    document.getElementById('dayNext').addEventListener('click', () => {
-      state.calDate = addDays(state.calDate, 1);
-      render();
-    });
-    document.getElementById('dayToday').addEventListener('click', () => {
-      state.calDate = new Date().toISOString().split('T')[0];
-      render();
-    });
-
-    // Week view navigation
-    document.getElementById('weekPrev').addEventListener('click', () => {
-      state.calDate = addDays(state.calDate, -7);
-      render();
-    });
-    document.getElementById('weekNext').addEventListener('click', () => {
-      state.calDate = addDays(state.calDate, 7);
-      render();
-    });
-    document.getElementById('weekToday').addEventListener('click', () => {
-      state.calDate = new Date().toISOString().split('T')[0];
-      render();
-    });
-
-    // Week view: click day header → switch to day view
-    document.getElementById('weekViewContent').addEventListener('click', (e) => {
-      const header = e.target.closest('.week-view__day-header');
-      if (header && header.dataset.date) {
-        state.calDate = header.dataset.date;
-        state.view = 'day';
-        saveSettings();
-        render();
-        return;
-      }
-      // Don't intercept link clicks
-      if (e.target.tagName === 'A') return;
-    });
 
     // Onboarding — 3-step flow
     document.getElementById('onboardingStart').addEventListener('click', completeOnboarding);
@@ -4718,6 +4484,11 @@ body {
       loadRecommendedEvents();
     }
   }
+  // Account page links here to manage calendar sync
+  if (window.location.hash === '#calendar-sync') {
+    setTimeout(() => { try { openCalSyncModal(); } catch (e) { /* not signed in yet */ } }, 400);
+  }
+
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();
 })();


### PR DESCRIPTION
Implements all six Epic 1 items from [future-work.md](docs/playground/events/strategy/future-work.md):

1. **Date+1 bug fixed** — 'today' was derived from `toISOString()` (UTC), so after 5pm PT the list started tomorrow. All client date sites now use a local-time helper. Verified live: at 5:29pm PDT Jul 6 the query correctly starts Jul 6 (old code: Jul 7).
2. **Day + Week views removed** (saved settings migrate to List)
3. **Date separators in the desktop list** (were mobile-only) — verified rendering
4. **'Table' → 'List'**
5. **Month-view day takeover** — tapping a day replaces the grid with that day's breakdown (Back to month); tapping an event chip focuses + highlights it. Verified: Death Guild chip → takeover scrolled with focus outline.
6. **Nav restructure** — Manage Sources pinned in the header beside the auth bar; Calendar moved to /account/ as a settings card linking to /events/#calendar-sync (opens the sync modal).

Browser-verified throughout; console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)