### PR TITLE
fix(events): sweep remaining UTC date anchors after the Luma bug

### DIFF
--- a/supabase/functions/add-event/index.ts
+++ b/supabase/functions/add-event/index.ts
@@ -13,8 +13,8 @@
 // Body: { url: string }
 // Returns: { event, visibility, merged: boolean }
 
-const VERSION = '1.0.0'
-console.log(`[add-event] v${VERSION} - one-off event submission by link`)
+const VERSION = '1.0.1'
+console.log(`[add-event] v${VERSION} - PT-local date anchor + Z-timestamp handling`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -72,12 +72,22 @@ function extractJsonLd(html: string): Extracted | null {
       const ev = findEventNode(JSON.parse(m[1]))
       if (!ev || !ev.name || !ev.startDate) continue
       const start = String(ev.startDate)
+      let date = start.split('T')[0]
+      let time = (start.split('T')[1] || '').slice(0, 5)
+      if (/Z$/.test(start)) {
+        // Z-normalized publishers need UTC->PT; offset-formatted are already local
+        const local = new Intl.DateTimeFormat('sv-SE', {
+          timeZone: 'America/Los_Angeles', year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit', hour12: false,
+        }).format(new Date(start))
+        ;[date, time] = local.split(' ')
+      }
       const loc = ev.location && !Array.isArray(ev.location) ? ev.location : (ev.location?.[0] || {})
       const addr = loc.address || {}
       const offers = Array.isArray(ev.offers) ? ev.offers[0] : ev.offers
       return {
-        date: start.split('T')[0],
-        time: (start.split('T')[1] || '').slice(0, 5),
+        date,
+        time,
         name: String(ev.name).slice(0, 200),
         venue: String(loc.name || '').slice(0, 120),
         address: String(typeof addr === 'string' ? addr : addr.streetAddress || '').slice(0, 200),
@@ -104,7 +114,7 @@ async function extractWithAI(html: string, url: string, apiKey: string): Promise
     .replace(/\s+/g, ' ')
     .slice(0, 4000)
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date())
   const resp = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },

--- a/supabase/functions/scrape-discord-events/index.ts
+++ b/supabase/functions/scrape-discord-events/index.ts
@@ -14,8 +14,8 @@
 //
 // Returns: { events: [...], meta: { ... }, cached: boolean }
 
-const VERSION = '1.4.0'
-console.log(`[scrape-discord-events] v${VERSION} - platform-link resolution (bare link posts resolved via page JSON-LD, PRD §4.1)`)
+const VERSION = '1.4.1'
+console.log(`[scrape-discord-events] v${VERSION} - PT-local date anchors (UTC 'today' mis-resolved relative dates after 5pm PT)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -221,11 +221,22 @@ async function resolveLinkEvent(url: string): Promise<Partial<ExtractedEvent> | 
         const ev = findLdEventNode(JSON.parse(m[1]))
         if (!ev || !ev.name || !ev.startDate) continue
         const start = String(ev.startDate)
+        // Z-normalized publishers (e.g. Meetup) need UTC->PT conversion;
+        // offset-formatted ones (Luma, Partiful, Eventbrite) are already local
+        let date = start.split('T')[0]
+        let time = (start.split('T')[1] || '').slice(0, 5)
+        if (/Z$/.test(start)) {
+          const local = new Intl.DateTimeFormat('sv-SE', {
+            timeZone: 'America/Los_Angeles', year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit', hour12: false,
+          }).format(new Date(start))
+          ;[date, time] = local.split(' ')
+        }
         const loc = ev.location && !Array.isArray(ev.location) ? ev.location : (ev.location?.[0] || {})
         const addr = loc.address || {}
         return {
-          date: start.split('T')[0],
-          time: (start.split('T')[1] || '').slice(0, 5),
+          date,
+          time,
           name: String(ev.name).slice(0, 200),
           venue: String(loc.name || '').slice(0, 120),
           address: String(typeof addr === 'string' ? addr : addr.streetAddress || '').slice(0, 200),
@@ -378,7 +389,7 @@ async function extractEventsWithAI(
   guildId: string,
   channelId: string
 ): Promise<ExtractedEvent[]> {
-  const today = new Date().toISOString().split('T')[0]
+  const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date())
   const BATCH_SIZE = 15
   const allEvents: ExtractedEvent[] = []
 

--- a/supabase/functions/scrape-events/parsers/ra.ts
+++ b/supabase/functions/scrape-events/parsers/ra.ts
@@ -9,8 +9,11 @@ const RA_AREAS: Record<string, number> = {
 }
 
 export async function scrapeRA(source: EventSource): Promise<ScrapedEvent[]> {
-  const today = new Date().toISOString().split('T')[0]
-  const endDate = new Date(Date.now() + 14 * 86400000).toISOString().split('T')[0]
+  // PT-local window: a UTC "today" is tomorrow after 5pm PT, which dropped
+  // same-evening events from evening cron runs
+  const fmt = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' })
+  const today = fmt.format(new Date())
+  const endDate = fmt.format(new Date(Date.now() + 14 * 86400000))
 
   // Extract area slug from URL
   const urlParts = source.url.replace(/\/$/, '').split('/')


### PR DESCRIPTION
Full audit of every date-producing path after the Luma iCal fix. Three more live instances of the UTC family, all fixed and deployed:

1. **AI extraction anchors** (Discord scraper + add-event): the "Today is X" prompt anchor was UTC — evening runs resolved relative dates ('tonight', 'this Friday') one day late
2. **RA scrape window** started from UTC-today, so evening crons skipped same-evening additions
3. **JSON-LD extractors** now convert Z-normalized timestamps (Meetup-style) to PT; offset-formatted publishers were already correct

Audited-safe: RA event dates (tz-naive local strings from their API), eventbrite-org (`start.local`), all text-date parsers (19hz, Screen Slate, Gary's Guide, ATA, Bottom of the Hill). The disabled bonobo/sfmoma parsers still carry the pattern — noted for if they're ever re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)