### PR TITLE
feat(events): pulse strip — LED-tick needles, 90-day window, static pitch (v1.22.0)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -113,19 +113,29 @@ body {
   flex-shrink: 0;
 }
 
+/* Track + axis share one horizontal scroller so the fixed needle pitch
+   survives narrow viewports (scrolls instead of squeezing) */
+.pulse__scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.pulse__scroll::-webkit-scrollbar { display: none; }
+
 .pulse__track {
   display: flex;
   align-items: stretch;
-  gap: 3px;
+  width: max-content;
+  min-width: 100%;
   height: 56px;
-  border-bottom: var(--border-thin) solid var(--border);
+  border-bottom: var(--border-thin) solid var(--border-subtle);
   transition: height var(--duration-normal) var(--ease-default);
 }
 
-/* Each day is a full-width click target; the visible needle is a narrow
-   3px bar centered inside it, segments stacked bottom-up in category order */
+/* Fixed-pitch needles: an 11px day cell with a 3px bar centered inside —
+   static 8px visual gap, full-pitch click target. LED-tick quantization. */
 .pulse__day {
-  flex: 1 1 0;
+  flex: 0 0 11px;
   min-width: 0;
   display: flex;
   flex-direction: column-reverse;
@@ -140,8 +150,18 @@ body {
 .pulse__day:hover .pulse__seg,
 .pulse__day:hover .pulse__dot { filter: brightness(1.3); }
 
-.pulse__seg { width: 3px; flex: 0 0 auto; }
-.pulse__seg--empty { height: 2px; background: var(--border-subtle); }
+.pulse__seg {
+  width: 3px;
+  flex: 0 0 auto;
+  -webkit-mask-image: repeating-linear-gradient(to top, #000 0 3px, transparent 3px 4px);
+  mask-image: repeating-linear-gradient(to top, #000 0 3px, transparent 3px 4px);
+}
+.pulse__seg--empty {
+  height: 2px;
+  background: var(--border-subtle);
+  -webkit-mask-image: none;
+  mask-image: none;
+}
 
 /* Dot-matrix mode: one dot per N events, stacked in category colors */
 .pulse--dots .pulse__day {
@@ -177,25 +197,30 @@ body {
 
 .pulse__axis {
   display: flex;
-  gap: 3px;
+  width: max-content;
+  min-width: 100%;
   max-height: 14px;
   overflow: hidden;
   transition: max-height var(--duration-normal) var(--ease-default),
               opacity var(--duration-normal) var(--ease-default);
 }
 
+/* Labels are wider than their 3px cell — center them over the needle
+   and let the text paint outside the box */
 .pulse__axis-cell {
-  flex: 1 1 0;
+  flex: 0 0 11px;
   min-width: 0;
+  display: flex;
+  justify-content: center;
   font-size: 9px;
   color: var(--fg-subtle);
-  text-align: center;
   letter-spacing: var(--tracking-wide);
   padding-top: 2px;
   white-space: nowrap;
 }
 
 .pulse__axis-cell--today { color: var(--fg); font-weight: 700; }
+.pulse__axis-cell--month { color: var(--fg-muted); font-weight: 700; letter-spacing: var(--tracking-wider); }
 
 /* Collapse on scroll — only where the strip is sticky (desktop) */
 @media (min-width: 601px) {
@@ -208,7 +233,6 @@ body {
 @media (max-width: 600px) {
   .pulse { position: static; padding-top: var(--space-2); }
   .pulse__track { height: 40px; }
-  .pulse__track, .pulse__axis { gap: 2px; }
   .pulse__legend { display: none; }
   .pulse__mode { margin-left: auto; }
 }
@@ -1671,7 +1695,7 @@ body {
     <!-- Pulse strip — events per day, next 30 days -->
     <div class="pulse" id="pulseStrip" style="display:none">
       <div class="pulse__head">
-        <span class="pulse__label">Next 30 days</span>
+        <span class="pulse__label">Next 90 days</span>
         <span class="pulse__total" id="pulseTotal"></span>
         <div class="pulse__legend" id="pulseLegend"></div>
         <div class="pulse__mode">
@@ -1679,8 +1703,10 @@ body {
           <button class="pulse__mode-btn" data-mode="dots">Dots</button>
         </div>
       </div>
-      <div class="pulse__track" id="pulseTrack"></div>
-      <div class="pulse__axis" id="pulseAxis"></div>
+      <div class="pulse__scroll">
+        <div class="pulse__track" id="pulseTrack"></div>
+        <div class="pulse__axis" id="pulseAxis"></div>
+      </div>
     </div>
 
     <!-- Sources bar -->
@@ -1989,8 +2015,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.21.0';
-  console.log(`[events] v${VERSION} - Pulse strip: narrow needle bars + dot-matrix mode toggle`);
+  const VERSION = '1.22.0';
+  console.log(`[events] v${VERSION} - Pulse strip: LED-tick needles, 90-day window, static pitch, subtle baseline`);
 
   // ============================================
   // Stock Sources Catalog
@@ -3082,7 +3108,7 @@ body {
   }
 
   // --- Pulse strip (events-per-day density) ---
-  const PULSE_DAYS = 30;
+  const PULSE_DAYS = 90;
 
   function renderPulse() {
     const strip = document.getElementById('pulseStrip');
@@ -3167,9 +3193,15 @@ body {
         });
       }
       trackHtml += `<button class="${cls.join(' ')}" data-date="${ds}" title="${escHtml(tip)}" aria-label="${escHtml(tip)}">${segs}</button>`;
-      // Label Mondays and today on the axis; the rest stay quiet
-      const label = (ds === today || d.getDay() === 1) ? String(d.getDate()) : '';
-      axisHtml += `<span class="pulse__axis-cell${ds === today ? ' pulse__axis-cell--today' : ''}">${label}</span>`;
+      // Axis: month name on the 1st, day number on Mondays and today —
+      // Mondays hugging a month boundary stay quiet so labels don't collide
+      const dayOfMonth = d.getDate();
+      const isMonth = dayOfMonth === 1;
+      const label = isMonth
+        ? d.toLocaleDateString('en-US', { month: 'short' }).toUpperCase()
+        : ((ds === today || d.getDay() === 1) && dayOfMonth > 2 && dayOfMonth < 29) ? String(dayOfMonth) : '';
+      const cellCls = ds === today ? ' pulse__axis-cell--today' : (isMonth ? ' pulse__axis-cell--month' : '');
+      axisHtml += `<span class="pulse__axis-cell${cellCls}">${label}</span>`;
     });
     const track = document.getElementById('pulseTrack');
     track.innerHTML = trackHtml;


### PR DESCRIPTION
## What
Applies the chosen stylization (S2 — LED ticks) from the four-way needle treatment review, plus the 90-day/static-spacing directives.

- **LED-tick needles**: segments quantized into VU-meter notches (3px on / 1px off mask) — hi-fi instrument read, still category-stacked.
- **90-day window** (was 30): month names label the 1sts; Monday day-numbers suppressed near month boundaries to avoid collisions.
- **Static needle pitch**: 11px day cells with a 3px needle centered inside — constant spacing at every viewport, and the full 11px column stays clickable. Track+axis sit in a hidden horizontal scroller so narrow screens scroll instead of squeezing (today anchored left).
- **Baseline reduced**: track underline now `--border-subtle` to match the table's row separators.

## Version
Events page v1.21.0 → **v1.22.0**

## Tested
Chrome on localhost with live data (787 events / 90 days): LED render, month axis, day-click filter round-trip, dots-mode toggle intact, scroll collapse to ribbon, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)