### PR TITLE
fix(events): unify event count in pulse strip header (v1.23.1)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1720,7 +1720,7 @@ body {
     <div class="pulse" id="pulseStrip">
       <div id="pulseViz" style="display:none">
         <div class="pulse__head">
-          <span class="pulse__label">Next 90 days</span>
+          <span class="pulse__label" id="statsText"></span>
           <span class="pulse__total" id="pulseTotal"></span>
           <div class="pulse__legend" id="pulseLegend"></div>
           <div class="pulse__mode">
@@ -1768,7 +1768,6 @@ body {
 
     <!-- Stats + View Toggle -->
     <div class="stats-bar">
-      <span id="statsText">0 events</span>
       <span id="statsFiltered"></span>
       <div class="view-toggle">
         <button class="view-toggle__btn active" data-view="table">List</button>
@@ -2042,8 +2041,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.23.0';
-  console.log(`[events] v${VERSION} - Pulse strip: sticky scroll header (date + filters), scrollspy highlight, tap-to-jump, 2x collapsed ribbon`);
+  const VERSION = '1.23.1';
+  console.log(`[events] v${VERSION} - Pulse strip head shows the global event/source count; duplicate stats line removed`);
 
   // ============================================
   // Stock Sources Catalog
@@ -3185,8 +3184,9 @@ body {
     strip.querySelectorAll('.pulse__mode-btn').forEach(b =>
       b.classList.toggle('active', b.dataset.mode === state.pulseMode));
 
-    document.getElementById('pulseTotal').textContent =
-      `${distinct.size} event${distinct.size !== 1 ? 's' : ''}` + (dots && dotUnit > 1 ? ` · 1 dot ≈ ${dotUnit}` : '');
+    // The head's count is the global statsText line; this slot only carries
+    // the dot-scale note when it applies
+    document.getElementById('pulseTotal').textContent = (dots && dotUnit > 1) ? `1 dot ≈ ${dotUnit}` : '';
     document.getElementById('pulseLegend').innerHTML = CATEGORY_ORDER.filter(c => catsSeen.has(c)).map(c =>
       `<span class="pulse__legend-item"><span class="pulse__legend-dot" style="background:${CATEGORY_COLORS[c]}"></span>${CATEGORY_LABELS[c]}</span>`
     ).join('');


### PR DESCRIPTION
## What
The strip header read "Next 90 days · 792 events" (window-scoped) while the All chip read 881 (everything loaded) — two different denominators that looked like a bug.

- The strip head now carries the single global **"N events from M sources"** line (`statsText` moved into the pulse header).
- The duplicate stats line above the table is removed; the stats bar keeps only the "Showing N" filtered indicator and the List/Month toggle.
- The header's secondary slot now only shows the dot-scale note ("1 dot ≈ N") in dots mode.

## Version
Events page v1.23.0 → **v1.23.1**

## Tested
Chrome on localhost: header shows "879 events from 17 sources" matching the All chip, no duplicate line, dots-mode note intact, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)