### PR TITLE
fix(events): reconcile cached event count on any DB difference (v1.24.1)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2045,8 +2045,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.24.0';
-  console.log(`[events] v${VERSION} - Settings rename, beta Month/List switcher (default off), Agape Recommended (no member), price column hidden`);
+  const VERSION = '1.24.1';
+  console.log(`[events] v${VERSION} - L2 freshness check reconciles on any count difference (live event count)`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2939,8 +2939,10 @@ body {
   async function checkL2Freshness() {
     try {
       const cachedL2 = await loadSupabaseCachedEvents();
-      if (cachedL2 && cachedL2.length > state.events.length + 5) {
-        log(`DB has fresher data (${cachedL2.length} vs ${state.events.length}): updating`);
+      // Any count difference means the visible "N events" line is lying —
+      // reconcile on shrinkage (expired/removed events) as well as growth
+      if (cachedL2 && cachedL2.length !== state.events.length) {
+        log(`DB count differs (${cachedL2.length} vs ${state.events.length}): updating`);
         state.events = cachedL2;
         state.events.forEach(ev => {
           ev.contentType = getSourceCategory(ev.source);


### PR DESCRIPTION
## What
"N events from M sources" recomputes on every render, but the 15-minute L1 cache could feed it stale data: the background freshness check only replaced events when the DB had **more than +5**, and never on shrinkage (expired/aged-out events). The header could sit wrong for up to 15 minutes.

The check now reconciles whenever the DB count differs at all, in either direction.

## Version
Events page v1.24.1

## Tested
Poisoned the v2 L1 cache by dropping 3 events (inside the old dead zone), reloaded: page rendered 876 from cache, then logged `DB count differs (879 vs 876): updating` within ~1s and the header + All chip both corrected to the live 879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)