### PR TITLE
fix(events): single ★ Agape token, wider single-line source tags (v1.27.1)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -595,7 +595,8 @@ body {
 .data-table .col-price { display: none; }
 .data-table .col-ages { display: none; }
 .data-table .col-promoter { display: none; }
-.data-table .col-source { width: 90px; }
+.data-table .col-source { width: 140px; }
+.data-table .col-source .token--source { white-space: nowrap; }
 .data-table .col-source .token--source + .token--source { margin-left: 3px; }
 .data-table .col-bm { width: 28px; padding-left: var(--space-2); padding-right: 0; }
 
@@ -2065,7 +2066,7 @@ body {
   'use strict';
 
   const VERSION = '1.27.1';
-  console.log(`[events] v${VERSION} - Agape rows show only the ★ Agape token (no duplicate source token)`);
+  console.log(`[events] v${VERSION} - Agape rows show only the ★ Agape token; wider source column (fewer wrapped tags)`);
 
   // ============================================
   // Stock Sources Catalog


### PR DESCRIPTION
## What
- **Agape rows show only "★ Agape"**: the `discord-agape-events` source token duplicated the gold star marker in the source column — it's now filtered out of the row. Events also scraped from real venue/listing sources keep those tokens.
- **Source column 90px → 140px** with `white-space: nowrap` on tokens, so names like "Screen Slate" and "Frontier Tower" render on one line instead of wrapping.

## Version
Events page v1.27.0 → **v1.27.1**

## Tested
Chrome on localhost: source tokens single-line in the wider column, table layout intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)