### PR TITLE
feat(events): Tech category hidden by default (v1.28.1)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2067,8 +2067,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.28.0';
-  console.log(`[events] v${VERSION} - Category hide toggles in Settings; collapse snaps (no mid-scroll jiggle) with hysteresis`);
+  const VERSION = '1.28.1';
+  console.log(`[events] v${VERSION} - Tech category hidden by default (one-time; re-enable in Settings)`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2430,6 +2430,15 @@ body {
         state.showViewSwitcher = !!settings.showViewSwitcher; // beta, default off
         if (!state.showViewSwitcher) state.view = 'table'; // no switcher, no calendar
         state.hiddenCategories = new Set(Array.isArray(settings.hiddenCategories) ? settings.hiddenCategories : []);
+      }
+    } catch (e) { /* ignore */ }
+    // Tech is hidden by default — applied once so re-enabling it in
+    // Settings → Categories sticks
+    try {
+      if (!localStorage.getItem('ctrl-rodeo-tech-hidden-applied')) {
+        state.hiddenCategories.add('tech');
+        localStorage.setItem('ctrl-rodeo-tech-hidden-applied', '1');
+        saveSettings(); // persist now or the next load reverts
       }
     } catch (e) { /* ignore */ }
   }


### PR DESCRIPTION
## What
Tech is now hidden by default. Implemented as a one-time migration (like the Agape-source migration): on first load it adds `tech` to `hiddenCategories`, persists immediately, and sets a flag — so it applies once to existing browsers too, and users who re-enable Tech in Settings → Categories keep their choice.

## Version
Events page v1.28.0 → **v1.28.1**

## Tested
Chrome on localhost with the flag cleared: on load Tech disappears from all counts (All 879 → 675), no Tech chip, Settings checkbox unchecked, setting persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)