### PR TITLE
fix(events): remove refresh button (v1.30.1)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1755,7 +1755,6 @@ body {
       <div class="sources-bar">
         <span class="pulse__current" id="pulseCurrent"></span>
         <div class="sources-bar__chips" id="sourceChips"></div>
-        <button class="btn btn--sm btn--ghost" id="forceRefreshBtn" title="Force refresh all sources (Shift+R)" style="padding:4px 6px;font-size:14px;line-height:1;opacity:0.5;min-width:0;" onclick="window.__forceRefreshSources && window.__forceRefreshSources()">⟳</button>
         <button class="btn btn--sm btn--ghost sources-bar__filter-btn" id="filterToggleBtn">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="1" y1="3" x2="11" y2="3"/><line x1="3" y1="6" x2="9" y2="6"/><line x1="5" y1="9" x2="7" y2="9"/></svg>
           Filter
@@ -2075,8 +2074,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.30.0';
-  console.log(`[events] v${VERSION} - ★ Agape as a top-level chip (cross-cut: composes with category filters)`);
+  const VERSION = '1.30.1';
+  console.log(`[events] v${VERSION} - Refresh button removed (Shift+R shortcut remains)`);
 
   // ============================================
   // Stock Sources Catalog


### PR DESCRIPTION
## What
Removes the ⟳ force-refresh button from the sources bar in the sticky header. The Shift+R keyboard shortcut and `window.__forceRefreshSources` hook remain functional (both already handle the button's absence).

## Version
Events page v1.30.0 → **v1.30.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)