### PR TITLE
fix(events): mobile card layout — bookmark joins time row (v1.30.2)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1557,16 +1557,17 @@ body {
   /* Hierarchy: time anchors scanning within a date group, name is primary,
      venue·city one muted line, tags + source demoted to plain text
      ("show, don't decorate" — no boxes inside boxes). */
+  /* Date and price columns are hidden, so the bookmark shares the time
+     row instead of holding an empty header row on every card */
   .data-table tbody tr {
     grid-template-columns: auto 1fr auto auto;
     grid-template-areas:
-      "date date date bm"
-      "time time ages price"
+      "time time ages bm"
       "name name name name"
       "venue venue venue venue"
       "genre genre genre source";
   }
-  .data-table .col-bm { grid-area: bm; width: auto; padding: 0; text-align: right; }
+  .data-table .col-bm { grid-area: bm; width: auto; padding: 0; text-align: right; align-self: start; }
   .data-table .col-date { display: none; }
   .data-table .col-time { grid-area: time; display: block; width: auto; max-width: none; font-size: var(--text-xs); color: var(--fg); }
   .col-time .mobile-date-range { display: inline; }
@@ -2074,8 +2075,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.30.1';
-  console.log(`[events] v${VERSION} - Refresh button removed (Shift+R shortcut remains)`);
+  const VERSION = '1.30.2';
+  console.log(`[events] v${VERSION} - Mobile audit fix: bookmark shares the time row (empty card header row removed)`);
 
   // ============================================
   // Stock Sources Catalog


### PR DESCRIPTION
## What
Mobile audit fix: since the date column was hidden (v1.25.0), the bookmark button sat alone on an empty first grid row of every mobile card — ~26px of dead space per card across ~700 cards. The card grid template drops the date row and puts the bookmark right-aligned on the time row.

## Audit summary (390px, all v1.20–v1.30 changes)
Everything else passed: no horizontal overflow anywhere, pulse strip scrolls horizontally at fixed pitch (today anchored left), chips row scrolls, sticky date headers pin under the page header, desktop-only collapse/current-date/scrollspy correctly inert on mobile, filter bar stacks full-width incl. the distance select, Settings modal + category toggle grid fit, 2-step onboarding + number keys + EQ loader all work at phone width.

## Version
Events page v1.30.1 → **v1.30.2**

🤖 Generated with [Claude Code](https://claude.com/claude-code)