### PR TITLE
gcal-sync 1.1.0: dedicated ctrl-events Google Cloud project

### DIFF
--- a/supabase/functions/gcal-sync/index.ts
+++ b/supabase/functions/gcal-sync/index.ts
@@ -11,7 +11,7 @@
 // POST /functions/v1/gcal-sync   (Authorization: Bearer <user JWT>)
 // Body: { action: 'connect-url' | 'exchange' | 'status' | 'settings' | 'sync' | 'disconnect', ... }
 
-const VERSION = '1.0.1'
+const VERSION = '1.1.0'
 console.log(`[gcal-sync] v${VERSION} — ctrl.events Google Calendar sync (bookmarked + agape)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -40,13 +40,13 @@ function getSupabase() {
   return createClient(url, key)
 }
 
-// Reuses the OAuth client already configured for the /calendar app
-// (same Google Cloud project; ctrl.rodeo/events/ must be an authorized redirect URI)
+// Dedicated events OAuth client: "ctrl.events web" in GCP project ctrl-events-501717
+// (kept separate from the /calendar app's client so quota/consent/verification are independent)
 function googleClientId(): string {
-  return Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID') || ''
+  return Deno.env.get('GOOGLE_EVENTS_CLIENT_ID') || ''
 }
 function googleClientSecret(): string {
-  return Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET') || ''
+  return Deno.env.get('GOOGLE_EVENTS_CLIENT_SECRET') || ''
 }
 
 // --- Auth: resolve the calling user from their JWT ---


### PR DESCRIPTION
Events gets its own Google Cloud project instead of piggybacking on the /calendar app's OAuth client.

**New GCP project: `ctrl-events-501717`**
- Calendar API enabled
- OAuth consent screen "ctrl.events" (External / Testing; fike101@gmail.com added as test user)
- Web OAuth client "ctrl.events web" with redirect URI `https://ctrl.rodeo/events/`
- Client ID + secret stored on the Boards Supabase project as `GOOGLE_EVENTS_CLIENT_ID` / `GOOGLE_EVENTS_CLIENT_SECRET`

This PR points gcal-sync at those new secret names (v1.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)