### PR TITLE
Sign in with Discord + Agape-membership-gated recommendations

### DIFF
--- a/account/index.html
+++ b/account/index.html
@@ -377,7 +377,7 @@
   <!-- Auth gate (shown when not logged in) -->
   <div class="auth-gate" id="authGate">
     <div class="auth-gate__title">Sign in to manage your account</div>
-    <p class="auth-gate__text">Log in with Google or email to view your account settings.</p>
+    <p class="auth-gate__text">Log in with Google, Discord, or email to view your account settings.</p>
     <button class="btn" id="authGateLogin">Sign In</button>
   </div>
 
@@ -433,6 +433,25 @@
           <span class="settings-row__description">Sync interested + Agape events to the ctrl.events calendar</span>
         </div>
         <a class="btn btn--sm" href="/events/#calendar-sync" style="text-decoration:none;">Manage</a>
+      </div>
+    </div>
+
+    <!-- Discord / Agape membership -->
+    <div class="account-card" id="discordSection">
+      <div class="account-card__header">Discord</div>
+      <div class="settings-row">
+        <div class="settings-row__label">
+          <span class="settings-row__title">Connection</span>
+          <span class="settings-row__description" id="discordStatusText">Not connected</span>
+        </div>
+        <button class="btn btn--sm" id="discordConnectBtn">Connect Discord</button>
+      </div>
+      <div class="settings-row" id="discordMembershipRow" style="display:none;">
+        <div class="settings-row__label">
+          <span class="settings-row__title">Agape Membership</span>
+          <span class="settings-row__description" id="discordMembershipText">Checking...</span>
+        </div>
+        <button class="btn btn--sm" id="discordRecheckBtn">Re-check</button>
       </div>
     </div>
 
@@ -734,6 +753,8 @@
       const provider = currentUser.app_metadata?.provider || 'email';
       if (provider === 'google') {
         accountAuthMethod.innerHTML = '<span class="auth-method"><svg class="auth-method__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg> Google</span>';
+      } else if (provider === 'discord') {
+        accountAuthMethod.innerHTML = '<span class="auth-method">Discord</span>';
       } else {
         accountAuthMethod.innerHTML = '<span class="auth-method">Email (Magic Link)</span>';
       }
@@ -744,11 +765,88 @@
         if (settingsSection) {
           setTimeout(() => settingsSection.scrollIntoView({ behavior: 'smooth' }), 100);
         }
+      } else if (window.location.hash === '#discord') {
+        const discordSection = document.getElementById('discordSection');
+        if (discordSection) {
+          setTimeout(() => discordSection.scrollIntoView({ behavior: 'smooth' }), 100);
+        }
       }
 
       // Load connector settings in background
       loadConnectorSettings();
+      loadDiscordStatus();
     }
+
+    // ============================================
+    // Discord / Agape Membership
+    // ============================================
+    const discordStatusText = document.getElementById('discordStatusText');
+    const discordConnectBtn = document.getElementById('discordConnectBtn');
+    const discordMembershipRow = document.getElementById('discordMembershipRow');
+    const discordMembershipText = document.getElementById('discordMembershipText');
+    const discordRecheckBtn = document.getElementById('discordRecheckBtn');
+
+    async function fetchDiscordMembership(action) {
+      const token = CtrlAuth.getSession()?.access_token;
+      if (!token) return null;
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ action })
+      });
+      if (!resp.ok) throw new Error(`discord-membership ${resp.status}`);
+      return resp.json();
+    }
+
+    function renderDiscordStatus(status) {
+      const identity = CtrlAuth.getDiscordIdentity();
+      if (!identity && !status?.linked) {
+        discordStatusText.textContent = 'Not connected';
+        discordConnectBtn.style.display = '';
+        discordMembershipRow.style.display = 'none';
+        return;
+      }
+      const name = status?.discordUsername || identity?.username;
+      discordStatusText.textContent = name ? `Connected as ${name}` : 'Connected';
+      discordConnectBtn.style.display = 'none';
+      discordMembershipRow.style.display = '';
+      if (status) {
+        discordMembershipText.textContent = status.isMember
+          ? 'Agape member — Agape recommendations unlocked'
+          : 'Not a member of the Agape server';
+      }
+    }
+
+    async function loadDiscordStatus() {
+      renderDiscordStatus(null);
+      try {
+        const status = await fetchDiscordMembership('status');
+        if (status) renderDiscordStatus(status);
+      } catch (e) {
+        discordMembershipText.textContent = 'Could not check membership';
+      }
+    }
+
+    discordConnectBtn.addEventListener('click', async () => {
+      try {
+        await CtrlAuth.linkDiscord(window.location.origin + '/account/#discord');
+      } catch (e) {
+        discordStatusText.textContent = e.message || 'Discord connect failed';
+      }
+    });
+
+    discordRecheckBtn.addEventListener('click', async () => {
+      discordMembershipText.textContent = 'Checking...';
+      discordRecheckBtn.disabled = true;
+      try {
+        const status = await fetchDiscordMembership('verify');
+        if (status) renderDiscordStatus(status);
+      } catch (e) {
+        discordMembershipText.textContent = 'Could not check membership';
+      } finally {
+        discordRecheckBtn.disabled = false;
+      }
+    });
 
     // ============================================
     // Theme Toggle

--- a/auth/ctrl-auth.css
+++ b/auth/ctrl-auth.css
@@ -281,6 +281,17 @@
   flex-shrink: 0;
 }
 
+/* Discord button */
+.ctrl-auth-btn--discord {
+  margin-bottom: var(--space-3);
+}
+
+.ctrl-auth-btn--discord svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 /* Divider */
 .ctrl-auth-divider {
   display: flex;

--- a/auth/ctrl-auth.js
+++ b/auth/ctrl-auth.js
@@ -140,6 +140,27 @@
     /** Returns the supabase client instance */
     getSupabaseClient() {
       return _supabase;
+    },
+
+    /** Returns the user's Discord identity ({ id, username }) or null */
+    getDiscordIdentity() {
+      const identity = (_currentUser?.identities || []).find(i => i.provider === 'discord');
+      if (!identity) return null;
+      const d = identity.identity_data || {};
+      return {
+        id: identity.id,
+        username: d.custom_claims?.global_name || d.full_name || d.name || null
+      };
+    },
+
+    /** Links a Discord identity to the current signed-in account (OAuth redirect) */
+    async linkDiscord(redirectTo) {
+      if (!_currentUser) throw new Error('Not signed in');
+      const { error } = await _supabase.auth.linkIdentity({
+        provider: 'discord',
+        options: { redirectTo: redirectTo || window.location.href, scopes: 'identify email' }
+      });
+      if (error) throw error;
     }
   };
 
@@ -182,6 +203,10 @@
             <button class="ctrl-auth-btn ctrl-auth-btn--google" id="ctrlAuthGoogleBtn">
               <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
               Continue with Google
+            </button>
+            <button class="ctrl-auth-btn ctrl-auth-btn--discord" id="ctrlAuthDiscordBtn">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.27 18.27 0 0 0-5.49 0 12.6 12.6 0 0 0-.62-1.25.08.08 0 0 0-.08-.04 19.74 19.74 0 0 0-4.88 1.52.07.07 0 0 0-.04.03C.53 9.05-.32 13.58.1 18.06a.08.08 0 0 0 .03.05 19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.22-2a.08.08 0 0 0-.04-.11 13.1 13.1 0 0 1-1.87-.9.08.08 0 0 1-.01-.12c.13-.1.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.8 8.18 1.8 12.06 0a.07.07 0 0 1 .08 0c.12.1.25.2.37.3a.08.08 0 0 1 0 .12 12.3 12.3 0 0 1-1.88.9.08.08 0 0 0-.04.1c.36.7.77 1.37 1.22 2a.08.08 0 0 0 .08.03 19.84 19.84 0 0 0 6.02-3.03.08.08 0 0 0 .03-.05c.5-5.18-.84-9.68-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42 0-1.33.96-2.42 2.16-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.15-1.08-2.15-2.42 0-1.33.95-2.42 2.15-2.42 1.22 0 2.18 1.1 2.16 2.42 0 1.34-.94 2.42-2.16 2.42z" fill="#5865F2"/></svg>
+              Continue with Discord
             </button>
             <div class="ctrl-auth-divider">or</div>
             <button class="ctrl-auth-btn ctrl-auth-btn--secondary" id="ctrlAuthEmailMethodBtn">Continue with Email</button>
@@ -234,7 +259,7 @@
       'ctrlAuthMenuAccount', 'ctrlAuthMenuSettings', 'ctrlAuthMenuLogout',
       'ctrlAuthModal', 'ctrlAuthModalClose',
       'ctrlAuthStepMethod', 'ctrlAuthStepEmail', 'ctrlAuthStepCheckEmail',
-      'ctrlAuthGoogleBtn', 'ctrlAuthEmailMethodBtn',
+      'ctrlAuthGoogleBtn', 'ctrlAuthDiscordBtn', 'ctrlAuthEmailMethodBtn',
       'ctrlAuthEmailForm', 'ctrlAuthEmailInput', 'ctrlAuthEmailSubmit', 'ctrlAuthEmailBack', 'ctrlAuthEmailStatus',
       'ctrlAuthCheckEmailStatus',
       'ctrlAuthUsernameModal', 'ctrlAuthUsernameInput', 'ctrlAuthUsernameStatus', 'ctrlAuthUsernameSave'
@@ -254,6 +279,9 @@
 
     // Google sign-in
     _els.ctrlAuthGoogleBtn.addEventListener('click', handleGoogleLogin);
+
+    // Discord sign-in
+    _els.ctrlAuthDiscordBtn.addEventListener('click', handleDiscordLogin);
 
     // Email method
     _els.ctrlAuthEmailMethodBtn.addEventListener('click', () => showStep('email'));
@@ -403,6 +431,19 @@
       if (error) throw error;
     } catch (e) {
       setEmailStatus(e.message || 'Google login failed', true);
+    }
+  }
+
+  async function handleDiscordLogin() {
+    try {
+      const redirectTo = _config.redirectTo || window.location.href;
+      const { error } = await _supabase.auth.signInWithOAuth({
+        provider: 'discord',
+        options: { redirectTo, scopes: 'identify email' }
+      });
+      if (error) throw error;
+    } catch (e) {
+      setEmailStatus(e.message || 'Discord login failed', true);
     }
   }
 

--- a/events/index.html
+++ b/events/index.html
@@ -2072,7 +2072,7 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.32.0';
+  const VERSION = '1.33.0';
   console.log(`[events] v${VERSION} - GCal connect race fix (ticketed status) + calendar-sync nudge after 2+ bookmarks`);
 
   // ============================================
@@ -2261,12 +2261,32 @@ body {
     if (el) el.style.display = (window.CtrlAuth && CtrlAuth.isAdmin()) ? '' : 'none';
   }
 
+  // Agape membership: null = unknown/anon, true/false once checked.
+  // Data access is enforced by RLS; this only drives the ★ Agape filter UX.
+  let agapeMember = null;
+  async function checkAgapeMembership() {
+    const token = getAccessToken();
+    if (!token) { agapeMember = null; return; }
+    try {
+      const resp = await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ action: 'status' })
+      });
+      if (!resp.ok) return;
+      const status = await resp.json();
+      agapeMember = !!status.isMember;
+      log(`Agape membership: ${status.linked ? (agapeMember ? 'member' : 'not a member') : 'discord not linked'}`);
+    } catch (e) { log('Agape membership check failed: ' + e.message); }
+  }
+
   document.addEventListener('ctrl:auth:signedin', async (e) => {
     const wasLoggedOut = !currentUser;
     currentUser = e.detail.user;
     updateDebugLogVisibility();
     if (wasLoggedOut) {
       log('Logged in as ' + (currentUser.email || 'user'));
+      checkAgapeMembership();
       loadBookmarks();
       loadCalendarSyncState();
       const cloudLoaded = await loadSourcesCloud();
@@ -2285,6 +2305,7 @@ body {
 
   document.addEventListener('ctrl:auth:signedout', () => {
     currentUser = null;
+    agapeMember = null;
     updateDebugLogVisibility();
     state.bookmarks = new Map();
     resetCalendarSyncState();
@@ -4416,6 +4437,14 @@ body {
     document.getElementById('filterDateFrom').addEventListener('change', (e) => { state.filters.dateFrom = e.target.value; render(); });
     document.getElementById('filterDateTo').addEventListener('change', (e) => { state.filters.dateTo = e.target.value; render(); });
     document.getElementById('filterAgape').addEventListener('click', () => {
+      // Agape recs are members-only: point non-members at the unlock path
+      if (!currentUser) { CtrlAuth.openLoginModal(); return; }
+      if (agapeMember === false) {
+        if (confirm('Agape recommendations are available to members of the Agape Discord server. Connect your Discord account on the account page?')) {
+          window.location.href = '/account/#discord';
+        }
+        return;
+      }
       state.filters.agape = !state.filters.agape;
       updateFilterChips();
       render();
@@ -5137,6 +5166,7 @@ body {
     if (currentUser && supabaseClient) {
       const cloudLoaded = await loadSourcesCloud();
       if (cloudLoaded) log('Init: using cloud sources');
+      checkAgapeMembership();
       loadBookmarks();
       loadCalendarSyncState();
     }

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -1,0 +1,131 @@
+// Supabase Edge Function: discord-membership
+// Verifies whether the calling user's linked Discord account is a member of
+// the Agape server, using the existing scraper bot's token (the bot lives in
+// the guild, so a plain Get Guild Member lookup works — no OAuth guilds scope,
+// no provider_token freshness problems).
+//
+// POST /functions/v1/discord-membership   (Authorization: Bearer <user JWT>)
+// Body: { action?: 'status' | 'verify' }
+//   status (default): return the cached membership row; auto-verifies when
+//                     there is no cached row yet or the cache is older than
+//                     REVERIFY_DAYS.
+//   verify:           force a fresh check against the Discord API.
+//
+// Response: { linked, isMember, discordUsername, verifiedAt }
+//   linked=false means the user has no Discord identity on their account.
+
+const VERSION = '1.0.0'
+console.log(`[discord-membership] v${VERSION} — Agape guild membership verification`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+const DISCORD_API = 'https://discord.com/api/v10'
+// Agape server (same guild the scrape-discord-events bot reads #events from)
+const AGAPE_GUILD_ID = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
+const REVERIFY_DAYS = 7
+
+function getSupabase() {
+  const url = Deno.env.get('SUPABASE_URL')!
+  const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+  return createClient(url, key)
+}
+
+interface DiscordIdentity {
+  discordUserId: string
+  username: string | null
+}
+
+function findDiscordIdentity(user: Record<string, unknown>): DiscordIdentity | null {
+  const identities = (user.identities || []) as Array<Record<string, unknown>>
+  const identity = identities.find(i => i.provider === 'discord')
+  if (!identity) return null
+  const data = (identity.identity_data || {}) as Record<string, unknown>
+  const discordUserId = String(identity.id || data.provider_id || data.sub || '')
+  if (!discordUserId) return null
+  const username = (data.custom_claims as Record<string, unknown>)?.global_name ||
+    data.full_name || data.name || data.preferred_username || null
+  return { discordUserId, username: username ? String(username) : null }
+}
+
+async function checkGuildMembership(discordUserId: string): Promise<boolean> {
+  const botToken = Deno.env.get('DISCORD_BOT_TOKEN')
+  if (!botToken) throw new Error('DISCORD_BOT_TOKEN not configured')
+  const resp = await fetch(`${DISCORD_API}/guilds/${AGAPE_GUILD_ID}/members/${discordUserId}`, {
+    headers: { 'Authorization': `Bot ${botToken}` },
+  })
+  if (resp.status === 200) return true
+  if (resp.status === 404) return false // unknown member — not in the guild
+  throw new Error(`Discord API ${resp.status}: ${(await resp.text()).slice(0, 200)}`)
+}
+
+async function verifyAndCache(userId: string, identity: DiscordIdentity) {
+  const isMember = await checkGuildMembership(identity.discordUserId)
+  const row = {
+    user_id: userId,
+    discord_user_id: identity.discordUserId,
+    discord_username: identity.username,
+    is_agape_member: isMember,
+    verified_at: new Date().toISOString(),
+  }
+  const { error } = await getSupabase()
+    .from('user_discord_membership')
+    .upsert(row, { onConflict: 'user_id' })
+  if (error) throw new Error(`Cache write failed: ${error.message}`)
+  console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember}`)
+  return row
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+    const db = getSupabase()
+    const { data: userData, error: userErr } = await db.auth.getUser(token)
+    if (userErr || !userData?.user) {
+      return new Response(JSON.stringify({ error: 'Not authenticated' }), { status: 401, headers: jsonHeaders })
+    }
+    const user = userData.user
+    const action = req.method === 'POST'
+      ? ((await req.json().catch(() => ({})))?.action || 'status')
+      : 'status'
+
+    const identity = findDiscordIdentity(user as unknown as Record<string, unknown>)
+    if (!identity) {
+      // Discord unlinked: drop any stale membership so RLS stops granting access
+      await db.from('user_discord_membership').delete().eq('user_id', user.id)
+      return new Response(JSON.stringify({ linked: false, isMember: false, discordUsername: null, verifiedAt: null }), { headers: jsonHeaders })
+    }
+
+    let row: { discord_username: string | null; is_agape_member: boolean; verified_at: string } | null = null
+    if (action !== 'verify') {
+      const { data } = await db
+        .from('user_discord_membership')
+        .select('discord_user_id, discord_username, is_agape_member, verified_at')
+        .eq('user_id', user.id)
+        .maybeSingle()
+      const fresh = data &&
+        data.discord_user_id === identity.discordUserId &&
+        (Date.now() - new Date(data.verified_at).getTime()) < REVERIFY_DAYS * 86400_000
+      if (fresh) row = data
+    }
+    if (!row) row = await verifyAndCache(user.id, identity)
+
+    return new Response(JSON.stringify({
+      linked: true,
+      isMember: row.is_agape_member,
+      discordUsername: row.discord_username,
+      verifiedAt: row.verified_at,
+    }), { headers: jsonHeaders })
+  } catch (err) {
+    console.error('discord-membership error:', (err as Error).message)
+    return new Response(JSON.stringify({ error: (err as Error).message }), { status: 500, headers: jsonHeaders })
+  }
+})

--- a/supabase/functions/gcal-sync/index.ts
+++ b/supabase/functions/gcal-sync/index.ts
@@ -11,7 +11,7 @@
 // POST /functions/v1/gcal-sync   (Authorization: Bearer <user JWT>)
 // Body: { action: 'connect-url' | 'exchange' | 'status' | 'settings' | 'sync' | 'disconnect', ... }
 
-const VERSION = '1.1.1'
+const VERSION = '1.2.0'
 console.log(`[gcal-sync] v${VERSION} — ctrl.events Google Calendar sync (bookmarked + agape)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -185,7 +185,19 @@ async function getDesiredItems(row: SyncRow): Promise<DesiredItem[]> {
   const today = todayISO()
   const byKey = new Map<string, DesiredItem>()
 
+  // Agape sync requires verified Agape Discord membership (this function runs
+  // service-role, so the events RLS gate doesn't apply — enforce it here too)
+  let agapeAllowed = false
   if (row.sync_agape) {
+    const { data: m } = await db
+      .from('user_discord_membership')
+      .select('is_agape_member')
+      .eq('user_id', row.user_id)
+      .maybeSingle()
+    agapeAllowed = !!m?.is_agape_member
+  }
+
+  if (row.sync_agape && agapeAllowed) {
     // Agape-recommended events: tagged rows + the Agape Discord feed
     const { data: agapeRows } = await db
       .from('events')

--- a/supabase/migrations/099_discord_membership.sql
+++ b/supabase/migrations/099_discord_membership.sql
@@ -1,0 +1,47 @@
+-- ============================================
+-- Discord membership gating for Agape recommendations
+-- Migration 099
+--
+-- 1. user_discord_membership: caches whether a Supabase user's linked
+--    Discord account is a member of the Agape server. Written only by
+--    the discord-membership edge function (service role); users read
+--    their own row.
+-- 2. Replaces migration 091's blanket "Authenticated read all events"
+--    policy: private rows from the Agape curation feed now require
+--    verified Agape membership. Other private rows (demoted feeds,
+--    user-submitted) keep the any-authenticated-user behavior, so
+--    there is no regression for existing signed-in users.
+--    Public rows remain covered by 089's "Public read access" policy,
+--    which applies to all roles (policies OR together).
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS user_discord_membership (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  discord_user_id TEXT NOT NULL,
+  discord_username TEXT,
+  is_agape_member BOOLEAN NOT NULL DEFAULT false,
+  verified_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE user_discord_membership ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users read own discord membership" ON user_discord_membership
+  FOR SELECT TO authenticated USING (auth.uid() = user_id);
+-- No insert/update/delete policies: writes go through the
+-- discord-membership edge function with the service role.
+
+DROP POLICY IF EXISTS "Authenticated read all events" ON events;
+
+CREATE POLICY "Authenticated read non-agape events" ON events
+  FOR SELECT TO authenticated
+  USING (source_id IS DISTINCT FROM 'discord-agape-events');
+
+CREATE POLICY "Agape members read agape events" ON events
+  FOR SELECT TO authenticated
+  USING (
+    source_id = 'discord-agape-events'
+    AND EXISTS (
+      SELECT 1 FROM user_discord_membership m
+      WHERE m.user_id = auth.uid() AND m.is_agape_member
+    )
+  );


### PR DESCRIPTION
## Summary
- **Discord OAuth** added to the shared auth module (`ctrl-auth.js`) — sign in with Discord, or link Discord to an existing Google/email account from the account page.
- **Agape recs are now members-only.** Private Agape rows (`source_id='discord-agape-events'`) require verified membership of the Agape Discord server; other private rows (demoted feeds, user-submitted) keep the any-authenticated-user behavior — no regression.
- **New edge function `discord-membership` (v1.0.0)**: checks guild membership via the existing scraper bot token (`GET /guilds/{id}/members/{discord_user_id}`), caches in new `user_discord_membership` table, re-verifies after 7 days. No `guilds` OAuth scope needed, so no provider-token staleness issues.
- **Migration 099**: membership table + replaces migration 091's blanket authenticated-read policy with the gated pair.
- **gcal-sync v1.2.0**: Agape calendar sync gated on membership (service-role path bypasses RLS, so enforced in-function).
- **events v1.33.0**: ★ Agape filter prompts sign-in when anonymous and offers the Discord-connect path for signed-in non-members.
- **Account page**: Discord card — connect, membership status, re-check.

## Manual step required
Enable the **Discord provider** in Supabase Auth (Boards project) with a Discord app's client ID/secret, redirect URL `https://yfhudwakpgzswiylhfbh.supabase.co/auth/v1/callback`. Until then the Discord button will error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)