### PR TITLE
feat(events): non-electronic music venues — The Chapel, Rickshaw Stop + picker fixes

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2113,6 +2113,10 @@ body {
     { id: 'user-submitted', name: 'Community adds', category: 'social', type: 'manual', url: null, region: 'bay-area', description: 'One-off events added by link' },
     { id: 'ata-sf', name: 'ATA', category: 'film', type: 'ata', url: 'https://www.atasite.org/calendar', region: 'bay-area', description: 'Underground film & experimental art' },
     { id: 'luma-tiat', name: 'tiat', category: 'art', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=calendar&id=cal-twiOosdGMMY66DI', region: 'bay-area', description: 'The intersection of art & technology' },
+    { id: 'thechapel-sf', name: 'The Chapel', category: 'music', type: 'seetickets-wp', url: 'https://thechapelsf.com/music/', region: 'bay-area', description: 'Live music — indie, folk, rock' },
+    { id: 'rickshawstop-sf', name: 'Rickshaw Stop', category: 'music', type: 'seetickets-wp', url: 'https://rickshawstop.com/', region: 'bay-area', description: 'Live music & dance parties' },
+    { id: 'bottomofthehill-sf', name: 'Bottom of the Hill', category: 'music', type: 'bottomofthehill', url: 'https://bottomofthehill.com/RSS.xml', region: 'bay-area', description: 'Punk, indie & rock institution' },
+    { id: 'frontiertower-sf', name: 'Frontier Tower', category: 'tech', type: 'ical', url: null, region: 'bay-area', description: 'Frontier Tower community events' },
     // Bay Area — Eventbrite orgs with Agape signal (scraped server-side)
     { id: 'eb-publicworks', name: 'Public Works', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/public-works-17405142071', region: 'bay-area', description: 'Public Works SF' },
     { id: 'eb-mannys', name: "Manny's", category: 'social', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/mannys-15114280512', region: 'bay-area', description: "Manny's civic events" },

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -10,7 +10,7 @@
 //   POST { action: "status" }                     → return last run info
 
 const VERSION = '1.8.0'
-console.log(`[scrape-events] v${VERSION} - RA window 14d → 90d with pagination (long-lead bookings were silently dropped)`)
+console.log(`[scrape-events] v${VERSION} - seetickets-wp parser (The Chapel, Rickshaw Stop server-rendered cards)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -29,6 +29,7 @@ import { scrapeIcal } from './parsers/ical.ts'
 import { scrapeEventbriteOrg } from './parsers/eventbrite-org.ts'
 import { scrapeAta } from './parsers/ata.ts'
 import { scrapeBottomOfTheHill } from './parsers/bottomofthehill.ts'
+import { scrapeSeeticketsWp } from './parsers/seetickets-wp.ts'
 import { scrapeJson } from './parsers/json.ts'
 import { scrapeRss } from './parsers/rss.ts'
 import { scrapeFamsf } from './parsers/famsf.ts'
@@ -105,6 +106,7 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'eventbrite-org': return scrapeEventbriteOrg(source)
     case 'ata': return scrapeAta(source)
     case 'bottomofthehill': return scrapeBottomOfTheHill(source)
+    case 'seetickets-wp': return scrapeSeeticketsWp(source)
     case 'json': return scrapeJson(source)
     case 'rss': return scrapeRss(source)
     case 'famsf': return scrapeFamsf(source)

--- a/supabase/functions/scrape-events/parsers/seetickets-wp.ts
+++ b/supabase/functions/scrape-events/parsers/seetickets-wp.ts
@@ -1,0 +1,96 @@
+// SeeTickets WordPress-widget parser.
+// Venues on the SeeTickets WP plugin (The Chapel, Rickshaw Stop, ...) server-
+// render complete event cards — earlier verification misread them as JS-only:
+//   <p class="... title"><a href="https://wl.seetickets.us/event/...">Name</a></p>
+//   <p class="... date">Sat Nov 14</p>
+//   ... doortime/showtime spans, ages, price, genre, headliners
+// Dates have no year: infer current year, rolling forward if >45 days past.
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+}
+
+function ptToday(): Date {
+  const s = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date())
+  return new Date(s + 'T00:00:00')
+}
+
+function inferDate(monthName: string, day: number): string {
+  const month = MONTHS[monthName.toLowerCase().slice(0, 3)]
+  if (!month) return ''
+  const today = ptToday()
+  let year = today.getFullYear()
+  const candidate = new Date(year, month - 1, day)
+  // A listing more than ~45 days in the past is next year's show
+  if ((today.getTime() - candidate.getTime()) / 86400000 > 45) year += 1
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  if (m[3].toUpperCase() === 'PM' && h !== 12) h += 12
+  if (m[3].toUpperCase() === 'AM' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${m[2] || '00'}`
+}
+
+function textOf(cardHtml: string, cls: string): string {
+  const m = cardHtml.match(new RegExp(`class="[^"]*\\b${cls}\\b[^"]*"[^>]*>([\\s\\S]*?)</p>`))
+  if (!m) return ''
+  return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+export async function scrapeSeeticketsWp(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url)
+  const events: ScrapedEvent[] = []
+
+  // Cards start at the content container; split and parse each segment
+  const segments = html.split('seetickets-list-event-content-container').slice(1)
+  const seen = new Set<string>()
+
+  for (const seg of segments) {
+    const card = seg.slice(0, 4000)
+    const titleM = card.match(/class="[^"]*\btitle\b[^"]*"[^>]*>\s*<a href="(https:\/\/wl\.seetickets\.us\/event\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/)
+    const dateM = textOf(card, 'date').match(/([A-Za-z]{3,9})\s+(\d{1,2})/)
+    if (!titleM || !dateM) continue
+
+    const url = titleM[1].split('?')[0]
+    const name = titleM[2].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+    const date = inferDate(dateM[1], parseInt(dateM[2], 10))
+    if (!name || !date) continue
+
+    const key = `${date}|${name}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const showM = card.match(/class="see-showtime[^"]*"[^>]*>([^<]+)</)
+    const doorM = card.match(/class="see-doortime[^"]*"[^>]*>([^<]+)</)
+    const time = to24h((showM?.[1] || doorM?.[1] || '').trim())
+    const agesM = card.match(/class="ages"[^>]*>([^<]+)</)
+    const priceM = card.match(/class="price"[^>]*>([^<]+)</)
+    const genre = textOf(card, 'genre')
+    const promoter = textOf(card, 'header')
+
+    events.push({
+      source: source.id,
+      date,
+      time,
+      name,
+      venue: source.name,
+      city: 'San Francisco',
+      genre,
+      price: (priceM?.[1] || '').trim(),
+      ages: (agesM?.[1] || '').trim(),
+      promoter,
+      url,
+      contentType: source.category,
+    })
+  }
+
+  return events
+}

--- a/supabase/migrations/099_seetickets_venues.sql
+++ b/supabase/migrations/099_seetickets_venues.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- Non-electronic music coverage: SeeTickets-WP venues
+-- Migration 099
+-- The Chapel and Rickshaw Stop server-render complete SeeTickets event cards
+-- (re-verified 2026-07-06; the earlier JS-only verdict was wrong for these).
+-- Parsed by seetickets-wp (scrape-events v1.8.0).
+-- ============================================
+UPDATE event_sources SET
+  type = 'seetickets-wp', url = 'https://thechapelsf.com/music/', enabled = true,
+  notes = 'Re-verified: SeeTickets WP widget server-renders event cards — seetickets-wp parser'
+WHERE id = 'thechapel-sf';
+
+UPDATE event_sources SET
+  type = 'seetickets-wp', url = 'https://rickshawstop.com/', enabled = true,
+  notes = 'Re-verified: SeeTickets WP widget server-renders event cards — seetickets-wp parser'
+WHERE id = 'rickshawstop-sf';


### PR DESCRIPTION
Addresses the non-electronica music gap (19hz/RA are electronic-only).

## seetickets-wp parser
Re-probed the 'JS-only' venues: The Chapel and Rickshaw Stop actually **server-render** complete SeeTickets event cards (the Wave-2 agent verdict was wrong for these two). New generic parser extracts title, date (year-inferred), showtime, price, ages, genre, promoter. Live: **29 events** — Dylan LeBlanc, White Denim, EMM, Petty Theft, Gimme Gimme Disco.

## Source picker fixes
Bottom of the Hill and Frontier Tower were enabled server-side (migration 096) but never added to the client stock list — their events were invisible to all users. Now in the picker along with the two new venues.

Migration 099 applied; scrape-events v1.8.0 deployed; client v1.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)