### PR TITLE
feat(events): The Faight Collective source (v1.9.0 / v1.32.0)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2069,8 +2069,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.31.3';
-  console.log(`[events] v${VERSION} - hiddenCategories + beta flags survive cloud sync (Tech toggle no longer reverts on refresh)`);
+  const VERSION = '1.32.0';
+  console.log(`[events] v${VERSION} - The Faight Collective source (auto-added once for existing users)`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2104,6 +2104,7 @@ body {
     { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
     // Bay Area — Social (Luma discover feed)
     { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
+    { id: 'thefaight-sf', name: 'The Faight', category: 'social', type: 'thefaight', url: 'https://www.thefaight.com/events', region: 'bay-area', description: 'Community arts venue on Haight St' },
     // Bay Area — Agape curation feed (private rows: visible only when signed in)
     { id: 'discord-agape-events', name: 'Agape Recommended', category: 'social', type: 'discord', url: null, region: 'bay-area', description: 'Agape community recommendations' },
     // One-off events added by users via the add-event function
@@ -2396,6 +2397,14 @@ body {
         if (us) state.sources.push({ ...us, enabled: true });
       }
       localStorage.setItem('ctrl-rodeo-user-submitted-added', '1');
+    }
+    // One-time migration: existing users get The Faight venue calendar
+    if (!localStorage.getItem('ctrl-rodeo-thefaight-source-added')) {
+      if (!state.sources.some(s => s.id === 'thefaight-sf')) {
+        const tf = STOCK_SOURCES.find(s => s.id === 'thefaight-sf');
+        if (tf) state.sources.push({ ...tf, enabled: true });
+      }
+      localStorage.setItem('ctrl-rodeo-thefaight-source-added', '1');
     }
 
     saveSources();

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.8.0'
-console.log(`[scrape-events] v${VERSION} - RA window 14d → 90d with pagination (long-lead bookings were silently dropped)`)
+const VERSION = '1.9.0'
+console.log(`[scrape-events] v${VERSION} - The Faight Collective parser (thefaight.com/events cards)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -34,6 +34,7 @@ import { scrapeRss } from './parsers/rss.ts'
 import { scrapeFamsf } from './parsers/famsf.ts'
 import { scrapeSfpl } from './parsers/sfpl.ts'
 import { scrapeCommonwealth } from './parsers/commonwealth.ts'
+import { scrapeTheFaight } from './parsers/thefaight.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -110,6 +111,7 @@ async function scrapeSource(source: EventSource): Promise<ScrapedEvent[]> {
     case 'famsf': return scrapeFamsf(source)
     case 'sfpl': return scrapeSfpl(source)
     case 'commonwealth': return scrapeCommonwealth(source)
+    case 'thefaight': return scrapeTheFaight(source)
     default:
       console.log(`[scrape-events] Unknown source type: ${source.type} for ${source.id}`)
       return []

--- a/supabase/functions/scrape-events/parsers/thefaight.ts
+++ b/supabase/functions/scrape-events/parsers/thefaight.ts
@@ -1,0 +1,74 @@
+// The Faight Collective (thefaight.com/events) parser.
+// Server-rendered event cards:
+//   <div id="slug" class="event-card">…>JUL<…>7<…class="event-title">Open Mic<
+//   …class="event-time">6:00 PM – 10:00 PM…>downstairs<
+// Dates carry no year — infer the nearest future occurrence (a month more
+// than one month in the past rolls to next year).
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const MONTHS: Record<string, number> = {
+  JAN: 1, FEB: 2, MAR: 3, APR: 4, MAY: 5, JUN: 6,
+  JUL: 7, AUG: 8, SEP: 9, OCT: 10, NOV: 11, DEC: 12,
+}
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  const mins = m[2] || '00'
+  const ampm = m[3].toUpperCase()
+  if (ampm === 'PM' && h !== 12) h += 12
+  if (ampm === 'AM' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${mins}`
+}
+
+export async function scrapeTheFaight(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+  })
+
+  // PT-local "now" for year inference
+  const now = new Date(new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date()) + 'T00:00:00')
+
+  const events: ScrapedEvent[] = []
+  const blocks = html.split(/(?=<div id="[\w-]+" class="event-card")/).slice(1)
+
+  for (const raw of blocks) {
+    const block = raw.replace(/<svg[\s\S]*?<\/svg>/g, '')
+    const id = block.match(/^<div id="([\w-]+)"/)?.[1] || ''
+    const title = block.match(/class="event-title"[^>]*>([\s\S]*?)<\//)?.[1]
+    const dateM = block.match(/>(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)<[\s\S]*?>(\d{1,2})</)
+    if (!title || !dateM) continue
+
+    const month = MONTHS[dateM[1]]
+    const day = parseInt(dateM[2], 10)
+    // Nearest future year: if the date is more than a month behind PT-today,
+    // it belongs to next year
+    let year = now.getFullYear()
+    const candidate = new Date(year, month - 1, day)
+    if (candidate.getTime() < now.getTime() - 35 * 86400000) year += 1
+    const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+
+    // "6:00 PM – 10:00 PM" → start time; keep full range in the string
+    const timeM = block.match(/class="event-time"[^>]*>([\s\S]*?)<\//)
+    const timeText = timeM ? timeM[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() : ''
+    const startM = timeText.match(/(\d{1,2}(?::\d{2})?\s*(?:AM|PM))/i)
+
+    events.push({
+      source: source.id,
+      date,
+      time: startM ? to24h(startM[1]) : '',
+      name: title.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim(),
+      venue: 'The Faight Collective',
+      address: '475 Haight St',
+      city: 'San Francisco',
+      url: `https://www.thefaight.com/events#${id}`,
+      contentType: 'social',
+    })
+  }
+
+  console.log(`[scrape-events] thefaight: ${events.length} events parsed`)
+  return events
+}

--- a/supabase/functions/scrape-events/sources.ts
+++ b/supabase/functions/scrape-events/sources.ts
@@ -27,6 +27,8 @@ export const STOCK_SOURCES: EventSource[] = [
   { id: 'garysguide-sf', name: "Gary's Guide SF", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=sf', region: 'bay-area', description: 'Tech & startup events' },
   // Bay Area — Social (Luma discover feed)
   { id: 'luma-sf', name: 'Luma SF', category: 'social', type: 'ical', url: 'https://api2.luma.com/ics/get?entity=discover&id=discplace-BDj7GNbGlsF7Cka', region: 'bay-area', description: "What's happening in San Francisco" },
+  // Bay Area — Community venue (Lower Haight)
+  { id: 'thefaight-sf', name: 'The Faight', category: 'social', type: 'thefaight', url: 'https://www.thefaight.com/events', region: 'bay-area', description: 'Community arts venue on Haight St' },
   // New York — Tech & Networking
   { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
 ]


### PR DESCRIPTION
## What
Coverage check for thefaight.com/events came back nearly empty: exactly **one** Faight event in the store (Jul 8, via the Luma discover feed + an Agape post) against **30** upcoming events on their calendar — so it becomes a first-class source.

- New `thefaight` parser: their event cards are server-rendered (no bot wall, no JSON-LD) with a month/day badge, title, time range, and room — parsed with nearest-future year inference since dates carry no year. Venue/address pinned to the space (The Faight Collective, 475 Haight St, SF); category `social` (umbrella) so the keyword classifier types each event (lectures → literary, comedy nights → comedy, etc.).
- Registered in the parser dispatch + STOCK_SOURCES fallbacks (function and client).
- One-time client migration auto-adds the source for existing users (same pattern as the Agape feed).
- DB `event_sources` row inserted post-merge.

## Validation
Parser logic run against the live page: **30/30 cards parsed**, dates Jul 7 → Nov 17 2026, all start times normalized to 24h.

## Versions
scrape-events v1.8.0 → **v1.9.0**; events page v1.31.3 → **v1.32.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)