### PR TITLE
fix(events): stale-cache purge, Eventim migration support, RA 60-day window

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2078,8 +2078,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.36.1';
-  console.log(`[events] v${VERSION} - paged L2 fetch past the 1000-row PostgREST cap (far-future events vanished)`);
+  const VERSION = '1.36.2';
+  console.log(`[events] v${VERSION} - cache purge (stale truncated lists), 12-page fetch, Eventim link support`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2414,7 +2414,7 @@ body {
   const STORAGE_KEY = 'ctrl-rodeo-event-sources';
   const ONBOARDED_KEY = 'ctrl-rodeo-events-onboarded';
   const SETTINGS_KEY = 'ctrl-rodeo-events-settings';
-  const CACHE_KEY = 'ctrl-rodeo-events-cache-v2' // v2: invalidates caches predating the iCal timezone fix;
+  const CACHE_KEY = 'ctrl-rodeo-events-cache-v3' // v2: invalidates caches predating the iCal timezone fix;
   const CACHE_MAX_AGE = 15 * 60 * 1000; // 15 minutes
 
   // --- Source Management ---
@@ -3109,7 +3109,7 @@ body {
       // 12s ceiling per page so a hung request can't leave the spinner up.
       const data = [];
       let error = null;
-      for (let page = 0; page < 8; page++) {
+      for (let page = 0; page < 12; page++) {
         const query = supabaseClient
           .from('events')
           .select('*')

--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,7 +7,7 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.7.0'
+const VERSION = '1.7.1'
 console.log(`[cache-events] v${VERSION} - music_type classification at insert (enrichment refines)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -141,7 +141,7 @@ const EVENT_URL_PATTERNS: RegExp[] = [
   /^https?:\/\/shotgun\.live\/(?:[a-z]{2}\/)?events\/[\w-]+$/,
   /^https?:\/\/tixr\.com\/groups\/[\w-]+\/events\/[\w-]+$/,
   /^https?:\/\/[\w-]+\.secretparty\.io\/[\w-]+$/,
-  /^https?:\/\/(?:wl\.)?seetickets\.us\/event\/[\w/-]+$/,
+  /^https?:\/\/(?:wl\.)?(?:seetickets|eventim)\.us\/event\/[\w/-]+$/,
   /^https?:\/\/meetup\.com\/[\w-]+\/events\/\d+$/,
 ]
 
@@ -152,7 +152,7 @@ function canonicalizeEventUrl(raw: string | undefined | null): string | null {
     u.hash = ''
     u.search = ''
     let s = u.toString().toLowerCase().replace(/\/+$/, '')
-    s = s.replace('://www.', '://').replace('://luma.com/', '://lu.ma/')
+    s = s.replace('://www.', '://').replace('://luma.com/', '://lu.ma/').replace('://wl.seetickets.us/', '://wl.eventim.us/')
     return EVENT_URL_PATTERNS.some(p => p.test(s)) ? s : null
   } catch {
     return null

--- a/supabase/functions/scrape-discord-events/index.ts
+++ b/supabase/functions/scrape-discord-events/index.ts
@@ -190,7 +190,7 @@ async function fetchAllMessages(
 // the AI can't extract a dated event from them, so resolve the linked page
 // itself (JSON-LD Event schema). Message text stays recommendation context.
 
-const PLATFORM_URL_RE = /https?:\/\/(?:www\.)?(?:partiful\.com\/e\/[\w-]+|lu\.ma\/[\w.-]+|luma\.com\/[\w.-]+|eventbrite\.com\/e\/[\w-]+|dice\.fm\/(?:event|partner)\/[\w/-]+|shotgun\.live\/(?:[a-z]{2}\/)?events\/[\w-]+|tixr\.com\/groups\/[\w-]+\/events\/[\w-]+|[\w-]+\.secretparty\.io\/[\w-]+|(?:wl\.)?seetickets\.us\/event\/[\w/-]+|meetup\.com\/[\w-]+\/events\/\d+)/gi
+const PLATFORM_URL_RE = /https?:\/\/(?:www\.)?(?:partiful\.com\/e\/[\w-]+|lu\.ma\/[\w.-]+|luma\.com\/[\w.-]+|eventbrite\.com\/e\/[\w-]+|dice\.fm\/(?:event|partner)\/[\w/-]+|shotgun\.live\/(?:[a-z]{2}\/)?events\/[\w-]+|tixr\.com\/groups\/[\w-]+\/events\/[\w-]+|[\w-]+\.secretparty\.io\/[\w-]+|(?:wl\.)?(?:seetickets|eventim)\.us\/event\/[\w/-]+|meetup\.com\/[\w-]+\/events\/\d+)/gi
 
 // deno-lint-ignore no-explicit-any
 function findLdEventNode(node: any): any | null {

--- a/supabase/functions/scrape-events/parsers/seetickets-wp.ts
+++ b/supabase/functions/scrape-events/parsers/seetickets-wp.ts
@@ -55,7 +55,7 @@ export async function scrapeSeeticketsWp(source: EventSource): Promise<ScrapedEv
 
   for (const seg of segments) {
     const card = seg.slice(0, 4000)
-    const titleM = card.match(/class="[^"]*\btitle\b[^"]*"[^>]*>\s*<a href="(https:\/\/wl\.seetickets\.us\/event\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/)
+    const titleM = card.match(/class="[^"]*\btitle\b[^"]*"[^>]*>\s*<a href="(https:\/\/wl\.(?:seetickets|eventim)\.us\/event\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/)
     const dateM = textOf(card, 'date').match(/([A-Za-z]{3,9})\s+(\d{1,2})/)
     if (!titleM || !dateM) continue
 


### PR DESCRIPTION
Both reports traced to the same root: devices holding the pre-paging **truncated cache**, which survives hard refresh. Oct 24 has 16 events in the store and every TM/SeeTickets row has a working URL (old `wl.seetickets.us` links 302 to `wl.eventim.us`).

- Cache key bumped (v3) to purge all stale truncated lists; fetch page cap raised to 12 (12k rows headroom)
- **Eventim migration hardening**: the SeeTickets parser accepts both domains, and canonical URLs normalize `seetickets → eventim` so the two forms dedupe together as venues flip over
- **RA window 14 → 60 days** per 'show all future events if possible' (re-scraped: RA now contributes its full two-month horizon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)