### PR TITLE
feat(events): remove Bars/Dots toggle and dot-matrix mode (v1.39.0)

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -161,8 +161,7 @@ body {
   transition: opacity var(--duration-fast) var(--ease-default);
 }
 
-.pulse__day:hover .pulse__seg,
-.pulse__day:hover .pulse__dot { filter: brightness(1.3); }
+.pulse__day:hover .pulse__seg { filter: brightness(1.3); }
 
 .pulse__seg {
   width: 3px;
@@ -177,34 +176,6 @@ body {
   mask-image: none;
 }
 
-/* Dot-matrix mode: one dot per N events, stacked in category colors */
-.pulse--dots .pulse__day {
-  gap: 2px;
-  padding-bottom: 3px;
-  overflow: hidden;
-}
-.pulse__dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
-  flex: 0 0 auto;
-}
-
-/* Mode toggle (bars | dots) */
-.pulse__mode { display: flex; gap: 2px; }
-.pulse__mode-btn {
-  background: none;
-  border: var(--border-thin) solid transparent;
-  color: var(--fg-subtle);
-  font-family: var(--font-primary);
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wider);
-  padding: 0 4px;
-  cursor: pointer;
-}
-.pulse__mode-btn:hover { color: var(--fg); }
-.pulse__mode-btn.active { color: var(--fg); border-color: var(--border-subtle); }
 
 /* A selected day keeps full strength; the rest recede */
 .pulse--has-selection .pulse__day:not(.pulse__day--selected) { opacity: 0.3; }
@@ -275,7 +246,6 @@ body {
   .pulse__track { height: 40px; }
   .pulse--collapsed .pulse__track { height: 24px; }
   .pulse__legend { display: none; }
-  .pulse__mode { margin-left: auto; }
   /* One compact row: scrolled-to date | chips (scroll) [| filter when collapsed] */
   .pulse .sources-bar { flex-wrap: nowrap; }
 }
@@ -1749,12 +1719,7 @@ body {
       <div id="pulseViz" style="display:none">
         <div class="pulse__head">
           <span class="pulse__label" id="statsText"></span>
-          <span class="pulse__total" id="pulseTotal"></span>
           <div class="pulse__legend" id="pulseLegend"></div>
-          <div class="pulse__mode">
-            <button class="pulse__mode-btn" data-mode="needles">Bars</button>
-            <button class="pulse__mode-btn" data-mode="dots">Dots</button>
-          </div>
         </div>
         <div class="pulse__viewport">
           <div class="pulse__scroll" id="pulseScroll">
@@ -2098,8 +2063,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.38.0';
-  console.log(`[events] v${VERSION} - pulse strip: full-horizon track, auto-follow scrolling, edge fades`);
+  const VERSION = '1.39.0';
+  console.log(`[events] v${VERSION} - Bars/Dots toggle removed; needles are the visualization`);
 
   // ============================================
   // Stock Sources Catalog
@@ -2417,7 +2382,6 @@ body {
     calDate: localToday(), // anchor date for day/week views
     selectedDate: null,
     onboarded: false,
-    pulseMode: localStorage.getItem('ctrl-rodeo-pulse-mode') || 'needles', // 'needles' | 'dots'
   };
 
   // --- Debug Logging ---
@@ -3578,16 +3542,6 @@ body {
     const selected = (state.filters.dateFrom && state.filters.dateFrom === state.filters.dateTo) ? state.filters.dateFrom : null;
     strip.classList.toggle('pulse--has-selection', !!selected);
 
-    const dots = state.pulseMode === 'dots';
-    // Dot mode: one dot per N events so the tallest day fits the track
-    const dotUnit = Math.max(1, Math.ceil(max / 8));
-    strip.classList.toggle('pulse--dots', dots);
-    strip.querySelectorAll('.pulse__mode-btn').forEach(b =>
-      b.classList.toggle('active', b.dataset.mode === state.pulseMode));
-
-    // The head's count is the global statsText line; this slot only carries
-    // the dot-scale note when it applies
-    document.getElementById('pulseTotal').textContent = (dots && dotUnit > 1) ? `1 dot ≈ ${dotUnit}` : '';
     document.getElementById('pulseLegend').innerHTML = CATEGORY_ORDER.filter(c => catsSeen.has(c)).map(c =>
       `<span class="pulse__legend-item"><span class="pulse__legend-dot" style="background:${CATEGORY_COLORS[c]}"></span>${CATEGORY_LABELS[c]}</span>`
     ).join('');
@@ -3606,18 +3560,6 @@ body {
       let segs = '';
       if (dayTotal === 0) {
         segs = '<span class="pulse__seg pulse__seg--empty"></span>';
-      } else if (dots) {
-        CATEGORY_ORDER.forEach(c => {
-          for (let k = 0; k < Math.round((byCat[c] || 0) / dotUnit); k++) {
-            segs += `<span class="pulse__dot" style="background:${CATEGORY_COLORS[c]}"></span>`;
-          }
-        });
-        // Rounding can drop every category on a light day — show at least one
-        // dot in the dominant category so the day doesn't read as empty
-        if (!segs) {
-          const dom = CATEGORY_ORDER.reduce((a, c) => (byCat[c] || 0) > (byCat[a] || 0) ? c : a);
-          segs = `<span class="pulse__dot" style="background:${CATEGORY_COLORS[dom]}"></span>`;
-        }
       } else {
         CATEGORY_ORDER.forEach(c => {
           if (!byCat[c]) return;
@@ -3672,14 +3614,6 @@ body {
     requestAnimationFrame(align);
   }
 
-  // Mode toggle (bars | dots), persisted per user
-  document.querySelectorAll('.pulse__mode-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      state.pulseMode = btn.dataset.mode;
-      localStorage.setItem('ctrl-rodeo-pulse-mode', state.pulseMode);
-      renderPulse();
-    });
-  });
 
   // Collapse the sticky strip to a slim ribbon once the page scrolls, and
   // scrollspy the list: while scrolled, only the needle for the date at the


### PR DESCRIPTION
## What
The pulse strip commits to the LED needles — the Bars/Dots switcher and the entire dot-matrix rendering path are removed:

- Header toggle (`.pulse__mode` buttons) gone from the strip head; the `pulseTotal` slot (which only carried the "1 dot ≈ N" scale note) goes with it.
- All dots CSS (`.pulse--dots`, `.pulse__dot`, mode-button styles, the mobile mode-toggle rule) removed.
- All dots JS removed: `state.pulseMode`, the `ctrl-rodeo-pulse-mode` localStorage persistence, the dot-unit scaling and dot-rendering branch in `renderPulse`, and the mode-button bindings. Users who had Dots selected fall back to needles automatically (the stored key is simply ignored).

Built against master's current tip (v1.38.0 with the music-taxonomy/Ticketmaster changes) via the API path since local `git fetch` is still hanging on this machine.

## Version
Events page v1.38.0 → **v1.39.0**

## Tested
Chrome against live data (1,172 events / 27 sources): strip renders needles-only, no toggle in the header, zero `pulseMode`/dots references remain in the file, JS parses, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)