### PR TITLE
fix(events): Bottom of the Hill RSS edit-log dedupe (scrape-events v1.11.1)

### DIFF
--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.11.0'
-console.log(`[scrape-events] v${VERSION} - stale-row reconciliation: renamed/cancelled listings no longer linger as duplicates`)
+const VERSION = '1.11.1'
+console.log(`[scrape-events] v${VERSION} - Bottom of the Hill: RSS edit-log dedupe (newest item per page), annotation-stripped names, time sanity guard`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/scrape-events/parsers/bottomofthehill.ts
+++ b/supabase/functions/scrape-events/parsers/bottomofthehill.ts
@@ -19,14 +19,29 @@ function to24h(time: string): string {
   const ampm = m[3].toUpperCase()
   if (ampm === 'PM' && h !== 12) h += 12
   if (ampm === 'AM' && h === 12) h = 0
-  return `${String(h).padStart(2, '0')}:${m[2] || '00'}`
+  if (h > 23) return ''
+  const out = `${String(h).padStart(2, '0')}:${m[2] || '00'}`
+  return /^([01]\d|2[0-3]):[0-5]\d$/.test(out) ? out : ''
 }
 
 export async function scrapeBottomOfTheHill(source: EventSource): Promise<ScrapedEvent[]> {
   const xml = await fetchUrl(source.url)
   const events: ScrapedEvent[] = []
 
+  // The feed is an append-only edit log: every upstream edit (lineup change,
+  // "----now All Ages" note, cancellation) adds a NEW <item> for the same
+  // per-date page and the old items stay — 100+ pages appear 2-3x. Group by
+  // link and keep only the newest pubDate: the venue's latest word.
+  const newestByLink = new Map<string, { ts: number; item: string }>()
   for (const item of xml.split('<item>').slice(1)) {
+    const link = item.match(/<link>([\s\S]*?)<\/link>/)?.[1]?.trim() || source.url
+    const pub = item.match(/<pubDate>([\s\S]*?)<\/pubDate>/)?.[1]?.trim() || ''
+    const ts = pub ? new Date(pub).getTime() || 0 : 0
+    const prev = newestByLink.get(link)
+    if (!prev || ts > prev.ts) newestByLink.set(link, { ts, item })
+  }
+
+  for (const { item } of newestByLink.values()) {
     const title = item.match(/<title>([\s\S]*?)<\/title>/)?.[1] || ''
     const desc = decodeEntities(item.match(/<description>([\s\S]*?)<\/description>/)?.[1] || '')
     const link = item.match(/<link>([\s\S]*?)<\/link>/)?.[1]?.trim() || source.url
@@ -41,7 +56,12 @@ export async function scrapeBottomOfTheHill(source: EventSource): Promise<Scrape
     cutoff.setDate(cutoff.getDate() - 7)
     if (date < cutoff.toISOString().split('T')[0]) continue
 
-    const name = dm[4].split('~').map(s => s.trim()).filter(s => s && s.toUpperCase() !== 'TBA').join(', ')
+    // Strip inline edit annotations ("----now All Ages", "----now this show
+    // is not announced...") — they're notes, not lineup
+    const name = dm[4].split('~')
+      .map(s => s.replace(/\s*-{2,}\s*now\b[\s\S]*$/i, '').trim())
+      .filter(s => s && s.toUpperCase() !== 'TBA')
+      .join(', ')
     if (!name) continue
 
     const descText = desc.replace(/<[^>]+>/g, ' ')


### PR DESCRIPTION
## Why
The stale-row reconciliation (#1087) cleared the 19hz duplicate but Bottom of the Hill pairs survived — because both name-variants carry the **same scrape timestamp**: the parser emits both in every run. The venue's FeedForAll RSS is an append-only edit log — every upstream edit (lineup change, "----now All Ages" note, cancellation note) adds a new `<item>` for the same per-date page and old items stay. 108 pages currently appear 2-3×.

## What
- **Group items by link, keep newest `pubDate`** — the venue's latest word on each show (verified against their live per-date pages).
- **Strip inline edit annotations** from names (`----now …` suffixes are notes, not lineup).
- **Time sanity guard** in `to24h` — rejects out-of-range results (the `99:30` incident).

One-time flush of the accumulated stale rows runs post-deploy (the reconciliation cap of max(20, 30%) rightly refuses to mass-delete ~50 rows in one pass — that guardrail proved itself today by skipping exactly this source).

## Version
scrape-events v1.11.0 → **v1.11.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)