### PR TITLE
fix(events): duplicate keys poisoned bulk updates — dedupe + surface errors (cache-events v1.8.0, scrape-events v1.11.2)

### DIFF
--- a/supabase/functions/cache-events/index.ts
+++ b/supabase/functions/cache-events/index.ts
@@ -7,8 +7,8 @@
 // Body: { events: Event[], sourceOutcomes?: SourceOutcome[] }
 // Returns: { cached, updated, enrichQueued, healthUpdated, errors }
 
-const VERSION = '1.7.1'
-console.log(`[cache-events] v${VERSION} - music_type classification at insert (enrichment refines)`)
+const VERSION = '1.8.0'
+console.log(`[cache-events] v${VERSION} - bulk-update dedupe by event_key (poisoned-batch fix: duplicate keys killed all updates in a batch)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -583,11 +583,18 @@ serve(async (req: Request) => {
     // single intra-batch collision doesn't abort the whole insert (Postgres
     // unique-constraint violation kills a multi-row insert atomically).
     const seenKeys = new Set<string>()
+    const seenUpdateKeys = new Set<string>()
     const toInsert: Record<string, unknown>[] = []
     const toUpdate: Record<string, unknown>[] = []
     for (const r of validRows) {
       const k = r.event_key as string
-      if (existingMap.has(k)) { toUpdate.push(r); continue }
+      if (existingMap.has(k)) {
+        // De-dupe updates too: a bulk upsert that touches the same row twice
+        // dies atomically ("ON CONFLICT cannot affect row a second time"),
+        // silently killing scraped_at refresh for every source in the batch
+        if (!seenUpdateKeys.has(k)) { seenUpdateKeys.add(k); toUpdate.push(r) }
+        continue
+      }
       if (seenKeys.has(k)) continue
       seenKeys.add(k)
       toInsert.push(r)

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.11.1'
-console.log(`[scrape-events] v${VERSION} - Bottom of the Hill: RSS edit-log dedupe (newest item per page), annotation-stripped names, time sanity guard`)
+const VERSION = '1.11.2'
+console.log(`[scrape-events] v${VERSION} - surface cache-events partial-failure errors; reconciliation skips on any`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -201,6 +201,11 @@ async function pushToCache(
 
       if (resp.ok) {
         const result = await resp.json()
+        // cache-events reports partial failures (e.g. a failed bulk update) inside
+        // a 200 body — surface them so reconciliation knows rows may look stale
+        if (Array.isArray(result.errors) && result.errors.length > 0) {
+          batchErrors.push(...result.errors.map((e: unknown) => String(e)))
+        }
         totalCached += result.cached || 0
         totalUpdated += result.updated || 0
         totalEnrichQueued += result.enrichQueued || 0


### PR DESCRIPTION
## The real dedupe bug
Diagnosis of the Bottom of the Hill duplicates went three layers deep; this is the bottom layer.

`cache-events` splits incoming rows into inserts (deduped by `event_key`) and updates (**not deduped**). When a scrape emits two rows with the same event_key — which Bottom of the Hill's append-only RSS edit-log does constantly — the 400-row bulk upsert dies atomically (`ON CONFLICT cannot affect row a second time`), and **every source in that batch silently loses its refresh**: no field updates, no `scraped_at` stamp. Evidence: RA rows untouched since Jun 30, Gary's Guide/Ticketmaster/Luma at zero fresh, single-row updates working fine. The error rode inside a 200 response body that scrape-events never read.

This also explains why renamed listings looked permanently duplicated: the stale-row reconciliation (#1087) depends on `scraped_at` as a presence watermark, which the poisoned batches were quietly breaking — its safety cap correctly refused to act on the garbage signal.

## What
- **cache-events v1.8.0**: `toUpdate` deduped by `event_key` (mirrors the insert path).
- **scrape-events v1.11.2**: partial-failure `errors[]` from cache-events' 200 responses now feed `batchErrors`, so reconciliation skips whenever any update failed — the watermark is only trusted when the write path was clean.

## Verification plan (post-deploy)
Trigger a run; Bottom of the Hill should refresh ~90 rows, leaving the ~12 renamed-stale variants under the reconciliation cap — which then deletes them. Duplicate pairs disappear without manual SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)