### PR TITLE
feat(events): Agape Recommended as per-event tag + bookmark icon consistency

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -1414,25 +1414,7 @@ body {
 }
 
 /* ---- Responsive: Tablet (768px) ---- */
-/* Agape Recommended bar — mobile-only tappable filter entry */
-.agape-bar {
-  display: none;
-  width: 100%;
-  padding: var(--space-2) var(--space-3);
-  margin-top: var(--space-1);
-  background: none;
-  border: var(--border-thin) solid #e8c54766;
-  border-radius: var(--radius-sm, 4px);
-  color: #e8c547;
-  font-size: var(--text-xs);
-  font-family: inherit;
-  letter-spacing: var(--tracking-wide);
-  text-transform: uppercase;
-  cursor: pointer;
-  text-align: center;
-}
-
-.venue-tap { cursor: pointer; }
+.venue-tap, .agape-tap { cursor: pointer; }
 .venue-tap:hover, .venue-tap--active { text-decoration: underline; text-underline-offset: 2px; }
 .genre-tag[data-tag] { cursor: pointer; }
 
@@ -1451,10 +1433,6 @@ body {
     margin-top: var(--space-1);
   }
   .sources-bar .pulse__current:empty { display: none; border: none; margin: 0; padding: 0; }
-  /* Agape chip hides in the slider until its filter is active */
-  .sources-bar__chips .token--agape { display: none; }
-  .sources-bar__chips .token--agape.token--active { display: inline-flex; }
-  .agape-bar { display: block; }
 
   .data-table .col-time,
   .data-table .col-type,
@@ -1781,8 +1759,6 @@ body {
         </button>
         <div class="sources-bar__chips" id="sourceChips"></div>
       </div>
-      <!-- Mobile: tappable Agape bar + scrolled-to date bar (CSS-gated) -->
-      <button id="agapeBar" class="agape-bar" style="display:none">★ Agape Recommended</button>
 
       <!-- Filters — DS: .filter-bar (collapsible), opens inside the sticky header -->
       <div class="filter-bar filter-bar--collapsible" id="filterBar" style="display:none">
@@ -1802,8 +1778,8 @@ body {
       </select>
       <input type="date" class="input input--date" id="filterDateFrom" title="From date">
       <input type="date" class="input input--date" id="filterDateTo" title="To date">
-      <button class="btn btn--sm btn--ghost" id="filterAgape" title="Only Agape Recommended events">★ Agape</button>
-      <button class="btn btn--sm btn--ghost" id="filterInterested" title="Only events you bookmarked as interested">🔖 Interested</button>
+      <button class="btn btn--sm btn--ghost" id="filterAgape" title="Only Agape Recommended events">★ Agape Recommended</button>
+      <button class="btn btn--sm btn--ghost" id="filterInterested" title="Only events you bookmarked as interested"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="vertical-align:-1px"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg> Interested</button>
       <button class="btn btn--sm btn--ghost" id="filterPast" title="Include past events (last 60 days)">Past events</button>
       <button class="btn btn--ghost btn--sm" id="filterClear">Clear</button>
       </div>
@@ -2106,8 +2082,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.40.0';
-  console.log(`[events] v${VERSION} - mobile: date bar, icon filter, Agape bar; venue+tag tap filters; bookmark chip; tag hygiene`);
+  const VERSION = '1.41.0';
+  console.log(`[events] v${VERSION} - Agape Recommended is a tappable per-event tag; bookmark filter uses the row icon`);
 
   // ============================================
   // Stock Sources Catalog
@@ -3828,7 +3804,7 @@ body {
         return `<span class="token token--source" data-source-id="${escHtml(sid)}" style="border-color: ${sColor}; color: ${sColor};">${escHtml(sName)}</span>`;
       }).join(' ');
       if (isAgape) {
-        sourceTagsHtml = `<span class="token token--agape" title="Agape Recommended">★ Agape</span> ` + sourceTagsHtml;
+        sourceTagsHtml = `<span class="token token--agape agape-tap" title="Tap to filter to Agape Recommended">★ Agape Recommended</span> ` + sourceTagsHtml;
       }
       const titleAttr = ev.description ? ` title="${escHtml(ev.description)}"` : '';
       const displayName = stripVenueFromTitle(ev.name, ev.venue);
@@ -4179,14 +4155,16 @@ body {
     let html = `<button class="token ${allActive ? 'token--active' : ''}" data-category="">All<span class="source-chip__count">${chipEvents.length}</span></button>`;
     // Agape rides as a top-level chip even though it's a cross-cut, not a
     // category — it composes with a category selection rather than replacing it
-    const agapeCount = chipEvents.filter(e => e.agape || isAgapeEvent(e)).length;
-    if (agapeCount > 0) {
-      html += `<button class="token token--agape ${state.filters.agape ? 'token--active' : ''}" data-agape="1">★ Agape<span class="source-chip__count">${agapeCount}</span></button>`;
+    // Agape rides in the slider only while its filter is active (removable
+    // chip); entry points are the per-event tag and the filter menu
+    if (state.filters.agape) {
+      const agapeCount = chipEvents.filter(e => e.agape || isAgapeEvent(e)).length;
+      html += `<button class="token token--agape token--active" data-agape="1" title="Tap to clear">★ Agape Recommended<span class="source-chip__count">${agapeCount}</span> ×</button>`;
     }
     // Bookmarked filter chip (shown once anything is bookmarked)
     if (state.bookmarks && state.bookmarks.size > 0) {
       const bmCount = chipEvents.filter(e => state.bookmarks.has(eventKeyFor(e))).length;
-      html += `<button class="token token--bookmark ${state.filters.interested ? 'token--active' : ''}" data-bookmarkchip="1" title="Only bookmarked events">🔖<span class="source-chip__count">${bmCount}</span></button>`;
+      html += `<button class="token token--bookmark ${state.filters.interested ? 'token--active' : ''}" data-bookmarkchip="1" title="Only bookmarked events"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="vertical-align:-1px"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg><span class="source-chip__count">${bmCount}</span></button>`;
     }
     // Active venue / tag filters ride as removable chips
     if (state.filters.venue) {
@@ -4232,13 +4210,6 @@ body {
       render();
     });
 
-    // Mobile: a dedicated tappable bar for Agape (the chip itself is hidden
-    // in the slider until the filter is active)
-    const bar = document.getElementById('agapeBar');
-    if (bar) {
-      bar.style.display = (agapeCount > 0 && !state.filters.agape) ? '' : 'none';
-      bar.onclick = () => { state.filters.agape = true; updateFilterChips(); render(); };
-    }
   }
 
   // --- Filtering ---
@@ -4823,6 +4794,14 @@ body {
         const key = venueEl.dataset.venue;
         if (state.filters.venue === key) { state.filters.venue = ''; state.filters.venueLabel = ''; }
         else { state.filters.venue = key; state.filters.venueLabel = venueEl.dataset.venueLabel; }
+        render();
+        return;
+      }
+      const agapeEl = e.target.closest('.agape-tap');
+      if (agapeEl) {
+        e.preventDefault(); e.stopPropagation();
+        state.filters.agape = !state.filters.agape;
+        updateFilterChips();
         render();
         return;
       }


### PR DESCRIPTION
- **★ Agape Recommended** is now a tappable tag on each recommended event rather than a global option: tapping it filters to Agape; the mobile bar is gone. While active, a removable `★ Agape Recommended · count ×` chip appears in the slider. The filter menu keeps its existing ★ Agape Recommended button (design unchanged, members-only gating intact).
- **Bookmark filter** (drawer + slider chip) now uses the same SVG bookmark icon as each row's bookmark button, replacing the 🔖 emoji.

Verified: chip hidden by default, renders/clears with the filter; syntax-checked; anon clicks correctly route to the members-only login gate (parallel session's membership gating preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)