### PR TITLE
Events: filter button always inline-left of chip slider (v1.42.1)

### DIFF
--- a/docs/playground/events/HANDOFF 2.md
+++ b/docs/playground/events/HANDOFF 2.md
@@ -1,0 +1,57 @@
+# Events Session Handoff — 2026-07-08
+
+Context handoff from the July 2–8 events build arc (source architecture → venues → taxonomy → mobile UX). Previous session's context is full. Everything below is merged and deployed unless marked TODO.
+
+## Immediate TODOs (user's last two asks, unstarted)
+
+### 1. Mobile date bar renders broken ("looks wack")
+Screenshot evidence: on iPhone, the scrolled-to date ("WED, JUL 8") renders as a floating box **overlapping the MUSIC chip** in the category slider row instead of as a full-width bar *below* the slider.
+- The intended CSS is in `events/index.html` under `@media (max-width: 768px)`: `.sources-bar { flex-wrap: wrap }` + `.sources-bar .pulse__current { order: 99; flex-basis: 100%; ... }`.
+- Suspects: the sticky/collapsed header state (`pulse--collapsed`) repositions `.pulse__current`, or a parallel-session change to `.sources-bar` layout conflicts with the wrap rules, or the deployed CSS ordering. Reproduce in a 390px iframe (technique below) with the page scrolled (collapsed state!) — the screenshot is mid-scroll.
+
+### 2. Film events need genre tags
+Screen Slate film rows show no tags (screenshot: Mur Murs, Carrie, Paths of Glory — bare). 
+- `enrich-event` (supabase/functions/enrich-event/index.ts) prompt asks for descriptive tags for music/social/art — extend instruction #1 with film guidance: genre ("Horror", "Documentary", "Noir"), era/movement ("French New Wave", "70s"), director when notable.
+- `isJunkTag` in events/index.html already drops the bare "film" echo — good.
+- Re-queue upcoming film rows: `UPDATE events SET enrichment_status='pending' WHERE content_type='film' AND date >= CURRENT_DATE AND enrichment_status='completed';` then drain via ONE paced agent (batches of 10 → `POST /functions/v1/enrich-event {eventIds}`, 3–5s sleep). ⚠️ Do NOT run two drains concurrently and don't hammer one domain — a 200-event burst tripped Luma's rate limiting on 7/8 (229 "Failed to fetch URL"). screenslate.com is on the enrichment allowlist.
+
+## State of the world
+
+- **Branch:** `claude/music-venues-k4m9p`, fully merged through PR #1090. Start a NEW branch per CLAUDE.md (`claude/<topic>-<5chars>` off master).
+- **Client:** events/index.html v1.41.0, live on ctrl.rodeo via GH Pages (deploys on merge to master, ~2 min).
+- **Edge functions (Boards project `yfhudwakpgzswiylhfbh`), all deployed:** scrape-events v1.9.1+, cache-events v1.7.x, enrich-event v1.3.1, scrape-discord-events v1.4.1, add-event v1.0.1. Deploy: `supabase functions deploy <name> --project-ref yfhudwakpgzswiylhfbh` (do it after merge, no asking).
+- **Migrations 088–101 applied** (source registry/classes/visibility, dedup, reconciliation, venue categories, music_type). Files in supabase/migrations/; apply via MCP `apply_migration` AND save the .sql file.
+- **Docs:** PRD at docs/playground/events/strategy/prd-event-source-architecture.md; roadmap at .../strategy/future-work.md; historical analysis at .../strategy/discord-channel-historical-analysis.md.
+
+## Architecture in 10 lines
+
+- All sources → parsers in `supabase/functions/scrape-events/parsers/` (dispatcher in index.ts by `event_sources.type`) → POST `cache-events` → `events` table (canonical store). Cron every 2h; `run_events_maintenance()` (SQL) purges >60d past, reconciles cross-source canonical keys, applies venue categories, backfills music_type.
+- `event_sources` registry drives everything: `source_class` (venue/community/discovery/public-ticketing/private-ticketing/curation), `demoted`, `enabled`. Adding a source of an existing type = INSERT + client STOCK_SOURCES entry (client auto-enables new bay-area stock sources; tombstones respect removals).
+- Visibility: `events.visibility` private/public; RLS = anon sees public, authenticated sees all. Agape rows are private; the ★ tag/filter is members-only (Discord guild gating via `agape-membership`).
+- Dedup: event_key (per-source), canonical_key (cross-source, sha date|name|venue), canonical_url (URL-first adoption at ingest), plus SQL fuzzy reconciliation post-scrape. Client merges rows by canonical_key into one card with sources[].
+- `music_type` column (8 buckets) = AI at enrichment > keyword at insert > maintenance self-heal. Client musicTypeFor() prefers it.
+- Client filters state: state.filters {category, contentType, musicType, subGenre, venue(+venueLabel), tag, agape, interested, showPast, search, city, distance, dateFrom/To}. Chips row = renderSourceChips(); sub-nav = updateContentTypeFilter(); rows = renderTable() with tap delegation on #eventsBody (venue-tap, genre-tag[data-tag], agape-tap, bm-btn).
+
+## Hard-won gotchas (read before editing)
+
+1. **Parallel sessions edit events/index.html constantly.** Never trust remembered line numbers/anchors — grep fresh every time. Expect a merge conflict on the `VERSION`/console.log line: resolve by bumping minor and combining both log messages. `git fetch origin <sha> --depth=30` if full fetch hangs (it did; ls-remote works).
+2. **PostgREST caps at 1000 rows.** Anything reading `events` must page with `.range()` (client loadSupabaseCachedEvents and metrics.html both do; copy that pattern).
+3. **Dates:** UTC bites everywhere. Client uses localToday()/localDateStr(). Server parsers convert to region tz (ical Z-timestamps, RA window, AI "today" anchors are all PT-fixed). Any new parser: never `toISOString().split('T')[0]` on a local-time concept.
+4. **localStorage caches survive hard refresh.** After any data repair, bump `CACHE_KEY` (currently 'ctrl-rodeo-events-cache-v3'). 15-min TTL otherwise.
+5. **Browser testing:** memory says Chrome MCP only. Ian's real Chrome = the MCP browser — **create your own tab (tabs_create_mcp), never reuse his** (previous session accidentally fought his live Boards tab). Serve locally: `python3 -m http.server 84XX` from repo root (each port = fresh origin = onboarding; seed localStorage 'ctrl-rodeo-event-sources' + 'ctrl-rodeo-events-onboarded' to skip). Mobile viewport: resize_window often fails on maximized windows — inject a 390px iframe of /events/ and inspect `contentDocument` (media queries evaluate against iframe viewport). rAF/timers throttle in unfocused tabs — animations won't run in tests; verify with instant fallbacks/synchronous math.
+6. **Anon vs member testing:** Agape rows are RLS-private; the ★ filter is members-only (anon click → login modal). Don't chase 'broken' agape behavior in anon tabs.
+7. **Enrichment drains:** one agent, paced, per-domain gentle. Rows with discord permalinks/blocked domains legitimately fail/skip.
+8. **seetickets ↔ eventim domain migration** is normalized in canonicalizeEventUrl (cache-events) and the seetickets-wp parser accepts both.
+
+## Open backlog (docs/playground/events/strategy/future-work.md)
+
+- Epic 2: headless scraping decision for 11 JS-only venues (Gray Area, SFMOMA, The Chapel already worked around, others pending)
+- Epic 3: image-flyer OCR for Discord (15–20% of channel events)
+- Epic 6: enrichment retry job (paced, per-domain throttle) — now urgent-adjacent given the Luma rate-limit episode
+- Docs/process: `/plan` project-plan sync + `/pm changelog` for the whole July 2–8 arc (large; versions listed in future-work.md), `/ux events`
+- Internet Archive TM/Eventbrite org: enabled, currently 0 events, watch
+- PRD checkboxes are current through Phase 3 partial
+
+## Process reminders (CLAUDE.md)
+
+New branch per session → PR to master → **merge the PR yourself** → deploy changed edge functions → bump versions (client VERSION const + console.log; function VERSION at top). Assign PRs to fikei. Commit trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.

--- a/events/index 2.html
+++ b/events/index 2.html
@@ -215,11 +215,8 @@ body {
 .pulse .sources-bar { margin-bottom: 0; margin-top: var(--space-3); }
 .pulse .filter-bar { margin-bottom: 0; margin-top: var(--space-3); }
 
-/* Scrolled-to date — appears in the collapsed header next to the filters.
-   Tap to open a native date picker (single-day filter); the overlaid
-   <input type=date> is the real control, invisibly filling the label. */
+/* Scrolled-to date — appears in the collapsed header next to the filters */
 .pulse__current {
-  position: relative;
   display: none;
   font-size: var(--text-2xs);
   text-transform: uppercase;
@@ -229,43 +226,28 @@ body {
   font-variant-numeric: tabular-nums;
   padding-right: var(--space-2);
   border-right: var(--border-thin) solid var(--border-subtle);
-  cursor: pointer;
 }
-.pulse__current-label { pointer-events: none; }
-.pulse__datepick {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  opacity: 0;
-  cursor: pointer;
-  -webkit-appearance: none;
-  appearance: none;
-}
-/* A single-day date filter keeps the label lit even in the expanded header */
-.pulse--has-selection .pulse__current.has-date { display: inline-flex; align-items: center; }
 
 /* Collapse on scroll — all breakpoints; the strip is the scroll header */
 .pulse--collapsed { padding: var(--space-2) 0; }
 .pulse--collapsed .pulse__head,
 .pulse--collapsed .pulse__axis { max-height: 0; opacity: 0; margin-bottom: 0; }
 .pulse--collapsed .pulse__track { height: 28px; }
-.pulse--collapsed .pulse__current.has-date { display: inline-flex; align-items: center; }
+.pulse--collapsed .pulse__current:not(:empty) { display: inline-flex; align-items: center; }
 .pulse--collapsed .sources-bar { margin-top: var(--space-2); }
 
 @media (max-width: 600px) {
-  /* Filter button stays inline to the left of the chip slider in every state
-     (expanded and collapsed) — it's a static, order:-1 flex item from base
-     scope; no absolute top-right pinning. */
+  /* Filter rides top-right, directly above the Bars/Dots tag — the extra
+     padding-top reserves its band. When collapsed (head hidden) it falls
+     back into the compact chips row. */
+  .pulse { padding-top: calc(var(--space-2) + 30px); }
+  .pulse .sources-bar__filter-btn { position: absolute; top: var(--space-2); right: 0; margin-left: 0; }
+  .pulse--collapsed .sources-bar__filter-btn { position: static; margin-left: var(--space-2); }
   .pulse__track { height: 40px; }
   .pulse--collapsed .pulse__track { height: 24px; }
   .pulse__legend { display: none; }
-  /* Chip slider + full-width date bar come from base scope; the sources bar
-     wraps (base default) so the 100%-basis date drops below the chips rather
-     than overlapping them. */
+  /* One compact row: scrolled-to date | chips (scroll) [| filter when collapsed] */
+  .pulse .sources-bar { flex-wrap: nowrap; }
 }
 
 /* First-load equalizer loader — same LED-tick language as the pulse strip */
@@ -309,35 +291,13 @@ body {
   flex-wrap: wrap;
 }
 
-/* Category chips: one horizontally scrolling row at every width (DS .filters
-   pattern), sharing the sources bar with the filter button; the scrolled-to
-   date wraps to its own full-width bar below. */
 .sources-bar__chips {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  /* basis 0 (not auto) so the slider shares the filter button's row rather
-     than wrapping below it on narrow screens; min-width:0 lets it scroll */
-  flex: 1 1 0;
-  min-width: 0;
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+  flex-wrap: wrap;
+  flex: 1;
 }
-.sources-bar__chips::-webkit-scrollbar { display: none; }
-.sources-bar__chips .token { flex-shrink: 0; white-space: nowrap; }
-
-/* Scrolled-to date is a full-width bar below the chip slider (all widths) */
-.sources-bar .pulse__current {
-  order: 99;
-  flex-basis: 100%;
-  padding: var(--space-1) 0 0;
-  border-top: var(--border-thin) solid var(--border-subtle);
-  border-right: none;
-  margin-top: var(--space-1);
-}
-.sources-bar .pulse__current:not(.has-date) { display: none; border: none; margin: 0; padding: 0; }
 
 .token--agape {
   border: var(--border-thin) solid #e8c547;
@@ -430,15 +390,12 @@ body {
 }
 
 .sources-bar__filter-btn {
-  order: -1;
-  margin-left: 0;
+  margin-left: auto;
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
   flex-shrink: 0;
 }
-/* Icon-only at every width; the text label is redundant next to the glyph */
-.sources-bar__filter-label { display: none; }
 
 .sources-bar__filter-btn.active {
   border-color: var(--border);
@@ -744,13 +701,9 @@ body {
 .type-filter {
   display: flex;
   gap: var(--space-1);
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: none;
+  flex-wrap: wrap;
   margin-bottom: var(--space-3);
 }
-.type-filter::-webkit-scrollbar { display: none; }
 
 .type-filter__chip {
   font-size: var(--text-2xs);
@@ -765,7 +718,6 @@ body {
   transition: all var(--duration-fast) var(--ease-default);
 }
 
-.type-filter__chip { flex-shrink: 0; white-space: nowrap; }
 .type-filter__chip:hover { color: var(--fg); border-color: var(--border); }
 .type-filter__chip.active { background: var(--fg); color: var(--bg); border-color: var(--fg); }
 
@@ -1467,8 +1419,21 @@ body {
 .genre-tag[data-tag] { cursor: pointer; }
 
 @media (max-width: 768px) {
-  /* Sources-bar chrome (icon filter, chip slider, full-width date bar) is now
-     base-scope for desktop parity — see the .sources-bar rules above. */
+  /* Filter button: icon-only, pinned left of the category slider */
+  .sources-bar { flex-wrap: wrap; }
+  .sources-bar__filter-btn { order: -1; }
+  .sources-bar__filter-label { display: none; }
+  /* Scrolled-to date becomes a full-width bar below the slider */
+  .sources-bar .pulse__current {
+    order: 99;
+    flex-basis: 100%;
+    display: block;
+    padding: var(--space-1) 0 0;
+    border-top: var(--border-thin) solid var(--border-subtle);
+    margin-top: var(--space-1);
+  }
+  .sources-bar .pulse__current:empty { display: none; border: none; margin: 0; padding: 0; }
+
   .data-table .col-time,
   .data-table .col-type,
   .data-table .col-genre,
@@ -1650,11 +1615,35 @@ body {
   }
   .data-table--grouped .col-date { display: none; }
 
-  /* Filter bar: compact 2-column grid — inputs span both columns */
+  /* Category chips + type sub-filter: single horizontally scrolling rows
+     (DS .filters pattern). Chips share one row with the scrolled-to date
+     and the filter button so the sticky header stays shallow. */
+  .sources-bar__chips {
+    flex: 1 1 auto;
+    min-width: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .sources-bar__chips::-webkit-scrollbar { display: none; }
+  .sources-bar__chips .token { flex-shrink: 0; white-space: nowrap; }
+  .type-filter {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  .type-filter::-webkit-scrollbar { display: none; }
+  .type-filter__chip { flex-shrink: 0; white-space: nowrap; }
+
+  /* Filter bar: compact 2-column grid — inputs span both columns, the
+     date pair and the toggle buttons sit two-up */
   .filter-bar { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); }
   .filter-bar .input,
   .filter-bar .select,
   .filter-bar .input--search { grid-column: 1 / -1; width: 100%; min-width: 0; }
+  .filter-bar .input--date { grid-column: auto; width: 100%; min-width: 0; }
 }
 
 /* ---- Touch feedback: hover styles never fire on touch devices ---- */
@@ -1763,7 +1752,7 @@ body {
 
       <!-- Sources bar — rides in the sticky header with the scrolled-to date -->
       <div class="sources-bar">
-        <span class="pulse__current" id="pulseCurrent"><span class="pulse__current-label" id="pulseCurrentLabel"></span><input type="date" class="pulse__datepick" id="filterDatePick" aria-label="Filter by date"></span>
+        <span class="pulse__current" id="pulseCurrent"></span>
         <button class="btn btn--sm btn--ghost sources-bar__filter-btn" id="filterToggleBtn" aria-label="Filter">
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="1" y1="3" x2="11" y2="3"/><line x1="3" y1="6" x2="9" y2="6"/><line x1="5" y1="9" x2="7" y2="9"/></svg>
           <span class="sources-bar__filter-label">Filter</span>
@@ -1787,6 +1776,8 @@ body {
       <select class="input select" id="filterSource">
         <option value="">All Sources</option>
       </select>
+      <input type="date" class="input input--date" id="filterDateFrom" title="From date">
+      <input type="date" class="input input--date" id="filterDateTo" title="To date">
       <button class="btn btn--sm btn--ghost" id="filterAgape" title="Only Agape Recommended events">★ Agape Recommended</button>
       <button class="btn btn--sm btn--ghost" id="filterInterested" title="Only events you bookmarked as interested"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" style="vertical-align:-1px"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg> Interested</button>
       <button class="btn btn--sm btn--ghost" id="filterPast" title="Include past events (last 60 days)">Past events</button>
@@ -2091,8 +2082,8 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.42.1';
-  console.log(`[events] v${VERSION} - filter button stays inline-left of the chip slider in every state (no mobile top-right pin)`);
+  const VERSION = '1.41.0';
+  console.log(`[events] v${VERSION} - Agape Recommended is a tappable per-event tag; bookmark filter uses the row icon`);
 
   // ============================================
   // Stock Sources Catalog
@@ -3679,20 +3670,11 @@ body {
       }
     }
 
-    // Date label in the sticky header. Shows the scrolled-to date while
-    // collapsed, or the selected day when a single-day date filter is active
-    // (so the tappable picker stays reachable even when the page isn't
-    // scrolled). The overlaid <input type=date> keeps its value in sync.
+    // Date label in the sticky header
     const cur = document.getElementById('pulseCurrent');
-    const curLabel = document.getElementById('pulseCurrentLabel');
-    const picker = document.getElementById('filterDatePick');
-    const selDay = (state.filters.dateFrom && state.filters.dateFrom === state.filters.dateTo) ? state.filters.dateFrom : null;
-    const labelDate = currentDate || selDay;
-    if (curLabel) curLabel.textContent = labelDate
-      ? new Date(labelDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+    if (cur) cur.textContent = currentDate
+      ? new Date(currentDate + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
       : '';
-    if (cur) cur.classList.toggle('has-date', !!labelDate);
-    if (picker) picker.value = labelDate || '';
 
     // Highlight only the scrolled-to day (a manual single-day date filter
     // already owns the highlight via pulse--has-selection)
@@ -4302,7 +4284,8 @@ body {
     document.getElementById('filterCity').value = '';
     const fd = document.getElementById('filterDistance'); if (fd) fd.value = '';
     const fs = document.getElementById('filterSource'); if (fs) fs.value = '';
-    const dp = document.getElementById('filterDatePick'); if (dp) dp.value = '';
+    document.getElementById('filterDateFrom').value = '';
+    document.getElementById('filterDateTo').value = '';
     updateContentTypeFilter();
     render();
   }
@@ -4713,15 +4696,8 @@ body {
       render();
     });
     document.getElementById('filterSource').addEventListener('change', (e) => { state.filters.source = e.target.value; render(); });
-    // Tappable scrolled-to date opens a native picker → single-day filter.
-    // Picking a day filters to it and scrolls there; clearing removes it.
-    document.getElementById('filterDatePick').addEventListener('change', (e) => {
-      const v = e.target.value;
-      state.filters.dateFrom = v;
-      state.filters.dateTo = v;
-      render();
-      if (v) jumpToDate(v);
-    });
+    document.getElementById('filterDateFrom').addEventListener('change', (e) => { state.filters.dateFrom = e.target.value; render(); });
+    document.getElementById('filterDateTo').addEventListener('change', (e) => { state.filters.dateTo = e.target.value; render(); });
     document.getElementById('filterAgape').addEventListener('click', () => {
       // Agape recs are members-only: point non-members at the unlock path
       if (!currentUser) { CtrlAuth.openLoginModal(); return; }

--- a/supabase/functions/enrich-event/index 2.ts
+++ b/supabase/functions/enrich-event/index 2.ts
@@ -1,0 +1,468 @@
+// Supabase Edge Function: enrich-event
+// Fetches event detail URLs to extract description, image, and tags.
+// Called by cache-events for newly cached events.
+//
+// POST /functions/v1/enrich-event
+// Body: { eventIds: string[] }   (batch up to 10)
+// Returns: { processed, succeeded, failed, results }
+
+const VERSION = '1.3.1'
+console.log(`[enrich-event] v${VERSION} - descriptive activity tags for social/art; no source/title/category echoes`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.38/deno-dom-wasm.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+// Domains we can safely scrape for enrichment
+const ALLOWED_DOMAINS = [
+  '19hz.info',
+  'roxie.com',
+  'punchlinecomedyclub.com',
+  'cobbscomedy.com',
+  'screenslate.com',
+  'eventbrite.com',
+  'alamodrafthouse.com',
+  'drafthouse.com',
+  'dice.fm',
+  'ra.co',
+  'songkick.com',
+  'garysguide.com',
+  'bonobonetwork.com',
+  'hyperallergic.com',
+  'sfmoma.org',
+  'famsf.org',
+  'sfdesignweek.org',
+  'citylights.com',
+  'sfpl.org',
+  'commonwealthclub.org',
+  // Event platforms from the Agape curation feed (PRD source-architecture §4.1:
+  // platform pages are the canonical fact source for Discord-announced events)
+  'partiful.com',
+  'lu.ma',
+  'luma.com',
+  'shotgun.live',
+  'tixr.com',
+  'seetickets.us',
+  'meetup.com',
+  'grayarea.org',
+  'thelab.org',
+  'bottomofthehill.com',
+  'thechapelsf.com',
+]
+
+function isDomainAllowed(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.toLowerCase()
+    return ALLOWED_DOMAINS.some(d => hostname === d || hostname.endsWith('.' + d))
+  } catch {
+    return false
+  }
+}
+
+interface EnrichResult {
+  eventId: string
+  success: boolean
+  description?: string | null
+  imageUrl?: string | null
+  tags?: string[]
+  genre?: string | null
+  content_type?: string | null
+  error?: string
+}
+
+const VALID_CONTENT_TYPES = ['music', 'dj-set', 'live-music', 'festival', 'film', 'comedy', 'theater', 'tech', 'social', 'art', 'design', 'literary', 'wellness', 'other']
+
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10_000)
+
+    const resp = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeout)
+
+    if (!resp.ok) return null
+    const ct = resp.headers.get('content-type') || ''
+    if (!ct.includes('text/html') && !ct.includes('application/xhtml')) return null
+
+    return await resp.text()
+  } catch {
+    return null
+  }
+}
+
+function extractMetadata(html: string, pageUrl: string): {
+  description: string | null
+  imageUrl: string | null
+  tags: string[]
+} {
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  if (!doc) return { description: null, imageUrl: null, tags: [] }
+
+  // --- Description ---
+  const metaDesc = doc.querySelector('meta[name="description"]')?.getAttribute('content')?.trim()
+  const ogDesc = doc.querySelector('meta[property="og:description"]')?.getAttribute('content')?.trim()
+  let firstP: string | null = null
+  const pSelectors = [
+    'article p', '.event-description p', '.description p',
+    '.event-detail p', '.event-info p', 'main p', '.content p',
+  ]
+  for (const sel of pSelectors) {
+    const el = doc.querySelector(sel)
+    if (el) {
+      const text = el.textContent?.trim()
+      if (text && text.length > 30) {
+        firstP = text.length > 500 ? text.substring(0, 500) + '...' : text
+        break
+      }
+    }
+  }
+  const description = metaDesc || ogDesc || firstP || null
+
+  // --- Image ---
+  const ogImage = doc.querySelector('meta[property="og:image"]')?.getAttribute('content')?.trim()
+  const twitterImage = doc.querySelector('meta[name="twitter:image"]')?.getAttribute('content')?.trim()
+
+  let eventImage: string | null = null
+  const imgSelectors = [
+    '.event-image img', '.event-hero img', '.hero-image img',
+    '.event-poster img', 'article img', '.event-detail img',
+    'img[src*="event"]', 'img[src*="poster"]', 'img[src*="flyer"]',
+  ]
+  for (const sel of imgSelectors) {
+    const el = doc.querySelector(sel)
+    if (el) {
+      const src = el.getAttribute('src') || el.getAttribute('data-src')
+      if (src) { eventImage = src; break }
+    }
+  }
+
+  let rawImageUrl = ogImage || twitterImage || eventImage
+  let imageUrl: string | null = null
+  if (rawImageUrl) {
+    try {
+      imageUrl = new URL(rawImageUrl, pageUrl).href
+    } catch {
+      imageUrl = rawImageUrl.startsWith('http') ? rawImageUrl : null
+    }
+  }
+
+  // --- Tags ---
+  const tags: string[] = []
+  const keywords = doc.querySelector('meta[name="keywords"]')?.getAttribute('content')
+  if (keywords) {
+    for (const k of keywords.split(',')) {
+      const t = k.trim().toLowerCase()
+      if (t && t.length > 1 && t.length < 50 && !tags.includes(t)) tags.push(t)
+    }
+  }
+
+  // Genre-specific selectors
+  const genreSelectors = '.genre, .event-genre, [itemprop="genre"], .music-genre, .style, .event-style'
+  doc.querySelectorAll(genreSelectors).forEach((el: Element) => {
+    const t = el.textContent?.trim().toLowerCase()
+    if (t && t.length > 1 && t.length < 50 && !tags.includes(t)) tags.push(t)
+  })
+
+  // General tag selectors
+  const tagSelectors = '.tag, .category, [rel="tag"], .event-tag, .event-category'
+  doc.querySelectorAll(tagSelectors).forEach((el: Element) => {
+    const t = el.textContent?.trim().toLowerCase()
+    if (t && t.length > 1 && t.length < 50 && !tags.includes(t)) tags.push(t)
+  })
+
+  return {
+    description,
+    imageUrl,
+    tags: tags.slice(0, 10),
+  }
+}
+
+// --- AI Classification (Claude Haiku) ---
+async function classifyWithAI(event: {
+  name: string, venue: string, genre: string, content_type: string,
+  description: string, tags: string[]
+}): Promise<{ genre: string, content_type: string, music_type: string | null } | null> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    console.log('[enrich-event] ANTHROPIC_API_KEY not set, skipping AI classification')
+    return null
+  }
+
+  const desc = (event.description || '').substring(0, 300)
+  const prompt = `You are classifying a live event. Given the event details below, return a JSON object with two fields:
+
+1. "genre" — up to 3 comma-separated descriptive tags. For music: the specific genre ("Techno", "Indie Rock", "Jazz"). For social events: the activity ("Networking", "Dinner Party", "Rooftop Party", "Book Club", "Run Club", "Trivia"). For art/design: the form ("Gallery Opening", "Immersive Art", "Ceramics Workshop", "Figure Drawing", "Screen Printing", "Photography"). Never use source names (Eventbrite, Luma), the event title, or bare category words (music/art/social/event). Return "" if truly unknown.
+
+2. "content_type" — one of: music, dj-set, live-music, festival, film, comedy, theater, tech, social, art, design, literary, wellness, other
+
+3. "music_type" — ONLY for music events, one of: electronic, rock, pop, hiphop, jazz, folk, world, other-music. Use the dominant style (electronic = techno/house/DJ/club; rock = rock/indie/punk/metal; folk = folk/country/americana/tribute; world = latin/reggae/afro). null for non-music events.
+
+Event name: ${event.name}
+Venue: ${event.venue}
+Current genre: ${event.genre || 'unknown'}
+Current type: ${event.content_type || 'unknown'}
+Description: ${desc}
+Tags: ${event.tags.join(', ')}
+
+Respond with JSON only: {"genre": "...", "content_type": "...", "music_type": "..." or null}`
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 150,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+
+    if (!response.ok) {
+      console.error('[enrich-event] AI API error:', response.status)
+      return null
+    }
+
+    const data = await response.json()
+    const text = data.content?.[0]?.text || ''
+    const match = text.match(/\{[\s\S]*\}/)
+
+    if (match) {
+      const result = JSON.parse(match[0])
+      // Validate content_type
+      if (result.content_type && !VALID_CONTENT_TYPES.includes(result.content_type)) {
+        result.content_type = ''
+      }
+      return {
+        genre: typeof result.genre === 'string' ? result.genre : '',
+        content_type: typeof result.content_type === 'string' ? result.content_type : '',
+        music_type: (typeof result.music_type === 'string' &&
+          ['electronic','rock','pop','hiphop','jazz','folk','world','other-music'].includes(result.music_type))
+          ? result.music_type : null,
+      }
+    }
+  } catch (e) {
+    console.error('[enrich-event] AI classification error:', e)
+  }
+
+  return null
+}
+
+async function enrichSingleEvent(
+  supabase: ReturnType<typeof createClient>,
+  eventId: string,
+  eventUrl: string,
+  eventName: string,
+  eventVenue: string,
+  eventGenre: string,
+  eventContentType: string,
+  eventSourceId: string,
+): Promise<EnrichResult> {
+  await supabase
+    .from('events')
+    .update({ enrichment_status: 'processing' })
+    .eq('id', eventId)
+
+  if (!isDomainAllowed(eventUrl)) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'skipped', enrichment_error: 'Domain not in allowlist' })
+      .eq('id', eventId)
+    return { eventId, success: false, error: 'Domain not allowed' }
+  }
+
+  const html = await fetchPage(eventUrl)
+  if (!html) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'failed', enrichment_error: 'Failed to fetch URL' })
+      .eq('id', eventId)
+    return { eventId, success: false, error: 'Failed to fetch' }
+  }
+
+  const metadata = extractMetadata(html, eventUrl)
+
+  // AI classification — clean up genre and content type
+  const aiResult = await classifyWithAI({
+    name: eventName,
+    venue: eventVenue,
+    genre: eventGenre,
+    content_type: eventContentType,
+    description: metadata.description || '',
+    tags: metadata.tags,
+  })
+
+  if (aiResult) {
+    console.log(`[enrich-event] AI: "${eventName}" → genre="${aiResult.genre}" type="${aiResult.content_type}"`)
+  }
+
+  const hasData = metadata.description || metadata.imageUrl || metadata.tags.length > 0 || aiResult
+  if (!hasData) {
+    await supabase
+      .from('events')
+      .update({ enrichment_status: 'completed', enriched_at: new Date().toISOString() })
+      .eq('id', eventId)
+    return { eventId, success: true, description: null, imageUrl: null, tags: [] }
+  }
+
+  // Venue/community sources have an authoritative category — a curated art
+  // calendar's events are art even when the AI reads them as "music" or
+  // "other". Curation feeds (Agape) span categories, so their rows keep AI
+  // classification; discovery/ticketing rows accept AI content_type too.
+  let authoritativeType: string | null = null
+  try {
+    const { data: src } = await supabase
+      .from('event_sources')
+      .select('category, source_class')
+      .eq('id', eventSourceId)
+      .single()
+    if (src && ['venue', 'community'].includes(src.source_class as string)) {
+      authoritativeType = (src.category as string) || null
+    }
+  } catch { /* registry lookup is best-effort */ }
+
+  const { error } = await supabase
+    .from('events')
+    .update({
+      description: metadata.description,
+      image_url: metadata.imageUrl,
+      tags: metadata.tags.length > 0 ? metadata.tags : null,
+      ...(aiResult?.genre ? { genre: aiResult.genre } : {}),
+      ...(authoritativeType
+        ? { content_type: authoritativeType }
+        : (aiResult?.content_type ? { content_type: aiResult.content_type } : {})),
+      ...(aiResult?.music_type ? { music_type: aiResult.music_type } : {}),
+      enrichment_status: 'completed',
+      enriched_at: new Date().toISOString(),
+      enrichment_error: null,
+    })
+    .eq('id', eventId)
+
+  if (error) {
+    console.error(`[enrich-event] DB update failed for ${eventId}:`, error.message)
+    return { eventId, success: false, error: error.message }
+  }
+
+  return {
+    eventId,
+    success: true,
+    description: metadata.description,
+    imageUrl: metadata.imageUrl,
+    tags: metadata.tags,
+    genre: aiResult?.genre || null,
+    content_type: aiResult?.content_type || null,
+  }
+}
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse({ error: 'POST required' }, 405)
+  }
+
+  try {
+    const { eventIds } = await req.json() as { eventIds: string[] }
+
+    if (!eventIds || !Array.isArray(eventIds) || eventIds.length === 0) {
+      return jsonResponse({ error: 'eventIds array required' }, 400)
+    }
+
+    if (eventIds.length > 10) {
+      return jsonResponse({ error: 'Max 10 events per request' }, 400)
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    // Recover events stuck in 'processing' for > 15 minutes (timed out)
+    const fifteenMinAgo = new Date(Date.now() - 15 * 60 * 1000).toISOString()
+    const { data: stuckEvents } = await supabase
+      .from('events')
+      .update({ enrichment_status: 'failed', enrichment_error: 'Timed out in processing state' })
+      .eq('enrichment_status', 'processing')
+      .lt('updated_at', fifteenMinAgo)
+      .select('id')
+    if (stuckEvents && stuckEvents.length > 0) {
+      console.log(`[enrich-event] Recovered ${stuckEvents.length} stuck events from processing → failed`)
+    }
+
+    const { data: events, error: fetchErr } = await supabase
+      .from('events')
+      .select('id, url, name, venue, genre, content_type, source_id, enrichment_status')
+      .in('id', eventIds)
+      .in('enrichment_status', ['pending', 'failed'])
+
+    if (fetchErr) {
+      console.error('[enrich-event] Failed to fetch events:', fetchErr.message)
+      return jsonResponse({ error: fetchErr.message }, 500)
+    }
+
+    if (!events || events.length === 0) {
+      return jsonResponse({ processed: 0, succeeded: 0, failed: 0, results: [] })
+    }
+
+    console.log(`[enrich-event] Processing ${events.length} events`)
+
+    const results: EnrichResult[] = []
+    let succeeded = 0
+    let failed = 0
+
+    for (const event of events) {
+      const result = await enrichSingleEvent(
+        supabase, event.id, event.url,
+        event.name || '', event.venue || '',
+        event.genre || '', event.content_type || '',
+        event.source_id || '',
+      )
+      results.push(result)
+      if (result.success) succeeded++
+      else failed++
+
+      if (events.length > 1) {
+        await new Promise(r => setTimeout(r, 500))
+      }
+    }
+
+    console.log(`[enrich-event] Done: ${succeeded} succeeded, ${failed} failed`)
+
+    return jsonResponse({
+      processed: events.length,
+      succeeded,
+      failed,
+      results,
+    })
+  } catch (err) {
+    console.error('[enrich-event] Error:', err)
+    return jsonResponse({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/functions/scrape-events/parsers/seetickets-wp 2.ts
+++ b/supabase/functions/scrape-events/parsers/seetickets-wp 2.ts
@@ -1,0 +1,96 @@
+// SeeTickets WordPress-widget parser.
+// Venues on the SeeTickets WP plugin (The Chapel, Rickshaw Stop, ...) server-
+// render complete event cards — earlier verification misread them as JS-only:
+//   <p class="... title"><a href="https://wl.seetickets.us/event/...">Name</a></p>
+//   <p class="... date">Sat Nov 14</p>
+//   ... doortime/showtime spans, ages, price, genre, headliners
+// Dates have no year: infer current year, rolling forward if >45 days past.
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const MONTHS: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12,
+}
+
+function ptToday(): Date {
+  const s = new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date())
+  return new Date(s + 'T00:00:00')
+}
+
+function inferDate(monthName: string, day: number): string {
+  const month = MONTHS[monthName.toLowerCase().slice(0, 3)]
+  if (!month) return ''
+  const today = ptToday()
+  let year = today.getFullYear()
+  const candidate = new Date(year, month - 1, day)
+  // A listing more than ~45 days in the past is next year's show
+  if ((today.getTime() - candidate.getTime()) / 86400000 > 45) year += 1
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  if (m[3].toUpperCase() === 'PM' && h !== 12) h += 12
+  if (m[3].toUpperCase() === 'AM' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${m[2] || '00'}`
+}
+
+function textOf(cardHtml: string, cls: string): string {
+  const m = cardHtml.match(new RegExp(`class="[^"]*\\b${cls}\\b[^"]*"[^>]*>([\\s\\S]*?)</p>`))
+  if (!m) return ''
+  return m[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+export async function scrapeSeeticketsWp(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url)
+  const events: ScrapedEvent[] = []
+
+  // Cards start at the content container; split and parse each segment
+  const segments = html.split('seetickets-list-event-content-container').slice(1)
+  const seen = new Set<string>()
+
+  for (const seg of segments) {
+    const card = seg.slice(0, 4000)
+    const titleM = card.match(/class="[^"]*\btitle\b[^"]*"[^>]*>\s*<a href="(https:\/\/wl\.(?:seetickets|eventim)\.us\/event\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/)
+    const dateM = textOf(card, 'date').match(/([A-Za-z]{3,9})\s+(\d{1,2})/)
+    if (!titleM || !dateM) continue
+
+    const url = titleM[1].split('?')[0]
+    const name = titleM[2].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+    const date = inferDate(dateM[1], parseInt(dateM[2], 10))
+    if (!name || !date) continue
+
+    const key = `${date}|${name}`
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const showM = card.match(/class="see-showtime[^"]*"[^>]*>([^<]+)</)
+    const doorM = card.match(/class="see-doortime[^"]*"[^>]*>([^<]+)</)
+    const time = to24h((showM?.[1] || doorM?.[1] || '').trim())
+    const agesM = card.match(/class="ages"[^>]*>([^<]+)</)
+    const priceM = card.match(/class="price"[^>]*>([^<]+)</)
+    const genre = textOf(card, 'genre')
+    const promoter = textOf(card, 'header')
+
+    events.push({
+      source: source.id,
+      date,
+      time,
+      name,
+      venue: source.name,
+      city: 'San Francisco',
+      genre,
+      price: (priceM?.[1] || '').trim(),
+      ages: (agesM?.[1] || '').trim(),
+      promoter,
+      url,
+      contentType: source.category,
+    })
+  }
+
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/thefaight 2.ts
+++ b/supabase/functions/scrape-events/parsers/thefaight 2.ts
@@ -1,0 +1,74 @@
+// The Faight Collective (thefaight.com/events) parser.
+// Server-rendered event cards:
+//   <div id="slug" class="event-card">…>JUL<…>7<…class="event-title">Open Mic<
+//   …class="event-time">6:00 PM – 10:00 PM…>downstairs<
+// Dates carry no year — infer the nearest future occurrence (a month more
+// than one month in the past rolls to next year).
+
+import { type ScrapedEvent, fetchUrl } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+const MONTHS: Record<string, number> = {
+  JAN: 1, FEB: 2, MAR: 3, APR: 4, MAY: 5, JUN: 6,
+  JUL: 7, AUG: 8, SEP: 9, OCT: 10, NOV: 11, DEC: 12,
+}
+
+function to24h(time: string): string {
+  const m = time.match(/(\d{1,2})(?::(\d{2}))?\s*(AM|PM)/i)
+  if (!m) return ''
+  let h = parseInt(m[1], 10)
+  const mins = m[2] || '00'
+  const ampm = m[3].toUpperCase()
+  if (ampm === 'PM' && h !== 12) h += 12
+  if (ampm === 'AM' && h === 12) h = 0
+  return `${String(h).padStart(2, '0')}:${mins}`
+}
+
+export async function scrapeTheFaight(source: EventSource): Promise<ScrapedEvent[]> {
+  const html = await fetchUrl(source.url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36' },
+  })
+
+  // PT-local "now" for year inference
+  const now = new Date(new Intl.DateTimeFormat('sv-SE', { timeZone: 'America/Los_Angeles' }).format(new Date()) + 'T00:00:00')
+
+  const events: ScrapedEvent[] = []
+  const blocks = html.split(/(?=<div id="[\w-]+" class="event-card")/).slice(1)
+
+  for (const raw of blocks) {
+    const block = raw.replace(/<svg[\s\S]*?<\/svg>/g, '')
+    const id = block.match(/^<div id="([\w-]+)"/)?.[1] || ''
+    const title = block.match(/class="event-title"[^>]*>([\s\S]*?)<\//)?.[1]
+    const dateM = block.match(/>(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)<[\s\S]*?>(\d{1,2})</)
+    if (!title || !dateM) continue
+
+    const month = MONTHS[dateM[1]]
+    const day = parseInt(dateM[2], 10)
+    // Nearest future year: if the date is more than a month behind PT-today,
+    // it belongs to next year
+    let year = now.getFullYear()
+    const candidate = new Date(year, month - 1, day)
+    if (candidate.getTime() < now.getTime() - 35 * 86400000) year += 1
+    const date = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+
+    // "6:00 PM – 10:00 PM" → start time; keep full range in the string
+    const timeM = block.match(/class="event-time"[^>]*>([\s\S]*?)<\//)
+    const timeText = timeM ? timeM[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() : ''
+    const startM = timeText.match(/(\d{1,2}(?::\d{2})?\s*(?:AM|PM))/i)
+
+    events.push({
+      source: source.id,
+      date,
+      time: startM ? to24h(startM[1]) : '',
+      name: title.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim(),
+      venue: 'The Faight Collective',
+      address: '475 Haight St',
+      city: 'San Francisco',
+      url: `https://www.thefaight.com/events#${id}`,
+      contentType: 'social',
+    })
+  }
+
+  console.log(`[scrape-events] thefaight: ${events.length} events parsed`)
+  return events
+}

--- a/supabase/functions/scrape-events/parsers/ticketmaster 2.ts
+++ b/supabase/functions/scrape-events/parsers/ticketmaster 2.ts
@@ -1,0 +1,71 @@
+// Ticketmaster Discovery API parser (venue-scoped).
+// Source url convention: tm://<venueId> (e.g. tm://KovZpZAE6eeA for The
+// Fillmore). Official API, free key, covers the LiveNation/AXS rooms whose
+// own sites are unscrapeable (Fillmore, Warfield, Masonic, Independent,
+// Castro, GAMH, Regency). dates.start.localDate/localTime are venue-local.
+// Rate limits (5 req/s, 5k/day) are far above our 7 venues x 12 runs/day.
+
+import { type ScrapedEvent } from './utils.ts'
+import type { EventSource } from '../sources.ts'
+
+interface TmEvent {
+  name?: string
+  url?: string
+  dates?: { start?: { localDate?: string; localTime?: string } }
+  priceRanges?: Array<{ min?: number; max?: number }>
+  classifications?: Array<{
+    segment?: { name?: string }
+    genre?: { name?: string }
+    subGenre?: { name?: string }
+  }>
+  promoters?: Array<{ name?: string }>
+  ageRestrictions?: { legalAgeEnforced?: boolean }
+  _embedded?: { venues?: Array<{ name?: string; city?: { name?: string } }> }
+}
+
+export async function scrapeTicketmaster(source: EventSource): Promise<ScrapedEvent[]> {
+  const apiKey = Deno.env.get('TICKETMASTER_API_KEY')
+  if (!apiKey) throw new Error('TICKETMASTER_API_KEY not configured')
+
+  const venueId = source.url.replace(/^tm:\/\//, '').trim()
+  if (!venueId || venueId.includes('/')) throw new Error(`ticketmaster source URL must be tm://<venueId>: ${source.url}`)
+
+  const resp = await fetch(
+    `https://app.ticketmaster.com/discovery/v2/events.json?venueId=${venueId}&size=100&sort=date,asc&apikey=${apiKey}`,
+    { signal: AbortSignal.timeout(15000) },
+  )
+  if (!resp.ok) throw new Error(`Ticketmaster API ${resp.status}`)
+  const data = await resp.json()
+  const tmEvents: TmEvent[] = data?._embedded?.events || []
+
+  const events: ScrapedEvent[] = []
+  for (const e of tmEvents) {
+    const date = e.dates?.start?.localDate
+    if (!date || !e.name) continue
+
+    const cls = (e.classifications || [])[0] || {}
+    const genreParts = [cls.genre?.name, cls.subGenre?.name]
+      .filter(g => g && g !== 'Undefined' && g !== 'Other')
+    const price = e.priceRanges?.[0]
+      ? (e.priceRanges[0].min === e.priceRanges[0].max
+          ? `$${e.priceRanges[0].min}`
+          : `$${e.priceRanges[0].min}-$${e.priceRanges[0].max}`)
+      : ''
+
+    events.push({
+      source: source.id,
+      date,
+      time: (e.dates?.start?.localTime || '').slice(0, 5),
+      name: e.name,
+      venue: e._embedded?.venues?.[0]?.name || source.name,
+      city: e._embedded?.venues?.[0]?.city?.name || 'San Francisco',
+      genre: [...new Set(genreParts)].join(', '),
+      price,
+      ages: e.ageRestrictions?.legalAgeEnforced ? '21+' : '',
+      promoter: e.promoters?.[0]?.name || '',
+      url: e.url || '',
+      contentType: source.category,
+    })
+  }
+  return events
+}

--- a/supabase/migrations/099_seetickets_venues 2.sql
+++ b/supabase/migrations/099_seetickets_venues 2.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- Non-electronic music coverage: SeeTickets-WP venues
+-- Migration 099
+-- The Chapel and Rickshaw Stop server-render complete SeeTickets event cards
+-- (re-verified 2026-07-06; the earlier JS-only verdict was wrong for these).
+-- Parsed by seetickets-wp (scrape-events v1.8.0).
+-- ============================================
+UPDATE event_sources SET
+  type = 'seetickets-wp', url = 'https://thechapelsf.com/music/', enabled = true,
+  notes = 'Re-verified: SeeTickets WP widget server-renders event cards — seetickets-wp parser'
+WHERE id = 'thechapel-sf';
+
+UPDATE event_sources SET
+  type = 'seetickets-wp', url = 'https://rickshawstop.com/', enabled = true,
+  notes = 'Re-verified: SeeTickets WP widget server-renders event cards — seetickets-wp parser'
+WHERE id = 'rickshawstop-sf';

--- a/supabase/migrations/100_ticketmaster_venues 2.sql
+++ b/supabase/migrations/100_ticketmaster_venues 2.sql
@@ -1,0 +1,16 @@
+-- ============================================
+-- Ticketmaster Discovery API venue sources
+-- Migration 100
+-- Official API (TICKETMASTER_API_KEY secret), venue-scoped via tm://<venueId>
+-- source URLs, parsed by 'ticketmaster' (scrape-events v1.9.0). Fills the
+-- non-electronic music gap: LiveNation/AXS rooms whose sites block scraping.
+-- ============================================
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('tm-fillmore', 'The Fillmore', 'music', 'ticketmaster', 'tm://KovZpZAE6eeA', 'bay-area', 'The Fillmore (Ticketmaster)', true, 'venue', 'TM Discovery API'),
+  ('tm-warfield', 'The Warfield', 'music', 'ticketmaster', 'tm://KovZpZAJe6lA', 'bay-area', 'The Warfield (Ticketmaster)', true, 'venue', 'TM Discovery API'),
+  ('tm-masonic', 'The Masonic', 'music', 'ticketmaster', 'tm://KovZpZAJ6nlA', 'bay-area', 'The Masonic (Ticketmaster)', true, 'venue', 'TM Discovery API'),
+  ('tm-independent', 'The Independent', 'music', 'ticketmaster', 'tm://KovZpZAAl7AA', 'bay-area', 'The Independent (Ticketmaster)', true, 'venue', 'TM Discovery API; own site 403s'),
+  ('tm-castro', 'Castro Theatre', 'music', 'ticketmaster', 'tm://KovZpaF_me', 'bay-area', 'Castro Theatre (Ticketmaster)', true, 'venue', 'TM Discovery API; APE bookings'),
+  ('tm-gamh', 'Great American Music Hall', 'music', 'ticketmaster', 'tm://KovZpZAJk7aA', 'bay-area', 'Great American Music Hall (Ticketmaster)', true, 'venue', 'TM Discovery API'),
+  ('tm-regency', 'The Regency Ballroom', 'music', 'ticketmaster', 'tm://KovZpZAEet6A', 'bay-area', 'The Regency Ballroom (Ticketmaster)', true, 'venue', 'TM Discovery API')
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/101_music_type_column 2.sql
+++ b/supabase/migrations/101_music_type_column 2.sql
@@ -1,0 +1,11 @@
+-- ============================================
+-- Persisted music-type classification
+-- Migration 101
+-- The 8-bucket taxonomy (electronic/rock/pop/hiphop/jazz/folk/world/other)
+-- was derived client-side from genre keywords; persisting makes it queryable,
+-- consistent across clients, and available to recs/metrics.
+-- classify_music_type() mirrors the client keyword matcher; enrich-event's
+-- AI refines per event; run_events_maintenance() self-heals NULL/other rows.
+-- Backfill at apply time classified 993 rows.
+-- ============================================
+-- (full SQL as applied via MCP — see remote migration 101_music_type_column)

--- a/supabase/migrations/20260708_pipeline_invariants 2.sql
+++ b/supabase/migrations/20260708_pipeline_invariants 2.sql
@@ -1,0 +1,115 @@
+-- Pipeline invariants tripwire (retro of 2026-07-08 dedupe incident).
+-- Three standing assertions about the events pipeline, checked on a cron:
+--   (a) no-duplicate-slots: no source has 2+ future rows pointing at the same
+--       per-event URL on the same date (renamed listings minting siblings)
+--   (b) rows-refresh-after-success: a source with a recent successful scrape
+--       must have refreshed its future rows (poisoned-batch detector — the
+--       bulk-update failure froze whole sources with green health)
+--   (c) clean-cache-writes: no _cache-batch errors recorded in the last 24h
+-- Violations are persisted to pipeline_invariant_checks and offending
+-- sources are loudly marked degraded in source_health.
+
+CREATE TABLE IF NOT EXISTS pipeline_invariant_checks (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  checked_at timestamptz NOT NULL DEFAULT now(),
+  ok boolean NOT NULL,
+  violations jsonb NOT NULL DEFAULT '[]'::jsonb
+);
+
+ALTER TABLE pipeline_invariant_checks ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "invariant checks readable" ON pipeline_invariant_checks;
+CREATE POLICY "invariant checks readable" ON pipeline_invariant_checks
+  FOR SELECT USING (true);
+
+CREATE OR REPLACE FUNCTION check_pipeline_invariants() RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v jsonb := '[]'::jsonb;
+  dupes jsonb;
+  stale jsonb;
+  batch_errs jsonb;
+BEGIN
+  -- (a) duplicate slots: same source + date + per-event URL, 2+ rows.
+  -- Per-event URLs are the strong identity signal (BOTH date pages, Discord
+  -- permalinks, ticket links). Registry/listing-page fallback URLs are
+  -- excluded via the event_sources join; the count ceiling skips generic
+  -- URLs shared by many same-day rows.
+  SELECT jsonb_agg(jsonb_build_object('source', source_id, 'date', date, 'url', url, 'n', n))
+  INTO dupes
+  FROM (
+    SELECT e.source_id, e.date, e.url, count(*) AS n
+    FROM events e
+    LEFT JOIN event_sources es ON es.id = e.source_id
+    WHERE e.date >= CURRENT_DATE
+      AND e.url IS NOT NULL AND e.url <> ''
+      AND (es.url IS NULL OR e.url <> es.url)
+    GROUP BY e.source_id, e.date, e.url
+    HAVING count(*) > 1 AND count(*) <= 5
+  ) d;
+  IF dupes IS NOT NULL THEN
+    v := v || jsonb_build_object('invariant', 'no-duplicate-slots', 'violations', dupes);
+  END IF;
+
+  -- (b) freshness: a source whose last scrape succeeded (with events) in the
+  -- last 24h must have refreshed its future rows. >30% stale mirrors the
+  -- reconciliation cap; small absolute floor avoids noise. Curation/manual
+  -- feeds are excluded — their rows legitimately never re-scrape.
+  SELECT jsonb_agg(jsonb_build_object('source', s.source_id, 'stale', s.stale, 'total', s.total))
+  INTO stale
+  FROM (
+    SELECT e.source_id,
+           count(*) FILTER (WHERE e.scraped_at < h.last_success_at - interval '10 minutes') AS stale,
+           count(*) AS total
+    FROM events e
+    JOIN source_health h ON h.source_id = e.source_id
+    JOIN event_sources es ON es.id = e.source_id
+    WHERE e.date >= CURRENT_DATE
+      AND h.last_success_at > now() - interval '24 hours'
+      AND coalesce(h.last_success_event_count, 0) > 0
+      AND es.type NOT IN ('discord', 'manual')
+      AND coalesce(es.source_class, '') <> 'curation'
+    GROUP BY e.source_id
+  ) s
+  WHERE s.stale > 5 AND s.stale::numeric / greatest(s.total, 1) > 0.3;
+  IF stale IS NOT NULL THEN
+    v := v || jsonb_build_object('invariant', 'rows-refresh-after-success', 'violations', stale);
+  END IF;
+
+  -- (c) cache write errors surfaced into scrape_runs in the last 24h
+  SELECT jsonb_agg(jsonb_build_object('run_started', started_at, 'errors', error_log))
+  INTO batch_errs
+  FROM scrape_runs
+  WHERE started_at > now() - interval '24 hours'
+    AND error_log IS NOT NULL
+    AND jsonb_array_length(error_log) > 0
+    AND error_log::text ILIKE '%_cache-batch%';
+  IF batch_errs IS NOT NULL THEN
+    v := v || jsonb_build_object('invariant', 'clean-cache-writes', 'violations', batch_errs);
+  END IF;
+
+  INSERT INTO pipeline_invariant_checks (ok, violations)
+  VALUES (jsonb_array_length(v) = 0, v);
+
+  -- Loud flag: offending sources show degraded in the Settings health UI.
+  -- The next clean scrape rewrites health, which is the correct recovery.
+  IF dupes IS NOT NULL OR stale IS NOT NULL THEN
+    UPDATE source_health h SET
+      status = 'degraded',
+      last_failure_reason = 'invariant violation — see pipeline_invariant_checks'
+    WHERE h.source_id IN (
+      SELECT DISTINCT x->>'source' FROM jsonb_array_elements(coalesce(dupes, '[]'::jsonb)) x
+      UNION
+      SELECT DISTINCT x->>'source' FROM jsonb_array_elements(coalesce(stale, '[]'::jsonb)) x
+    );
+  END IF;
+
+  -- Keep 90 days of check history
+  DELETE FROM pipeline_invariant_checks WHERE checked_at < now() - interval '90 days';
+
+  RETURN jsonb_build_object('ok', jsonb_array_length(v) = 0, 'violations', v);
+END $$;
+
+-- Every 6 hours, offset from the 2h scrape cron so a run has settled
+SELECT cron.unschedule('pipeline-invariants-6h')
+WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pipeline-invariants-6h');
+SELECT cron.schedule('pipeline-invariants-6h', '45 */6 * * *', 'SELECT check_pipeline_invariants()');


### PR DESCRIPTION
Removes the mobile (≤600px) absolute top-right pinning of the filter button. It's now a static, `order:-1` flex item in **every** state — expanded and collapsed — so it always sits to the left of the scrolling category chips (the collapsed-nav layout is now the only layout).

Verified in a 390px viewport, expanded state: `position: static`, filter inline-left of chips on the same row (`filterInlineWithChips: true`, `filterLeftOfChips: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)