### PR TITLE
ladder: draining loader on For You + Gmail reconnect force-kicks a scan

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -65,4 +65,11 @@ The For You surface follows a **triage, don't browse** model (inbox → review �
 
 ## Cache busting
 
-Every PR that touches `/ladder/js` or `/ladder/css` bumps `VERSION` in `ladder/js/app.js`, the `?v=` on every HTML `<link>`/`<script>`, **and the `@import url("./components.css?v=…")` inside `base.css`** — that import is the easy one to forget and it silently pins component styles to the 10-minute edge cache.
+Every PR that touches `/ladder/js` or `/ladder/css` bumps `VERSION` in `ladder/js/app.js`, the `?v=` on every HTML `<link>`/`<script>`, **and the `@import url("./components.css?v=…")` inside `base.css`** — that import is the easy one to forget and it silently pins component styles to the 10-minute edge cache. (`grep -rn "v=<old>" ladder/` catches them all.)
+
+## For You — source state banners
+
+Above the recommendations table (`ladder-recommendations-table`), two mutually-informative strips:
+
+- `.recs-health-banner` (error-colored) — a source is **blind**: dead Gmail token (`needsReauth` → "Reconnect Gmail" button) or a `lastError`. Distinct from "no new recs".
+- `.recs-draining` (accent-colored, with `.recs-draining__spinner`) — the backend is **actively scanning Gmail**. Shown while a pull run we kicked is in flight; auto-clears when the gmail-jobs source's `lastRunAt` advances past the kick (polled every 8s) or after a 150s safety cap. Triggered by: the manual **Refresh** button, a fresh **Gmail reconnect** (which also force-runs the scan), and resumed on mount if a recent kick hasn't completed (survives the reconnect OAuth round-trip). The kick timestamp lives in `localStorage['job:lastPullKickAt']`, shared with `pipeline.js` `refreshSources()`.

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.23.0");
+@import url("./components.css?v=2.24.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -2712,6 +2712,35 @@ button.link-subtle {
 }
 .recs-health-banner__msg { font-size: var(--font-size-body-sm); }
 
+/* Draining loader — persistent while the backend is actively scanning Gmail
+   (kicked by a manual refresh or a fresh Gmail reconnect). Auto-clears when
+   the scan run completes. Uses the accent color to read as "working", not
+   "error" like the health banner above. */
+.recs-draining {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.recs-draining__msg { font-size: var(--font-size-body-sm); }
+.recs-draining__spinner {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-top-color: var(--accent);
+  animation: recs-draining-spin 0.8s linear infinite;
+}
+@keyframes recs-draining-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .recs-draining__spinner { animation-duration: 2.4s; }
+}
+
 /* Infinite-scroll footer for the For You table. The sentinel is an
    invisible trip-wire the IntersectionObserver watches; the loadmore row
    shows a status line while the next page is fetched. */

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.23.0";
-console.log(`[ladder] v${VERSION} - per-day below-your-bar drawer on the Inbox (floor=below complement view)`);
+const VERSION = "2.24.0";
+console.log(`[ladder] v${VERSION} - persistent "Scanning Gmail…" draining loader on For You; Gmail reconnect now force-kicks a scan`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -21,6 +21,11 @@ import('./ladder-review-overlay.js' + V);
 // Page size for the infinite-scroll fetch. Server caps at 200; 100 keeps
 // each round-trip light while filling a tall viewport in one or two pages.
 const PAGE_SIZE = 100;
+// Draining loader tuning. A single pull run is ~30–90s; cap the loader so it
+// can never stick if a run dies. Poll cadence balances responsiveness vs load.
+const DRAIN_MAX_MS   = 150 * 1000;
+const DRAIN_POLL_MS  = 8 * 1000;
+const PULL_KICK_KEY  = 'job:lastPullKickAt';   // shared with pipeline.js refreshSources
 
 function fitClass(s) {
   if (s == null) return 'fit-pill fit-pill--poor';
@@ -60,6 +65,7 @@ export class JobRecommendationsTable extends LitElement {
     _refreshFeedback:    { state: true },
     _health:             { state: true },
     _reconnecting:       { state: true },
+    _draining:           { state: true },
     _total:              { state: true },
     _loadingMore:        { state: true },
     _hasMore:            { state: true },
@@ -84,6 +90,12 @@ export class JobRecommendationsTable extends LitElement {
     this._refreshFeedback = '';
     this._health = [];
     this._reconnecting = false;
+    // Draining = a scan the backend is actively working. Set when we kick a
+    // pull (manual refresh, Gmail reconnect) and cleared when the gmail-jobs
+    // source's lastRunAt advances past the kick, or after DRAIN_MAX_MS.
+    this._draining = false;
+    this._drainKickAt = 0;   // ms epoch of the kick we're waiting on
+    this._drainPoll = null;  // setInterval handle
     this._total = 0;
     this._offset = 0;
     this._loadingMore = false;
@@ -189,23 +201,89 @@ export class JobRecommendationsTable extends LitElement {
     `;
   }
 
+  // ----- Draining loader -------------------------------------------------
+  // "Draining" means the backend is actively scanning Gmail for this user.
+  // We know a scan is in flight because we (or a prior page, via the shared
+  // localStorage kick timestamp) just fired one; it's done when the
+  // gmail-jobs source's lastRunAt advances past the kick we're waiting on.
+
+  _gmailHealth() {
+    return (this._health || []).find(s => s.type === 'gmail-jobs') || null;
+  }
+
+  // Has the gmail-jobs source completed a run since `kickAt`?
+  _drainDoneFor(kickAt) {
+    const g = this._gmailHealth();
+    if (!g || !g.lastRunAt) return false;
+    return new Date(g.lastRunAt).getTime() >= kickAt - 1000;   // 1s clock slack
+  }
+
+  // Begin/refresh the draining indicator for the run kicked at `kickAt`.
+  // Idempotent: re-kicking (e.g. a second refresh) just extends the wait.
+  _startDraining(kickAt) {
+    this._drainKickAt = kickAt || Date.now();
+    this._draining = true;
+    this.requestUpdate();
+    if (this._drainPoll) return;   // already polling
+    this._drainPoll = setInterval(() => this._pollDrain(), DRAIN_POLL_MS);
+  }
+
+  _stopDraining() {
+    this._draining = false;
+    if (this._drainPoll) { clearInterval(this._drainPoll); this._drainPoll = null; }
+    this.requestUpdate();
+  }
+
+  async _pollDrain() {
+    // Timed out — clear so the loader can never wedge on a dead run.
+    if (Date.now() - this._drainKickAt > DRAIN_MAX_MS) { this._stopDraining(); return; }
+    // Re-fetch to pick up fresh recs AND updated sourceHealth.lastRunAt.
+    await this._fetchPage({ reset: true });
+    if (this._drainDoneFor(this._drainKickAt)) this._stopDraining();
+    this.requestUpdate();
+  }
+
+  // On (re)mount, resume the loader if a recent kick hasn't completed yet —
+  // survives navigation and the Gmail-reconnect OAuth round-trip.
+  _resumeDrainingIfPending() {
+    let kickAt = 0;
+    try { kickAt = Number(localStorage.getItem(PULL_KICK_KEY) || 0); } catch { /* ignore */ }
+    if (!kickAt) return;
+    if (Date.now() - kickAt > DRAIN_MAX_MS) return;   // stale kick, ignore
+    if (this._drainDoneFor(kickAt)) return;           // already finished
+    this._startDraining(kickAt);
+  }
+
+  _renderDrainingBanner() {
+    if (!this._draining) return nothing;
+    return html`
+      <div class="recs-draining" role="status" aria-live="polite">
+        <span class="recs-draining__spinner" aria-hidden="true"></span>
+        <span class="recs-draining__msg">Scanning Gmail for new roles… new matches appear here automatically.</span>
+      </div>
+    `;
+  }
+
   async _onRefresh() {
     if (this._refreshing) return;
     this._refreshing = true;
     this.requestUpdate();
     try {
-      const r = await refreshSources();
-      this._refreshFeedback = r.throttled
-        ? 'Recently refreshed — try again in a few minutes.'
-        : 'Scanning Gmail for new roles…';
-      setTimeout(async () => {
-        await this._fetchPage({ reset: true });
-        this.requestUpdate();
-      }, 8000);
+      // Force-run the gmail-jobs source by id (bypasses the server is-due gate)
+      // so an explicit Refresh always scans and the loader clears on real
+      // completion; keep the client throttle so the button can't be spammed.
+      const gmailId = (this._gmailHealth() || {}).id || null;
+      const r = await refreshSources({ sourceId: gmailId });
+      if (r.throttled) {
+        this._refreshFeedback = 'Recently refreshed — try again in a few minutes.';
+        setTimeout(() => { this._refreshFeedback = ''; this.requestUpdate(); }, 10000);
+      } else {
+        // Real kick → show the persistent draining loader until it completes.
+        this._startDraining(r.kickAt || Date.now());
+      }
     } finally {
       this._refreshing = false;
       this.requestUpdate();
-      setTimeout(() => { this._refreshFeedback = ''; this.requestUpdate(); }, 10000);
     }
   }
 
@@ -238,9 +316,20 @@ export class JobRecommendationsTable extends LitElement {
     // Gmail just reconnected (app.js fires this after a successful token
     // exchange) → hide the disconnected banner optimistically without
     // waiting for the next scan to clear last_error server-side.
-    this._onGmailConnected = () => {
+    this._onGmailConnected = async () => {
+      // Capture the source id before we drop the row from _health.
+      const gmailId = (this._gmailHealth() || {}).id || null;
+      // Optimistically clear the disconnected banner without waiting for the
+      // next scan to clear last_error server-side.
       this._health = (this._health || []).filter(s => s.type !== 'gmail-jobs');
       this.requestUpdate();
+      // Reconnect is a high-signal trigger: force an immediate scan (bypass the
+      // client throttle AND the server is-due gate) and show the draining
+      // loader until it completes, instead of waiting up to 15 min for cron.
+      try {
+        const r = await refreshSources({ force: true, sourceId: gmailId });
+        if (r.kicked) this._startDraining(r.kickAt || Date.now());
+      } catch (e) { console.warn('[recs-table] post-reconnect kick failed', e); }
     };
     document.addEventListener('job:gmail:connected', this._onGmailConnected);
     // While a health issue is showing, revalidate every 5 minutes so the
@@ -271,6 +360,7 @@ export class JobRecommendationsTable extends LitElement {
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('job:gmail:connected', this._onGmailConnected);
     clearInterval(this._healthTimer);
+    if (this._drainPoll) { clearInterval(this._drainPoll); this._drainPoll = null; }
     document.removeEventListener('click', this._onDocClick);
     window.removeEventListener('scroll', this._onScroll);
     window.removeEventListener('resize', this._onScroll);
@@ -293,6 +383,9 @@ export class JobRecommendationsTable extends LitElement {
     this.state = 'loading';
     await this._fetchPage({ reset: true });
     if (this.state === 'loading') this.state = 'loaded';
+    // If a scan was kicked recently (this session or just before an OAuth
+    // reconnect round-trip) and hasn't finished, resume the draining loader.
+    this._resumeDrainingIfPending();
     // Wildcards strip loads after the list — never block or fail the
     // page over it.
     try {
@@ -692,6 +785,7 @@ export class JobRecommendationsTable extends LitElement {
         ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
         ${this._renderHeaderMenu()}
       </header>
+      ${this._renderDrainingBanner()}
       ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`
         <div class="placeholder">

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -10,11 +10,19 @@ const PULL_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-rec
 // truth (user_sources.schedule_cron vs last_run_at).
 const PULL_MIN_INTERVAL_MS = 5 * 60 * 1000;     // 5 min — half the server's 15-min cadence
 
-export async function refreshSources({ silent = false } = {}) {
-  // Throttle: if we kicked a pull within PULL_MIN_INTERVAL_MS, skip.
+// force:    bypass the client throttle (used for high-signal triggers like a
+//           fresh Gmail reconnect where the user expects an immediate scan).
+// sourceId: force-run ONE user_source by id, bypassing the server's is-due
+//           gate (POST {id}). Without it we POST {} → all enabled+due sources,
+//           same as cron. Reconnect passes the gmail-jobs id so the scan runs
+//           even if the source ran (and failed) minutes ago and isn't "due".
+export async function refreshSources({ silent = false, force = false, sourceId = null } = {}) {
+  // Throttle: if we kicked a pull within PULL_MIN_INTERVAL_MS, skip — unless
+  // force is set. The kick timestamp doubles as the "draining since" marker
+  // the recs table polls against, so we always stamp it when we actually fire.
   try {
     const lastTs = Number(localStorage.getItem('job:lastPullKickAt') || 0);
-    if (Date.now() - lastTs < PULL_MIN_INTERVAL_MS) {
+    if (!force && Date.now() - lastTs < PULL_MIN_INTERVAL_MS) {
       return { kicked: false, throttled: true, lastKickAt: new Date(lastTs).toISOString() };
     }
     localStorage.setItem('job:lastPullKickAt', String(Date.now()));
@@ -30,15 +38,15 @@ export async function refreshSources({ silent = false } = {}) {
     fetch(PULL_URL, {
       method: 'POST',
       headers: { ...headers, 'Content-Type': 'application/json' },
-      // No body → all enabled+due user_sources run, same as the cron path.
-      body: JSON.stringify({}),
+      // {id} → force that one source (bypasses is-due); {} → all due sources.
+      body: JSON.stringify(sourceId ? { id: sourceId } : {}),
       keepalive: true,
     }).catch(() => { /* fire-and-forget; server completes its own work */ });
   } catch (e) {
     kickedOk = false;
     if (!silent) console.warn('[refreshSources] kick failed:', e.message);
   }
-  return { kicked: kickedOk, throttled: false };
+  return { kicked: kickedOk, throttled: false, kickAt: Date.now() };
 }
 
 async function authHeader() {

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.23.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.24.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -7,8 +7,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.18.0';
-console.log(`[recommendations] v${VERSION} - ?floor=below complement view for the per-day below-your-bar drawer`);
+const VERSION = '0.19.0';
+console.log(`[recommendations] v${VERSION} - sourceHealth returns source id so the UI can force-run gmail-jobs on reconnect and show a draining loader`);
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -303,7 +303,8 @@ serve(async (req) => {
       let sourceHealth: unknown[] = [];
       try {
         sourceHealth = await sql`
-          select s.type,
+          select s.id,
+                 s.type,
                  s.enabled,
                  s.last_run_at   as "lastRunAt",
                  s.last_run_count as "lastRunCount",


### PR DESCRIPTION
## Why
The For You page gave no signal the backend was scanning. A Refresh showed only a transient 10s text; a Gmail **reconnect kicked no scan at all** — you waited up to 15 min for cron. This adds a persistent "backend is draining" indicator and makes reconnect trigger an immediate scan.

## Current drain triggers (for reference)
- **Server cron** `pull-recommendations-15min` (every 15 min) — the real scan.
- **Refresh button** on For You.
- **Recs / Pipeline page load** (auto-kick, throttled 1/5min).
- **NEW → Gmail reconnect** (`job:gmail:connected`).

## Changes
**Loader (`.recs-draining`)** — accent bar + spinner, "Scanning Gmail for new roles…". Shows while a kicked pull run is in flight; clears when the gmail-jobs source's `lastRunAt` advances past the kick (polled every 8s) or after a 150s safety cap. Resumes on mount if a recent kick hasn't completed — survives navigation and the reconnect OAuth round-trip (shared `localStorage['job:lastPullKickAt']`).

**Reconnect trigger** — `job:gmail:connected` now force-runs the user's gmail-jobs source (bypasses client throttle + server is-due gate) and shows the loader.

**Manual Refresh** — force-runs gmail-jobs by id so the loader clears on real completion instead of spinning to the timeout when the source isn't "due".

**Backend** — `recommendations` `sourceHealth` now returns the source `id`. `refreshSources()` gains `{force, sourceId}`.

### Files
- `supabase/functions/recommendations/index.ts` — `sourceHealth` returns `id`; v0.18.0 → v0.19.0.
- `ladder/js/pipeline.js` — `refreshSources({force, sourceId})`.
- `ladder/js/components/ladder-recommendations-table.js` — draining state, poll-to-completion, reconnect kick, banner.
- `ladder/css/components.css` — `.recs-draining` + spinner (respects `prefers-reduced-motion`).
- `ladder/DESIGN.md` — documented the two For You source-state banners.
- Frontend cache-bust v2.23.0 → v2.24.0 (app.js + base.css import + 11 HTML files).

Respun onto current master after a worktree recycle left the original branch on a stale snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)