### PR TITLE
feat(ladder): Inbox row dismiss ("not for me") button (v2.24.0)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.23.0");
+@import url("./components.css?v=2.24.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -6180,6 +6180,14 @@ body[data-auth-state="out"] job-chat { display: none; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Trailing action cluster — quiet dismiss + primary Review, balanced as a
+   pair so the row reads as a two-choice triage (skip / look closer). */
+.inbox-row__actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
 .inbox-row__review {
   flex-shrink: 0;
   height: 36px;
@@ -6188,6 +6196,24 @@ body[data-auth-state="out"] job-chat { display: none; }
   border: 0;
 }
 .inbox-row__review:hover { background: var(--bg-overlay); }
+/* "Not for me" — icon-only, muted until hover so Review stays the dominant
+   action; hover reveals an error tint to signal removal. Same 36px target
+   and pill radius as the header ⋯ trigger for a consistent icon-button feel. */
+.inbox-row__dismiss {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  display: inline-grid;
+  place-items: center;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--fg-subtle);
+  cursor: pointer;
+  transition: background 80ms ease, color 80ms ease, transform 80ms ease;
+}
+.inbox-row__dismiss:hover { background: var(--bg-overlay); color: var(--error); }
+.inbox-row__dismiss:active { transform: translateY(1px); }
 .inbox-row--skeleton { gap: var(--space-3); }
 .inbox-row--skeleton .inbox-row__text { flex: 1; gap: 6px; }
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.23.0";
-console.log(`[ladder] v${VERSION} - per-day below-your-bar drawer on the Inbox (floor=below complement view)`);
+const VERSION = "2.24.0";
+console.log(`[ladder] v${VERSION} - per-row dismiss ("not for me") button on Inbox rows`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -514,9 +514,19 @@ export class JobRecommendationsTable extends LitElement {
             ${sub ? html`<span class="inbox-row__sub">${sub}</span>` : nothing}
           </span>
         </button>
-        <button class="btn btn--sm inbox-row__review" @click=${open}>
-          Review <span aria-hidden="true">→</span>
-        </button>
+        <div class="inbox-row__actions">
+          <button class="inbox-row__dismiss" title="Not for me"
+                  aria-label=${'Dismiss ' + (rec.title || 'this role')}
+                  @click=${() => this._onDismiss(rec)}>
+            <svg viewBox="0 0 20 20" width="16" height="16" aria-hidden="true" focusable="false">
+              <path d="M5.5 5.5l9 9M14.5 5.5l-9 9" fill="none" stroke="currentColor"
+                    stroke-width="1.75" stroke-linecap="round"/>
+            </svg>
+          </button>
+          <button class="btn btn--sm inbox-row__review" @click=${open}>
+            Review <span aria-hidden="true">→</span>
+          </button>
+        </div>
       </li>
     `;
   }

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.23.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.24.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.23.0">
-  <script src="/ladder/js/theme.js?v=2.23.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.24.0">
+  <script src="/ladder/js/theme.js?v=2.24.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.23.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.24.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds a per-row **dismiss (✕)** control to the Ladder Inbox (`/ladder/jobs/recommended/`), left of the primary **Review** pill, so a role can be skipped without opening the review overlay.

## What changed
- **New button** in `_renderInboxRow` wired to the existing `_onDismiss` → `dismissRecommendation` path (sets `recommended_roles.dismissed_at`). No backend change.
- **New `.inbox-row__actions` cluster** groups dismiss + Review as a balanced two-choice triage. The ✕ is icon-only and muted (`--fg-subtle`) so Review stays dominant; on hover it picks up the `--error` tint + overlay background. Matches the 36px / pill icon-button treatment of the header ⋯ trigger.
- **Version bump** `2.23.0 → 2.24.0` (`app.js` const + all `?v=` cache-busts) so the component graph re-fetches past the GitHub Pages cache.

## Verification
Rendered the row markup against the real `base.css`/tokens in Chrome (generic-dark). Default and hover (error-tint) states confirmed; layout stays balanced with a wrapping title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)