### PR TITLE
fix(ladder): Back closes Review overlay & returns to Inbox (v2.26.0)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.25.0");
+@import url("./components.css?v=2.26.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.25.0";
-console.log(`[ladder] v${VERSION} - per-row dismiss ("not for me") button on Inbox rows`);
+const VERSION = "2.26.0";
+console.log(`[ladder] v${VERSION} - Review overlay pushes history so Back closes it and returns to the Inbox`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -115,6 +115,19 @@ export class JobRecommendationsTable extends LitElement {
     // When set (a day label), the review overlay walks that day's
     // below-bar queue instead of the main inbox.
     this._reviewBelowDay = null;
+    // Review overlay ↔ browser history. Opening the overlay pushes a history
+    // entry so the phone/desktop Back gesture closes the overlay and returns
+    // to the Inbox, instead of navigating off the page (to /jobs). True while
+    // that pushed entry is live.
+    this._reviewHistoryActive = false;
+    this._onReviewPop = () => {
+      // Back pressed with the overlay open: the entry is already popped, so
+      // just tear down the overlay state and stop listening.
+      this._reviewHistoryActive = false;
+      window.removeEventListener('popstate', this._onReviewPop);
+      this._reviewIndex = null;
+      this._reviewBelowDay = null;
+    };
   }
 
   // ----- Source health banner ------------------------------------------
@@ -364,6 +377,7 @@ export class JobRecommendationsTable extends LitElement {
     document.removeEventListener('click', this._onDocClick);
     window.removeEventListener('scroll', this._onScroll);
     window.removeEventListener('resize', this._onScroll);
+    window.removeEventListener('popstate', this._onReviewPop);
     super.disconnectedCallback();
   }
 
@@ -513,9 +527,33 @@ export class JobRecommendationsTable extends LitElement {
 
   // ----- Review overlay --------------------------------------------------
 
-  _openReview(index) { this._reviewBelowDay = null; this._reviewIndex = index; }
-  _openBelowReview(day, index) { this._reviewBelowDay = day; this._reviewIndex = index; }
-  _closeReview()     { this._reviewIndex = null; this._reviewBelowDay = null; }
+  _openReview(index) { this._reviewBelowDay = null; this._reviewIndex = index; this._enterReviewHistory(); }
+  _openBelowReview(day, index) { this._reviewBelowDay = day; this._reviewIndex = index; this._enterReviewHistory(); }
+
+  // Push a single history entry for this open session (guarded so advancing
+  // through the queue doesn't stack duplicates) and listen for Back.
+  _enterReviewHistory() {
+    if (this._reviewHistoryActive) return;
+    this._reviewHistoryActive = true;
+    history.pushState({ ladderReview: true }, '');
+    window.addEventListener('popstate', this._onReviewPop);
+  }
+
+  // Programmatic close (× / Esc / queue drained). If our pushed entry is still
+  // on top, pop it — that fires _onReviewPop, which clears the overlay state.
+  // Otherwise clear directly.
+  _closeReview() {
+    if (this._reviewHistoryActive) {
+      // Flip the guard synchronously so a re-entrant close (× + Esc racing)
+      // can't fire a second history.back() before popstate lands and over-pop
+      // us off the page.
+      this._reviewHistoryActive = false;
+      history.back();   // → popstate → _onReviewPop tears down overlay state
+      return;
+    }
+    this._reviewIndex = null;
+    this._reviewBelowDay = null;
+  }
 
   _renderReview() {
     if (this._reviewIndex == null) return nothing;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.25.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.26.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.25.0">
-  <script src="/ladder/js/theme.js?v=2.25.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.26.0">
+  <script src="/ladder/js/theme.js?v=2.26.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.25.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.26.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Clicking **Review** on an Inbox row opened the overlay via component state only (`_reviewIndex`) — no history entry — so browser/phone **Back** fell through to the previous page (`/ladder/jobs`) instead of closing the overlay.

## Fix
Opening the overlay now pushes one history entry and listens for `popstate`:
- **Back** pops it → overlay closes → user stays on the **Inbox**.
- **Programmatic close** (× / Esc / queue drained) calls `history.back()` so the stack stays consistent.

Guards: single push per open session (advancing through the save/dismiss queue does not stack duplicates), a re-entrancy flag so × + Esc racing can not over-pop off the page, and `popstate` listener cleanup in `disconnectedCallback`.

## Verification
Drove an isolated history harness (Jobs → Inbox → open → Back): overlay closes and stays on Inbox (`#inbox`), not Jobs. Programmatic ✕ close path verified identically. Final state clean (`historyActive=false`, on Inbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)