### PR TITLE
feat(ladder): split In progress into 4 stage pages under Jobs primary nav

### DIFF
--- a/ladder/DESIGN.md
+++ b/ladder/DESIGN.md
@@ -43,7 +43,7 @@ Nav labels are one-word nouns in sentence case; URLs and DB status values never 
 | Surface | Name | Notes |
 |-|-|-|
 | /ladder/jobs/recommended/ | **Inbox** | Top-level nav item (the daily loop), not under Jobs. Formerly "For You". |
-| /ladder/jobs/ buckets | **Saved · In progress · Archive** | Display labels; DB status values stay `Saved/Active/Archive` (`STATUS_LABELS` in ladder-pipeline.js). |
+| /ladder/jobs/ buckets | **Saved · Drafting · Applied · Interviewing · Offer · Archive** | Six first-class buckets, all at the same level, nested under **Jobs** in primary nav (rail `sub` + mobile drawer — there is no in-page sub-nav bar). Derived from DB `status` (`Saved/Active/Archive`) + `stage` (`drafting/applied/interviewing/offer`) by the shared `bucketFor()` in `pipeline.js` (single source of truth; `BUCKETS`/`BUCKET_LABELS` there too). An Active row always has a stage (default `drafting`). URLs: `?bucket=<id>`; legacy `leads`→`saved`, `active`→`drafting`. |
 | /ladder/history/ | **Profile** | Formerly "Your career". |
 | /ladder/vision/ | **Search plan** | Subpages: Targets · Signals · Rules · Sources. |
 | Page titles | `<Page> — Ladder` | No slash-prefix branding anywhere ("Ask Ladder", gate says "Ladder"). |

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.27.0");
+@import url("./components.css?v=2.28.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -3557,74 +3557,8 @@ button.link-subtle {
   text-overflow: ellipsis;
 }
 
-/* Stage tabs — filterable sub-tabs on the Active bucket. */
-.stage-tabs {
-  display: inline-flex;
-  gap: 2px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
-  background: var(--bg-surface);
-  margin-bottom: var(--space-4);
-  flex-wrap: wrap;
-}
-/* On phones, the 5 stage chips can't fit on one line in 360–400px. Drop
-   the pill container so the row can scroll horizontally without an ugly
-   wrapping pill. The chips themselves keep their pill styling. */
-@media (max-width: 720px) {
-  .stage-tabs {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none;
-    padding: 0;
-    border: 0;
-    background: transparent;
-    border-radius: 0;
-    max-width: 100%;
-    gap: var(--space-2);
-  }
-  .stage-tabs::-webkit-scrollbar { display: none; }
-  .stage-tabs__tab {
-    flex-shrink: 0;
-    border: 1px solid var(--border);
-    background: var(--bg-surface);
-  }
-  .stage-tabs__tab.is-active {
-    border-color: var(--accent);
-  }
-}
-.stage-tabs__tab {
-  appearance: none;
-  background: transparent;
-  border: 0;
-  padding: 6px var(--space-3);
-  border-radius: var(--radius-pill);
-  font-size: var(--font-size-small);
-  font-weight: var(--fw-medium);
-  color: var(--fg-muted);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.stage-tabs__tab:hover { background: var(--bg-elevated); color: var(--fg); }
-.stage-tabs__tab.is-active { background: var(--accent); color: var(--accent-fg); }
-.stage-tabs__count {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  padding: 0 6px;
-  height: 16px;
-  border-radius: 999px;
-  background: var(--bg-elevated);
-  color: var(--fg-muted);
-  font-size: 10px;
-  font-weight: var(--fw-semibold);
-}
-.stage-tabs__tab.is-active .stage-tabs__count { background: rgba(255,255,255,0.18); color: inherit; }
+/* (Stage filter tabs removed — the four in-progress stages are now first-class
+   bucket pages in the primary nav, not sub-tabs on an "Active" bucket.) */
 
 /* Archive modal — softer-language exit reason picker. */
 .archive-modal-scrim {
@@ -6587,6 +6521,34 @@ body[data-auth-state="out"] job-chat { display: none; }
   font-weight: var(--fw-semibold);
 }
 .nav-drawer__item .nav-count { margin-left: auto; }
+
+/* Nested pipeline buckets under Jobs in the mobile drawer. Mirrors the rail's
+   .nav-sublist (indent + left rule), sized for touch. */
+.nav-drawer__sublist {
+  list-style: none;
+  margin: var(--space-1) 0 var(--space-2) calc(var(--space-3) + 20px);
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.nav-drawer__subitem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted);
+  font-weight: var(--fw-medium);
+  font-size: var(--font-size-small);
+  text-decoration: none;
+}
+.nav-drawer__subitem:hover { background: var(--bg-surface); color: var(--fg); text-decoration: none; }
+.nav-drawer__subitem[aria-current="page"] { background: var(--bg-overlay); color: var(--fg); font-weight: var(--fw-semibold); }
+.nav-drawer__subitem .nav-count { margin-left: auto; }
+
 .nav-drawer__user,
 .rail-user {
   display: flex;

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.27.0";
-console.log(`[ladder] v${VERSION} - review viewer: ?rec= deep-link in URL, ←/→ arrow-key traversal, Skip button`);
+const VERSION = "2.28.0";
+console.log(`[ladder] v${VERSION} - pipeline split into 6 buckets (Saved · Drafting · Applied · Interviewing · Offer · Archive) under Jobs in primary nav; flat "Move to" menu`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -117,7 +117,6 @@ async function applySignedInState(email) {
   document.dispatchEvent(new CustomEvent('job:auth:ready', { detail: { email } }));
   injectFooter();
   injectMobileBar();
-  injectSubnavBar();
   injectChat();
 }
 
@@ -171,8 +170,18 @@ function injectMobileBar() {
 const DRAWER_ITEMS = [
   { href: '/ladder/jobs/recommended/', label: 'Inbox',       countKey: 'recommended', match: /^\/ladder\/jobs\/recommended\/?/,
     icon: '<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>' },
-  { href: '/ladder/jobs/',             label: 'Jobs',        countKey: 'leads',       match: /^\/ladder\/jobs(?!\/recommended)\/?/,
-    icon: '<rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>' },
+  { href: '/ladder/jobs/',             label: 'Jobs',        match: /^\/ladder\/jobs(?!\/recommended)\/?/,
+    icon: '<rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>',
+    // Six pipeline buckets as first-class sub-items (primary nav, no in-page
+    // sub-nav bar). Keep in sync with the Jobs `sub` in components/ladder-rail.js.
+    sub: [
+      { href: '/ladder/jobs/?bucket=saved',        label: 'Saved',        bucket: 'saved',        countKey: 'saved' },
+      { href: '/ladder/jobs/?bucket=drafting',     label: 'Drafting',     bucket: 'drafting',     countKey: 'drafting' },
+      { href: '/ladder/jobs/?bucket=applied',      label: 'Applied',      bucket: 'applied',      countKey: 'applied' },
+      { href: '/ladder/jobs/?bucket=interviewing', label: 'Interviewing', bucket: 'interviewing', countKey: 'interviewing' },
+      { href: '/ladder/jobs/?bucket=offer',        label: 'Offer',        bucket: 'offer',        countKey: 'offer' },
+      { href: '/ladder/jobs/?bucket=archive',      label: 'Archive',      bucket: 'archive',      countKey: 'archive' },
+    ] },
   { href: '/ladder/history/',          label: 'Profile',     match: /^\/ladder\/history\/?/,
     icon: '<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>' },
   { href: '/ladder/vision/',           label: 'Search plan', match: /^\/ladder\/vision\/?/,
@@ -195,14 +204,36 @@ function injectNavDrawer() {
         <span class="brand__text">Ladder</span>
       </a>
       <ul class="nav-drawer__list">
-        ${DRAWER_ITEMS.map(i => `
+        ${DRAWER_ITEMS.map(i => {
+          const parentActive = i.match.test(here);
+          // Normalize the current ?bucket= so legacy links still highlight
+          // the right sub-item (leads→saved, active→drafting).
+          const curBucket = (() => {
+            const b = new URLSearchParams(location.search).get('bucket');
+            if (!b || b === 'leads') return 'saved';
+            if (b === 'active') return 'drafting';
+            return b;
+          })();
+          const sub = (parentActive && i.sub) ? `
+            <ul class="nav-drawer__sublist">
+              ${i.sub.map(s => `
+                <li>
+                  <a class="nav-drawer__subitem" href="${s.href}" aria-current="${curBucket === s.bucket ? 'page' : 'false'}">
+                    <span class="nav-sub__label">${s.label}</span>
+                    ${s.countKey ? `<span class="nav-count" data-count="${s.countKey}" hidden></span>` : ''}
+                  </a>
+                </li>`).join('')}
+            </ul>` : '';
+          return `
           <li>
-            <a class="nav-drawer__item" href="${i.href}" aria-current="${i.match.test(here) ? 'page' : 'false'}">
+            <a class="nav-drawer__item" href="${i.href}" aria-current="${parentActive ? 'page' : 'false'}">
               <span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">${i.icon}</svg></span>
               <span class="nav-label">${i.label}</span>
               ${i.countKey ? `<span class="nav-count" data-count="${i.countKey}" hidden></span>` : ''}
             </a>
-          </li>`).join('')}
+            ${sub}
+          </li>`;
+        }).join('')}
       </ul>
       <div class="nav-drawer__user">
         <span class="rail-user__dot" aria-hidden="true"></span>
@@ -239,77 +270,9 @@ function toggleNavDrawer(open) {
   document.body.style.overflow = open ? 'hidden' : '';
 }
 
-// Inject the mobile segmented sub-nav (sticky under mobile-bar). Only
-// populated on /ladder/jobs/ today; data-has-items toggles visibility so
-// CSS only shows it when there's something to switch between. Counts are
-// kept in sync by listening to the same 'job:pipeline:refresh' that the
-// rail uses to refresh its count badges.
-function injectSubnavBar() {
-  if (document.querySelector('.subnav-bar')) return;
-  const app = document.querySelector('.app');
-  if (!app) return;
-
-  const bar = document.createElement('nav');
-  bar.className = 'subnav-bar';
-  bar.setAttribute('aria-label', 'Sub-navigation');
-  bar.dataset.hasItems = 'false';
-  bar.innerHTML = `<div class="subnav-bar__row"></div>`;
-  // Place directly after the mobile-bar (which has been inserted before .app).
-  const mb = document.querySelector('.mobile-bar');
-  if (mb) mb.after(bar);
-  else document.body.insertBefore(bar, app);
-
-  const row = bar.querySelector('.subnav-bar__row');
-  const here = location.pathname;
-  // Pipeline buckets only — the Inbox is its own top-level page now, so
-  // /ladder/jobs/recommended/ gets no segmented sub-nav.
-  const isJobs = /^\/ladder\/jobs(?!\/recommended)\/?/.test(here) && !/^\/ladder\/jobs\/drill/.test(here);
-
-  if (!isJobs) {
-    bar.dataset.hasItems = 'false';
-    return;
-  }
-
-  // Keep in sync with the Jobs sub-items in components/ladder-rail.js.
-  const ITEMS = [
-    { href: '/ladder/jobs/?bucket=leads',   label: 'Saved',       bucket: 'leads',  countKey: 'leads' },
-    { href: '/ladder/jobs/?bucket=active',  label: 'In progress', bucket: 'active', countKey: 'active' },
-    { href: '/ladder/jobs/?bucket=archive', label: 'Archive',     bucket: 'archive' },
-  ];
-  const bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
-  row.innerHTML = ITEMS.map(i => {
-    const active = bucket === i.bucket;
-    return `<a class="subnav-bar__item" href="${i.href}" aria-current="${active ? 'page' : 'false'}"
-              data-count-key="${i.countKey || ''}">
-              <span class="subnav-bar__label">${i.label}</span>
-              ${i.countKey ? `<span class="nav-count" data-count="${i.countKey}" hidden></span>` : ''}
-            </a>`;
-  }).join('');
-  bar.dataset.hasItems = 'true';
-
-  const applyCounts = (counts) => {
-    if (!counts) return;
-    for (const el of bar.querySelectorAll('[data-count]')) {
-      const k = el.getAttribute('data-count');
-      const n = counts[k];
-      if (n == null) { el.hidden = true; continue; }
-      el.hidden = false;
-      el.textContent = String(n);
-    }
-  };
-
-  // The rail component already fetches and stores counts on itself; listen
-  // for its broadcast event and apply.
-  const askRail = () => {
-    const rail = document.querySelector('ladder-rail');
-    if (rail?.counts) applyCounts(rail.counts);
-  };
-  document.addEventListener('job:rail:counts', (e) => applyCounts(e.detail));
-  document.addEventListener('job:pipeline:refresh', () => setTimeout(askRail, 200));
-  askRail();
-}
-
-// (Bottom tab bar removed — drawer is the only mobile nav now.)
+// (The mobile segmented sub-nav bar was removed — the pipeline buckets now
+// live in primary navigation, nested under Jobs in both the rail and the
+// mobile drawer above. Bottom tab bar was removed earlier too.)
 
 // Global toast host. Components all over the app dispatch
 // `job:toast { detail: { msg } }` — this is the single renderer (there

--- a/ladder/js/components/ladder-home.js
+++ b/ladder/js/components/ladder-home.js
@@ -7,22 +7,9 @@
 
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchPipeline, fetchRecommendations }] = await Promise.all([
+const [{ fetchPipeline, fetchRecommendations, bucketFor, isVisibleRole, STAGE_IDS }] = await Promise.all([
   import('../pipeline.js' + V),
 ]);
-
-function isVisibleRole(r) {
-  if (!r.url) return false;
-  const company = (r.company || '').toLowerCase();
-  if (company === 'strava') return false;
-  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
-  return true;
-}
-function bucketOf(r) {
-  if (r.status === 'Active') return 'active';
-  if (r.status === 'Archive') return 'archive';
-  return 'leads';
-}
 
 export class JobHome extends LitElement {
   createRenderRoot() { return this; }
@@ -60,8 +47,9 @@ export class JobHome extends LitElement {
         fetchRecommendations({ view: 'top' }).catch(() => null),
       ]);
       const roles = (pipe?.roles || []).filter(isVisibleRole);
-      const leads  = roles.filter(r => bucketOf(r) === 'leads').length;
-      const active = roles.filter(r => bucketOf(r) === 'active').length;
+      const leads  = roles.filter(r => bucketFor(r) === 'saved').length;
+      // "In progress" summary = every role in one of the four stage buckets.
+      const active = roles.filter(r => STAGE_IDS.includes(bucketFor(r))).length;
       const recommended = recs?.count ?? (recs?.recommendations?.length ?? 0);
       this.counts = { leads, active, recommended };
       this.topRecs = (recs?.recommendations || []).slice(0, 5);

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -2,27 +2,20 @@
 // rows. Each column header is a sort toggle (3-state: none → asc → desc).
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 const V = (new URL(import.meta.url)).search;
-const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole, refreshSources } = await import('../pipeline.js' + V);
+const { fetchPipeline, updateRole, setArchived, deleteRole, stashRolePrefill, checkLiveness, addRole, refreshSources,
+        STAGES, STAGE_IDS, BUCKETS, BUCKET_LABELS, bucketFor, normalizeBucket, isVisibleRole } = await import('../pipeline.js' + V);
 const { logoSrc, logoInitial } = await import('../logo.js' + V);
 const { renderScoreModal, renderScorePair, scoreClass: sharedScoreClass } = await import('./ladder-fit-modal.js' + V);
 const { loadRoleSignals, chipClassForSignal, ackEvent } = await import('../applicationEvents.js' + V);
 const { renderLocation } = await import('../format.js' + V);
 
-// Status taxonomy (3-value). Bucket name → status name:
-//   leads  → 'Saved'
-//   active → 'Active'  (with sub-stage: drafting/applied/interviewing/offer)
-//   archive→ 'Archive' (with exit_reason)
-const STATUS_OPTIONS = ['Saved', 'Active', 'Archive'];
-// Display labels for status values — the DB keeps 'Active'; the UI says
-// 'In progress' (clearer state pair with Saved/Archive).
-const STATUS_LABELS = { Saved: 'Saved', Active: 'In progress', Archive: 'Archive' };
-
-const STAGES = [
-  { id: 'drafting',     label: 'Drafting' },
-  { id: 'applied',      label: 'Applied' },
-  { id: 'interviewing', label: 'Interviewing' },
-  { id: 'offer',        label: 'Offer' },
-];
+// Bucket taxonomy (STAGES / BUCKETS / BUCKET_LABELS / bucketFor / isVisibleRole)
+// is imported from ../pipeline.js — the single source of truth shared with the
+// rail and mobile home. The six buckets are Saved · Drafting · Applied ·
+// Interviewing · Offer · Archive, derived from status (Saved/Active/Archive) +
+// stage. The "Move to" menu offers all six flat; picking a stage promotes the
+// row to Active with that stage, Saved clears the stage, Archive opens the
+// exit-reason modal.
 
 // Softer-language exit reasons. Order = "didn't apply" → "applied but
 // didn't progress" → "circumstance" so the user sees the natural
@@ -40,14 +33,6 @@ const EXIT_REASONS = [
   { id: 'other',                    label: "Something else" },
 ];
 
-function bucketFor(r) {
-  switch (r.status) {
-    case 'Active':  return 'active';
-    case 'Archive': return 'archive';
-    default:        return 'leads';
-  }
-}
-
 // Fit modal labels + render helper live in ./ladder-fit-modal.js so the
 // recommendations carousel can reuse the same tooltip.
 
@@ -64,32 +49,26 @@ const COLUMNS = [
   { id: 'menu',   label: '',       sortKey: null },
 ];
 
-// Manual ordering — user can drag rows in the Saved (leads) bucket. Order
-// persists in localStorage as a per-bucket array of slugs. Any column sort
-// overrides it; a "Use custom order" button restores it.
+// Manual ordering — user can drag rows within a bucket. Order persists in
+// localStorage as a per-bucket array of slugs (one key per bucket). Any column
+// sort overrides it; a "Use custom order" button restores it.
 const MANUAL_ORDER_KEY = 'job:jobs:manualOrder';
 function loadManualOrders() {
+  const empty = () => Object.fromEntries(BUCKETS.map(b => [b, []]));
   try {
     const raw = localStorage.getItem(MANUAL_ORDER_KEY);
     const parsed = raw ? JSON.parse(raw) : {};
-    return {
-      leads:   Array.isArray(parsed.leads)   ? parsed.leads   : [],
-      active:  Array.isArray(parsed.active)  ? parsed.active  : [],
-      archive: Array.isArray(parsed.archive) ? parsed.archive : [],
-    };
-  } catch { return { leads: [], active: [], archive: [] }; }
+    const out = empty();
+    for (const b of BUCKETS) if (Array.isArray(parsed[b])) out[b] = parsed[b];
+    // Legacy migration: the old 3-bucket shape stored 'leads' (→ saved). The
+    // old 'active' order spanned all stages, so it can't be split cleanly —
+    // drop it and let each stage page re-establish its own order.
+    if (Array.isArray(parsed.leads) && !out.saved.length) out.saved = parsed.leads;
+    return out;
+  } catch { return empty(); }
 }
 function saveManualOrders(orders) {
   try { localStorage.setItem(MANUAL_ORDER_KEY, JSON.stringify(orders)); } catch {}
-}
-
-// Drop rows without an apply link, and any Strava postings (out of scope).
-function isVisibleRole(r) {
-  if (!r.url) return false;
-  const company = (r.company || '').toLowerCase();
-  if (company === 'strava') return false;
-  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
-  return true;
 }
 
 function isArchived(r) { return !!r.archivedAt; }
@@ -108,7 +87,7 @@ export class JobPipeline extends LitElement {
     sortDir: { state: true },
     selectedRow:          { state: true },
     selectedScoreWhich:   { state: true },
-    bucket: { state: true },         // 'leads' | 'active' | 'archive'
+    bucket: { state: true },         // saved | drafting | applied | interviewing | offer | archive
     openMenuSlug: { state: true },
     livenessChecking: { state: true },
     livenessResult: { state: true },
@@ -122,8 +101,6 @@ export class JobPipeline extends LitElement {
     // "N new jobs added" banner. Accumulates entries dispatched via
     // job:pipeline:added until the user dismisses it.
     addedBanner: { state: true },
-    // Active sub-stage tab filter. null = "All".
-    activeStageFilter: { state: true },
     // Archive-flow modal state.
     archivingRow:    { state: true },
     archiveReason:   { state: true },
@@ -149,15 +126,22 @@ export class JobPipeline extends LitElement {
     this.hoverConns = null;
     const params = new URLSearchParams(location.search);
     const b = params.get('bucket');
-    this.bucket = (b === 'leads' || b === 'active' || b === 'archive') ? b : 'leads';
+    const stageQ = params.get('stage');
+    // Six buckets now (Saved · 4 stages · Archive). Normalize legacy names:
+    // leads→saved, active→drafting, and the old ?bucket=active&stage=<X> form
+    // collapses to the <X> stage page.
+    let resolved = normalizeBucket(b);
+    if (b === 'active' && STAGE_IDS.includes(stageQ)) resolved = stageQ;
+    this.bucket = resolved || 'saved';
     // Default to fit-score (desc) on every bucket, including Saved. A saved
     // manual drag order is still one click away via "Use my order".
     this.sortKey = 'score';
     this.sortDir = 'desc';
-    if (b !== this.bucket) {
-      // Normalise URL so subnav highlight matches.
+    if (b !== this.bucket || stageQ != null) {
+      // Normalise URL so nav highlight matches and the legacy stage param drops.
       const qs = new URLSearchParams(location.search);
       qs.set('bucket', this.bucket);
+      qs.delete('stage');
       history.replaceState(null, '', `${location.pathname}?${qs}`);
     }
     document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: this.bucket } }));
@@ -172,8 +156,6 @@ export class JobPipeline extends LitElement {
     this.pasteSaving = false;
     this.pasteError = '';
     this.addedBanner = { roles: [], dismissed: false };
-    const stageQ = params.get('stage');
-    this.activeStageFilter = STAGES.some(s => s.id === stageQ) ? stageQ : null;
     this.archivingRow = null;
     this.archiveReason = null;
     this.archiveContext = '';
@@ -231,7 +213,7 @@ export class JobPipeline extends LitElement {
     };
     document.addEventListener('job:pipeline:added', this._onAdded);
     this._onPopState = () => {
-      const b = new URLSearchParams(location.search).get('bucket') || 'leads';
+      const b = normalizeBucket(new URLSearchParams(location.search).get('bucket')) || 'saved';
       if (b !== this.bucket) {
         this.bucket = b;
         document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: b } }));
@@ -299,7 +281,7 @@ export class JobPipeline extends LitElement {
       // background. Debounced via localStorage so we don't hammer ATSes
       // on every page load. Replaces the explicit "Check liveness"
       // button — list reflects whatever's still posted at the URL.
-      if (this.bucket === 'leads') this._maybeAutoLiveness();
+      if (this._isSaved) this._maybeAutoLiveness();
     } catch (e) {
       this.error = String(e);
       this.state = 'error';
@@ -424,14 +406,7 @@ export class JobPipeline extends LitElement {
   _sorted() {
     const key = this.sortKey;
     const dir = this.sortDir === 'desc' ? -1 : 1;
-    const arr = this.roles.filter(r => {
-      if (!isVisibleRole(r) || !bucketFilter(r, this.bucket)) return false;
-      // Active sub-tab filter: when set, only rows whose stage matches.
-      if (this.bucket === 'active' && this.activeStageFilter) {
-        return (r.stage || null) === this.activeStageFilter;
-      }
-      return true;
-    });
+    const arr = this.roles.filter(r => isVisibleRole(r) && bucketFilter(r, this.bucket));
     if (key === 'manual') {
       const order = this._manualOrders[this.bucket] || [];
       const idx = new Map(order.map((slug, i) => [slug, i]));
@@ -518,14 +493,17 @@ export class JobPipeline extends LitElement {
     this.requestUpdate();
   }
 
-  // Status-only change (used by 3-button status group on Active rows).
-  async _changeStatus(r, status) {
-    if (status === r.status) return;
-    if (status === 'Archive') return this._openArchiveModal(r);
-    // Saved or Active — clear stage when leaving Active, otherwise keep it.
-    const patch = { status, stage: status === 'Active' ? r.stage : null };
-    if (status !== 'Archive') patch.exit_reason = null;
-    await this._applyPatch(r, patch);
+  // "Move to <bucket>" — the single flat action behind every menu option.
+  // Saved / a stage / Archive all live at the same level; a stage promotes the
+  // row to Active with that stage (the server mirrors the auto-promote rule),
+  // Saved clears the stage, Archive opens the exit-reason modal.
+  async _moveToBucket(r, bucket) {
+    this.openMenuSlug = null;
+    if (bucket === bucketFor(r)) return;                       // already there
+    if (bucket === 'archive') return this._openArchiveModal(r);
+    if (bucket === 'saved')   return this._applyPatch(r, { status: 'Saved', stage: null, exit_reason: null });
+    // A stage bucket → Active + that stage.
+    return this._applyPatch(r, { status: 'Active', stage: bucket, exit_reason: null });
   }
 
   _detailHref(r) { return `/ladder/jobs/${r.slug}/`; }
@@ -535,26 +513,9 @@ export class JobPipeline extends LitElement {
     this.openMenuSlug = this.openMenuSlug === slug ? null : slug;
   }
 
-  _switchBucket(bucket, e) {
-    e.preventDefault();
-    if (bucket === this.bucket) return;
-    this.bucket = bucket;
-    // Clear stage filter when leaving Active; it's a no-op elsewhere.
-    if (bucket !== 'active') {
-      this.activeStageFilter = null;
-      const qs = new URLSearchParams(location.search);
-      qs.delete('stage');
-      history.replaceState(null, '', `${location.pathname}?${qs}`);
-    }
-    // All buckets default to fit-desc, including Saved. The user's manual drag
-    // order is still available via "Use my order".
-    this.sortKey = 'score';
-    this.sortDir = 'desc';
-    const qs = new URLSearchParams(location.search);
-    qs.set('bucket', bucket);
-    history.pushState(null, '', `${location.pathname}?${qs}`);
-    document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket } }));
-  }
+  // Bucket-shape helpers used across render/column logic.
+  get _isStageBucket() { return STAGE_IDS.includes(this.bucket); }
+  get _isSaved()       { return this.bucket === 'saved'; }
 
   async _onArchive(r, archived) {
     this.openMenuSlug = null;
@@ -593,7 +554,7 @@ export class JobPipeline extends LitElement {
   _onBackdropClick(e) { if (e.target.classList.contains('fit-modal__backdrop')) this._closeFitModal(); }
 
   // --- Drag-to-reorder (Saved bucket only) -----------------------------
-  _canReorder() { return this.bucket === 'leads'; }
+  _canReorder() { return this._isSaved; }
 
   _onDragStart(r, e) {
     if (!this._canReorder()) return;
@@ -660,8 +621,7 @@ export class JobPipeline extends LitElement {
 
   _renderMenuCell(r) {
     const menuOpen = this.openMenuSlug === r.slug;
-    const cur = r.status || 'Saved';
-    const curStage = r.stage || null;
+    const cur = bucketFor(r);
     return html`
       <div class="row-menu">
         <button class="row-menu__trigger" aria-label="Row actions"
@@ -670,26 +630,14 @@ export class JobPipeline extends LitElement {
         ${menuOpen ? html`
           <div class="row-menu__panel row-menu__panel--wide" role="menu" @click=${(e) => e.stopPropagation()}>
             <div class="row-menu__group-label">Move to</div>
-            ${STATUS_OPTIONS.map(s => html`
+            ${BUCKETS.map(b => html`
               <button role="menuitem"
-                      class=${'row-menu__item row-menu__item--status' + (cur === s ? ' is-current' : '')}
-                      @click=${() => this._changeStatusFromMenu(r, s)}>
-                <span class="row-menu__check" aria-hidden="true">${cur === s ? '✓' : ''}</span>
-                <span>${STATUS_LABELS[s] || s}</span>
+                      class=${'row-menu__item row-menu__item--status' + (cur === b ? ' is-current' : '')}
+                      @click=${() => this._moveToBucket(r, b)}>
+                <span class="row-menu__check" aria-hidden="true">${cur === b ? '✓' : ''}</span>
+                <span>${BUCKET_LABELS[b]}</span>
               </button>
             `)}
-            ${cur === 'Active' ? html`
-              <div class="row-menu__divider" role="separator"></div>
-              <div class="row-menu__group-label">Stage</div>
-              ${STAGES.map(s => html`
-                <button role="menuitem"
-                        class=${'row-menu__item row-menu__item--stage' + (curStage === s.id ? ' is-current' : '')}
-                        @click=${() => this._setStageFromMenu(r, s.id)}>
-                  <span class="row-menu__check" aria-hidden="true">${curStage === s.id ? '✓' : ''}</span>
-                  <span>${s.label}</span>
-                </button>
-              `)}
-            ` : nothing}
             <div class="row-menu__divider" role="separator"></div>
             <button role="menuitem" class="row-menu__item row-menu__item--danger" @click=${() => this._onDelete(r)}>
               Delete…
@@ -698,20 +646,6 @@ export class JobPipeline extends LitElement {
         ` : nothing}
       </div>
     `;
-  }
-
-  async _changeStatusFromMenu(r, status) {
-    this.openMenuSlug = null;
-    await this._changeStatus(r, status);
-  }
-
-  // Selecting a stage from the menu auto-promotes status to Active on
-  // a Saved row (mirror of server-side rule). Re-selecting the same
-  // stage clears it.
-  async _setStageFromMenu(r, stage) {
-    this.openMenuSlug = null;
-    const next = r.stage === stage ? null : stage;
-    await this._applyPatch(r, { stage: next, status: 'Active' });
   }
 
   _openArchiveModal(r) {
@@ -789,50 +723,15 @@ export class JobPipeline extends LitElement {
     `;
   }
 
-  _setStageFilter(stage, e) {
-    e?.preventDefault?.();
-    this.activeStageFilter = stage;
-    const qs = new URLSearchParams(location.search);
-    if (stage) qs.set('stage', stage);
-    else qs.delete('stage');
-    history.pushState(null, '', `${location.pathname}?${qs}`);
-  }
-
-  _renderActiveStageTabs(rows) {
-    // Count Active rows per stage (including 'unset' bucket). Counts are
-    // taken from this.roles (full set), not the filtered rows, so the
-    // tabs always show totals even when one is active.
-    const allActive = this.roles.filter(r => isVisibleRole(r) && bucketFor(r) === 'active');
-    const counts = { all: allActive.length };
-    for (const s of STAGES) counts[s.id] = allActive.filter(r => (r.stage || null) === s.id).length;
-    const cur = this.activeStageFilter;
-    void rows;
-    return html`
-      <nav class="stage-tabs" aria-label="Active stage filter">
-        <button class=${'stage-tabs__tab' + (cur === null ? ' is-active' : '')}
-                @click=${(e) => this._setStageFilter(null, e)}>
-          All <span class="stage-tabs__count">${counts.all}</span>
-        </button>
-        ${STAGES.map(s => html`
-          <button class=${'stage-tabs__tab' + (cur === s.id ? ' is-active' : '')}
-                  @click=${(e) => this._setStageFilter(s.id, e)}>
-            ${s.label} <span class="stage-tabs__count">${counts[s.id]}</span>
-          </button>
-        `)}
-      </nav>
-    `;
-  }
-
   _renderStatusCell(r) {
     const s = r.status || 'Saved';
-    const stageObj = r.stage ? STAGES.find(x => x.id === r.stage) : null;
+    const bucket = bucketFor(r);
+    const stageObj = STAGES.find(x => x.id === bucket);
     const exitObj = r.exitReason ? EXIT_REASONS.find(x => x.id === r.exitReason) : null;
 
-    // On the Active bucket the high-level status is always "Active" — the
-    // useful information is the current interview step. Promote the stage
-    // to the primary pill; fall back to the Active pill only when no
-    // stage is set yet (e.g. just-promoted row awaiting first stage).
-    if (this.bucket === 'active' && stageObj) {
+    // On a stage page the useful information is which step the role is at, so
+    // the stage is the primary pill (reusing the existing stage pill classes).
+    if (stageObj) {
       const stageCls = 'status-pill status-pill--stage-' + stageObj.id;
       return html`
         <span class=${stageCls + (r._saving ? ' is-saving' : '')}>${stageObj.label}</span>
@@ -853,14 +752,15 @@ export class JobPipeline extends LitElement {
     // Status column is meaningless on Leads (it's always New/empty there).
     // On the Active bucket the column shows the interview stage, so the
     // header reads "Stage" rather than "Status".
-    // 'connections' (warm-intro avatars) only appears on the Leads bucket —
+    // 'connections' (warm-intro avatars) only appears on the Saved bucket —
     // that's where Ian is deciding whether to pursue, so "who do I know
     // here?" is most actionable. It replaces the Status column there (Status
-    // is meaningless on Leads anyway).
+    // is meaningless on Saved anyway). On a stage page the Status column shows
+    // the stage.
     return COLUMNS
-      .filter(c => !(c.id === 'status' && this.bucket === 'leads'))
-      .filter(c => !(c.id === 'connections' && this.bucket !== 'leads'))
-      .map(c => (c.id === 'status' && this.bucket === 'active') ? { ...c, label: 'Stage', sortKey: 'stage' } : c);
+      .filter(c => !(c.id === 'status' && this._isSaved))
+      .filter(c => !(c.id === 'connections' && !this._isSaved))
+      .map(c => (c.id === 'status' && this._isStageBucket) ? { ...c, label: 'Stage', sortKey: 'stage' } : c);
   }
 
   _renderHeader() {
@@ -900,7 +800,7 @@ export class JobPipeline extends LitElement {
   }
 
   _renderRow(r) {
-    const showStatus = this.bucket !== 'leads';
+    const showStatus = !this._isSaved;
     const reorder = this._canReorder();
     const cls = 'pipeline-row'
       + (r.status === 'Archive' ? ' is-archived' : '')
@@ -928,7 +828,7 @@ export class JobPipeline extends LitElement {
             <div class="role-cell__text">
               <div class="role-cell__title">
                 ${r.title || '(untitled)'}
-                ${this.bucket === 'leads' && r.engagedAt
+                ${this._isSaved && r.engagedAt
                   ? html`<span class="in-progress-pill" title="You've viewed or applied to this role">In progress</span>`
                   : nothing}
               </div>
@@ -938,7 +838,7 @@ export class JobPipeline extends LitElement {
           </div>
         </td>
         <td class="col col-signal" data-label="">${this._renderSignalCell(r)}</td>
-        ${this.bucket === 'leads' ? html`<td class="col col-connections" data-label="Network">${this._renderConnectionsCell(r)}</td>` : nothing}
+        ${this._isSaved ? html`<td class="col col-connections" data-label="Network">${this._renderConnectionsCell(r)}</td>` : nothing}
         <td class="col col-sector" data-label="Sector">${this._renderSectorCell(r)}</td>
         ${showStatus ? html`<td class="col col-status status-cell" data-label="Status">${this._renderStatusCell(r)}</td>` : nothing}
         <td class="col col-menu">${this._renderMenuCell(r)}</td>
@@ -1091,7 +991,7 @@ export class JobPipeline extends LitElement {
   }
 
   _renderSkeletonRow() {
-    const showStatus = this.bucket !== 'leads';
+    const showStatus = !this._isSaved;
     return html`
       <tr class="skeleton-row">
         <td class="col col-fit"><span class="skeleton skeleton--pill" style="width:40px;height:24px;"></span></td>
@@ -1101,7 +1001,7 @@ export class JobPipeline extends LitElement {
           <span class="skeleton" style="width:50%;height:11px;display:block;"></span>
         </td>
         <td class="col col-signal"></td>
-        ${this.bucket === 'leads' ? html`<td class="col col-connections"><span class="skeleton skeleton--pill" style="width:64px;height:28px;"></span></td>` : nothing}
+        ${this._isSaved ? html`<td class="col col-connections"><span class="skeleton skeleton--pill" style="width:64px;height:28px;"></span></td>` : nothing}
         <td class="col col-sector"><span class="skeleton" style="width:80px;height:16px;"></span></td>
         ${showStatus ? html`<td class="col col-status"><span class="skeleton skeleton--pill" style="width:120px;height:32px;"></span></td>` : nothing}
         <td class="col col-menu"><span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);"></span></td>
@@ -1245,13 +1145,13 @@ export class JobPipeline extends LitElement {
       </div>`;
     }
     const rows = this._sorted();
-    const bucketLabel = { leads: 'Saved', active: 'In progress', archive: 'Archive' }[this.bucket];
+    const bucketLabel = BUCKET_LABELS[this.bucket] || 'Saved';
     const added = this.addedBanner?.roles || [];
     const showAddedBanner = added.length > 0 && !this.addedBanner.dismissed;
 
     return html`
-      ${this.bucket === 'active' ? this._renderLiveBanners() : nothing}
-      ${this.bucket === 'active' ? this._renderNeedsAttention() : nothing}
+      ${this._isStageBucket ? this._renderLiveBanners() : nothing}
+      ${this._isStageBucket ? this._renderNeedsAttention() : nothing}
 
       ${showAddedBanner ? this._renderAddedBanner(added) : nothing}
 
@@ -1291,10 +1191,10 @@ export class JobPipeline extends LitElement {
         ${this.sortKey === 'manual'
           ? html`in your custom order. <span class="muted">Drag rows to rearrange.</span>`
           : html`sorted by ${this.sortKey} ${this.sortDir === 'asc' ? '↑' : '↓'}.`}
-        ${this.bucket === 'leads' && this.sortKey !== 'manual' && this._manualOrders.leads.length ? html`
+        ${this._isSaved && this.sortKey !== 'manual' && this._manualOrders.saved.length ? html`
           <button class="btn btn--sm" @click=${() => this._useCustomOrder()}>Use my order</button>
         ` : nothing}
-        ${this.bucket === 'leads' && this.sortKey !== 'manual' && !this._manualOrders.leads.length ? html`
+        ${this._isSaved && this.sortKey !== 'manual' && !this._manualOrders.saved.length ? html`
           <button class="btn btn--sm" @click=${() => this._useCustomOrder()}>Arrange manually</button>
         ` : nothing}
         <button class="btn btn--sm btn--accent"
@@ -1315,7 +1215,6 @@ export class JobPipeline extends LitElement {
           ${this.pasteError ? html`<span class="muted" style="color:var(--error);font-size:var(--font-size-small);">${this.pasteError}</span>` : nothing}
         </form>
       ` : nothing}
-      ${this.bucket === 'active' ? this._renderActiveStageTabs(rows) : nothing}
       <div class="pipeline-table-wrap">
         <table class="pipeline-table">
           <thead>${this._renderHeader()}</thead>
@@ -1328,8 +1227,8 @@ export class JobPipeline extends LitElement {
       ${rows.length === 0 ? html`
         <div class="placeholder" style="margin-top:var(--space-4);">
           <h2>No ${bucketLabel.toLowerCase()} ${rows.length === 1 ? 'role' : 'roles'} yet</h2>
-          <p>${this.bucket === 'leads' ? 'Add a posting or wait for the crawler to find a fit.'
-              : this.bucket === 'active' ? 'Pick a stage on a Saved role via the row menu — it moves here automatically.'
+          <p>${this._isSaved ? 'Add a posting or wait for the crawler to find a fit.'
+              : this._isStageBucket ? `Use a role's row menu → Move to → ${bucketLabel} to bring it here.`
               : 'Archived roles land here, with the reason you gave.'}</p>
         </div>
       ` : nothing}

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -5,26 +5,9 @@
 import { LitElement, html, nothing } from 'https://esm.run/lit@3';
 import { unsafeHTML } from 'https://esm.run/lit@3/directives/unsafe-html.js';
 const V = (new URL(import.meta.url)).search;
-const [{ fetchPipeline, fetchRecommendations }] = await Promise.all([
+const [{ fetchPipeline, fetchRecommendations, BUCKETS, bucketFor, isVisibleRole, normalizeBucket }] = await Promise.all([
   import('../pipeline.js' + V),
 ]);
-
-// Bucket-assignment for pipeline rows — mirrors job-pipeline.js exactly.
-// Kept in sync by hand. Status taxonomy is now 3 values.
-function bucketFor(r) {
-  switch (r.status) {
-    case 'Active':  return 'active';
-    case 'Archive': return 'archive';
-    default:        return 'leads';
-  }
-}
-function isVisibleRole(r) {
-  if (!r.url) return false;
-  const company = (r.company || '').toLowerCase();
-  if (company === 'strava') return false;
-  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
-  return true;
-}
 
 // Primary-nav line icons — 20px, 1.8 stroke, inherit currentColor.
 // The ONLY place icons are allowed (DESIGN.md rule 7). Keep in sync with
@@ -38,10 +21,10 @@ export const NAV_ICONS = {
 };
 
 // Nav taxonomy: Inbox is top-level (the daily loop shouldn't hide under
-// Jobs); Jobs holds the pipeline buckets. Sub-items are either a
-// bucket-filter on /ladder/jobs/ (matched by `bucket`) or a real sub-page
-// (matched by `path` prefix). `countKey` says which count to show.
-// Bucket VALUES ('active') are the data model; labels are display-only.
+// Jobs); Jobs holds the six pipeline buckets — Saved, the four in-progress
+// stages, and Archive — as first-class sub-items (matched by `bucket`). The
+// Search plan sub-items are real sub-pages (matched by `section`). `countKey`
+// says which count to show. Keep in sync with the mobile drawer in app.js.
 const ROUTES = [
   { href: '/ladder/jobs/recommended/', label: 'Inbox', icon: 'inbox',
     match: /^\/ladder\/jobs\/recommended\/?/, countKey: 'recommended' },
@@ -51,9 +34,12 @@ const ROUTES = [
     icon: 'jobs',
     match: /^\/ladder\/jobs(?!\/recommended)\/?/,
     sub: [
-      { href: '/ladder/jobs/?bucket=leads',     label: 'Saved',       bucket: 'leads',   countKey: 'leads' },
-      { href: '/ladder/jobs/?bucket=active',    label: 'In progress', bucket: 'active',  countKey: 'active' },
-      { href: '/ladder/jobs/?bucket=archive',   label: 'Archive',     bucket: 'archive' },
+      { href: '/ladder/jobs/?bucket=saved',        label: 'Saved',        bucket: 'saved',        countKey: 'saved' },
+      { href: '/ladder/jobs/?bucket=drafting',     label: 'Drafting',     bucket: 'drafting',     countKey: 'drafting' },
+      { href: '/ladder/jobs/?bucket=applied',      label: 'Applied',      bucket: 'applied',      countKey: 'applied' },
+      { href: '/ladder/jobs/?bucket=interviewing', label: 'Interviewing', bucket: 'interviewing', countKey: 'interviewing' },
+      { href: '/ladder/jobs/?bucket=offer',        label: 'Offer',        bucket: 'offer',        countKey: 'offer' },
+      { href: '/ladder/jobs/?bucket=archive',      label: 'Archive',      bucket: 'archive',      countKey: 'archive' },
     ],
   },
   { href: '/ladder/history/',  label: 'Profile',     icon: 'profile',  match: /^\/ladder\/history\/?/ },
@@ -81,14 +67,14 @@ export class JobRail extends LitElement {
   static properties = {
     path:   { state: true },
     bucket: { state: true },
-    counts: { state: true },        // { leads, active, recommended } or null
+    counts: { state: true },        // { saved, drafting, applied, interviewing, offer, archive, recommended } or null
     email:  { state: true },
   };
 
   constructor() {
     super();
     this.path = location.pathname;
-    this.bucket = new URLSearchParams(location.search).get('bucket') || 'leads';
+    this.bucket = normalizeBucket(new URLSearchParams(location.search).get('bucket')) || 'saved';
     this.sectionParam = new URLSearchParams(location.search).get('section') || null;
     this.counts = null;
     this.email = window.CtrlAuth?.getUser?.()?.email || '';
@@ -137,14 +123,16 @@ export class JobRail extends LitElement {
         fetchRecommendations({ view: 'all', floor: true, limit: 1 }).catch(() => null),
       ]);
       const roles = (pipe?.roles || []).filter(isVisibleRole);
-      const leads  = roles.filter(r => bucketFor(r) === 'leads').length;
-      const active = roles.filter(r => bucketFor(r) === 'active').length;
+      // One count per bucket (Saved · 4 stages · Archive), derived from the
+      // shared bucketFor so the rail never drifts from the list.
+      const counts = Object.fromEntries(BUCKETS.map(b => [b, 0]));
+      for (const r of roles) counts[bucketFor(r)]++;
       // `total` is the true count of all matching recs; `count` is only the
       // returned page size (caps at the server's page limit, e.g. 100).
-      const recommended = recs?.total ?? recs?.count ?? (recs?.recommendations?.length ?? 0);
-      this.counts = { leads, active, recommended };
-      // Broadcast so other mobile chrome (the drawer + segmented .subnav-bar
-      // in app.js) can pull the same counts without re-fetching.
+      counts.recommended = recs?.total ?? recs?.count ?? (recs?.recommendations?.length ?? 0);
+      this.counts = counts;
+      // Broadcast so the mobile drawer in app.js can pull the same counts
+      // without re-fetching.
       document.dispatchEvent(new CustomEvent('job:rail:counts', { detail: this.counts }));
     } finally {
       this._loading = false;

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -5,6 +5,56 @@ const ADD_ROLE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/add-
 const REC_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recommendations';
 const PULL_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations';
 
+// ----- Pipeline bucket taxonomy (single source of truth) -------------------
+// The DB stores status (Saved/Active/Archive) + stage (drafting/applied/
+// interviewing/offer). The UI derives SIX first-class buckets from those:
+// Saved, the four in-progress stages, and Archive. bucketFor() is the one
+// mapping — imported by the rail, the jobs list, and the mobile home so the
+// three never drift (they each used to carry their own copy).
+export const STAGES = [
+  { id: 'drafting',     label: 'Drafting' },
+  { id: 'applied',      label: 'Applied' },
+  { id: 'interviewing', label: 'Interviewing' },
+  { id: 'offer',        label: 'Offer' },
+];
+export const STAGE_IDS = STAGES.map(s => s.id);
+export const BUCKETS = ['saved', ...STAGE_IDS, 'archive'];
+export const BUCKET_LABELS = {
+  saved: 'Saved',
+  drafting: 'Drafting', applied: 'Applied', interviewing: 'Interviewing', offer: 'Offer',
+  archive: 'Archive',
+};
+
+// status + stage → bucket. An Active row always resolves to a stage bucket;
+// a missing/unknown stage falls back to 'drafting' (the pipeline entry point),
+// matching the backend default so no Active row is ever bucket-less.
+export function bucketFor(r) {
+  if (r?.status === 'Archive') return 'archive';
+  if (r?.status === 'Active')  return STAGE_IDS.includes(r.stage) ? r.stage : 'drafting';
+  return 'saved';
+}
+
+// Normalize a raw ?bucket= value, translating legacy names (leads→saved,
+// active→drafting) so old links/bookmarks keep working. Returns null when
+// the value isn't recognizable so callers can apply their own default.
+export function normalizeBucket(raw) {
+  if (!raw) return null;
+  if (BUCKETS.includes(raw)) return raw;
+  if (raw === 'leads')  return 'saved';
+  if (raw === 'active') return 'drafting';
+  return null;
+}
+
+// Shared visibility filter — drops rows without a URL and Strava postings.
+// (Was duplicated in the rail and the jobs list.)
+export function isVisibleRole(r) {
+  if (!r?.url) return false;
+  const company = (r.company || '').toLowerCase();
+  if (company === 'strava') return false;
+  if (/(^|\.)strava\.com\b/i.test(r.url)) return false;
+  return true;
+}
+
 // Soft client-side rate limit so first-load auto-fire doesn't hammer the
 // endpoint when the user tab-hops. Server-side gating is the source of
 // truth (user_sources.schedule_cron vs last_run_at).

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.27.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.28.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.27.0">
-  <script src="/ladder/js/theme.js?v=2.27.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.28.0">
+  <script src="/ladder/js/theme.js?v=2.28.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.27.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.28.0"></script>
 </body>
 </html>

--- a/supabase/functions/jobs-pipe/index.ts
+++ b/supabase/functions/jobs-pipe/index.ts
@@ -19,8 +19,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.15.1';
-console.log(`[jobs-pipe] v${VERSION} - fit.ts: optional watchedCompany flag suppresses the public/mega-cap hard fail for watched-company roles`);
+const VERSION = '0.16.0';
+console.log(`[jobs-pipe] v${VERSION} - every Active row carries a stage (default 'drafting'); stage-less Active writes no longer wipe the stage`);
 
 const STATUS_ENUM = new Set(['Saved', 'Active', 'Archive']);
 const STAGE_ENUM  = new Set(['drafting', 'applied', 'interviewing', 'offer']);
@@ -212,10 +212,11 @@ serve(async (req) => {
       }
 
       // Read current row so we can apply the auto-promote / exit-reason rules.
-      const cur = await sql<{ status: string | null }[]>`
-        select status from job.pipeline_roles where slug = ${slug} limit 1`;
+      const cur = await sql<{ status: string | null; stage: string | null }[]>`
+        select status, stage from job.pipeline_roles where slug = ${slug} limit 1`;
       if (!cur[0]) return err('role not found', 404);
       const currentStatus = cur[0].status || 'Saved';
+      const currentStage  = cur[0].stage || null;
 
       // Auto-promotion rule: any non-null stage implies Active. Caller
       // may pass stage='applied' alone (no status) on a Saved row;
@@ -230,8 +231,14 @@ serve(async (req) => {
         return err('exit_reason required when archiving', 400);
       }
 
-      // Stage only valid on Active rows. Saved/Archive carry stage=null.
-      const finalStage = finalStatus === 'Active' ? (stage ?? null) : null;
+      // Stage only valid on Active rows (Saved/Archive carry stage=null), and
+      // every Active row MUST have a stage — the four stages are first-class
+      // bucket pages now, so a stage-less Active row would have no home.
+      // Default to 'drafting' (the pipeline entry point). Writes that don't
+      // touch stage preserve the current one rather than wiping it.
+      const finalStage = finalStatus === 'Active'
+        ? (hasStage ? (stage ?? 'drafting') : (currentStage ?? 'drafting'))
+        : null;
 
       // exit_reason cleared when not Archive.
       const finalExitReason = finalStatus === 'Archive'

--- a/supabase/migrations/102_pipeline_stage_backfill.sql
+++ b/supabase/migrations/102_pipeline_stage_backfill.sql
@@ -1,0 +1,15 @@
+-- 102_pipeline_stage_backfill.sql
+-- The four in-progress stages (Drafting / Applied / Interviewing / Offer) are
+-- now first-class bucket pages in the Ladder pipeline nav, derived from
+-- job.pipeline_roles.stage on Active rows. Any Active row without a stage would
+-- have no bucket to live in, so give every stage-less Active row the pipeline
+-- entry point, 'drafting'. Idempotent — safe to re-run.
+--
+-- Going forward the jobs-pipe edge function (v0.16.0+) guarantees every Active
+-- row gets a stage on write; this backfills the rows that predate that rule.
+
+update job.pipeline_roles
+   set stage = 'drafting',
+       updated_at = now()
+ where status = 'Active'
+   and stage is null;


### PR DESCRIPTION
## What
The pipeline's three buckets (**Saved · In progress · Archive**) become **six** — **Saved · Drafting · Applied · Interviewing · Offer · Archive** — all at the same hierarchy level, nested under **Jobs** in the primary navigation (desktop rail + mobile drawer). The in-page segmented sub-nav bar is gone. The row **"Move to"** menu now lists all six buckets in one flat group.

## Why it's low-risk
No schema change. The four stages **already existed** as a `stage` sub-field of `status='Active'` (backend `STAGE_ENUM`, CSS stage pills, even filter tabs). This PR promotes them from a secondary filter to first-class bucket pages — the six buckets are **derived** from `status` + `stage` by one shared `bucketFor()`.

## Changes
- **Shared taxonomy** (`ladder/js/pipeline.js`): `STAGES / BUCKETS / BUCKET_LABELS / bucketFor / normalizeBucket / isVisibleRole` now live in one place; rail, jobs list, and mobile home import them (removes the 3-way `bucketFor` copy-paste).
- **Routing** (`ladder-pipeline.js`): `?bucket=<saved|drafting|applied|interviewing|offer|archive>`, default `saved`. Legacy `leads`→`saved`, `active`→`drafting`, and `?bucket=active&stage=X`→`X` (param dropped via `replaceState`). Removed the stage filter tabs + `?stage=`.
- **"Move to" menu**: one flat group of six. A stage promotes the row to `Active`+stage (server auto-promote), Saved clears the stage, Archive opens the existing exit-reason modal.
- **Primary nav** (`ladder-rail.js`): Jobs `sub` expands to six with per-bucket counts; `_loadCounts` computes six counts from the shared helper.
- **Mobile** (`app.js`): the six buckets render nested under Jobs in the drawer; `injectSubnavBar` (segmented bar) removed. New `.nav-drawer__sublist/subitem` CSS; dead `.stage-tabs` CSS removed.
- **Home** (`ladder-home.js`): uses the shared helper; "in progress" summary = sum of the four stage buckets.
- **Backend** (`jobs-pipe` v0.16.0): every Active row carries a stage (default `drafting`); stage-less Active writes now **preserve** the existing stage instead of wiping it (latent bug fix). **Migration 102** backfills `stage='drafting'` on stage-less Active rows.
- Docs: `DESIGN.md` naming table updated. Ladder cache-busters bumped to **v2.28.0**.

## Deploy (after merge)
- `supabase functions deploy jobs-pipe`
- Run migration `102_pipeline_stage_backfill.sql`

## Out of scope (flagged)
- `check-liveness` still uses legacy status names — untouched, follow-up.
- Role-detail shows status read-only (no Move-to control there today) — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)