### PR TITLE
docs(ladder): Easy Apply plan v2 — Phase 16 breakdown + PRD restructure

### DIFF
--- a/docs/execution/project-plan/index.md
+++ b/docs/execution/project-plan/index.md
@@ -33,6 +33,7 @@
 | [Phase 13: Boards React Rewrite](./phase-13-react-rewrite.md) | Pending | 0/272 |
 | [Phase 14: Gmail → Jobs Pipe](./phase-14-gmail-jobs-pipe.md) | IN PROGRESS | 0/73 |
 | [Phase 15: Gmail Application Tracker](./phase-15-gmail-application-tracker.md) | IN PROGRESS | 23/25 |
+| [Phase 16: Ladder Easy Apply](./phase-16-easy-apply.md) | Pending | 0/40 |
 | [Backlog](./backlog.md) | Future | 1/118 |
 
 ---

--- a/docs/execution/project-plan/phase-16-easy-apply.md
+++ b/docs/execution/project-plan/phase-16-easy-apply.md
@@ -1,0 +1,131 @@
+# Phase 16: Ladder Easy Apply
+
+> Back to [Project Plan](./index.md)
+>
+> **Reference**: [PRD: Ladder Easy Apply](/docs/strategy/prds/ladder-easy-apply.md) (audit of live Saved/Drafting forms, 2026-07-13)
+>
+> **Vision**: Ladder knows which saved jobs are 2-minute submits and which are essay sessions — and for the easy ones, it fills the entire form from what it already knows about the user and submits with one reviewed click.
+
+---
+
+## Goal
+
+**16.1 (Flag):** every Saved/Drafting role carries a simple, direct Easy Apply badge — no new flows, just truth in the table.
+**16.2 (Feature):** an Easy Apply feature with its own feature-level onboarding that captures Tier 1/2/3 answers (prefilled from data already on record, resume upload as fallback), prefills the whole form, and submits via API where possible and an automated-browser path where not.
+
+## Success Criteria
+
+- [ ] ≥85% of Saved/Drafting roles carry a non-`unknown` `apply_ease` tier (requires LinkedIn URL resolution)
+- [ ] `⚡ Easy apply` badge renders in Saved + Drafting tables within one nightly sweep of a role being saved
+- [ ] Onboarding: a user with existing Ladder data (Job History, Narratives, base resume) confirms — not types — ≥70% of Tier 1/2 answers
+- [ ] An `easy`-tier Greenhouse/Lever role goes from Saved → Applied in under 2 minutes with zero free typing
+- [ ] Every submission stores a full answer snapshot in `job.application_draft` and emits an application event
+- [ ] Zero CAPTCHA bypasses; zero submissions without an explicit user confirm
+
+## Decisions locked (per PRD)
+
+1. Easy = no required long-form free-response, no video/portfolio, no email-apply. Tiers: `easy | short_answer | essay | special | portal | unknown`.
+2. Demographics (Tier 3) answered only from explicit user-set defaults; global default is decline-to-self-identify.
+3. Legal/consent checkboxes (arbitration, privacy) always require an explicit per-application tap.
+4. Review-then-submit in v1 — no silent submissions. Batch submit deferred.
+5. Postings that ask candidates not to use AI (e.g. Splitwise) are tiered `special` and excluded permanently.
+6. LinkedIn native Easy Apply not automated (none in the current bucket; ToS-hostile).
+
+---
+
+## Phase 16.1 — Flag: the Easy Apply badge
+
+Simple and direct: classify every role's application form, show one chip.
+
+### Epic 16.1-A: Classification backend
+
+**Story: apply-ease schema**
+- [ ] Migration: `pipeline_roles` + `recommended_roles` gain `apply_ease text`, `apply_ease_meta jsonb`, `apply_ease_checked_at timestamptz`, `canonical_apply_url text`
+- [ ] `apply_ease_meta` shape: `{ats, questions, required_essays, short_answers, requires_cover_letter, video, email_apply, source_url}`
+
+**Story: classifier**
+- [ ] Pure tier function over `extract-application-fields` output (required `long_text` → essay; video/portfolio/email → special; non-whitelisted required `short_text` → short_answer; else easy)
+- [ ] Unit-test against the 21 audited forms as fixtures (OpenAI/Airbnb/Speak → easy, Mindbody ×2 → short_answer, Midi/Galileo/Kiddom → essay, Solace/Splitwise → special)
+- [ ] `extract-application-fields` version bump; classification returned alongside the schema
+
+**Story: sweep + on-save**
+- [ ] Nightly sweep (jobs-pipe action or dedicated cron): Saved + Drafting roles where `apply_ease_checked_at` is null or >14d, call extraction, store tier
+- [ ] Fire-and-forget classify when a role enters Saved from the frontend
+- [ ] Per-run cap + backoff so one sweep can't hammer an ATS
+
+**Story: LinkedIn → ATS resolution**
+- [ ] For `linkedin.com/jobs/view/*` URLs, resolve offsite `companyApplyUrl` (guest endpoint first, Haiku-over-careers-page fallback, same pattern as `enrich-job-source`)
+- [ ] Store in `canonical_apply_url`; classify the resolved URL
+- [ ] Closed-on-LinkedIn detection while we're there (audit found Symbium dead but `is_live=true`)
+
+**Story: liveness fix (piggyback)**
+- [ ] Greenhouse `302 → board root` counted as closed, not alive (audit: Anthropic + Garner false-alive)
+
+### Epic 16.1-B: Badge UI
+
+- [ ] Chip in Saved/Drafting table rows: `⚡ Easy apply` / `✍️ Short answers` / `📝 Essays` / `🎥 Video` / `✉️ Email` — no chip when `unknown`
+- [ ] Tooltip renders `apply_ease_meta` (ATS, #questions, cover letter y/n)
+- [ ] "Easy apply" quick-filter pill on the Saved page
+- [ ] Role detail: "Application requirements" card (auto-fillable ✅ vs needs-your-words ✍️, estimated effort)
+- [ ] Updates queue digest row when a sweep finds new easy applies ("⚡ 3 saved jobs are easy applies — ~2 min each"), click → filtered Saved table; Dismiss supported
+- [ ] Ladder version bump + `design-system/README.md` entry for the chip variants
+
+---
+
+## Phase 16.2 — Feature: Easy Apply with onboarding, prefill, submission
+
+### Epic 16.2-A: Answer bank + prefill backend
+
+**Story: answer bank schema**
+- [ ] Migration: `job.application_answers` (`user_id`, `canonical_key`, `value jsonb`, `source text` — `onboarding | resume_extract | derived | writeback`, `updated_at`), RLS to owner
+- [ ] Canonical key registry (Tier 1/2/3 from the PRD appendix): identity/contact, work-auth pair, links, onsite-by-metro rules, comp expectation + phrasing policy, years-of-experience facts, how-heard default, start date, EEOC set, rare-question defaults (family relationship, non-compete, procurement, SMS consent)
+
+**Story: prefill from data already on record**
+- [ ] Seeding service: profile/settings → contact; Job History → years-of-PM / years-managing / domain-experience derivations + prior-employer flags; Narratives + base resume → LinkedIn/links; `global_assets` → default resume file; `company_connections` → referral prompts at apply time
+- [ ] Seeded answers marked `source='derived'` and shown as "confirm" not "type" in onboarding
+
+**Story: resume upload as secondary prefill**
+- [ ] If Tier 1/2 coverage after seeding is below threshold, onboarding offers resume upload ("or upload a resume and I'll fill most of this")
+- [ ] Reuse `pdf-extract` + Haiku to extract name, contact, location, links, employers, dates → seed bank as `source='resume_extract'` for user confirmation
+- [ ] Uploaded file becomes the default application resume in `global_assets` if none exists
+
+**Story: question matcher**
+- [ ] Edge function: map a form's `custom_questions` → canonical keys (heuristics for the ~6 sponsorship phrasings; Haiku for the tail; cache matches per question hash)
+- [ ] Coverage calculator: % of required fields answerable from the bank → drives "Ready to submit" state
+
+### Epic 16.2-B: Feature-level onboarding flow
+
+Triggered on first Easy Apply use (badge click / "Set up Easy Apply" card) — not part of account onboarding.
+
+- [ ] Step 1 — confirm what we know: prefilled Tier 1 card (contact, work auth, links) rendered from seeded answers; edit-in-place; Apt-style conversational framing
+- [ ] Step 2 — Tier 2 quick pass: onsite-metros + max days/week, comp number + phrasing policy, start date/notice, how-heard default (~90s)
+- [ ] Step 3 — Tier 3 consent card: saved demographic answers vs decline-everywhere (default decline); shown once, editable in Settings
+- [ ] Step 4 — policies: cover letter (never / when required / auto-generate), review mode (always review in v1), daily cap
+- [ ] Resume-upload branch when seeding coverage is low (see 16.2-A)
+- [ ] Settings → "Easy Apply" section mirroring the whole bank; every Apply-wizard answer writes back (`source='writeback'`)
+- [ ] "Ready to submit" chip state (filled ⚡) when a role's form is 100% covered; Updates queue row upgrades to "Ready to submit — review"
+
+### Epic 16.2-C (subphase): API submissions — Greenhouse & Lever
+
+- [ ] `submit-application` edge function: multipart form-POST to the ATS public application endpoint; resume streamed from `global_assets`/`role_assets`; EEOC answers mapped to ATS field ids
+- [ ] Review screen: every field + answer + consent checkboxes itemized; explicit Submit tap; no Undo after submit (copy says so)
+- [ ] Post-submit: stage → applied, application event logged, full snapshot into `application_draft`, confirmation email watched by the existing Gmail tracker
+- [ ] Guardrails: liveness + posting-age check at submit time; per-day cap; failure → wizard fallback with fields still prefilled
+- [ ] Start Greenhouse-only behind a flag; add Lever after N clean submissions
+
+### Epic 16.2-D (subphase): Headless-browser path — Ashby & the long tail
+
+- [ ] Headless worker (Playwright) that loads the apply page, fills from the answer bank, uploads resume — for ATSes without a form-POST path
+- [ ] CAPTCHA handoff: worker fills everything, then hands the user a live session/prefilled page to complete the CAPTCHA and tap Submit themselves (Ashby ships reCAPTCHA — never bypassed, by decision #6 → decision 3/4 above)
+- [ ] Degraded "assisted apply" mode when headless is blocked: deep-link + copy-paste panel of prepared answers next to the form
+- [ ] Same review screen, guardrails, event logging, and snapshot as 16.2-C
+- [ ] Selector drift detection: form-fill mismatch aborts before submit and falls back to assisted mode
+
+---
+
+## Out of Scope — deferred
+
+- Batch submit ("apply to all ready") — revisit after 2 weeks of clean single submissions
+- For You (pre-save) classification — lazily, floor-1 only, after 16.1 proves out
+- LinkedIn native Easy Apply automation
+- Auto-submitted essays (essay-tier keeps the wizard + `generate-question-answer` assist)

--- a/docs/strategy/prds/ladder-easy-apply.md
+++ b/docs/strategy/prds/ladder-easy-apply.md
@@ -68,6 +68,11 @@ prerequisite work is URL enrichment for LinkedIn saves, not just form parsing.
 
 ## Plan
 
+> Task-level breakdown: [Phase 16 — Ladder Easy Apply](/docs/execution/project-plan/phase-16-easy-apply.md).
+> Two phases: **flag** (badge only), then **enable** (the Easy Apply feature: feature-level
+> onboarding for Tier 1/2/3 answers, prefill from data on record with resume-upload fallback,
+> and two submission subphases — API and headless browser).
+
 ### Phase 1 — Flag (ship first)
 
 **Backend**
@@ -103,38 +108,63 @@ prerequisite work is URL enrichment for LinkedIn saves, not just form parsing.
    "⚡ 3 saved jobs are easy applies (Airbnb, OpenAI, Speak) — ~2 min each" → click filters
    the Saved table. Follows the existing one-action-per-row pattern; Dismiss supported.
 
-### Phase 2 — Capture & auto-answer
+### Phase 2 — Enable: the Easy Apply feature
 
-1. `job.application_answers` — user answer bank keyed by canonical question
-   (`work_auth`, `sponsorship`, `location`, `comp_expectation`, `start_date`, `pronouns`,
-   `veteran_status`, `disability`, `gender`, `race`, `hear_about_us`, `referral`, plus
-   fuzzy-matched frees). Seeded from Settings → new "Application defaults" section; every
-   answer given in the Apply wizard is written back to the bank.
-2. Question matcher: Haiku maps a form's questions onto the bank (the forms in the audit
-   are ~90% covered by ~15 canonical questions). Unmatched required questions are the only
-   thing the wizard asks the user.
-3. New state: a Saved role whose form is 100% covered becomes **"Ready to submit"** — stronger
-   chip (filled ⚡), and the Updates queue row upgrades to "Ready to submit — review".
-4. EEOC handling: demographics are answered only from explicit user-set defaults, never
-   inferred. "Decline to self-identify" is the fallback.
+One feature, four subphases: answer bank + prefill (2a), feature-level onboarding (2b),
+then submission — API path (2c) and headless-browser path (2d).
 
-### Phase 3 — Auto-apply (assisted submit)
+**2a — Answer bank + prefill from data on record**
+1. `job.application_answers` — user answer bank keyed by canonical question, covering the
+   PRD appendix Tiers 1–3 (`work_auth`, `sponsorship`, `location`, onsite-by-metro rules,
+   `comp_expectation` + phrasing policy, years-of-experience facts, `start_date`,
+   `hear_about_us`, EEOC set, rare-question defaults). Each answer carries a `source`
+   (`onboarding | resume_extract | derived | writeback`).
+2. **Prefill first, ask second**: seed the bank from what Ladder already knows — profile
+   contact info, Job History (years-of-PM / years-managing / domain experience / prior
+   employers), Narratives + base resume (links), `global_assets` (default resume file),
+   `company_connections` (referral prompts at apply time). Seeded answers render as
+   *confirm* cards, not blank inputs.
+3. **Resume upload as secondary prefill**: when seeding coverage is low (new or thin
+   profile), onboarding offers a resume upload — `pdf-extract` + Haiku extract contact,
+   location, links, employers → seed Tier 1/2 for confirmation. The upload also becomes the
+   default application resume if none exists.
+4. Question matcher: Haiku + heuristics map a form's questions onto the bank (the audited
+   forms are ~90% covered by ~15 canonical questions; sponsorship alone appears in 6
+   phrasings). Unmatched required questions are the only thing the wizard asks.
 
-1. **Review-then-submit, never silent**: user clicks "Submit" on a fully-prefilled review
-   screen (per-role, or batch "submit all ready"). Post-submit lands in Applied with an
-   application event; Undo is not possible after submission, so the confirm is explicit.
-2. Transport per ATS:
-   - **Greenhouse / Lever**: direct form POST to the public application endpoint from an edge
-     function (multipart with resume from `role_assets` / `global_assets`). Most reliable.
-   - **Ashby**: has reCAPTCHA (`recaptchaPublicSiteKey` in appData) → cannot and should not be
-     submitted headlessly. Route through a browser-assisted flow where the user completes the
-     CAPTCHA; everything else is prefilled.
-   - **Portal/special**: never automated. Splitwise-style "please don't use AI" postings are
-     respected: flagged `special`, excluded, with the reason shown in the detail card.
-3. Legal/consent checkboxes (arbitration agreements, privacy policies — seen at OpenAI,
-   Airbnb) always require an explicit user tap, itemized on the review screen.
-4. Rate/quality guardrails: per-day submit cap; posting-age check + liveness check at submit
-   time; every submission stores a snapshot of answers into `application_draft` for the record.
+**2b — Feature-level onboarding flow**
+Triggered on first Easy Apply use (not account onboarding), Apt-style conversational pass:
+1. Confirm-what-we-know card (Tier 1, prefilled from 2a) → 2. Tier 2 quick pass (onsite
+   metros + max days/week, comp, start date, how-heard default) → 3. Tier 3 consent card
+   (saved demographic answers vs decline-everywhere; default decline; never inferred) →
+   4. Policies (cover letter: never / when required / auto-generate; review mode; daily cap).
+   Resume-upload branch per 2a-3. Total target: ~3 minutes.
+2. Settings → "Easy Apply" section mirrors the full bank; every Apply-wizard answer writes
+   back, so coverage converges after the first 2–3 applications.
+3. New state: a role whose form is 100% covered becomes **"Ready to submit"** — filled ⚡
+   chip, Updates queue row upgrades to "Ready to submit — review".
+
+**2c — Subphase: API submissions (Greenhouse, Lever)**
+1. `submit-application` edge function: multipart form-POST to the ATS public application
+   endpoint, resume streamed from `global_assets`/`role_assets`, EEOC mapped to ATS field ids.
+2. **Review-then-submit, never silent**: fully-itemized review screen (every field, every
+   consent checkbox); explicit Submit tap; no Undo after submission, and the copy says so.
+3. Post-submit: stage → applied, application event, full snapshot into `application_draft`;
+   the Gmail tracker picks up the confirmation email as corroboration.
+4. Guardrails: liveness + posting-age check at submit time, per-day cap, failure falls back
+   to the wizard with fields still prefilled. Greenhouse first behind a flag; Lever after
+   N clean submissions.
+
+**2d — Subphase: headless-browser path (Ashby + long tail)**
+1. Headless worker (Playwright) loads the apply page, fills from the answer bank, uploads
+   the resume — for ATSes with no form-POST path.
+2. **CAPTCHA handoff, never bypass**: Ashby ships reCAPTCHA — the worker fills everything,
+   then hands the user a live/prefilled page to complete the CAPTCHA and tap Submit.
+3. Degraded "assisted apply" mode when headless is blocked: deep link + a prepared-answers
+   panel beside the form. Selector-drift detection aborts before submit, falls back to assisted.
+4. Same review screen, guardrails, event logging, and snapshot as 2c.
+5. **Portal/special**: never automated. Splitwise-style "please don't use AI" postings are
+   respected: flagged `special`, excluded, with the reason shown in the detail card.
 
 ### Out of scope
 - LinkedIn native Easy Apply automation (none present in the current bucket; ToS-hostile).
@@ -151,7 +181,50 @@ prerequisite work is URL enrichment for LinkedIn saves, not just form parsing.
 ## Open questions (1:3:1 resolved in review)
 1. Should For You (recommended_roles) also get the chip pre-save? Cost: extraction call per
    recommendation. Proposal: classify lazily — only floor-1 recommendations, nightly.
-2. Batch submit ("apply to all 5 ready") in Phase 3 v1, or per-role only? Proposal: per-role
+2. Batch submit ("apply to all 5 ready") in 2c v1, or per-role only? Proposal: per-role
    first; batch after 2 weeks of clean submissions.
-3. Where does the answer bank live in Settings vs. onboarding chat? Proposal: Settings section
-   now; onboarding-chat capture later.
+
+**Decided 2026-07-13:** answer capture is a feature-level onboarding flow (first Easy Apply
+use) with a Settings mirror — not account onboarding, not Settings-only. Resume upload is the
+secondary prefill path when existing data gives low coverage.
+
+---
+
+## Appendix — Onboarding capture set (from the form audit)
+
+Ordered by form coverage; onboarding asks Tiers 1–3, Tier 4 defaults + write-back, Tier 5 is policy.
+
+**Tier 1 — on nearly every form (must capture)**
+| Key | Question | Format |
+|---|---|---|
+| `legal_name` / `preferred_name` | Legal name as on ID; preferred name | text |
+| `email` / `phone` | Contact | text |
+| `location` | Current city / state / country | structured |
+| `work_auth_us` | Authorized to work in the US? | y/n — ~90% of forms |
+| `sponsorship` | Require sponsorship now or in future? | y/n — most common custom question, 6+ phrasings |
+| `linkedin_url` | LinkedIn profile | url — ~70% of forms |
+| `resume_default` | Default resume file | file (exists in `global_assets`) |
+
+**Tier 2 — on 20–50% of forms**
+| Key | Question | Format |
+|---|---|---|
+| `onsite_rules` | Metros you're in/near + max in-office days/week | rules — answers every "can you work from X n days?" gate |
+| `comp_expectation` | Number + phrasing policy (range / floor / flexible) | number+policy |
+| `experience_years` | Years: PM total, managing PMs, 0→1, consumer, enterprise, growth | numbers — also feeds 1–5 self-rating scales |
+| `hear_about_us` | Default source answer | select policy |
+| `start_date` | Start date / notice period | text |
+
+**Tier 3 — EEOC/demographics (one consent card, never inferred)**
+`gender`, `race_ethnicity`, `veteran_status`, `disability`; Lever adds `pronouns`,
+`transgender`, `sexual_orientation`, `age`. One question: use saved answers everywhere, or
+decline-to-self-identify everywhere (default: decline).
+
+**Tier 4 — rare/conditional (defaults + write-back, never asked up front)**
+family-financial-relationship (No), non-compete/obligations (No), prior-employee (derive from
+Job History), state-procurement (No), SMS consent (standing pref), referral (per-role prompt
+from `company_connections`).
+
+**Tier 5 — automation policy**
+cover-letter policy (never / when required / auto-generate), review mode (always review in v1),
+daily submit cap, excluded companies (`blocked_companies`), standing note that legal acks are
+always per-application taps.


### PR DESCRIPTION
Restructures the Easy Apply plan per review:

- **Phase 1 — Flag**: unchanged; simple Easy Apply badge + classification sweep.
- **Phase 2 — Enable**: the Easy Apply feature with feature-level onboarding (Tier 1/2/3 capture), prefill from data already on record (Job History, Narratives, global_assets, company_connections), resume upload as secondary prefill, and two submission subphases: **2c API form-POST (Greenhouse/Lever)** and **2d headless browser with CAPTCHA handoff (Ashby + long tail)**.
- New task-level breakdown: docs/execution/project-plan/phase-16-easy-apply.md (added to plan index).
- PRD gains the onboarding capture-set appendix (Tiers 1–5) and locks the answer-capture-location decision.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)