### PR TITLE
feat(ladder): Easy Apply answer bank + prefill backend — Phase 16.2a

### DIFF
--- a/supabase/functions/_shared/answer-bank.ts
+++ b/supabase/functions/_shared/answer-bank.ts
@@ -1,0 +1,164 @@
+// _shared/answer-bank.ts — canonical application-answer registry (Phase 16.2a).
+//
+// One key per question employers actually ask (derived from the 2026-07-13
+// form audit: ~15 canonical questions cover ~90% of forms). The matcher maps
+// a form's extracted fields onto these keys with regex heuristics; the
+// coverage calculator says how much of a form the saved bank can fill.
+
+import type { Schema, CustomQ, GenField } from './apply-extract.ts';
+
+export type CanonicalKey = string;
+
+export type CanonicalQuestion = {
+  key: CanonicalKey;
+  tier: 1 | 2 | 3 | 4;
+  label: string;                 // human label for Settings / onboarding
+  hint?: string;                 // onboarding helper copy
+  kind: 'text' | 'boolean' | 'number' | 'select' | 'json';
+  match: RegExp[];               // prompt heuristics
+  mapsTo?: string[];             // apply-extract general.maps_to values this key fills
+};
+
+export const CANONICAL_QUESTIONS: CanonicalQuestion[] = [
+  // ---- Tier 1 — on nearly every form ----
+  { key: 'legal_name',     tier: 1, label: 'Legal name',      kind: 'text',
+    match: [/legal name|full name|^name$/i], mapsTo: ['full_name', 'first_name', 'last_name'] },
+  { key: 'preferred_name', tier: 1, label: 'Preferred name',  kind: 'text',
+    match: [/preferred (first )?name/i] },
+  { key: 'email',          tier: 1, label: 'Email',           kind: 'text',
+    match: [/^e-?mail/i], mapsTo: ['email'] },
+  { key: 'phone',          tier: 1, label: 'Phone',           kind: 'text',
+    match: [/phone|mobile|cell/i], mapsTo: ['phone'] },
+  { key: 'location',       tier: 1, label: 'Current location', kind: 'text',
+    match: [/where are you (currently )?(based|located)|current location|country of residence|current city|time ?zone|mailing address|full address/i],
+    mapsTo: ['location'] },
+  { key: 'work_auth',      tier: 1, label: 'Authorized to work in the US', kind: 'boolean',
+    match: [/authoriz(ed)?.*work|legally.*work|eligible to work|work authorization/i], mapsTo: ['work_auth'] },
+  { key: 'sponsorship',    tier: 1, label: 'Will require visa sponsorship', kind: 'boolean',
+    match: [/sponsor|visa|work permit/i], mapsTo: ['sponsorship'] },
+  { key: 'linkedin_url',   tier: 1, label: 'LinkedIn URL',    kind: 'text',
+    match: [/linkedin/i], mapsTo: ['linkedin'] },
+  { key: 'github_url',     tier: 1, label: 'GitHub URL',      kind: 'text',
+    match: [/github/i], mapsTo: ['github'] },
+  { key: 'portfolio_url',  tier: 1, label: 'Portfolio / website', kind: 'text',
+    match: [/portfolio|personal (web)?site|^website|other website/i], mapsTo: ['portfolio'] },
+  { key: 'pronouns',       tier: 1, label: 'Pronouns',        kind: 'text',
+    match: [/pronoun/i], mapsTo: ['pronouns'] },
+
+  // ---- Tier 2 — on 20–50% of forms ----
+  { key: 'onsite_willingness', tier: 2, label: 'Onsite / hybrid willingness',
+    hint: 'Metros you can work from and max days per week in office — answers every "can you work from X?" gate.',
+    kind: 'json',
+    match: [/office|onsite|on-?site|hybrid|days per week|in person|willing to (work|relocate|commute|go)|work from (our|the)/i] },
+  { key: 'comp_expectation', tier: 2, label: 'Compensation expectation',
+    hint: 'Number plus phrasing policy (range / floor / "flexible").',
+    kind: 'json',
+    match: [/salary|compensation|\bcomp\b|pay (expectation|range)|targeting/i] },
+  { key: 'years_experience_pm', tier: 2, label: 'Years of product experience', kind: 'number',
+    match: [/(how many )?years.*(product|as a pm|pm experience)|rate your.*(product|experience)|please rate/i] },
+  { key: 'years_experience_mgmt', tier: 2, label: 'Years managing PMs', kind: 'number',
+    match: [/years.*(managing|management|direct reports)|managing (at least )?\d* ?(product managers|pms)/i] },
+  { key: 'start_date',     tier: 2, label: 'Start date / notice period', kind: 'text',
+    match: [/start (date|a new role)|when can you start|notice period|availability/i] },
+  { key: 'hear_about',     tier: 2, label: '"How did you hear about us" default', kind: 'text',
+    match: [/how did you hear|hear about (this|the|us)/i] },
+
+  // ---- Tier 3 — EEOC / demographics (explicit consent; default decline) ----
+  { key: 'eeoc_gender',     tier: 3, label: 'Gender (EEOC)',     kind: 'text', match: [/^gender/i] },
+  { key: 'eeoc_race',       tier: 3, label: 'Race / ethnicity (EEOC)', kind: 'text', match: [/^race|ethnicit/i] },
+  { key: 'eeoc_veteran',    tier: 3, label: 'Veteran status (EEOC)',   kind: 'text', match: [/veteran/i] },
+  { key: 'eeoc_disability', tier: 3, label: 'Disability status (EEOC)', kind: 'text', match: [/disability/i] },
+  { key: 'eeoc_orientation',tier: 3, label: 'Sexual orientation (EEOC)', kind: 'text', match: [/sexual orientation|transgender/i] },
+
+  // ---- Tier 4 — rare/conditional; defaults, never asked up front ----
+  { key: 'prior_employee',  tier: 4, label: 'Previously employed by target company', kind: 'boolean',
+    match: [/currently employed by|(ever|previously) worked (at|for)|current or former.*(employee|worked)/i] },
+  { key: 'referral',        tier: 4, label: 'Referral name', kind: 'text',
+    match: [/referr(al|ed)|name the employee|who referred/i] },
+  { key: 'non_compete',     tier: 4, label: 'Non-compete / conflicting obligations', kind: 'boolean',
+    match: [/non-?compete|non-?solicit|obligations that would interfere|conflict of interest/i] },
+  { key: 'family_relationship', tier: 4, label: 'Family financial relationship with employer', kind: 'boolean',
+    match: [/immediate family|family members? (have|with).*(relationship|employ)/i] },
+  { key: 'gov_procurement', tier: 4, label: 'State procurement involvement', kind: 'boolean',
+    match: [/state agency.*procurement|procurement of goods/i] },
+  { key: 'sms_consent',     tier: 4, label: 'SMS consent', kind: 'boolean',
+    match: [/text messages|sms|message and data rates/i] },
+];
+
+const BY_KEY = new Map(CANONICAL_QUESTIONS.map(c => [c.key, c]));
+export function canonicalQuestion(key: CanonicalKey) { return BY_KEY.get(key); }
+
+// Legal/consent acknowledgements are never auto-answered from the bank —
+// they always get an explicit user tap on the review screen (decision #3).
+export const CONSENT_RE = /arbitration|privacy policy|acknowledge|i confirm|i certify|consent to the|terms/i;
+
+// prompt → canonical key (heuristics only; the Haiku tail runs server-side
+// for whatever this misses).
+export function matchPrompt(prompt: string): CanonicalKey | null {
+  const p = (prompt || '').trim();
+  if (!p) return null;
+  for (const c of CANONICAL_QUESTIONS) {
+    if (c.match.some(re => re.test(p))) return c.key;
+  }
+  return null;
+}
+
+export type QuestionMapping = {
+  id: string;
+  prompt: string;
+  required: boolean;
+  type: CustomQ['type'] | GenField['type'];
+  canonical_key: CanonicalKey | null;
+  consent: boolean;        // needs an explicit tap regardless of the bank
+  answered: boolean;       // bank has a value for the matched key
+};
+
+export type Coverage = {
+  total_required: number;
+  covered_required: number;
+  pct: number;             // 0–100 over required fields
+  ready: boolean;          // every required non-consent field covered
+  mappings: QuestionMapping[];
+  missing_keys: CanonicalKey[];      // matched but no saved answer
+  unmatched_required: string[];      // prompts we couldn't map at all
+};
+
+// How much of a form the saved bank can fill. `answers` is the set of
+// canonical keys that have a stored value.
+export function computeCoverage(schema: Schema, answeredKeys: Set<string>): Coverage {
+  const mappings: QuestionMapping[] = [];
+
+  for (const g of (schema.general || [])) {
+    const viaMapsTo = CANONICAL_QUESTIONS.find(c => g.maps_to && (c.mapsTo || []).includes(g.maps_to));
+    const key = viaMapsTo?.key ?? matchPrompt(g.label);
+    mappings.push({
+      id: g.id, prompt: g.label, required: !!g.required, type: g.type,
+      canonical_key: key, consent: false,
+      answered: !!(key && answeredKeys.has(key)),
+    });
+  }
+  for (const q of (schema.custom_questions || [])) {
+    const consent = CONSENT_RE.test(q.prompt || '') && (q.type === 'yes_no' || q.type === 'select' || q.type === 'multiselect');
+    const key = consent ? null : matchPrompt(q.prompt);
+    mappings.push({
+      id: q.id, prompt: q.prompt, required: !!q.required, type: q.type,
+      canonical_key: key, consent,
+      answered: !!(key && answeredKeys.has(key)),
+    });
+  }
+
+  const req = mappings.filter(m => m.required && !m.consent);
+  const covered = req.filter(m => m.answered);
+  const missingKeys = [...new Set(req.filter(m => m.canonical_key && !m.answered).map(m => m.canonical_key!))]
+  const unmatched = req.filter(m => !m.canonical_key).map(m => m.prompt);
+
+  return {
+    total_required: req.length,
+    covered_required: covered.length,
+    pct: req.length ? Math.round((covered.length / req.length) * 100) : 100,
+    ready: req.length > 0 ? covered.length === req.length : false,
+    mappings,
+    missing_keys: missingKeys,
+    unmatched_required: unmatched,
+  };
+}

--- a/supabase/functions/_shared/apply-ease.ts
+++ b/supabase/functions/_shared/apply-ease.ts
@@ -41,6 +41,7 @@ const SHORT_TEXT_WHITELIST: RegExp[] = [
   /current (company|employer|location|role|title)|where are you (currently )?(based|located)/i,
   /^\s*if (yes|no|you selected|applicable)/i,
   /currently employed by|worked (at|for)/i,
+  /please rate|rate your/i,     // 1–5 self-rating scales (Ashby Score fields)/i
   /country|state|city|time ?zone/i,
   /visa|sponsorship/i,
 ];

--- a/supabase/functions/application-answers/index.ts
+++ b/supabase/functions/application-answers/index.ts
@@ -1,0 +1,235 @@
+// application-answers — the Easy Apply answer bank (Phase 16.2a).
+// One row per (user_id, canonical_key) in job.application_answers.
+//
+//   POST { action: 'list' }                        → { answers: {key: {value, source, updated_at}} }
+//   POST { action: 'upsert', answers: [{key, value, source?}] }
+//                                                  → { saved: n }
+//   POST { action: 'delete', keys: [key…] }        → { deleted: n }
+//   POST { action: 'seed' }                        → derive answers from data
+//        already on record (career history tenure, vision comp floors +
+//        geographies, base-resume links, auth profile). Only fills keys with
+//        no existing row; returns { seeded: {key: value}, coverage_keys }.
+//   POST { action: 'coverage', slug }              → match the role's
+//        extracted form (job.application_draft.fields — extracts on the fly
+//        from the role URL when absent) against the bank → Coverage report.
+//        Unmatched required questions get one Haiku pass before reporting.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { verifyJobUserDetailed, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
+import { db } from '../_shared/job-db.ts';
+import { extractSchema, callClaude, type Schema } from '../_shared/apply-extract.ts';
+import { CANONICAL_QUESTIONS, computeCoverage, matchPrompt } from '../_shared/answer-bank.ts';
+
+const VERSION = '0.1.0';
+console.log(`[application-answers] v${VERSION} - Easy Apply answer bank (list/upsert/seed/coverage)`);
+
+const KEY_RE = /^[a-z0-9_]+$/;
+const SLUG_RE = /^[a-z0-9_-]+$/;
+const SOURCES = new Set(['onboarding', 'resume_extract', 'derived', 'writeback']);
+const VALID_KEYS = new Set(CANONICAL_QUESTIONS.map(c => c.key));
+
+type Sql = ReturnType<typeof db>;
+
+async function listAnswers(sql: Sql, userId: string) {
+  const rows = await sql`
+    select canonical_key, value, source, updated_at
+    from job.application_answers where user_id = ${userId};
+  `;
+  const answers: Record<string, unknown> = {};
+  for (const r of rows) answers[r.canonical_key] = { value: r.value, source: r.source, updated_at: r.updated_at };
+  return answers;
+}
+
+// ---- seed: prefill from what Ladder already knows -------------------------
+async function seed(sql: Sql, user: { id: string; email?: string; user_metadata?: Record<string, unknown> }) {
+  const existing = new Set((await sql`
+    select canonical_key from job.application_answers where user_id = ${user.id};
+  `).map((r: { canonical_key: string }) => r.canonical_key));
+
+  const seeded: Record<string, unknown> = {};
+  const put = (key: string, value: unknown) => {
+    if (value == null || value === '' || existing.has(key) || key in seeded) return;
+    seeded[key] = value;
+  };
+
+  // Auth profile → contact.
+  put('email', user.email);
+  const meta = user.user_metadata || {};
+  put('legal_name', (meta.full_name || meta.name) as string | undefined);
+
+  // Career history → years of experience + current employer/location.
+  try {
+    const hist = await sql`
+      select name, tenure_start, tenure_end, location from job.companies
+      where tenure_start is not null order by tenure_start asc;
+    `;
+    if (hist.length) {
+      let months = 0;
+      for (const h of hist) {
+        const start = new Date(h.tenure_start).getTime();
+        const end = h.tenure_end ? new Date(h.tenure_end).getTime() : Date.now();
+        if (end > start) months += (end - start) / (1000 * 3600 * 24 * 30.44);
+      }
+      put('years_experience_pm', Math.round(months / 12));
+      const current = hist.find((h: { tenure_end: string | null }) => !h.tenure_end);
+      if (current?.location) put('location', current.location);
+    }
+  } catch (e) { console.warn('[application-answers] seed history failed', (e as Error).message); }
+
+  // Vision → comp expectation + metro rules.
+  try {
+    const v = (await sql`select comp_floor_base, comp_floor_total, target_geographies from job.vision limit 1;`)[0];
+    if (v?.comp_floor_base || v?.comp_floor_total) {
+      put('comp_expectation', {
+        base_floor: v.comp_floor_base ?? null,
+        total_floor: v.comp_floor_total ?? null,
+        policy: 'floor',      // phrase answers as "looking for at least X" until the user edits
+      });
+    }
+    if (Array.isArray(v?.target_geographies) && v.target_geographies.length) {
+      put('onsite_willingness', { metros: v.target_geographies, max_days_per_week: null });
+    }
+  } catch (e) { console.warn('[application-answers] seed vision failed', (e as Error).message); }
+
+  // Base resume markdown → links.
+  try {
+    const g = (await sql`select content_md from job.global_assets where kind = 'resume' limit 1;`)[0];
+    const md = String(g?.content_md || '');
+    put('linkedin_url', md.match(/https?:\/\/(?:www\.)?linkedin\.com\/in\/[\w-]+/i)?.[0]);
+    put('github_url',   md.match(/https?:\/\/(?:www\.)?github\.com\/[\w-]+/i)?.[0]);
+    put('phone',        md.match(/(\+?1[\s.-]?)?\(?\d{3}\)?[\s.-]\d{3}[\s.-]\d{4}/)?.[0]?.trim());
+  } catch (e) { console.warn('[application-answers] seed resume failed', (e as Error).message); }
+
+  // Universal sane defaults for rare Tier-4 booleans (user can flip in
+  // Settings; these are the truthful answer for almost everyone).
+  put('prior_employee', false);
+  put('non_compete', false);
+  put('family_relationship', false);
+  put('gov_procurement', false);
+
+  const entries = Object.entries(seeded);
+  for (const [key, value] of entries) {
+    await sql`
+      insert into job.application_answers (user_id, canonical_key, value, source)
+      values (${user.id}, ${key}, ${sql.json(value)}, 'derived')
+      on conflict (user_id, canonical_key) do nothing;
+    `;
+  }
+  return seeded;
+}
+
+// ---- coverage: match a role's form against the bank -----------------------
+async function coverage(sql: Sql, userId: string, slug: string) {
+  // Prefer the already-extracted schema; extract on the fly otherwise.
+  let schema: Schema | null = null;
+  const draft = (await sql`
+    select fields from job.application_draft
+    where user_id = ${userId} and role_slug = ${slug} limit 1;
+  `)[0];
+  if (draft?.fields && (draft.fields.general?.length || draft.fields.custom_questions?.length)) {
+    schema = draft.fields as Schema;
+  } else {
+    const role = (await sql`
+      select coalesce(canonical_apply_url, url) as apply_url from job.pipeline_roles
+      where slug = ${slug} and deleted_at is null limit 1;
+    `)[0];
+    if (!role?.apply_url) return err('role has no apply URL', 404);
+    schema = await extractSchema(role.apply_url);
+  }
+
+  const answered = new Set(Object.keys(await listAnswers(sql, userId)));
+  const cov = computeCoverage(schema!, answered);
+
+  // Haiku tail: try to map required questions the heuristics missed.
+  if (cov.unmatched_required.length) {
+    try {
+      const keyList = CANONICAL_QUESTIONS.map(c => `${c.key}: ${c.label}`).join('\n');
+      const text = await callClaude(
+        `You map job-application questions to canonical answer keys. Keys:\n${keyList}\n\nReturn ONLY JSON: {"<question>": "<key or null>", ...}`,
+        JSON.stringify(cov.unmatched_required), 800);
+      const mapped = JSON.parse(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1));
+      for (const m of cov.mappings) {
+        if (m.canonical_key || m.consent) continue;
+        const k = mapped[m.prompt];
+        if (typeof k === 'string' && VALID_KEYS.has(k)) {
+          m.canonical_key = k;
+          m.answered = answered.has(k);
+        }
+      }
+      // Recompute the aggregates with the Haiku-augmented mappings.
+      const req = cov.mappings.filter(m => m.required && !m.consent);
+      const covered = req.filter(m => m.answered);
+      cov.total_required = req.length;
+      cov.covered_required = covered.length;
+      cov.pct = req.length ? Math.round((covered.length / req.length) * 100) : 100;
+      cov.ready = req.length > 0 ? covered.length === req.length : false;
+      cov.missing_keys = [...new Set(req.filter(m => m.canonical_key && !m.answered).map(m => m.canonical_key!))]
+      cov.unmatched_required = req.filter(m => !m.canonical_key).map(m => m.prompt);
+    } catch (e) {
+      console.warn('[application-answers] haiku tail failed', (e as Error).message);
+    }
+  }
+
+  return jsonResp({ slug, ats: schema!.ats, coverage: cov });
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
+  if (req.method !== 'POST') return err('POST only', 405);
+
+  try {
+    const user = await verifyJobUserDetailed(req);
+    if (!user) return err('unauthorized', 401);
+    const sql = db();
+    const body = await req.json().catch(() => ({}));
+    const action = String(body.action || 'list');
+
+    if (action === 'list') {
+      return jsonResp({ answers: await listAnswers(sql, user.id), registry: CANONICAL_QUESTIONS });
+    }
+
+    if (action === 'upsert') {
+      const items = Array.isArray(body.answers) ? body.answers : [];
+      let saved = 0;
+      for (const it of items) {
+        const key = String(it?.key || '');
+        const source = SOURCES.has(it?.source) ? it.source : 'writeback';
+        if (!KEY_RE.test(key) || !VALID_KEYS.has(key) || it?.value === undefined) continue;
+        await sql`
+          insert into job.application_answers (user_id, canonical_key, value, source, updated_at)
+          values (${user.id}, ${key}, ${sql.json(it.value)}, ${source}, now())
+          on conflict (user_id, canonical_key) do update set
+            value = excluded.value, source = excluded.source, updated_at = now();
+        `;
+        saved++;
+      }
+      return jsonResp({ saved });
+    }
+
+    if (action === 'delete') {
+      const keys = (Array.isArray(body.keys) ? body.keys : []).filter((k: unknown) => typeof k === 'string' && KEY_RE.test(k));
+      if (!keys.length) return jsonResp({ deleted: 0 });
+      const res = await sql`
+        delete from job.application_answers
+        where user_id = ${user.id} and canonical_key = any(${keys});
+      `;
+      return jsonResp({ deleted: res.count ?? keys.length });
+    }
+
+    if (action === 'seed') {
+      const seeded = await seed(sql, user);
+      return jsonResp({ seeded, answers: await listAnswers(sql, user.id) });
+    }
+
+    if (action === 'coverage') {
+      const slug = String(body.slug || '').toLowerCase();
+      if (!SLUG_RE.test(slug)) return err('invalid slug', 400);
+      return await coverage(sql, user.id, slug);
+    }
+
+    return err(`unknown action '${action}'`, 400);
+  } catch (e) {
+    console.error('[application-answers] error', e);
+    return err((e as Error).message || 'server error', 500);
+  }
+});

--- a/supabase/migrations/105_application_answers.sql
+++ b/supabase/migrations/105_application_answers.sql
@@ -1,0 +1,24 @@
+-- 105_application_answers.sql — Easy Apply answer bank (Phase 16.2a).
+--
+-- One row per (user_id, canonical_key). Keys come from the canonical
+-- registry in supabase/functions/_shared/answer-bank.ts (Tier 1–4 of the
+-- PRD's onboarding capture set). Values are jsonb — text, boolean, number,
+-- or structured (onsite_willingness rules, comp_expectation policy).
+--
+-- Access goes through the application-answers edge function (service role +
+-- per-user auth), mirroring job.application_draft; the job schema isn't
+-- exposed via PostgREST.
+
+create table if not exists job.application_answers (
+  user_id       uuid not null,
+  canonical_key text not null,
+  value         jsonb not null,
+  source        text not null default 'onboarding'
+                check (source in ('onboarding','resume_extract','derived','writeback')),
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  primary key (user_id, canonical_key)
+);
+
+comment on table job.application_answers is
+  'Easy Apply answer bank: canonical application answers per user. Registry in _shared/answer-bank.ts.';


### PR DESCRIPTION
Phase 16.2a of [Easy Apply](docs/strategy/prds/ladder-easy-apply.md): the answer bank behind the Easy Apply feature.

- `job.application_answers` (migration 105) + 28-key canonical registry
- `application-answers` edge fn: list/upsert/delete/**seed** (prefill from career history, vision, base resume, auth profile) /**coverage** (form ↔ bank matching with Haiku tail, ready-to-submit calc)
- Matcher validated against all audit question phrasings (15 cases) + coverage smoke test

Deploy after merge: migration 105 + `application-answers`, redeploy `classify-apply-ease` (whitelist fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)