### PR TITLE
fix(ladder): bulk closures collapse to one digest row; queue matches inbox width (v2.32.1)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.32.0");
+@import url("./components.css?v=2.32.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -4313,11 +4313,15 @@ button.link-subtle {
 }
 .role-header__apply-req .ease-chip { margin-left: 0; }
 
-/* Updates queue — the single notification surface, top of every Jobs
-   bucket page. One elevated card, hairline-divided rows (inbox pattern).
-   Each row: tinted icon circle · text · ONE action button · × dismiss.
+/* Updates queue — the single notification surface, top of the Inbox.
+   One elevated card, hairline-divided rows (inbox pattern). Each row:
+   tinted icon circle · text · ONE action button · × dismiss.
    Lifecycle: rows are server-backed (auto-actions ≤7d, prompts until
-   resolved); × persists to dismissed_at (localStorage for synthetic rows). */
+   resolved); × persists to dismissed_at (localStorage for synthetic rows).
+   Width matches the inbox column so the two read as one surface. */
+ladder-updates { display: block; }
+ladder-updates .updates-queue { max-width: 760px; }
+
 .updates-queue {
   margin: 0 0 var(--space-4);
   padding: var(--space-2) var(--space-4);

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,6 +30,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.32.0";
-console.log(`[ladder] v${VERSION} - Updates queue moves to Inbox as the Today surface; role closures join the queue (red closed-banner removed)`);
+const VERSION = "2.32.1";
+console.log(`[ladder] v${VERSION} - fix: bulk closures collapse to one digest row; queue matches inbox width`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-updates.js
+++ b/ladder/js/components/ladder-updates.js
@@ -112,24 +112,39 @@ export class LadderUpdates extends LitElement {
   }
 
   // Role closures — the liveness sweep found the posting gone and already
-  // archived the role; the queue row is the record of that (replaces the
-  // old red closed-banner). Dismiss keys on the closure date, so a role
-  // closed → dismissed → re-opened → re-closed months later re-surfaces.
+  // archived the role; the queue records that (replaces the old red
+  // closed-banner, same since-last-visit + watermark semantics). Liveness
+  // archives in bulk, so 3+ closures collapse into ONE digest row — the
+  // queue must never be a wall of closures.
   _closureRows() {
-    const cutoff = this._lastVisitAt ? Date.parse(this._lastVisitAt) - 7 * 86_400_000 : 0;
+    const cutoff = this._lastVisitAt ? Date.parse(this._lastVisitAt) : 0;
     let seenThrough = 0;
-    try { seenThrough = Number(localStorage.getItem('job:jobs:closedSeenThrough') || 0); } catch { /* legacy watermark */ }
-    return this._roles
-      .filter(r => r.closedDetectedAt
-        && Date.parse(r.closedDetectedAt) > Math.max(cutoff, seenThrough)
-        && Date.now() - Date.parse(r.closedDetectedAt) < 7 * 86_400_000)
-      .map(r => ({
+    try { seenThrough = Number(localStorage.getItem('job:jobs:closedSeenThrough') || 0); } catch { /* */ }
+    const closed = this._roles
+      .filter(r => r.closedDetectedAt && Date.parse(r.closedDetectedAt) > Math.max(cutoff, seenThrough))
+      .sort((a, b) => Date.parse(b.closedDetectedAt) - Date.parse(a.closedDetectedAt));
+    if (!closed.length) return [];
+    if (closed.length <= 2) {
+      return closed.map(r => ({
         kind: 'role_closed', action: 'open_role', priority: 4,
         role_slug: r.slug, company: r.company, title: r.title,
         text: `${r.company || r.slug} closed the posting`,
         detail: 'Archived automatically — the role is no longer listed',
         received_at: r.closedDetectedAt,
+        _closureWatermark: Date.parse(r.closedDetectedAt),
       }));
+    }
+    const preview = closed.slice(0, 3).map(r => r.company).filter(Boolean).join(', ');
+    return [{
+      kind: 'role_closed', action: 'open_role', priority: 4,
+      role_slug: 'role-closures',
+      href: '/ladder/jobs/?bucket=archive',
+      actionLabel: 'Open archive',
+      text: `${closed.length} roles closed since your last visit`,
+      detail: `Archived automatically — ${preview}${closed.length > 3 ? ` +${closed.length - 3} more` : ''}`,
+      received_at: closed[0].closedDetectedAt,
+      _closureWatermark: Math.max(...closed.map(r => Date.parse(r.closedDetectedAt) || 0)),
+    }];
   }
 
   // Synthetic "N saved jobs are easy applies" digest (Phase 16.1).
@@ -236,7 +251,7 @@ export class LadderUpdates extends LitElement {
       case 'open_role':
       default: {
         if (it.event_id) { try { await ackEvent(it.event_id); } catch { /* best-effort */ } }
-        window.location.assign(`/ladder/jobs/${it.role_slug}/`);
+        window.location.assign(it.href || `/ladder/jobs/${it.role_slug}/`);
       }
     }
   }
@@ -255,6 +270,12 @@ export class LadderUpdates extends LitElement {
     this.requestUpdate();
     if (it.event_id) {
       try { await dismissUpdate(it.event_id); } catch (e) { console.warn('[ladder-updates] dismiss failed:', e.message); }
+    } else if (it._closureWatermark) {
+      // Closure rows use the legacy watermark: everything closed up to the
+      // dismissed row never resurfaces (matches the old banner behavior).
+      let seenThrough = 0;
+      try { seenThrough = Number(localStorage.getItem('job:jobs:closedSeenThrough') || 0); } catch { /* */ }
+      try { localStorage.setItem('job:jobs:closedSeenThrough', String(Math.max(seenThrough, it._closureWatermark))); } catch { /* */ }
     } else {
       this._localDismissed.add(this._updateKey(it));
       try { localStorage.setItem(DISMISSED_KEY, JSON.stringify([...this._localDismissed])); } catch { /* */ }
@@ -291,7 +312,7 @@ export class LadderUpdates extends LitElement {
         </div>
         <button class="btn btn--sm updates-row__action" ?disabled=${busy}
                 @click=${() => this._onUpdateAction(it)}>
-          ${busy ? 'Working…' : meta.actionLabel}
+          ${busy ? 'Working…' : (it.actionLabel || meta.actionLabel)}
         </button>
         <button class="updates-row__dismiss" aria-label="Dismiss"
                 @click=${() => this._onDismissUpdate(it)}>×</button>

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.32.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.32.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.0">
-  <script src="/ladder/js/theme.js?v=2.32.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.32.1">
+  <script src="/ladder/js/theme.js?v=2.32.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.32.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.32.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #1121 from live verification: liveness archives postings in bulk, so per-role closure rows flooded the queue (12+ rows). Closures now use the original since-last-visit + watermark window and 3+ collapse into one 'N roles closed since your last visit' digest (Open archive; × advances the watermark). Queue width capped at the inbox column's 760px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)