### PR TITLE
fix(ladder): Easy Apply submission robustness — jsonb, schema persistence, no-downgrade (16.2c)

### DIFF
--- a/supabase/functions/classify-apply-ease/index.ts
+++ b/supabase/functions/classify-apply-ease/index.ts
@@ -19,7 +19,7 @@ import { db } from '../_shared/job-db.ts';
 import { extractSchema } from '../_shared/apply-extract.ts';
 import { classifyApplyEase, type ApplyEaseTier, type ApplyEaseMeta } from '../_shared/apply-ease.ts';
 
-const VERSION = '0.1.0';
+const VERSION = '0.2.0';
 console.log(`[classify-apply-ease] v${VERSION} - apply-ease sweep for Saved+Drafting`);
 
 const BATCH = 8;
@@ -107,6 +107,7 @@ async function classifyRole(sql: ReturnType<typeof db>, row: { slug: string; url
     await sql`update job.pipeline_roles set canonical_apply_url = ${applyUrl} where slug = ${row.slug};`;
   }
 
+  let extractedSchema: unknown = null;
   if (applyUrl.startsWith('mailto:')) {
     tier = 'special';
     meta = { reason: 'apply by email', source_url: applyUrl };
@@ -115,13 +116,28 @@ async function classifyRole(sql: ReturnType<typeof db>, row: { slug: string; url
     const c = classifyApplyEase(schema);
     tier = c.tier;
     meta = c.meta;
+    // Only keep the schema when extraction actually produced fields — a bare
+    // fallback (JS-shell page, rate-limited ATS API) yields nothing usable.
+    if ((schema.general?.length || schema.custom_questions?.length)) extractedSchema = schema;
+  }
+
+  // Data integrity: a transient extraction failure (ATS API rate-limited from
+  // the edge) must not overwrite a previously-good classification with
+  // `unknown`. Only downgrade to unknown when there's no prior good tier.
+  if (tier === 'unknown') {
+    const prior = (await sql`select apply_ease from job.pipeline_roles where slug = ${row.slug};`)[0]?.apply_ease;
+    if (prior && prior !== 'unknown') {
+      await sql`update job.pipeline_roles set apply_ease_checked_at = now() where slug = ${row.slug};`;
+      return { slug: row.slug, tier: prior as ApplyEaseTier, applyUrl, reason: 'kept prior (extraction transient-failed)' };
+    }
   }
 
   await sql`
     update job.pipeline_roles set
       apply_ease = ${tier},
       apply_ease_meta = ${sql.json(meta)},
-      apply_ease_checked_at = now()
+      apply_ease_checked_at = now(),
+      apply_schema = ${extractedSchema ? sql.json(extractedSchema) : sql`apply_schema`}
     where slug = ${row.slug};
   `;
   return { slug: row.slug, tier, applyUrl, reason: (meta as ApplyEaseMeta).reason };

--- a/supabase/functions/extract-application-fields/index.ts
+++ b/supabase/functions/extract-application-fields/index.ts
@@ -25,7 +25,7 @@ import { db } from '../_shared/job-db.ts';
 import { extractSchema } from '../_shared/apply-extract.ts';
 import { classifyApplyEase } from '../_shared/apply-ease.ts';
 
-const VERSION = '0.3.0';
+const VERSION = '0.4.0';
 console.log(`[extract-application-fields] v${VERSION} - shared extraction core + apply-ease classification`);
 
 serve(async (req) => {
@@ -47,9 +47,11 @@ serve(async (req) => {
 
     // Persist into the draft row so the takeover can pick it up.
     const sql = db();
+    // sql.json() stores a real jsonb object. (`${JSON.stringify(x)}::jsonb`
+    // double-encodes into a jsonb *string* under postgres.js prepare:false.)
     await sql`
       insert into job.application_draft (user_id, role_slug, apply_url, ats, fields, extracted_at)
-      values (${user.id}, ${slug}, ${url}, ${schema.ats}, ${JSON.stringify(schema)}::jsonb, now())
+      values (${user.id}, ${slug}, ${url}, ${schema.ats}, ${sql.json(schema)}, now())
       on conflict (user_id, role_slug) do update set
         apply_url = excluded.apply_url,
         ats       = excluded.ats,
@@ -60,15 +62,22 @@ serve(async (req) => {
 
     // Keep the table badge in sync — an on-demand extraction is the freshest
     // signal we ever get for a role's tier. Best-effort: the wizard must not
-    // fail because the badge column couldn't be stamped.
+    // fail because the badge column couldn't be stamped. A bare fallback
+    // (empty schema) must NOT downgrade a previously-good classification, and
+    // we persist the schema for reuse when it has real fields.
     try {
-      await sql`
-        update job.pipeline_roles set
-          apply_ease = ${tier},
-          apply_ease_meta = ${sql.json(meta)},
-          apply_ease_checked_at = now()
-        where slug = ${slug};
-      `;
+      const hasFields = !!(schema.general?.length || schema.custom_questions?.length);
+      const prior = (await sql`select apply_ease from job.pipeline_roles where slug = ${slug};`)[0]?.apply_ease;
+      if (!(tier === 'unknown' && prior && prior !== 'unknown')) {
+        await sql`
+          update job.pipeline_roles set
+            apply_ease = ${tier},
+            apply_ease_meta = ${sql.json(meta)},
+            apply_ease_checked_at = now(),
+            apply_schema = ${hasFields ? sql.json(schema) : sql`apply_schema`}
+          where slug = ${slug};
+        `;
+      }
     } catch (e) {
       console.warn('[extract-application-fields] apply_ease stamp failed', (e as Error).message);
     }

--- a/supabase/functions/submit-application/index.ts
+++ b/supabase/functions/submit-application/index.ts
@@ -25,7 +25,7 @@ import { db } from '../_shared/job-db.ts';
 import { extractSchema, detectAts, type Schema } from '../_shared/apply-extract.ts';
 import { computeCoverage, canonicalQuestion, type QuestionMapping } from '../_shared/answer-bank.ts';
 
-const VERSION = '0.1.0';
+const VERSION = '0.2.0';
 console.log(`[submit-application] v${VERSION} - Easy Apply prepare/submit (Greenhouse, flag-gated)`);
 
 const SLUG_RE = /^[a-z0-9_-]+$/;
@@ -85,17 +85,24 @@ type ReviewRow = {
 
 async function buildReview(sql: Sql, userId: string, slug: string) {
   const role = (await sql`
-    select slug, company_name, title, coalesce(canonical_apply_url, url) as apply_url, apply_ease
+    select slug, company_name, title, coalesce(canonical_apply_url, url) as apply_url, apply_ease, apply_schema
     from job.pipeline_roles where slug = ${slug} and deleted_at is null limit 1;
   `)[0];
   if (!role?.apply_url) throw new Error('role has no apply URL');
 
-  // Schema: prefer the persisted draft extraction, refresh otherwise.
+  // Schema precedence: the user's own draft extraction, then the role's
+  // persisted apply_schema (written by classify/extract when the ATS API
+  // last succeeded), then a fresh live extraction as the last resort. Live
+  // extraction is flaky from the edge (ATS rate-limiting), so the persisted
+  // copy is what keeps the review reliable.
   const draft = (await sql`
     select fields, answers from job.application_draft
     where user_id = ${userId} and role_slug = ${slug} limit 1;
   `)[0];
-  let schema: Schema | null = (draft?.fields?.general || draft?.fields?.custom_questions) ? draft.fields as Schema : null;
+  const usable = (o: any) => o && (o.general?.length || o.custom_questions?.length) ? o as Schema : null;
+  let persisted: any = draft?.fields;
+  if (typeof persisted === 'string') { try { persisted = JSON.parse(persisted); } catch { persisted = null; } }
+  let schema: Schema | null = usable(persisted) || usable(role.apply_schema);
   if (!schema) schema = await extractSchema(role.apply_url);
 
   const bankRows = await sql`
@@ -212,8 +219,9 @@ serve(async (req) => {
       await sql`
         insert into job.application_draft (user_id, role_slug, apply_url, ats, fields, answers, current_step, status, extracted_at)
         values (${user.id}, ${slug}, ${review.role.apply_url}, ${review.ats},
-                ${JSON.stringify(review.schema)}::jsonb, ${sql.json(answersById)}, 'review', 'draft', now())
+                ${sql.json(review.schema)}, ${sql.json(answersById)}, 'review', 'draft', now())
         on conflict (user_id, role_slug) do update set
+          fields = ${sql.json(review.schema)},
           answers = ${sql.json(answersById)},
           current_step = 'review',
           updated_at = now();

--- a/supabase/migrations/107_apply_schema.sql
+++ b/supabase/migrations/107_apply_schema.sql
@@ -1,0 +1,11 @@
+-- 107_apply_schema.sql — persist the extracted application form schema on the
+-- role (Phase 16.2c robustness).
+--
+-- classify-apply-ease / extract-application-fields write the full field schema
+-- here whenever the ATS API returns real fields. submit-application's review
+-- reads it instead of re-extracting live, because live extraction is flaky
+-- from the edge (Ashby/Greenhouse rate-limit the egress IP). A transient
+-- failure never overwrites a good schema — the functions only write on success.
+
+alter table job.pipeline_roles
+  add column if not exists apply_schema jsonb;


### PR DESCRIPTION
Three bugs the 16.2c review flow surfaced (all already deployed + migration 107 applied):

1. **jsonb double-encoding** — `${JSON.stringify(x)}::jsonb` stored a jsonb *string* under postgres.js; the Apply takeover + review read back garbage. Now `sql.json()`.
2. **Flaky edge extraction** — Ashby/Greenhouse rate-limit the egress IP. Migration 107 adds `pipeline_roles.apply_schema`; classify/extract persist the schema on success and the review reads it first, so it no longer depends on live extraction.
3. **Transient failure downgraded good data** — a failed extraction was overwriting a good tier with `unknown` and wiping the badge. Writers now refuse that downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)