### PR TITLE
fix+refactor(ladder): opaque setup modal, cleaner role header, relocated setup CTA (v2.36.0)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.35.0");
+@import url("./components.css?v=2.36.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -4144,7 +4144,7 @@ button.link-subtle {
   padding: 2px var(--space-2);
   border-radius: var(--radius-pill);
   border: 1px solid var(--border);
-  background: var(--bg-elev);
+  background: var(--bg-elevated);
   color: var(--fg-muted);
   white-space: nowrap;
   max-width: 100%;
@@ -4178,7 +4178,7 @@ button.link-subtle {
   padding: 1px var(--space-2);
   border-radius: var(--radius-pill);
   border: 1px solid var(--border);
-  background: var(--bg-elev);
+  background: var(--bg-elevated);
   color: var(--fg-muted);
   white-space: nowrap;
   vertical-align: 1px;
@@ -4290,7 +4290,7 @@ button.link-subtle {
   font-size: 26px;
 }
 .eas {
-  background: var(--bg-elev);
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg, 12px);
   width: min(680px, 100%);
@@ -4361,10 +4361,40 @@ button.link-subtle {
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
-  margin: var(--space-1) 0 0;
+  margin: var(--space-2) 0 0;
   font-size: var(--font-size-caption);
 }
 .role-header__apply-req .ease-chip { margin-left: 0; }
+
+/* Easy Apply setup nudge banner (Saved page). */
+.ease-setup-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--success) 45%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+}
+.ease-setup-banner__icon { display: inline-flex; width: 18px; height: 18px; color: var(--success); flex: 0 0 auto; }
+.ease-setup-banner__icon svg { width: 18px; height: 18px; }
+.ease-setup-banner__body { flex: 1; font-size: var(--font-size-small); color: var(--fg-muted); }
+.ease-setup-banner__body strong { color: var(--fg); }
+.ease-setup-banner__x {
+  background: none; border: none; color: var(--fg-subtle);
+  font-size: 18px; line-height: 1; cursor: pointer; padding: 2px 6px; border-radius: var(--radius-pill);
+}
+.ease-setup-banner__x:hover { color: var(--fg); }
+
+/* "Set up Easy Apply to autofill" hint inside the review overlay. */
+.ar-setup-hint {
+  display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap;
+  margin: 0 0 var(--space-2); padding: var(--space-2) var(--space-3);
+  border: 1px dashed color-mix(in srgb, var(--success) 45%, var(--border));
+  border-radius: var(--radius-md); background: color-mix(in srgb, var(--success) 6%, transparent);
+  font-size: var(--font-size-small); color: var(--fg-muted);
+}
 
 /* Updates queue — the single notification surface, top of the Inbox.
    One elevated card, hairline-divided rows (inbox pattern). Each row:
@@ -4513,7 +4543,7 @@ ladder-updates .updates-queue { max-width: 760px; }
   padding: var(--space-3);
   border: 1px solid var(--border);
   border-radius: var(--radius-2);
-  background: var(--bg-elev);
+  background: var(--bg-elevated);
 }
 .activity-event__rail {
   background: var(--border);

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,6 +30,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.35.0";
-console.log(`[ladder] v${VERSION} - closures are server-backed events: archive with role_closed rationale + persistent notification`);
+const VERSION = "2.36.0";
+console.log(`[ladder] v${VERSION} - Easy Apply: fix transparent setup modal; declutter role header; setup CTA → Saved banner + row menu`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-apply-review.js
+++ b/ladder/js/components/ladder-apply-review.js
@@ -182,6 +182,11 @@ export class LadderApplyReview extends LitElement {
         ${missing.length ? html`
           <div class="ar-group">
             <h3 class="ar-group__title ar-group__title--warn">${missing.length} answer${missing.length === 1 ? '' : 's'} still needed</h3>
+            ${missing.length >= 3 ? html`
+              <p class="ar-setup-hint">
+                Set up Easy Apply once and these autofill from your saved answers next time.
+                <button class="btn btn--sm" @click=${() => document.dispatchEvent(new CustomEvent('job:easyapply:launch-setup'))}>⚡ Set up Easy Apply</button>
+              </p>` : nothing}
             ${missing.map(r => this._renderRow(r))}
           </div>` : nothing}
 

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -10,6 +10,7 @@ const { logoSrc, logoInitial } = await import('../logo.js' + V);
 const { renderScoreModal, renderScorePair, scoreClass: sharedScoreClass } = await import('./ladder-fit-modal.js' + V);
 const { loadUpdates, updateKindMeta, roleMatchedEvents } = await import('../applicationEvents.js' + V);
 const { renderLocation } = await import('../format.js' + V);
+const { easyApplySetupDone } = await import('./ladder-easy-apply-setup.js' + V);   // also registers <ladder-easy-apply-setup>
 
 // Bucket taxonomy (STAGES / BUCKETS / BUCKET_LABELS / bucketFor / isVisibleRole)
 // is imported from ../pipeline.js — the single source of truth shared with the
@@ -126,6 +127,8 @@ export class JobPipeline extends LitElement {
     hoverEase:       { state: true },
     // "⚡ Easy apply" quick filter (Saved + Drafting). Mirrored in ?ease=easy.
     easeFilter:      { state: true },
+    // Easy Apply setup banner (Saved page, periodic cadence).
+    easeBannerHidden: { state: true },
   };
 
   constructor() {
@@ -139,6 +142,15 @@ export class JobPipeline extends LitElement {
     this.selectedRow = null;
     this.hoverConns = null;
     this.hoverEase = null;
+    // Setup banner cadence: hidden if setup is done, or dismissed within the
+    // last 7 days. Re-surfaces afterward so it nudges without nagging.
+    this.easeBannerHidden = (() => {
+      try {
+        if (easyApplySetupDone()) return true;
+        const at = Number(localStorage.getItem('job:easeSetupBannerDismissedAt') || 0);
+        return Date.now() - at < 7 * 24 * 3600 * 1000;
+      } catch { return false; }
+    })();
     const params = new URLSearchParams(location.search);
     const b = params.get('bucket');
     const stageQ = params.get('stage');
@@ -199,6 +211,9 @@ export class JobPipeline extends LitElement {
       } catch {}
     };
     document.addEventListener('job:pipeline:refresh', this._onRefresh);
+    // Finishing Easy Apply setup retires the banner immediately.
+    this._onEaseSetupDone = () => { this.easeBannerHidden = true; };
+    document.addEventListener('job:easyapply:setup-done', this._onEaseSetupDone);
     // Surface added jobs (paste-URL, recs, future batch import) via a
     // dismissible banner at the top of the table. Accumulates entries
     // until the user dismisses or navigates away.
@@ -237,6 +252,7 @@ export class JobPipeline extends LitElement {
     document.removeEventListener('keydown', this._onKey);
     document.removeEventListener('click', this._onDocClick);
     document.removeEventListener('job:pipeline:refresh', this._onRefresh);
+    document.removeEventListener('job:easyapply:setup-done', this._onEaseSetupDone);
     document.removeEventListener('job:pipeline:added', this._onAdded);
     window.removeEventListener('popstate', this._onPopState);
     super.disconnectedCallback();
@@ -624,6 +640,12 @@ export class JobPipeline extends LitElement {
                 <span>${BUCKET_LABELS[b]}</span>
               </button>
             `)}
+            ${(r.applyEase === 'easy' || r.applyEase === 'short_answer') ? html`
+              <div class="row-menu__divider" role="separator"></div>
+              ${easyApplySetupDone()
+                ? html`<button role="menuitem" class="row-menu__item" @click=${() => this._openRoleReview(r)}>Review &amp; apply…</button>`
+                : html`<button role="menuitem" class="row-menu__item" @click=${() => this._launchEaseSetup()}>⚡ Set up Easy Apply</button>`}
+            ` : nothing}
             <div class="row-menu__divider" role="separator"></div>
             <button role="menuitem" class="row-menu__item row-menu__item--danger" @click=${() => this._onDelete(r)}>
               Delete…
@@ -891,6 +913,44 @@ export class JobPipeline extends LitElement {
     const qs = new URLSearchParams(location.search);
     if (this.easeFilter) qs.set('ease', 'easy'); else qs.delete('ease');
     history.replaceState(null, '', `${location.pathname}?${qs}`);
+  }
+
+  // Setup nudge: one dismissable banner atop the Saved page when Easy Apply
+  // isn't set up yet and there's at least one easy-tier role to apply to.
+  // Cadence handled in the constructor (re-shows 7 days after dismissal).
+  _renderEaseSetupBanner() {
+    if (!this._isSaved || this.easeBannerHidden) return nothing;
+    const easyCount = this.roles.filter(r => isVisibleRole(r) && r.applyEase === 'easy').length;
+    if (!easyCount) return nothing;
+    return html`
+      <div class="ease-setup-banner" role="status">
+        <span class="ease-setup-banner__icon" aria-hidden="true">${unsafeHTML(EASE_ICONS.easy)}</span>
+        <div class="ease-setup-banner__body">
+          <strong>${easyCount} saved ${easyCount === 1 ? 'role is an easy apply' : 'roles are easy applies'}.</strong>
+          Set up Easy Apply once and Ladder fills these forms from your saved answers.
+        </div>
+        <button class="btn btn--sm btn--accent" @click=${() => this._launchEaseSetup()}>Set up Easy Apply</button>
+        <button class="ease-setup-banner__x" aria-label="Dismiss" @click=${() => this._dismissEaseBanner()}>×</button>
+      </div>
+    `;
+  }
+
+  _launchEaseSetup() {
+    this.openMenuSlug = null;
+    this.renderRoot.querySelector('#ease-setup')?.launch();
+  }
+
+  _dismissEaseBanner() {
+    this.easeBannerHidden = true;
+    try { localStorage.setItem('job:easeSetupBannerDismissedAt', String(Date.now())); } catch { /* */ }
+  }
+
+  // Row-menu "Review & apply" — the review takeover lives on the role page,
+  // so navigate there with a flag that auto-opens it.
+  _openRoleReview(r) {
+    this.openMenuSlug = null;
+    stashRolePrefill(r);
+    window.location.assign(`/ladder/jobs/${r.slug}/?review=1`);
   }
 
   // (The "N saved jobs are easy applies" digest row moved to
@@ -1161,6 +1221,8 @@ export class JobPipeline extends LitElement {
         </div>
       ` : nothing}
 
+      ${this._renderEaseSetupBanner()}
+
       <div class="pipeline-meta">
         <strong>${rows.length}</strong> ${bucketLabel.toLowerCase()} ${rows.length === 1 ? 'role' : 'roles'},
         ${this.sortKey === 'manual'
@@ -1208,6 +1270,7 @@ export class JobPipeline extends LitElement {
       ${this._renderConnTip()}
       ${this._renderEaseTip()}
       ${this._renderArchiveModal()}
+      <ladder-easy-apply-setup id="ease-setup"></ladder-easy-apply-setup>
 
       ${rows.length === 0 ? html`
         <div class="placeholder" style="margin-top:var(--space-4);">

--- a/ladder/js/components/ladder-role-detail.js
+++ b/ladder/js/components/ladder-role-detail.js
@@ -51,7 +51,6 @@ const KIND_BY_TAB = {
 
 const { listEvents, ackEvent: ackApplicationEvent, eventTypeLabel,
         resolveEvent: resolveApplicationEvent, undoEvent: undoApplicationEvent } = await import('../applicationEvents.js' + V);
-const { answersCoverage } = await import('../apply.js' + V);
 const { easyApplySetupDone } = await import('./ladder-easy-apply-setup.js' + V);
 // Side-effect import — registers the <ladder-apply> custom element used by the
 // "Apply with /ladder" launch button below.
@@ -97,7 +96,6 @@ export class JobRoleDetail extends LitElement {
     coverHistory: { state: true },    // [{ id, ts, source, content, label, instruction? }] reverse-chrono
     genTick: { state: true },         // 0..n — drives the rotating-word label inside shimmer indicators
     // Easy Apply readiness (16.2b): null | 'loading' | Coverage object.
-    easeCoverage:   { state: true },
     // Phase 2.0 — Activity timeline.
     activityState:  { state: true },  // 'idle' | 'loading' | 'loaded' | 'error'
     activityEvents: { state: true },  // EventRow[]
@@ -161,12 +159,17 @@ export class JobRoleDetail extends LitElement {
       if (t) this._switchTab(t);
     };
     window.addEventListener('apply:opentab', this._onApplyOpenTab);
+    // The review overlay offers "Set up Easy Apply to autofill" when the
+    // answer bank is thin; it asks us to open the setup takeover.
+    this._onLaunchSetup = () => this._launchEaseSetup();
+    document.addEventListener('job:easyapply:launch-setup', this._onLaunchSetup);
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);
     document.removeEventListener('job:auth:ready', this._onAuth);
     document.removeEventListener('selectionchange', this._onSelectionChange);
     window.removeEventListener('apply:opentab', this._onApplyOpenTab);
+    document.removeEventListener('job:easyapply:launch-setup', this._onLaunchSetup);
     this._teardownBodyObserver();
     if (this._genTimer) { clearInterval(this._genTimer); this._genTimer = null; }
     // Flush pending autosaves on unmount.
@@ -201,6 +204,11 @@ export class JobRoleDetail extends LitElement {
       // "in progress." Fire-and-forget; the helper is idempotent so
       // re-opens are no-ops on the server.
       if (this.role) engageRole(this.slug);
+      // Deep-link from the Saved row menu ("Review & apply…") auto-opens the
+      // review takeover once the role has loaded.
+      if (this.role && new URLSearchParams(location.search).get('review') === '1') {
+        this.updateComplete.then(() => this._launchApplyReview());
+      }
       // Seed history with the loaded cover letter so the user has a
       // baseline to revert to even before they make any edits.
       if (cover?.content) {
@@ -2028,6 +2036,10 @@ export class JobRoleDetail extends LitElement {
   // "Application requirements" line (Phase 16.1) — the ease tier chip plus a
   // one-line breakdown of what the form actually asks for, so the user knows
   // whether this is a 2-minute submit before opening anything.
+  // One clean line under the title: the ease chip, a plain-language summary of
+  // what the form asks for, and — for auto-fillable tiers — a single
+  // "Review & apply" action. Setup lives on the Saved banner + row menu now,
+  // not here, so the header stays uncluttered.
   _renderApplyRequirements(r) {
     const info = applyEaseInfo(r);
     if (!info) return nothing;
@@ -2041,43 +2053,15 @@ export class JobRoleDetail extends LitElement {
     }
     if (m.short_answers > 0) bits.push(`${m.short_answers} short answer${m.short_answers === 1 ? '' : 's'}`);
     if (m.required_essays > 0) bits.push(`${m.required_essays} essay${m.required_essays === 1 ? '' : 's'}`);
+    const canReview = info.tier === 'easy' || info.tier === 'short_answer';
     return html`
-      <p class="role-header__apply-req">
+      <div class="role-header__apply-req">
         <span class="ease-chip ease-chip--${info.tier}" title=${info.title}>${info.label}</span>
-        ${bits.length ? html`<span class="muted">Application asks for: ${bits.join(', ')}.</span>` : nothing}
-        ${this._renderEaseReadiness(r, info)}
-      </p>
-    `;
-  }
-
-  // Easy-tier roles get a readiness line: setup CTA when the answer bank
-  // hasn't been set up, otherwise a live coverage check against the bank.
-  _renderEaseReadiness(r, info) {
-    if (info.tier !== 'easy' && info.tier !== 'short_answer') return nothing;
-    if (!easyApplySetupDone()) {
-      return html`
-        <button class="btn btn--sm eas-cta" @click=${() => this._launchEaseSetup()}>
-          ⚡ Set up Easy Apply
-        </button>
-      `;
-    }
-    const cov = this.easeCoverage;
-    if (cov == null) {
-      return html`
-        <button class="btn btn--sm" @click=${() => this._checkEaseCoverage()}>Check readiness</button>
-      `;
-    }
-    if (cov === 'loading') return html`<span class="muted">Checking your saved answers…</span>`;
-    if (cov.ready) {
-      return html`
-        <span class="ease-chip ease-chip--ready" title="Every required field is covered by your saved answers">Ready to submit</span>
-        <button class="btn btn--sm btn--accent eas-cta" @click=${() => this._launchApplyReview()}>Review &amp; submit</button>
-      `;
-    }
-    const n = cov.total_required - cov.covered_required;
-    return html`
-      <span class="muted">${cov.pct}% covered — ${n} answer${n === 1 ? '' : 's'} missing.</span>
-      <button class="btn btn--sm" @click=${() => this._launchApplyReview()}>Review &amp; submit</button>
+        ${bits.length ? html`<span class="muted">Asks for ${bits.join(', ')}.</span>` : nothing}
+        ${canReview ? html`
+          <button class="btn btn--sm btn--accent eas-cta" @click=${() => this._launchApplyReview()}>Review &amp; apply</button>
+        ` : nothing}
+      </div>
     `;
   }
 
@@ -2092,18 +2076,6 @@ export class JobRoleDetail extends LitElement {
     try { engageRole(this.slug); } catch { /* silent */ }
     const el = this.renderRoot.querySelector('#apply-review');
     if (el) el.launch({ slug: this.slug });
-  }
-
-  async _checkEaseCoverage() {
-    this.easeCoverage = 'loading';
-    try {
-      const res = await answersCoverage(this.slug);
-      this.easeCoverage = res.coverage;
-    } catch (e) {
-      console.warn('[job-role-detail] coverage failed', e.message);
-      this.easeCoverage = null;
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Readiness check failed: ${e.message}` } }));
-    }
   }
 
   _launchApply() {

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.0">
+  <script src="/ladder/js/theme.js?v=2.36.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.0"></script>
 </body>
 </html>


### PR DESCRIPTION
- **Fixes the transparent setup modal** — `.eas` used a non-existent `--bg-elev` token so the card rendered see-through over the role page.
- **Declutters the role header** to one line: chip + "Asks for …" + a single "Review & apply".
- **Moves "Set up Easy Apply"** off the header to a dismissable Saved-page banner (7-day cadence) + the per-row ⋮ menu on easy/short rows, with a contextual hint in the review overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)