### PR TITLE
fix(ladder): Inbox loads top-down with shimmer placeholders (v2.35.1)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.35.0");
+@import url("./components.css?v=2.35.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,6 +30,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.35.0";
-console.log(`[ladder] v${VERSION} - closures are server-backed events: archive with role_closed rationale + persistent notification`);
+const VERSION = "2.35.1";
+console.log(`[ladder] v${VERSION} - Inbox load order: shimmer placeholders for Updates queue + Wildcards (no late pop-in)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -71,6 +71,7 @@ export class JobRecommendationsTable extends LitElement {
     _hasMore:            { state: true },
     _recentlyExpired:    { state: true },
     _wildcards:          { state: true },
+    _wildcardsState:     { state: true },
     _floorOn:            { state: true },
     _reviewIndex:        { state: true },
     _below:              { state: true },
@@ -102,6 +103,7 @@ export class JobRecommendationsTable extends LitElement {
     this._hasMore = false;
     this._recentlyExpired = 0;
     this._wildcards = [];
+    this._wildcardsState = 'loading';
     // Quality floors (fit >= 50, strength >= 50, no hard fails) apply by
     // default; the ⋯ menu toggle flips to the unfiltered audit view.
     this._floorOn = true;
@@ -403,11 +405,13 @@ export class JobRecommendationsTable extends LitElement {
     // reconnect round-trip) and hasn't finished, resume the draining loader.
     this._resumeDrainingIfPending();
     // Wildcards strip loads after the list — never block or fail the
-    // page over it.
+    // page over it. _wildcardsState drives the shimmer placeholder so the
+    // strip's slot is reserved from first paint (no late pop-in).
     try {
       const wc = await fetchRecommendations({ view: 'wildcard' });
       this._wildcards = Array.isArray(wc?.recommendations) ? wc.recommendations : [];
     } catch { this._wildcards = []; }
+    this._wildcardsState = 'loaded';
     // Below-your-bar rows for the per-day drawers. 200 newest covers the
     // visible date range; older groups simply don't show a drawer.
     try {
@@ -753,6 +757,26 @@ export class JobRecommendationsTable extends LitElement {
   // High candidate-strength / low stated-criteria-fit roles (view=wildcard).
   // Leads with WHY the fit is low — the strip exists to pressure-test the
   // search criteria, not to list more of the same.
+  _renderWildcardsSkeleton() {
+    return html`
+      <section class="rec-wildcards" aria-hidden="true">
+        <header class="rec-shell__head rec-wildcards__head">
+          <span class="skeleton" style="width:110px;height:20px;display:inline-block;"></span>
+        </header>
+        <div class="rec-row rec-row--wildcards" role="presentation">
+          ${Array.from({ length: 3 }).map(() => html`
+            <article class="rec-card rec-card--wildcard">
+              <span class="skeleton" style="width:70%;height:16px;display:block;margin-bottom:8px;"></span>
+              <span class="skeleton" style="width:45%;height:12px;display:block;margin-bottom:12px;"></span>
+              <span class="skeleton" style="width:90%;height:12px;display:block;margin-bottom:16px;"></span>
+              <span class="skeleton skeleton--pill" style="width:84px;height:32px;display:inline-block;"></span>
+            </article>
+          `)}
+        </div>
+      </section>
+    `;
+  }
+
   _wildcardDetailUrl(r) {
     return `/ladder/jobs/${roleSlug(r.company, r.title)}/?rec=${r.id}`;
   }
@@ -797,6 +821,7 @@ export class JobRecommendationsTable extends LitElement {
   }
 
   _renderWildcards() {
+    if (this._wildcardsState !== 'loaded') return this._renderWildcardsSkeleton();
     if (!this._wildcards.length) return nothing;
     return html`
       <section class="rec-wildcards" aria-label="Wildcards">
@@ -833,6 +858,7 @@ export class JobRecommendationsTable extends LitElement {
             `)}
           </ul>
         </section>
+        ${this._renderWildcardsSkeleton()}
       `;
     }
     if (this.state === 'error') {

--- a/ladder/js/components/ladder-updates.js
+++ b/ladder/js/components/ladder-updates.js
@@ -28,6 +28,7 @@ export class LadderUpdates extends LitElement {
   createRenderRoot() { return this; }
 
   static properties = {
+    state:         { state: true },
     updates:       { state: true },
     updateBusy:    { state: true },
     expandedKinds: { state: true },
@@ -35,6 +36,7 @@ export class LadderUpdates extends LitElement {
 
   constructor() {
     super();
+    this.state = 'idle';
     this.updates = [];
     this.updateBusy = null;
     this.expandedKinds = new Set();
@@ -62,6 +64,7 @@ export class LadderUpdates extends LitElement {
     if (document.body.dataset.authState !== 'in') return;
     if (this._loading) return;
     this._loading = true;
+    if (this.state === 'idle') this.state = 'loading';
     try {
       const [feedRes, calRes, pipeRes] = await Promise.allSettled([
         loadUpdates(),
@@ -106,6 +109,7 @@ export class LadderUpdates extends LitElement {
           || new Date(b.received_at || 0).getTime() - new Date(a.received_at || 0).getTime());
     } finally {
       this._loading = false;
+      this.state = 'loaded';
     }
   }
 
@@ -289,7 +293,31 @@ export class LadderUpdates extends LitElement {
     this.expandedKinds = next;
   }
 
+  // Shimmer placeholder — reserves the queue's slot at the top of the
+  // Inbox so content below never jumps when the feed lands. Collapses to
+  // nothing only once we KNOW the queue is empty.
+  _renderSkeleton() {
+    return html`
+      <section class="updates-queue" aria-hidden="true">
+        <div class="updates-queue__header">
+          <span class="skeleton" style="width:72px;height:16px;display:inline-block;"></span>
+        </div>
+        ${Array.from({ length: 2 }).map(() => html`
+          <div class="updates-row">
+            <span class="skeleton" style="width:32px;height:32px;border-radius:var(--radius-pill);flex-shrink:0;"></span>
+            <div class="updates-row__body">
+              <span class="skeleton" style="width:55%;height:14px;display:inline-block;"></span>
+              <span class="skeleton" style="width:35%;height:11px;display:inline-block;"></span>
+            </div>
+            <span class="skeleton skeleton--pill" style="width:96px;height:32px;"></span>
+          </div>
+        `)}
+      </section>
+    `;
+  }
+
   render() {
+    if (this.state !== 'loaded') return this._renderSkeleton();
     const items = this.updates || [];
     if (!items.length) return nothing;
     const groups = this._grouped(items);

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.0">
-  <script src="/ladder/js/theme.js?v=2.35.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.35.1">
+  <script src="/ladder/js/theme.js?v=2.35.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.35.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.35.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Updates → Today → Wildcards each reserve their slot from first paint with shimmer skeletons — the queue and the Wildcards strip no longer pop in late and shift the layout. The queue skeleton collapses only once the feed is known-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)