### PR TITLE
fix(ladder): Updates card below the Inbox header; drop header roles counter (v2.36.2)

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.36.1");
+@import url("./components.css?v=2.36.2");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -25,11 +25,10 @@
   <div class="app">
     <ladder-rail></ladder-rail>
     <main class="app__main">
-      <ladder-updates></ladder-updates>
       <ladder-recommendations-table></ladder-recommendations-table>
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.36.1";
-console.log(`[ladder] v${VERSION} - Inbox load order: shimmer placeholders for Updates queue + Wildcards (no late pop-in)`);
+const VERSION = "2.36.2";
+console.log(`[ladder] v${VERSION} - Inbox: Updates card sits below the page header; roles counter removed from header`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -842,6 +842,7 @@ export class JobRecommendationsTable extends LitElement {
         <header class="recs-page__head">
           <h1>Inbox</h1>
         </header>
+        <ladder-updates></ladder-updates>
         <section class="inbox-group" aria-hidden="true">
           <header class="inbox-group__head">
             <span class="skeleton" style="width:96px;height:20px;display:inline-block;"></span>
@@ -871,9 +872,6 @@ export class JobRecommendationsTable extends LitElement {
     return html`
       <header class="recs-page__head">
         <h1>Inbox</h1>
-        <span class="muted">${this._total > rows.length
-          ? `${rows.length} of ${this._total} roles`
-          : `${rows.length} ${rows.length === 1 ? 'role' : 'roles'}`}</span>
         ${!this._floorOn ? html`
           <button class="link-subtle recs-page__floor-toggle" @click=${() => this._toggleFloor()}>
             Showing all · apply floors
@@ -882,6 +880,7 @@ export class JobRecommendationsTable extends LitElement {
         ${this._refreshFeedback ? html`<span class="muted recs-page__refresh-status">${this._refreshFeedback}</span>` : nothing}
         ${this._renderHeaderMenu()}
       </header>
+      <ladder-updates></ladder-updates>
       ${this._renderDrainingBanner()}
       ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.1">
-  <script src="/ladder/js/theme.js?v=2.36.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <script src="/ladder/js/theme.js?v=2.36.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
 </body>
 </html>


### PR DESCRIPTION
Two Inbox layout tweaks from Ian: the Updates card now sits below the 'Inbox' H1 (rendered inside the table component in both skeleton and loaded branches), and the roles counter next to the header is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)