### PR TITLE
Agape recruiting viewer at /applications — Discord-gated, Supabase-backed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ Personal curation platform — collect, organize, and build on everything that m
 | AI Widgets | `supabase/functions/generate-widget/` | `index.ts` | Product recommendations (Claude Haiku) |
 | Soundscape | `soundscape/` | `PROJECT_PLAN.md` | Audio-reactive visualization |
 | Systemic | `systemic/` | `js/crawler.js` | Design system analyzer |
+| Recruiting | `applications/` | `applications/index.html` | Agape applicant triage — Discord-gated (Recruiting Society channel) |
 
 **Supabase projects:** Boards (`yfhudwakpgzswiylhfbh`), Ops (`ycilriwjnmcelkspmfmg`), Systemic (`atdqdfpdeytfuvvpsasz`)
 

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1,0 +1,463 @@
+/* Agape recruiting viewer — Wise design system tokens (mirrors /ladder). */
+
+[data-theme="light"] {
+  --bg: #FAFAF9;
+  --bg-surface: #F4F4F2;
+  --bg-elevated: #FFFFFF;
+  --bg-overlay: rgba(22, 51, 0, 0.08);
+  --fg: #0E0F0C;
+  --fg-muted: #454745;
+  --fg-subtle: #6A6C6A;
+  --fg-link: #163300;
+  --accent: #163300;
+  --accent-fg: #FFFFFF;
+  --accent-muted: rgba(159, 232, 112, 0.20);
+  --accent-strong: #9FE870;
+  --accent-strong-fg: #163300;
+  --border: rgba(14, 15, 12, 0.12);
+  --border-strong: rgba(14, 15, 12, 0.24);
+  --success: #2F5711;
+  --error: #A8200D;
+  --warning: #EDC843;
+  --hold-tint: rgba(237, 200, 67, 0.22);
+  --hold-fg: #6b5310;
+  --pass-tint: rgba(14, 15, 12, 0.07);
+  --outreach-tint: rgba(159, 232, 112, 0.28);
+  --outreach-fg: #2F5711;
+  --shadow-sm: 0 2px 6px rgba(0,0,0,0.05);
+  --shadow-md: 0 8px 24px rgba(0,0,0,0.10);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.16);
+}
+[data-theme="dark"] {
+  --bg: #0d1117;
+  --bg-surface: #161b22;
+  --bg-elevated: #1f2630;
+  --bg-overlay: rgba(255, 255, 255, 0.06);
+  --fg: #f0f6fc;
+  --fg-muted: rgba(240, 246, 252, 0.72);
+  --fg-subtle: rgba(240, 246, 252, 0.50);
+  --fg-link: #9FE870;
+  --accent: #9FE870;
+  --accent-fg: #0d1117;
+  --accent-muted: rgba(159, 232, 112, 0.16);
+  --accent-strong: #9FE870;
+  --accent-strong-fg: #0d1117;
+  --border: rgba(240, 246, 252, 0.12);
+  --border-strong: rgba(240, 246, 252, 0.24);
+  --success: #9FE870;
+  --error: #FF7A6E;
+  --warning: #FFEB69;
+  --hold-tint: rgba(255, 235, 105, 0.14);
+  --hold-fg: #FFEB69;
+  --pass-tint: rgba(240, 246, 252, 0.08);
+  --outreach-tint: rgba(159, 232, 112, 0.16);
+  --outreach-fg: #9FE870;
+  --shadow-sm: 0 2px 6px rgba(0,0,0,0.30);
+  --shadow-md: 0 8px 24px rgba(0,0,0,0.40);
+  --shadow-lg: 0 16px 48px rgba(0,0,0,0.55);
+}
+:root {
+  --font-body: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-display: var(--font-body);
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-size-title-1: 24px;
+  --font-size-title-3: 18px;
+  --font-size-title-4: 16px;
+  --font-size-body: 15px;
+  --font-size-small: 13px;
+  --font-size-caption: 12px;
+  --lh-title: 1.25;
+  --lh-body: 1.5;
+  --lh-tight: 1.35;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+  --radius-xs: 6px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 32px; --space-8: 40px;
+}
+
+* { box-sizing: border-box; }
+html, body {
+  margin: 0; padding: 0;
+  background: var(--bg); color: var(--fg);
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: var(--lh-body);
+  -webkit-font-smoothing: antialiased;
+}
+a { color: var(--fg-link); text-decoration: none; }
+a:hover { text-decoration: underline; }
+button { font: inherit; cursor: pointer; }
+::selection { background: var(--accent-muted); color: var(--fg); }
+
+.btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: var(--space-2);
+  height: 40px; padding: 0 var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated); color: var(--fg);
+  font-weight: var(--fw-semibold); font-size: var(--font-size-body);
+  transition: background 80ms ease, border-color 80ms ease, transform 80ms ease;
+}
+.btn:hover { border-color: var(--border-strong); }
+.btn:active { transform: translateY(1px); }
+.btn--accent {
+  background: var(--accent-strong); color: var(--accent-strong-fg);
+  border-color: var(--accent-strong); border-radius: var(--radius-pill);
+}
+.btn--accent:hover { filter: brightness(0.97); }
+
+/* --- Gate --- */
+.gate {
+  min-height: 100vh; display: grid; place-items: center;
+  padding: var(--space-4);
+}
+.gate[hidden] { display: none; }
+.page[hidden] { display: none; }
+/* No gate flash while CtrlAuth restores an existing session. */
+body[data-auth-state="loading"] .gate { visibility: hidden; }
+.gate__card {
+  width: 100%; max-width: 380px;
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-md);
+  padding: var(--space-7) var(--space-6);
+  display: flex; flex-direction: column; gap: var(--space-4);
+  text-align: center;
+}
+.gate__title {
+  margin: 0; font-weight: var(--fw-bold);
+  font-size: var(--font-size-title-1); letter-spacing: -0.02em;
+}
+.gate__sub { margin: 0; color: var(--fg-muted); font-size: var(--font-size-body); }
+.gate__input {
+  height: 48px; padding: 0 var(--space-4);
+  border-radius: var(--radius-sm); border: 1px solid var(--border);
+  background: var(--bg-surface); color: var(--fg);
+  font: inherit; text-align: center;
+}
+.gate__input:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: transparent; }
+.gate__error { margin: 0; color: var(--error); font-size: var(--font-size-small); min-height: 1.4em; }
+.gate__btn { height: 48px; border-radius: var(--radius-pill); }
+.gate__hint { margin: 0; color: var(--fg-subtle); font-size: var(--font-size-small); }
+
+/* --- Comments ("House notes") --- */
+.notes { margin-bottom: var(--space-6); }
+.notes__list { list-style: none; margin: 0 0 var(--space-4); padding: 0; display: flex; flex-direction: column; }
+.notes__empty { color: var(--fg-subtle); font-size: var(--font-size-small); margin: 0 0 var(--space-4); }
+.note { display: flex; gap: var(--space-3); padding: var(--space-3) 0; position: relative; }
+.note::after {
+  content: ''; position: absolute; left: 40px; right: 0; bottom: 0;
+  border-bottom: 1px solid var(--border);
+}
+.note:last-child::after { display: none; }
+.note__body-wrap { min-width: 0; flex: 1; }
+.note__meta { display: flex; align-items: baseline; gap: var(--space-2); margin-bottom: 2px; }
+.note__author { font-weight: var(--fw-semibold); font-size: var(--font-size-small); }
+.note__time { color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.note__body { margin: 0; font-size: var(--font-size-body); line-height: var(--lh-body); white-space: pre-wrap; overflow-wrap: anywhere; }
+.note__delete {
+  flex-shrink: 0; align-self: flex-start;
+  width: 28px; height: 28px; display: inline-grid; place-items: center;
+  border: 0; border-radius: var(--radius-pill);
+  background: transparent; color: var(--fg-subtle); font-size: 14px;
+}
+.note__delete:hover { background: var(--bg-overlay); color: var(--error); }
+.notes__form { display: flex; flex-direction: column; gap: var(--space-3); }
+.notes__input {
+  min-height: 72px; padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm); border: 1px solid var(--border);
+  background: var(--bg-elevated); color: var(--fg);
+  font: inherit; resize: vertical;
+}
+.notes__input:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: transparent; }
+.notes__submit { align-self: flex-end; }
+.note-count {
+  display: inline-flex; align-items: center; gap: 4px;
+  color: var(--fg-subtle); font-size: var(--font-size-caption);
+}
+
+/* --- Page shell --- */
+.page { max-width: 760px; margin: 0 auto; padding: var(--space-7) var(--space-4) 96px; }
+.page__head { display: flex; align-items: flex-start; gap: var(--space-3); margin-bottom: var(--space-5); }
+.page__head-text { min-width: 0; }
+.page__title {
+  margin: 0; font-weight: var(--fw-bold);
+  font-size: var(--font-size-title-1); letter-spacing: -0.02em; line-height: var(--lh-title);
+}
+.page__sub { margin: var(--space-1) 0 0; color: var(--fg-subtle); font-size: var(--font-size-small); }
+
+/* Header ⋯ menu */
+.page-menu { margin-left: auto; position: relative; flex-shrink: 0; }
+.page-menu__trigger {
+  width: 36px; height: 36px; border-radius: var(--radius-pill);
+  display: inline-grid; place-items: center;
+  border: 0; background: transparent; color: var(--fg-muted);
+  font-size: 20px; line-height: 1;
+}
+.page-menu__trigger:hover { background: var(--bg-overlay); }
+.page-menu__list {
+  position: absolute; right: 0; top: calc(100% + 4px); z-index: 40;
+  min-width: 220px;
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-md);
+  padding: var(--space-2); display: none;
+}
+.page-menu__list.is-open { display: block; }
+.page-menu__item {
+  display: block; width: 100%; text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border: 0; background: transparent; color: var(--fg);
+  border-radius: var(--radius-xs); font-size: var(--font-size-body);
+}
+.page-menu__item:hover { background: var(--bg-overlay); }
+
+/* Filter pills */
+.filters { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-bottom: var(--space-6); }
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated); color: var(--fg-muted);
+  font-size: var(--font-size-small); font-weight: var(--fw-medium);
+}
+.chip:hover { border-color: var(--border-strong); }
+.chip.is-on { background: var(--bg-overlay); color: var(--fg); font-weight: var(--fw-semibold); border-color: transparent; }
+.chip__count { font-size: var(--font-size-caption); color: var(--fg-subtle); }
+.chip.is-on .chip__count { color: var(--fg-muted); }
+
+/* --- Inbox --- */
+.inbox { display: flex; flex-direction: column; gap: var(--space-6); }
+.inbox-group__head { display: flex; align-items: baseline; gap: var(--space-3); margin: 0 0 var(--space-3); }
+.inbox-group__label {
+  margin: 0; font-weight: var(--fw-bold);
+  font-size: var(--font-size-title-3); letter-spacing: -0.02em;
+}
+.inbox-group__count { font-size: var(--font-size-small); color: var(--fg-subtle); }
+.inbox-card {
+  list-style: none; margin: 0;
+  padding: var(--space-2) var(--space-4);
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-sm);
+}
+.inbox-row { display: flex; align-items: center; gap: var(--space-3); padding: 10px 0; position: relative; }
+.inbox-row::after {
+  content: ''; position: absolute; left: 40px; right: 0; bottom: 0;
+  border-bottom: 1px solid var(--border);
+}
+.inbox-row:last-child::after { display: none; }
+.inbox-row__main {
+  display: flex; align-items: center; gap: var(--space-3);
+  flex: 1; min-width: 0;
+  border: 0; background: transparent; padding: 0; text-align: left;
+  cursor: pointer; font: inherit; color: inherit;
+}
+.inbox-row__text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.inbox-row__title { font-weight: var(--fw-medium); font-size: var(--font-size-body); color: var(--fg); overflow-wrap: anywhere; }
+.inbox-row__sub {
+  font-size: var(--font-size-small); color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.inbox-row__actions { flex-shrink: 0; display: flex; align-items: center; gap: var(--space-2); }
+.inbox-row__review {
+  flex-shrink: 0; height: 36px; padding: 0 var(--space-3);
+  background: var(--bg-surface); border: 0;
+}
+.inbox-row__review:hover { background: var(--bg-overlay); }
+.inbox-empty { color: var(--fg-subtle); text-align: center; padding: var(--space-8) var(--space-4); }
+
+/* Avatars — initials on a neutral surface (28 list / 56 review). */
+.avatar {
+  flex-shrink: 0; display: grid; place-items: center;
+  width: 28px; height: 28px; border-radius: var(--radius-xs);
+  background: var(--bg-surface); color: var(--fg-muted);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+}
+.avatar--lg { width: 56px; height: 56px; border-radius: var(--radius-sm); font-size: var(--font-size-title-3); }
+
+/* Decision chips (signal-chip taxonomy: green outreach · amber hold · gray pass) */
+.decision-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 24px; padding: 0 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+  white-space: nowrap;
+}
+.decision-chip--outreach { background: var(--outreach-tint); color: var(--outreach-fg); }
+.decision-chip--hold { background: var(--hold-tint); color: var(--hold-fg); }
+.decision-chip--pass { background: var(--pass-tint); color: var(--fg-subtle); }
+
+/* --- Review overlay --- */
+.review { position: fixed; inset: 0; z-index: 80; background: var(--bg); display: flex; flex-direction: column; }
+.review[hidden] { display: none; }
+.review__bar {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  padding-top: max(var(--space-3), env(safe-area-inset-top));
+  flex-shrink: 0;
+}
+.review__bar-actions { display: inline-flex; align-items: center; gap: var(--space-2); }
+.review__dots { display: inline-flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; }
+.review__dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--bg-overlay); flex-shrink: 0;
+  transition: width 160ms ease, background 160ms ease;
+}
+.review__dot.is-current { width: 24px; background: var(--fg); }
+.review__counter { font-size: var(--font-size-small); color: var(--fg-muted); }
+.review__close, .review__nav {
+  width: 40px; height: 40px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border); background: var(--bg-elevated); color: var(--fg);
+  font-size: 18px; line-height: 1; display: inline-grid; place-items: center;
+}
+.review__nav:disabled { opacity: .35; cursor: default; }
+/* Scroll container spans the full window so the scrollbar sits at the far
+   right edge (browser standard); the reading column is capped inside. */
+.review__scroll {
+  flex: 1; overflow-y: auto; -webkit-overflow-scrolling: touch;
+  width: 100%;
+}
+.review__inner {
+  max-width: 720px; width: 100%; margin: 0 auto;
+  padding: 0 var(--space-4) var(--space-6);
+}
+.review__card {
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-sm);
+  padding: var(--space-4); margin-bottom: var(--space-5);
+}
+.review__head { display: flex; gap: var(--space-4); align-items: flex-start; }
+.review__head-text { min-width: 0; }
+.review__title {
+  margin: 0 0 var(--space-1);
+  font-weight: var(--fw-semibold); font-size: var(--font-size-title-3);
+  line-height: var(--lh-tight); letter-spacing: -0.01em; overflow-wrap: anywhere;
+}
+.review__pronouns { font-weight: 400; color: var(--fg-subtle); font-size: var(--font-size-small); }
+.review__meta { margin: 0; color: var(--fg-muted); font-size: var(--font-size-body); overflow-wrap: anywhere; }
+.review__badges { display: flex; flex-wrap: wrap; gap: var(--space-2); margin: var(--space-3) 0 0; }
+.review__badge {
+  display: inline-flex; align-items: center;
+  padding: 5px var(--space-3); border-radius: var(--radius-pill);
+  background: var(--bg-surface); color: var(--fg-muted);
+  font-size: var(--font-size-small); font-weight: var(--fw-medium);
+}
+.review__badge--track { background: var(--accent-muted); color: var(--fg); }
+.review__facts { margin: var(--space-3) 0 0; display: flex; flex-direction: column; gap: var(--space-1); font-size: var(--font-size-body); }
+.review__fact { display: flex; gap: var(--space-2); }
+.review__fact-label { color: var(--fg-subtle); font-size: var(--font-size-small); min-width: 88px; padding-top: 1px; }
+.review__fact-value { color: var(--fg); overflow-wrap: anywhere; min-width: 0; }
+/* Link chips — resolved socials + links mined from answers. */
+.link-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); min-width: 0; }
+.link-chip {
+  display: inline-flex; align-items: center;
+  height: 28px; padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface); color: var(--fg);
+  font-size: var(--font-size-small); font-weight: var(--fw-medium);
+  max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.link-chip:hover { background: var(--bg-overlay); text-decoration: none; }
+
+/* (i) dot — hover/focus reveals the applicant's original response text. */
+.info-dot {
+  display: inline-grid; place-items: center;
+  width: 16px; height: 16px; padding: 0;
+  border: 1px solid var(--border-strong); border-radius: var(--radius-pill);
+  background: transparent; color: var(--fg-subtle);
+  font-size: 10px; font-style: italic; font-weight: var(--fw-semibold);
+  font-family: var(--font-body);
+  vertical-align: 2px; position: relative; cursor: help;
+}
+.info-dot::after {
+  content: attr(data-tip);
+  position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%);
+  width: max-content; max-width: min(340px, 80vw);
+  background: var(--fg); color: var(--bg);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm); box-shadow: var(--shadow-md);
+  font-size: var(--font-size-caption); font-style: normal; font-weight: 400;
+  line-height: var(--lh-tight); text-align: left; white-space: normal;
+  opacity: 0; visibility: hidden; transition: opacity 120ms ease;
+  pointer-events: none; z-index: 90;
+}
+.info-dot:hover::after, .info-dot:focus-visible::after { opacity: 1; visibility: visible; }
+
+.review__section { margin-bottom: var(--space-5); }
+.review__section-title { margin: 0 0 var(--space-3); font-weight: var(--fw-semibold); font-size: var(--font-size-title-4); }
+.review__prose { margin: 0; font-size: var(--font-size-body); line-height: var(--lh-body); white-space: pre-wrap; overflow-wrap: anywhere; }
+.review__decided {
+  display: flex; align-items: center; gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-small); color: var(--fg-muted);
+}
+.review__decided .link-clear { background: none; border: 0; padding: 0; color: var(--fg-link); font-size: inherit; text-decoration: underline; }
+
+/* Footer — three decisions pinned at the bottom. */
+.review__foot {
+  display: grid; grid-template-columns: 1fr 1fr 1fr;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  padding-bottom: max(var(--space-3), env(safe-area-inset-bottom));
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated); flex-shrink: 0;
+}
+.review__foot[hidden] { display: none; }
+@media (min-width: 721px) { .review__foot { max-width: 760px; width: 100%; margin-inline: auto; border-inline: 1px solid var(--border); border-radius: var(--radius-lg) var(--radius-lg) 0 0; } }
+.review__btn { width: 100%; height: 48px; border-radius: var(--radius-pill); }
+.review__btn--pass, .review__btn--hold { background: var(--bg-surface); border: 0; }
+.review__btn--pass:hover, .review__btn--hold:hover { background: var(--bg-overlay); }
+.review__btn.is-active--pass { background: var(--pass-tint); box-shadow: inset 0 0 0 1.5px var(--border-strong); }
+.review__btn.is-active--hold { background: var(--hold-tint); color: var(--hold-fg); box-shadow: inset 0 0 0 1.5px currentColor; }
+.review__btn.is-active--outreach { box-shadow: inset 0 0 0 2px var(--outreach-fg); }
+
+/* Hold reason sheet — slides over the footer. */
+.hold-sheet {
+  border-top: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: var(--space-4);
+  padding-bottom: max(var(--space-4), env(safe-area-inset-bottom));
+  flex-shrink: 0;
+}
+.hold-sheet[hidden] { display: none; }
+@media (min-width: 721px) { .hold-sheet { max-width: 760px; width: 100%; margin-inline: auto; border-inline: 1px solid var(--border); border-radius: var(--radius-lg) var(--radius-lg) 0 0; } }
+.hold-sheet__title { margin: 0 0 var(--space-3); font-weight: var(--fw-semibold); font-size: var(--font-size-title-4); }
+.hold-sheet__options { display: flex; flex-direction: column; gap: var(--space-2); }
+.hold-sheet__option {
+  height: 48px; padding: 0 var(--space-4); text-align: left;
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+  background: var(--bg-surface); color: var(--fg);
+  font-weight: var(--fw-medium);
+}
+.hold-sheet__option:hover { background: var(--bg-overlay); border-color: var(--border-strong); }
+.hold-sheet__option.is-selected { background: var(--hold-tint); color: var(--hold-fg); border-color: currentColor; }
+.hold-sheet__cancel {
+  margin-top: var(--space-3);
+  background: transparent; border: 0; color: var(--fg-muted);
+  padding: var(--space-2) 0; width: 100%;
+}
+.hold-sheet__cancel:hover { color: var(--fg); }
+
+/* Toast */
+.toast-host { position: fixed; left: 50%; bottom: 24px; transform: translateX(-50%); z-index: 120; display: flex; flex-direction: column; gap: var(--space-2); }
+.toast {
+  background: var(--fg); color: var(--bg);
+  padding: 10px var(--space-4); border-radius: var(--radius-sm);
+  font-size: var(--font-size-small); font-weight: var(--fw-medium);
+  box-shadow: var(--shadow-md); cursor: pointer;
+}
+
+@media (max-width: 480px) {
+  .page { padding-top: var(--space-5); }
+  .page__title { font-size: 20px; }
+  .inbox-row__review { display: none; } /* whole row is tappable on phones */
+  .review__foot { gap: var(--space-2); }
+  .review__btn { padding-inline: var(--space-2); font-size: var(--font-size-small); }
+}

--- a/applications/index.html
+++ b/applications/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Applications — Agape recruiting</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
+  <link rel="stylesheet" href="css/app.css?v=2.0.0">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="/auth/ctrl-auth.js"></script>
+</head>
+<body data-auth-state="loading">
+
+  <!-- Gate: Discord sign-in, then Recruiting Society channel verification. -->
+  <div class="gate" id="gate">
+    <div class="gate__card">
+      <h1 class="gate__title">Agape recruiting</h1>
+      <p class="gate__sub" id="gate-sub">Sign in with Discord to open the applicant inbox.</p>
+      <button class="btn btn--accent gate__btn" id="gate-btn" type="button">Sign in</button>
+      <p class="gate__error" id="gate-error"></p>
+      <p class="gate__hint" id="gate-hint">Access is limited to members of the Recruiting Society channel on the Agape server.</p>
+      <div id="ctrl-auth-root"></div>
+    </div>
+  </div>
+
+  <main class="page" id="app" hidden>
+    <header class="page__head">
+      <div class="page__head-text">
+        <h1 class="page__title">Inbox</h1>
+        <p class="page__sub" id="page-sub"></p>
+      </div>
+      <div class="page-menu">
+        <button class="page-menu__trigger" id="menu-trigger" aria-label="Page menu">⋯</button>
+        <div class="page-menu__list" id="menu-list">
+          <button class="page-menu__item" id="menu-export">Export decisions (CSV)</button>
+          <button class="page-menu__item" id="menu-sheet">Open source spreadsheet</button>
+          <button class="page-menu__item" id="menu-theme">Toggle theme</button>
+          <button class="page-menu__item" id="menu-signout">Sign out</button>
+        </div>
+      </div>
+    </header>
+
+    <div class="filters" id="filters"></div>
+    <div class="inbox" id="inbox"></div>
+  </main>
+
+  <!-- Review overlay — one applicant at a time, three decisions pinned at the bottom. -->
+  <div class="review" id="review" hidden>
+    <div class="review__bar">
+      <div class="review__bar-actions">
+        <button class="review__nav" id="review-prev" aria-label="Previous">←</button>
+        <button class="review__nav" id="review-next" aria-label="Next">→</button>
+      </div>
+      <div id="review-progress"></div>
+      <button class="review__close" id="review-close" aria-label="Close">✕</button>
+    </div>
+    <div class="review__scroll"><div class="review__inner" id="review-body"></div></div>
+    <div class="review__foot" id="review-foot">
+      <button class="btn review__btn review__btn--pass" id="btn-pass">Pass</button>
+      <button class="btn review__btn review__btn--hold" id="btn-hold">Hold</button>
+      <button class="btn btn--accent review__btn" id="btn-outreach">Outreach</button>
+    </div>
+    <div class="hold-sheet" id="hold-sheet" hidden>
+      <h3 class="hold-sheet__title">Why hold?</h3>
+      <div class="hold-sheet__options" id="hold-options"></div>
+      <button class="hold-sheet__cancel" id="hold-cancel">Cancel</button>
+    </div>
+  </div>
+
+  <div class="toast-host" id="toast-host"></div>
+
+  <script src="js/app.js?v=2.0.0"></script>
+</body>
+</html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -1,0 +1,663 @@
+/* Agape recruiting viewer — /applications
+   Discord-gated (Recruiting Society channel on the Agape server, verified by
+   the discord-membership edge fn). Applicants, shared decisions, and house
+   notes live in Supabase behind RLS (migration 108). */
+const VERSION = '2.0.0';
+console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
+
+const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+
+const HOLD_REASONS = [
+  { id: 'fit', label: 'Fit needs review' },
+  { id: 'timing', label: 'Length of timing' },
+  { id: 'needs', label: 'Current Agape needs (e.g. couple)' },
+];
+const DECISION_LABELS = { outreach: 'Outreach', hold: 'Hold', pass: 'Pass' };
+
+let sb = null;                // supabase client (from CtrlAuth)
+let me = null;                // { id, name }
+let applicants = [];          // newest first
+let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
+let commentCounts = {};       // applicant_id -> n
+let comments = [];            // comments for the applicant open in review
+let filter = 'all';
+let queue = [];
+let qIndex = 0;
+
+/* ---------- helpers (shared with the static viewer) ---------- */
+const esc = s => String(s || '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+const initials = a => ((a.first[0] || '') + (a.last[0] || '')).toUpperCase();
+const fullName = a => `${a.first} ${a.last}`.trim();
+const isSublet = a => /short/i.test(a.residency);
+const trackLabel = a => isSublet(a) ? 'Sublet' : 'Full-time';
+const fmtDate = iso => new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+const monthKey = iso => iso.slice(0, 7);
+const monthLabel = iso => new Date(iso + (iso.length === 7 ? '-01T12:00' : '')).toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+const relTime = iso => {
+  const s = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (s < 90) return 'just now';
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  if (s < 86400 * 30) return `${Math.round(s / 86400)}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+function subLine(a) {
+  const bits = [trackLabel(a)];
+  const mi = normalizeMoveIn(a);
+  const bu = normalizeBudget(a.budget);
+  if (mi) bits.push(mi);
+  if (bu) bits.push(bu);
+  return bits.join(' · ');
+}
+
+/* ---------- normalizers (raw text stays behind the (i) tooltip) ---------- */
+const MONTHS = ['january','february','march','april','may','june','july','august','september','october','november','december'];
+const MONTH_ABBR = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function normalizeMoveIn(a) {
+  const raw = (a.movein || '').trim();
+  if (!raw || /^n\/?a$/i.test(raw)) return '';
+  const flexible = /flexib|anytime|any time|whenever|open to|open for/i.test(raw);
+  if (/asap|as soon as/i.test(raw)) return 'ASAP' + (flexible ? ' · flexible' : '');
+
+  const found = [];
+  const rx = new RegExp(`\\b(${MONTHS.join('|')}|${MONTH_ABBR.join('|')})\\b`, 'gi');
+  let m;
+  while ((m = rx.exec(raw))) {
+    let idx = MONTHS.findIndex(x => x.startsWith(m[1].slice(0, 3).toLowerCase()));
+    if (idx >= 0 && !found.includes(idx)) found.push(idx);
+  }
+  if (!found.length) return flexible ? 'Flexible' : '';
+
+  const first = found[0];
+  const monthName = `(?:${MONTHS[first]}|${MONTH_ABBR[first]})`;
+  const day = raw.match(new RegExp(`${monthName}\\.?\\s+(\\d{1,2})(?:st|nd|rd|th)?\\b`, 'i'))
+    || raw.match(new RegExp(`\\b(\\d{1,2})(?:st|nd|rd|th)?\\s+(?:of\\s+)?${monthName}`, 'i'));
+
+  const yearMatch = raw.match(/\b(20\d{2})\b/);
+  const applied = new Date(a.ts_iso);
+  const year = yearMatch ? +yearMatch[1] : (first < applied.getMonth() ? applied.getFullYear() + 1 : applied.getFullYear());
+
+  let label;
+  if (found.length > 1) {
+    const lo = Math.min(...found), hi = Math.max(...found);
+    label = `${MONTH_ABBR[lo]}–${MONTH_ABBR[hi]} ${year}`;
+  } else if (day) {
+    label = `${MONTH_ABBR[first]} ${+day[1]}, ${year}`;
+  } else {
+    label = `${MONTH_ABBR[first]} ${year}`;
+  }
+  return label + (flexible ? ' · flexible' : '');
+}
+
+function normalizeBudget(raw) {
+  raw = (raw || '').trim();
+  if (!raw || /^n\/?a$/i.test(raw)) return '';
+  const nums = [];
+  const rx = /\$?\s?(\d{1,2}(?:[.,]\d{1,3})?)\s*[kK]\b|\$?\s?(\d{1,3}(?:,\d{3})+|\d{3,4})(?!\d)/g;
+  let m;
+  while ((m = rx.exec(raw))) {
+    let n = m[1] ? parseFloat(m[1].replace(',', '.')) * 1000 : parseInt(m[2].replace(/,/g, ''), 10);
+    if (n >= 300 && n <= 10000) nums.push(Math.round(n));
+  }
+  if (!nums.length) return /flexib/i.test(raw) ? 'Flexible' : '';
+  const fmt = n => '$' + n.toLocaleString('en-US');
+  const lo = Math.min(...nums), hi = Math.max(...nums);
+  const capped = /up to|max|below|under|less than|<|limit|upper bound|no more than/i.test(raw);
+  const plus = /\d\s*\+/.test(raw);
+  let label;
+  if (lo !== hi) label = `${fmt(lo)}–${fmt(hi)}`;
+  else if (capped) label = `Up to ${fmt(hi)}`;
+  else if (plus) label = `${fmt(hi)}+`;
+  else label = fmt(hi);
+  return label + '/mo';
+}
+
+function infoDot(raw, normalized) {
+  if (!raw || !normalized || raw.trim() === normalized) return '';
+  return `<button class="info-dot" type="button" data-tip="${esc(raw)}" aria-label="Original response">i</button>`;
+}
+
+/* ---------- links helper ---------- */
+const HANDLE_STOPWORDS = /^(https?|www|and|but|not|the|don|dont|use|media|active|com|net|org|only|though|really)$/i;
+const LINK_LABELS = [
+  [/instagram\.com/i, 'Instagram'], [/linkedin\.com/i, 'LinkedIn'],
+  [/facebook\.com/i, 'Facebook'], [/(?:^|\.)x\.com|twitter\.com/i, 'X'],
+  [/github\.com/i, 'GitHub'], [/tiktok\.com/i, 'TikTok'],
+  [/substack\.com/i, 'Substack'], [/youtube\.com|youtu\.be/i, 'YouTube'],
+  [/soundcloud\.com/i, 'SoundCloud'], [/spotify\.com/i, 'Spotify'],
+];
+
+function linkLabel(url) {
+  try {
+    const u = new URL(url);
+    for (const [rx, name] of LINK_LABELS) {
+      if (rx.test(u.hostname + u.pathname)) {
+        let seg = u.pathname.split('/').filter(Boolean).pop() || '';
+        if (!seg && /substack\.com$/i.test(u.hostname) && !/^www\./i.test(u.hostname)) seg = u.hostname.split('.')[0];
+        const handle = decodeURIComponent(seg).replace(/^@/, '').replace(/\/$/, '');
+        return handle && !/^(in|company|profile|people)$/i.test(handle) ? `${name} · ${handle}` : name;
+      }
+    }
+    return u.hostname.replace(/^www\./, '') + (u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '');
+  } catch { return url; }
+}
+
+function collectLinks(a) {
+  const found = new Map();
+  const add = url => {
+    if (!url) return;
+    url = url.replace(/[.,;:!?)\]]+$/, '');
+    if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
+    const key = url.toLowerCase().replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '');
+    if (!found.has(key)) found.set(key, { url, label: linkLabel(url) });
+  };
+
+  const social = a.social || '';
+  const answers = [a.about, a.why, a.gifts].join('  ');
+  const all = social + '  ' + answers;
+
+  for (const m of all.matchAll(/https?:\/\/[^\s,<>()"']+/gi)) add(m[0]);
+  for (const m of all.matchAll(/(?<![@\w.])((?:[a-z0-9-]+\.)+(?:com|org|net|io|co|ai|me|dev|house|fm|xyz))(\/[^\s,<>()"']*)?/gi)) {
+    if (/@/.test(m[0])) continue;
+    add(m[1] + (m[2] || ''));
+  }
+  if (social && !/^(i don'?t|none|n\/?a|right now)/i.test(social.trim())) {
+    for (const m of social.matchAll(/(?:^|[\s,])(?:(insta(?:gram)?|ig|tiktok|fb|facebook|linkedin|twitter|x)\b[:\s]*)?@([a-z0-9._]{2,30})\b(?:\s*(?:on\s+)?\(?(insta(?:gram)?|ig|tiktok|fb|facebook)\)?)?/gi)) {
+      const hint = (m[1] || m[3] || 'instagram').toLowerCase();
+      const handle = m[2];
+      if (HANDLE_STOPWORDS.test(handle)) continue;
+      const host = /tiktok/.test(hint) ? `tiktok.com/@${handle}`
+        : /fb|facebook/.test(hint) ? `facebook.com/${handle}`
+        : /linkedin/.test(hint) ? `linkedin.com/in/${handle}`
+        : /twitter|^x$/.test(hint) ? `x.com/${handle}`
+        : `instagram.com/${handle}`;
+      add(host);
+    }
+    for (const m of social.matchAll(/(?:(insta(?:gram)?|ig|fb|facebook)\b[:\s]+([a-z0-9._]{3,30})\b|\b([a-z0-9._]{3,30})\s+on\s+(insta(?:gram)?|ig|fb|facebook)\b)/gi)) {
+      const hint = (m[1] || m[4] || '').toLowerCase();
+      const handle = m[2] || m[3];
+      if (!handle || HANDLE_STOPWORDS.test(handle)) continue;
+      add(/fb|facebook/.test(hint) ? `facebook.com/${handle}` : `instagram.com/${handle}`);
+    }
+  }
+  return [...found.values()];
+}
+
+/* ---------- data ---------- */
+async function loadAll() {
+  const [aRes, dRes, cRes] = await Promise.all([
+    sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
+    sb.from('recruit_decisions').select('*'),
+    sb.from('recruit_comments').select('applicant_id'),
+  ]);
+  if (aRes.error) throw aRes.error;
+  applicants = (aRes.data || []).map(r => ({
+    id: r.id, ts_iso: r.submitted_at,
+    first: r.first_name, last: r.last_name, pronouns: r.pronouns,
+    email: r.email, social: r.social, about: r.about, why: r.why_agape,
+    gifts: r.gifts, source: r.heard_from, residency: r.residency,
+    movein: r.move_in, budget: r.budget,
+  }));
+  decisions = {};
+  for (const d of (dRes.data || [])) {
+    decisions[d.applicant_id] = { d: d.decision, reason: d.hold_reason, byName: d.decided_by_name, at: d.decided_at };
+  }
+  commentCounts = {};
+  for (const c of (cRes.data || [])) commentCounts[c.applicant_id] = (commentCounts[c.applicant_id] || 0) + 1;
+}
+
+async function saveDecision(id, d, reason) {
+  if (d === null) {
+    delete decisions[id];
+    const { error } = await sb.from('recruit_decisions').delete().eq('applicant_id', id);
+    if (error) toast(`Save failed: ${error.message}`);
+    return;
+  }
+  decisions[id] = { d, reason: reason || null, byName: me.name, at: new Date().toISOString() };
+  const { error } = await sb.from('recruit_decisions').upsert({
+    applicant_id: id, decision: d, hold_reason: reason || null,
+    decided_by: me.id, decided_by_name: me.name,
+    decided_at: new Date().toISOString(),
+  });
+  if (error) toast(`Save failed: ${error.message}`);
+}
+
+async function loadComments(applicantId) {
+  const { data, error } = await sb.from('recruit_comments')
+    .select('*').eq('applicant_id', applicantId).order('created_at');
+  comments = error ? [] : (data || []);
+}
+
+/* ---------- inbox render ---------- */
+function matchesFilter(a) {
+  const rec = decisions[a.id];
+  if (filter === 'all') return true;
+  if (filter === 'undecided') return !rec;
+  return rec?.d === filter;
+}
+
+function counts() {
+  const c = { all: applicants.length, undecided: 0, outreach: 0, hold: 0, pass: 0 };
+  for (const a of applicants) {
+    const rec = decisions[a.id];
+    if (!rec) c.undecided++; else c[rec.d]++;
+  }
+  return c;
+}
+
+function decisionChip(id) {
+  const rec = decisions[id];
+  if (!rec) return '';
+  const reason = rec.reason ? ` — ${HOLD_REASONS.find(r => r.id === rec.reason)?.label || rec.reason}` : '';
+  const by = rec.byName ? ` · ${rec.byName}` : '';
+  return `<span class="decision-chip decision-chip--${rec.d}" title="${esc(DECISION_LABELS[rec.d] + reason + by)}">${DECISION_LABELS[rec.d]}</span>`;
+}
+
+function renderFilters() {
+  const c = counts();
+  const defs = [
+    ['all', 'All'], ['undecided', 'Needs review'],
+    ['outreach', 'Outreach'], ['hold', 'Hold'], ['pass', 'Pass'],
+  ];
+  document.getElementById('filters').innerHTML = defs.map(([id, label]) =>
+    `<button class="chip ${filter === id ? 'is-on' : ''}" data-filter="${id}">${label} <span class="chip__count">${c[id]}</span></button>`
+  ).join('');
+}
+
+function renderInbox() {
+  renderFilters();
+  const list = applicants.filter(matchesFilter);
+  document.getElementById('page-sub').textContent =
+    `${applicants.length} applicants · ${counts().undecided} to review`;
+
+  const host = document.getElementById('inbox');
+  if (!list.length) {
+    host.innerHTML = `<p class="inbox-empty">Nothing here — every applicant in this view is decided.</p>`;
+    return;
+  }
+  const groups = [];
+  for (const a of list) {
+    const k = monthKey(a.ts_iso);
+    if (!groups.length || groups[groups.length - 1].key !== k) groups.push({ key: k, items: [] });
+    groups[groups.length - 1].items.push(a);
+  }
+  host.innerHTML = groups.map(g => `
+    <section class="inbox-group">
+      <div class="inbox-group__head">
+        <h2 class="inbox-group__label">${monthLabel(g.key)}</h2>
+        <span class="inbox-group__count">${g.items.length} applicant${g.items.length === 1 ? '' : 's'}</span>
+      </div>
+      <ul class="inbox-card">
+        ${g.items.map(a => `
+          <li class="inbox-row">
+            <button class="inbox-row__main" data-review="${a.id}">
+              <span class="avatar">${esc(initials(a))}</span>
+              <span class="inbox-row__text">
+                <span class="inbox-row__title">${esc(fullName(a))}</span>
+                <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
+              </span>
+            </button>
+            <span class="inbox-row__actions">
+              ${commentCounts[a.id] ? `<span class="note-count" title="${commentCounts[a.id]} house note${commentCounts[a.id] === 1 ? '' : 's'}">✎ ${commentCounts[a.id]}</span>` : ''}
+              ${decisionChip(a.id)}
+              <button class="btn inbox-row__review" data-review="${a.id}">Review</button>
+            </span>
+          </li>`).join('')}
+      </ul>
+    </section>`).join('');
+}
+
+/* ---------- review overlay ---------- */
+function openReview(id) {
+  queue = applicants.filter(matchesFilter).map(a => a.id);
+  if (!queue.includes(id)) queue = applicants.map(a => a.id);
+  qIndex = Math.max(0, queue.indexOf(id));
+  document.getElementById('review').hidden = false;
+  document.body.style.overflow = 'hidden';
+  hideHoldSheet();
+  renderReview();
+  resetScroll();
+}
+
+function closeReview() {
+  document.getElementById('review').hidden = true;
+  document.body.style.overflow = '';
+  const url = new URL(location); url.searchParams.delete('a');
+  history.replaceState(null, '', url);
+  renderInbox();
+}
+
+function step(delta) {
+  const next = qIndex + delta;
+  if (next < 0 || next >= queue.length) { if (delta > 0) closeReview(); return; }
+  qIndex = next;
+  hideHoldSheet();
+  renderReview();
+  resetScroll();
+}
+
+function resetScroll() {
+  const el = document.querySelector('.review__scroll');
+  el.scrollTop = 0;
+  requestAnimationFrame(() => { el.scrollTop = 0; });
+}
+
+function renderReview() {
+  const a = applicants.find(x => x.id === queue[qIndex]);
+  if (!a) { closeReview(); return; }
+  const url = new URL(location); url.searchParams.set('a', a.id);
+  history.replaceState(null, '', url);
+
+  const dotsHost = document.getElementById('review-progress');
+  dotsHost.innerHTML = queue.length <= 12
+    ? `<span class="review__dots">${queue.map((_, i) => `<span class="review__dot ${i === qIndex ? 'is-current' : ''}"></span>`).join('')}</span>`
+    : `<span class="review__counter">${qIndex + 1} of ${queue.length}</span>`;
+
+  document.getElementById('review-prev').disabled = qIndex === 0;
+  document.getElementById('review-next').disabled = qIndex === queue.length - 1;
+
+  const rec = decisions[a.id];
+  const links = collectLinks(a);
+  const linksHtml = links.length
+    ? `<div class="link-chips">${links.map(l =>
+        `<a class="link-chip" href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.label)}</a>`).join('')}${a.social ? infoDot(a.social, 'links') : ''}</div>`
+    : (a.social ? `<span class="review__fact-value">${esc(a.social)}</span>` : '');
+  const miNorm = normalizeMoveIn(a);
+  const buNorm = normalizeBudget(a.budget);
+
+  document.getElementById('review-body').innerHTML = `
+    ${rec ? `<p class="review__decided">Decided: ${DECISION_LABELS[rec.d]}${rec.reason ? ` — ${esc(HOLD_REASONS.find(r => r.id === rec.reason)?.label || rec.reason)}` : ''}${rec.byName ? ` · by ${esc(rec.byName)}` : ''} · <button class="link-clear" data-clear="${a.id}">Undo</button></p>` : ''}
+    <div class="review__card">
+      <div class="review__head">
+        <span class="avatar avatar--lg">${esc(initials(a))}</span>
+        <div class="review__head-text">
+          <h2 class="review__title">${esc(fullName(a))}${a.pronouns ? ` <span class="review__pronouns">${esc(a.pronouns)}</span>` : ''}</h2>
+          <p class="review__meta"><a href="mailto:${esc(a.email)}">${esc(a.email)}</a></p>
+          <div class="review__badges">
+            <span class="review__badge review__badge--track">${trackLabel(a)}</span>
+            ${a.source ? `<span class="review__badge" title="How they heard about Agape">${esc(a.source)}</span>` : ''}
+          </div>
+          <div class="review__facts">
+            <div class="review__fact"><span class="review__fact-label">Move-in</span><span class="review__fact-value">${esc(miNorm || a.movein || '—')} ${infoDot(a.movein, miNorm)}</span></div>
+            <div class="review__fact"><span class="review__fact-label">Budget</span><span class="review__fact-value">${esc(buNorm || a.budget || '—')} ${infoDot(a.budget, buNorm)}</span></div>
+            <div class="review__fact"><span class="review__fact-label">Applied</span><span class="review__fact-value">${new Date(a.ts_iso).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' })}</span></div>
+            ${linksHtml ? `<div class="review__fact"><span class="review__fact-label">Links</span>${linksHtml}</div>` : ''}
+          </div>
+        </div>
+      </div>
+    </div>
+    ${section('About them', a.about)}
+    ${section('Why Agape', a.why)}
+    ${section('Gifts to share', a.gifts)}
+    <section class="review__section notes" id="notes">
+      <h3 class="review__section-title">House notes</h3>
+      <div id="notes-body"><p class="notes__empty">Loading notes…</p></div>
+      <form class="notes__form" id="notes-form">
+        <textarea class="notes__input" id="notes-input" placeholder="Add an internal note for the house — only Recruiting Society members see these." maxlength="4000"></textarea>
+        <button class="btn btn--accent btn--sm notes__submit" type="submit">Add note</button>
+      </form>
+    </section>
+  `;
+
+  for (const d of ['pass', 'hold', 'outreach']) {
+    const btn = document.getElementById(`btn-${d}`);
+    btn.classList.toggle(`is-active--${d}`, rec?.d === d);
+  }
+
+  loadComments(a.id).then(() => {
+    // guard against navigating away while the query was in flight
+    if (queue[qIndex] === a.id) renderNotes(a.id);
+  });
+  document.getElementById('notes-form').addEventListener('submit', e => {
+    e.preventDefault();
+    postNote(a.id);
+  });
+}
+
+function renderNotes(applicantId) {
+  const host = document.getElementById('notes-body');
+  if (!host) return;
+  commentCounts[applicantId] = comments.length;
+  if (!comments.length) {
+    host.innerHTML = `<p class="notes__empty">No notes yet — be the first.</p>`;
+    return;
+  }
+  host.innerHTML = `<ul class="notes__list">${comments.map(c => `
+    <li class="note">
+      <span class="avatar">${esc((c.author_name || '?')[0].toUpperCase())}</span>
+      <div class="note__body-wrap">
+        <div class="note__meta">
+          <span class="note__author">${esc(c.author_name || 'Housemate')}</span>
+          <span class="note__time">${relTime(c.created_at)}</span>
+        </div>
+        <p class="note__body">${esc(c.body)}</p>
+      </div>
+      ${c.user_id === me.id ? `<button class="note__delete" data-delete-note="${c.id}" aria-label="Delete note">✕</button>` : ''}
+    </li>`).join('')}</ul>`;
+}
+
+async function postNote(applicantId) {
+  const input = document.getElementById('notes-input');
+  const body = (input.value || '').trim();
+  if (!body) return;
+  input.value = '';
+  const { data, error } = await sb.from('recruit_comments')
+    .insert({ applicant_id: applicantId, user_id: me.id, author_name: me.name, body })
+    .select().single();
+  if (error) { toast(`Note failed: ${error.message}`); input.value = body; return; }
+  comments.push(data);
+  renderNotes(applicantId);
+}
+
+async function deleteNote(noteId, applicantId) {
+  const { error } = await sb.from('recruit_comments').delete().eq('id', noteId);
+  if (error) { toast(`Delete failed: ${error.message}`); return; }
+  comments = comments.filter(c => c.id !== noteId);
+  renderNotes(applicantId);
+}
+
+function section(title, text) {
+  if (!text) return '';
+  return `<section class="review__section">
+    <h3 class="review__section-title">${title}</h3>
+    <p class="review__prose">${esc(text)}</p>
+  </section>`;
+}
+
+function decide(d, reason) {
+  const a = applicants.find(x => x.id === queue[qIndex]);
+  if (!a) return;
+  saveDecision(a.id, d, reason);
+  toast(`${fullName(a)} → ${DECISION_LABELS[d]}${reason ? ` (${HOLD_REASONS.find(r => r.id === reason)?.label})` : ''}`);
+  if (qIndex === queue.length - 1) closeReview(); else step(1);
+}
+
+function showHoldSheet() {
+  const a = applicants.find(x => x.id === queue[qIndex]);
+  const current = decisions[a?.id]?.reason;
+  document.getElementById('hold-options').innerHTML = HOLD_REASONS.map(r =>
+    `<button class="hold-sheet__option ${current === r.id ? 'is-selected' : ''}" data-reason="${r.id}">${r.label}</button>`).join('');
+  document.getElementById('hold-sheet').hidden = false;
+  document.getElementById('review-foot').hidden = true;
+}
+function hideHoldSheet() {
+  document.getElementById('hold-sheet').hidden = true;
+  document.getElementById('review-foot').hidden = false;
+}
+
+/* ---------- export ---------- */
+function exportCsv() {
+  const cols = ['first', 'last', 'email', 'ts_iso', 'residency', 'movein', 'budget', 'source'];
+  const head = [...cols, 'decision', 'hold_reason', 'decided_by', 'decided_at', 'notes'];
+  const q = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
+  const lines = [head.join(',')];
+  for (const a of applicants) {
+    const rec = decisions[a.id] || {};
+    lines.push([...cols.map(c => q(a[c])), q(DECISION_LABELS[rec.d] || ''),
+      q(rec.reason ? (HOLD_REASONS.find(r => r.id === rec.reason)?.label || rec.reason) : ''),
+      q(rec.byName || ''), q(rec.at || ''), q(commentCounts[a.id] || 0)].join(','));
+  }
+  const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
+  const aEl = document.createElement('a');
+  aEl.href = URL.createObjectURL(blob);
+  aEl.download = `agape-decisions-${new Date().toISOString().slice(0, 10)}.csv`;
+  aEl.click();
+  URL.revokeObjectURL(aEl.href);
+}
+
+/* ---------- toast ---------- */
+function toast(msg) {
+  const host = document.getElementById('toast-host');
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.textContent = msg;
+  el.onclick = () => el.remove();
+  host.appendChild(el);
+  setTimeout(() => el.remove(), 4500);
+}
+
+/* ---------- theme ---------- */
+function applyTheme(t) {
+  document.documentElement.dataset.theme = t;
+  localStorage.setItem('agape:theme', t);
+}
+
+/* ---------- auth + boot ---------- */
+function setGate(sub, btnLabel, hint) {
+  document.getElementById('gate-sub').textContent = sub;
+  const btn = document.getElementById('gate-btn');
+  btn.textContent = btnLabel || 'Sign in';
+  btn.hidden = !btnLabel;
+  document.getElementById('gate-hint').textContent = hint ||
+    'Access is limited to members of the Recruiting Society channel on the Agape server.';
+}
+
+async function checkMembershipAndEnter() {
+  const session = await sb.auth.getSession();
+  const token = session?.data?.session?.access_token;
+  if (!token) return;
+  setGate('Checking your Recruiting Society access…', null);
+  try {
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ action: 'status' }),
+    });
+    const status = await resp.json();
+    if (!status.linked) {
+      setGate('Your account has no Discord linked.', 'Link Discord',
+        'Link the Discord account that’s in the Agape server, then try again.');
+      document.getElementById('gate-btn').onclick = () => window.CtrlAuth.linkDiscord(location.href);
+      return;
+    }
+    if (!status.isRecruitingMember) {
+      setGate(`Signed in as ${status.discordUsername || 'you'} — but this account can’t see the Recruiting Society channel.`,
+        'Re-check access',
+        'Ask in the Agape server for access to the Recruiting Society channel, then re-check.');
+      document.getElementById('gate-btn').onclick = async () => {
+        setGate('Re-checking…', null);
+        await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+          body: JSON.stringify({ action: 'verify' }),
+        });
+        checkMembershipAndEnter();
+      };
+      return;
+    }
+    // in — identify self, load data, render
+    const user = window.CtrlAuth.getUser();
+    me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
+    await loadAll();
+    document.getElementById('gate').hidden = true;
+    document.getElementById('app').hidden = false;
+    renderInbox();
+    const deep = new URLSearchParams(location.search).get('a');
+    if (deep && applicants.some(x => x.id === deep)) openReview(deep);
+  } catch (e) {
+    setGate('Something went wrong checking access.', 'Try again');
+    document.getElementById('gate-btn').onclick = checkMembershipAndEnter;
+    console.error(e);
+  }
+}
+
+function init() {
+  applyTheme(localStorage.getItem('agape:theme') ||
+    (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'));
+
+  // Listeners before init — CtrlAuth can dispatch signedin synchronously.
+  document.addEventListener('ctrl:auth:signedin', () => {
+    document.body.dataset.authState = 'in';
+    checkMembershipAndEnter();
+  });
+  document.addEventListener('ctrl:auth:signedout', () => {
+    document.body.dataset.authState = 'out';
+    document.getElementById('app').hidden = true;
+    document.getElementById('gate').hidden = false;
+    setGate('Sign in with Discord to open the applicant inbox.', 'Sign in');
+    document.getElementById('gate-btn').onclick = () => window.CtrlAuth.openLoginModal();
+  });
+
+  window.CtrlAuth.init({
+    supabaseUrl: SUPABASE_URL,
+    supabaseAnonKey: SUPABASE_ANON_KEY,
+    redirectTo: window.location.origin + window.location.pathname,
+    mountTo: '#ctrl-auth-root',
+  });
+  sb = window.CtrlAuth.getSupabaseClient();
+
+  document.getElementById('gate-btn').onclick = () => window.CtrlAuth.openLoginModal();
+  // If no signedin event lands shortly, we're signed out — show the gate.
+  setTimeout(() => {
+    if (document.body.dataset.authState === 'loading' && !window.CtrlAuth.getUser()) {
+      document.body.dataset.authState = 'out';
+    }
+  }, 2500);
+
+  // delegation
+  document.addEventListener('click', e => {
+    const review = e.target.closest('[data-review]');
+    if (review) { openReview(review.dataset.review); return; }
+    const fil = e.target.closest('[data-filter]');
+    if (fil) { filter = fil.dataset.filter; renderInbox(); return; }
+    const clear = e.target.closest('[data-clear]');
+    if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const reason = e.target.closest('[data-reason]');
+    if (reason) { hideHoldSheet(); decide('hold', reason.dataset.reason); return; }
+    const delNote = e.target.closest('[data-delete-note]');
+    if (delNote) { deleteNote(delNote.dataset.deleteNote, queue[qIndex]); return; }
+    if (!e.target.closest('.page-menu')) document.getElementById('menu-list')?.classList.remove('is-open');
+  });
+
+  document.getElementById('menu-trigger').onclick = () =>
+    document.getElementById('menu-list').classList.toggle('is-open');
+  document.getElementById('menu-export').onclick = () => { exportCsv(); document.getElementById('menu-list').classList.remove('is-open'); };
+  document.getElementById('menu-theme').onclick = () => {
+    applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
+    document.getElementById('menu-list').classList.remove('is-open');
+  };
+  document.getElementById('menu-signout').onclick = () => window.CtrlAuth.signOut();
+  document.getElementById('menu-sheet').onclick = () =>
+    window.open('https://docs.google.com/spreadsheets/d/1dyDpPv7LhFSjL2Nz2E_2GMBIR-qGZg4qW4TjEkt7Epg/edit', '_blank');
+
+  document.getElementById('review-close').onclick = closeReview;
+  document.getElementById('review-prev').onclick = () => step(-1);
+  document.getElementById('review-next').onclick = () => step(1);
+  document.getElementById('btn-pass').onclick = () => decide('pass');
+  document.getElementById('btn-outreach').onclick = () => decide('outreach');
+  document.getElementById('btn-hold').onclick = showHoldSheet;
+  document.getElementById('hold-cancel').onclick = hideHoldSheet;
+
+  document.addEventListener('keydown', e => {
+    if (document.getElementById('review').hidden) return;
+    if (e.target instanceof Element && e.target.matches('input, textarea')) return;
+    if (e.key === 'Escape') { if (!document.getElementById('hold-sheet').hidden) hideHoldSheet(); else closeReview(); }
+    if (e.key === 'ArrowRight') step(1);
+    if (e.key === 'ArrowLeft') step(-1);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -11,11 +11,17 @@
 //                     REVERIFY_DAYS.
 //   verify:           force a fresh check against the Discord API.
 //
-// Response: { linked, isMember, discordUsername, verifiedAt }
+// Response: { linked, isMember, isRecruitingMember, discordUsername, verifiedAt }
 //   linked=false means the user has no Discord identity on their account.
+//
+// v1.1.0: also verifies channel-level access to the Recruiting Society
+// channel (RECRUITING_CHANNEL_ID env, else first channel whose name matches
+// /recruit/i) by computing the member's effective permissions from guild
+// roles + channel permission overwrites. Cached as is_recruiting_member and
+// used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.0.0'
-console.log(`[discord-membership] v${VERSION} — Agape guild membership verification`)
+const VERSION = '1.1.0'
+console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -54,31 +60,99 @@ function findDiscordIdentity(user: Record<string, unknown>): DiscordIdentity | n
   return { discordUserId, username: username ? String(username) : null }
 }
 
-async function checkGuildMembership(discordUserId: string): Promise<boolean> {
+function botHeaders() {
   const botToken = Deno.env.get('DISCORD_BOT_TOKEN')
   if (!botToken) throw new Error('DISCORD_BOT_TOKEN not configured')
-  const resp = await fetch(`${DISCORD_API}/guilds/${AGAPE_GUILD_ID}/members/${discordUserId}`, {
-    headers: { 'Authorization': `Bot ${botToken}` },
-  })
-  if (resp.status === 200) return true
-  if (resp.status === 404) return false // unknown member — not in the guild
-  throw new Error(`Discord API ${resp.status}: ${(await resp.text()).slice(0, 200)}`)
+  return { 'Authorization': `Bot ${botToken}` }
+}
+
+async function discordGet(path: string): Promise<Response> {
+  const resp = await fetch(`${DISCORD_API}${path}`, { headers: botHeaders() })
+  if (resp.status !== 200 && resp.status !== 404) {
+    throw new Error(`Discord API ${resp.status} ${path}: ${(await resp.text()).slice(0, 200)}`)
+  }
+  return resp
+}
+
+// Guild member (with roles), or null when not in the guild.
+async function fetchGuildMember(discordUserId: string): Promise<{ roles: string[] } | null> {
+  const resp = await discordGet(`/guilds/${AGAPE_GUILD_ID}/members/${discordUserId}`)
+  if (resp.status === 404) return null
+  return await resp.json()
+}
+
+const VIEW_CHANNEL = 1n << 10n
+const ADMINISTRATOR = 1n << 3n
+
+// Effective-permission check for the Recruiting Society channel: base perms
+// from @everyone + the member's roles, then channel overwrites in Discord's
+// documented order (@everyone → roles → member).
+async function checkRecruitingChannel(discordUserId: string, memberRoles: string[]): Promise<boolean> {
+  const [channelsResp, rolesResp] = await Promise.all([
+    discordGet(`/guilds/${AGAPE_GUILD_ID}/channels`),
+    discordGet(`/guilds/${AGAPE_GUILD_ID}/roles`),
+  ])
+  if (channelsResp.status === 404 || rolesResp.status === 404) return false
+  const channels = await channelsResp.json() as Array<Record<string, unknown>>
+  const roles = await rolesResp.json() as Array<{ id: string; permissions: string }>
+
+  const wantedId = Deno.env.get('RECRUITING_CHANNEL_ID')
+  const channel = wantedId
+    ? channels.find(c => String(c.id) === wantedId)
+    : channels.find(c => /recruit/i.test(String(c.name || '')) && c.type !== 4 /* not a category */)
+  if (!channel) {
+    console.warn('Recruiting channel not found (set RECRUITING_CHANNEL_ID)')
+    return false
+  }
+
+  const roleById = new Map(roles.map(r => [r.id, BigInt(r.permissions)]))
+  let base = roleById.get(AGAPE_GUILD_ID) ?? 0n // @everyone
+  for (const rid of memberRoles) base |= roleById.get(rid) ?? 0n
+  if (base & ADMINISTRATOR) return true
+
+  type Overwrite = { id: string; type: number; allow: string; deny: string }
+  const overwrites = (channel.permission_overwrites || []) as Overwrite[]
+  let perms = base
+  const everyoneOw = overwrites.find(o => o.id === AGAPE_GUILD_ID)
+  if (everyoneOw) { perms &= ~BigInt(everyoneOw.deny); perms |= BigInt(everyoneOw.allow) }
+  let roleAllow = 0n, roleDeny = 0n
+  for (const ow of overwrites) {
+    if (ow.type === 0 && ow.id !== AGAPE_GUILD_ID && memberRoles.includes(ow.id)) {
+      roleAllow |= BigInt(ow.allow); roleDeny |= BigInt(ow.deny)
+    }
+  }
+  perms &= ~roleDeny; perms |= roleAllow
+  const memberOw = overwrites.find(o => o.type === 1 && o.id === discordUserId)
+  if (memberOw) { perms &= ~BigInt(memberOw.deny); perms |= BigInt(memberOw.allow) }
+
+  return (perms & VIEW_CHANNEL) === VIEW_CHANNEL
 }
 
 async function verifyAndCache(userId: string, identity: DiscordIdentity) {
-  const isMember = await checkGuildMembership(identity.discordUserId)
+  const member = await fetchGuildMember(identity.discordUserId)
+  const isMember = member !== null
+  let isRecruiting = false
+  if (member) {
+    try {
+      isRecruiting = await checkRecruitingChannel(identity.discordUserId, member.roles || [])
+    } catch (err) {
+      // Channel check failing must not break the guild gate the events page uses.
+      console.error('Recruiting channel check failed:', (err as Error).message)
+    }
+  }
   const row = {
     user_id: userId,
     discord_user_id: identity.discordUserId,
     discord_username: identity.username,
     is_agape_member: isMember,
+    is_recruiting_member: isRecruiting,
     verified_at: new Date().toISOString(),
   }
   const { error } = await getSupabase()
     .from('user_discord_membership')
     .upsert(row, { onConflict: 'user_id' })
   if (error) throw new Error(`Cache write failed: ${error.message}`)
-  console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember}`)
+  console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember} recruiting=${isRecruiting}`)
   return row
 }
 
@@ -101,14 +175,14 @@ serve(async (req) => {
     if (!identity) {
       // Discord unlinked: drop any stale membership so RLS stops granting access
       await db.from('user_discord_membership').delete().eq('user_id', user.id)
-      return new Response(JSON.stringify({ linked: false, isMember: false, discordUsername: null, verifiedAt: null }), { headers: jsonHeaders })
+      return new Response(JSON.stringify({ linked: false, isMember: false, isRecruitingMember: false, discordUsername: null, verifiedAt: null }), { headers: jsonHeaders })
     }
 
-    let row: { discord_username: string | null; is_agape_member: boolean; verified_at: string } | null = null
+    let row: { discord_username: string | null; is_agape_member: boolean; is_recruiting_member?: boolean; verified_at: string } | null = null
     if (action !== 'verify') {
       const { data } = await db
         .from('user_discord_membership')
-        .select('discord_user_id, discord_username, is_agape_member, verified_at')
+        .select('discord_user_id, discord_username, is_agape_member, is_recruiting_member, verified_at')
         .eq('user_id', user.id)
         .maybeSingle()
       const fresh = data &&
@@ -121,6 +195,7 @@ serve(async (req) => {
     return new Response(JSON.stringify({
       linked: true,
       isMember: row.is_agape_member,
+      isRecruitingMember: !!row.is_recruiting_member,
       discordUsername: row.discord_username,
       verifiedAt: row.verified_at,
     }), { headers: jsonHeaders })

--- a/supabase/migrations/108_recruit_applications.sql
+++ b/supabase/migrations/108_recruit_applications.sql
@@ -1,0 +1,103 @@
+-- ============================================
+-- Agape recruiting: applicants, shared decisions, house comments
+-- Migration 108
+--
+-- Moves the /applications viewer (formerly recruit.ctrl.rodeo's encrypted
+-- static blob) server-side. Access is gated on membership in the Agape
+-- Discord's Recruiting Society channel, verified by the discord-membership
+-- edge function (v1.1.0) which now also writes is_recruiting_member.
+--
+-- 1. user_discord_membership.is_recruiting_member — channel-level gate,
+--    written only by the edge function (service role).
+-- 2. recruit_applicants — one row per application form response. Loaded by
+--    an import; only recruiting members can read. No client writes.
+-- 3. recruit_decisions — one shared house decision per applicant
+--    (outreach / hold / pass, hold carries a reason). Any recruiting
+--    member can set or clear it; the row records who decided.
+-- 4. recruit_comments — internal per-user notes on a case. Authors write
+--    their own; all recruiting members read.
+-- ============================================
+
+ALTER TABLE user_discord_membership
+  ADD COLUMN IF NOT EXISTS is_recruiting_member BOOLEAN NOT NULL DEFAULT false;
+
+-- Pre-v1.1.0 cache rows never computed the channel gate; age them out so the
+-- next status call re-verifies instead of serving a stale false for 7 days.
+UPDATE user_discord_membership SET verified_at = '1970-01-01' WHERE NOT is_recruiting_member;
+
+CREATE OR REPLACE FUNCTION is_recruiting_member()
+RETURNS BOOLEAN
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM user_discord_membership m
+    WHERE m.user_id = auth.uid() AND m.is_recruiting_member
+  );
+$$;
+
+CREATE TABLE IF NOT EXISTS recruit_applicants (
+  id TEXT PRIMARY KEY,                -- slugged name + submission timestamp
+  submitted_at TIMESTAMPTZ NOT NULL,
+  first_name TEXT NOT NULL,
+  last_name TEXT NOT NULL DEFAULT '',
+  pronouns TEXT DEFAULT '',
+  email TEXT NOT NULL,
+  social TEXT DEFAULT '',
+  about TEXT DEFAULT '',
+  why_agape TEXT DEFAULT '',
+  gifts TEXT DEFAULT '',
+  heard_from TEXT DEFAULT '',
+  residency TEXT DEFAULT '',
+  move_in TEXT DEFAULT '',
+  budget TEXT DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS recruit_decisions (
+  applicant_id TEXT PRIMARY KEY REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  decision TEXT NOT NULL CHECK (decision IN ('outreach', 'hold', 'pass')),
+  hold_reason TEXT CHECK (hold_reason IN ('fit', 'timing', 'needs')),
+  decided_by UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  decided_by_name TEXT,
+  decided_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS recruit_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  author_name TEXT,
+  body TEXT NOT NULL CHECK (char_length(body) BETWEEN 1 AND 4000),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_comments_applicant
+  ON recruit_comments(applicant_id, created_at);
+
+ALTER TABLE recruit_applicants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recruit_decisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recruit_comments ENABLE ROW LEVEL SECURITY;
+
+-- Applicants: read-only for recruiting members (imports use service role).
+CREATE POLICY "Recruiting members read applicants" ON recruit_applicants
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+
+-- Decisions: shared house state — any recruiting member reads/sets/clears.
+CREATE POLICY "Recruiting members read decisions" ON recruit_decisions
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members insert decisions" ON recruit_decisions
+  FOR INSERT TO authenticated
+  WITH CHECK (is_recruiting_member() AND decided_by = auth.uid());
+CREATE POLICY "Recruiting members update decisions" ON recruit_decisions
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member())
+  WITH CHECK (is_recruiting_member() AND decided_by = auth.uid());
+CREATE POLICY "Recruiting members delete decisions" ON recruit_decisions
+  FOR DELETE TO authenticated USING (is_recruiting_member());
+
+-- Comments: everyone in the channel reads; authors own their writes.
+CREATE POLICY "Recruiting members read comments" ON recruit_comments
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members write own comments" ON recruit_comments
+  FOR INSERT TO authenticated
+  WITH CHECK (is_recruiting_member() AND user_id = auth.uid());
+CREATE POLICY "Authors delete own comments" ON recruit_comments
+  FOR DELETE TO authenticated
+  USING (is_recruiting_member() AND user_id = auth.uid());


### PR DESCRIPTION
## Summary
- **/applications** — Agape applicant triage viewer in the Ladder Inbox UX: month-grouped inbox, full-screen review overlay, decisions **Outreach / Hold (fit · timing · current needs) / Pass**
- **Discord gate**: standard ctrl.rodeo Discord sign-in; access requires seeing the **Recruiting Society channel** on the Agape server (`discord-membership` v1.1.0 computes channel permissions from guild roles + overwrites, caches `is_recruiting_member`)
- **Supabase-backed** (migration 108): `recruit_applicants` (110 seeded from the Google Sheet), `recruit_decisions` (shared house decision with attribution), `recruit_comments` (per-user house notes on every case) — all RLS-gated
- **Links helper**: socials + URLs mined from answers, @handles resolved to profile links; normalized move-in/budget with (i) hover revealing the raw response
- Supersedes the passphrase-gated static viewer at recruit.ctrl.rodeo (that repo becomes a redirect)

## Deploy notes
- Migration 108 **already applied** to Boards project; data seeded
- `discord-membership` v1.1.0 **already deployed**
- Optional env: `RECRUITING_CHANNEL_ID` (falls back to first channel matching /recruit/i)

🤖 Generated with [Claude Code](https://claude.com/claude-code)