### PR TITLE
Applications v2.1.0 — avatars, blue accents, brand icons, auto-pass, Discord-branded sign-in

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -4,16 +4,16 @@
   --bg: #FAFAF9;
   --bg-surface: #F4F4F2;
   --bg-elevated: #FFFFFF;
-  --bg-overlay: rgba(22, 51, 0, 0.08);
+  --bg-overlay: rgba(6, 38, 77, 0.08);
   --fg: #0E0F0C;
   --fg-muted: #454745;
   --fg-subtle: #6A6C6A;
-  --fg-link: #163300;
-  --accent: #163300;
+  --fg-link: #1D4ED8;
+  --accent: #1D4ED8;
   --accent-fg: #FFFFFF;
-  --accent-muted: rgba(159, 232, 112, 0.20);
-  --accent-strong: #9FE870;
-  --accent-strong-fg: #163300;
+  --accent-muted: rgba(92, 178, 255, 0.20);
+  --accent-strong: #5CB2FF;
+  --accent-strong-fg: #06264D;
   --border: rgba(14, 15, 12, 0.12);
   --border-strong: rgba(14, 15, 12, 0.24);
   --success: #2F5711;
@@ -22,8 +22,8 @@
   --hold-tint: rgba(237, 200, 67, 0.22);
   --hold-fg: #6b5310;
   --pass-tint: rgba(14, 15, 12, 0.07);
-  --outreach-tint: rgba(159, 232, 112, 0.28);
-  --outreach-fg: #2F5711;
+  --outreach-tint: rgba(92, 178, 255, 0.25);
+  --outreach-fg: #1D4ED8;
   --shadow-sm: 0 2px 6px rgba(0,0,0,0.05);
   --shadow-md: 0 8px 24px rgba(0,0,0,0.10);
   --shadow-lg: 0 16px 48px rgba(0,0,0,0.16);
@@ -36,11 +36,11 @@
   --fg: #f0f6fc;
   --fg-muted: rgba(240, 246, 252, 0.72);
   --fg-subtle: rgba(240, 246, 252, 0.50);
-  --fg-link: #9FE870;
-  --accent: #9FE870;
+  --fg-link: #5CB2FF;
+  --accent: #5CB2FF;
   --accent-fg: #0d1117;
-  --accent-muted: rgba(159, 232, 112, 0.16);
-  --accent-strong: #9FE870;
+  --accent-muted: rgba(92, 178, 255, 0.16);
+  --accent-strong: #5CB2FF;
   --accent-strong-fg: #0d1117;
   --border: rgba(240, 246, 252, 0.12);
   --border-strong: rgba(240, 246, 252, 0.24);
@@ -50,8 +50,8 @@
   --hold-tint: rgba(255, 235, 105, 0.14);
   --hold-fg: #FFEB69;
   --pass-tint: rgba(240, 246, 252, 0.08);
-  --outreach-tint: rgba(159, 232, 112, 0.16);
-  --outreach-fg: #9FE870;
+  --outreach-tint: rgba(92, 178, 255, 0.18);
+  --outreach-fg: #5CB2FF;
   --shadow-sm: 0 2px 6px rgba(0,0,0,0.30);
   --shadow-md: 0 8px 24px rgba(0,0,0,0.40);
   --shadow-lg: 0 16px 48px rgba(0,0,0,0.55);
@@ -135,13 +135,6 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   font-size: var(--font-size-title-1); letter-spacing: -0.02em;
 }
 .gate__sub { margin: 0; color: var(--fg-muted); font-size: var(--font-size-body); }
-.gate__input {
-  height: 48px; padding: 0 var(--space-4);
-  border-radius: var(--radius-sm); border: 1px solid var(--border);
-  background: var(--bg-surface); color: var(--fg);
-  font: inherit; text-align: center;
-}
-.gate__input:focus { outline: 2px solid var(--accent); outline-offset: -1px; border-color: transparent; }
 .gate__error { margin: 0; color: var(--error); font-size: var(--font-size-small); min-height: 1.4em; }
 .gate__btn { height: 48px; border-radius: var(--radius-pill); }
 .gate__hint { margin: 0; color: var(--fg-subtle); font-size: var(--font-size-small); }
@@ -274,6 +267,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 
 /* Avatars — initials on a neutral surface (28 list / 56 review). */
 .avatar {
+  position: relative; overflow: hidden;
   flex-shrink: 0; display: grid; place-items: center;
   width: 28px; height: 28px; border-radius: var(--radius-xs);
   background: var(--bg-surface); color: var(--fg-muted);
@@ -461,3 +455,28 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   .review__foot { gap: var(--space-2); }
   .review__btn { padding-inline: var(--space-2); font-size: var(--font-size-small); }
 }
+
+/* Social profile photo layered over the initials; broken loads self-remove. */
+.avatar__img {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  object-fit: cover;
+}
+
+/* Link chips carry the platform's official mark instead of its name. */
+.link-chip { gap: 6px; }
+.link-chip__icon { width: 14px; height: 14px; flex-shrink: 0; display: inline-flex; }
+.link-chip__icon svg { width: 100%; height: 100%; fill: currentColor; }
+
+/* Discord-branded primary sign-in (Discord blurple #5865F2, unmodified Clyde). */
+.gate__btn--discord {
+  background: #5865F2; border-color: #5865F2; color: #FFFFFF;
+  display: inline-flex; align-items: center; justify-content: center; gap: 10px;
+}
+.gate__btn--discord:hover { background: #4752C4; border-color: #4752C4; }
+.gate__btn--discord svg { width: 22px; height: 22px; fill: currentColor; flex-shrink: 0; }
+.gate__alt {
+  background: none; border: 0; padding: 0;
+  color: var(--fg-subtle); font-size: var(--font-size-small);
+  text-decoration: underline; cursor: pointer;
+}
+.gate__alt:hover { color: var(--fg); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.0.0">
+  <link rel="stylesheet" href="css/app.css?v=2.1.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -19,9 +19,13 @@
     <div class="gate__card">
       <h1 class="gate__title">Agape recruiting</h1>
       <p class="gate__sub" id="gate-sub">Sign in with Discord to open the applicant inbox.</p>
-      <button class="btn btn--accent gate__btn" id="gate-btn" type="button">Sign in</button>
+      <button class="btn gate__btn gate__btn--discord" id="gate-btn" type="button">
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>
+        <span id="gate-btn-label">Continue with Discord</span>
+      </button>
       <p class="gate__error" id="gate-error"></p>
       <p class="gate__hint" id="gate-hint">Access is limited to members of the Recruiting Society channel on the Agape server.</p>
+      <button class="gate__alt" id="gate-alt" type="button">Other sign-in options</button>
       <div id="ctrl-auth-root"></div>
     </div>
   </div>
@@ -72,6 +76,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.0.0"></script>
+  <script src="js/app.js?v=2.1.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.0.0';
+const VERSION = '2.1.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -43,12 +43,11 @@ const relTime = iso => {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 };
 
+/* Row subline stays clean: track + move-in. Budget lives on the review page. */
 function subLine(a) {
   const bits = [trackLabel(a)];
   const mi = normalizeMoveIn(a);
-  const bu = normalizeBudget(a.budget);
   if (mi) bits.push(mi);
-  if (bu) bits.push(bu);
   return bits.join(' · ');
 }
 
@@ -92,9 +91,7 @@ function normalizeMoveIn(a) {
   return label + (flexible ? ' · flexible' : '');
 }
 
-function normalizeBudget(raw) {
-  raw = (raw || '').trim();
-  if (!raw || /^n\/?a$/i.test(raw)) return '';
+function budgetNumbers(raw) {
   const nums = [];
   const rx = /\$?\s?(\d{1,2}(?:[.,]\d{1,3})?)\s*[kK]\b|\$?\s?(\d{1,3}(?:,\d{3})+|\d{3,4})(?!\d)/g;
   let m;
@@ -102,6 +99,19 @@ function normalizeBudget(raw) {
     let n = m[1] ? parseFloat(m[1].replace(',', '.')) * 1000 : parseInt(m[2].replace(/,/g, ''), 10);
     if (n >= 300 && n <= 10000) nums.push(Math.round(n));
   }
+  return nums;
+}
+
+/* The applicant's stated ceiling, or null when no number was parseable. */
+function budgetMax(raw) {
+  const nums = budgetNumbers((raw || '').trim());
+  return nums.length ? Math.max(...nums) : null;
+}
+
+function normalizeBudget(raw) {
+  raw = (raw || '').trim();
+  if (!raw || /^n\/?a$/i.test(raw)) return '';
+  const nums = budgetNumbers(raw);
   if (!nums.length) return /flexib/i.test(raw) ? 'Flexible' : '';
   const fmt = n => '$' + n.toLocaleString('en-US');
   const lo = Math.min(...nums), hi = Math.max(...nums);
@@ -122,27 +132,77 @@ function infoDot(raw, normalized) {
 
 /* ---------- links helper ---------- */
 const HANDLE_STOPWORDS = /^(https?|www|and|but|not|the|don|dont|use|media|active|com|net|org|only|though|really)$/i;
-const LINK_LABELS = [
-  [/instagram\.com/i, 'Instagram'], [/linkedin\.com/i, 'LinkedIn'],
-  [/facebook\.com/i, 'Facebook'], [/(?:^|\.)x\.com|twitter\.com/i, 'X'],
-  [/github\.com/i, 'GitHub'], [/tiktok\.com/i, 'TikTok'],
-  [/substack\.com/i, 'Substack'], [/youtube\.com|youtu\.be/i, 'YouTube'],
-  [/soundcloud\.com/i, 'SoundCloud'], [/spotify\.com/i, 'Spotify'],
+// Official brand marks (Simple Icons paths, 24x24) — shown instead of the
+// platform's name on link chips. Unmodified single-path glyphs.
+const BRAND_ICONS = {
+  instagram: 'M12 0C8.74 0 8.333.015 7.053.072 5.775.132 4.905.333 4.14.63c-.789.306-1.459.717-2.126 1.384S.935 3.35.63 4.14C.333 4.905.131 5.775.072 7.053.012 8.333 0 8.74 0 12s.015 3.667.072 4.947c.06 1.277.261 2.148.558 2.913.306.788.717 1.459 1.384 2.126.667.666 1.336 1.079 2.126 1.384.766.296 1.636.499 2.913.558C8.333 23.988 8.74 24 12 24s3.667-.015 4.947-.072c1.277-.06 2.148-.262 2.913-.558.788-.306 1.459-.718 2.126-1.384.666-.667 1.079-1.335 1.384-2.126.296-.765.499-1.636.558-2.913.06-1.28.072-1.687.072-4.947s-.015-3.667-.072-4.947c-.06-1.277-.262-2.149-.558-2.913-.306-.789-.718-1.459-1.384-2.126C21.319 1.347 20.651.935 19.86.63c-.765-.297-1.636-.499-2.913-.558C15.667.012 15.26 0 12 0zm0 2.16c3.203 0 3.585.016 4.85.071 1.17.055 1.805.249 2.227.415.562.217.96.477 1.382.896.419.42.679.819.896 1.381.164.422.36 1.057.413 2.227.057 1.266.07 1.646.07 4.85s-.015 3.585-.074 4.85c-.061 1.17-.256 1.805-.421 2.227-.224.562-.479.96-.899 1.382-.419.419-.824.679-1.38.896-.42.164-1.065.36-2.235.413-1.274.057-1.649.07-4.859.07-3.211 0-3.586-.015-4.859-.074-1.171-.061-1.816-.256-2.236-.421-.569-.224-.96-.479-1.379-.899-.421-.419-.69-.824-.9-1.38-.165-.42-.359-1.065-.42-2.235-.045-1.26-.061-1.649-.061-4.844 0-3.196.016-3.586.061-4.861.061-1.17.255-1.814.42-2.234.21-.57.479-.96.9-1.381.419-.419.81-.689 1.379-.898.42-.166 1.051-.361 2.221-.421 1.275-.045 1.65-.06 4.859-.06l.045.03zm0 3.678c-3.405 0-6.162 2.76-6.162 6.162 0 3.405 2.76 6.162 6.162 6.162 3.405 0 6.162-2.76 6.162-6.162 0-3.405-2.76-6.162-6.162-6.162zM12 16c-2.21 0-4-1.79-4-4s1.79-4 4-4 4 1.79 4 4-1.79 4-4 4zm7.846-10.405c0 .795-.646 1.44-1.44 1.44-.795 0-1.44-.646-1.44-1.44 0-.794.646-1.439 1.44-1.439.793-.001 1.44.645 1.44 1.439z',
+  linkedin: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
+  facebook: 'M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z',
+  x: 'M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z',
+  github: 'M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12',
+  tiktok: 'M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z',
+  substack: 'M22.539 8.242H1.46V5.406h21.08v2.836zM1.46 10.812V24L12 18.11 22.54 24V10.812H1.46zM22.54 0H1.46v2.836h21.08V0z',
+  youtube: 'M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
+  soundcloud: 'M1.175 12.225c-.051 0-.094.046-.101.1l-.233 2.154.233 2.105c.007.058.05.098.101.098.05 0 .09-.04.099-.098l.255-2.105-.27-2.154c0-.057-.045-.1-.09-.1m-.899.828c-.06 0-.091.037-.104.094L0 14.479l.165 1.308c0 .055.045.094.09.094s.089-.045.104-.104l.21-1.319-.21-1.334c0-.061-.044-.09-.09-.09m1.83-1.229c-.061 0-.12.045-.12.104l-.21 2.563.225 2.458c0 .06.045.12.119.12.061 0 .105-.061.121-.12l.254-2.474-.254-2.548c-.016-.06-.061-.12-.121-.12m.945-.089c-.075 0-.135.06-.15.135l-.193 2.64.21 2.544c.016.077.075.138.149.138.075 0 .135-.061.15-.15l.24-2.532-.24-2.623c0-.075-.06-.135-.135-.135l-.031-.017zm1.155.36c-.005-.09-.075-.149-.159-.149-.09 0-.158.06-.164.149l-.217 2.43.2 2.563c0 .09.075.157.159.157.074 0 .148-.068.148-.158l.227-2.563-.227-2.444.033.015zm.809-1.709c-.101 0-.18.09-.18.181l-.21 3.957.187 2.563c0 .09.08.164.18.164.094 0 .174-.09.18-.18l.209-2.563-.209-3.972c-.008-.104-.088-.18-.18-.18m.959-.914c-.105 0-.195.09-.203.194l-.18 4.872.165 2.548c0 .12.09.209.195.209.104 0 .194-.089.21-.209l.193-2.548-.192-4.856c-.016-.12-.105-.21-.21-.21m.989-.449c-.121 0-.211.089-.225.209l-.165 5.275.165 2.52c.014.119.104.225.225.225.119 0 .225-.105.225-.225l.195-2.52-.196-5.275c0-.12-.105-.225-.225-.225m1.245.045c0-.135-.105-.24-.24-.24-.119 0-.24.105-.24.24l-.149 5.441.149 2.503c.016.135.121.24.256.24s.24-.105.24-.24l.164-2.503-.164-5.456-.016.015zm.749-.134c-.135 0-.255.119-.255.254l-.15 5.322.15 2.473c0 .15.12.255.255.255s.255-.12.255-.27l.15-2.474-.165-5.307c0-.148-.12-.255-.255-.255m1.005.166c-.164 0-.284.135-.284.285l-.103 5.143.135 2.474c0 .149.119.277.284.277.149 0 .271-.128.284-.284l.121-2.443-.135-5.112c-.012-.164-.135-.285-.285-.285m1.184-.945c-.045-.029-.105-.044-.165-.044s-.119.015-.165.044c-.09.054-.149.15-.149.255v.061l-.104 6.048.115 2.449v.008c.008.06.03.135.074.18.06.075.149.12.24.12.074 0 .149-.03.209-.09.06-.06.09-.135.09-.225l.015-.24.117-2.203-.135-6.086c0-.104-.061-.193-.135-.24l-.007-.037zm1.006-.547c-.045-.045-.09-.061-.15-.061-.074 0-.149.016-.209.061-.075.061-.119.15-.119.24v.029l-.137 6.609.076 1.215.061 1.185c0 .164.148.311.328.311.181 0 .33-.147.33-.327l.15-2.399-.15-6.637c0-.12-.074-.221-.165-.277m8.934 3.777c-.405 0-.795.086-1.139.232-.24-2.654-2.46-4.736-5.188-4.736-.659 0-1.305.135-1.889.359-.225.09-.27.18-.285.359v9.368c.016.18.15.33.33.345h8.185C22.681 17.218 24 15.914 24 14.28s-1.319-2.952-2.938-2.952',
+  spotify: 'M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z',
+};
+const GLOBE_ICON = 'M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm7.938 8h-3.032a15.6 15.6 0 0 0-1.7-4.575A10.03 10.03 0 0 1 19.938 8zM12 2.09c.96 1.32 1.86 3.24 2.4 5.91H9.6c.54-2.67 1.44-4.59 2.4-5.91zM2.462 14A9.984 9.984 0 0 1 2 12c0-.69.07-1.36.2-2h3.632c-.06.65-.1 1.31-.1 2s.04 1.35.1 2H2.462zm1.332 2h3.032c.42 1.77 1.02 3.3 1.7 4.575A10.03 10.03 0 0 1 3.794 16zm3.032-8H3.794a10.03 10.03 0 0 1 4.732-4.575A15.6 15.6 0 0 0 6.826 8zM12 21.91c-.96-1.32-1.86-3.24-2.4-5.91h4.8c-.54 2.67-1.44 4.59-2.4 5.91zM14.7 14H9.3c-.066-.64-.11-1.307-.11-2s.044-1.36.11-2h5.4c.066.64.11 1.307.11 2s-.044 1.36-.11 2zm.474 6.575c.68-1.275 1.28-2.805 1.7-4.575h3.032a10.03 10.03 0 0 1-4.732 4.575zM18.168 14c.06-.65.1-1.31.1-2s-.04-1.35-.1-2H21.8c.13.64.2 1.31.2 2s-.07 1.36-.2 2h-3.632z';
+
+const LINK_PLATFORMS = [
+  [/instagram\.com/i, 'instagram'], [/linkedin\.com/i, 'linkedin'],
+  [/facebook\.com/i, 'facebook'], [/(?:^|\.)x\.com|twitter\.com/i, 'x'],
+  [/github\.com/i, 'github'], [/tiktok\.com/i, 'tiktok'],
+  [/substack\.com/i, 'substack'], [/youtube\.com|youtu\.be/i, 'youtube'],
+  [/soundcloud\.com/i, 'soundcloud'], [/spotify\.com/i, 'spotify'],
 ];
 
-function linkLabel(url) {
+function linkMeta(url) {
   try {
     const u = new URL(url);
-    for (const [rx, name] of LINK_LABELS) {
+    for (const [rx, platform] of LINK_PLATFORMS) {
       if (rx.test(u.hostname + u.pathname)) {
         let seg = u.pathname.split('/').filter(Boolean).pop() || '';
         if (!seg && /substack\.com$/i.test(u.hostname) && !/^www\./i.test(u.hostname)) seg = u.hostname.split('.')[0];
         const handle = decodeURIComponent(seg).replace(/^@/, '').replace(/\/$/, '');
-        return handle && !/^(in|company|profile|people)$/i.test(handle) ? `${name} · ${handle}` : name;
+        const label = handle && !/^(in|company|profile|people)$/i.test(handle) ? handle : platform;
+        return { platform, label };
       }
     }
-    return u.hostname.replace(/^www\./, '') + (u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '');
-  } catch { return url; }
+    return { platform: null, label: u.hostname.replace(/^www\./, '') + (u.pathname !== '/' ? u.pathname.replace(/\/$/, '') : '') };
+  } catch { return { platform: null, label: url }; }
+}
+
+function linkLabel(url) {
+  const { platform, label } = linkMeta(url);
+  return platform && label !== platform ? `${platform} · ${label}` : label; // CSV/dedup label
+}
+
+function linkChip(l) {
+  const { platform, label } = linkMeta(l.url);
+  const icon = BRAND_ICONS[platform] || GLOBE_ICON;
+  const title = platform ? `${platform[0].toUpperCase()}${platform.slice(1)} — ${label}` : label;
+  return `<a class="link-chip" href="${esc(l.url)}" target="_blank" rel="noopener" title="${esc(title)}">` +
+    `<span class="link-chip__icon" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="${icon}"/></svg></span>${esc(label)}</a>`;
+}
+
+/* ---------- avatars ---------- */
+/* Social profile photo via unavatar.io when a linked account exists;
+   falls back to initials when the lookup 404s or is rate-limited. */
+const AVATAR_PROVIDERS = ['github', 'x', 'instagram', 'tiktok', 'facebook', 'youtube', 'soundcloud'];
+function avatarSource(a) {
+  const metas = collectLinks(a).map(l => linkMeta(l.url));
+  for (const p of AVATAR_PROVIDERS) {
+    const m = metas.find(x => x.platform === p && x.label && x.label !== p);
+    if (m) return `https://unavatar.io/${p === 'x' ? 'twitter' : p}/${encodeURIComponent(m.label)}?fallback=false`;
+  }
+  if (a.email) return `https://unavatar.io/gravatar/${encodeURIComponent(a.email.trim().toLowerCase())}?fallback=false`;
+  return null;
+}
+function avatarHtml(a, large) {
+  const src = avatarSource(a);
+  return `<span class="avatar ${large ? 'avatar--lg' : ''}">${esc(initials(a))}` +
+    (src ? `<img class="avatar__img" src="${esc(src)}" alt="" loading="lazy" onerror="this.remove()">` : '') +
+    `</span>`;
 }
 
 function collectLinks(a) {
@@ -209,20 +269,32 @@ async function loadAll() {
   for (const c of (cRes.data || [])) commentCounts[c.applicant_id] = (commentCounts[c.applicant_id] || 0) + 1;
 }
 
-async function saveDecision(id, d, reason) {
+async function saveDecision(id, d, reason, byName) {
   if (d === null) {
     delete decisions[id];
     const { error } = await sb.from('recruit_decisions').delete().eq('applicant_id', id);
     if (error) toast(`Save failed: ${error.message}`);
     return;
   }
-  decisions[id] = { d, reason: reason || null, byName: me.name, at: new Date().toISOString() };
+  const name = byName || me.name;
+  decisions[id] = { d, reason: reason || null, byName: name, at: new Date().toISOString() };
   const { error } = await sb.from('recruit_decisions').upsert({
     applicant_id: id, decision: d, hold_reason: reason || null,
-    decided_by: me.id, decided_by_name: me.name,
+    decided_by: me.id, decided_by_name: name,
     decided_at: new Date().toISOString(),
   });
   if (error) toast(`Save failed: ${error.message}`);
+}
+
+/* House rule: a stated budget ceiling under $1,500/mo is an automatic pass.
+   Applied to undecided applicants after load; recorded like any decision so
+   it syncs, shows attribution, and can be undone from the review page. */
+async function applyAutoPass() {
+  const auto = applicants.filter(a => !decisions[a.id] && budgetMax(a.budget) !== null && budgetMax(a.budget) < 1500);
+  for (const a of auto) {
+    await saveDecision(a.id, 'pass', null, 'Auto — budget under $1,500');
+  }
+  return auto.length;
 }
 
 async function loadComments(applicantId) {
@@ -294,7 +366,7 @@ function renderInbox() {
         ${g.items.map(a => `
           <li class="inbox-row">
             <button class="inbox-row__main" data-review="${a.id}">
-              <span class="avatar">${esc(initials(a))}</span>
+              ${avatarHtml(a)}
               <span class="inbox-row__text">
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
                 <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
@@ -362,8 +434,7 @@ function renderReview() {
   const rec = decisions[a.id];
   const links = collectLinks(a);
   const linksHtml = links.length
-    ? `<div class="link-chips">${links.map(l =>
-        `<a class="link-chip" href="${esc(l.url)}" target="_blank" rel="noopener">${esc(l.label)}</a>`).join('')}${a.social ? infoDot(a.social, 'links') : ''}</div>`
+    ? `<div class="link-chips">${links.map(linkChip).join('')}${a.social ? infoDot(a.social, 'links') : ''}</div>`
     : (a.social ? `<span class="review__fact-value">${esc(a.social)}</span>` : '');
   const miNorm = normalizeMoveIn(a);
   const buNorm = normalizeBudget(a.budget);
@@ -372,7 +443,7 @@ function renderReview() {
     ${rec ? `<p class="review__decided">Decided: ${DECISION_LABELS[rec.d]}${rec.reason ? ` — ${esc(HOLD_REASONS.find(r => r.id === rec.reason)?.label || rec.reason)}` : ''}${rec.byName ? ` · by ${esc(rec.byName)}` : ''} · <button class="link-clear" data-clear="${a.id}">Undo</button></p>` : ''}
     <div class="review__card">
       <div class="review__head">
-        <span class="avatar avatar--lg">${esc(initials(a))}</span>
+        ${avatarHtml(a, true)}
         <div class="review__head-text">
           <h2 class="review__title">${esc(fullName(a))}${a.pronouns ? ` <span class="review__pronouns">${esc(a.pronouns)}</span>` : ''}</h2>
           <p class="review__meta"><a href="mailto:${esc(a.email)}">${esc(a.email)}</a></p>
@@ -526,10 +597,24 @@ function applyTheme(t) {
 }
 
 /* ---------- auth + boot ---------- */
+/* Direct Discord OAuth — the gate's primary action goes straight to Discord
+   rather than through the multi-provider modal. */
+async function signInWithDiscord() {
+  try {
+    const { error } = await sb.auth.signInWithOAuth({
+      provider: 'discord',
+      options: { redirectTo: window.location.origin + window.location.pathname, scopes: 'identify email' },
+    });
+    if (error) throw error;
+  } catch (e) {
+    document.getElementById('gate-error').textContent = e.message || 'Discord sign-in failed';
+  }
+}
+
 function setGate(sub, btnLabel, hint) {
   document.getElementById('gate-sub').textContent = sub;
   const btn = document.getElementById('gate-btn');
-  btn.textContent = btnLabel || 'Sign in';
+  document.getElementById('gate-btn-label').textContent = btnLabel || '';
   btn.hidden = !btnLabel;
   document.getElementById('gate-hint').textContent = hint ||
     'Access is limited to members of the Recruiting Society channel on the Agape server.';
@@ -572,9 +657,11 @@ async function checkMembershipAndEnter() {
     const user = window.CtrlAuth.getUser();
     me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
     await loadAll();
+    const autoPassed = await applyAutoPass();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;
     renderInbox();
+    if (autoPassed) toast(`${autoPassed} applicant${autoPassed === 1 ? '' : 's'} auto-passed (budget under $1,500)`);
     const deep = new URLSearchParams(location.search).get('a');
     if (deep && applicants.some(x => x.id === deep)) openReview(deep);
   } catch (e) {
@@ -597,8 +684,8 @@ function init() {
     document.body.dataset.authState = 'out';
     document.getElementById('app').hidden = true;
     document.getElementById('gate').hidden = false;
-    setGate('Sign in with Discord to open the applicant inbox.', 'Sign in');
-    document.getElementById('gate-btn').onclick = () => window.CtrlAuth.openLoginModal();
+    setGate('Sign in with Discord to open the applicant inbox.', 'Continue with Discord');
+    document.getElementById('gate-btn').onclick = signInWithDiscord;
   });
 
   window.CtrlAuth.init({
@@ -609,7 +696,8 @@ function init() {
   });
   sb = window.CtrlAuth.getSupabaseClient();
 
-  document.getElementById('gate-btn').onclick = () => window.CtrlAuth.openLoginModal();
+  document.getElementById('gate-btn').onclick = signInWithDiscord;
+  document.getElementById('gate-alt').onclick = () => window.CtrlAuth.openLoginModal();
   // If no signedin event lands shortly, we're signed out — show the gate.
   setTimeout(() => {
     if (document.body.dataset.authState === 'loading' && !window.CtrlAuth.getUser()) {

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,7 +20,7 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.1.0'
+const VERSION = '1.1.2'
 console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -96,10 +96,13 @@ async function checkRecruitingChannel(discordUserId: string, memberRoles: string
   const channels = await channelsResp.json() as Array<Record<string, unknown>>
   const roles = await rolesResp.json() as Array<{ id: string; permissions: string }>
 
+  // The guild has several recruiting-* channels (per-cohort); the gate is the
+  // "Recruiting Society" one, so prefer a society match over the first hit.
   const wantedId = Deno.env.get('RECRUITING_CHANNEL_ID')
+  const named = (rx: RegExp) => channels.find(c => rx.test(String(c.name || '')) && c.type !== 4 /* not a category */)
   const channel = wantedId
     ? channels.find(c => String(c.id) === wantedId)
-    : channels.find(c => /recruit/i.test(String(c.name || '')) && c.type !== 4 /* not a category */)
+    : (named(/recruit.*society|society.*recruit/i) || named(/recruit/i))
   if (!channel) {
     console.warn('Recruiting channel not found (set RECRUITING_CHANNEL_ID)')
     return false


### PR DESCRIPTION
## Summary
- Profile photos on rows + review via unavatar.io from linked socials (initials fallback)
- Global accent shift green → bright blue; Outreach chips/buttons now blue
- Link chips use official platform icons (Simple Icons) over platform names
- Auto-pass applicants whose stated budget max is under $1,500/mo (attributed 'Auto — budget under $1,500', undoable); budget no longer shown on rows
- Sign-in follows Discord branding: blurple #5865F2 button, unmodified Clyde mark, 'Continue with Discord', direct OAuth (multi-provider modal behind 'Other sign-in options')
- discord-membership v1.1.2 deployed: channel matcher prefers 🌱recruiting-society (fikei was matched against 🌱recruiting-endsept2025 and denied)

## Data already imported (server-side, no code)
- 13 sheet comments → house notes under fikei
- 17 color decisions: yellow→Hold/fit, orange→Hold(needs for couples, else timing), red→Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)