### PR TITLE
Applications v2.1.1 — guard duplicate enter sequence

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.1.0">
+  <link rel="stylesheet" href="css/app.css?v=2.1.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -76,6 +76,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.1.0"></script>
+  <script src="js/app.js?v=2.1.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.1.0';
+const VERSION = '2.1.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -620,7 +620,18 @@ function setGate(sub, btnLabel, hint) {
     'Access is limited to members of the Recruiting Society channel on the Agape server.';
 }
 
+let _entering = false;
 async function checkMembershipAndEnter() {
+  // CtrlAuth can dispatch signedin twice (fast-restore + auth event); the
+  // enter sequence (load + auto-pass + toast) must only run once.
+  if (_entering) return;
+  _entering = true;
+  try { await _checkMembershipAndEnter(); } finally {
+    if (document.getElementById('app').hidden) _entering = false; // gate paths may retry
+  }
+}
+
+async function _checkMembershipAndEnter() {
   const session = await sb.auth.getSession();
   const token = session?.data?.session?.access_token;
   if (!token) return;


### PR DESCRIPTION
Fixes double auto-pass toast: CtrlAuth dispatches signedin on both fast-restore and the auth event; the load + auto-pass + toast sequence now runs once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)