### PR TITLE
Applications v2.2.0 — rail nav, Occupancy, Listings

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -175,8 +175,86 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   color: var(--fg-subtle); font-size: var(--font-size-caption);
 }
 
-/* --- Page shell --- */
-.page { max-width: 760px; margin: 0 auto; padding: var(--space-7) var(--space-4) 96px; }
+/* --- App shell: Ladder-style left rail + main column --- */
+.app { display: grid; grid-template-columns: 280px 1fr; min-height: 100vh; }
+.app[hidden] { display: none; }
+.app__rail {
+  border-right: 1px solid var(--border);
+  background: var(--bg-surface);
+  padding: var(--space-6) var(--space-5);
+  display: flex; flex-direction: column; gap: var(--space-6);
+  position: sticky; top: 0; height: 100vh;
+}
+.app__main {
+  min-width: 0;
+  max-width: 820px;
+  padding: var(--space-7) var(--space-7) 96px;
+}
+.brand {
+  font-weight: var(--fw-semibold); font-size: 20px; letter-spacing: -0.015em;
+  color: var(--fg); text-decoration: none;
+}
+.brand:hover { text-decoration: none; }
+.rail-nav { display: flex; flex-direction: column; gap: 2px; }
+.rail-nav__group {
+  margin: var(--space-4) 0 var(--space-2);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+  color: var(--fg-subtle);
+}
+.rail-nav__group:first-child { margin-top: 0; }
+.rail-nav__row {
+  display: flex; align-items: center; justify-content: space-between;
+  height: 40px; padding: 0 var(--space-3);
+  border-radius: var(--radius-sm);
+  color: var(--fg-muted); font-size: var(--font-size-body); font-weight: var(--fw-medium);
+  text-decoration: none;
+}
+.rail-nav__row:hover { background: var(--bg-overlay); text-decoration: none; color: var(--fg); }
+.rail-nav__row.is-current { background: var(--bg-overlay); color: var(--fg); font-weight: var(--fw-semibold); }
+.rail-nav__count { font-size: var(--font-size-caption); color: var(--fg-subtle); }
+.rail-foot {
+  margin-top: auto; display: flex; flex-direction: column; gap: var(--space-2);
+  font-size: var(--font-size-small); color: var(--fg-muted);
+}
+.rail-foot__user { font-weight: var(--fw-semibold); color: var(--fg); }
+.rail-foot__link {
+  background: none; border: 0; padding: 0; text-align: left;
+  color: var(--fg-muted); font-size: var(--font-size-small); cursor: pointer;
+}
+.rail-foot__link:hover { color: var(--fg); text-decoration: underline; }
+
+/* Mobile top bar + drawer */
+.mobile-bar { display: none; }
+.rail-scrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(0,0,0,0.4);
+}
+.rail-scrim[hidden] { display: none; }
+@media (max-width: 959px) {
+  .app { display: block; }
+  .mobile-bar {
+    position: sticky; top: 0; z-index: 50;
+    display: flex; align-items: center; gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    padding-top: max(var(--space-3), env(safe-area-inset-top));
+    background: var(--bg); border-bottom: 1px solid var(--border);
+  }
+  .mobile-bar__menu {
+    width: 40px; height: 40px; display: inline-grid; place-items: center;
+    border: 0; border-radius: var(--radius-pill); background: transparent; color: var(--fg);
+  }
+  .mobile-bar__menu svg { width: 22px; height: 22px; }
+  .mobile-bar__title { font-weight: var(--fw-semibold); font-size: var(--font-size-title-4); }
+  .app__rail {
+    position: fixed; inset: 0 auto 0 0; z-index: 70;
+    width: min(300px, 84vw); height: 100vh;
+    transform: translateX(-102%);
+    transition: transform 200ms ease;
+    box-shadow: var(--shadow-lg);
+  }
+  .app__rail.is-open { transform: none; }
+  .app__main { padding: var(--space-5) var(--space-4) 96px; }
+}
 .page__head { display: flex; align-items: flex-start; gap: var(--space-3); margin-bottom: var(--space-5); }
 .page__head-text { min-width: 0; }
 .page__title {
@@ -480,3 +558,87 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   text-decoration: underline; cursor: pointer;
 }
 .gate__alt:hover { color: var(--fg); }
+
+/* --- Occupancy grid --- */
+.occ-legend {
+  display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  font-size: var(--font-size-small); color: var(--fg-muted);
+}
+.occ-legend__item { display: inline-flex; align-items: center; gap: 6px; }
+.occ-legend__hint { color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.occ-swatch { width: 12px; height: 12px; border-radius: 4px; display: inline-block; border: 1px solid var(--border); }
+.occ-swatch--resident { background: var(--bg-elevated); }
+.occ-swatch--sublet { background: var(--hold-tint); }
+.occ-swatch--candidate { background: var(--outreach-tint); }
+.occ-swatch--vacant { background: rgba(168, 32, 13, 0.12); }
+
+.occ-scroll {
+  overflow-x: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+.occ { border-collapse: collapse; width: 100%; font-size: var(--font-size-small); }
+.occ th, .occ td { border-bottom: 1px solid var(--border); text-align: left; }
+.occ thead th {
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+  color: var(--fg-subtle); background: var(--bg-surface);
+  position: sticky; top: 0;
+}
+.occ thead th.is-now { color: var(--accent); }
+.occ__room-head { min-width: 180px; }
+.occ__room {
+  padding: var(--space-2) var(--space-3);
+  position: sticky; left: 0; background: var(--bg-elevated);
+  min-width: 180px; max-width: 220px;
+  font-weight: 400;
+  border-right: 1px solid var(--border);
+}
+.occ__room-name { display: block; font-weight: var(--fw-semibold); font-size: var(--font-size-small); }
+.occ__room-sub { display: block; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.occ__leaving {
+  margin-top: 2px; padding: 0;
+  background: none; border: 0;
+  color: var(--fg-subtle); font-size: var(--font-size-caption);
+  text-decoration: underline; cursor: pointer;
+}
+.occ__leaving:hover { color: var(--error); }
+.occ__cell {
+  padding: var(--space-2); min-width: 76px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 110px;
+  color: var(--fg-muted);
+}
+.occ__cell--resident { color: var(--fg); }
+.occ__cell--sublet { background: var(--hold-tint); }
+.occ__cell--candidate { background: var(--outreach-tint); }
+.occ__cell--shared { color: var(--fg-subtle); font-style: italic; }
+.occ__cell--vacant { background: rgba(168, 32, 13, 0.10); color: var(--fg-subtle); }
+.occ__cell.is-listable { cursor: pointer; text-align: center; font-weight: var(--fw-semibold); }
+.occ__cell.is-listable:hover { background: rgba(168, 32, 13, 0.22); color: var(--fg); }
+.occ__cell.is-now, td.occ__cell.is-now { box-shadow: inset 2px 0 0 var(--accent), inset -2px 0 0 var(--accent); }
+
+/* --- Listings --- */
+.listing-list { padding-inline: var(--space-4); }
+.listing-row.is-done .inbox-row__title, .listing-row.is-done .inbox-row__sub { opacity: 0.5; }
+.listing-kind {
+  display: inline-flex; align-items: center;
+  margin-left: var(--space-2);
+  height: 22px; padding: 0 var(--space-2);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+}
+.listing-kind--sublet { background: var(--hold-tint); color: var(--hold-fg); }
+.listing-kind--resident { background: var(--outreach-tint); color: var(--outreach-fg); }
+.listing-status {
+  height: 32px; padding: 0 var(--space-2);
+  border-radius: var(--radius-sm); border: 1px solid var(--border);
+  background: var(--bg-surface); color: var(--fg);
+  font: inherit; font-size: var(--font-size-small);
+}
+.listing-status--filled { color: var(--outreach-fg); }
+.listing-status--closed { color: var(--fg-subtle); }
+.listing-hint { margin-top: var(--space-4); font-size: var(--font-size-small); color: var(--fg-subtle); }
+.house { display: block; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="robots" content="noindex, nofollow">
-  <title>Applications — Agape recruiting</title>
+  <title>Agape recruiting</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.1.1">
+  <link rel="stylesheet" href="css/app.css?v=2.2.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -30,26 +30,48 @@
     </div>
   </div>
 
-  <main class="page" id="app" hidden>
-    <header class="page__head">
-      <div class="page__head-text">
-        <h1 class="page__title">Inbox</h1>
-        <p class="page__sub" id="page-sub"></p>
-      </div>
-      <div class="page-menu">
-        <button class="page-menu__trigger" id="menu-trigger" aria-label="Page menu">⋯</button>
-        <div class="page-menu__list" id="menu-list">
-          <button class="page-menu__item" id="menu-export">Export decisions (CSV)</button>
-          <button class="page-menu__item" id="menu-sheet">Open source spreadsheet</button>
-          <button class="page-menu__item" id="menu-theme">Toggle theme</button>
-          <button class="page-menu__item" id="menu-signout">Sign out</button>
-        </div>
-      </div>
+  <div class="app" id="app" hidden>
+    <!-- Mobile top bar -->
+    <header class="mobile-bar">
+      <button class="mobile-bar__menu" id="mobile-menu" aria-label="Menu">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+      </button>
+      <span class="mobile-bar__title" id="mobile-title">Inbox</span>
     </header>
 
-    <div class="filters" id="filters"></div>
-    <div class="inbox" id="inbox"></div>
-  </main>
+    <aside class="app__rail" id="rail">
+      <a class="brand" href="?view=inbox" data-view-link="inbox">
+        <span class="brand__text">Agape recruiting</span>
+      </a>
+      <nav class="rail-nav" id="rail-nav">
+        <div class="rail-nav__group">Applicants</div>
+        <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Inbox <span class="rail-nav__count" id="count-inbox"></span></a>
+        <a class="rail-nav__row" href="?view=outreach" data-view-link="outreach">Outreach <span class="rail-nav__count" id="count-outreach"></span></a>
+        <a class="rail-nav__row" href="?view=hold" data-view-link="hold">Hold <span class="rail-nav__count" id="count-hold"></span></a>
+        <a class="rail-nav__row" href="?view=archive" data-view-link="archive">Archive <span class="rail-nav__count" id="count-archive"></span></a>
+        <div class="rail-nav__group">House</div>
+        <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
+        <a class="rail-nav__row" href="?view=listings" data-view-link="listings">Listings <span class="rail-nav__count" id="count-listings"></span></a>
+      </nav>
+      <div class="rail-foot">
+        <span class="rail-foot__user" id="rail-user"></span>
+        <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
+        <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
+        <button class="rail-foot__link" id="menu-signout" type="button">Sign out</button>
+      </div>
+    </aside>
+    <div class="rail-scrim" id="rail-scrim" hidden></div>
+
+    <main class="app__main">
+      <header class="page__head">
+        <div class="page__head-text">
+          <h1 class="page__title" id="page-title">Inbox</h1>
+          <p class="page__sub" id="page-sub"></p>
+        </div>
+      </header>
+      <div id="view-root"></div>
+    </main>
+  </div>
 
   <!-- Review overlay — one applicant at a time, three decisions pinned at the bottom. -->
   <div class="review" id="review" hidden>
@@ -63,7 +85,7 @@
     </div>
     <div class="review__scroll"><div class="review__inner" id="review-body"></div></div>
     <div class="review__foot" id="review-foot">
-      <button class="btn review__btn review__btn--pass" id="btn-pass">Pass</button>
+      <button class="btn review__btn review__btn--pass" id="btn-pass">Archive</button>
       <button class="btn review__btn review__btn--hold" id="btn-hold">Hold</button>
       <button class="btn btn--accent review__btn" id="btn-outreach">Outreach</button>
     </div>
@@ -76,6 +98,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.1.1"></script>
+  <script src="js/app.js?v=2.2.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.1.1';
+const VERSION = '2.2.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -13,7 +13,17 @@ const HOLD_REASONS = [
   { id: 'timing', label: 'Length of timing' },
   { id: 'needs', label: 'Current Agape needs (e.g. couple)' },
 ];
-const DECISION_LABELS = { outreach: 'Outreach', hold: 'Hold', pass: 'Pass' };
+// DB keeps 'pass'; the surface calls it Archive.
+const DECISION_LABELS = { outreach: 'Outreach', hold: 'Hold', pass: 'Archive' };
+
+const VIEWS = {
+  inbox: { title: 'Inbox', kind: 'applicants' },
+  outreach: { title: 'Outreach', kind: 'applicants' },
+  hold: { title: 'Hold', kind: 'applicants' },
+  archive: { title: 'Archive', kind: 'applicants' },
+  occupancy: { title: 'Occupancy', kind: 'house' },
+  listings: { title: 'Listings', kind: 'house' },
+};
 
 let sb = null;                // supabase client (from CtrlAuth)
 let me = null;                // { id, name }
@@ -21,7 +31,11 @@ let applicants = [];          // newest first
 let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
 let commentCounts = {};       // applicant_id -> n
 let comments = [];            // comments for the applicant open in review
-let filter = 'all';
+let view = 'inbox';           // current rail view
+let rooms = [];               // recruit_rooms
+let occupancy = [];           // recruit_occupancy rows
+let listings = [];            // recruit_listings rows
+let houseLoaded = false;
 let queue = [];
 let qIndex = 0;
 
@@ -303,21 +317,79 @@ async function loadComments(applicantId) {
   comments = error ? [] : (data || []);
 }
 
-/* ---------- inbox render ---------- */
-function matchesFilter(a) {
+/* ---------- house data ---------- */
+async function loadHouse() {
+  const [rRes, oRes, lRes] = await Promise.all([
+    sb.from('recruit_rooms').select('*').order('sort'),
+    sb.from('recruit_occupancy').select('*').order('month'),
+    sb.from('recruit_listings').select('*').order('starts_on'),
+  ]);
+  rooms = rRes.data || [];
+  occupancy = oRes.data || [];
+  listings = lRes.data || [];
+  houseLoaded = true;
+}
+
+/* ---------- router ---------- */
+function setView(next, push = true) {
+  if (!VIEWS[next]) next = 'inbox';
+  view = next;
+  if (push) {
+    const url = new URL(location);
+    url.searchParams.set('view', view);
+    url.searchParams.delete('a');
+    history.pushState(null, '', url);
+  }
+  document.getElementById('rail').classList.remove('is-open');
+  document.getElementById('rail-scrim').hidden = true;
+  render();
+}
+
+async function render() {
+  const def = VIEWS[view];
+  document.getElementById('page-title').textContent = def.title;
+  document.getElementById('mobile-title').textContent = def.title;
+  document.querySelectorAll('[data-view-link]').forEach(el =>
+    el.classList.toggle('is-current', el.dataset.viewLink === view && el.classList.contains('rail-nav__row')));
+  renderRailCounts();
+
+  const root = document.getElementById('view-root');
+  if (def.kind === 'house' && !houseLoaded) {
+    root.innerHTML = `<p class="inbox-empty">Loading…</p>`;
+    await loadHouse();
+    if (VIEWS[view].kind !== 'house') return; // navigated away meanwhile
+  }
+  if (def.kind === 'applicants') renderApplicants();
+  else if (view === 'occupancy') renderOccupancy();
+  else if (view === 'listings') renderListings();
+}
+
+/* ---------- applicants render ---------- */
+function matchesView(a) {
   const rec = decisions[a.id];
-  if (filter === 'all') return true;
-  if (filter === 'undecided') return !rec;
-  return rec?.d === filter;
+  if (view === 'inbox') return !rec;
+  if (view === 'archive') return rec?.d === 'pass';
+  return rec?.d === view;
 }
 
 function counts() {
-  const c = { all: applicants.length, undecided: 0, outreach: 0, hold: 0, pass: 0 };
+  const c = { inbox: 0, outreach: 0, hold: 0, archive: 0 };
   for (const a of applicants) {
     const rec = decisions[a.id];
-    if (!rec) c.undecided++; else c[rec.d]++;
+    if (!rec) c.inbox++;
+    else if (rec.d === 'pass') c.archive++;
+    else c[rec.d]++;
   }
+  c.listings = listings.filter(l => l.status === 'open').length;
   return c;
+}
+
+function renderRailCounts() {
+  const c = counts();
+  for (const key of ['inbox', 'outreach', 'hold', 'archive', 'listings']) {
+    const el = document.getElementById(`count-${key}`);
+    if (el) el.textContent = (key === 'listings' && !houseLoaded) ? '' : (c[key] || '');
+  }
 }
 
 function decisionChip(id) {
@@ -328,26 +400,17 @@ function decisionChip(id) {
   return `<span class="decision-chip decision-chip--${rec.d}" title="${esc(DECISION_LABELS[rec.d] + reason + by)}">${DECISION_LABELS[rec.d]}</span>`;
 }
 
-function renderFilters() {
-  const c = counts();
-  const defs = [
-    ['all', 'All'], ['undecided', 'Needs review'],
-    ['outreach', 'Outreach'], ['hold', 'Hold'], ['pass', 'Pass'],
-  ];
-  document.getElementById('filters').innerHTML = defs.map(([id, label]) =>
-    `<button class="chip ${filter === id ? 'is-on' : ''}" data-filter="${id}">${label} <span class="chip__count">${c[id]}</span></button>`
-  ).join('');
-}
-
-function renderInbox() {
-  renderFilters();
-  const list = applicants.filter(matchesFilter);
+function renderApplicants() {
+  const list = applicants.filter(matchesView);
   document.getElementById('page-sub').textContent =
-    `${applicants.length} applicants · ${counts().undecided} to review`;
+    view === 'inbox'
+      ? `${list.length} applicant${list.length === 1 ? '' : 's'} to review`
+      : `${list.length} applicant${list.length === 1 ? '' : 's'}`;
 
-  const host = document.getElementById('inbox');
+  const host = document.getElementById('view-root');
+  host.className = 'inbox';
   if (!list.length) {
-    host.innerHTML = `<p class="inbox-empty">Nothing here — every applicant in this view is decided.</p>`;
+    host.innerHTML = `<p class="inbox-empty">${view === 'inbox' ? 'Inbox zero — every applicant is decided.' : 'Nothing here yet.'}</p>`;
     return;
   }
   const groups = [];
@@ -382,9 +445,142 @@ function renderInbox() {
     </section>`).join('');
 }
 
+/* ---------- occupancy ---------- */
+const KIND_LABELS = { resident: 'Resident', sublet: 'Sublet', candidate: 'Candidate', shared: 'Shared', vacant: 'Open' };
+
+function renderOccupancy() {
+  const host = document.getElementById('view-root');
+  host.className = 'house';
+  document.getElementById('page-sub').textContent =
+    `${rooms.length} rooms · 2026 · every name is a resident or a subletter`;
+
+  const months = [...Array(12)].map((_, i) => `2026-${String(i + 1).padStart(2, '0')}-01`);
+  const byRoom = {};
+  for (const o of occupancy) (byRoom[o.room_id] ||= {})[o.month] = o;
+  const nowKey = new Date().toISOString().slice(0, 8) + '01';
+
+  host.innerHTML = `
+    <div class="occ-legend">
+      ${['resident', 'sublet', 'candidate', 'vacant'].map(k =>
+        `<span class="occ-legend__item"><span class="occ-swatch occ-swatch--${k}"></span>${KIND_LABELS[k]}</span>`).join('')}
+      <span class="occ-legend__hint">Click an open month to create a listing · residents stay unless marked leaving</span>
+    </div>
+    <div class="occ-scroll">
+      <table class="occ">
+        <thead><tr>
+          <th class="occ__room-head">Room</th>
+          ${months.map(m => `<th class="${m === nowKey ? 'is-now' : ''}">${MONTH_ABBR[+m.slice(5, 7) - 1]}</th>`).join('')}
+        </tr></thead>
+        <tbody>
+          ${rooms.map(r => `
+            <tr>
+              <th class="occ__room">
+                <span class="occ__room-name">${esc(r.name)}</span>
+                <span class="occ__room-sub">${esc(r.floor)}${r.resident ? ` · ${esc(r.resident)}` : ' · open room'}</span>
+                ${r.resident ? `<button class="occ__leaving" data-leaving-room="${r.id}" title="Mark resident as leaving — creates a listing">Mark leaving</button>` : ''}
+              </th>
+              ${months.map(m => {
+                const cell = byRoom[r.id]?.[m];
+                const kind = cell?.kind || 'vacant';
+                const label = cell?.occupant || '';
+                const now = m === nowKey ? ' is-now' : '';
+                if (kind === 'vacant' && m >= nowKey) {
+                  return `<td class="occ__cell occ__cell--vacant is-listable${now}" data-list-room="${r.id}" data-list-month="${m}" title="Open — click to create a listing">${esc(label) || '+'}</td>`;
+                }
+                return `<td class="occ__cell occ__cell--${kind}${now}" title="${esc(label)} (${KIND_LABELS[kind]})">${esc(label)}</td>`;
+              }).join('')}
+            </tr>`).join('')}
+        </tbody>
+      </table>
+    </div>`;
+}
+
+async function createListingFromCell(roomId, month) {
+  const room = rooms.find(r => r.id === roomId);
+  if (!room) return;
+  const pretty = new Date(month + 'T12:00').toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+  if (!confirm(`Create a sublet listing for ${room.name} starting ${pretty}?`)) return;
+  const { data, error } = await sb.from('recruit_listings').insert({
+    room_id: roomId, kind: 'sublet', starts_on: month, status: 'open',
+    source: 'gap', notes: `Created from the occupancy grid (${pretty} open).`,
+    created_by: me.id, created_by_name: me.name,
+  }).select().single();
+  if (error) { toast(`Listing failed: ${error.message}`); return; }
+  listings.push(data);
+  toast(`Listing created — ${room.name}, ${pretty}`);
+  renderRailCounts();
+}
+
+async function markLeaving(roomId) {
+  const room = rooms.find(r => r.id === roomId);
+  if (!room) return;
+  const when = prompt(`Mark ${room.resident} as leaving ${room.name}.\nRoom opens from (YYYY-MM-DD):`,
+    new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1).toISOString().slice(0, 10));
+  if (!when || !/^\d{4}-\d{2}-\d{2}$/.test(when)) return;
+  const { data, error } = await sb.from('recruit_listings').insert({
+    room_id: roomId, kind: 'resident', starts_on: when, status: 'open',
+    source: 'leaving', notes: `${room.resident} marked as leaving.`,
+    created_by: me.id, created_by_name: me.name,
+  }).select().single();
+  if (error) { toast(`Listing failed: ${error.message}`); return; }
+  listings.push(data);
+  toast(`${room.resident} marked leaving — resident listing created for ${room.name}`);
+  setView('listings');
+}
+
+/* ---------- listings ---------- */
+function fmtDay(d) {
+  return new Date(d + 'T12:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function renderListings() {
+  const host = document.getElementById('view-root');
+  host.className = 'house';
+  const open = listings.filter(l => l.status === 'open').length;
+  document.getElementById('page-sub').textContent =
+    `${open} open · a listing is a future opening for a given Agape room`;
+
+  const roomById = Object.fromEntries(rooms.map(r => [r.id, r]));
+  const order = { open: 0, filled: 1, closed: 2 };
+  const sorted = [...listings].sort((a, b) => (order[a.status] - order[b.status]) || a.starts_on.localeCompare(b.starts_on));
+
+  host.innerHTML = `
+    ${sorted.length ? `<ul class="inbox-card listing-list">
+      ${sorted.map(l => {
+        const room = roomById[l.room_id];
+        const window = l.ends_on ? `${fmtDay(l.starts_on)} – ${fmtDay(l.ends_on)}` : `From ${fmtDay(l.starts_on)}`;
+        return `<li class="inbox-row listing-row ${l.status !== 'open' ? 'is-done' : ''}">
+          <span class="inbox-row__text">
+            <span class="inbox-row__title">${esc(room?.name || 'Room')}
+              <span class="listing-kind listing-kind--${l.kind}">${l.kind === 'resident' ? 'Resident' : 'Sublet'}</span>
+            </span>
+            <span class="inbox-row__sub">${window}${l.notes ? ` · ${esc(l.notes)}` : ''}</span>
+          </span>
+          <span class="inbox-row__actions">
+            <select class="listing-status listing-status--${l.status}" data-listing-status="${l.id}">
+              ${['open', 'filled', 'closed'].map(s => `<option value="${s}" ${l.status === s ? 'selected' : ''}>${s[0].toUpperCase()}${s.slice(1)}</option>`).join('')}
+            </select>
+          </span>
+        </li>`;
+      }).join('')}
+    </ul>` : `<p class="inbox-empty">No listings — create one from an open month on the Occupancy grid.</p>`}
+    <p class="listing-hint">New listings come from the <a href="?view=occupancy" data-view-link="occupancy">Occupancy grid</a>: click an open month, or mark a resident as leaving.</p>`;
+}
+
+async function updateListingStatus(id, status) {
+  const l = listings.find(x => x.id === id);
+  if (!l) return;
+  const prev = l.status;
+  l.status = status;
+  const { error } = await sb.from('recruit_listings').update({ status }).eq('id', id);
+  if (error) { l.status = prev; toast(`Update failed: ${error.message}`); }
+  renderListings();
+  renderRailCounts();
+}
+
 /* ---------- review overlay ---------- */
 function openReview(id) {
-  queue = applicants.filter(matchesFilter).map(a => a.id);
+  queue = applicants.filter(matchesView).map(a => a.id);
   if (!queue.includes(id)) queue = applicants.map(a => a.id);
   qIndex = Math.max(0, queue.indexOf(id));
   document.getElementById('review').hidden = false;
@@ -399,7 +595,7 @@ function closeReview() {
   document.body.style.overflow = '';
   const url = new URL(location); url.searchParams.delete('a');
   history.replaceState(null, '', url);
-  renderInbox();
+  render();
 }
 
 function step(delta) {
@@ -671,8 +867,11 @@ async function _checkMembershipAndEnter() {
     const autoPassed = await applyAutoPass();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;
-    renderInbox();
-    if (autoPassed) toast(`${autoPassed} applicant${autoPassed === 1 ? '' : 's'} auto-passed (budget under $1,500)`);
+    document.getElementById('rail-user').textContent = me.name;
+    view = new URLSearchParams(location.search).get('view') || 'inbox';
+    if (!VIEWS[view]) view = 'inbox';
+    render();
+    if (autoPassed) toast(`${autoPassed} applicant${autoPassed === 1 ? '' : 's'} auto-archived (budget under $1,500)`);
     const deep = new URLSearchParams(location.search).get('a');
     if (deep && applicants.some(x => x.id === deep)) openReview(deep);
   } catch (e) {
@@ -718,29 +917,49 @@ function init() {
 
   // delegation
   document.addEventListener('click', e => {
+    const navLink = e.target.closest('[data-view-link]');
+    if (navLink) { e.preventDefault(); setView(navLink.dataset.viewLink); return; }
     const review = e.target.closest('[data-review]');
     if (review) { openReview(review.dataset.review); return; }
-    const fil = e.target.closest('[data-filter]');
-    if (fil) { filter = fil.dataset.filter; renderInbox(); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
     const reason = e.target.closest('[data-reason]');
     if (reason) { hideHoldSheet(); decide('hold', reason.dataset.reason); return; }
     const delNote = e.target.closest('[data-delete-note]');
     if (delNote) { deleteNote(delNote.dataset.deleteNote, queue[qIndex]); return; }
-    if (!e.target.closest('.page-menu')) document.getElementById('menu-list')?.classList.remove('is-open');
+    const listCell = e.target.closest('[data-list-room]');
+    if (listCell) { createListingFromCell(+listCell.dataset.listRoom, listCell.dataset.listMonth); return; }
+    const leaving = e.target.closest('[data-leaving-room]');
+    if (leaving) { markLeaving(+leaving.dataset.leavingRoom); return; }
+    const lstatus = e.target.closest('[data-listing-status]');
+    if (lstatus) { return; } // handled by change event on the select
   });
 
-  document.getElementById('menu-trigger').onclick = () =>
-    document.getElementById('menu-list').classList.toggle('is-open');
-  document.getElementById('menu-export').onclick = () => { exportCsv(); document.getElementById('menu-list').classList.remove('is-open'); };
-  document.getElementById('menu-theme').onclick = () => {
-    applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
-    document.getElementById('menu-list').classList.remove('is-open');
+  document.addEventListener('change', e => {
+    const sel = e.target.closest('[data-listing-status]');
+    if (sel) updateListingStatus(sel.dataset.listingStatus, sel.value);
+  });
+
+  window.addEventListener('popstate', () => {
+    const v = new URLSearchParams(location.search).get('view') || 'inbox';
+    setView(v, false);
+  });
+
+  // mobile drawer
+  document.getElementById('mobile-menu').onclick = () => {
+    const rail = document.getElementById('rail');
+    const open = rail.classList.toggle('is-open');
+    document.getElementById('rail-scrim').hidden = !open;
   };
+  document.getElementById('rail-scrim').onclick = () => {
+    document.getElementById('rail').classList.remove('is-open');
+    document.getElementById('rail-scrim').hidden = true;
+  };
+
+  document.getElementById('menu-export').onclick = exportCsv;
+  document.getElementById('menu-theme').onclick = () =>
+    applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
   document.getElementById('menu-signout').onclick = () => window.CtrlAuth.signOut();
-  document.getElementById('menu-sheet').onclick = () =>
-    window.open('https://docs.google.com/spreadsheets/d/1dyDpPv7LhFSjL2Nz2E_2GMBIR-qGZg4qW4TjEkt7Epg/edit', '_blank');
 
   document.getElementById('review-close').onclick = closeReview;
   document.getElementById('review-prev').onclick = () => step(-1);

--- a/supabase/migrations/109_recruit_occupancy.sql
+++ b/supabase/migrations/109_recruit_occupancy.sql
@@ -1,0 +1,72 @@
+-- ============================================
+-- Agape recruiting: rooms, occupancy, listings
+-- Migration 109
+--
+-- Models the "Agape Occupancy & Rent Calculator" sheet (2026 tab) for the
+-- /applications viewer:
+-- 1. recruit_rooms — the 14 rooms, sheet order preserved.
+-- 2. recruit_occupancy — one row per room per month. kind classifies the
+--    occupant: resident (canonical), sublet (short-term), candidate
+--    (resident candidate on trial), shared (Studio), vacant (empty / "?").
+-- 3. recruit_listings — a sublet or resident opening for a room over a
+--    future window. Created from occupancy gaps, from marking a resident
+--    as leaving, or manually. status: open → filled | closed.
+-- All gated on is_recruiting_member(); members can write occupancy and
+-- listings (shared house state, like decisions).
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_rooms (
+  id INT PRIMARY KEY,
+  name TEXT NOT NULL,
+  floor TEXT DEFAULT '',
+  resident TEXT DEFAULT '',          -- canonical resident label from the sheet
+  sort INT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS recruit_occupancy (
+  room_id INT NOT NULL REFERENCES recruit_rooms(id) ON DELETE CASCADE,
+  month DATE NOT NULL,               -- first of month
+  occupant TEXT DEFAULT '',          -- as written in the sheet ("Sam / ?")
+  kind TEXT NOT NULL DEFAULT 'vacant'
+    CHECK (kind IN ('resident', 'sublet', 'candidate', 'shared', 'vacant')),
+  PRIMARY KEY (room_id, month)
+);
+
+CREATE TABLE IF NOT EXISTS recruit_listings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  room_id INT NOT NULL REFERENCES recruit_rooms(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL DEFAULT 'sublet' CHECK (kind IN ('sublet', 'resident')),
+  starts_on DATE NOT NULL,
+  ends_on DATE,                      -- null = open-ended (resident search)
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'filled', 'closed')),
+  source TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('gap', 'leaving', 'manual')),
+  notes TEXT DEFAULT '',
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_by_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_listings_room ON recruit_listings(room_id, status);
+
+ALTER TABLE recruit_rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recruit_occupancy ENABLE ROW LEVEL SECURITY;
+ALTER TABLE recruit_listings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Recruiting members read rooms" ON recruit_rooms
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+
+CREATE POLICY "Recruiting members read occupancy" ON recruit_occupancy
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members write occupancy" ON recruit_occupancy
+  FOR ALL TO authenticated
+  USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+
+CREATE POLICY "Recruiting members read listings" ON recruit_listings
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members insert listings" ON recruit_listings
+  FOR INSERT TO authenticated
+  WITH CHECK (is_recruiting_member() AND created_by = auth.uid());
+CREATE POLICY "Recruiting members update listings" ON recruit_listings
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+CREATE POLICY "Recruiting members delete listings" ON recruit_listings
+  FOR DELETE TO authenticated USING (is_recruiting_member());


### PR DESCRIPTION
## Summary
- **Left rail** (Ladder pattern): Applicants — Inbox (needs review) · Outreach · Hold · **Archive** (formerly Pass); House — Occupancy · Listings. Mobile gets a top bar + drawer.
- **Occupancy**: month-grid of the 2026 tab of the Occupancy & Rent Calculator. Every name is a resident or subletter; candidates (Sophia, Alejandra) tinted blue, sublets (Eli, Chris, Nathaniel, Dave, …) amber, open months red. Residents stay indefinitely unless **Mark leaving** — which creates a resident listing.
- **Listings**: a future opening for a given room. Click any open month on the grid to create a sublet listing; status lifecycle open → filled/closed.
- Migration 109 applied + seeded: 14 rooms, 168 room-months, 4 listings from the sheet's gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)