### PR TITLE
Applications v2.7.0 — AI listing match + soft alerts; inbox filters removed

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -811,3 +811,26 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .occupants__past .inbox-card { margin-top: var(--space-2); }
 .decision-banner__actions { display: flex; gap: var(--space-2); flex-shrink: 0; }
 .listing-kind--trial { background: var(--trial-tint); color: var(--trial-fg); }
+
+/* --- AI match hint + soft flags (v2.7) --- */
+.match-hint {
+  display: flex; align-items: flex-start; gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--accent-muted);
+  font-size: var(--font-size-small);
+}
+.match-hint--empty { background: transparent; color: var(--fg-subtle); padding: var(--space-2) 0; margin: var(--space-2) 0 0; }
+.match-hint__text { flex: 1; min-width: 0; }
+.match-hint__conf { color: var(--fg-subtle); font-size: var(--font-size-caption); margin-left: 4px; }
+.match-hint__why { display: block; color: var(--fg-muted); margin-top: 2px; }
+.match-flag {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--hold-tint); color: var(--hold-fg);
+  font-size: var(--font-size-small);
+}
+.match-flag strong { text-transform: capitalize; }
+.inbox-row__ai { color: var(--fg-subtle); font-style: italic; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.6.0">
+  <link rel="stylesheet" href="css/app.css?v=2.7.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -95,6 +95,7 @@
       <label class="listing-form__field decision-sheet__attach" id="decision-attach-wrap" hidden>Attach to a listing
         <select class="listing-status" id="decision-listing"></select>
       </label>
+      <div id="decision-ai"></div>
       <div class="decision-sheet__note">
         <textarea class="notes__input decision-sheet__input" id="decision-note" rows="2" placeholder="Optional context for the house…" maxlength="2000"></textarea>
         <div class="decision-sheet__note-tools">
@@ -114,6 +115,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.6.0"></script>
+  <script src="js/app.js?v=2.7.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.6.0';
+const VERSION = '2.7.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -62,6 +62,7 @@ let rooms = [];               // recruit_rooms
 let occupancy = [];           // recruit_occupancy rows
 let listings = [];            // recruit_listings rows
 let houseLoaded = false;
+let suggestions = {};         // applicant_id -> recruit_match_suggestions row
 let queue = [];
 let qIndex = 0;
 
@@ -385,11 +386,13 @@ function collectLinks(a) {
 
 /* ---------- data ---------- */
 async function loadAll() {
-  const [aRes, dRes, cRes] = await Promise.all([
+  const [aRes, dRes, cRes, sRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
     sb.from('recruit_comments').select('applicant_id'),
+    sb.from('recruit_match_suggestions').select('*'),
   ]);
+  suggestions = Object.fromEntries((sRes.data || []).map(r => [r.applicant_id, r]));
   if (aRes.error) throw aRes.error;
   applicants = (aRes.data || []).map(r => ({
     id: r.id, ts_iso: r.submitted_at,
@@ -423,6 +426,26 @@ async function saveDecision(id, d, reason, byName, note, listingId) {
     decided_at: new Date().toISOString(),
   });
   if (error) toast(`Save failed: ${error.message}`);
+}
+
+/* Ask the recruit-match fn to (re)compute one applicant's suggestion. */
+async function computeMatch(applicantId) {
+  try {
+    const { data } = await sb.auth.getSession();
+    const token = data?.session?.access_token;
+    if (!token) return;
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ applicantId }),
+    });
+    const out = await resp.json();
+    const s = out.suggestions?.[0];
+    if (s) suggestions[applicantId] = {
+      applicant_id: applicantId, listing_id: s.listingId, confidence: s.confidence,
+      rationale: s.rationale, flags: s.flags, created_at: new Date().toISOString(),
+    };
+  } catch (e) { console.warn('recruit-match failed', e); }
 }
 
 /* Short label for what an outreach decision is attached to. */
@@ -591,7 +614,7 @@ function renderApplicants() {
 
   const host = document.getElementById('view-root');
   host.className = 'inbox';
-  const bar = renderFilterBar(viewList);
+  const bar = view === 'inbox' ? '' : renderFilterBar(viewList); // inbox stays clean
   if (!list.length) {
     host.innerHTML = bar + `<p class="inbox-empty">${filtered ? 'No applicants match these filters.' : (view === 'inbox' ? 'Inbox zero — every applicant is decided.' : 'Nothing here yet.')}</p>`;
     return;
@@ -617,6 +640,7 @@ function renderApplicants() {
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
                 <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
                 ${view === 'outreach' && decisions[a.id] ? `<span class="inbox-row__sub inbox-row__attach">→ ${esc(attachmentLabel(decisions[a.id]))}</span>` : ''}
+                ${view === 'outreach' && decisions[a.id] && !decisions[a.id].listingId && suggestions[a.id]?.listing_id ? `<span class="inbox-row__sub inbox-row__ai">AI suggests ${esc(matchListingLabel(suggestions[a.id]))} — Review to apply</span>` : ''}
               </span>
             </button>
             <span class="inbox-row__actions">
@@ -1259,6 +1283,9 @@ async function _openDecisionSheet(d) {
       `<option value="">General interest — future availability</option>` +
       open.map(l => `<option value="${l.id}" ${rec?.listingId === l.id ? 'selected' : ''}>` +
         `${esc(roomById[l.room_id]?.name || 'Room')} — ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}</option>`).join('');
+    renderMatchHint(a);
+  } else {
+    document.getElementById('decision-ai').innerHTML = '';
   }
   const noteEl = document.getElementById('decision-note');
   noteEl.value = (rec?.d === d ? rec.note : '') || '';
@@ -1267,6 +1294,29 @@ async function _openDecisionSheet(d) {
     !('webkitSpeechRecognition' in window || 'SpeechRecognition' in window);
   document.getElementById('decision-sheet').hidden = false;
   document.getElementById('review-foot').hidden = true;
+}
+
+function matchListingLabel(sug) {
+  if (!sug?.listing_id) return 'General interest — future availability';
+  const l = listings.find(x => x.id === sug.listing_id);
+  const room = rooms.find(r => r.id === l?.room_id);
+  return l ? `${room?.name || 'Room'} — ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}` : 'General interest — future availability';
+}
+
+function renderMatchHint(a) {
+  const host = document.getElementById('decision-ai');
+  const sug = suggestions[a.id];
+  if (!sug) { host.innerHTML = `<p class="match-hint match-hint--empty">AI match runs after you save — reopen Edit to see it.</p>`; return; }
+  const flags = Array.isArray(sug.flags) ? sug.flags : [];
+  host.innerHTML = `
+    <div class="match-hint">
+      <span class="match-hint__text"><strong>AI suggests:</strong> ${esc(matchListingLabel(sug))}
+        ${sug.confidence ? `<span class="match-hint__conf">${Math.round(sug.confidence * 100)}%</span>` : ''}
+        <span class="match-hint__why">${esc(sug.rationale || '')}</span>
+      </span>
+      <button type="button" class="btn btn--sm" data-use-suggestion="${esc(sug.listing_id || '')}">Use</button>
+    </div>
+    ${flags.map(f => `<div class="match-flag"><strong>${esc((f.type || 'heads-up'))}:</strong> ${esc(f.message || '')}</div>`).join('')}`;
 }
 
 function renderDecisionOptions() {
@@ -1297,6 +1347,7 @@ function submitDecision() {
   hideDecisionSheet();
   saveDecision(a.id, d, reason, null, note, listingId);
   toast(`${fullName(a)} → ${DECISION_LABELS[d]}${d === 'outreach' ? ` · ${attachmentLabel(decisions[a.id])}` : (reason ? ` (${reasonLabel(reason)})` : '')}`);
+  if (d === 'outreach') computeMatch(a.id); // refresh the AI suggestion in the background
   if (editing) { renderReview(); return; }
   if (qIndex === queue.length - 1) closeReview(); else step(1);
 }
@@ -1522,6 +1573,8 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const useSug = e.target.closest('[data-use-suggestion]');
+    if (useSug) { document.getElementById('decision-listing').value = useSug.dataset.useSuggestion || ''; return; }
     const editDec = e.target.closest('[data-edit-decision]');
     if (editDec) {
       const rec = decisions[editDec.dataset.editDecision];

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -1,0 +1,166 @@
+// Supabase Edge Function: recruit-match
+// Matches an Agape applicant in Outreach to the open room listings with
+// Claude Haiku: which listing fits (or General interest), a one-line
+// rationale, and practicality flags (couple / timing / budget / duration)
+// that the UI shows as soft alerts. Suggestions land in
+// recruit_match_suggestions (service-role write, member read).
+//
+// POST /functions/v1/recruit-match   (Authorization: Bearer <user JWT>)
+// Body: { applicantId: string }      one applicant (recompute even if fresh)
+//       { backfill: true }           every outreach applicant without a
+//                                    fresh (<7d) suggestion
+// Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
+
+const VERSION = '1.0.0'
+console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+
+const MODEL = 'claude-haiku-4-5-20251001'
+const FRESH_MS = 7 * 24 * 3600 * 1000
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+async function callClaude(prompt: string): Promise<Record<string, unknown>> {
+  const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
+  if (!key) throw new Error('No Anthropic API key configured')
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: MODEL,
+      max_tokens: 500,
+      system: 'You match housing applicants to room listings for a communal house. Respond with a single JSON object only — no prose, no markdown fences.',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+  if (!resp.ok) throw new Error(`Anthropic ${resp.status}: ${(await resp.text()).slice(0, 200)}`)
+  const data = await resp.json()
+  const text = (data.content?.[0]?.text || '').trim().replace(/^```json?\s*|\s*```$/g, '')
+  return JSON.parse(text)
+}
+
+// deno-lint-ignore no-explicit-any
+function buildPrompt(a: any, listings: any[], rooms: any[]) {
+  const roomById = Object.fromEntries(rooms.map((r) => [r.id, r]))
+  const listingLines = listings.map((l) => {
+    const room = roomById[l.room_id]
+    const window = l.ends_on ? `${l.starts_on} to ${l.ends_on}` : `from ${l.starts_on}, open-ended`
+    const kind = l.kind === 'resident' ? '3-month resident trial (full-time candidates)' : 'short-term sublet (3 months or less)'
+    return `- id "${l.id}": ${room?.name || 'Room'} (${room?.floor || ''}) — ${kind}, ${window}${l.notes ? `. Notes: ${l.notes}` : ''}`
+  }).join('\n')
+  const trim = (s: string, n = 700) => (s || '').replace(/\s+/g, ' ').slice(0, n)
+
+  return `Today is ${new Date().toISOString().slice(0, 10)}.
+
+APPLICANT
+Name: ${a.first_name} ${a.last_name}
+Residency sought: ${a.residency}
+Move-in (their words): ${a.move_in}
+Budget (their words): ${a.budget}
+About: ${trim(a.about)}
+Why this house: ${trim(a.why_agape)}
+
+OPEN LISTINGS
+${listingLines || '(none)'}
+
+Match this applicant to the single best listing, or to none.
+Rules of thumb:
+- "Short (1 month or less)" or an explicitly bounded stay → sublet listings only; full-time applicants → resident-trial listings (a sublet is acceptable as a bridge only if their timing matches).
+- Timing must genuinely overlap the listing window.
+- Rooms are single-occupancy unless notes say otherwise; couples ("we", partner mentioned) usually need a large room — flag them.
+- Budget under $1500/mo is impractical for this house — flag it.
+- If nothing fits well, return listing_id null (they stay in General interest for future availability).
+
+Return exactly: {"listing_id": "<id or null>", "confidence": <0..1>, "rationale": "<one or two sentences, plain language>", "flags": [{"type": "couple|timing|budget|duration|fit", "message": "<short practical heads-up>"}]}
+flags must be [] when there is no practical concern.`
+}
+
+// deno-lint-ignore no-explicit-any
+async function suggestFor(client: any, applicant: any, listings: any[], rooms: any[]) {
+  const raw = await callClaude(buildPrompt(applicant, listings, rooms))
+  const listingId = typeof raw.listing_id === 'string' && raw.listing_id !== 'null' &&
+    listings.some((l) => l.id === raw.listing_id) ? raw.listing_id : null
+  const row = {
+    applicant_id: applicant.id,
+    listing_id: listingId,
+    confidence: Math.max(0, Math.min(1, Number(raw.confidence) || 0)),
+    rationale: String(raw.rationale || '').slice(0, 500),
+    flags: Array.isArray(raw.flags) ? raw.flags.slice(0, 5).map((f: Record<string, unknown>) => ({
+      type: String(f.type || 'fit').slice(0, 20),
+      message: String(f.message || '').slice(0, 200),
+    })) : [],
+    model: MODEL,
+    created_at: new Date().toISOString(),
+  }
+  const { error } = await client.from('recruit_match_suggestions').upsert(row, { onConflict: 'applicant_id' })
+  if (error) throw new Error(`Suggestion write failed: ${error.message}`)
+  console.log(`Matched ${applicant.id} → ${listingId || 'general interest'} (${row.confidence})`)
+  return row
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+    const client = db()
+    const { data: userData, error: userErr } = await client.auth.getUser(token)
+    if (userErr || !userData?.user) {
+      return new Response(JSON.stringify({ error: 'Not authenticated' }), { status: 401, headers: jsonHeaders })
+    }
+    const { data: membership } = await client.from('user_discord_membership')
+      .select('is_recruiting_member').eq('user_id', userData.user.id).maybeSingle()
+    if (!membership?.is_recruiting_member) {
+      return new Response(JSON.stringify({ error: 'Not a recruiting member' }), { status: 403, headers: jsonHeaders })
+    }
+
+    const body = await req.json().catch(() => ({}))
+    const [{ data: listings }, { data: rooms }] = await Promise.all([
+      client.from('recruit_listings').select('*').eq('status', 'open'),
+      client.from('recruit_rooms').select('*'),
+    ])
+
+    let targets: string[] = []
+    if (body.applicantId) {
+      targets = [String(body.applicantId)]
+    } else if (body.backfill) {
+      const { data: outreach } = await client.from('recruit_decisions')
+        .select('applicant_id').eq('decision', 'outreach')
+      const { data: fresh } = await client.from('recruit_match_suggestions')
+        .select('applicant_id, created_at')
+      const freshSet = new Set((fresh || [])
+        .filter((s) => Date.now() - new Date(s.created_at).getTime() < FRESH_MS)
+        .map((s) => s.applicant_id))
+      targets = (outreach || []).map((d) => d.applicant_id).filter((id) => !freshSet.has(id))
+    } else {
+      return new Response(JSON.stringify({ error: 'Pass applicantId or backfill:true' }), { status: 400, headers: jsonHeaders })
+    }
+
+    const suggestions = []
+    for (const id of targets.slice(0, 30)) {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', id).maybeSingle()
+      if (!applicant) continue
+      try {
+        const s = await suggestFor(client, applicant, listings || [], rooms || [])
+        suggestions.push({ applicantId: id, listingId: s.listing_id, confidence: s.confidence, rationale: s.rationale, flags: s.flags })
+      } catch (err) {
+        console.error(`Match failed for ${id}:`, (err as Error).message)
+      }
+    }
+
+    return new Response(JSON.stringify({ suggestions }), { headers: jsonHeaders })
+  } catch (err) {
+    console.error('recruit-match error:', (err as Error).message)
+    return new Response(JSON.stringify({ error: (err as Error).message }), { status: 500, headers: jsonHeaders })
+  }
+})

--- a/supabase/migrations/112_recruit_match_suggestions.sql
+++ b/supabase/migrations/112_recruit_match_suggestions.sql
@@ -1,0 +1,24 @@
+-- ============================================
+-- Migration 112: AI listing-match suggestions
+--
+-- recruit-match (edge fn, Claude Haiku) writes one suggestion per applicant:
+-- which open listing they fit (null = General interest), a short rationale,
+-- and practicality flags (couple / timing / budget / duration) that the UI
+-- surfaces as soft alerts. Server-written, member-read.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_match_suggestions (
+  applicant_id TEXT PRIMARY KEY REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  listing_id UUID REFERENCES recruit_listings(id) ON DELETE SET NULL,
+  confidence REAL CHECK (confidence BETWEEN 0 AND 1),
+  rationale TEXT DEFAULT '',
+  flags JSONB NOT NULL DEFAULT '[]',
+  model TEXT DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE recruit_match_suggestions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Recruiting members read match suggestions" ON recruit_match_suggestions
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+-- No client writes: the recruit-match edge function uses the service role.


### PR DESCRIPTION
## Summary
- **recruit-match** edge fn (Claude Haiku, ~1k tok/applicant): picks the best open listing (or General interest) with a rationale and practicality **flags** (couple/timing/budget/duration). Stored in `recruit_match_suggestions` (migration 112 applied), 7-day TTL.
- **Backfill ran**: all 11 Outreach candidates matched (all → Priest resident trial — the only trial listing; 7 with flags, e.g. an Aug-vs-Sep timing gap suggesting the Balcony sublet as a bridge).
- **Decision sheet**: AI suggestion box with confidence + one-tap **Use**; flags as amber **soft alerts** that never block the human decision.
- **Future decisions**: saving an Outreach fires recruit-match in the background; unattached outreach rows show the suggestion inline.
- **Inbox**: filter bar removed (kept on Outreach/Hold/Archive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)