### PR TITLE
Applications v2.7.1 — server-side avatar resolution

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.7.0">
+  <link rel="stylesheet" href="css/app.css?v=2.7.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -115,6 +115,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.7.0"></script>
+  <script src="js/app.js?v=2.7.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.7.0';
+const VERSION = '2.7.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -273,115 +273,40 @@ function avatarSource(a) {
   if (a.email) return `https://unavatar.io/gravatar/${encodeURIComponent(a.email.trim().toLowerCase())}?fallback=false`;
   return null;
 }
-/* unavatar's free tier rate-limits hard (~50 req/min → 429 across 110 rows), so:
-   1. images route through weserv's long-lived proxy cache (one house member
-      warming a photo caches it for everyone),
-   2. unknown avatars load through a paced queue instead of all at once,
-   3. results persist in localStorage — known-good load instantly, known-bad
-      skip retries for a week. */
-const AVATAR_LS = 'agape:avatars';
-let avatarCache = {};
-try { avatarCache = JSON.parse(localStorage.getItem(AVATAR_LS)) || {}; } catch { /* */ }
-function rememberAvatar(key, ok) {
-  avatarCache[key] = { ok, at: Date.now() };
-  try { localStorage.setItem(AVATAR_LS, JSON.stringify(avatarCache)); } catch { /* */ }
-}
-function proxiedAvatar(src, px) {
-  return `https://images.weserv.nl/?url=${encodeURIComponent(src.replace(/^https:\/\//, ''))}&w=${px}&h=${px}&fit=cover`;
-}
-
-const avatarQueue = [];
-let avatarPumping = false;
-function pumpAvatars() {
-  if (avatarPumping) return;
-  avatarPumping = true;
-  (async () => {
-    while (avatarQueue.length) {
-      const { el, src, key } = avatarQueue.shift();
-      if (!document.contains(el)) continue;
-      await new Promise(resolve => {
-        const img = new Image();
-        img.className = 'avatar__img';
-        img.alt = '';
-        img.onload = () => { el.appendChild(img); rememberAvatar(key, true); resolve(); };
-        img.onerror = () => { rememberAvatar(key, false); resolve(); };
-        img.src = src;
-      });
-      await new Promise(r => setTimeout(r, 900)); // stay under upstream rate limits
-    }
-    avatarPumping = false;
-  })();
-}
-
-function hydrateAvatars(root) {
-  (root || document).querySelectorAll('.avatar[data-av]').forEach(el => {
-    const src = el.dataset.av;
-    const key = el.dataset.avkey;
-    el.removeAttribute('data-av');
-    const known = avatarCache[key];
-    // Failures retry after a day — an upstream 429 during first warm-up
-    // shouldn't hide a real photo for long.
-    if (known && !known.ok && Date.now() - known.at < 86400_000) return;
-    if (known?.ok) {
-      const img = new Image();
-      img.className = 'avatar__img'; img.alt = ''; img.loading = 'lazy';
-      img.onerror = () => { img.remove(); rememberAvatar(key, false); };
-      img.src = src;
-      el.appendChild(img);
-    } else {
-      avatarQueue.push({ el, src, key });
-    }
-  });
-  pumpAvatars();
-}
-
+/* Avatars are resolved once, server-side (recruit-avatar fn) from the links
+   we extract, and stored on the applicant. The client just renders the URL,
+   sized + cached through weserv. */
 function avatarHtml(a, large) {
-  const src = avatarSource(a);
   const cls = `avatar ${large ? 'avatar--lg' : ''}`;
-  if (!src) return `<span class="${cls}">${esc(initials(a))}</span>`;
-  const key = src.replace(/^https:\/\/unavatar\.io\//, '');
-  return `<span class="${cls}" data-av="${esc(proxiedAvatar(src, large ? 112 : 56))}" data-avkey="${esc(key)}">${esc(initials(a))}</span>`;
+  if (!a.avatarUrl) return `<span class="${cls}">${esc(initials(a))}</span>`;
+  const px = large ? 112 : 56;
+  const src = `https://images.weserv.nl/?url=${encodeURIComponent(a.avatarUrl.replace(/^https:\/\//, ''))}&w=${px}&h=${px}&fit=cover`;
+  return `<span class="${cls}">${esc(initials(a))}<img class="avatar__img" src="${esc(src)}" alt="" loading="lazy" onerror="this.remove()"></span>`;
 }
 
-function collectLinks(a) {
-  const found = new Map();
-  const add = url => {
-    if (!url) return;
-    url = url.replace(/[.,;:!?)\]]+$/, '');
-    if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
-    const key = url.toLowerCase().replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '');
-    if (!found.has(key)) found.set(key, { url, label: linkLabel(url) });
-  };
-
-  const social = a.social || '';
-  const answers = [a.about, a.why, a.gifts].join('  ');
-  const all = social + '  ' + answers;
-
-  for (const m of all.matchAll(/https?:\/\/[^\s,<>()"']+/gi)) add(m[0]);
-  for (const m of all.matchAll(/(?<![@\w.])((?:[a-z0-9-]+\.)+(?:com|org|net|io|co|ai|me|dev|house|fm|xyz))(\/[^\s,<>()"']*)?/gi)) {
-    if (/@/.test(m[0])) continue;
-    add(m[1] + (m[2] || ''));
-  }
-  if (social && !/^(i don'?t|none|n\/?a|right now)/i.test(social.trim())) {
-    for (const m of social.matchAll(/(?:^|[\s,])(?:(insta(?:gram)?|ig|tiktok|fb|facebook|linkedin|twitter|x)\b[:\s]*)?@([a-z0-9._]{2,30})\b(?:\s*(?:on\s+)?\(?(insta(?:gram)?|ig|tiktok|fb|facebook)\)?)?/gi)) {
-      const hint = (m[1] || m[3] || 'instagram').toLowerCase();
-      const handle = m[2];
-      if (HANDLE_STOPWORDS.test(handle)) continue;
-      const host = /tiktok/.test(hint) ? `tiktok.com/@${handle}`
-        : /fb|facebook/.test(hint) ? `facebook.com/${handle}`
-        : /linkedin/.test(hint) ? `linkedin.com/in/${handle}`
-        : /twitter|^x$/.test(hint) ? `x.com/${handle}`
-        : `instagram.com/${handle}`;
-      add(host);
+/* Kick server-side resolution for anyone not yet checked (fire-and-forget;
+   converges because the fn writes '' for misses). */
+async function resolveAvatars() {
+  if (!applicants.some(a => a.avatarUrl === null || a.avatarUrl === undefined)) return;
+  try {
+    const { data } = await sb.auth.getSession();
+    const token = data?.session?.access_token;
+    if (!token) return;
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-avatar`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ backfill: true }),
+    });
+    const out = await resp.json();
+    if (out.resolved) {
+      const { data: fresh } = await sb.from('recruit_applicants').select('id, avatar_url');
+      for (const row of (fresh || [])) {
+        const a = applicants.find(x => x.id === row.id);
+        if (a) a.avatarUrl = row.avatar_url;
+      }
+      if (VIEWS[view]?.kind === 'applicants') renderApplicants();
     }
-    for (const m of social.matchAll(/(?:(insta(?:gram)?|ig|fb|facebook)\b[:\s]+([a-z0-9._]{3,30})\b|\b([a-z0-9._]{3,30})\s+on\s+(insta(?:gram)?|ig|fb|facebook)\b)/gi)) {
-      const hint = (m[1] || m[4] || '').toLowerCase();
-      const handle = m[2] || m[3];
-      if (!handle || HANDLE_STOPWORDS.test(handle)) continue;
-      add(/fb|facebook/.test(hint) ? `facebook.com/${handle}` : `instagram.com/${handle}`);
-    }
-  }
-  return [...found.values()];
+  } catch (e) { console.warn('avatar resolution failed', e); }
 }
 
 /* ---------- data ---------- */
@@ -399,7 +324,7 @@ async function loadAll() {
     first: r.first_name, last: r.last_name, pronouns: r.pronouns,
     email: r.email, social: r.social, about: r.about, why: r.why_agape,
     gifts: r.gifts, source: r.heard_from, residency: r.residency,
-    movein: r.move_in, budget: r.budget,
+    movein: r.move_in, budget: r.budget, avatarUrl: r.avatar_url,
   }));
   decisions = {};
   for (const d of (dRes.data || [])) {
@@ -651,7 +576,6 @@ function renderApplicants() {
           </li>`).join('')}
       </ul>
     </section>`).join('');
-  hydrateAvatars(host);
 }
 
 /* ---------- occupancy ---------- */
@@ -1188,7 +1112,6 @@ function renderReview() {
     btn.classList.toggle(`is-active--${d}`, rec?.d === d);
   }
 
-  hydrateAvatars(document.getElementById('review-body'));
   loadComments(a.id).then(() => {
     // guard against navigating away while the query was in flight
     if (queue[qIndex] === a.id) renderNotes(a.id);
@@ -1506,6 +1429,7 @@ async function _checkMembershipAndEnter() {
     me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
     await loadAll();
     loadHouse().then(renderRailCounts); // background — outreach attachments + rail badge need it
+    resolveAvatars(); // background — server resolves any unchecked profile photos
     const autoPassed = await applyAutoPass();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;

--- a/supabase/functions/recruit-avatar/index.ts
+++ b/supabase/functions/recruit-avatar/index.ts
@@ -1,0 +1,120 @@
+// Supabase Edge Function: recruit-avatar
+// Resolves a profile photo per applicant, once, server-side: extracts social
+// handles from the application, probes unavatar (paced — its free tier
+// rate-limits around 50/min), and stores the first working image URL on
+// recruit_applicants.avatar_url (NULL = unchecked, '' = none found).
+//
+// POST /functions/v1/recruit-avatar   (Authorization: Bearer <user JWT>)
+// Body: { applicantId: string }   resolve one (recheck even if set)
+//       { backfill: true }        resolve up to 25 unchecked applicants
+// Response: { resolved: n, remaining: n }
+
+const VERSION = '1.0.0'
+console.log(`[recruit-avatar] v${VERSION} — server-side avatar resolution`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
+const BATCH = 25
+const PACE_MS = 1200
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+// Candidate unavatar sources in priority order, mined from the applicant's
+// links (a compact port of the frontend links helper).
+// deno-lint-ignore no-explicit-any
+function avatarCandidates(a: any): string[] {
+  const social = a.social || ''
+  const all = [social, a.about, a.why_agape, a.gifts].join('  ')
+  const out: Array<[number, string]> = []
+  const push = (prio: number, provider: string, handle: string) => {
+    if (!handle || /^(https?|www|and|but|not|the)$/i.test(handle)) return
+    out.push([prio, `https://unavatar.io/${provider}/${encodeURIComponent(handle)}?fallback=false`])
+  }
+  for (const m of all.matchAll(/github\.com\/([A-Za-z0-9-]{2,40})/g)) push(0, 'github', m[1])
+  for (const m of all.matchAll(/(?:twitter|x)\.com\/([A-Za-z0-9_]{2,20})/g)) push(1, 'twitter', m[1])
+  for (const m of all.matchAll(/instagram\.com\/([A-Za-z0-9._]{2,32})/g)) push(2, 'instagram', m[1].replace(/\/$/, ''))
+  for (const m of all.matchAll(/tiktok\.com\/@?([A-Za-z0-9._]{2,32})/g)) push(3, 'tiktok', m[1])
+  for (const m of all.matchAll(/facebook\.com\/([A-Za-z0-9.]{3,50})/g)) push(4, 'facebook', m[1])
+  // bare @handles in the socials field — platform hints or instagram default
+  for (const m of social.matchAll(/(?:(insta(?:gram)?|ig|tiktok|fb|facebook|twitter|x)\b[:\s]*)?@([A-Za-z0-9._]{2,30})\b/gi)) {
+    const hint = (m[1] || 'instagram').toLowerCase()
+    const provider = /tiktok/.test(hint) ? 'tiktok' : /fb|facebook/.test(hint) ? 'facebook' : /twitter|^x$/.test(hint) ? 'twitter' : 'instagram'
+    push(2, provider, m[2])
+  }
+  // "IG: name" / "name on ig" without @
+  for (const m of social.matchAll(/(?:insta(?:gram)?|ig)\b[:\s]+([A-Za-z0-9._]{3,30})\b/gi)) push(2, 'instagram', m[1])
+  if (a.email?.includes('@')) push(9, 'gravatar', a.email.trim().toLowerCase())
+  return [...new Set(out.sort((x, y) => x[0] - y[0]).map(x => x[1]))].slice(0, 4)
+}
+
+async function resolveOne(client: ReturnType<typeof db>, applicant: Record<string, unknown>): Promise<string> {
+  for (const url of avatarCandidates(applicant)) {
+    try {
+      const resp = await fetch(url, { redirect: 'follow' })
+      // read a little to confirm it's an image, then discard
+      const type = resp.headers.get('content-type') || ''
+      await resp.body?.cancel()
+      if (resp.ok && type.startsWith('image/')) {
+        await client.from('recruit_applicants').update({ avatar_url: url }).eq('id', applicant.id)
+        console.log(`avatar ${applicant.id} → ${url}`)
+        return url
+      }
+    } catch { /* try next */ }
+    await new Promise((r) => setTimeout(r, PACE_MS))
+  }
+  await client.from('recruit_applicants').update({ avatar_url: '' }).eq('id', applicant.id)
+  return ''
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+    const client = db()
+    const { data: userData, error: userErr } = await client.auth.getUser(token)
+    if (userErr || !userData?.user) {
+      return new Response(JSON.stringify({ error: 'Not authenticated' }), { status: 401, headers: jsonHeaders })
+    }
+    const { data: membership } = await client.from('user_discord_membership')
+      .select('is_recruiting_member').eq('user_id', userData.user.id).maybeSingle()
+    if (!membership?.is_recruiting_member) {
+      return new Response(JSON.stringify({ error: 'Not a recruiting member' }), { status: 403, headers: jsonHeaders })
+    }
+
+    const body = await req.json().catch(() => ({}))
+    let resolved = 0
+    let remaining = 0
+
+    if (body.applicantId) {
+      const { data: a } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId)).maybeSingle()
+      if (a) { await resolveOne(client, a); resolved = 1 }
+    } else if (body.backfill) {
+      const { data: pending } = await client.from('recruit_applicants')
+        .select('*').is('avatar_url', null).order('submitted_at', { ascending: false }).limit(BATCH + 1)
+      const batch = (pending || []).slice(0, BATCH)
+      remaining = Math.max(0, (pending || []).length - BATCH)
+      for (const a of batch) { await resolveOne(client, a); resolved++ }
+      if (remaining === 0) {
+        const { count } = await client.from('recruit_applicants')
+          .select('id', { count: 'exact', head: true }).is('avatar_url', null)
+        remaining = count || 0
+      }
+    } else {
+      return new Response(JSON.stringify({ error: 'Pass applicantId or backfill:true' }), { status: 400, headers: jsonHeaders })
+    }
+
+    return new Response(JSON.stringify({ resolved, remaining }), { headers: jsonHeaders })
+  } catch (err) {
+    console.error('recruit-avatar error:', (err as Error).message)
+    return new Response(JSON.stringify({ error: (err as Error).message }), { status: 500, headers: jsonHeaders })
+  }
+})

--- a/supabase/migrations/113_recruit_avatar_url.sql
+++ b/supabase/migrations/113_recruit_avatar_url.sql
@@ -1,0 +1,10 @@
+-- ============================================
+-- Migration 113: resolved avatar per applicant
+--
+-- The recruit-avatar edge fn probes unavatar (rate-limited, server-side,
+-- once per applicant) for the social links we extracted and stores the
+-- first working image URL. NULL = not yet checked, '' = checked, none found.
+-- Clients render the stored URL directly — no per-browser probing.
+-- ============================================
+
+ALTER TABLE recruit_applicants ADD COLUMN IF NOT EXISTS avatar_url TEXT DEFAULT NULL;


### PR DESCRIPTION
Avatars are now resolved once, server-side, from each applicant's links (recruit-avatar fn + migration 113) and stored on the row; clients render the stored URL via weserv. Fixes the vanished avatars (unavatar rate-limiting defeated per-browser probing). Backfill running for all 110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)