### PR TITLE
Applications v2.8.0 — color decisions + house preferences (couples)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -834,3 +834,20 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 }
 .match-flag strong { text-transform: capitalize; }
 .inbox-row__ai { color: var(--fg-subtle); font-style: italic; }
+
+/* --- v2.8: color-coded decision footer --- */
+.review__btn--notfit { background: rgba(168, 32, 13, 0.14); border: 0; color: var(--error); }
+.review__btn--notfit:hover { background: rgba(168, 32, 13, 0.24); }
+.review__btn--future { background: var(--hold-tint); border: 0; color: var(--hold-fg); }
+.review__btn--future:hover { filter: brightness(1.05); }
+.review__btn--place { background: #9FE870; border: 1px solid #9FE870; color: #163300; border-radius: var(--radius-pill); }
+.review__btn--place:hover { filter: brightness(0.97); }
+.review__btn.is-active--pass { background: rgba(168, 32, 13, 0.22); box-shadow: inset 0 0 0 1.5px var(--error); color: var(--error); }
+.review__btn.is-active--hold { box-shadow: inset 0 0 0 1.5px var(--hold-fg); }
+.review__btn.is-active--outreach { box-shadow: inset 0 0 0 2px #163300; }
+.match-flag--strong { background: rgba(168, 32, 13, 0.14); color: var(--error); }
+.rail-foot__pref {
+  display: flex; align-items: center; gap: var(--space-2);
+  font-size: var(--font-size-small); color: var(--fg-muted); cursor: pointer;
+}
+.rail-foot__pref input { accent-color: var(--accent); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.7.1">
+  <link rel="stylesheet" href="css/app.css?v=2.8.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -55,6 +55,7 @@
       </nav>
       <div class="rail-foot">
         <span class="rail-foot__user" id="rail-user"></span>
+        <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
         <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
         <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
         <button class="rail-foot__link" id="menu-signout" type="button">Sign out</button>
@@ -85,9 +86,9 @@
     </div>
     <div class="review__scroll"><div class="review__inner" id="review-body"></div></div>
     <div class="review__foot" id="review-foot">
-      <button class="btn review__btn review__btn--pass" id="btn-pass">Archive</button>
-      <button class="btn review__btn review__btn--hold" id="btn-hold">Hold</button>
-      <button class="btn btn--accent review__btn" id="btn-outreach">Outreach</button>
+      <button class="btn review__btn review__btn--notfit" id="btn-pass">Not a fit</button>
+      <button class="btn review__btn review__btn--future" id="btn-hold">Future fit</button>
+      <button class="btn review__btn review__btn--place" id="btn-outreach">Add to listing</button>
     </div>
     <div class="hold-sheet decision-sheet" id="decision-sheet" hidden>
       <h3 class="hold-sheet__title" id="decision-sheet-title">Why?</h3>
@@ -115,6 +116,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.7.1"></script>
+  <script src="js/app.js?v=2.8.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.7.1';
+const VERSION = '2.8.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -17,13 +17,14 @@ const DECISION_REASONS = {
     { id: 'other', label: 'Other' },
   ],
   hold: [
-    { id: 'fit', label: 'Fit needs 2nd review' },
-    { id: 'timing', label: 'Length or timing' },
+    { id: 'no-room', label: 'No room open for them yet' },
+    { id: 'timing', label: 'Timing — revisit later' },
+    { id: 'fit', label: 'Fit needs a 2nd review' },
     { id: 'needs', label: 'Current Agape needs (e.g. couple)' },
     { id: 'other', label: 'Other' },
   ],
   pass: [
-    { id: 'fit', label: 'Not a fit' },
+    { id: 'fit', label: 'Not a community fit' },
     { id: 'budget', label: 'Budget too low' },
     { id: 'timing', label: 'Timing doesn’t work' },
     { id: 'short', label: 'Stay too short' },
@@ -63,6 +64,7 @@ let occupancy = [];           // recruit_occupancy rows
 let listings = [];            // recruit_listings rows
 let houseLoaded = false;
 let suggestions = {};         // applicant_id -> recruit_match_suggestions row
+let settings = { open_to_couples: true };
 let queue = [];
 let qIndex = 0;
 
@@ -260,19 +262,47 @@ function linkChip(l) {
     `<span class="link-chip__icon" aria-hidden="true"><svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="${icon}"/></svg></span>${esc(label)}</a>`;
 }
 
-/* ---------- avatars ---------- */
-/* Social profile photo via unavatar.io when a linked account exists;
-   falls back to initials when the lookup 404s or is rate-limited. */
-const AVATAR_PROVIDERS = ['github', 'x', 'instagram', 'tiktok', 'facebook', 'youtube', 'soundcloud'];
-function avatarSource(a) {
-  const metas = collectLinks(a).map(l => linkMeta(l.url));
-  for (const p of AVATAR_PROVIDERS) {
-    const m = metas.find(x => x.platform === p && x.label && x.label !== p);
-    if (m) return `https://unavatar.io/${p === 'x' ? 'twitter' : p}/${encodeURIComponent(m.label)}?fallback=false`;
+function collectLinks(a) {
+  const found = new Map();
+  const add = url => {
+    if (!url) return;
+    url = url.replace(/[.,;:!?)\]]+$/, '');
+    if (!/^https?:\/\//i.test(url)) url = 'https://' + url;
+    const key = url.toLowerCase().replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '');
+    if (!found.has(key)) found.set(key, { url, label: linkLabel(url) });
+  };
+
+  const social = a.social || '';
+  const answers = [a.about, a.why, a.gifts].join('  ');
+  const all = social + '  ' + answers;
+
+  for (const m of all.matchAll(/https?:\/\/[^\s,<>()"']+/gi)) add(m[0]);
+  for (const m of all.matchAll(/(?<![@\w.])((?:[a-z0-9-]+\.)+(?:com|org|net|io|co|ai|me|dev|house|fm|xyz))(\/[^\s,<>()"']*)?/gi)) {
+    if (/@/.test(m[0])) continue;
+    add(m[1] + (m[2] || ''));
   }
-  if (a.email) return `https://unavatar.io/gravatar/${encodeURIComponent(a.email.trim().toLowerCase())}?fallback=false`;
-  return null;
+  if (social && !/^(i don'?t|none|n\/?a|right now)/i.test(social.trim())) {
+    for (const m of social.matchAll(/(?:^|[\s,])(?:(insta(?:gram)?|ig|tiktok|fb|facebook|linkedin|twitter|x)\b[:\s]*)?@([a-z0-9._]{2,30})\b(?:\s*(?:on\s+)?\(?(insta(?:gram)?|ig|tiktok|fb|facebook)\)?)?/gi)) {
+      const hint = (m[1] || m[3] || 'instagram').toLowerCase();
+      const handle = m[2];
+      if (HANDLE_STOPWORDS.test(handle)) continue;
+      const host = /tiktok/.test(hint) ? `tiktok.com/@${handle}`
+        : /fb|facebook/.test(hint) ? `facebook.com/${handle}`
+        : /linkedin/.test(hint) ? `linkedin.com/in/${handle}`
+        : /twitter|^x$/.test(hint) ? `x.com/${handle}`
+        : `instagram.com/${handle}`;
+      add(host);
+    }
+    for (const m of social.matchAll(/(?:(insta(?:gram)?|ig|fb|facebook)\b[:\s]+([a-z0-9._]{3,30})\b|\b([a-z0-9._]{3,30})\s+on\s+(insta(?:gram)?|ig|fb|facebook)\b)/gi)) {
+      const hint = (m[1] || m[4] || '').toLowerCase();
+      const handle = m[2] || m[3];
+      if (!handle || HANDLE_STOPWORDS.test(handle)) continue;
+      add(/fb|facebook/.test(hint) ? `facebook.com/${handle}` : `instagram.com/${handle}`);
+    }
+  }
+  return [...found.values()];
 }
+
 /* Avatars are resolved once, server-side (recruit-avatar fn) from the links
    we extract, and stored on the applicant. The client just renders the URL,
    sized + cached through weserv. */
@@ -318,6 +348,11 @@ async function loadAll() {
     sb.from('recruit_match_suggestions').select('*'),
   ]);
   suggestions = Object.fromEntries((sRes.data || []).map(r => [r.applicant_id, r]));
+  sb.from('recruit_settings').select('*').then(({ data }) => {
+    for (const row of (data || [])) settings[row.key] = row.value;
+    const box = document.getElementById('pref-couples');
+    if (box) box.checked = settings.open_to_couples !== false;
+  });
   if (aRes.error) throw aRes.error;
   applicants = (aRes.data || []).map(r => ({
     id: r.id, ts_iso: r.submitted_at,
@@ -1192,7 +1227,7 @@ async function _openDecisionSheet(d) {
   const rec = decisions[a.id];
   pendingReason = (rec?.d === d ? rec.reason : null) || null;
   document.getElementById('decision-sheet-title').textContent =
-    d === 'outreach' ? 'Why outreach?' : d === 'hold' ? 'Why hold?' : 'Why archive?';
+    d === 'outreach' ? 'Add to a listing' : d === 'hold' ? 'Future fit — why not now?' : 'Not a fit — why?';
   renderDecisionOptions();
 
   // Outreach targets a specific open listing, or General interest.
@@ -1239,7 +1274,11 @@ function renderMatchHint(a) {
       </span>
       <button type="button" class="btn btn--sm" data-use-suggestion="${esc(sug.listing_id || '')}">Use</button>
     </div>
-    ${flags.map(f => `<div class="match-flag"><strong>${esc((f.type || 'heads-up'))}:</strong> ${esc(f.message || '')}</div>`).join('')}`;
+    ${flags.map(f => {
+      const pref = f.type === 'couple' && settings.open_to_couples === false
+        ? ' House preference: not open to couples right now.' : '';
+      return `<div class="match-flag ${pref ? 'match-flag--strong' : ''}"><strong>${esc((f.type || 'heads-up'))}:</strong> ${esc((f.message || '') + pref)}</div>`;
+    }).join('')}`;
 }
 
 function renderDecisionOptions() {
@@ -1565,6 +1604,15 @@ function init() {
   document.getElementById('menu-theme').onclick = () =>
     applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
   document.getElementById('menu-signout').onclick = () => window.CtrlAuth.signOut();
+  document.getElementById('pref-couples').onchange = async (e) => {
+    const value = e.target.checked;
+    settings.open_to_couples = value;
+    const { error } = await sb.from('recruit_settings').upsert({
+      key: 'open_to_couples', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+    });
+    if (error) { toast(`Preference save failed: ${error.message}`); e.target.checked = !value; settings.open_to_couples = !value; }
+    else toast(value ? 'House preference: open to couples' : 'House preference: not open to couples');
+  };
 
   document.getElementById('review-close').onclick = closeReview;
   document.getElementById('review-prev').onclick = () => step(-1);

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.0.0'
+const VERSION = '1.1.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -50,7 +50,7 @@ async function callClaude(prompt: string): Promise<Record<string, unknown>> {
 }
 
 // deno-lint-ignore no-explicit-any
-function buildPrompt(a: any, listings: any[], rooms: any[]) {
+function buildPrompt(a: any, listings: any[], rooms: any[], openToCouples: boolean) {
   const roomById = Object.fromEntries(rooms.map((r) => [r.id, r]))
   const listingLines = listings.map((l) => {
     const room = roomById[l.room_id]
@@ -78,6 +78,7 @@ Rules of thumb:
 - "Short (1 month or less)" or an explicitly bounded stay → sublet listings only; full-time applicants → resident-trial listings (a sublet is acceptable as a bridge only if their timing matches).
 - Timing must genuinely overlap the listing window.
 - Rooms are single-occupancy unless notes say otherwise; couples ("we", partner mentioned) usually need a large room — flag them.
+- ${openToCouples ? 'The house is currently open to couples, but still flag them so the room choice accounts for it.' : 'HOUSE PREFERENCE: the house is NOT open to couples right now — flag any couple prominently and lean toward listing_id null for them.'}
 - Budget under $1500/mo is impractical for this house — flag it.
 - If nothing fits well, return listing_id null (they stay in General interest for future availability).
 
@@ -86,8 +87,8 @@ flags must be [] when there is no practical concern.`
 }
 
 // deno-lint-ignore no-explicit-any
-async function suggestFor(client: any, applicant: any, listings: any[], rooms: any[]) {
-  const raw = await callClaude(buildPrompt(applicant, listings, rooms))
+async function suggestFor(client: any, applicant: any, listings: any[], rooms: any[], openToCouples: boolean) {
+  const raw = await callClaude(buildPrompt(applicant, listings, rooms, openToCouples))
   const listingId = typeof raw.listing_id === 'string' && raw.listing_id !== 'null' &&
     listings.some((l) => l.id === raw.listing_id) ? raw.listing_id : null
   const row = {
@@ -125,10 +126,12 @@ serve(async (req) => {
     }
 
     const body = await req.json().catch(() => ({}))
-    const [{ data: listings }, { data: rooms }] = await Promise.all([
+    const [{ data: listings }, { data: rooms }, { data: settingsRows }] = await Promise.all([
       client.from('recruit_listings').select('*').eq('status', 'open'),
       client.from('recruit_rooms').select('*'),
+      client.from('recruit_settings').select('*'),
     ])
+    const openToCouples = (settingsRows || []).find((r) => r.key === 'open_to_couples')?.value !== false
 
     let targets: string[] = []
     if (body.applicantId) {
@@ -151,7 +154,7 @@ serve(async (req) => {
       const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', id).maybeSingle()
       if (!applicant) continue
       try {
-        const s = await suggestFor(client, applicant, listings || [], rooms || [])
+        const s = await suggestFor(client, applicant, listings || [], rooms || [], openToCouples)
         suggestions.push({ applicantId: id, listingId: s.listing_id, confidence: s.confidence, rationale: s.rationale, flags: s.flags })
       } catch (err) {
         console.error(`Match failed for ${id}:`, (err as Error).message)

--- a/supabase/migrations/114_recruit_settings.sql
+++ b/supabase/migrations/114_recruit_settings.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- Migration 114: house-wide recruiting preferences
+--
+-- Small key/value store for global recruiting preferences — first key:
+-- open_to_couples. Read/write by any recruiting member; recruit-match reads
+-- it server-side to steer suggestions and flags.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_settings (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL,
+  updated_by_name TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE recruit_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Recruiting members read settings" ON recruit_settings
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members write settings" ON recruit_settings
+  FOR ALL TO authenticated
+  USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+
+INSERT INTO recruit_settings (key, value) VALUES ('open_to_couples', 'true'::jsonb)
+  ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary
- Footer decisions are now color-coded: **Not a fit** (red) · **Future fit** (yellow) · **Add to listing** (green); sheet titles and sub-reasons match ('No room open for them yet' leads Future fit)
- **House preferences**: `recruit_settings` (migration 114 applied) with an **Open to couples** toggle in the rail footer — when off, couple alerts turn red with the house preference appended, and recruit-match v1.1.0 (deployed) steers couples to General interest
- Hotfix folded in: v2.7.1 dropped `collectLinks`, breaking review pages — restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)