### PR TITLE
Applications v2.8.2 — attachment label render race (real fix)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.8.1">
+  <link rel="stylesheet" href="css/app.css?v=2.8.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -116,6 +116,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.8.1"></script>
+  <script src="js/app.js?v=2.8.2"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.8.1';
+const VERSION = '2.8.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1467,7 +1467,12 @@ async function _checkMembershipAndEnter() {
     const user = window.CtrlAuth.getUser();
     me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
     await loadAll();
-    loadHouse().then(renderRailCounts); // background — outreach attachments + rail badge need it
+    // background — outreach attachment labels + rail badges need house data;
+    // re-render the open view once it lands so labels don't show stale fallbacks
+    loadHouse().then(() => {
+      renderRailCounts();
+      if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+    });
     resolveAvatars(); // background — server resolves any unchecked profile photos
     const autoPassed = await applyAutoPass();
     document.getElementById('gate').hidden = true;


### PR DESCRIPTION
v2.8.1 merged without the intended change (edit failed, commit went ahead). This lands it: re-render the open applicants view once listings load so attachment labels and AI-suggestion lines render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)