### PR TITLE
Applications v2.10.0 — Second opinion + decision sheet cleanup

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -851,3 +851,9 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   font-size: var(--font-size-small); color: var(--fg-muted); cursor: pointer;
 }
 .rail-foot__pref input { accent-color: var(--accent); }
+
+/* The attach select must actually hide for Future fit / Not a fit —
+   [hidden] loses to the display:flex on .listing-form__field. */
+.decision-sheet__attach[hidden] { display: none; }
+.notes__head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-3); }
+.notes__head .review__section-title { margin-bottom: 0; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.9.0">
+  <link rel="stylesheet" href="css/app.css?v=2.10.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -116,6 +116,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.9.0"></script>
+  <script src="js/app.js?v=2.10.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.9.0';
+const VERSION = '2.10.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -434,6 +434,30 @@ function matchBlockHtml(a) {
 function renderReviewMatch(a) {
   const host = document.getElementById('review-ai');
   if (host && queue[qIndex] === a.id) host.innerHTML = matchBlockHtml(a);
+}
+
+/* Independent AI read (Sonnet) posted into the house notes for everyone. */
+async function requestSecondOpinion(applicantId, btn) {
+  if (btn) { btn.disabled = true; btn.textContent = 'Thinking…'; }
+  try {
+    const { data } = await sb.auth.getSession();
+    const token = data?.session?.access_token;
+    if (!token) throw new Error('No session');
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ action: 'second_opinion', applicantId }),
+    });
+    const out = await resp.json();
+    if (out.error) throw new Error(out.error);
+    await loadComments(applicantId);
+    if (queue[qIndex] === applicantId) renderNotes(applicantId);
+    toast('Second opinion added to house notes');
+  } catch (e) {
+    toast(`Second opinion failed: ${e.message}`);
+  } finally {
+    if (btn && document.contains(btn)) { btn.disabled = false; btn.textContent = 'Second opinion'; }
+  }
 }
 
 /* Ask the recruit-match fn to (re)compute one applicant's suggestion. */
@@ -1182,7 +1206,10 @@ function renderReview() {
     ${section('Why Agape', a.why)}
     ${section('Gifts to share', a.gifts)}
     <section class="review__section notes" id="notes">
-      <h3 class="review__section-title">House notes</h3>
+      <div class="notes__head">
+        <h3 class="review__section-title">House notes</h3>
+        <button type="button" class="btn btn--sm" id="second-opinion" data-second-opinion="${a.id}">Second opinion</button>
+      </div>
       <div id="notes-body"><p class="notes__empty">Loading notes…</p></div>
       <form class="notes__form" id="notes-form">
         <textarea class="notes__input" id="notes-input" placeholder="Add an internal note for the house — only Recruiting Society members see these." maxlength="4000"></textarea>
@@ -1577,6 +1604,8 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const so = e.target.closest('[data-second-opinion]');
+    if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
     const useSug = e.target.closest('[data-use-suggestion]');
     if (useSug) {
       const val = useSug.dataset.useSuggestion || '';

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.1.0'
+const VERSION = '1.2.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -24,29 +24,69 @@ const corsHeaders = {
 const jsonHeaders = { ...corsHeaders, 'Content-Type': 'application/json' }
 
 const MODEL = 'claude-haiku-4-5-20251001'
+const OPINION_MODEL = 'claude-sonnet-5'
 const FRESH_MS = 7 * 24 * 3600 * 1000
 
 function db() {
   return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
 }
 
-async function callClaude(prompt: string): Promise<Record<string, unknown>> {
+async function callClaudeRaw(model: string, system: string, prompt: string, maxTokens = 500): Promise<string> {
   const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
   if (!key) throw new Error('No Anthropic API key configured')
   const resp = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
-    body: JSON.stringify({
-      model: MODEL,
-      max_tokens: 500,
-      system: 'You match housing applicants to room listings for a communal house. Respond with a single JSON object only — no prose, no markdown fences.',
-      messages: [{ role: 'user', content: prompt }],
-    }),
+    body: JSON.stringify({ model, max_tokens: maxTokens, system, messages: [{ role: 'user', content: prompt }] }),
   })
   if (!resp.ok) throw new Error(`Anthropic ${resp.status}: ${(await resp.text()).slice(0, 200)}`)
   const data = await resp.json()
-  const text = (data.content?.[0]?.text || '').trim().replace(/^```json?\s*|\s*```$/g, '')
-  return JSON.parse(text)
+  // models may emit thinking blocks before text — take all text blocks
+  const text = (data.content || []).filter((b: Record<string, unknown>) => b.type === 'text')
+    .map((b: Record<string, unknown>) => b.text).join('').trim()
+  if (!text) throw new Error('Empty completion')
+  return text
+}
+
+async function callClaude(prompt: string): Promise<Record<string, unknown>> {
+  const text = await callClaudeRaw(MODEL,
+    'You match housing applicants to room listings for a communal house. Respond with a single JSON object only — no prose, no markdown fences.',
+    prompt)
+  return JSON.parse(text.replace(/^```json?\s*|\s*```$/g, ''))
+}
+
+// Independent, deeper read on an applicant — posted into the house notes so
+// every recruiting member sees the same second opinion.
+// deno-lint-ignore no-explicit-any
+async function secondOpinion(client: any, applicant: any, notes: any[], userId: string): Promise<string> {
+  const trim = (s: string, n = 1200) => (s || '').replace(/\s+/g, ' ').slice(0, n)
+  const noteLines = notes.map((n) => `- ${n.author_name || 'Housemate'}: ${trim(n.body, 200)}`).join('\n') || '(none yet)'
+  const prompt = `You are giving a communal house (Agape, SF — do-ocracy, creative, emotionally mature, community-first) a second opinion on an applicant. Housemates already formed first impressions; be an independent voice — concise, concrete, and willing to disagree.
+
+APPLICANT
+Name: ${applicant.first_name} ${applicant.last_name}
+Residency sought: ${applicant.residency}
+Move-in: ${applicant.move_in} · Budget: ${applicant.budget}
+About: ${trim(applicant.about)}
+Why Agape: ${trim(applicant.why_agape)}
+Gifts: ${trim(applicant.gifts)}
+Heard from: ${applicant.heard_from}
+
+EXISTING HOUSE NOTES
+${noteLines}
+
+Write a second opinion in under 120 words, three tight parts:
+Strengths: …
+Watch for: …
+Read: … (your one-sentence overall call, including anything the notes above may have missed)
+Plain text, no markdown headers beyond those three labels.`
+  const text = await callClaudeRaw(OPINION_MODEL,
+    'You are a thoughtful, direct housing-committee advisor. Plain text only.', prompt, 400)
+  const { error } = await client.from('recruit_comments').insert({
+    applicant_id: applicant.id, user_id: userId, author_name: 'AI · second opinion', body: text.slice(0, 3900),
+  })
+  if (error) throw new Error(`Note write failed: ${error.message}`)
+  return text
 }
 
 // deno-lint-ignore no-explicit-any
@@ -132,6 +172,15 @@ serve(async (req) => {
       client.from('recruit_settings').select('*'),
     ])
     const openToCouples = (settingsRows || []).find((r) => r.key === 'open_to_couples')?.value !== false
+
+    if (body.action === 'second_opinion' && body.applicantId) {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId)).maybeSingle()
+      if (!applicant) return new Response(JSON.stringify({ error: 'Unknown applicant' }), { status: 404, headers: jsonHeaders })
+      const { data: notes } = await client.from('recruit_comments')
+        .select('author_name, body').eq('applicant_id', applicant.id).neq('author_name', 'AI · second opinion').order('created_at')
+      const text = await secondOpinion(client, applicant, notes || [], userData.user.id)
+      return new Response(JSON.stringify({ opinion: text }), { headers: jsonHeaders })
+    }
 
     let targets: string[] = []
     if (body.applicantId) {


### PR DESCRIPTION
## Summary
- **Second opinion** button on the review page (House notes header): an independent Sonnet read — Strengths / Watch for / Read — over the full application plus existing house notes, posted as an `AI · second opinion` note visible to the whole house. Tested live on Timothy.
- **Fix**: the attach-to-listing select was appearing on Future fit / Not a fit sheets (`[hidden]` vs `display:flex` again) — now scoped to Add to listing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)