### PR TITLE
fix(ladder): deterministic comp_acceptable — stop false compensation mismatches

### DIFF
--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -627,8 +627,9 @@ button.link-subtle {
   font-size: 13px; font-weight: var(--fw-semibold);
   line-height: 1;
 }
-.fit-breakdown__check--met   { background: rgba(47,157,77,0.15); color: var(--success, #2f9d4d); }
-.fit-breakdown__check--unmet { background: rgba(196,56,42,0.15); color: var(--error,   #c4382a); }
+.fit-breakdown__check--met     { background: rgba(47,157,77,0.15);   color: var(--success, #2f9d4d); }
+.fit-breakdown__check--unmet   { background: rgba(196,56,42,0.15);   color: var(--error,   #c4382a); }
+.fit-breakdown__check--unknown { background: rgba(255,255,255,0.06); color: var(--fg-subtle); }
 
 /* Score pair — Fit pill on top, Candidate pill below, used everywhere
    a row appears in a list. Each is independently clickable. */

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.36.2";
-console.log(`[ladder] v${VERSION} - Inbox: Updates card sits below the page header; roles counter removed from header`);
+const VERSION = "2.37.0";
+console.log(`[ladder] v${VERSION} - Comp check tri-state: ✓ clears floor / ✗ under floor / — not disclosed; verdict now deterministic, not Haiku's`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-fit-modal.js
+++ b/ladder/js/components/ladder-fit-modal.js
@@ -25,7 +25,7 @@ export const CANDIDATE_DIM_LABELS = {
   domain:  { label: 'Domain familiarity',  max: 15, hint: 'Worked in their sector before or domain on-ramp.' },
   stretch: { label: 'Stretch level',       max: 15, hint: 'Healthy stretch vs. comfort zone vs. risky reach.' },
   reach:   { label: 'Reach factors',       max: 10, hint: 'Specific things a hiring manager could push on — missing specialty, gaps, overqualification.' },
-  comp:    { label: 'Compensation',        max: 1,  hint: 'No money-mismatch risk — range clears your floor.', binary: true },
+  comp:    { label: 'Compensation',        max: 1,  hint: 'Posted range top clears your $200k floor. "—" means the posting doesn\'t disclose comp.', binary: true },
 };
 
 // The 1-2 fit dimensions dragging a rec's score down, as
@@ -151,7 +151,9 @@ const VIEWS = {
     breakdownOf: (row) => row.candidateBreakdown || {},
     rationalesOf:(row) => row.candidateRationales || {},
     hardFailsOf: (_row) => [],
-    binaryOf:    (row, k) => k === 'comp' ? Boolean(row.compAcceptable) : null,
+    // Tri-state: true / false / null ("comp not disclosed"). null must NOT
+    // collapse to ✗ — undisclosed is unknown, not a mismatch.
+    binaryOf:    (row, k) => k === 'comp' ? (row.compAcceptable ?? null) : null,
   },
 };
 
@@ -219,15 +221,20 @@ export function renderBreakdown(row, which = 'fit') {
         const meta = dims[k];
         const v = (breakdown && breakdown[k]) || 0;
         const binary = meta.binary === true;
-        const binaryMet = binary ? Boolean(view.binaryOf(row, k)) : null;
+        // Tri-state: true = met, false = not met, null = unknown (e.g. comp
+        // not disclosed). Unknown renders as a neutral "—", never as ✗.
+        const binaryMet = binary ? view.binaryOf(row, k) : null;
         const pct = Math.max(0, Math.min(100, (v / meta.max) * 100));
         if (binary) {
+          const state = binaryMet === null ? 'unknown' : binaryMet ? 'met' : 'unmet';
+          const glyph = { met: '✓', unmet: '✗', unknown: '—' }[state];
+          const label = { met: 'Met', unmet: 'Not met', unknown: 'Not disclosed' }[state];
           return html`
             <li class="fit-breakdown__row fit-breakdown__row--binary">
               <div class="fit-breakdown__head">
                 <span class="fit-breakdown__label">${meta.label}</span>
-                <span class=${'fit-breakdown__check ' + (binaryMet ? 'fit-breakdown__check--met' : 'fit-breakdown__check--unmet')}
-                      aria-label=${binaryMet ? 'Met' : 'Not met'}>${binaryMet ? '✓' : '✗'}</span>
+                <span class=${'fit-breakdown__check fit-breakdown__check--' + state}
+                      aria-label=${label} title=${label}>${glyph}</span>
               </div>
               <p class="fit-breakdown__hint">${rationales[k] || meta.hint}</p>
             </li>

--- a/supabase/functions/_shared/comp.ts
+++ b/supabase/functions/_shared/comp.ts
@@ -17,6 +17,28 @@ const NOT_COMP_WORDS = /(budget|revenue|\bARR\b|\bGMV\b|funding|raised|savings|v
 const MIN_SALARY = 30_000;
 const MAX_SALARY = 2_000_000;
 
+// The candidate's stated base-salary floor. Also hardcoded in the Haiku
+// grading prompt (job-fit-haiku.ts) and scoreComp's reasons (fit.ts).
+export const COMP_FLOOR = 200_000;
+
+// Deterministic comp verdict: does the top of a stored salary string clear
+// the floor? Pure arithmetic — comp_acceptable must never come from an LLM
+// guess. Returns null when there's no salary or nothing parses as an annual
+// figure ("not disclosed"), which the UI renders as unknown, not a mismatch.
+export function compClears(salary: string | null | undefined, floor = COMP_FLOOR): boolean | null {
+  if (!salary) return null;
+  const txt = salary.toLowerCase().replace(/[,$\s]/g, '');
+  const nums = Array.from(txt.matchAll(/(\d+(?:\.\d+)?)(k)?/g))
+    .map(m => (m[2] === 'k' ? parseFloat(m[1]) * 1000 : parseFloat(m[1])))
+    .filter(n => Number.isFinite(n));
+  if (!nums.length) return null;
+  const top = Math.max(...nums);
+  // Sub-10k tops are percentages / hourly rates, not a base — same guard
+  // as scoreComp. Unknown, not a fail.
+  if (top < 10_000) return null;
+  return top >= floor;
+}
+
 // "$207,000", "$207000", "$185K", "148,000 USD", "148000 USD"
 const AMOUNT_RE = /(?:\$\s?(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d+(?:\.\d+)?\s?[kK]\b|\d{5,7})|(\d{1,3}(?:,\d{3})+(?:\.\d+)?|\d{5,7})\s?USD\b)/g;
 

--- a/supabase/functions/_shared/job-fit-haiku.ts
+++ b/supabase/functions/_shared/job-fit-haiku.ts
@@ -3,6 +3,7 @@
 // add-role (user-saved rows) so all entry points walk the same v3 path.
 import { computeFit, type RoleRow, type UserContext as FitUserContext } from '../jobs-pipe/fit.ts';
 import { loadVisionFields } from './job-vision.ts';
+import { compClears } from './comp.ts';
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -141,9 +142,9 @@ Output JSON only:
       "domain":  "<one short sentence: sector overlap with their past work>",
       "stretch": "<one short sentence: is this a stretch up, sideways, or down>",
       "reach":   "<one short sentence: what would a hiring manager push on>",
-      "comp":    "<one short sentence: is the offered comp range likely to clear their floor>"
+      "comp":    "<one short sentence, strictly factual: state the posted range and whether its TOP clears the candidate's $200k base floor. Top ≥ $200k = clears, full stop — do NOT speculate about buffers, negotiation room, or what the candidate 'likely expects'. If no comp is disclosed, say exactly that>"
     },
-    "compAcceptable": <boolean: true if the JD-listed comp range top clears the candidate's stated comp floor of $200k base, or null when no comp is disclosed>,
+    "compAcceptable": <boolean: true if and only if the top of the disclosed comp range is ≥ the candidate's $200k base floor — a range topping at exactly $200k or above is true, no matter how small the margin. null when no comp is disclosed>,
     "summary": "<2-4 sentence prose, max 100 words. From a hiring manager's lens: can this person do the job? where are they strong? where are they reaching? Be honest about competition. Speak about the candidate in third person.>"
   }
 }
@@ -303,7 +304,10 @@ No prose outside the JSON.`;
           reach:   trim(r.reach),
           comp:    trim(r.comp),
         },
-        compAcceptable: typeof parsed.candidate.compAcceptable === 'boolean' ? parsed.candidate.compAcceptable : null,
+        // Deterministic first: comp is arithmetic, and the model editorializes
+        // ("clears the floor but only by $10k → false"). Fall back to the
+        // model's boolean only when no salary string exists to check.
+        compAcceptable: compClears(r.salary) ?? (typeof parsed.candidate.compAcceptable === 'boolean' ? parsed.candidate.compAcceptable : null),
         summary: String(parsed.candidate.summary || '').slice(0, 1200),
       };
     }

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -10,12 +10,13 @@ import { db } from '../_shared/job-db.ts';
 import { parseSectorTags } from '../_shared/sector-tags.ts';
 import { computeFit } from '../jobs-pipe/fit.ts';
 import { scoreOne } from '../_shared/job-fit-haiku.ts';
+import { compClears } from '../_shared/comp.ts';
 
-const VERSION = '0.5.0';
+const VERSION = '0.6.0';
 // Status default: 'Saved' (post-taxonomy collapse).
 // Source-email-link: stash payload.gmailApiId as a Gmail web URL when
 // the rec came from Gmail.
-console.log(`[add-role] v${VERSION} - Haiku extracts location from JD when JSON-LD/rec have none`);
+console.log(`[add-role] v${VERSION} - comp_acceptable computed deterministically from the salary range (compClears)`);
 
 const URL_RE = /^https?:\/\//i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
@@ -575,7 +576,7 @@ serve(async (req) => {
                candidate_breakdown  = ${fitOut.candidate ? JSON.stringify(fitOut.candidate.breakdown) : null}::jsonb,
                candidate_rationales = ${fitOut.candidate ? JSON.stringify(fitOut.candidate.rationales) : null}::jsonb,
                candidate_summary    = ${fitOut.candidate?.summary ?? null},
-               comp_acceptable      = ${fitOut.candidate?.compAcceptable ?? null}
+               comp_acceptable      = ${compClears(sal.range) ?? fitOut.candidate?.compAcceptable ?? null}
          where slug = ${slug};
       `;
     } catch (e) { console.warn('[add-role] fit calc failed', e); }

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -20,12 +20,12 @@ import { computeFit, type RoleRow, type UserContext as FitUserContext } from '..
 import { SOURCES } from '../_shared/sources/registry.ts';
 import type { RecommendedRoleInput } from '../_shared/sources/types.ts';
 import { loadFitContext, fetchJdText, haikuRoleMatch } from '../_shared/job-fit-haiku.ts';
-import { extractCompensation } from '../_shared/comp.ts';
+import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.26.1';
-console.log(`[pull-recommendations] v${VERSION} - Haiku grader also emits company_description (factual 1-2 sentence blurb) persisted on recs`);
+const VERSION = '0.27.0';
+console.log(`[pull-recommendations] v${VERSION} - comp_acceptable computed deterministically from salary (compClears), not the Haiku boolean`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -223,7 +223,7 @@ serve(async (req) => {
                candidate_breakdown  = coalesce(${candidate ? sql.json(candidate.breakdown) : null}, candidate_breakdown),
                candidate_rationales = coalesce(${candidate ? sql.json(candidate.rationales) : null}, candidate_rationales),
                candidate_summary    = coalesce(${candidate?.summary ?? null}, candidate_summary),
-               comp_acceptable      = coalesce(${candidate?.compAcceptable ?? null}, comp_acceptable)
+               comp_acceptable      = ${compClears(r.salary || extractedComp) ?? candidate?.compAcceptable ?? null}
          where id = ${r.id}
       `;
       updated++;
@@ -277,7 +277,7 @@ serve(async (req) => {
                candidate_breakdown  = coalesce(${pipeCandidate ? sql.json(pipeCandidate.breakdown) : null}, candidate_breakdown),
                candidate_rationales = coalesce(${pipeCandidate ? sql.json(pipeCandidate.rationales) : null}, candidate_rationales),
                candidate_summary    = coalesce(${pipeCandidate?.summary ?? null}, candidate_summary),
-               comp_acceptable      = coalesce(${pipeCandidate?.compAcceptable ?? null}, comp_acceptable)
+               comp_acceptable      = ${compClears(r.salary_range || pipeExtractedComp) ?? pipeCandidate?.compAcceptable ?? null}
          where slug = ${r.slug}`;
       pipeUpdated++;
     }
@@ -834,7 +834,7 @@ async function enrichAndScoreNewRows(
              candidate_breakdown  = ${candidate ? sql.json(candidate.breakdown) : null},
              candidate_rationales = ${candidate ? sql.json(candidate.rationales) : null},
              candidate_summary    = ${candidate?.summary ?? null},
-             comp_acceptable      = ${candidate?.compAcceptable ?? null}
+             comp_acceptable      = ${compClears(salary) ?? candidate?.compAcceptable ?? null}
        where id = ${r.id}::uuid`;
   }
 }


### PR DESCRIPTION
## Problem
Compensation showed as a mismatch (✗) on review pages and in AI rationales even when the posted range met or greatly exceeded the $200k floor.

Live-data diagnosis (job.recommended_roles, 553 graded rows):
- **397 rows had `comp_acceptable = NULL`** (graded before the field existed or before the salary was extracted), and the UI rendered NULL as ✗ via `Boolean(row.compAcceptable)`. Rescore never fixed them because Haiku only runs when `candidate_score is null`.
- **24 rows with tops ≥ $200k were marked `false`** — Haiku editorialized ("$210k clears the floor by only $10k, candidate likely expects $220k+") and occasionally hallucinated ranges.

## Fix
- **`_shared/comp.ts`** — new `COMP_FLOOR` + `compClears(salary)`: deterministic verdict from the salary-string top; `null` = not disclosed, never a guess.
- **`job-fit-haiku.ts`** — `compAcceptable` is now `compClears(salary)` first, model boolean only when no salary string exists; prompt tightened so the comp prose states facts (no negotiation-room speculation).
- **`pull-recommendations` v0.27.0** — all three write sites set `comp_acceptable` deterministically, so every rescore self-heals stale rows.
- **`add-role` v0.6.0** — same on save.
- **ladder v2.37.0** — comp check is tri-state: ✓ clears floor / ✗ under floor / — not disclosed (neutral chip, new `--unknown` CSS state).

## Backfill (already applied to prod)
SQL recompute from stored salary strings: 127 recommended_roles + 63 pipeline_roles corrected. Post-backfill: 140 true / 48 false (all genuinely under floor) / nulls only where comp is truly undisclosed.

## Testing
`compClears` logic verified against 15 real salary strings from prod (DoorDash $210k, ClickHouse $203k, hourly rates, percentages, empty) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)