### PR TITLE
Applications v2.11.0 — outreach listing groups + AI email drafts

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -857,3 +857,35 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .decision-sheet__attach[hidden] { display: none; }
 .notes__head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); margin-bottom: var(--space-3); }
 .notes__head .review__section-title { margin-bottom: 0; }
+
+/* --- v2.11: outreach listing groups + email drafts --- */
+.inbox-group__grip { cursor: grab; color: var(--fg-subtle); font-size: 14px; margin-right: 2px; }
+.inbox-group.is-dragging { opacity: 0.5; }
+.inbox-group__head[draggable="true"] { cursor: grab; }
+.inbox-group__link {
+  margin-left: auto;
+  background: none; border: 0; padding: 0;
+  color: var(--fg-subtle); font-size: var(--font-size-caption);
+  text-decoration: none; cursor: pointer;
+}
+.inbox-group__link:hover { color: var(--fg-link); text-decoration: underline; }
+
+.email-modal {
+  position: fixed; inset: 0; z-index: 110;
+  background: rgba(0,0,0,0.5);
+  display: grid; place-items: center;
+  padding: var(--space-4);
+}
+.email-modal[hidden] { display: none; }
+.email-modal__card {
+  width: 100%; max-width: 620px; max-height: 90vh; overflow-y: auto;
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-lg); box-shadow: var(--shadow-lg);
+  padding: var(--space-5);
+  display: flex; flex-direction: column; gap: var(--space-3);
+}
+.email-modal__head { display: flex; align-items: center; justify-content: space-between; }
+.email-modal__close { width: 32px; height: 32px; font-size: 14px; }
+.email-modal__status { margin: 0; color: var(--fg-subtle); font-size: var(--font-size-small); min-height: 1.3em; }
+.email-modal__subject { width: 100%; height: 40px; }
+.email-modal__body { min-height: 260px; font-size: var(--font-size-small); line-height: 1.55; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.10.0">
+  <link rel="stylesheet" href="css/app.css?v=2.11.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -114,8 +114,30 @@
     </div>
   </div>
 
+  <!-- AI outreach email draft -->
+  <div class="email-modal" id="email-modal" hidden>
+    <div class="email-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title" id="email-title">Email draft</h3>
+        <button class="review__close email-modal__close" id="email-close" aria-label="Close">✕</button>
+      </div>
+      <p class="email-modal__status" id="email-status"></p>
+      <label class="listing-form__field">Subject
+        <input type="text" class="listing-status email-modal__subject" id="email-subject">
+      </label>
+      <label class="listing-form__field">Body
+        <textarea class="notes__input email-modal__body" id="email-body" rows="12"></textarea>
+      </label>
+      <div class="decision-sheet__actions">
+        <button class="hold-sheet__cancel" id="email-regen" type="button">Regenerate</button>
+        <button class="btn btn--sm" id="email-mailto" type="button">Open in Mail</button>
+        <button class="btn btn--accent btn--sm" id="email-copy" type="button">Copy email</button>
+      </div>
+    </div>
+  </div>
+
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.10.0"></script>
+  <script src="js/app.js?v=2.11.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.10.0';
+const VERSION = '2.11.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -89,7 +89,9 @@ const relTime = iso => {
 /* Row subline stays clean: track + move-in (+ stay length for sublets).
    Budget lives on the review page. */
 function subLine(a) {
-  const bits = [trackLabel(a)];
+  const bits = [];
+  if (a.pronouns) bits.push(a.pronouns.toLowerCase());
+  bits.push(trackLabel(a));
   const mi = normalizeMoveIn(a);
   if (mi) bits.push(mi);
   if (isSublet(a)) {
@@ -436,6 +438,47 @@ function renderReviewMatch(a) {
   if (host && queue[qIndex] === a.id) host.innerHTML = matchBlockHtml(a);
 }
 
+/* ---------- outreach email drafts ---------- */
+let emailApplicantId = null;
+
+async function openEmailModal(applicantId) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  emailApplicantId = applicantId;
+  document.getElementById('email-title').textContent = `Email ${fullName(a)}`;
+  document.getElementById('email-subject').value = '';
+  document.getElementById('email-body').value = '';
+  document.getElementById('email-status').textContent = 'Drafting from their application, the listing, and any flags…';
+  document.getElementById('email-modal').hidden = false;
+  await generateEmail(applicantId);
+}
+
+async function generateEmail(applicantId) {
+  document.getElementById('email-status').textContent = 'Drafting…';
+  try {
+    const { data } = await sb.auth.getSession();
+    const token = data?.session?.access_token;
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+      body: JSON.stringify({ action: 'draft_email', applicantId }),
+    });
+    const out = await resp.json();
+    if (out.error) throw new Error(out.error);
+    if (emailApplicantId !== applicantId) return; // closed / switched meanwhile
+    document.getElementById('email-subject').value = out.subject || '';
+    document.getElementById('email-body').value = out.body || '';
+    document.getElementById('email-status').textContent = 'Edit freely, then copy.';
+  } catch (e) {
+    document.getElementById('email-status').textContent = `Draft failed: ${e.message}`;
+  }
+}
+
+function closeEmailModal() {
+  emailApplicantId = null;
+  document.getElementById('email-modal').hidden = true;
+}
+
 /* Independent AI read (Sonnet) posted into the house notes for everyone. */
 async function requestSecondOpinion(applicantId, btn) {
   if (btn) { btn.disabled = true; btn.textContent = 'Thinking…'; }
@@ -651,16 +694,44 @@ function renderApplicants() {
     host.innerHTML = bar + `<p class="inbox-empty">${filtered ? 'No applicants match these filters.' : (view === 'inbox' ? 'Inbox zero — every applicant is decided.' : 'Nothing here yet.')}</p>`;
     return;
   }
+  // Outreach groups by listing (custom-orderable); other views group by month.
   const groups = [];
-  for (const a of list) {
-    const k = monthKey(a.ts_iso);
-    if (!groups.length || groups[groups.length - 1].key !== k) groups.push({ key: k, items: [] });
-    groups[groups.length - 1].items.push(a);
+  if (view === 'outreach') {
+    const byKey = new Map();
+    for (const a of list) {
+      const key = decisions[a.id]?.listingId || 'general';
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key).push(a);
+    }
+    const order = Array.isArray(settings.outreach_group_order) ? settings.outreach_group_order : [];
+    const keys = [...byKey.keys()].sort((x, y) => {
+      const ix = order.indexOf(x), iy = order.indexOf(y);
+      return (ix === -1 ? 1e9 : ix) - (iy === -1 ? 1e9 : iy); // unknown groups sink to the bottom
+    });
+    for (const key of keys) groups.push({ key, items: byKey.get(key) });
+  } else {
+    for (const a of list) {
+      const k = monthKey(a.ts_iso);
+      if (!groups.length || groups[groups.length - 1].key !== k) groups.push({ key: k, items: [] });
+      groups[groups.length - 1].items.push(a);
+    }
   }
+
+  const groupHead = g => {
+    if (view !== 'outreach') return `<h2 class="inbox-group__label">${monthLabel(g.key)}</h2>`;
+    if (g.key === 'general') return `<h2 class="inbox-group__label">General interest</h2>`;
+    const l = listings.find(x => x.id === g.key);
+    const room = rooms.find(r => r.id === l?.room_id);
+    return `<h2 class="inbox-group__label">${esc(room?.name || 'Listing')}</h2>
+      <span class="inbox-group__count">${l ? `${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}` : ''}</span>
+      <button class="inbox-group__link" data-view-link="listings" title="Open Listings">View listing →</button>`;
+  };
+
   host.innerHTML = bar + groups.map(g => `
-    <section class="inbox-group">
-      <div class="inbox-group__head">
-        <h2 class="inbox-group__label">${monthLabel(g.key)}</h2>
+    <section class="inbox-group" ${view === 'outreach' ? `data-group-key="${esc(g.key)}"` : ''}>
+      <div class="inbox-group__head" ${view === 'outreach' ? 'draggable="true"' : ''}>
+        ${view === 'outreach' ? '<span class="inbox-group__grip" title="Drag to reorder">⠿</span>' : ''}
+        ${groupHead(g)}
         <span class="inbox-group__count">${g.items.length} applicant${g.items.length === 1 ? '' : 's'}</span>
       </div>
       <ul class="inbox-card">
@@ -671,18 +742,45 @@ function renderApplicants() {
               <span class="inbox-row__text">
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
                 <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
-                ${view === 'outreach' && decisions[a.id] ? `<span class="inbox-row__sub inbox-row__attach">→ ${esc(attachmentLabel(decisions[a.id]))}</span>` : ''}
-                ${view === 'outreach' && decisions[a.id] && !decisions[a.id].listingId && suggestions[a.id]?.listing_id ? `<span class="inbox-row__sub inbox-row__ai">AI suggests ${esc(matchListingLabel(suggestions[a.id]))} — Review to apply</span>` : ''}
+                ${view === 'outreach' && decisions[a.id] && !decisions[a.id].listingId && suggestions[a.id]?.listing_id ? `<span class="inbox-row__sub inbox-row__ai">AI suggests ${esc(matchListingLabel(suggestions[a.id]))} — open to apply</span>` : ''}
               </span>
             </button>
             <span class="inbox-row__actions">
               ${commentCounts[a.id] ? `<span class="note-count" title="${commentCounts[a.id]} house note${commentCounts[a.id] === 1 ? '' : 's'}">✎ ${commentCounts[a.id]}</span>` : ''}
-              ${decisionChip(a.id)}
-              <button class="btn inbox-row__review" data-review="${a.id}">Review</button>
+              ${view === 'outreach' ? `<button class="btn inbox-row__review" data-email="${a.id}">Send email</button>` : `${decisionChip(a.id)}<button class="btn inbox-row__review" data-review="${a.id}">Review</button>`}
             </span>
           </li>`).join('')}
       </ul>
     </section>`).join('');
+  if (view === 'outreach') wireGroupDrag(host);
+}
+
+/* Drag-to-reorder the outreach listing groups; order is shared house state. */
+let dragKey = null;
+function wireGroupDrag(host) {
+  host.querySelectorAll('.inbox-group[data-group-key]').forEach(sec => {
+    const head = sec.querySelector('.inbox-group__head');
+    head.addEventListener('dragstart', e => {
+      dragKey = sec.dataset.groupKey;
+      sec.classList.add('is-dragging');
+      e.dataTransfer.effectAllowed = 'move';
+    });
+    head.addEventListener('dragend', () => { sec.classList.remove('is-dragging'); dragKey = null; });
+    sec.addEventListener('dragover', e => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; });
+    sec.addEventListener('drop', e => {
+      e.preventDefault();
+      const targetKey = sec.dataset.groupKey;
+      if (!dragKey || dragKey === targetKey) return;
+      const keys = [...host.querySelectorAll('.inbox-group[data-group-key]')].map(x => x.dataset.groupKey);
+      keys.splice(keys.indexOf(targetKey), 0, keys.splice(keys.indexOf(dragKey), 1)[0]);
+      settings.outreach_group_order = keys;
+      sb.from('recruit_settings').upsert({
+        key: 'outreach_group_order', value: keys,
+        updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+      }).then(({ error }) => { if (error) toast(`Order save failed: ${error.message}`); });
+      renderApplicants();
+    });
+  });
 }
 
 /* ---------- occupancy ---------- */
@@ -1604,6 +1702,8 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const em = e.target.closest('[data-email]');
+    if (em) { openEmailModal(em.dataset.email); return; }
     const so = e.target.closest('[data-second-opinion]');
     if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
     const useSug = e.target.closest('[data-use-suggestion]');
@@ -1692,6 +1792,18 @@ function init() {
     else toast(value ? 'House preference: open to couples' : 'House preference: not open to couples');
   };
 
+  document.getElementById('email-close').onclick = closeEmailModal;
+  document.getElementById('email-regen').onclick = () => emailApplicantId && generateEmail(emailApplicantId);
+  document.getElementById('email-copy').onclick = async () => {
+    const text = `Subject: ${document.getElementById('email-subject').value}\n\n${document.getElementById('email-body').value}`;
+    try { await navigator.clipboard.writeText(text); toast('Email copied'); }
+    catch { toast('Copy failed — select and copy manually'); }
+  };
+  document.getElementById('email-mailto').onclick = () => {
+    const a = applicants.find(x => x.id === emailApplicantId);
+    const url = `mailto:${encodeURIComponent(a?.email || '')}?subject=${encodeURIComponent(document.getElementById('email-subject').value)}&body=${encodeURIComponent(document.getElementById('email-body').value)}`;
+    window.open(url, '_blank');
+  };
   document.getElementById('review-close').onclick = closeReview;
   document.getElementById('review-prev').onclick = () => step(-1);
   document.getElementById('review-next').onclick = () => step(1);
@@ -1707,6 +1819,9 @@ function init() {
     if (document.getElementById('review').hidden) return;
     if (e.target instanceof Element && e.target.matches('input, textarea')) return;
     if (e.key === 'Escape') { if (!document.getElementById('decision-sheet').hidden) hideDecisionSheet(); else closeReview(); }
+  });
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && !document.getElementById('email-modal').hidden) closeEmailModal();
     if (e.key === 'ArrowRight') step(1);
     if (e.key === 'ArrowLeft') step(-1);
   });

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.2.0'
+const VERSION = '1.3.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -149,6 +149,68 @@ async function suggestFor(client: any, applicant: any, listings: any[], rooms: a
   return row
 }
 
+// House reference copy (Notion: "Recruiting Copy" — outreach to applicants).
+const REFERENCE_COPY = `Subject line: Hi from Agape! (co-op in the Mission)
+
+Hi [name],
+
+I'm [sender]. I saw your application and wanted to share that my co-op, Agape, is looking for a new [subletter/resident].
+
+Here are the details:
+1 bedroom is available in a 13 bedroom co-op in the Mission.
+$1435 covers rent, utilities, cleaners for common spaces
++$210 for shared organic groceries
+Room available starting [date].
+
+Come live with a bunch of artists, musicians, academics, and entrepreneurs. We have a weekly vegan gf family dinner meal and often do shared activities together.
+
+agapesf.org
+instagram.com/agapeandfriends
+
+Let me know if you have any questions and if this sounds interesting to you, apply on our website so we have your info on hand! :)
+
+[sender]`
+
+// Draft a tailored outreach email for an applicant + their listing.
+// deno-lint-ignore no-explicit-any
+async function draftEmail(applicant: any, listing: any, room: any, flags: any[], senderName: string): Promise<{ subject: string; body: string }> {
+  const trim = (t: string, n = 600) => (t || '').replace(/\s+/g, ' ').slice(0, n)
+  const listingLine = listing
+    ? `${room?.name || 'A room'} — ${listing.kind === 'resident' ? '3-month resident trial (full residency track, house vote at the end)' : 'short-term sublet'}, available from ${listing.starts_on}${listing.ends_on ? ` through ${listing.ends_on}` : ''}${listing.notes ? `. Notes: ${listing.notes}` : ''}`
+    : 'No specific room right now — we want to keep them warm for future availability (general interest).'
+  const conflictLines = (flags || []).map((f) => `- ${f.type}: ${f.message}`).join('\n') || '(none)'
+
+  const prompt = `Draft an outreach email from ${senderName} at Agape (13-bedroom intentional community / co-op in a Victorian near Dolores Park, SF) to a housing applicant we want to move forward with.
+
+REFERENCE COPY — match this voice exactly (warm, casual, concrete, lowercase-friendly, no corporate tone):
+${REFERENCE_COPY}
+
+APPLICANT
+Name: ${applicant.first_name}
+Pronouns: ${applicant.pronouns || 'unknown'}
+Track they applied for: ${applicant.residency}
+Their move-in words: ${applicant.move_in}
+Their budget words: ${applicant.budget}
+Why they want Agape (their words): ${trim(applicant.why_agape)}
+
+WHAT WE'RE OFFERING
+${listingLine}
+
+PRACTICAL WRINKLES TO ADDRESS HONESTLY (gently, in one short line each — don't hide them, don't dwell):
+${conflictLines}
+
+Rules:
+- Tailor the middle details block to the listing kind: sublet → emphasize the window and dates; resident trial → explain the 3-month trial then house vote; general interest → say no room right now but we liked their application and will reach out when one opens.
+- Reference one specific thing from their application so it feels personal.
+- Keep the $1435 + $210 groceries structure only if a room is offered; adjust availability date to the listing.
+- Under 180 words. Sign off with ${senderName}.
+Return exactly: {"subject": "...", "body": "..."} — body with real newlines, no markdown.`
+
+  const text = await callClaudeRaw(OPINION_MODEL, 'You write warm, concise community-house outreach emails. Respond with a single JSON object only.', prompt, 700)
+  const parsed = JSON.parse(text.replace(/^```json?\s*|\s*```$/g, ''))
+  return { subject: String(parsed.subject || 'Hi from Agape!').slice(0, 150), body: String(parsed.body || '').slice(0, 3000) }
+}
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
 
@@ -172,6 +234,19 @@ serve(async (req) => {
       client.from('recruit_settings').select('*'),
     ])
     const openToCouples = (settingsRows || []).find((r) => r.key === 'open_to_couples')?.value !== false
+
+    if (body.action === 'draft_email' && body.applicantId) {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId)).maybeSingle()
+      if (!applicant) return new Response(JSON.stringify({ error: 'Unknown applicant' }), { status: 404, headers: jsonHeaders })
+      const { data: decision } = await client.from('recruit_decisions').select('listing_id').eq('applicant_id', applicant.id).maybeSingle()
+      const { data: sug } = await client.from('recruit_match_suggestions').select('flags').eq('applicant_id', applicant.id).maybeSingle()
+      const listing = decision?.listing_id ? (listings || []).find((l) => l.id === decision.listing_id) ||
+        (await client.from('recruit_listings').select('*').eq('id', decision.listing_id).maybeSingle()).data : null
+      const room = listing ? (rooms || []).find((r) => r.id === listing.room_id) : null
+      const { data: prof } = await client.from('user_discord_membership').select('discord_username').eq('user_id', userData.user.id).maybeSingle()
+      const draft = await draftEmail(applicant, listing, room, sug?.flags || [], prof?.discord_username || 'a housemate')
+      return new Response(JSON.stringify(draft), { headers: jsonHeaders })
+    }
 
     if (body.action === 'second_opinion' && body.applicantId) {
       const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId)).maybeSingle()


### PR DESCRIPTION
## Summary
- **Pronouns** open each row's metadata
- **Outreach grouped by listing** (General interest last by default): header carries room + window + subtle *View listing →*; **drag the grip** to reorder groups — order persists house-wide (`recruit_settings.outreach_group_order`); new groups land at the bottom
- **Send email** on outreach rows: modal with an editable AI-drafted subject+body — tailored to the attached listing (sublet window vs 3-month trial vs general interest), honest about flags (timing gaps, couples), personalized from their application, in the voice of the Notion 'Recruiting Copy' reference. Copy / Open in Mail / Regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)