### PR TITLE
Applications v2.12.0 — display names + shared Gmail pipe + Emails tab

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -889,3 +889,23 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .email-modal__status { margin: 0; color: var(--fg-subtle); font-size: var(--font-size-small); min-height: 1.3em; }
 .email-modal__subject { width: 100%; height: 40px; }
 .email-modal__body { min-height: 260px; font-size: var(--font-size-small); line-height: 1.55; }
+
+/* --- v2.12: review tabs + emails --- */
+.review-tabs { display: flex; gap: var(--space-2); margin-bottom: var(--space-5); border-bottom: 1px solid var(--border); }
+.review-tabs__tab {
+  background: none; border: 0; padding: var(--space-2) var(--space-3);
+  color: var(--fg-muted); font-size: var(--font-size-body); font-weight: var(--fw-medium);
+  border-bottom: 2px solid transparent; margin-bottom: -1px;
+}
+.review-tabs__tab:hover { color: var(--fg); }
+.review-tabs__tab.is-on { color: var(--fg); font-weight: var(--fw-semibold); border-bottom-color: var(--accent); }
+.emails-toolbar { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-3); }
+.email-list { padding-inline: var(--space-4); }
+.email-row { display: flex; align-items: flex-start; gap: var(--space-3); padding: var(--space-3) 0; position: relative; }
+.email-row::after { content: ''; position: absolute; left: 28px; right: 0; bottom: 0; border-bottom: 1px solid var(--border); }
+.email-row:last-child::after { display: none; }
+.email-row__dir { flex-shrink: 0; width: 20px; text-align: center; font-weight: var(--fw-bold); }
+.email-row--out .email-row__dir { color: var(--outreach-fg); }
+.email-row--in .email-row__dir { color: var(--success); }
+.email-row .inbox-row__sub { white-space: normal; }
+.rail-foot__edit { display: inline; color: var(--fg-subtle); font-size: var(--font-size-caption); text-decoration: underline; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.11.0">
+  <link rel="stylesheet" href="css/app.css?v=2.12.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -131,13 +131,14 @@
       <div class="decision-sheet__actions">
         <button class="hold-sheet__cancel" id="email-regen" type="button">Regenerate</button>
         <button class="btn btn--sm" id="email-mailto" type="button">Open in Mail</button>
-        <button class="btn btn--accent btn--sm" id="email-copy" type="button">Copy email</button>
+        <button class="btn btn--sm" id="email-copy" type="button">Copy email</button>
+        <button class="btn btn--accent btn--sm" id="email-send" type="button">Send via Agape Gmail</button>
       </div>
     </div>
   </div>
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.11.0"></script>
+  <script src="js/app.js?v=2.12.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.11.0';
+const VERSION = '2.12.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -65,6 +65,9 @@ let listings = [];            // recruit_listings rows
 let houseLoaded = false;
 let suggestions = {};         // applicant_id -> recruit_match_suggestions row
 let settings = { open_to_couples: true };
+let gmailStatus = { connected: false };
+let reviewTab = 'profile';   // 'profile' | 'emails'
+let emailsCache = {};        // applicant_id -> rows
 let queue = [];
 let qIndex = 0;
 
@@ -1215,6 +1218,7 @@ function openReview(id) {
   queue = applicants.filter(a => matchesView(a) && matchesFilters(a)).map(a => a.id);
   if (!queue.includes(id)) queue = applicants.map(a => a.id);
   qIndex = Math.max(0, queue.indexOf(id));
+  reviewTab = 'profile';
   document.getElementById('review').hidden = false;
   document.body.style.overflow = 'hidden';
   hideHoldSheet();
@@ -1299,6 +1303,11 @@ function renderReview() {
         </div>
       </div>
     </div>
+    <div class="review-tabs">
+      <button class="review-tabs__tab ${reviewTab === 'profile' ? 'is-on' : ''}" data-review-tab="profile">Profile</button>
+      <button class="review-tabs__tab ${reviewTab === 'emails' ? 'is-on' : ''}" data-review-tab="emails">Emails${(emailsCache[a.id] || []).length ? ` (${emailsCache[a.id].length})` : ''}</button>
+    </div>
+    ${reviewTab === 'emails' ? `<div id="emails-panel"><p class="notes__empty">Loading emails…</p></div>` : `
     <div id="review-ai">${matchBlockHtml(a)}</div>
     ${section('About them', a.about)}
     ${section('Why Agape', a.why)}
@@ -1313,7 +1322,7 @@ function renderReview() {
         <textarea class="notes__input" id="notes-input" placeholder="Add an internal note for the house — only Recruiting Society members see these." maxlength="4000"></textarea>
         <button class="btn btn--accent btn--sm notes__submit" type="submit">Add note</button>
       </form>
-    </section>
+    </section>`}
   `;
 
   for (const d of ['pass', 'hold', 'outreach']) {
@@ -1321,13 +1330,14 @@ function renderReview() {
     btn.classList.toggle(`is-active--${d}`, rec?.d === d);
   }
 
+  if (reviewTab === 'emails') loadEmailsPanel(a);
   if (houseLoaded) ensureMatch(a);
   else loadHouse().then(() => { houseLoaded = true; ensureMatch(a); renderReviewMatch(a); });
   loadComments(a.id).then(() => {
     // guard against navigating away while the query was in flight
     if (queue[qIndex] === a.id) renderNotes(a.id);
   });
-  document.getElementById('notes-form').addEventListener('submit', e => {
+  document.getElementById('notes-form')?.addEventListener('submit', e => {
     e.preventDefault();
     postNote(a.id);
   });
@@ -1381,6 +1391,50 @@ function section(title, text) {
     <h3 class="review__section-title">${title}</h3>
     <p class="review__prose">${esc(text)}</p>
   </section>`;
+}
+
+/* ---------- emails panel ---------- */
+function emailRow(m) {
+  const arrow = m.direction === 'out' ? '↗' : '↙';
+  const who = m.direction === 'out' ? `Agape${m.sent_by_name ? ` (${esc(m.sent_by_name)})` : ''}` : esc(m.from_email.replace(/<.*>/, '').trim() || m.from_email);
+  return `<li class="email-row email-row--${m.direction}">
+    <span class="email-row__dir" title="${m.direction === 'out' ? 'Sent by the house' : 'Received'}">${arrow}</span>
+    <span class="inbox-row__text">
+      <span class="inbox-row__title">${esc(m.subject || '(no subject)')}</span>
+      <span class="inbox-row__sub">${who} · ${new Date(m.sent_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}${m.snippet ? ` — ${esc(m.snippet.slice(0, 110))}` : ''}</span>
+    </span>
+  </li>`;
+}
+
+async function loadEmailsPanel(a) {
+  const host = () => document.getElementById('emails-panel');
+  if (!host()) return;
+  if (!gmailStatus.connected) {
+    host().innerHTML = `
+      <div class="match-hint">
+        <span class="match-hint__text"><strong>Shared inbox not connected.</strong>
+          <span class="match-hint__why">All applicant email runs through live.at.agapesf@gmail.com. Connect it once (you must be signed into that Google account in this browser).</span>
+        </span>
+        <button type="button" class="btn btn--sm" id="gmail-connect">Connect</button>
+      </div>`;
+    document.getElementById('gmail-connect').onclick = connectSharedGmail;
+    return;
+  }
+  host().innerHTML = `<p class="notes__empty">Syncing with the shared inbox…</p>`;
+  try {
+    const out = await gmailCall({ action: 'sync', applicantId: a.id });
+    emailsCache[a.id] = out.emails || [];
+    if (queue[qIndex] !== a.id || reviewTab !== 'emails' || !host()) return;
+    host().innerHTML = `
+      <div class="emails-toolbar">
+        <span class="notes__empty">${emailsCache[a.id].length} message${emailsCache[a.id].length === 1 ? '' : 's'} with ${esc(a.email)}</span>
+        <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
+      </div>
+      ${emailsCache[a.id].length ? `<ul class="inbox-card email-list">${emailsCache[a.id].map(emailRow).join('')}</ul>`
+        : `<p class="inbox-empty">No emails yet — Compose starts the thread through the shared account.</p>`}`;
+  } catch (e) {
+    if (host()) host().innerHTML = `<p class="notes__empty">Email sync failed: ${esc(e.message)}</p>`;
+  }
 }
 
 /* ---------- decision sheet ----------
@@ -1556,6 +1610,58 @@ function applyTheme(t) {
   localStorage.setItem('agape:theme', t);
 }
 
+/* ---------- display name + shared gmail ---------- */
+function renderRailUser() {
+  const el = document.getElementById('rail-user');
+  el.innerHTML = `${esc(me.name)} <button class="rail-foot__link rail-foot__edit" id="edit-name" title="Set display name">edit</button>`;
+  el.querySelector('#edit-name').onclick = async () => {
+    const name = prompt('Display name (shown on decisions, notes, and emails):', me.name);
+    if (!name || !name.trim()) return;
+    const clean = name.trim().slice(0, 60);
+    const { error } = await sb.from('recruit_profiles').upsert({
+      user_id: me.id, display_name: clean, updated_at: new Date().toISOString(),
+    });
+    if (error) { toast(`Save failed: ${error.message}`); return; }
+    me.name = clean;
+    renderRailUser();
+    toast(`Display name set to ${clean}`);
+  };
+}
+
+async function gmailCall(payload) {
+  const { data } = await sb.auth.getSession();
+  const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-gmail`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${data?.session?.access_token}` },
+    body: JSON.stringify(payload),
+  });
+  const out = await resp.json();
+  if (out.error) throw new Error(out.error);
+  return out;
+}
+
+/* OAuth callback (state=agape-gmail, forwarded from /ladder/). */
+async function handleGmailCallback() {
+  const params = new URLSearchParams(location.search);
+  if (params.get('state') !== 'agape-gmail' || !params.get('code')) return;
+  const code = params.get('code');
+  const clean = new URL(location.href);
+  clean.searchParams.delete('code'); clean.searchParams.delete('state'); clean.searchParams.delete('scope');
+  history.replaceState(null, '', clean);
+  try {
+    const out = await gmailCall({ action: 'connect', code });
+    gmailStatus = { connected: true, email: out.email };
+    toast(`Shared Gmail connected: ${out.email}`);
+  } catch (e) { toast(`Gmail connect failed: ${e.message}`); }
+}
+
+async function connectSharedGmail() {
+  try {
+    const { url } = await gmailCall({ action: 'auth-url' });
+    location.href = url;
+  } catch (e) { toast(`Couldn't start Gmail connect: ${e.message}`); }
+}
+
 /* ---------- auth + boot ---------- */
 /* Direct Discord OAuth — the gate's primary action goes straight to Discord
    rather than through the multi-provider modal. */
@@ -1627,6 +1733,13 @@ async function _checkMembershipAndEnter() {
     // in — identify self, load data, render
     const user = window.CtrlAuth.getUser();
     me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
+    sb.from('recruit_profiles').select('display_name').eq('user_id', user.id).maybeSingle()
+      .then(({ data }) => { if (data?.display_name) { me.name = data.display_name; renderRailUser(); } });
+    fetch(`${SUPABASE_URL}/functions/v1/recruit-gmail`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${(await sb.auth.getSession()).data?.session?.access_token}` },
+      body: JSON.stringify({ action: 'status' }),
+    }).then(r => r.json()).then(st => { gmailStatus = st || { connected: false }; }).catch(() => {});
     await loadAll();
     // background — outreach attachment labels + rail badges need house data;
     // re-render the open view once it lands so labels don't show stale fallbacks
@@ -1638,7 +1751,8 @@ async function _checkMembershipAndEnter() {
     const autoPassed = await applyAutoPass();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;
-    document.getElementById('rail-user').textContent = me.name;
+    renderRailUser();
+    handleGmailCallback();
     view = new URLSearchParams(location.search).get('view') || 'inbox';
     if (!VIEWS[view]) view = 'inbox';
     render();
@@ -1702,6 +1816,8 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const rtab = e.target.closest('[data-review-tab]');
+    if (rtab) { reviewTab = rtab.dataset.reviewTab; renderReview(); return; }
     const em = e.target.closest('[data-email]');
     if (em) { openEmailModal(em.dataset.email); return; }
     const so = e.target.closest('[data-second-opinion]');
@@ -1794,6 +1910,22 @@ function init() {
 
   document.getElementById('email-close').onclick = closeEmailModal;
   document.getElementById('email-regen').onclick = () => emailApplicantId && generateEmail(emailApplicantId);
+  document.getElementById('email-send').onclick = async () => {
+    if (!gmailStatus.connected) { toast('Connect the shared Gmail first (Emails tab)'); return; }
+    const btn = document.getElementById('email-send');
+    btn.disabled = true; btn.textContent = 'Sending…';
+    try {
+      await gmailCall({
+        action: 'send', applicantId: emailApplicantId,
+        subject: document.getElementById('email-subject').value,
+        body: document.getElementById('email-body').value,
+      });
+      toast('Sent from live.at.agapesf@gmail.com');
+      delete emailsCache[emailApplicantId];
+      closeEmailModal();
+    } catch (e) { toast(`Send failed: ${e.message}`); }
+    btn.disabled = false; btn.textContent = 'Send via Agape Gmail';
+  };
   document.getElementById('email-copy').onclick = async () => {
     const text = `Subject: ${document.getElementById('email-subject').value}\n\n${document.getElementById('email-body').value}`;
     try { await navigator.clipboard.writeText(text); toast('Email copied'); }

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.36.2");
+@import url("./components.css?v=2.36.3");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
 
 
 
@@ -75,7 +75,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,7 +2,7 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.36.2";
+const VERSION = "2.36.3";
 console.log(`[ladder] v${VERSION} - Inbox: Updates card sits below the page header; roles counter removed from header`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
@@ -361,6 +361,12 @@ window.CtrlAuth.init({
   const params = new URLSearchParams(location.search);
   const code = params.get('code');
   const state = params.get('state') || '';
+  // The Agape recruiting app shares this OAuth redirect; bounce its
+  // callback over to /applications/ untouched.
+  if (code && state === 'agape-gmail') {
+    location.replace('/applications/?code=' + encodeURIComponent(code) + '&state=agape-gmail');
+    return;
+  }
   if (code && state.startsWith('gmail:')) {
     try { sessionStorage.setItem('job:pendingGmailOAuth', JSON.stringify({ code, state, at: Date.now() })); } catch {}
     const clean = new URL(location.href);

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.2">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.3">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.2">
-  <script src="/ladder/js/theme.js?v=2.36.2"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.36.3">
+  <script src="/ladder/js/theme.js?v=2.36.3"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.36.2"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.36.3"></script>
 </body>
 </html>

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -1,0 +1,211 @@
+// Supabase Edge Function: recruit-gmail
+// All applicant communication runs through ONE shared Google account
+// (live.at.agapesf@gmail.com), regardless of who is signed into the app.
+// Reuses the existing Google OAuth client (GOOGLE_CALENDAR_* secrets, same
+// client gmail-auth uses) — the refresh token lives in recruit_gmail_account
+// (service-role only; members never see it).
+//
+// POST /functions/v1/recruit-gmail   (Authorization: Bearer <user JWT>)
+// Actions:
+//   auth-url                  → { url } Google consent URL (state=agape-gmail)
+//   connect { code }          → exchange + verify the account is the shared
+//                               address, store refresh token
+//   status                    → { connected, email, connectedAt }
+//   send { applicantId, subject, body } → send via Gmail as the shared
+//                               account, log to recruit_emails (direction out)
+//   sync { applicantId }      → pull recent messages to/from the applicant's
+//                               address into recruit_emails (direction in/out)
+
+const VERSION = '1.0.0'
+console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+
+const CLIENT_ID = Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID')!
+const CLIENT_SECRET = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!
+// Same whitelisted redirect the ladder gmail flow uses; /ladder forwards
+// state=agape-gmail callbacks to /applications/.
+const REDIRECT_URI = Deno.env.get('GMAIL_OAUTH_REDIRECT_URI') || 'https://ctrl.rodeo/job/'
+const SHARED_EMAIL = Deno.env.get('AGAPE_GMAIL_ADDRESS') || 'live.at.agapesf@gmail.com'
+const SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.send',
+]
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+async function accessToken(client: ReturnType<typeof db>): Promise<string> {
+  const { data: acct } = await client.from('recruit_gmail_account').select('*').eq('id', 1).maybeSingle()
+  if (!acct) throw new Error('Shared Gmail not connected yet')
+  const resp = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID, client_secret: CLIENT_SECRET,
+      refresh_token: acct.refresh_token, grant_type: 'refresh_token',
+    }),
+  })
+  const tok = await resp.json()
+  if (!resp.ok || !tok.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(tok).slice(0, 180)}`)
+  return tok.access_token
+}
+
+function b64url(s: string): string {
+  return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function header(headers: Array<{ name: string; value: string }>, name: string): string {
+  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value || ''
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+    const client = db()
+    const { data: userData, error: userErr } = await client.auth.getUser(token)
+    if (userErr || !userData?.user) return json({ error: 'Not authenticated' }, 401)
+    const { data: membership } = await client.from('user_discord_membership')
+      .select('is_recruiting_member, discord_username').eq('user_id', userData.user.id).maybeSingle()
+    if (!membership?.is_recruiting_member) return json({ error: 'Not a recruiting member' }, 403)
+
+    const body = await req.json().catch(() => ({}))
+    const action = body.action
+
+    if (action === 'auth-url') {
+      const url = 'https://accounts.google.com/o/oauth2/v2/auth?' + new URLSearchParams({
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT_URI,
+        response_type: 'code',
+        scope: SCOPES.join(' '),
+        access_type: 'offline',
+        prompt: 'consent',
+        login_hint: SHARED_EMAIL,
+        state: 'agape-gmail',
+      })
+      return json({ url })
+    }
+
+    if (action === 'connect') {
+      const resp = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          code: String(body.code || ''), client_id: CLIENT_ID, client_secret: CLIENT_SECRET,
+          redirect_uri: REDIRECT_URI, grant_type: 'authorization_code',
+        }),
+      })
+      const tok = await resp.json()
+      if (!resp.ok || !tok.refresh_token) return json({ error: `Exchange failed: ${JSON.stringify(tok).slice(0, 180)}` }, 400)
+      // verify the connected mailbox is the shared house account
+      const prof = await (await fetch('https://gmail.googleapis.com/gmail/v1/users/me/profile', {
+        headers: { Authorization: `Bearer ${tok.access_token}` },
+      })).json()
+      if ((prof.emailAddress || '').toLowerCase() !== SHARED_EMAIL) {
+        return json({ error: `Wrong account: signed into ${prof.emailAddress}. Connect ${SHARED_EMAIL}.` }, 400)
+      }
+      // find the requester's display name for attribution
+      const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', userData.user.id).maybeSingle()
+      const { error } = await client.from('recruit_gmail_account').upsert({
+        id: 1, email: SHARED_EMAIL, refresh_token: tok.refresh_token,
+        connected_by_name: rp?.display_name || membership.discord_username || null,
+        connected_at: new Date().toISOString(),
+      })
+      if (error) return json({ error: error.message }, 500)
+      return json({ connected: true, email: SHARED_EMAIL })
+    }
+
+    if (action === 'status') {
+      const { data: acct } = await client.from('recruit_gmail_account')
+        .select('email, connected_by_name, connected_at').eq('id', 1).maybeSingle()
+      return json(acct ? { connected: true, ...acct } : { connected: false })
+    }
+
+    if (action === 'send') {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
+      if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      const subject = String(body.subject || '').slice(0, 300)
+      const text = String(body.body || '').slice(0, 10000)
+      if (!subject || !text) return json({ error: 'Subject and body required' }, 400)
+
+      const at = await accessToken(client)
+      // RFC 2047 encode the subject for safety with unicode
+      const encSubject = `=?UTF-8?B?${b64url(subject).replace(/-/g, '+').replace(/_/g, '/')}?=`
+      const raw = [
+        `From: Agape <${SHARED_EMAIL}>`,
+        `To: ${applicant.email}`,
+        `Subject: ${encSubject}`,
+        'MIME-Version: 1.0',
+        'Content-Type: text/plain; charset=UTF-8',
+        '',
+        text,
+      ].join('\r\n')
+      const resp = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ raw: b64url(raw) }),
+      })
+      const sent = await resp.json()
+      if (!resp.ok) return json({ error: `Send failed: ${JSON.stringify(sent).slice(0, 180)}` }, 500)
+
+      const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', userData.user.id).maybeSingle()
+      await client.from('recruit_emails').upsert({
+        applicant_id: applicant.id, gmail_id: sent.id, thread_id: sent.threadId,
+        direction: 'out', subject, snippet: text.slice(0, 180), body_text: text,
+        from_email: SHARED_EMAIL, to_email: applicant.email,
+        sent_by_name: rp?.display_name || membership.discord_username || null,
+        sent_at: new Date().toISOString(),
+      }, { onConflict: 'gmail_id' })
+      console.log(`sent → ${applicant.email} (${sent.id})`)
+      return json({ sent: true, gmailId: sent.id })
+    }
+
+    if (action === 'sync') {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
+      if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      const at = await accessToken(client)
+      const q = `from:${applicant.email} OR to:${applicant.email}`
+      const list = await (await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${encodeURIComponent(q)}&maxResults=25`, {
+        headers: { Authorization: `Bearer ${at}` },
+      })).json()
+      let added = 0
+      for (const m of (list.messages || [])) {
+        const { data: existing } = await client.from('recruit_emails').select('id').eq('gmail_id', m.id).maybeSingle()
+        if (existing) continue
+        const msg = await (await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Date`, {
+          headers: { Authorization: `Bearer ${at}` },
+        })).json()
+        const hs = msg.payload?.headers || []
+        const from = header(hs, 'From')
+        const direction = from.toLowerCase().includes(SHARED_EMAIL) ? 'out' : 'in'
+        await client.from('recruit_emails').upsert({
+          applicant_id: applicant.id, gmail_id: msg.id, thread_id: msg.threadId,
+          direction, subject: header(hs, 'Subject').slice(0, 300),
+          snippet: (msg.snippet || '').slice(0, 300),
+          from_email: from.slice(0, 200), to_email: header(hs, 'To').slice(0, 200),
+          sent_at: new Date(Number(msg.internalDate) || Date.now()).toISOString(),
+        }, { onConflict: 'gmail_id' })
+        added++
+      }
+      const { data: rows } = await client.from('recruit_emails')
+        .select('*').eq('applicant_id', applicant.id).order('sent_at', { ascending: false }).limit(50)
+      return json({ synced: added, emails: rows || [] })
+    }
+
+    return json({ error: 'Unknown action' }, 400)
+  } catch (err) {
+    console.error('recruit-gmail error:', (err as Error).message)
+    return json({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/migrations/115_recruit_gmail.sql
+++ b/supabase/migrations/115_recruit_gmail.sql
@@ -1,0 +1,55 @@
+-- ============================================
+-- Migration 115: per-user display names + shared Gmail pipe
+--
+-- 1. recruit_profiles — display name per recruiting member ("Ian Fike"
+--    instead of the Discord handle). Read by all members, written by owner.
+-- 2. recruit_gmail_account — the single shared Google account
+--    (live.at.agapesf@gmail.com) the house sends/receives through. Holds
+--    the OAuth refresh token: NO member policies at all — only the
+--    recruit-gmail edge fn (service role) touches it.
+-- 3. recruit_emails — every inbound/outbound message exchanged with an
+--    applicant through the shared account, shown on the applicant's
+--    Emails tab. Written by the edge fn, read by members.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_profiles (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name TEXT NOT NULL CHECK (char_length(display_name) BETWEEN 1 AND 60),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE recruit_profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read profiles" ON recruit_profiles
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Members write own profile" ON recruit_profiles
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid() AND is_recruiting_member());
+
+CREATE TABLE IF NOT EXISTS recruit_gmail_account (
+  id INT PRIMARY KEY DEFAULT 1 CHECK (id = 1),
+  email TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  connected_by_name TEXT,
+  connected_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE recruit_gmail_account ENABLE ROW LEVEL SECURITY;
+-- no policies: service-role only.
+
+CREATE TABLE IF NOT EXISTS recruit_emails (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  gmail_id TEXT UNIQUE,
+  thread_id TEXT,
+  direction TEXT NOT NULL CHECK (direction IN ('in', 'out')),
+  subject TEXT DEFAULT '',
+  snippet TEXT DEFAULT '',
+  body_text TEXT DEFAULT '',
+  from_email TEXT DEFAULT '',
+  to_email TEXT DEFAULT '',
+  sent_by_name TEXT,                -- housemate who hit send (outbound)
+  sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_emails_applicant ON recruit_emails(applicant_id, sent_at DESC);
+ALTER TABLE recruit_emails ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read emails" ON recruit_emails
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+-- writes via the recruit-gmail edge fn (service role).


### PR DESCRIPTION
## Summary
- **Display name preference**: rail footer → edit ('Ian Fike'); flows into decision attribution, house notes, and outgoing email sign-offs (`recruit_profiles`, migration 115 applied)
- **Shared Gmail pipe** (`recruit-gmail` fn, deployed): every send goes out as **live.at.agapesf@gmail.com** no matter who's signed in; the refresh token is service-role-only; connect flow reuses the existing Google OAuth client with the /ladder redirect forwarding `state=agape-gmail` callbacks (ladder v2.36.3)
- **Emails tab** on each applicant profile: Profile | Emails — syncs the shared inbox for that applicant's address on open, tracks all inbound + outbound in `recruit_emails` (↗ sent w/ housemate attribution, ↙ received); **Compose** opens the AI draft modal, now with **Send via Agape Gmail**

## One manual step
Open any applicant → Emails → **Connect** while signed into live.at.agapesf@gmail.com in the browser. Note: if the OAuth client is still in Testing mode, Google expires refresh tokens after 7 days (same gotcha as /ladder Gmail) — publish the consent screen to Production for a durable connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)