### PR TITLE
Applications v2.13.1 — per-listing pricing

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.13.0">
+  <link rel="stylesheet" href="css/app.css?v=2.13.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -139,6 +139,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.13.0"></script>
+  <script src="js/app.js?v=2.13.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.13.0';
+const VERSION = '2.13.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -734,7 +734,7 @@ function renderApplicants() {
     const l = listings.find(x => x.id === g.key);
     const room = rooms.find(r => r.id === l?.room_id);
     return `<h2 class="inbox-group__label">${esc(room?.name || 'Listing')}</h2>
-      <span class="inbox-group__count">${l ? `${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}` : ''}</span>
+      <span class="inbox-group__count">${l ? `${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}${listingPricing(l) ? ` · ${listingPricing(l)}` : ''}` : ''}</span>
       <button class="inbox-group__link" data-view-link="listings" title="Open Listings">View listing →</button>`;
   };
 
@@ -1051,6 +1051,14 @@ function fmtDay(d) {
    resident's room (3 months or less) or a 3-month resident trial. */
 let editingListingId = null;   // listing id, 'new', or null
 
+function listingPricing(l) {
+  const parts = [];
+  if (l.rent_monthly != null) parts.push(`$${Number(l.rent_monthly).toLocaleString()} rent`);
+  if (l.dues_monthly != null) parts.push(`$${Number(l.dues_monthly).toLocaleString()} house dues`);
+  if (l.groceries_monthly != null) parts.push(`$${Number(l.groceries_monthly).toLocaleString()} groceries`);
+  return parts.join(' + ');
+}
+
 function listingWindow(l) {
   const len = windowLength(l.starts_on, l.ends_on);
   if (l.kind === 'resident') {
@@ -1079,6 +1087,15 @@ function listingForm(l) {
       </label>
       <label class="listing-form__field">Sublet ends
         <input type="date" name="ends_on" class="listing-status" value="${l.ends_on || ''}">
+      </label>
+      <label class="listing-form__field">Rent / mo
+        <input type="number" name="rent_monthly" class="listing-status" min="0" max="10000" step="5" value="${l.rent_monthly ?? ''}" placeholder="1490">
+      </label>
+      <label class="listing-form__field">House dues / mo
+        <input type="number" name="dues_monthly" class="listing-status" min="0" max="5000" step="5" value="${l.dues_monthly ?? ''}" placeholder="0">
+      </label>
+      <label class="listing-form__field">Groceries / mo
+        <input type="number" name="groceries_monthly" class="listing-status" min="0" max="5000" step="5" value="${l.groceries_monthly ?? ''}" placeholder="210">
       </label>
     </div>
     <label class="listing-form__field">Notes
@@ -1130,6 +1147,7 @@ function renderListings() {
                   <span class="listing-kind listing-kind--${l.kind}">${l.kind === 'resident' ? 'Resident trial' : 'Sublet'}</span>
                 </span>
                 <span class="inbox-row__sub">${listingWindow(l)}</span>
+                ${listingPricing(l) ? `<span class="inbox-row__sub listing-row__pricing">${listingPricing(l)}</span>` : ''}
                 ${l.notes ? `<span class="inbox-row__sub listing-row__notes">${esc(l.notes)}</span>` : ''}
                 <span class="inbox-row__sub listing-row__source">${SOURCE_LABELS[l.source] || ''}${l.created_by_name ? ` · ${esc(l.created_by_name)}` : ''}</span>
                 ${attached.length ? `<span class="listing-row__people">${attached.map(a =>
@@ -1167,11 +1185,15 @@ async function onListingSubmit(e) {
   const form = e.target;
   const id = form.dataset.listingForm;
   const fd = new FormData(form);
+  const num = k => { const v = fd.get(k); return v === '' || v === null ? null : Math.round(+v); };
   const rec = {
     room_id: +fd.get('room_id'),
     kind: fd.get('kind'),
     starts_on: fd.get('starts_on'),
     ends_on: fd.get('ends_on') || null,
+    rent_monthly: num('rent_monthly'),
+    dues_monthly: num('dues_monthly'),
+    groceries_monthly: num('groceries_monthly'),
     notes: (fd.get('notes') || '').trim(),
   };
   const err = form.querySelector('[data-form-error]');

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.4.0'
+const VERSION = '1.5.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -177,8 +177,13 @@ Let me know if you have any questions and if this sounds interesting to you!
 // deno-lint-ignore no-explicit-any
 async function draftEmail(applicant: any, listing: any, room: any, flags: any[], senderName: string): Promise<{ subject: string; body: string }> {
   const trim = (t: string, n = 600) => (t || '').replace(/\s+/g, ' ').slice(0, n)
+  const pricing = listing ? [
+    listing.rent_monthly != null ? `$${listing.rent_monthly} rent (covers utilities and cleaners for common spaces)` : null,
+    listing.dues_monthly ? `$${listing.dues_monthly} house dues` : null,
+    listing.groceries_monthly != null ? `$${listing.groceries_monthly} shared organic groceries` : null,
+  ].filter(Boolean).join(' + ') : ''
   const listingLine = listing
-    ? `${room?.name || 'A room'} — ${listing.kind === 'resident' ? '3-month resident trial (full residency track, house vote at the end)' : 'short-term sublet'}, available from ${listing.starts_on}${listing.ends_on ? ` through ${listing.ends_on}` : ''}${listing.notes ? `. Notes: ${listing.notes}` : ''}`
+    ? `${room?.name || 'A room'} — ${listing.kind === 'resident' ? '3-month resident trial (full residency track, house vote at the end)' : 'short-term sublet'}, available from ${listing.starts_on}${listing.ends_on ? ` through ${listing.ends_on}` : ''}${pricing ? `. Pricing: ${pricing}` : ''}${listing.notes ? `. Notes: ${listing.notes}` : ''}`
     : 'No specific room right now — we want to keep them warm for future availability (general interest).'
   const conflictLines = (flags || []).map((f) => `- ${f.type}: ${f.message}`).join('\n') || '(none)'
 
@@ -206,7 +211,7 @@ Hard rules:
 - Never say "apply on our website" — they already did. The CTA is the next step: answer questions, and invite them to come by (house dinner or a visit) / hop on a quick chat if the room sounds right.
 - Reference one specific thing they wrote so it reads personally — ideally connect it to house life.
 - Details block: tailor to the listing kind. Sublet → the window and dates matter most. Resident trial → explain plainly: the room starts as a 3-month trial, then the house votes on full residency. General interest → no room right now, we liked their application, we'll reach out when one opens (no details block).
-- Keep the $1435-1490 + $210 groceries structure only when offering a room; set availability from the listing.
+- Pricing: if the listing carries exact numbers, use them verbatim in the details block; if a room is offered without numbers, keep the reference $1490 + $210 structure but phrase availability/pricing as "roughly" so nobody quotes it as final.
 - Address wrinkles in one honest line ("heads up — the room opens Sep 1, a bit after your August timing; let us know if that still works").
 - Under 160 words. Sign off with ${senderName}.
 Return exactly: {"subject": "...", "body": "..."} — body with real newlines, no markdown.`

--- a/supabase/migrations/116_recruit_listing_pricing.sql
+++ b/supabase/migrations/116_recruit_listing_pricing.sql
@@ -1,0 +1,9 @@
+-- ============================================
+-- Migration 116: per-listing pricing
+-- Rent + house dues (communal goods) + shared groceries, matching the
+-- structure in the house's room-ad copy. NULL = not set yet.
+-- ============================================
+
+ALTER TABLE recruit_listings ADD COLUMN IF NOT EXISTS rent_monthly INT CHECK (rent_monthly BETWEEN 0 AND 10000);
+ALTER TABLE recruit_listings ADD COLUMN IF NOT EXISTS dues_monthly INT CHECK (dues_monthly BETWEEN 0 AND 5000);
+ALTER TABLE recruit_listings ADD COLUMN IF NOT EXISTS groceries_monthly INT CHECK (groceries_monthly BETWEEN 0 AND 5000);


### PR DESCRIPTION
Rent / house dues / shared groceries per listing (migration 116 applied): three fields in the listing editor, pricing shown on listing rows + outreach group headers, and email drafts (recruit-match v1.5.0, deployed) quote the listing's exact numbers — approximate reference pricing only when unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)