### PR TITLE
recruit-match v1.6.0 — screening-call CTA

### DIFF
--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.5.0'
+const VERSION = '1.6.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -169,7 +169,9 @@ Come live with a bunch of artists, musicians, academics, and entrepreneurs. We h
 agapesf.org
 instagram.com/agapeandfriends
 
-Let me know if you have any questions and if this sounds interesting to you!
+Next step is a quick call so one of us can get to know you — could you send a Calendly (or similar) link, or 3 days in the next week where you have a couple hours free? We'll match you with a housemate for an initial screening chat.
+
+Let me know if you have any questions!
 
 [sender]`
 
@@ -208,7 +210,8 @@ ${conflictLines}
 
 Hard rules:
 - This is a RESPONSE to their application, never cold outreach. Open by acknowledging their application to Agape ("thanks for applying", "we read your application", etc.). Do NOT introduce or pitch Agape as if they don't know it — they applied; skip the agapesf.org/instagram links and the "come live with artists..." pitch line entirely.
-- Never say "apply on our website" — they already did. The CTA is the next step: answer questions, and invite them to come by (house dinner or a visit) / hop on a quick chat if the room sounds right.
+- Never say "apply on our website" — they already did.
+- The CTA is ALWAYS to set up an initial screening call with a housemate: ask them to either share a Calendly (or similar scheduling) link, OR reply with 3 days where they have at least a couple hours of availability, so we can match them with a housemate for a get-to-know-you call. This is the single ask — don't offer dinners/visits as the first step.
 - Reference one specific thing they wrote so it reads personally — ideally connect it to house life.
 - Details block: tailor to the listing kind. Sublet → the window and dates matter most. Resident trial → explain plainly: the room starts as a 3-month trial, then the house votes on full residency. General interest → no room right now, we liked their application, we'll reach out when one opens (no details block).
 - Pricing: if the listing carries exact numbers, use them verbatim in the details block; if a room is offered without numbers, keep the reference $1490 + $210 structure but phrase availability/pricing as "roughly" so nobody quotes it as final.


### PR DESCRIPTION
Outreach drafts now always close by scheduling the initial screening call: Calendly link or 3 days with 2+ hours of availability, matched to a housemate. Deployed + verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)