### PR TITLE
Applications v2.14.0 — availability collection + screening scheduler

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -914,3 +914,17 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .inbox-row[draggable="true"] { cursor: default; }
 .inbox-row__grip { flex-shrink: 0; cursor: grab; color: var(--fg-subtle); font-size: 13px; user-select: none; }
 .inbox-row.is-dragging { opacity: 0.45; }
+
+/* --- v2.14: availability + screening scheduler --- */
+.avail-card {
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: var(--space-4);
+  margin-bottom: var(--space-4);
+  display: flex; flex-direction: column; gap: var(--space-3);
+}
+.avail-card__title { margin: 0; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.avail-card__window { display: flex; flex-direction: column; gap: var(--space-1); }
+.avail-card__range { font-size: var(--font-size-small); color: var(--fg-muted); font-weight: var(--fw-medium); }
+.avail-card__slots { display: flex; flex-wrap: wrap; gap: var(--space-1); }
+.avail-card__slots .chip { height: 28px; }
+.screening-card { margin-bottom: var(--space-4); background: var(--outreach-tint); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.13.1">
+  <link rel="stylesheet" href="css/app.css?v=2.14.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -139,6 +139,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.13.1"></script>
+  <script src="js/app.js?v=2.14.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.13.1';
+const VERSION = '2.14.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -68,6 +68,8 @@ let settings = { open_to_couples: true };
 let gmailStatus = { connected: false };
 let reviewTab = 'profile';   // 'profile' | 'emails'
 let emailsCache = {};        // applicant_id -> rows
+let availCache = {};         // applicant_id -> { windows, updated_at }
+let screeningsCache = {};    // applicant_id -> rows
 let queue = [];
 let qIndex = 0;
 
@@ -1457,8 +1459,11 @@ async function loadEmailsPanel(a) {
   try {
     const out = await gmailCall({ action: 'sync', applicantId: a.id });
     emailsCache[a.id] = out.emails || [];
+    availCache[a.id] = out.availability || null;
+    screeningsCache[a.id] = out.screenings || [];
     if (queue[qIndex] !== a.id || reviewTab !== 'emails' || !host()) return;
     host().innerHTML = `
+      ${schedulingHtml(a)}
       <div class="emails-toolbar">
         <span class="notes__empty">${emailsCache[a.id].length} message${emailsCache[a.id].length === 1 ? '' : 's'} with ${esc(a.email)}</span>
         <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
@@ -1467,6 +1472,65 @@ async function loadEmailsPanel(a) {
         : `<p class="inbox-empty">No emails yet — Compose starts the thread through the shared account.</p>`}`;
   } catch (e) {
     if (host()) host().innerHTML = `<p class="notes__empty">Email sync failed: ${esc(e.message)}</p>`;
+  }
+}
+
+/* ---------- screening scheduler ---------- */
+function fmtSlot(iso) {
+  return new Date(iso).toLocaleString(undefined, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function windowSlots(w) {
+  // 30-min start times within the offered window (last start 30m before end)
+  const slots = [];
+  const start = new Date(`${w.date}T${w.start}:00`);
+  const end = new Date(`${w.date}T${w.end}:00`);
+  for (let t = start.getTime(); t + 30 * 60000 <= end.getTime(); t += 30 * 60000) {
+    if (t > Date.now()) slots.push(new Date(t));
+  }
+  return slots.slice(0, 16);
+}
+
+function schedulingHtml(a) {
+  const screenings = (screeningsCache[a.id] || []).filter(x => x.status === 'scheduled');
+  const avail = availCache[a.id];
+  const parts = [];
+  for (const sc of screenings) {
+    parts.push(`<div class="match-hint screening-card">
+      <span class="match-hint__text"><strong>Screening call scheduled</strong>
+        <span class="match-hint__why">${fmtSlot(sc.starts_at)} with ${esc(sc.housemate_name || 'a housemate')} · invites sent to both${sc.meet_link ? ` · <a href="${esc(sc.meet_link)}" target="_blank" rel="noopener">Meet link</a>` : ''}</span>
+      </span>
+    </div>`);
+  }
+  if (!screenings.length && avail?.windows?.length) {
+    parts.push(`<div class="avail-card">
+      <p class="avail-card__title">They offered availability — pick a time and both get a calendar invite:</p>
+      ${avail.windows.map((w, i) => `
+        <div class="avail-card__window">
+          <span class="avail-card__range">${new Date(w.date + 'T12:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })} · ${w.start}–${w.end}</span>
+          <span class="avail-card__slots">${windowSlots(w).map(d =>
+            `<button type="button" class="chip" data-slot="${d.toISOString()}" data-slot-applicant="${a.id}">${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</button>`).join('') || '<span class="notes__empty">window already passed</span>'}</span>
+        </div>`).join('')}
+    </div>`);
+  } else if (!screenings.length) {
+    parts.push(`<p class="notes__empty">No availability captured yet — when they reply with days/times, windows appear here automatically.</p>`);
+  }
+  return parts.join('');
+}
+
+async function scheduleSlot(applicantId, iso, btn) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  if (!confirm(`Book the screening call for ${fmtSlot(iso)} (30 min)?\nCalendar invites go to ${a.email} and you.`)) return;
+  if (btn) { btn.disabled = true; btn.textContent = 'Booking…'; }
+  try {
+    const out = await gmailCall({ action: 'schedule', applicantId, startsAt: iso, minutes: 30 });
+    (screeningsCache[applicantId] ||= []).unshift(out.screening);
+    toast('Screening call booked — invites sent to both');
+    if (queue[qIndex] === applicantId && reviewTab === 'emails') loadEmailsPanel(a);
+  } catch (e) {
+    toast(`Booking failed: ${e.message}`);
+    if (btn) { btn.disabled = false; }
   }
 }
 
@@ -1849,6 +1913,8 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const slot = e.target.closest('[data-slot]');
+    if (slot) { scheduleSlot(slot.dataset.slotApplicant, slot.dataset.slot, slot); return; }
     const rtab = e.target.closest('[data-review-tab]');
     if (rtab) { reviewTab = rtab.dataset.reviewTab; renderReview(); return; }
     const em = e.target.closest('[data-email]');

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.0.0'
+const VERSION = '1.2.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -38,7 +38,9 @@ const SHARED_EMAIL = Deno.env.get('AGAPE_GMAIL_ADDRESS') || 'live.at.agapesf@gma
 const SCOPES = [
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.send',
+  'https://www.googleapis.com/auth/calendar.events', // screening-call invites
 ]
+const TZ = 'America/Los_Angeles' 
 
 function db() {
   return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
@@ -62,6 +64,34 @@ async function accessToken(client: ReturnType<typeof db>): Promise<string> {
 
 function b64url(s: string): string {
   return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+// Extract availability windows from an applicant's reply (Haiku).
+async function extractAvailability(text: string): Promise<Array<{ date: string; start: string; end: string }>> {
+  const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
+  if (!key || !text.trim()) return []
+  const prompt = `Today is ${new Date().toLocaleDateString('en-CA', { timeZone: TZ })} (${TZ}).
+Extract every availability window this person offers for a call. Resolve relative days ("next Tuesday") to dates. Assume ${TZ} unless stated. If they give a day with no hours, use 09:00-18:00. Ignore anything that is not availability.
+EMAIL START
+${text.slice(0, 3000)}
+EMAIL END
+Return exactly: [{"date":"YYYY-MM-DD","start":"HH:MM","end":"HH:MM"}] — [] if none.`
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001', max_tokens: 400,
+      system: 'You extract meeting availability from emails. Respond with a JSON array only.',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+  if (!resp.ok) return []
+  const data = await resp.json()
+  const out = (data.content || []).filter((b: Record<string, unknown>) => b.type === 'text').map((b: Record<string, unknown>) => b.text).join('')
+  try {
+    const arr = JSON.parse(out.trim().replace(/^```json?\s*|\s*```$/g, ''))
+    return Array.isArray(arr) ? arr.filter((w) => /^\d{4}-\d{2}-\d{2}$/.test(w.date) && /^\d{2}:\d{2}$/.test(w.start) && /^\d{2}:\d{2}$/.test(w.end)).slice(0, 10) : []
+  } catch { return [] }
 }
 
 function header(headers: Array<{ name: string; value: string }>, name: string): string {
@@ -183,24 +213,96 @@ serve(async (req) => {
       for (const m of (list.messages || [])) {
         const { data: existing } = await client.from('recruit_emails').select('id').eq('gmail_id', m.id).maybeSingle()
         if (existing) continue
-        const msg = await (await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Date`, {
+        const msg = await (await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=full`, {
           headers: { Authorization: `Bearer ${at}` },
         })).json()
         const hs = msg.payload?.headers || []
         const from = header(hs, 'From')
         const direction = from.toLowerCase().includes(SHARED_EMAIL) ? 'out' : 'in'
+        // best-effort plain-text body (availability extraction needs it)
+        let bodyText = ''
+        // deno-lint-ignore no-explicit-any
+        const walk = (part: any) => {
+          if (!part) return
+          if (part.mimeType === 'text/plain' && part.body?.data) {
+            try { bodyText += atob(String(part.body.data).replace(/-/g, '+').replace(/_/g, '/')) } catch { /* */ }
+          }
+          for (const sub of (part.parts || [])) walk(sub)
+        }
+        walk(msg.payload || {})
         await client.from('recruit_emails').upsert({
           applicant_id: applicant.id, gmail_id: msg.id, thread_id: msg.threadId,
           direction, subject: header(hs, 'Subject').slice(0, 300),
           snippet: (msg.snippet || '').slice(0, 300),
+          body_text: bodyText.slice(0, 8000),
           from_email: from.slice(0, 200), to_email: header(hs, 'To').slice(0, 200),
           sent_at: new Date(Number(msg.internalDate) || Date.now()).toISOString(),
         }, { onConflict: 'gmail_id' })
         added++
+        if (direction === 'in' && bodyText.trim()) {
+          const { data: existingAv } = await client.from('recruit_availability')
+            .select('source_gmail_id').eq('applicant_id', applicant.id).maybeSingle()
+          if (existingAv?.source_gmail_id !== msg.id) {
+            const windows = await extractAvailability(bodyText)
+            if (windows.length) {
+              await client.from('recruit_availability').upsert({
+                applicant_id: applicant.id, windows, source_gmail_id: msg.id,
+                updated_at: new Date().toISOString(),
+              })
+            }
+          }
+        }
       }
-      const { data: rows } = await client.from('recruit_emails')
-        .select('*').eq('applicant_id', applicant.id).order('sent_at', { ascending: false }).limit(50)
-      return json({ synced: added, emails: rows || [] })
+      const [{ data: rows }, { data: avail }, { data: screenings }] = await Promise.all([
+        client.from('recruit_emails').select('*').eq('applicant_id', applicant.id).order('sent_at', { ascending: false }).limit(50),
+        client.from('recruit_availability').select('*').eq('applicant_id', applicant.id).maybeSingle(),
+        client.from('recruit_screenings').select('*').eq('applicant_id', applicant.id).order('starts_at', { ascending: false }),
+      ])
+      return json({ synced: added, emails: rows || [], availability: avail || null, screenings: screenings || [] })
+    }
+
+    if (action === 'schedule') {
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
+      if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      const startsAt = new Date(String(body.startsAt || ''))
+      if (isNaN(startsAt.getTime()) || startsAt < new Date()) return json({ error: 'Pick a future start time' }, 400)
+      const endsAt = new Date(startsAt.getTime() + (Number(body.minutes) || 30) * 60000)
+
+      const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', userData.user.id).maybeSingle()
+      const housemateName = rp?.display_name || membership.discord_username || 'an Agape housemate'
+      const housemateEmail = (userData.user.email || '').toLowerCase()
+
+      const at = await accessToken(client)
+      const event = {
+        summary: `Agape screening call — ${applicant.first_name} ${applicant.last_name} × ${housemateName}`,
+        description: `Get-to-know-you call with ${applicant.first_name} (Agape application), scheduled from their offered availability.`,
+        start: { dateTime: startsAt.toISOString(), timeZone: TZ },
+        end: { dateTime: endsAt.toISOString(), timeZone: TZ },
+        attendees: [
+          { email: applicant.email },
+          ...(housemateEmail.includes('@') ? [{ email: housemateEmail }] : []),
+        ],
+        conferenceData: { createRequest: { requestId: crypto.randomUUID(), conferenceSolutionKey: { type: 'hangoutsMeet' } } },
+        reminders: { useDefault: true },
+      }
+      const resp = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=all&conferenceDataVersion=1', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(event),
+      })
+      const created = await resp.json()
+      if (!resp.ok) return json({ error: `Calendar failed: ${JSON.stringify(created).slice(0, 200)} — if this mentions scopes, reconnect the shared Gmail to grant calendar access` }, 500)
+      // deno-lint-ignore no-explicit-any
+      const meet = created.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || created.hangoutLink || null
+      const { data: row, error } = await client.from('recruit_screenings').insert({
+        applicant_id: applicant.id, housemate_user_id: userData.user.id,
+        housemate_name: housemateName, housemate_email: housemateEmail,
+        starts_at: startsAt.toISOString(), ends_at: endsAt.toISOString(),
+        gcal_event_id: created.id, meet_link: meet, status: 'scheduled',
+      }).select().single()
+      if (error) return json({ error: error.message }, 500)
+      console.log(`screening ${applicant.id} x ${housemateName} @ ${startsAt.toISOString()}`)
+      return json({ scheduled: true, screening: row })
     }
 
     return json({ error: 'Unknown action' }, 400)

--- a/supabase/migrations/117_recruit_screenings.sql
+++ b/supabase/migrations/117_recruit_screenings.sql
@@ -1,0 +1,42 @@
+-- ============================================
+-- Migration 117: applicant availability + screening calls
+--
+-- Applicants reply to outreach with availability ranges; recruit-gmail
+-- extracts structured windows from inbound mail (AI) into
+-- recruit_availability. A housemate picks a concrete slot in the app and
+-- recruit-gmail creates a Google Calendar event on the shared account
+-- inviting both — recorded in recruit_screenings.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_availability (
+  applicant_id TEXT PRIMARY KEY REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  windows JSONB NOT NULL DEFAULT '[]',   -- [{date:'YYYY-MM-DD', start:'HH:MM', end:'HH:MM'}]
+  source_gmail_id TEXT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE recruit_availability ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read availability" ON recruit_availability
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+-- writes via recruit-gmail (service role).
+
+CREATE TABLE IF NOT EXISTS recruit_screenings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  housemate_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  housemate_name TEXT,
+  housemate_email TEXT,
+  starts_at TIMESTAMPTZ NOT NULL,
+  ends_at TIMESTAMPTZ NOT NULL,
+  gcal_event_id TEXT,
+  meet_link TEXT,
+  status TEXT NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'completed', 'cancelled')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_screenings_applicant ON recruit_screenings(applicant_id, starts_at DESC);
+ALTER TABLE recruit_screenings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read screenings" ON recruit_screenings
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members update screening status" ON recruit_screenings
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+-- inserts via recruit-gmail (service role) after the calendar event exists.


### PR DESCRIPTION
## Flow
1. Outreach CTA already asks for ranges → applicant replies in prose
2. Inbound sync extracts structured windows (Haiku) → `recruit_availability`
3. Emails tab shows the windows as 30-min slot chips
4. A housemate clicks a slot → Google Calendar event on **live.at.agapesf@gmail.com** with a Meet link, **inviting both applicant and housemate** (Google sends the invites) → `recruit_screenings` (migration 117 applied)

## Action needed
The shared account needs one **reconnect** (Emails tab → Connect) to grant the new calendar scope before booking works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)