### PR TITLE
Applications v2.14.1 — applicant availability picker

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -928,3 +928,4 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .avail-card__slots { display: flex; flex-wrap: wrap; gap: var(--space-1); }
 .avail-card__slots .chip { height: 28px; }
 .screening-card { margin-bottom: var(--space-4); background: var(--outreach-tint); }
+.emails-toolbar__actions { display: inline-flex; gap: var(--space-2); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.14.0">
+  <link rel="stylesheet" href="css/app.css?v=2.14.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -139,6 +139,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.14.0"></script>
+  <script src="js/app.js?v=2.14.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.14.0';
+const VERSION = '2.14.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -366,7 +366,7 @@ async function loadAll() {
     first: r.first_name, last: r.last_name, pronouns: r.pronouns,
     email: r.email, social: r.social, about: r.about, why: r.why_agape,
     gifts: r.gifts, source: r.heard_from, residency: r.residency,
-    movein: r.move_in, budget: r.budget, avatarUrl: r.avatar_url,
+    movein: r.move_in, budget: r.budget, avatarUrl: r.avatar_url, scheduleToken: r.schedule_token,
   }));
   decisions = {};
   for (const d of (dRes.data || [])) {
@@ -1466,7 +1466,10 @@ async function loadEmailsPanel(a) {
       ${schedulingHtml(a)}
       <div class="emails-toolbar">
         <span class="notes__empty">${emailsCache[a.id].length} message${emailsCache[a.id].length === 1 ? '' : 's'} with ${esc(a.email)}</span>
-        <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
+        <span class="emails-toolbar__actions">
+          ${a.scheduleToken ? `<button type="button" class="btn btn--sm" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
+          <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
+        </span>
       </div>
       ${emailsCache[a.id].length ? `<ul class="inbox-card email-list">${emailsCache[a.id].map(emailRow).join('')}</ul>`
         : `<p class="inbox-empty">No emails yet — Compose starts the thread through the shared account.</p>`}`;
@@ -1913,6 +1916,13 @@ function init() {
     if (review) { openReview(review.dataset.review); return; }
     const clear = e.target.closest('[data-clear]');
     if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    const cps = e.target.closest('[data-copy-schedule]');
+    if (cps) {
+      const a = applicants.find(x => x.id === cps.dataset.copySchedule);
+      navigator.clipboard.writeText(`https://ctrl.rodeo/applications/schedule/?t=${a?.scheduleToken}`)
+        .then(() => toast('Availability link copied'));
+      return;
+    }
     const slot = e.target.closest('[data-slot]');
     if (slot) { scheduleSlot(slot.dataset.slotApplicant, slot.dataset.slot, slot); return; }
     const rtab = e.target.closest('[data-review-tab]');

--- a/applications/schedule/index.html
+++ b/applications/schedule/index.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Share your availability — Agape</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #FAFAF9; --bg-surface: #F4F4F2; --bg-elevated: #FFFFFF;
+      --fg: #0E0F0C; --fg-muted: #454745; --fg-subtle: #6A6C6A;
+      --accent: #1D4ED8; --accent-strong: #5CB2FF; --accent-strong-fg: #06264D;
+      --border: rgba(14,15,12,0.12); --border-strong: rgba(14,15,12,0.24);
+      --error: #A8200D; --ok: #2F5711;
+      --radius: 12px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117; --bg-surface: #161b22; --bg-elevated: #1f2630;
+        --fg: #f0f6fc; --fg-muted: rgba(240,246,252,0.72); --fg-subtle: rgba(240,246,252,0.5);
+        --accent: #5CB2FF; --accent-strong: #5CB2FF; --accent-strong-fg: #06264D;
+        --border: rgba(240,246,252,0.12); --border-strong: rgba(240,246,252,0.24);
+        --error: #FF7A6E; --ok: #9FE870;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; background: var(--bg); color: var(--fg);
+      font: 15px/1.5 'Inter', -apple-system, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      display: grid; place-items: start center; min-height: 100vh; padding: 24px 16px 64px;
+    }
+    .card {
+      width: 100%; max-width: 560px;
+      background: var(--bg-elevated); border: 1px solid var(--border);
+      border-radius: 16px; padding: 28px 24px;
+      display: flex; flex-direction: column; gap: 16px;
+    }
+    h1 { margin: 0; font-size: 24px; letter-spacing: -0.02em; }
+    p { margin: 0; color: var(--fg-muted); }
+    .muted { color: var(--fg-subtle); font-size: 13px; }
+    .window {
+      display: grid; grid-template-columns: 1.4fr 1fr 1fr auto; gap: 8px; align-items: end;
+    }
+    label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; font-weight: 600; color: var(--fg-subtle); }
+    input, select {
+      height: 40px; padding: 0 10px;
+      border: 1px solid var(--border); border-radius: 8px;
+      background: var(--bg-surface); color: var(--fg); font: inherit;
+    }
+    input:focus, select:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
+    .remove {
+      height: 40px; width: 40px; border: 0; border-radius: 999px;
+      background: transparent; color: var(--fg-subtle); font-size: 16px; cursor: pointer;
+    }
+    .remove:hover { color: var(--error); background: var(--bg-surface); }
+    .add {
+      align-self: flex-start; background: none; border: 1px dashed var(--border-strong);
+      border-radius: 999px; padding: 8px 16px; color: var(--fg-muted); font: inherit; cursor: pointer;
+    }
+    .add:hover { color: var(--fg); }
+    .submit {
+      height: 48px; border: 0; border-radius: 999px;
+      background: var(--accent-strong); color: var(--accent-strong-fg);
+      font: inherit; font-weight: 600; font-size: 15px; cursor: pointer;
+    }
+    .submit:disabled { opacity: 0.6; cursor: default; }
+    .status { min-height: 1.4em; font-size: 13px; }
+    .status.err { color: var(--error); }
+    .status.ok { color: var(--ok); }
+    .done { text-align: center; padding: 24px 0; }
+    .done h2 { margin: 0 0 8px; }
+    @media (max-width: 480px) { .window { grid-template-columns: 1fr 1fr; } .window label:first-child { grid-column: 1 / -1; } }
+  </style>
+</head>
+<body>
+  <div class="card" id="card">
+    <h1>Share your availability</h1>
+    <p id="intro">Pick a few windows over the next couple of weeks when you're free for a 30-minute call with an Agape housemate. We'll send a calendar invite once someone books a time.</p>
+    <div id="windows"></div>
+    <button class="add" id="add" type="button">+ Add another window</button>
+    <p class="muted">Times are Pacific (San Francisco). 2–3 windows of a couple hours each is perfect.</p>
+    <p class="status" id="status"></p>
+    <button class="submit" id="submit" type="button">Share availability</button>
+  </div>
+
+  <script>
+    const FN = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-availability';
+    const token = new URLSearchParams(location.search).get('t') || '';
+    const windowsEl = document.getElementById('windows');
+    const statusEl = document.getElementById('status');
+
+    function timeOptions(sel) {
+      let out = '';
+      for (let h = 7; h <= 21; h++) for (const m of ['00', '30']) {
+        const v = `${String(h).padStart(2, '0')}:${m}`;
+        const label = new Date(`2000-01-01T${v}:00`).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+        out += `<option value="${v}" ${v === sel ? 'selected' : ''}>${label}</option>`;
+      }
+      return out;
+    }
+
+    function addRow(w) {
+      const div = document.createElement('div');
+      div.className = 'window';
+      const today = new Date();
+      const min = today.toISOString().slice(0, 10);
+      const max = new Date(today.getTime() + 21 * 86400000).toISOString().slice(0, 10);
+      div.innerHTML = `
+        <label>Day <input type="date" name="date" min="${min}" max="${max}" value="${w?.date || ''}" required></label>
+        <label>From <select name="start">${timeOptions(w?.start || '17:00')}</select></label>
+        <label>Until <select name="end">${timeOptions(w?.end || '19:00')}</select></label>
+        <button class="remove" type="button" title="Remove">✕</button>`;
+      div.querySelector('.remove').onclick = () => { div.remove(); };
+      windowsEl.appendChild(div);
+    }
+
+    document.getElementById('add').onclick = () => addRow();
+
+    document.getElementById('submit').onclick = async () => {
+      const rows = [...windowsEl.querySelectorAll('.window')];
+      const windows = rows.map(r => ({
+        date: r.querySelector('[name=date]').value,
+        start: r.querySelector('[name=start]').value,
+        end: r.querySelector('[name=end]').value,
+      })).filter(w => w.date && w.start < w.end);
+      statusEl.className = 'status';
+      if (!windows.length) { statusEl.className = 'status err'; statusEl.textContent = 'Add at least one window (and make sure "Until" is after "From").'; return; }
+      const btn = document.getElementById('submit');
+      btn.disabled = true; btn.textContent = 'Sharing…';
+      try {
+        const resp = await fetch(FN, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token, windows }),
+        });
+        const out = await resp.json();
+        if (out.error) throw new Error(out.error);
+        document.getElementById('card').innerHTML = `
+          <div class="done">
+            <h2>Got it — thank you!</h2>
+            <p>A housemate will pick a time from your windows and you'll get a calendar invite with a video link. You can reopen this page anytime to update your availability.</p>
+          </div>`;
+      } catch (e) {
+        statusEl.className = 'status err';
+        statusEl.textContent = e.message || 'Something went wrong — try again.';
+        btn.disabled = false; btn.textContent = 'Share availability';
+      }
+    };
+
+    (async () => {
+      if (!token) {
+        document.getElementById('card').innerHTML = '<div class="done"><h2>Invalid link</h2><p>Check the link in your email from Agape, or just reply to the email with your availability.</p></div>';
+        return;
+      }
+      try {
+        const resp = await fetch(FN, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ token }) });
+        const out = await resp.json();
+        if (out.error) throw new Error(out.error);
+        if (out.firstName) document.getElementById('intro').textContent =
+          `Hi ${out.firstName} — pick a few windows over the next couple of weeks when you're free for a 30-minute call with an Agape housemate. We'll send a calendar invite once someone books a time.`;
+        (out.windows?.length ? out.windows : [null, null]).forEach(w => addRow(w));
+      } catch (e) {
+        document.getElementById('card').innerHTML = `<div class="done"><h2>Invalid link</h2><p>Check the link in your email from Agape, or just reply to the email with your availability.</p></div>`;
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -1,0 +1,68 @@
+// Supabase Edge Function: recruit-availability
+// PUBLIC (deployed with --no-verify-jwt): the applicant-facing endpoint for
+// the /applications/schedule/ page. Auth = knowledge of the per-applicant
+// schedule_token (migration 118). Applicants can read their own first name
+// + saved windows, and submit new windows. Nothing else is exposed.
+//
+// POST { token }                      → { firstName, windows }
+// POST { token, windows: [...] }      → save; { saved: true, windows }
+
+const VERSION = '1.0.0'
+console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const body = await req.json().catch(() => ({}))
+    const token = String(body.token || '')
+    if (!UUID_RE.test(token)) return json({ error: 'Invalid link' }, 400)
+
+    const client = db()
+    const { data: applicant } = await client.from('recruit_applicants')
+      .select('id, first_name').eq('schedule_token', token).maybeSingle()
+    if (!applicant) return json({ error: 'Invalid link' }, 404)
+
+    if (Array.isArray(body.windows)) {
+      const windows = body.windows
+        .filter((w: Record<string, unknown>) =>
+          /^\d{4}-\d{2}-\d{2}$/.test(String(w.date)) &&
+          /^\d{2}:\d{2}$/.test(String(w.start)) &&
+          /^\d{2}:\d{2}$/.test(String(w.end)) &&
+          String(w.start) < String(w.end))
+        .slice(0, 14)
+        .map((w: Record<string, unknown>) => ({ date: w.date, start: w.start, end: w.end }))
+      if (!windows.length) return json({ error: 'Add at least one time window' }, 400)
+      const { error } = await client.from('recruit_availability').upsert({
+        applicant_id: applicant.id, windows, source_gmail_id: 'self-service',
+        updated_at: new Date().toISOString(),
+      })
+      if (error) return json({ error: 'Could not save — try again' }, 500)
+      console.log(`availability saved for ${applicant.id} (${windows.length} windows)`)
+      return json({ saved: true, windows })
+    }
+
+    const { data: avail } = await client.from('recruit_availability')
+      .select('windows').eq('applicant_id', applicant.id).maybeSingle()
+    return json({ firstName: applicant.first_name, windows: avail?.windows || [] })
+  } catch (err) {
+    console.error('recruit-availability error:', (err as Error).message)
+    return json({ error: 'Something went wrong' }, 500)
+  }
+})

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.6.0'
+const VERSION = '1.7.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -178,6 +178,7 @@ Let me know if you have any questions!
 // Draft a tailored outreach email for an applicant + their listing.
 // deno-lint-ignore no-explicit-any
 async function draftEmail(applicant: any, listing: any, room: any, flags: any[], senderName: string): Promise<{ subject: string; body: string }> {
+  const scheduleUrl = applicant.schedule_token ? `https://ctrl.rodeo/applications/schedule/?t=${applicant.schedule_token}` : null
   const trim = (t: string, n = 600) => (t || '').replace(/\s+/g, ' ').slice(0, n)
   const pricing = listing ? [
     listing.rent_monthly != null ? `$${listing.rent_monthly} rent (covers utilities and cleaners for common spaces)` : null,
@@ -211,7 +212,7 @@ ${conflictLines}
 Hard rules:
 - This is a RESPONSE to their application, never cold outreach. Open by acknowledging their application to Agape ("thanks for applying", "we read your application", etc.). Do NOT introduce or pitch Agape as if they don't know it — they applied; skip the agapesf.org/instagram links and the "come live with artists..." pitch line entirely.
 - Never say "apply on our website" — they already did.
-- The CTA is ALWAYS to set up an initial screening call with a housemate: ask them to either share a Calendly (or similar scheduling) link, OR reply with 3 days where they have at least a couple hours of availability, so we can match them with a housemate for a get-to-know-you call. This is the single ask — don't offer dinners/visits as the first step.
+- The CTA is ALWAYS to set up an initial screening call with a housemate. ${scheduleUrl ? `Primary ask: pick your availability at ${scheduleUrl} (takes a minute) — include this exact URL on its own line. Secondary: or just reply with 3 days where you have a couple hours free.` : 'Ask them to reply with 3 days where they have at least a couple hours of availability.'} This is the single ask — don't offer dinners/visits as the first step.
 - Reference one specific thing they wrote so it reads personally — ideally connect it to house life.
 - Details block: tailor to the listing kind. Sublet → the window and dates matter most. Resident trial → explain plainly: the room starts as a 3-month trial, then the house votes on full residency. General interest → no room right now, we liked their application, we'll reach out when one opens (no details block).
 - Pricing: if the listing carries exact numbers, use them verbatim in the details block; if a room is offered without numbers, keep the reference $1490 + $210 structure but phrase availability/pricing as "roughly" so nobody quotes it as final.

--- a/supabase/migrations/118_recruit_schedule_token.sql
+++ b/supabase/migrations/118_recruit_schedule_token.sql
@@ -1,0 +1,8 @@
+-- ============================================
+-- Migration 118: public scheduling token per applicant
+-- Knowledge of the token authorizes an applicant to view/submit their own
+-- availability on the public /applications/schedule/ page (no account).
+-- ============================================
+
+ALTER TABLE recruit_applicants ADD COLUMN IF NOT EXISTS schedule_token UUID NOT NULL DEFAULT gen_random_uuid();
+CREATE UNIQUE INDEX IF NOT EXISTS idx_recruit_applicants_schedule_token ON recruit_applicants(schedule_token);


### PR DESCRIPTION
Applicants get an active picker instead of prose-only: a tokenized public page (`/applications/schedule/?t=…`) with day + time-range rows that writes straight into `recruit_availability` — feeding the same slot-chips → book → dual-invite flow. Email drafts lead with the personal link (reply-with-days remains the fallback); housemates can copy any applicant's link from the Emails tab. Verified live end-to-end with a real token (read, save, bad-token rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)