### PR TITLE
feat(ladder): source Kimble Group recruiter digests from Gmail

### DIFF
--- a/supabase/functions/_shared/sources/gmail-jobs.ts
+++ b/supabase/functions/_shared/sources/gmail-jobs.ts
@@ -71,6 +71,10 @@ const DEFAULT_ALLOW_SENDERS = [
   // Jack & Jill — AI recruiter that emails curated, comp-included, pre-
   // matched roles in conversational prose (multi-role digests). High signal.
   '@jackandjill.ai',
+  // Kimble Group — recruiter digest ("Recommended Jobs With X, Y and Z"),
+  // plain company/title/location listings with tracking links. Mixed
+  // relevance; downstream fit scoring filters the noise.
+  '@kimblegroup.com',
 ];
 
 // Subjects/senders that are almost always multi-role digests. We log
@@ -86,6 +90,7 @@ const DIGEST_HINTS = [
   'job digest',
   'jobs digest',
   'more matches',                  // Wellfound: "New job: X at Y, and 24 more matches"
+  'recommended jobs',              // Kimble Group: "Recommended Jobs With X, Y and Z"
 ];
 
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';
@@ -596,6 +601,9 @@ function looksLikeDigest(subject: string, sender: string): boolean {
   // per-role job-view links the link-counter would catch. Force the
   // multi-extractor so we don't grab just the first role.
   if (/@jackandjill\.ai/i.test(sender)) return true;
+  // Kimble Group digests list many roles behind tracking links the
+  // link-counter can't see — force the multi-extractor.
+  if (/@kimblegroup\.com/i.test(sender)) return true;
   return false;
 }
 

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.27.0';
-console.log(`[pull-recommendations] v${VERSION} - comp_acceptable computed deterministically from salary (compClears), not the Haiku boolean`);
+const VERSION = '0.28.0';
+console.log(`[pull-recommendations] v${VERSION} - gmail-jobs: Kimble Group digests allowlisted + forced through the multi-role extractor`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Emails like "Recommended Jobs With Workos, Syntricate Technologies and Amazon" from kimble@kimblegroup.com now flow into the sourcing pipeline.

- Allowlist `@kimblegroup.com` in gmail-jobs DEFAULT_ALLOW_SENDERS
- Add `recommended jobs` digest subject hint
- Force the multi-role extractor for the sender — the digest's tracking links are invisible to the job-link counter, so without this only the first role would be extracted
- pull-recommendations v0.28.0

Mixed-relevance listings are fine: downstream Haiku fit scoring filters the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)