### PR TITLE
feat(events): Talks & Lectures category + Curiosity Guild source

### DIFF
--- a/events/index.html
+++ b/events/index.html
@@ -2091,7 +2091,7 @@ body {
 (function() {
   'use strict';
 
-  const VERSION = '1.42.1';
+  const VERSION = '1.43.0';
   console.log(`[events] v${VERSION} - filter button stays inline-left of the chip slider in every state (no mobile top-right pin)`);
 
   // ============================================
@@ -2151,6 +2151,7 @@ body {
     { id: 'eb-thecentersf', name: 'The Center SF', category: 'wellness', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/the-center-sf-3493443113', region: 'bay-area', description: 'Community & wellness' },
     { id: 'eb-envelop', name: 'Envelop SF', category: 'music', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/envelop-17478025710', region: 'bay-area', description: 'Spatial audio venue' },
     { id: 'eb-fluxvertical', name: 'Flux Vertical Theatre', category: 'theater', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/16887986144', region: 'bay-area', description: 'Vertical theater & circus' },
+    { id: 'eb-curiosityguild', name: 'Curiosity Guild', category: 'talks', type: 'eventbrite-org', url: 'https://www.eventbrite.com/o/curiosity-guild-120760437937', region: 'bay-area', description: 'History storytelling talks' },
     // New York — Tech & Networking
     { id: 'garysguide-nyc', name: "Gary's Guide NYC", category: 'tech', type: 'garysguide', url: 'https://www.garysguide.com/events?region=nyc', region: 'new-york', description: 'Tech & startup events' },
   ];
@@ -2230,15 +2231,16 @@ body {
     'tech': 'tech',
     'social': 'social',
     'art': 'art', 'exhibition': 'art', 'design': 'art',
+    'talk': 'talks', 'talks': 'talks',
     'literary': 'literary',
     'wellness': 'wellness',
   };
   const CATEGORY_LABELS = {
     'music': 'Music', 'film': 'Film & Cinema', 'art': 'Art & Design', 'comedy': 'Comedy',
-    'theater': 'Theater', 'tech': 'Tech & Startups', 'social': 'Social',
+    'theater': 'Theater', 'tech': 'Tech & Startups', 'talks': 'Talks & Lectures', 'social': 'Social',
     'literary': 'Literary', 'wellness': 'Wellness', 'other': 'Other',
   };
-  const CATEGORY_ORDER = ['music', 'film', 'art', 'comedy', 'theater', 'tech', 'social', 'literary', 'wellness', 'other'];
+  const CATEGORY_ORDER = ['music', 'film', 'art', 'comedy', 'theater', 'tech', 'talks', 'social', 'literary', 'wellness', 'other'];
   // Fixed hues per category for the pulse strip, so a color always means the
   // same thing (unlike per-source hash colors)
   const CATEGORY_COLORS = {
@@ -2248,6 +2250,7 @@ body {
     'comedy': 'hsl(48, 90%, 56%)',
     'theater': 'hsl(18, 80%, 60%)',
     'tech': 'hsl(258, 65%, 66%)',
+    'talks': 'hsl(0, 65%, 62%)',
     'social': 'hsl(178, 55%, 52%)',
     'literary': 'hsl(288, 45%, 62%)',
     'wellness': 'hsl(140, 40%, 55%)',
@@ -2951,7 +2954,8 @@ body {
     { type: 'tech',       tags: ['Networking'], re: /\b(meetup|networking|hackathon|roundtable|panel|summit|forum|breakfast|mixer\s+for)\b/i },
     { type: 'art',        tags: ['Art'],      re: /\b(gallery|exhibition|art\s*walk|opening\s*reception|museum|installation|sculpture|mural|vernissage)\b/i },
     { type: 'art',        tags: ['Design'],   re: /\b(design|architecture|\bux\b|creative\s*direction|portfolio|typography|graphic\s*design)\b/i },
-    { type: 'literary',   tags: ['Literary'], re: /\b(reading|author|book\s*launch|poetry|literary|zine|book\s*signing|bookstore|lecture|speaker)\b/i },
+    { type: 'talk',       tags: ['Talk'],     re: /\b(lecture|speaker\s*series|storytell(?:ing|ers?)?|fireside\s*chat|keynote|symposium|public\s*talk)\b/i },
+    { type: 'literary',   tags: ['Literary'], re: /\b(reading|author|book\s*launch|poetry|literary|zine|book\s*signing|bookstore|speaker)\b/i },
     { type: 'wellness',   tags: ['Wellness'], re: /\b(yoga|meditation|wellness|mindfulness|breathwork|healing|sound\s*bath)\b/i },
     { type: 'social',     tags: ['Social'],   re: /\b(happy\s*hour|brunch|picnic|party|gathering|community|social\b)\b/i },
   ];

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -6,8 +6,8 @@
 // Body: { eventIds: string[] }   (batch up to 10)
 // Returns: { processed, succeeded, failed, results }
 
-const VERSION = '1.4.0'
-console.log(`[enrich-event] v${VERSION} - film genre/era/director tags; descriptive activity tags for social/art; no source/title/category echoes`)
+const VERSION = '1.5.0'
+console.log(`[enrich-event] v${VERSION} - add 'talk' content_type (Talks & Lectures category)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -83,7 +83,7 @@ interface EnrichResult {
   error?: string
 }
 
-const VALID_CONTENT_TYPES = ['music', 'dj-set', 'live-music', 'festival', 'film', 'comedy', 'theater', 'tech', 'social', 'art', 'design', 'literary', 'wellness', 'other']
+const VALID_CONTENT_TYPES = ['music', 'dj-set', 'live-music', 'festival', 'film', 'comedy', 'theater', 'tech', 'talk', 'social', 'art', 'design', 'literary', 'wellness', 'other']
 
 async function fetchPage(url: string): Promise<string | null> {
   try {
@@ -215,7 +215,7 @@ async function classifyWithAI(event: {
 
 1. "genre" — up to 3 comma-separated descriptive tags. For music: the specific genre ("Techno", "Indie Rock", "Jazz"). For social events: the activity ("Networking", "Dinner Party", "Rooftop Party", "Book Club", "Run Club", "Trivia"). For art/design: the form ("Gallery Opening", "Immersive Art", "Ceramics Workshop", "Figure Drawing", "Screen Printing", "Photography"). For film: the genre ("Horror", "Documentary", "Noir", "Sci-Fi", "Comedy"), era or movement ("French New Wave", "70s", "Silent", "Pre-Code"), and the director when notable ("Kubrick", "Varda"). Never use source names (Eventbrite, Luma), the event title, or bare category words (music/art/social/event/film). Return "" if truly unknown.
 
-2. "content_type" — one of: music, dj-set, live-music, festival, film, comedy, theater, tech, social, art, design, literary, wellness, other
+2. "content_type" — one of: music, dj-set, live-music, festival, film, comedy, theater, tech, talk, social, art, design, literary, wellness, other. Use "talk" for lectures, speaker series, storytelling shows, panels, and idea/history talks.
 
 3. "music_type" — ONLY for music events, one of: electronic, rock, pop, hiphop, jazz, folk, world, other-music. Use the dominant style (electronic = techno/house/DJ/club; rock = rock/indie/punk/metal; folk = folk/country/americana/tribute; world = latin/reggae/afro). null for non-music events.
 

--- a/supabase/functions/scrape-events/index.ts
+++ b/supabase/functions/scrape-events/index.ts
@@ -9,8 +9,8 @@
 //   POST { action: "refresh", sourceId: "..." }   → scrape single source
 //   POST { action: "status" }                     → return last run info
 
-const VERSION = '1.11.2'
-console.log(`[scrape-events] v${VERSION} - surface cache-events partial-failure errors; reconciliation skips on any`)
+const VERSION = '1.12.0'
+console.log(`[scrape-events] v${VERSION} - commonwealth events are 'talk' content_type (new Talks & Lectures category)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/scrape-events/parsers/commonwealth.ts
+++ b/supabase/functions/scrape-events/parsers/commonwealth.ts
@@ -46,7 +46,7 @@ export async function scrapeCommonwealth(source: EventSource): Promise<ScrapedEv
         venue,
         city: 'San Francisco',
         url,
-        contentType: 'literary',
+        contentType: 'talk',
       })
     } catch (_e) { /* skip broken node */ }
   })

--- a/supabase/migrations/119_curiosityguild_source.sql
+++ b/supabase/migrations/119_curiosityguild_source.sql
@@ -1,0 +1,14 @@
+-- ============================================
+-- Curiosity Guild — history storytelling talks (Eventbrite org page)
+-- Migration 119
+-- User-requested. First source in the new 'talks' category (Talks &
+-- Lectures). Monthly public-talk series at the Balboa Theatre; events
+-- come from the existing eventbrite-org parser, so this INSERT is the
+-- whole registration — new events appear on the normal 2h scrape cron.
+-- ============================================
+INSERT INTO event_sources (id, name, category, type, url, region, description, enabled, source_class, notes) VALUES
+  ('eb-curiosityguild', 'Curiosity Guild', 'talks', 'eventbrite-org',
+   'https://www.eventbrite.com/o/curiosity-guild-120760437937', 'bay-area',
+   'History storytelling talks', true, 'community',
+   'User-requested; curiosityguild.org monthly series, tickets via Eventbrite org 120760437937')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds a new top-level **Talks & Lectures** (`talks`) event category: tab/label, pulse-strip hue, contentType→category mapping, and a keyword classifier rule (lecture, speaker series, storytelling, fireside chat, keynote, symposium).
- Registers **Curiosity Guild** (curiosityguild.org — monthly history-storytelling talks at the Balboa) as an `eventbrite-org` source via migration 119. The existing parser handles it, so future events flow in automatically on the 2h scrape cron — no further code needed when the series adds dates.
- `enrich-event` AI vocabulary gains the `talk` content_type; Commonwealth Club parser reclassified from `literary` to `talk`.

## Versions
- events UI 1.42.1 → 1.43.0
- enrich-event 1.4.0 → 1.5.0
- scrape-events 1.11.2 → 1.12.0

## Post-merge
- Apply `supabase/migrations/119_curiosityguild_source.sql` (Boards project)
- Deploy `enrich-event` and `scrape-events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)