### PR TITLE
Applications v2.15.1 — global Gmail connection setting

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -956,3 +956,5 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   border-radius: 0 0 var(--radius-md) var(--radius-md);
   padding: var(--space-4); text-align: left; margin: 0;
 }
+.rail-foot__gmail { color: var(--fg-subtle); }
+.rail-foot__gmail:hover { color: var(--fg); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.15.0">
+  <link rel="stylesheet" href="css/app.css?v=2.15.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -55,6 +55,7 @@
       <div class="rail-foot">
         <span class="rail-foot__user" id="rail-user"></span>
         <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
+        <button class="rail-foot__link rail-foot__gmail" id="gmail-conn" type="button">Checking shared Gmail…</button>
         <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
         <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
         <button class="rail-foot__link" id="menu-signout" type="button">Sign out</button>
@@ -142,6 +143,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.15.0"></script>
+  <script src="js/app.js?v=2.15.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.15.0';
+const VERSION = '2.15.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1746,6 +1746,22 @@ async function gmailCall(payload) {
   return out;
 }
 
+/* Global shared-account connection row (rail footer). Set once, house-wide. */
+function renderGmailStatus() {
+  const el = document.getElementById('gmail-conn');
+  if (!el) return;
+  if (gmailStatus.connected) {
+    el.textContent = `✓ ${gmailStatus.email || 'shared Gmail'} connected`;
+    el.title = `House email + calendar run through this account${gmailStatus.connected_by_name ? ` · connected by ${gmailStatus.connected_by_name}` : ''}${gmailStatus.connected_at ? ` · ${new Date(gmailStatus.connected_at).toLocaleDateString()}` : ''}. Click to reconnect (e.g. after a scope change).`;
+  } else {
+    el.textContent = 'Connect shared Gmail (house-wide, one time)';
+    el.title = 'All applicant email + screening invites run through live.at.agapesf@gmail.com. Sign into that Google account in this browser first.';
+  }
+  el.onclick = () => {
+    if (!gmailStatus.connected || confirm('Reconnect the shared Google account? Only needed after scope changes or if sending breaks.')) connectSharedGmail();
+  };
+}
+
 /* Throttled inbox-wide sweep: matches recent shared-inbox mail to
    applicants so outreach rows can badge replies. */
 async function scanInbox() {
@@ -1779,7 +1795,8 @@ async function handleGmailCallback() {
   history.replaceState(null, '', clean);
   try {
     const out = await gmailCall({ action: 'connect', code });
-    gmailStatus = { connected: true, email: out.email };
+    gmailStatus = { connected: true, email: out.email, connected_by_name: me?.name };
+    renderGmailStatus();
     toast(`Shared Gmail connected: ${out.email}`);
   } catch (e) { toast(`Gmail connect failed: ${e.message}`); }
 }
@@ -1868,7 +1885,7 @@ async function _checkMembershipAndEnter() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${(await sb.auth.getSession()).data?.session?.access_token}` },
       body: JSON.stringify({ action: 'status' }),
-    }).then(r => r.json()).then(st => { gmailStatus = st || { connected: false }; }).catch(() => {});
+    }).then(r => r.json()).then(st => { gmailStatus = st || { connected: false }; renderGmailStatus(); }).catch(() => {});
     await loadAll();
     // background — outreach attachment labels + rail badges need house data;
     // re-render the open view once it lands so labels don't show stale fallbacks


### PR DESCRIPTION
The shared-account connection now has a global home in the rail footer (status + who connected it + reconnect), reflecting that it's set once house-wide rather than per applicant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)