### PR TITLE
Applications v2.15.2 — Esc layers + ordered review navigation

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.15.1">
+  <link rel="stylesheet" href="css/app.css?v=2.15.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -143,6 +143,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.15.1"></script>
+  <script src="js/app.js?v=2.15.2"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2,7 +2,7 @@
    Discord-gated (Recruiting Society channel on the Agape server, verified by
    the discord-membership edge fn). Applicants, shared decisions, and house
    notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.15.1';
+const VERSION = '2.15.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1255,8 +1255,17 @@ async function updateListingStatus(id, status) {
 }
 
 /* ---------- review overlay ---------- */
+/* The review queue mirrors whatever order is on screen — listing groups,
+   manual drag order, filters — falling back to data order off-list. */
+function renderedQueue() {
+  const ids = [...document.querySelectorAll('#view-root .inbox-row__main[data-review]')].map(b => b.dataset.review);
+  return [...new Set(ids)];
+}
+
 function openReview(id) {
-  queue = applicants.filter(a => matchesView(a) && matchesFilters(a)).map(a => a.id);
+  const domOrder = VIEWS[view]?.kind === 'applicants' ? renderedQueue() : [];
+  queue = domOrder.includes(id) ? domOrder
+    : applicants.filter(a => matchesView(a) && matchesFilters(a)).map(a => a.id);
   if (!queue.includes(id)) queue = applicants.map(a => a.id);
   qIndex = Math.max(0, queue.indexOf(id));
   reviewTab = 'profile';
@@ -2106,9 +2115,17 @@ function init() {
   document.getElementById('decision-use-notes').onclick = summarizeNotesIntoDecision;
 
   document.addEventListener('keydown', e => {
-    if (document.getElementById('review').hidden) return;
+    const reviewOpen = !document.getElementById('review').hidden;
+    const modalOpen = !document.getElementById('email-modal').hidden || !document.getElementById('listing-modal').hidden;
+    if (!reviewOpen && !modalOpen) return;
+    if (!reviewOpen && e.key !== 'Escape') return;
     if (e.target instanceof Element && e.target.matches('input, textarea')) return;
-    if (e.key === 'Escape') { if (!document.getElementById('decision-sheet').hidden) hideDecisionSheet(); else closeReview(); }
+    if (e.key === 'Escape') {
+      if (!document.getElementById('email-modal').hidden) closeEmailModal();
+      else if (!document.getElementById('listing-modal').hidden) closeListingModal();
+      else if (!document.getElementById('decision-sheet').hidden) hideDecisionSheet();
+      else closeReview();
+    }
   });
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape' && !document.getElementById('email-modal').hidden) closeEmailModal();


### PR DESCRIPTION
Esc closes whichever modal layer is on top (email → listing → decision sheet → review). Arrow keys and prev/next walk applicants in the rendered order — custom drag order, listing grouping, and filters all respected. Verified: custom order [a3,a1,a2,a4] honored, Esc peels the email modal while the review stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)