### PR TITLE
Ladder v2.37.2 — forward agape-gmail callbacks in the inline pre-route

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.37.1");
+@import url("./components.css?v=2.37.2");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
 
 
 
@@ -36,6 +36,12 @@
         // looks "disconnected"). Let app.js handle the callback on this page.
         var _sp = new URLSearchParams(location.search);
         if (_sp.get('code') && (_sp.get('state') || '').indexOf('gmail:') === 0) {
+          return;
+        }
+        // Agape recruiting shares this OAuth redirect — hand its callback to
+        // /applications/ before any pre-route can strip the ?code.
+        if (_sp.get('code') && _sp.get('state') === 'agape-gmail') {
+          location.replace('/applications/?code=' + encodeURIComponent(_sp.get('code')) + '&state=agape-gmail');
           return;
         }
         var raw = localStorage.getItem('sb-yfhudwakpgzswiylhfbh-auth-token');
@@ -75,7 +81,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,7 +2,7 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.37.1";
+const VERSION = "2.37.2";
 console.log(`[ladder] v${VERSION} - Comp check tri-state; forward agape-gmail OAuth callbacks to /applications/`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.37.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.37.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.1">
-  <script src="/ladder/js/theme.js?v=2.37.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.37.2">
+  <script src="/ladder/js/theme.js?v=2.37.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.37.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.37.2"></script>
 </body>
 </html>


### PR DESCRIPTION
The desktop pre-route on /ladder/ stripped ?code from agape-gmail OAuth callbacks before the module-level forwarder ran, so the Agape shared-Gmail connect landed on /ladder/jobs and never completed. The inline script now hands those callbacks to /applications/ immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)