### PR TITLE
feat(recruiting): screening-call claim automation

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -99,6 +99,11 @@ supabase functions deploy enrich-link
 supabase functions deploy generate-widget
 supabase functions deploy categorize
 
+# Recruiting (Agape) functions — Boards project
+supabase functions deploy recruit-gmail
+supabase functions deploy recruit-availability --no-verify-jwt   # public schedule-token picker
+supabase functions deploy recruit-discord --no-verify-jwt        # Discord interactions (Ed25519-signed)
+
 # Ops project functions
 supabase link --project-ref ycilriwjnmcelkspmfmg
 supabase functions deploy notion-sync
@@ -143,6 +148,11 @@ supabase functions deploy {function-name}
 | `notion-sync` | Ops | GitHub ↔ Notion documentation sync | 2026-02-04 |
 | `systemic-analyze` | Systemic | Design system analysis | Previous |
 | `systemic-fetch` | Systemic | Design system data fetching | Previous |
+| `recruit-gmail` | Boards | Shared-inbox applicant email pipe + availability extraction + Discord claim posts | — |
+| `recruit-availability` | Boards | Public applicant schedule picker backend (schedule_token auth) | — |
+| `recruit-discord` | Boards | Discord interactions endpoint for screening-claim buttons | — |
+
+**recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-interviews` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
 
 ---
 

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -29,7 +29,7 @@ Applicant uses the /schedule picker ───────────┤
                                                ▼
                         recruit_availability updated (existing)
                                                ▼
-                 NEW: post to #screening-claims (bot message)
+                 NEW: post to #recruiting-interviews (bot message)
                  One message per applicant. Buttons = concrete
                  30-min slots derived from their windows (max ~8,
                  spread across days) + "Other time…"
@@ -51,7 +51,7 @@ Dedup rules: one open post per applicant (re-availability edits the existing pos
 
 ## Channel
 
-New channel **`#screening-claims`** (bot-writable, visible to the Recruiting Society role). Keep it single-purpose: posts and claims only, discussion goes to the applicant thread in `#recruiting`.
+**`#recruiting-interviews`** (ID `1529576830514762029`) — bot-writable, visible to the Recruiting Society role. Keep it single-purpose: posts and claims only, discussion goes to the applicant thread in `#recruiting`.
 
 ## Hosting
 
@@ -99,8 +99,17 @@ Expected: `windows: [{date: 2026-07-25, start: 09:00, end: 12:00}]`, `platform: 
 
 ---
 
-## Open questions for the house
+## Decisions (adopted 2026-07-22, shipped in v1)
 
-1. **Claim scope** — anyone in Recruiting Society, or an opt-in "interviewer" role (the pipeline doc's model)? Recommend starting with the whole channel; add the role when volume demands it.
-2. **Instagram-call requests** — honor them (claimer DMs the handle, no Meet link) or steer to Meet in the confirmation email? Recommend steering to Meet by default with the IG handle noted for the claimer.
-3. **Applicant confirmation email** — is the bare Google Calendar invite enough, or should `recruit-gmail` also send a short "you're confirmed with {name}, {time}" email? Recommend the short email; invites alone get missed.
+1. **Claim scope** — anyone in Recruiting Society can claim. Revisit an opt-in "interviewer" role when volume demands it.
+2. **Instagram-call requests** — steer to Meet by default; the IG handle and context are surfaced to the claimer (post warning line + their confirmation DM) so they can DM the applicant about it.
+3. **Applicant confirmation email** — yes: `sendApplicantConfirmation` sends a short "you're confirmed with {name}, {time}" email in addition to the GCal invite, logged to `recruit_emails` as `sent_by_name: 'auto'`.
+
+## Implementation notes (v1, 2026-07-22)
+
+- The v2 extraction prompt above is live in `recruit-gmail` v1.4.0, with one refinement: `needs_human` is only true for emails that are *about scheduling* but yield no concrete window — non-scheduling replies return `windows: []` + `needs_human: false` and produce no Discord post (otherwise every "thanks!" would spam the channel).
+- New pieces: migration 121 (`recruit_claim_posts`), `_shared/recruit-schedule.ts` (scheduling + confirmation email, shared by app and Discord paths), `_shared/discord.ts` (post/edit/DM/slot derivation), `recruit-discord` fn v1.0.0 (Ed25519-verified interactions; public key fetched via the bot token, no new secrets).
+- Button `custom_id`s are `claim|<applicantId>|<epochMs>` (ISO timestamps contain `:`; epoch avoids delimiter collisions).
+- Claim is first-write-wins via `UPDATE ... WHERE status='open'`; the 3s interaction deadline is met by ACKing with DEFERRED_UPDATE_MESSAGE and doing GCal/edit/DM/email in `EdgeRuntime.waitUntil`. Calendar failure after a claim never reopens the post (no double-booking) — the post flips to a ⚠️ state and the claimer is DM'd to book manually.
+- App-side booking (`schedule` action in /applications) also closes any open claim post for that applicant.
+- The 96h stuck nudge piggybacks on `recruit-gmail scan` (no new cron).

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -5,3 +5,8 @@ project_id = "yfhudwakpgzswiylhfbh"
 # Disable platform JWT verification so cron can hit it.
 [functions.pull-recommendations]
 verify_jwt = false
+
+# recruit-discord is Discord's interactions endpoint — authenticated by
+# Ed25519 request signatures, not JWTs.
+[functions.recruit-discord]
+verify_jwt = false

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -1,0 +1,235 @@
+// _shared/discord.ts
+// Discord REST helpers for the screening-claim flow: post/edit the claimable
+// message in #recruiting-interviews, DM the claimer, nudge stuck posts.
+// Used by recruit-gmail, recruit-availability, and recruit-discord.
+
+// deno-lint-ignore-file no-explicit-any
+
+import { TZ } from './recruit-schedule.ts'
+
+const DISCORD_API = 'https://discord.com/api/v10'
+// #recruiting-interviews in the Agape guild (952961396121931838)
+export const CLAIMS_CHANNEL_ID = Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || '1529576830514762029'
+
+function botHeaders(): Record<string, string> {
+  const token = Deno.env.get('DISCORD_BOT_TOKEN')
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set')
+  return { Authorization: `Bot ${token}`, 'Content-Type': 'application/json' }
+}
+
+async function discordFetch(path: string, options: RequestInit): Promise<any> {
+  const resp = await fetch(`${DISCORD_API}${path}`, { ...options, headers: botHeaders() })
+  const text = await resp.text()
+  if (!resp.ok) {
+    const err = new Error(`Discord ${resp.status} ${options.method || 'GET'} ${path}: ${text.slice(0, 200)}`) as any
+    err.status = resp.status
+    throw err
+  }
+  return text ? JSON.parse(text) : null
+}
+
+// ---- timezone-correct slot derivation -------------------------------------
+
+// Offset (ms) between UTC and `tz` at instant d — the formatToParts trick,
+// since Deno's runtime TZ is UTC and windows are Pacific wall times.
+function tzOffsetMs(d: Date, tz: string): number {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: tz, hour12: false,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    }).formatToParts(d).map((p) => [p.type, p.value]),
+  )
+  const asUTC = Date.UTC(+parts.year, +parts.month - 1, +parts.day, +parts.hour % 24, +parts.minute, +parts.second)
+  return asUTC - d.getTime()
+}
+
+// Pacific wall time ("2026-07-25", "09:00") → UTC instant.
+export function ptToUTC(date: string, hhmm: string): Date {
+  const guess = new Date(`${date}T${hhmm}:00Z`)
+  return new Date(guess.getTime() - tzOffsetMs(guess, TZ))
+}
+
+export function slotLabel(d: Date): string {
+  const day = d.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: TZ })
+  const time = d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ })
+    .toLowerCase().replace(' am', 'a').replace(' pm', 'p')
+  return `${day} · ${time}`
+}
+
+export interface Slot { start: string; label: string }
+
+// Windows → up to 8 concrete 30-min slots. Round-robin across windows so one
+// long window doesn't crowd out the others; drop starts already in the past.
+export function deriveSlots(windows: Array<{ date: string; start: string; end: string }>): Slot[] {
+  const now = Date.now()
+  const perWindow: Date[][] = windows.map((w) => {
+    const starts: Date[] = []
+    const end = ptToUTC(w.date, w.end)
+    for (let t = ptToUTC(w.date, w.start); t.getTime() + 30 * 60000 <= end.getTime(); t = new Date(t.getTime() + 30 * 60000)) {
+      if (t.getTime() > now) starts.push(t)
+    }
+    return starts
+  })
+  const slots: Slot[] = []
+  for (let i = 0; slots.length < 8; i++) {
+    let any = false
+    for (const starts of perWindow) {
+      if (i < starts.length && slots.length < 8) {
+        slots.push({ start: starts[i].toISOString(), label: slotLabel(starts[i]) })
+        any = true
+      }
+    }
+    if (!any) break
+  }
+  slots.sort((a, b) => a.start.localeCompare(b.start))
+  return slots
+}
+
+// ---- claim message --------------------------------------------------------
+
+export interface ClaimPostInput {
+  applicantId: string
+  firstName: string
+  whyLine: string | null
+  windows: Array<{ date: string; start: string; end: string }>
+  platform: { kind: string; handle?: string } | null
+  timezoneNote: string | null
+  needsHuman: boolean
+}
+
+function appLink(applicantId: string): string {
+  return `https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`
+}
+
+function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<string, unknown> {
+  const why = (input.whyLine || '').trim().replace(/\s+/g, ' ').slice(0, 140)
+  const manual = input.needsHuman || !slots.length
+
+  let description = why ? `_${why}_\n\n` : ''
+  if (manual) {
+    description += `Couldn't extract concrete times from their reply — read their thread and coordinate by email.\n\n[Open in the app](${appLink(input.applicantId)})`
+  } else {
+    description += `Offered times for a screening call — tap one to claim it.`
+  }
+  const warnings: string[] = []
+  if (input.timezoneNote) warnings.push(`⚠️ ${input.timezoneNote}`)
+  if (input.platform?.kind) {
+    const handle = input.platform.handle ? ` (@${input.platform.handle})` : ''
+    warnings.push(`⚠️ Asked for ${input.platform.kind}${handle} — default is Meet; claimer can DM them about it.`)
+  }
+  if (warnings.length) description += `\n\n${warnings.join('\n')}`
+  if (!manual) description += `\n\n_Tap a time to claim the call — you'll both get a calendar invite._`
+
+  const components: Array<Record<string, unknown>> = []
+  if (!manual) {
+    let row: Array<Record<string, unknown>> = []
+    for (const slot of slots) {
+      row.push({ type: 2, style: 1, label: slot.label, custom_id: `claim|${input.applicantId}|${Date.parse(slot.start)}` })
+      if (row.length === 5) { components.push({ type: 1, components: row }); row = [] }
+    }
+    row.push({ type: 2, style: 5, label: 'Other time…', url: appLink(input.applicantId) })
+    components.push({ type: 1, components: row })
+  }
+
+  return {
+    embeds: [{
+      title: `${input.firstName} — screening call`,
+      description,
+      color: manual ? 0xe67e22 : 0x3498db,
+    }],
+    components,
+  }
+}
+
+// Post (or edit, per the one-open-post-per-applicant rule) the claim message.
+// Returns the recruit_claim_posts row, or null when posting was skipped.
+export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promise<any | null> {
+  const { data: existing } = await db.from('recruit_claim_posts')
+    .select('*').eq('applicant_id', input.applicantId).maybeSingle()
+  if (existing?.status === 'claimed') {
+    console.log(`[discord] claim post for ${input.applicantId} already claimed — skipping repost`)
+    return null
+  }
+
+  const slots = input.needsHuman ? [] : deriveSlots(input.windows)
+  const payload = buildMessage(input, slots)
+  const status = (input.needsHuman || !slots.length) ? 'manual' : 'open'
+
+  let message: any = null
+  if (existing && existing.status !== 'expired') {
+    try {
+      message = await discordFetch(`/channels/${existing.discord_channel_id}/messages/${existing.discord_message_id}`, {
+        method: 'PATCH', body: JSON.stringify(payload),
+      })
+    } catch (err) {
+      if ((err as any).status !== 404) throw err
+      // message was deleted in Discord — fall through to a fresh post
+    }
+  }
+  if (!message) {
+    message = await discordFetch(`/channels/${CLAIMS_CHANNEL_ID}/messages`, {
+      method: 'POST', body: JSON.stringify(payload),
+    })
+  }
+
+  const { data: row, error } = await db.from('recruit_claim_posts').upsert({
+    applicant_id: input.applicantId,
+    discord_message_id: message.id,
+    discord_channel_id: message.channel_id || CLAIMS_CHANNEL_ID,
+    slots, platform: input.platform, timezone_note: input.timezoneNote,
+    needs_human: input.needsHuman, status,
+    posted_at: existing?.posted_at || new Date().toISOString(),
+    reminded_at: null,
+    updated_at: new Date().toISOString(),
+  }).select().single()
+  if (error) throw new Error(`claim post upsert failed: ${error.message}`)
+  console.log(`[discord] claim post ${existing ? 'updated' : 'created'} for ${input.applicantId} (${slots.length} slots, ${status})`)
+  return row
+}
+
+// Close a claimed post: strip buttons, green "claimed" embed.
+export async function editClaimMessageClaimed(
+  channelId: string, messageId: string, claimerDiscordId: string, label: string,
+): Promise<void> {
+  await discordFetch(`/channels/${channelId}/messages/${messageId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      embeds: [{ description: `✅ **Claimed by <@${claimerDiscordId}>** — ${label} · invite sent`, color: 0x2ecc71 }],
+      components: [],
+    }),
+  })
+}
+
+// Mark a claimed post that hit an error downstream (calendar etc.).
+export async function editClaimMessageFailed(
+  channelId: string, messageId: string, claimerDiscordId: string, label: string,
+): Promise<void> {
+  await discordFetch(`/channels/${channelId}/messages/${messageId}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      embeds: [{ description: `⚠️ **Claimed by <@${claimerDiscordId}>** — ${label}, but the calendar invite failed. Book manually in the app.`, color: 0xe74c3c }],
+      components: [],
+    }),
+  })
+}
+
+export async function dmUser(discordUserId: string, content: string): Promise<void> {
+  const channel = await discordFetch('/users/@me/channels', {
+    method: 'POST', body: JSON.stringify({ recipient_id: discordUserId }),
+  })
+  await discordFetch(`/channels/${channel.id}/messages`, {
+    method: 'POST', body: JSON.stringify({ content }),
+  })
+}
+
+// One channel nudge for a post nobody claimed within 96h.
+export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {
+  const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
+  await discordFetch(`/channels/${channelId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({
+      content: `⏰ **${firstName}**'s screening call has been unclaimed for 4 days — anyone free? https://discord.com/channels/${guildId}/${channelId}/${messageId}`,
+    }),
+  })
+}

--- a/supabase/functions/_shared/recruit-schedule.ts
+++ b/supabase/functions/_shared/recruit-schedule.ts
@@ -1,0 +1,133 @@
+// _shared/recruit-schedule.ts
+// Screening-call scheduling on the shared Agape Google account, used by both
+// recruit-gmail (app-side "schedule" action) and recruit-discord (claim
+// button). Also owns the shared-account token refresh and the short applicant
+// confirmation email, so there is exactly one implementation of each.
+
+// deno-lint-ignore-file no-explicit-any
+
+export const SHARED_EMAIL = Deno.env.get('AGAPE_GMAIL_ADDRESS') || 'live.at.agapesf@gmail.com'
+export const TZ = 'America/Los_Angeles'
+
+const CLIENT_ID = Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID')!
+const CLIENT_SECRET = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!
+
+// Minimal structural type so we don't pin a supabase-js version here.
+type Db = any
+
+// Refresh an access token for the shared account (recruit_gmail_account row 1).
+export async function sharedAccessToken(db: Db): Promise<string> {
+  const { data: acct } = await db.from('recruit_gmail_account').select('*').eq('id', 1).maybeSingle()
+  if (!acct) throw new Error('Shared Gmail not connected yet')
+  const resp = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: CLIENT_ID, client_secret: CLIENT_SECRET,
+      refresh_token: acct.refresh_token, grant_type: 'refresh_token',
+    }),
+  })
+  const tok = await resp.json()
+  if (!resp.ok || !tok.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(tok).slice(0, 180)}`)
+  return tok.access_token
+}
+
+export function b64url(s: string): string {
+  return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export interface ScheduleOpts {
+  applicantId: string
+  startsAt: Date
+  minutes?: number
+  housemateUserId: string
+  housemateName: string
+  housemateEmail: string
+}
+
+// Create the GCal event (both attendees + Meet) and the recruit_screenings row.
+// Throws on any failure; callers map to their own error shapes.
+export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
+  screening: any; meetLink: string | null; applicant: any
+}> {
+  const { data: applicant } = await db.from('recruit_applicants').select('*').eq('id', opts.applicantId).maybeSingle()
+  if (!applicant?.email?.includes('@')) throw new Error('Applicant has no email')
+  const endsAt = new Date(opts.startsAt.getTime() + (opts.minutes || 30) * 60000)
+
+  const at = await sharedAccessToken(db)
+  const event = {
+    summary: `Agape screening call — ${applicant.first_name} ${applicant.last_name} × ${opts.housemateName}`,
+    description: `Get-to-know-you call with ${applicant.first_name} (Agape application), scheduled from their offered availability.`,
+    start: { dateTime: opts.startsAt.toISOString(), timeZone: TZ },
+    end: { dateTime: endsAt.toISOString(), timeZone: TZ },
+    attendees: [
+      { email: applicant.email },
+      ...(opts.housemateEmail.includes('@') ? [{ email: opts.housemateEmail }] : []),
+    ],
+    conferenceData: { createRequest: { requestId: crypto.randomUUID(), conferenceSolutionKey: { type: 'hangoutsMeet' } } },
+    reminders: { useDefault: true },
+  }
+  const resp = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=all&conferenceDataVersion=1', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(event),
+  })
+  const created = await resp.json()
+  if (!resp.ok) throw new Error(`Calendar failed: ${JSON.stringify(created).slice(0, 200)} — if this mentions scopes, reconnect the shared Gmail to grant calendar access`)
+  const meet = created.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || created.hangoutLink || null
+
+  const { data: row, error } = await db.from('recruit_screenings').insert({
+    applicant_id: applicant.id, housemate_user_id: opts.housemateUserId,
+    housemate_name: opts.housemateName, housemate_email: opts.housemateEmail,
+    starts_at: opts.startsAt.toISOString(), ends_at: endsAt.toISOString(),
+    gcal_event_id: created.id, meet_link: meet, status: 'scheduled',
+  }).select().single()
+  if (error) throw new Error(error.message)
+  return { screening: row, meetLink: meet, applicant }
+}
+
+// Short plain-text confirmation so the booking isn't missed if the bare
+// calendar invite is. Logged to recruit_emails as an automated send.
+export async function sendApplicantConfirmation(
+  db: Db, applicant: any, housemateName: string, startsAt: Date, meetLink: string | null,
+): Promise<void> {
+  const when = startsAt.toLocaleString('en-US', {
+    weekday: 'long', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ,
+  })
+  const subject = `You're confirmed — Agape call with ${housemateName}`
+  const text = [
+    `Hi ${applicant.first_name},`,
+    '',
+    `You're confirmed for a call with ${housemateName} on ${when} (Pacific time).`,
+    meetLink ? `Google Meet link: ${meetLink}` : `The Google Meet link is in your calendar invite.`,
+    `A calendar invite from ${SHARED_EMAIL} is on its way to this address.`,
+    '',
+    `Looking forward to it!`,
+    `— Agape`,
+  ].join('\n')
+
+  const at = await sharedAccessToken(db)
+  const encSubject = `=?UTF-8?B?${b64url(subject).replace(/-/g, '+').replace(/_/g, '/')}?=`
+  const raw = [
+    `From: Agape <${SHARED_EMAIL}>`,
+    `To: ${applicant.email}`,
+    `Subject: ${encSubject}`,
+    'MIME-Version: 1.0',
+    'Content-Type: text/plain; charset=UTF-8',
+    '',
+    text,
+  ].join('\r\n')
+  const resp = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ raw: b64url(raw) }),
+  })
+  const sent = await resp.json()
+  if (!resp.ok) throw new Error(`Confirmation send failed: ${JSON.stringify(sent).slice(0, 180)}`)
+  await db.from('recruit_emails').upsert({
+    applicant_id: applicant.id, gmail_id: sent.id, thread_id: sent.threadId,
+    direction: 'out', subject, snippet: text.slice(0, 180), body_text: text,
+    from_email: SHARED_EMAIL, to_email: applicant.email,
+    sent_by_name: 'auto', sent_at: new Date().toISOString(),
+  }, { onConflict: 'gmail_id' })
+}

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -7,11 +7,12 @@
 // POST { token }                      → { firstName, windows }
 // POST { token, windows: [...] }      → save; { saved: true, windows }
 
-const VERSION = '1.0.0'
-console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint`)
+const VERSION = '1.1.0'
+console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint + Discord claim post`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { upsertClaimMessage } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -55,6 +56,21 @@ serve(async (req) => {
       })
       if (error) return json({ error: 'Could not save — try again' }, 500)
       console.log(`availability saved for ${applicant.id} (${windows.length} windows)`)
+
+      // Post/refresh the claimable message in #recruiting-interviews.
+      // Warn-only: Discord being down never blocks the applicant's save.
+      try {
+        const { data: full } = await client.from('recruit_applicants')
+          .select('why_agape').eq('id', applicant.id).maybeSingle()
+        await upsertClaimMessage(client, {
+          applicantId: applicant.id, firstName: applicant.first_name,
+          whyLine: full?.why_agape || null,
+          windows, platform: null, timezoneNote: null, needsHuman: false,
+        })
+      } catch (err) {
+        console.warn(`claim post failed for ${applicant.id}: ${(err as Error).message}`)
+      }
+
       return json({ saved: true, windows })
     }
 

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -1,0 +1,193 @@
+// Supabase Edge Function: recruit-discord
+// Discord interactions endpoint for the screening-claim flow (verify_jwt=false
+// in config.toml — Discord authenticates with an Ed25519 signature, not a JWT).
+//
+// PING (type 1)              → PONG
+// Button click (type 3)      → custom_id "claim|<applicantId>|<startEpochMs>"
+//   1. resolve the tapper via user_discord_membership (must be recruiting member)
+//   2. atomic first-write-wins claim on recruit_claim_posts (status open → claimed)
+//   3. ACK within Discord's 3s deadline (DEFERRED_UPDATE_MESSAGE)
+//   4. background: GCal event + Meet via scheduleScreening, edit the post,
+//      DM the claimer, email the applicant a short confirmation.
+//
+// The app public key is fetched from GET /applications/@me with the bot token
+// (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
+
+const VERSION = '1.0.0'
+console.log(`[recruit-discord] v${VERSION} — screening-claim interactions endpoint`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { scheduleScreening, sendApplicantConfirmation } from '../_shared/recruit-schedule.ts'
+import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel } from '../_shared/discord.ts'
+
+declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
+
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+// ---- signature verification ----
+
+let cachedPublicKey: string | null = null
+
+async function publicKeyHex(): Promise<string> {
+  if (cachedPublicKey) return cachedPublicKey
+  const env = Deno.env.get('DISCORD_PUBLIC_KEY')
+  if (env) return (cachedPublicKey = env)
+  const resp = await fetch('https://discord.com/api/v10/applications/@me', {
+    headers: { Authorization: `Bot ${Deno.env.get('DISCORD_BOT_TOKEN')}` },
+  })
+  const app = await resp.json()
+  if (!resp.ok || !app.verify_key) throw new Error(`Could not fetch app verify_key: ${JSON.stringify(app).slice(0, 150)}`)
+  return (cachedPublicKey = app.verify_key)
+}
+
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  return out
+}
+
+async function verifySignature(req: Request, body: string): Promise<boolean> {
+  const signature = req.headers.get('X-Signature-Ed25519')
+  const timestamp = req.headers.get('X-Signature-Timestamp')
+  if (!signature || !timestamp) return false
+  const keyBytes = hexToBytes(await publicKeyHex())
+  const message = new TextEncoder().encode(timestamp + body)
+  const sigBytes = hexToBytes(signature)
+  try {
+    const key = await crypto.subtle.importKey('raw', keyBytes, 'Ed25519', false, ['verify'])
+    return await crypto.subtle.verify('Ed25519', key, sigBytes, message)
+  } catch {
+    // runtime without WebCrypto Ed25519 — tweetnacl fallback (CJS: exports on default)
+    // deno-lint-ignore no-explicit-any
+    const mod: any = await import('https://esm.sh/tweetnacl@1.0.3')
+    const nacl = mod.default ?? mod
+    return nacl.sign.detached.verify(message, sigBytes, keyBytes)
+  }
+}
+
+// ---- interaction responses ----
+
+const PONG = { type: 1 }
+const DEFERRED_UPDATE = { type: 6 }
+const ephemeral = (content: string) => ({ type: 4, data: { content, flags: 64 } })
+
+// ---- claim background work (runs after the 3s ACK) ----
+
+async function finishClaim(client: ReturnType<typeof db>, opts: {
+  claimPost: Record<string, any>
+  applicantId: string
+  startsAt: Date
+  label: string
+  userId: string
+  discordUserId: string
+  discordUsername: string
+}): Promise<void> {
+  const { claimPost, applicantId, startsAt, label } = opts
+  try {
+    const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', opts.userId).maybeSingle()
+    const housemateName = rp?.display_name || opts.discordUsername || 'an Agape housemate'
+    const { data: authUser, error: authErr } = await client.auth.admin.getUserById(opts.userId)
+    const housemateEmail = (authUser?.user?.email || '').toLowerCase()
+    if (authErr || !housemateEmail.includes('@')) throw new Error('Could not resolve your account email')
+
+    const { screening, meetLink, applicant } = await scheduleScreening(client, {
+      applicantId, startsAt, housemateUserId: opts.userId, housemateName, housemateEmail,
+    })
+
+    await editClaimMessageClaimed(claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId, label)
+
+    const platform = claimPost.platform as { kind?: string; handle?: string } | null
+    const platformLine = platform?.kind
+      ? `\nHeads up: they asked for ${platform.kind}${platform.handle ? ` (@${platform.handle})` : ''} — default is the Meet link, but feel free to DM them about it.`
+      : ''
+    await dmUser(opts.discordUserId,
+      `✅ You claimed **${applicant.first_name}**'s screening call — ${label}.\n` +
+      `Calendar invites are out to you both. Meet: ${meetLink || '(see calendar invite)'}${platformLine}`)
+
+    try {
+      await sendApplicantConfirmation(client, applicant, housemateName, startsAt, meetLink)
+    } catch (err) {
+      console.warn(`[recruit-discord] confirmation email failed for ${applicantId}: ${(err as Error).message}`)
+    }
+    console.log(`[recruit-discord] claim complete: ${applicantId} × ${housemateName} @ ${startsAt.toISOString()} (screening ${screening.id})`)
+  } catch (err) {
+    // Never reopen the post (avoids double-booking) — flag it and tell the claimer.
+    console.error(`[recruit-discord] claim finish failed for ${applicantId}: ${(err as Error).message}`)
+    try {
+      await editClaimMessageFailed(claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId, label)
+    } catch { /* best effort */ }
+    try {
+      await dmUser(opts.discordUserId,
+        `⚠️ You claimed the call with this applicant (${label}), but scheduling hit an error: ${(err as Error).message.slice(0, 200)}\n` +
+        `Please book it manually in the app: https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`)
+    } catch { /* best effort */ }
+  }
+}
+
+async function handleClaim(interaction: Record<string, any>): Promise<Response> {
+  const customId = String(interaction.data?.custom_id || '')
+  const [action, applicantId, startMsRaw] = customId.split('|')
+  if (action !== 'claim' || !applicantId) return json(ephemeral('Unsupported button.'))
+  const startsAt = new Date(Number(startMsRaw))
+  if (isNaN(startsAt.getTime())) return json(ephemeral('Bad slot — try another.'))
+
+  const discordUserId = interaction.member?.user?.id || interaction.user?.id
+  const discordUsername = interaction.member?.user?.username || interaction.user?.username || ''
+  if (!discordUserId) return json(ephemeral('Could not identify you.'))
+
+  const client = db()
+  const { data: membership } = await client.from('user_discord_membership')
+    .select('user_id, is_recruiting_member, discord_username')
+    .eq('discord_user_id', discordUserId).maybeSingle()
+  if (!membership?.user_id || !membership.is_recruiting_member) {
+    return json(ephemeral('Sign in at https://ctrl.rodeo/applications with Discord first, then tap again.'))
+  }
+
+  if (startsAt < new Date()) return json(ephemeral('That time has already passed — pick another or use "Other time…".'))
+
+  const label = slotLabel(startsAt)
+  // First-write-wins: only an 'open' row can transition to 'claimed'.
+  const { data: claimed } = await client.from('recruit_claim_posts')
+    .update({
+      status: 'claimed',
+      claimed_by_user_id: membership.user_id,
+      claimed_slot: { start: startsAt.toISOString(), label },
+      claimed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('applicant_id', applicantId).eq('status', 'open')
+    .select().maybeSingle()
+  if (!claimed) return json(ephemeral('Already claimed — thanks for the quick trigger finger though!'))
+
+  const work = finishClaim(client, {
+    claimPost: claimed, applicantId, startsAt, label,
+    userId: membership.user_id, discordUserId,
+    discordUsername: membership.discord_username || discordUsername,
+  })
+  if (typeof EdgeRuntime !== 'undefined' && EdgeRuntime?.waitUntil) EdgeRuntime.waitUntil(work)
+  else work.catch(() => { /* logged inside */ })
+
+  return json(DEFERRED_UPDATE)
+}
+
+serve(async (req) => {
+  try {
+    const body = await req.text()
+    if (!(await verifySignature(req, body))) {
+      return json({ error: 'invalid request signature' }, 401)
+    }
+    const interaction = JSON.parse(body)
+    if (interaction.type === 1) return json(PONG)
+    if (interaction.type === 3) return await handleClaim(interaction)
+    return json(ephemeral('Unsupported interaction.'))
+  } catch (err) {
+    console.error('[recruit-discord] error:', (err as Error).message)
+    return json({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,11 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.3.0'
-console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe`)
+const VERSION = '1.4.0'
+console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendApplicantConfirmation, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
+import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -34,64 +36,111 @@ const CLIENT_SECRET = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!
 // Same whitelisted redirect the ladder gmail flow uses; /ladder forwards
 // state=agape-gmail callbacks to /applications/.
 const REDIRECT_URI = Deno.env.get('GMAIL_OAUTH_REDIRECT_URI') || 'https://ctrl.rodeo/job/'
-const SHARED_EMAIL = Deno.env.get('AGAPE_GMAIL_ADDRESS') || 'live.at.agapesf@gmail.com'
 const SCOPES = [
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/calendar.events', // screening-call invites
 ]
-const TZ = 'America/Los_Angeles' 
 
 function db() {
   return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
 }
 
-async function accessToken(client: ReturnType<typeof db>): Promise<string> {
-  const { data: acct } = await client.from('recruit_gmail_account').select('*').eq('id', 1).maybeSingle()
-  if (!acct) throw new Error('Shared Gmail not connected yet')
-  const resp = await fetch('https://oauth2.googleapis.com/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      client_id: CLIENT_ID, client_secret: CLIENT_SECRET,
-      refresh_token: acct.refresh_token, grant_type: 'refresh_token',
-    }),
-  })
-  const tok = await resp.json()
-  if (!resp.ok || !tok.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(tok).slice(0, 180)}`)
-  return tok.access_token
+interface Extraction {
+  windows: Array<{ date: string; start: string; end: string }>
+  platform: { kind: string; handle?: string } | null
+  timezone_note: string | null
+  needs_human: boolean
 }
+const NO_EXTRACTION: Extraction = { windows: [], platform: null, timezone_note: null, needs_human: false }
 
-function b64url(s: string): string {
-  return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-}
-
-// Extract availability windows from an applicant's reply (Haiku).
-async function extractAvailability(text: string): Promise<Array<{ date: string; start: string; end: string }>> {
+// Extract scheduling info from an applicant's reply (Haiku, v2 prompt):
+// availability windows in PT, platform requests (IG/WhatsApp/phone),
+// timezone conversions, and a needs_human flag for unparseable replies.
+async function extractAvailability(text: string): Promise<Extraction> {
   const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
-  if (!key || !text.trim()) return []
-  const prompt = `Today is ${new Date().toLocaleDateString('en-CA', { timeZone: TZ })} (${TZ}).
-Extract every availability window this person offers for a call. Resolve relative days ("next Tuesday") to dates. Assume ${TZ} unless stated. If they give a day with no hours, use 09:00-18:00. Ignore anything that is not availability.
+  if (!key || !text.trim()) return NO_EXTRACTION
+  const prompt = `Today is ${new Date().toLocaleDateString('en-CA', { timeZone: TZ })} (${TZ}). You are extracting scheduling information from an email a housing applicant sent to Agape (San Francisco, Pacific time).
+
+Extract:
+1. "windows": every availability window they offer, as [{"date":"YYYY-MM-DD","start":"HH:MM","end":"HH:MM"}] in Pacific time.
+   - Resolve relative days ("next Tuesday", "the 25th") to concrete dates, never in the past.
+   - If they name their own timezone or location ("I'm in Europe", "CET", "9 hour difference"), convert to Pacific. When they say "morning your time" they mean Pacific morning — take them at their word.
+   - Vague day-parts map to: morning 09:00-12:00, afternoon 12:00-17:00, evening 17:00-21:00, a bare day 09:00-18:00.
+   - Windows must be >=30 minutes. Cap at 10.
+2. "platform": if they request a specific medium (Instagram video, WhatsApp, phone, "not video"), return {"kind":..., "handle":...}; else null. Default assumption is Google Meet — only capture explicit requests.
+3. "timezone_note": one short string when a conversion happened ("applicant is in Europe, +9h from PT — windows converted"), else null.
+4. "needs_human": true when the email is clearly about scheduling but you cannot produce at least one concrete window (e.g. "whenever works!", a Calendly link, questions instead of times) — a human will read the thread instead. If the email is not about scheduling at all, return windows [] and needs_human false.
+
 EMAIL START
 ${text.slice(0, 3000)}
 EMAIL END
-Return exactly: [{"date":"YYYY-MM-DD","start":"HH:MM","end":"HH:MM"}] — [] if none.`
+Return one JSON object: {"windows":..., "platform":..., "timezone_note":..., "needs_human":...}. No prose.`
   const resp = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
     body: JSON.stringify({
-      model: 'claude-haiku-4-5-20251001', max_tokens: 400,
-      system: 'You extract meeting availability from emails. Respond with a JSON array only.',
+      model: 'claude-haiku-4-5-20251001', max_tokens: 600,
+      system: 'You extract scheduling information from emails. Respond with a single JSON object only.',
       messages: [{ role: 'user', content: prompt }],
     }),
   })
-  if (!resp.ok) return []
+  if (!resp.ok) return NO_EXTRACTION
   const data = await resp.json()
   const out = (data.content || []).filter((b: Record<string, unknown>) => b.type === 'text').map((b: Record<string, unknown>) => b.text).join('')
   try {
-    const arr = JSON.parse(out.trim().replace(/^```json?\s*|\s*```$/g, ''))
-    return Array.isArray(arr) ? arr.filter((w) => /^\d{4}-\d{2}-\d{2}$/.test(w.date) && /^\d{2}:\d{2}$/.test(w.start) && /^\d{2}:\d{2}$/.test(w.end)).slice(0, 10) : []
-  } catch { return [] }
+    const obj = JSON.parse(out.trim().replace(/^```json?\s*|\s*```$/g, ''))
+    const windows = (Array.isArray(obj.windows) ? obj.windows : [])
+      // deno-lint-ignore no-explicit-any
+      .filter((w: any) => /^\d{4}-\d{2}-\d{2}$/.test(w.date) && /^\d{2}:\d{2}$/.test(w.start) && /^\d{2}:\d{2}$/.test(w.end) && w.start < w.end)
+      .slice(0, 10)
+    return {
+      windows,
+      platform: obj.platform?.kind ? { kind: String(obj.platform.kind).slice(0, 40), ...(obj.platform.handle ? { handle: String(obj.platform.handle).replace(/^@/, '').slice(0, 60) } : {}) } : null,
+      timezone_note: obj.timezone_note ? String(obj.timezone_note).slice(0, 200) : null,
+      needs_human: Boolean(obj.needs_human) && !windows.length,
+    }
+  } catch { return NO_EXTRACTION }
+}
+
+// After availability lands, post/refresh the claimable message in
+// #recruiting-interviews. Warn-only: Discord being down never breaks a scan.
+async function postClaim(client: ReturnType<typeof db>, applicantId: string, extraction: Extraction): Promise<void> {
+  if (!extraction.windows.length && !extraction.needs_human) return
+  try {
+    const { data: applicant } = await client.from('recruit_applicants')
+      .select('first_name, why_agape').eq('id', applicantId).maybeSingle()
+    if (!applicant) return
+    await upsertClaimMessage(client, {
+      applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape,
+      windows: extraction.windows, platform: extraction.platform,
+      timezoneNote: extraction.timezone_note, needsHuman: extraction.needs_human,
+    })
+  } catch (err) {
+    console.warn(`claim post failed for ${applicantId}: ${(err as Error).message}`)
+  }
+}
+
+// 96h stuck-metric: one channel nudge per unclaimed post. Piggybacks on scan
+// (the app triggers scans regularly) — no extra cron infrastructure.
+async function remindStuckPosts(client: ReturnType<typeof db>): Promise<void> {
+  try {
+    const cutoff = new Date(Date.now() - 96 * 3600 * 1000).toISOString()
+    const { data: stuck } = await client.from('recruit_claim_posts')
+      .select('applicant_id, discord_channel_id, discord_message_id, posted_at')
+      .eq('status', 'open').is('reminded_at', null).lt('posted_at', cutoff).limit(5)
+    for (const post of (stuck || [])) {
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('first_name').eq('id', post.applicant_id).maybeSingle()
+      await notifyStuck(post.discord_channel_id, post.discord_message_id, applicant?.first_name || 'An applicant')
+      await client.from('recruit_claim_posts')
+        .update({ reminded_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+        .eq('applicant_id', post.applicant_id)
+      console.log(`stuck reminder sent for ${post.applicant_id} (open since ${post.posted_at})`)
+    }
+  } catch (err) {
+    console.warn(`stuck reminder sweep failed: ${(err as Error).message}`)
+  }
 }
 
 function header(headers: Array<{ name: string; value: string }>, name: string): string {
@@ -243,13 +292,14 @@ serve(async (req) => {
           const { data: existingAv } = await client.from('recruit_availability')
             .select('source_gmail_id').eq('applicant_id', applicant.id).maybeSingle()
           if (existingAv?.source_gmail_id !== msg.id) {
-            const windows = await extractAvailability(bodyText)
-            if (windows.length) {
+            const extraction = await extractAvailability(bodyText)
+            if (extraction.windows.length) {
               await client.from('recruit_availability').upsert({
-                applicant_id: applicant.id, windows, source_gmail_id: msg.id,
+                applicant_id: applicant.id, windows: extraction.windows, source_gmail_id: msg.id,
                 updated_at: new Date().toISOString(),
               })
             }
+            await postClaim(client, applicant.id, extraction)
           }
         }
       }
@@ -262,47 +312,53 @@ serve(async (req) => {
     }
 
     if (action === 'schedule') {
-      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
-      if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      const applicantId = String(body.applicantId || '')
       const startsAt = new Date(String(body.startsAt || ''))
       if (isNaN(startsAt.getTime()) || startsAt < new Date()) return json({ error: 'Pick a future start time' }, 400)
-      const endsAt = new Date(startsAt.getTime() + (Number(body.minutes) || 30) * 60000)
 
       const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', userData.user.id).maybeSingle()
       const housemateName = rp?.display_name || membership.discord_username || 'an Agape housemate'
       const housemateEmail = (userData.user.email || '').toLowerCase()
 
-      const at = await accessToken(client)
-      const event = {
-        summary: `Agape screening call — ${applicant.first_name} ${applicant.last_name} × ${housemateName}`,
-        description: `Get-to-know-you call with ${applicant.first_name} (Agape application), scheduled from their offered availability.`,
-        start: { dateTime: startsAt.toISOString(), timeZone: TZ },
-        end: { dateTime: endsAt.toISOString(), timeZone: TZ },
-        attendees: [
-          { email: applicant.email },
-          ...(housemateEmail.includes('@') ? [{ email: housemateEmail }] : []),
-        ],
-        conferenceData: { createRequest: { requestId: crypto.randomUUID(), conferenceSolutionKey: { type: 'hangoutsMeet' } } },
-        reminders: { useDefault: true },
+      let result
+      try {
+        result = await scheduleScreening(client, {
+          applicantId, startsAt, minutes: Number(body.minutes) || 30,
+          housemateUserId: userData.user.id, housemateName, housemateEmail,
+        })
+      } catch (err) {
+        const msg = (err as Error).message
+        return json({ error: msg }, msg === 'Applicant has no email' ? 400 : 500)
       }
-      const resp = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=all&conferenceDataVersion=1', {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify(event),
-      })
-      const created = await resp.json()
-      if (!resp.ok) return json({ error: `Calendar failed: ${JSON.stringify(created).slice(0, 200)} — if this mentions scopes, reconnect the shared Gmail to grant calendar access` }, 500)
-      // deno-lint-ignore no-explicit-any
-      const meet = created.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || created.hangoutLink || null
-      const { data: row, error } = await client.from('recruit_screenings').insert({
-        applicant_id: applicant.id, housemate_user_id: userData.user.id,
-        housemate_name: housemateName, housemate_email: housemateEmail,
-        starts_at: startsAt.toISOString(), ends_at: endsAt.toISOString(),
-        gcal_event_id: created.id, meet_link: meet, status: 'scheduled',
-      }).select().single()
-      if (error) return json({ error: error.message }, 500)
-      console.log(`screening ${applicant.id} x ${housemateName} @ ${startsAt.toISOString()}`)
-      return json({ scheduled: true, screening: row })
+
+      // App-side booking closes any open Discord claim post for this applicant.
+      try {
+        const label = slotLabel(startsAt)
+        const { data: post } = await client.from('recruit_claim_posts')
+          .update({
+            status: 'claimed', claimed_by_user_id: userData.user.id,
+            claimed_slot: { start: startsAt.toISOString(), label },
+            claimed_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+          })
+          .eq('applicant_id', applicantId).in('status', ['open', 'manual'])
+          .select('discord_channel_id, discord_message_id').maybeSingle()
+        if (post) {
+          const { data: dm } = await client.from('user_discord_membership')
+            .select('discord_user_id').eq('user_id', userData.user.id).maybeSingle()
+          if (dm?.discord_user_id) await editClaimMessageClaimed(post.discord_channel_id, post.discord_message_id, dm.discord_user_id, label)
+        }
+      } catch (err) {
+        console.warn(`claim post close failed for ${applicantId}: ${(err as Error).message}`)
+      }
+
+      try {
+        await sendApplicantConfirmation(client, result.applicant, housemateName, startsAt, result.meetLink)
+      } catch (err) {
+        console.warn(`confirmation email failed for ${applicantId}: ${(err as Error).message}`)
+      }
+
+      console.log(`screening ${applicantId} x ${housemateName} @ ${startsAt.toISOString()}`)
+      return json({ scheduled: true, screening: result.screening })
     }
 
     if (action === 'scan') {
@@ -353,16 +409,18 @@ serve(async (req) => {
         if (direction === 'in') {
           replied.add(applicantId)
           if (bodyText.trim()) {
-            const windows = await extractAvailability(bodyText)
-            if (windows.length) {
+            const extraction = await extractAvailability(bodyText)
+            if (extraction.windows.length) {
               await client.from('recruit_availability').upsert({
-                applicant_id: applicantId, windows, source_gmail_id: msg.id,
+                applicant_id: applicantId, windows: extraction.windows, source_gmail_id: msg.id,
                 updated_at: new Date().toISOString(),
               })
             }
+            await postClaim(client, applicantId, extraction)
           }
         }
       }
+      await remindStuckPosts(client)
       console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied`)
       return json({ matched, replied: [...replied] })
     }

--- a/supabase/migrations/121_recruit_claim_posts.sql
+++ b/supabase/migrations/121_recruit_claim_posts.sql
@@ -1,0 +1,38 @@
+-- ============================================
+-- Migration 121: Discord screening-claim posts
+--
+-- When applicant availability lands (email extraction or the /schedule
+-- picker), a claimable message is posted to #recruiting-interviews.
+-- One row per applicant (the dedup rule: re-availability edits the
+-- existing post). First housemate to tap a slot claims atomically via
+-- UPDATE ... WHERE status='open'.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_claim_posts (
+  applicant_id TEXT PRIMARY KEY REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  discord_message_id TEXT NOT NULL,
+  discord_channel_id TEXT NOT NULL,
+  -- Concrete 30-min slots that were posted: [{start: ISO-UTC, label: "Fri Jul 25 · 9:00a"}]
+  slots JSONB NOT NULL DEFAULT '[]',
+  -- Requested medium from extraction: {kind, handle?} or null (default = Meet)
+  platform JSONB,
+  -- e.g. "applicant is in Europe, +9h from PT — windows converted"
+  timezone_note TEXT,
+  -- true = couldn't parse concrete times; post asks for manual coordination
+  needs_human BOOLEAN NOT NULL DEFAULT false,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'claimed', 'expired', 'manual')),
+  claimed_by_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  claimed_slot JSONB,
+  posted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  claimed_at TIMESTAMPTZ,
+  reminded_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_recruit_claim_posts_open
+  ON recruit_claim_posts(posted_at) WHERE status = 'open';
+
+ALTER TABLE recruit_claim_posts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read claim posts" ON recruit_claim_posts
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+-- Writes are service-role only (recruit-gmail / recruit-availability / recruit-discord).


### PR DESCRIPTION
## What

An applicant's scheduling reply (email or the /schedule picker) now becomes a claimable post in **#recruiting-interviews**. First housemate to tap a slot claims the call — GCal event on the shared account invites both with a Meet link, the post closes, the claimer gets a DM, and the applicant gets a short confirmation email.

PRD: `docs/strategy/prds/agape-screening-claim-automation.md` (decisions + implementation notes updated in this PR).

## Pieces

| Piece | Change |
|---|---|
| `recruit-gmail` → **1.4.0** | v2 Haiku extraction (windows + platform + timezone_note + needs_human), Discord post after availability lands, schedule logic extracted to shared helper, app-side booking closes claim posts, applicant confirmation email, 96h stuck nudge piggybacked on scan |
| `recruit-availability` → **1.1.0** | picker submissions post/refresh the claim message |
| `recruit-discord` → **1.0.0** (new) | Ed25519-verified interactions endpoint; resolve claimer → atomic first-write-wins claim → deferred ACK inside Discord's 3s deadline → GCal/edit/DM/email in `EdgeRuntime.waitUntil` |
| `_shared/recruit-schedule.ts`, `_shared/discord.ts` | shared scheduling + Discord REST helpers (timezone-correct slot derivation, round-robin across days) |
| migration **121** | `recruit_claim_posts` (one row per applicant; open→claimed transition is the atomic claim) |

## Safety

- All new posting code is warn-only — Discord failures never break scan/sync/picker saves.
- Calendar failure after a claim never reopens the post (no double-booking); post flips to ⚠️ and the claimer is DM'd.
- No new secrets: channel ID defaults to `1529576830514762029`, public key fetched via `DISCORD_BOT_TOKEN` from `GET /applications/@me`.

## Verified

- `deno check` clean on all three functions.
- Unit checks pass: PT→UTC conversion (PDT + PST), Marisa-case slot derivation (6 slots), round-robin day spread, past/short-window filtering, Ed25519 verify roundtrip (valid ✓ / tampered ✗) incl. tweetnacl fallback shape.
- Live Marisa prompt eval pending post-deploy (no local Anthropic key).

## After merge

1. Deploy: `supabase functions deploy recruit-gmail recruit-availability && supabase functions deploy recruit-discord --no-verify-jwt` + run migration 121.
2. **Ian:** set the Discord app's Interactions Endpoint URL to `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord` (portal verifies with PING + bad-signature probes).
3. Confirm bot perms in #recruiting-interviews (View/Send/Embed/Read History).

🤖 Generated with [Claude Code](https://claude.com/claude-code)