### PR TITLE
Agape recruiting v3: collective review votes + staged funnel (Phase A)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -483,9 +483,9 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 }
 .review__decided .link-clear { background: none; border: 0; padding: 0; color: var(--fg-link); font-size: inherit; text-decoration: underline; }
 
-/* Footer — three decisions pinned at the bottom. */
+/* Footer — contextual: vote bar in review, recruiter actions for candidates. */
 .review__foot {
-  display: grid; grid-template-columns: 1fr 1fr 1fr;
+  display: flex;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
   padding-bottom: max(var(--space-3), env(safe-area-inset-bottom));
@@ -494,7 +494,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 }
 .review__foot[hidden] { display: none; }
 @media (min-width: 721px) { .review__foot { max-width: 760px; width: 100%; margin-inline: auto; border-inline: 1px solid var(--border); border-radius: var(--radius-lg) var(--radius-lg) 0 0; } }
-.review__btn { width: 100%; height: 48px; border-radius: var(--radius-pill); }
+.review__btn { flex: 1; height: 48px; border-radius: var(--radius-pill); }
 .review__btn--pass, .review__btn--hold { background: var(--bg-surface); border: 0; }
 .review__btn--pass:hover, .review__btn--hold:hover { background: var(--bg-overlay); }
 .review__btn.is-active--pass { background: var(--pass-tint); box-shadow: inset 0 0 0 1.5px var(--border-strong); }
@@ -1004,3 +1004,42 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   .cal-nav { margin-left: auto; }
   .cal__row { min-height: 48px; }
 }
+
+/* --- v3.0.0: collective review — vote bar, tally, chips --- */
+.vote-bar {
+  flex: 1;
+  display: flex; flex-wrap: wrap; align-items: center;
+  gap: var(--space-2) var(--space-3);
+}
+.vote-bar__q { font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.vote-bar__scores { display: inline-flex; gap: var(--space-2); }
+.vote-bar__score {
+  width: 44px; height: 44px; border-radius: var(--radius-pill);
+  border: 1px solid var(--border); background: var(--bg-surface);
+  font-size: var(--font-size-body); font-weight: var(--fw-semibold);
+  color: var(--fg); cursor: pointer;
+}
+.vote-bar__score:hover { background: var(--bg-overlay); }
+.vote-bar__score.is-on { background: #9FE870; border-color: #9FE870; color: #163300; }
+.vote-bar__veto {
+  height: 44px; padding: 0 var(--space-3); border-radius: var(--radius-pill);
+  border: 1px solid rgba(168, 32, 13, 0.35); background: none;
+  color: var(--error); font-size: var(--font-size-small); font-weight: var(--fw-semibold);
+  cursor: pointer;
+}
+.vote-bar__veto:hover { background: rgba(168, 32, 13, 0.10); }
+.vote-bar__veto.is-on { background: rgba(168, 32, 13, 0.16); box-shadow: inset 0 0 0 1.5px var(--error); }
+.vote-bar__note { flex: 1 1 180px; min-width: 0; height: 44px; }
+.vote-bar__cast { height: 44px; border-radius: var(--radius-pill); }
+@media (max-width: 720px) {
+  .vote-bar__q { flex-basis: 100%; }
+  .vote-bar__scores { flex: 1; justify-content: space-between; }
+  .vote-bar__score { width: 40px; height: 40px; }
+  .vote-bar__note { flex-basis: 100%; order: 5; }
+  .vote-bar__cast { flex: 1; order: 6; }
+}
+
+.decision-chip--vote { background: var(--bg-surface); color: var(--fg-muted); }
+.vote-summary { margin: 0 0 var(--space-3); font-size: var(--font-size-small); font-weight: var(--fw-semibold); color: var(--fg-muted); }
+.vote-score { font-weight: var(--fw-semibold); color: var(--fg); }
+.vote-score--veto { color: var(--error); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=2.16.1">
+  <link rel="stylesheet" href="css/app.css?v=3.0.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -36,20 +36,21 @@
       <button class="mobile-bar__menu" id="mobile-menu" aria-label="Menu">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
       </button>
-      <span class="mobile-bar__title" id="mobile-title">Inbox</span>
+      <span class="mobile-bar__title" id="mobile-title">Review</span>
     </header>
 
     <aside class="app__rail" id="rail">
-      <a class="brand" href="?view=inbox" data-view-link="inbox">
+      <a class="brand" href="?view=review" data-view-link="review">
         <span class="brand__text">Agape recruiting</span>
       </a>
       <nav class="rail-nav" id="rail-nav">
         <div class="rail-nav__group">House</div>
         <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
-        <div class="rail-nav__group">Applicants</div>
-        <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Inbox <span class="rail-nav__count" id="count-inbox"></span></a>
-        <a class="rail-nav__row" href="?view=outreach" data-view-link="outreach">Outreach <span class="rail-nav__count" id="count-outreach"></span></a>
-        <a class="rail-nav__row" href="?view=hold" data-view-link="hold">Hold <span class="rail-nav__count" id="count-hold"></span></a>
+        <div class="rail-nav__group">Funnel</div>
+        <a class="rail-nav__row" href="?view=review" data-view-link="review">Review <span class="rail-nav__count" id="count-review"></span></a>
+        <a class="rail-nav__row" href="?view=candidates" data-view-link="candidates">Candidates <span class="rail-nav__count" id="count-candidates"></span></a>
+        <a class="rail-nav__row" href="?view=openings" data-view-link="openings">Openings <span class="rail-nav__count" id="count-openings"></span></a>
+        <a class="rail-nav__row" href="?view=screening" data-view-link="screening">Screening <span class="rail-nav__count" id="count-screening"></span></a>
         <a class="rail-nav__row" href="?view=archive" data-view-link="archive">Archive <span class="rail-nav__count" id="count-archive"></span></a>
       </nav>
       <div class="rail-foot">
@@ -85,11 +86,8 @@
       <button class="review__close" id="review-close" aria-label="Close">✕</button>
     </div>
     <div class="review__scroll"><div class="review__inner" id="review-body"></div></div>
-    <div class="review__foot" id="review-foot">
-      <button class="btn review__btn review__btn--notfit" id="btn-pass">Not a fit</button>
-      <button class="btn review__btn review__btn--future" id="btn-hold">Future fit</button>
-      <button class="btn review__btn review__btn--place" id="btn-outreach">Add to listing</button>
-    </div>
+    <!-- Contextual: vote bar while in review, recruiter actions for candidates. -->
+    <div class="review__foot" id="review-foot"></div>
     <div class="hold-sheet decision-sheet" id="decision-sheet" hidden>
       <h3 class="hold-sheet__title" id="decision-sheet-title">Why?</h3>
       <div class="decision-sheet__options" id="decision-options"></div>
@@ -143,6 +141,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=2.16.1"></script>
+  <script src="js/app.js?v=3.0.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -1,8 +1,13 @@
 /* Agape recruiting viewer — /applications
    Discord-gated (Recruiting Society channel on the Agape server, verified by
-   the discord-membership edge fn). Applicants, shared decisions, and house
-   notes live in Supabase behind RLS (migration 108). */
-const VERSION = '2.16.1';
+   the discord-membership edge fn). Applicants, votes, shared decisions, and
+   house notes live in Supabase behind RLS (migrations 108 + 120).
+
+   v3 funnel: Review (collective 1–5 votes, veto rejects) → Candidates →
+   Openings (listing shortlists) → Screening → Archive. The applicant's
+   stage column is recomputed server-side by a trigger on recruit_votes;
+   manual moves go through the recruit_set_stage RPC. */
+const VERSION = '3.0.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -43,20 +48,26 @@ const HOLD_REASONS = DECISION_REASONS.hold; // legacy references
 const DECISION_LABELS = { outreach: 'Outreach', hold: 'Hold', pass: 'Archive' };
 
 const VIEWS = {
-  inbox: { title: 'Inbox', kind: 'applicants' },
-  outreach: { title: 'Outreach', kind: 'applicants' },
-  hold: { title: 'Hold', kind: 'applicants' },
+  review: { title: 'Review', kind: 'applicants' },
+  candidates: { title: 'Candidates', kind: 'applicants' },
+  openings: { title: 'Openings', kind: 'applicants' },
+  screening: { title: 'Screening', kind: 'applicants' },
   archive: { title: 'Archive', kind: 'applicants' },
   occupancy: { title: 'Occupancy', kind: 'house' },
 };
+// Old bookmarks and deep links keep working.
+const LEGACY_VIEWS = { inbox: 'review', outreach: 'openings', hold: 'candidates', listings: 'openings' };
 
 let sb = null;                // supabase client (from CtrlAuth)
 let me = null;                // { id, name }
-let applicants = [];          // newest first
+let applicants = [];          // newest first; each carries .stage
 let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
+let votes = {};               // applicant_id -> recruit_votes rows
+let screeningState = {};      // applicant_id -> { at?, with?, availability? }
+let pendingVote = null;       // { score, veto } while the vote bar is open
 let commentCounts = {};       // applicant_id -> n
 let comments = [];            // comments for the applicant open in review
-let view = 'inbox';           // current rail view
+let view = 'review';          // current rail view
 let filters = { track: 'all', month: 'any', budget: 'any' }; // shared across applicant views
 let rooms = [];               // recruit_rooms
 let stays = [];               // recruit_stays rows (date-based tenures)
@@ -348,13 +359,23 @@ async function resolveAvatars() {
 
 /* ---------- data ---------- */
 async function loadAll() {
-  const [aRes, dRes, cRes, sRes, eRes] = await Promise.all([
+  const [aRes, dRes, cRes, sRes, eRes, vRes, scRes, avRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
     sb.from('recruit_comments').select('applicant_id'),
     sb.from('recruit_match_suggestions').select('*'),
     sb.from('recruit_emails').select('applicant_id, direction, sent_at').order('sent_at'),
+    sb.from('recruit_votes').select('*').order('created_at'),
+    sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name').order('starts_at'),
+    sb.from('recruit_availability').select('applicant_id, updated_at'),
   ]);
+  votes = {};
+  for (const v of (vRes.data || [])) (votes[v.applicant_id] ||= []).push(v);
+  screeningState = {};
+  for (const s of (scRes.data || [])) {
+    if (s.status === 'scheduled') screeningState[s.applicant_id] = { at: s.starts_at, with: s.housemate_name };
+  }
+  for (const av of (avRes.data || [])) screeningState[av.applicant_id] ||= { availability: true };
   emailState = {};
   for (const e of (eRes.data || [])) {
     const st = (emailState[e.applicant_id] ||= { lastDir: null, lastAt: null, replies: 0 });
@@ -374,6 +395,7 @@ async function loadAll() {
     email: r.email, social: r.social, about: r.about, why: r.why_agape,
     gifts: r.gifts, source: r.heard_from, residency: r.residency,
     movein: r.move_in, budget: r.budget, avatarUrl: r.avatar_url, scheduleToken: r.schedule_token,
+    stage: r.stage || 'review',
   }));
   decisions = {};
   for (const d of (dRes.data || [])) {
@@ -545,13 +567,71 @@ function attachmentLabel(rec) {
   return `${room?.name || 'Room'} — ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}`;
 }
 
-/* House rule: a stated budget ceiling under $1,500/mo is an automatic pass.
-   Applied to undecided applicants after load; recorded like any decision so
-   it syncs, shows attribution, and can be undone from the review page. */
-async function applyAutoPass() {
-  const auto = applicants.filter(a => !decisions[a.id] && budgetMax(a.budget) !== null && budgetMax(a.budget) < 1500);
+/* ---------- votes + stage machine ---------- */
+/* Thresholds come from recruit_settings (tunable without a deploy). */
+const voteMin = () => Number(settings.vote_min_count) || 3;
+const votePassAvg = () => Number(settings.vote_pass_avg) || 3.5;
+
+const myVote = id => (votes[id] || []).find(v => v.voter_id === me?.id) || null;
+
+function voteStats(id) {
+  const list = votes[id] || [];
+  const scored = list.filter(v => !v.veto && v.score != null);
+  const avg = scored.length ? scored.reduce((s, v) => s + v.score, 0) / scored.length : null;
+  return {
+    n: list.length,
+    scored: scored.length,
+    avg,
+    veto: list.find(v => v.veto) || null,
+  };
+}
+
+/* Manual stage moves go through the RPC — recruit_applicants is read-only
+   to clients; vote-driven moves happen in the DB trigger. */
+async function setStage(id, stage) {
+  const { error } = await sb.rpc('recruit_set_stage', { p_applicant: id, p_stage: stage });
+  if (error) { toast(`Stage change failed: ${error.message}`); return false; }
+  const a = applicants.find(x => x.id === id);
+  if (a) a.stage = stage;
+  return true;
+}
+
+/* Upsert my vote, then pick up whatever stage the DB trigger computed. */
+async function castVote(applicantId) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a || !pendingVote) return;
+  const note = (document.getElementById('vote-note')?.value || '').trim();
+  const { score, veto } = pendingVote;
+  if (!veto && !score) { toast('Pick a score — or veto'); return; }
+  if (veto && note.length < 3) { toast('A veto needs a short why'); return; }
+  const { data, error } = await sb.from('recruit_votes').upsert({
+    applicant_id: applicantId, voter_id: me.id, voter_name: me.name,
+    score: veto ? null : score, veto, note,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'applicant_id,voter_id' }).select().single();
+  if (error) { toast(`Vote failed: ${error.message}`); return; }
+  votes[applicantId] = [...(votes[applicantId] || []).filter(v => v.voter_id !== me.id), data];
+  const { data: fresh } = await sb.from('recruit_applicants').select('stage').eq('id', applicantId).single();
+  const before = a.stage;
+  if (fresh) a.stage = fresh.stage;
+  pendingVote = null;
+  const st = voteStats(applicantId);
+  if (a.stage === 'rejected') toast(`${fullName(a)} vetoed — auto-archived, update email queued`);
+  else if (a.stage === 'candidate' && before !== 'candidate') toast(`${fullName(a)} passed review → Candidates`);
+  else toast(`Vote saved — ${st.scored}/${voteMin()} votes${st.avg ? ` · avg ${st.avg.toFixed(1)}` : ''}`);
+  renderRailCounts();
+  renderReview();
+}
+
+/* House rule: a stated budget ceiling under $1,500/mo is an auto-flag —
+   straight to Archive (rejected: an update email is owed). Recorded as a
+   decision too, for attribution and undo. */
+async function applyAutoFlags() {
+  const auto = applicants.filter(a => a.stage === 'review' && !decisions[a.id]
+    && budgetMax(a.budget) !== null && budgetMax(a.budget) < 1500);
   for (const a of auto) {
-    await saveDecision(a.id, 'pass', null, 'Auto — budget under $1,500');
+    await saveDecision(a.id, 'pass', 'budget', 'Auto — budget under $1,500');
+    await setStage(a.id, 'rejected');
   }
   return auto.length;
 }
@@ -577,8 +657,8 @@ async function loadHouse() {
 
 /* ---------- router ---------- */
 function setView(next, push = true) {
-  if (next === 'listings') next = 'outreach'; // merged in v2.15
-  if (!VIEWS[next]) next = 'inbox';
+  next = LEGACY_VIEWS[next] || next;
+  if (!VIEWS[next]) next = 'review';
   view = next;
   if (push) {
     const url = new URL(location);
@@ -600,7 +680,7 @@ async function render() {
   renderRailCounts();
 
   const root = document.getElementById('view-root');
-  if ((def.kind === 'house' || view === 'outreach') && !houseLoaded) {
+  if ((def.kind === 'house' || view === 'openings') && !houseLoaded) {
     root.innerHTML = `<p class="inbox-empty">Loading…</p>`;
     await loadHouse();
     if (VIEWS[view].kind !== 'house') return; // navigated away meanwhile
@@ -612,9 +692,13 @@ async function render() {
 /* ---------- applicants render ---------- */
 function matchesView(a) {
   const rec = decisions[a.id];
-  if (view === 'inbox') return !rec;
-  if (view === 'archive') return rec?.d === 'pass';
-  return rec?.d === view;
+  const out = a.stage !== 'rejected' && a.stage !== 'archived';
+  if (view === 'review') return a.stage === 'review';
+  if (view === 'candidates') return a.stage === 'candidate' && rec?.d !== 'outreach';
+  if (view === 'openings') return rec?.d === 'outreach' && out;
+  if (view === 'screening') return !!screeningState[a.id] && out;
+  if (view === 'archive') return !out;
+  return false;
 }
 
 /* Shared filters — applied on top of whichever applicant view is open. */
@@ -663,19 +747,21 @@ function renderFilterBar(viewList) {
 }
 
 function counts() {
-  const c = { inbox: 0, outreach: 0, hold: 0, archive: 0 };
+  const c = { review: 0, candidates: 0, openings: 0, screening: 0, archive: 0 };
   for (const a of applicants) {
     const rec = decisions[a.id];
-    if (!rec) c.inbox++;
-    else if (rec.d === 'pass') c.archive++;
-    else c[rec.d]++;
+    if (a.stage === 'rejected' || a.stage === 'archived') { c.archive++; continue; }
+    if (a.stage === 'review') c.review++;
+    else if (rec?.d === 'outreach') c.openings++;
+    else c.candidates++;
+    if (screeningState[a.id]) c.screening++;
   }
   return c;
 }
 
 function renderRailCounts() {
   const c = counts();
-  for (const key of ['inbox', 'outreach', 'hold', 'archive']) {
+  for (const key of ['review', 'candidates', 'openings', 'screening', 'archive']) {
     const el = document.getElementById(`count-${key}`);
     if (el) el.textContent = c[key] || '';
   }
@@ -689,6 +775,41 @@ function decisionChip(id) {
   return `<span class="decision-chip decision-chip--${rec.d}" title="${esc(DECISION_LABELS[rec.d] + reason + by)}">${DECISION_LABELS[rec.d]}</span>`;
 }
 
+/* Per-view row badge: vote progress in Review, funnel state in Archive,
+   call state in Screening, the recruiter decision elsewhere. */
+function voteChip(a) {
+  const st = voteStats(a.id);
+  if (st.veto) return `<span class="decision-chip decision-chip--pass" title="Vetoed by ${esc(st.veto.voter_name || 'a housemate')}">Vetoed</span>`;
+  if (!st.scored) return '';
+  // The average stays blind until you've cast your own vote.
+  if (!myVote(a.id)) return `<span class="decision-chip decision-chip--vote" title="${voteMin()} votes needed — tally shows after you vote">${st.scored}/${voteMin()} votes</span>`;
+  const passing = st.scored >= voteMin() && st.avg >= votePassAvg();
+  return `<span class="decision-chip decision-chip--vote ${passing ? 'decision-chip--outreach' : ''}" title="${st.scored} of ${voteMin()} votes needed · passing average is ${votePassAvg()}">${st.scored}/${voteMin()} · avg ${st.avg.toFixed(1)}</span>`;
+}
+
+function stageChip(a) {
+  if (a.stage === 'rejected') {
+    const st = voteStats(a.id);
+    const why = st.veto ? `Vetoed by ${st.veto.voter_name || 'a housemate'}` : (decisions[a.id]?.note || 'Did not pass review');
+    return `<span class="decision-chip decision-chip--hold" title="${esc(why)}">Update queued</span>`;
+  }
+  return `<span class="decision-chip decision-chip--pass">Archived</span>`;
+}
+
+function screeningChip(a) {
+  const sc = screeningState[a.id];
+  if (!sc) return '';
+  if (sc.at) return `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
+  return `<span class="decision-chip decision-chip--vote">Availability received</span>`;
+}
+
+function rowBadge(a) {
+  if (view === 'review') return voteChip(a);
+  if (view === 'archive') return stageChip(a);
+  if (view === 'screening') return screeningChip(a);
+  return decisionChip(a.id);
+}
+
 function renderApplicants() {
   const viewList = applicants.filter(matchesView);
   const list = viewList.filter(matchesFilters);
@@ -696,18 +817,19 @@ function renderApplicants() {
   document.getElementById('page-sub').textContent =
     (filtered ? `${list.length} of ${viewList.length}` : `${viewList.length}`) +
     ` applicant${(filtered ? viewList.length : list.length) === 1 ? '' : 's'}` +
-    (view === 'inbox' ? ' to review' : '');
+    (view === 'review' ? ` gathering votes · ${voteMin()} needed, one veto rejects` :
+     view === 'candidates' ? ' passed review — waiting for a room' : '');
 
   const host = document.getElementById('view-root');
   host.className = 'inbox';
-  const bar = view === 'inbox' ? '' : renderFilterBar(viewList); // inbox stays clean
+  const bar = view === 'review' ? '' : renderFilterBar(viewList); // review stays clean
   if (!list.length) {
-    host.innerHTML = bar + `<p class="inbox-empty">${filtered ? 'No applicants match these filters.' : (view === 'inbox' ? 'Inbox zero — every applicant is decided.' : 'Nothing here yet.')}</p>`;
+    host.innerHTML = bar + `<p class="inbox-empty">${filtered ? 'No applicants match these filters.' : (view === 'review' ? 'All caught up — every application has its votes.' : 'Nothing here yet.')}</p>`;
     return;
   }
-  // Outreach groups by listing (custom-orderable); other views group by month.
+  // Openings groups by listing (custom-orderable); other views group by month.
   const groups = [];
-  if (view === 'outreach') {
+  if (view === 'openings') {
     const byKey = new Map();
     for (const l of listings.filter(x => x.status === 'open')) byKey.set(l.id, []);
     for (const a of list) {
@@ -738,7 +860,7 @@ function renderApplicants() {
   }
 
   const groupHead = g => {
-    if (view !== 'outreach') return `<h2 class="inbox-group__label">${monthLabel(g.key)}</h2>`;
+    if (view !== 'openings') return `<h2 class="inbox-group__label">${monthLabel(g.key)}</h2>`;
     if (g.key === 'general') return `<div class="listing-head__text"><h2 class="inbox-group__label">General interest</h2>
       <span class="inbox-group__count">no room yet — kept warm for future availability</span></div>`;
     const l = listings.find(x => x.id === g.key);
@@ -760,12 +882,12 @@ function renderApplicants() {
       </span>`;
   };
 
-  const outreachChrome = view === 'outreach' ? `
+  const outreachChrome = view === 'openings' ? `
     <div class="listing-toolbar">
       <span class="notes__empty">Each open listing is a ranked shortlist — drag rows to reorder.</span>
       <button class="btn btn--sm" data-new-listing>New listing</button>
     </div>` : '';
-  const doneListings = view === 'outreach' ? listings.filter(l => l.status !== 'open') : [];
+  const doneListings = view === 'openings' ? listings.filter(l => l.status !== 'open') : [];
   const doneDrawer = doneListings.length ? `
     <details class="occupants__past">
       <summary>Filled & closed listings (${doneListings.length})</summary>
@@ -789,35 +911,35 @@ function renderApplicants() {
         }).join('')}
       </ul>
     </details>` : '';
-  const outreachHint = view === 'outreach' ? `<p class="listing-hint">Listings also come from the <a href="?view=occupancy" data-view-link="occupancy">Occupancy calendar</a>: click an open stretch, or mark a resident as leaving.</p>` : '';
+  const outreachHint = view === 'openings' ? `<p class="listing-hint">Listings also come from the <a href="?view=occupancy" data-view-link="occupancy">Occupancy calendar</a>: click an open stretch, or mark a resident as leaving.</p>` : '';
 
   host.innerHTML = bar + outreachChrome + groups.map(g => `
-    <section class="inbox-group ${view === 'outreach' && g.key !== 'general' ? 'listing-group' : ''}" ${view === 'outreach' ? `data-group-key="${esc(g.key)}"` : ''}>
-      <div class="inbox-group__head ${view === 'outreach' ? 'listing-head' : ''}">
+    <section class="inbox-group ${view === 'openings' && g.key !== 'general' ? 'listing-group' : ''}" ${view === 'openings' ? `data-group-key="${esc(g.key)}"` : ''}>
+      <div class="inbox-group__head ${view === 'openings' ? 'listing-head' : ''}">
         ${groupHead(g)}
         <span class="inbox-group__count listing-head__n">${g.items.length} applicant${g.items.length === 1 ? '' : 's'}</span>
       </div>
-      ${view === 'outreach' && !g.items.length ? `<p class="inbox-empty inbox-empty--group">No one attached yet — add applicants via Review → Add to listing.</p>` : `<ul class="inbox-card">
+      ${view === 'openings' && !g.items.length ? `<p class="inbox-empty inbox-empty--group">No one attached yet — add candidates via their review page → Add to listing.</p>` : `<ul class="inbox-card">
         ${g.items.map(a => `
-          <li class="inbox-row" ${view === 'outreach' ? `draggable="true" data-row-id="${a.id}" data-row-group="${esc(g.key)}"` : ''}>
-            ${view === 'outreach' ? '<span class="inbox-row__grip" title="Drag to reorder">⠿</span>' : ''}
+          <li class="inbox-row" ${view === 'openings' ? `draggable="true" data-row-id="${a.id}" data-row-group="${esc(g.key)}"` : ''}>
+            ${view === 'openings' ? '<span class="inbox-row__grip" title="Drag to reorder">⠿</span>' : ''}
             <button class="inbox-row__main" data-review="${a.id}">
               ${avatarHtml(a)}
               <span class="inbox-row__text">
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
                 <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
-                ${view === 'outreach' && decisions[a.id] && !decisions[a.id].listingId && suggestions[a.id]?.listing_id ? `<span class="inbox-row__sub inbox-row__ai">AI suggests ${esc(matchListingLabel(suggestions[a.id]))} — open to apply</span>` : ''}
+                ${view === 'openings' && decisions[a.id] && !decisions[a.id].listingId && suggestions[a.id]?.listing_id ? `<span class="inbox-row__sub inbox-row__ai">AI suggests ${esc(matchListingLabel(suggestions[a.id]))} — open to apply</span>` : ''}
               </span>
             </button>
             <span class="inbox-row__actions">
-              ${emailState[a.id]?.lastDir === 'in' ? `<span class="decision-chip decision-chip--replied" title="They replied — last message ${relTime(emailState[a.id].lastAt)}">↙ Replied</span>` : (view === 'outreach' && emailState[a.id]?.lastDir === 'out' ? `<span class="note-count" title="Waiting on their reply">sent ${relTime(emailState[a.id].lastAt)}</span>` : '')}
+              ${emailState[a.id]?.lastDir === 'in' ? `<span class="decision-chip decision-chip--replied" title="They replied — last message ${relTime(emailState[a.id].lastAt)}">↙ Replied</span>` : (view === 'openings' && emailState[a.id]?.lastDir === 'out' ? `<span class="note-count" title="Waiting on their reply">sent ${relTime(emailState[a.id].lastAt)}</span>` : '')}
               ${commentCounts[a.id] ? `<span class="note-count" title="${commentCounts[a.id]} house note${commentCounts[a.id] === 1 ? '' : 's'}">✎ ${commentCounts[a.id]}</span>` : ''}
-              ${view === 'outreach' ? `<button class="btn inbox-row__review" data-email="${a.id}">Send email</button>` : `${decisionChip(a.id)}<button class="btn inbox-row__review" data-review="${a.id}">Review</button>`}
+              ${view === 'openings' ? `<button class="btn inbox-row__review" data-email="${a.id}">Send email</button>` : `${rowBadge(a)}<button class="btn inbox-row__review" data-review="${a.id}">${view === 'review' && !myVote(a.id) ? 'Vote' : 'Open'}</button>`}
             </span>
           </li>`).join('')}
       </ul>`}
     </section>`).join('') + doneDrawer + outreachHint;
-  if (view === 'outreach') wireRowDrag(host);
+  if (view === 'openings') wireRowDrag(host);
 }
 
 /* Drag-to-reorder applicants inside each listing group; shared house state. */
@@ -1244,7 +1366,7 @@ async function markLeaving(roomId, defaultDate) {
   if (error) { toast(`Listing failed: ${error.message}`); return; }
   listings.push(data);
   toast(`${room.resident || 'Resident'} marked leaving — resident listing created for ${room.name}`);
-  setView('outreach');
+  setView('openings');
 }
 
 /* ---------- listings ---------- */
@@ -1340,7 +1462,7 @@ function closeListingModal() {
 function rerenderAfterListingChange() {
   closeListingModal();
   renderRailCounts();
-  if (view === 'outreach') renderApplicants();
+  if (view === 'openings') renderApplicants();
   else if (view === 'occupancy') renderOccupancy();
 }
 
@@ -1420,6 +1542,7 @@ function openReview(id) {
   if (!queue.includes(id)) queue = applicants.map(a => a.id);
   qIndex = Math.max(0, queue.indexOf(id));
   reviewTab = 'profile';
+  pendingVote = null;
   document.getElementById('review').hidden = false;
   document.body.style.overflow = 'hidden';
   hideHoldSheet();
@@ -1439,6 +1562,7 @@ function step(delta) {
   const next = qIndex + delta;
   if (next < 0 || next >= queue.length) { if (delta > 0) closeReview(); return; }
   qIndex = next;
+  pendingVote = null;
   hideHoldSheet();
   renderReview();
   resetScroll();
@@ -1472,8 +1596,24 @@ function renderReview() {
   const miNorm = normalizeMoveIn(a);
   const buNorm = normalizeBudget(a.budget);
 
+  const archived = a.stage === 'rejected' || a.stage === 'archived';
+  const archiveBanner = () => {
+    const st = voteStats(a.id);
+    const why = st.veto ? `Vetoed by ${st.veto.voter_name || 'a housemate'}${st.veto.note ? ` — “${st.veto.note}”` : ''}`
+      : rec?.note || (rec?.reason ? reasonLabel(rec.reason) : 'Did not pass review');
+    return `<div class="decision-banner decision-banner--pass">
+      <div class="decision-banner__text">
+        <span class="decision-banner__label">${a.stage === 'rejected' ? 'Archived — update email queued' : 'Archived'}</span>
+        <span class="decision-banner__meta">${esc(why)}</span>
+      </div>
+      <span class="decision-banner__actions">
+        <button class="decision-banner__undo" data-reopen="${a.id}">Reopen — back to Review</button>
+      </span>
+    </div>`;
+  };
+
   document.getElementById('review-body').innerHTML = `
-    ${rec ? `<div class="decision-banner decision-banner--${rec.d}">
+    ${archived ? archiveBanner() : rec ? `<div class="decision-banner decision-banner--${rec.d}">
       <div class="decision-banner__text">
         <span class="decision-banner__label">${DECISION_LABELS[rec.d]}</span>
         <span class="decision-banner__meta">${rec.reason ? esc(reasonLabel(rec.reason)) : 'No reason recorded'}${rec.byName ? ` · by ${esc(rec.byName)}` : ''}${rec.at ? ` · ${fmtDate(rec.at)}` : ''}</span>
@@ -1510,6 +1650,7 @@ function renderReview() {
     </div>
     ${reviewTab === 'emails' ? `<div id="emails-panel"><p class="notes__empty">Loading emails…</p></div>` : `
     <div id="review-ai">${matchBlockHtml(a)}</div>
+    ${voteSectionHtml(a)}
     ${section('About them', a.about)}
     ${section('Why Agape', a.why)}
     ${section('Gifts to share', a.gifts)}
@@ -1526,10 +1667,7 @@ function renderReview() {
     </section>`}
   `;
 
-  for (const d of ['pass', 'hold', 'outreach']) {
-    const btn = document.getElementById(`btn-${d}`);
-    btn.classList.toggle(`is-active--${d}`, rec?.d === d);
-  }
+  renderReviewFoot(a);
 
   if (reviewTab === 'emails') loadEmailsPanel(a);
   if (houseLoaded) ensureMatch(a);
@@ -1542,6 +1680,84 @@ function renderReview() {
     e.preventDefault();
     postNote(a.id);
   });
+}
+
+/* House votes in the review body. The tally stays hidden until you've cast
+   yours — no anchoring. */
+function voteSectionHtml(a) {
+  const list = votes[a.id] || [];
+  const mine = myVote(a.id);
+  const st = voteStats(a.id);
+  let body;
+  if (!list.length) {
+    body = `<p class="notes__empty">No votes yet — be the first.</p>`;
+  } else if (!mine && a.stage === 'review') {
+    body = `<p class="notes__empty">${list.length} vote${list.length === 1 ? '' : 's'} cast — the tally appears after you cast yours.</p>`;
+  } else {
+    const summary = st.veto
+      ? `Vetoed — auto-archived, update email queued.`
+      : st.scored
+        ? `${st.scored}/${voteMin()} votes · avg ${st.avg.toFixed(1)} · ${st.scored >= voteMin() && st.avg >= votePassAvg() ? 'passing' : `needs avg ≥ ${votePassAvg()}`}`
+        : '';
+    body = `${summary ? `<p class="vote-summary">${esc(summary)}</p>` : ''}
+      <ul class="notes__list">${list.map(v => `
+        <li class="note">
+          <span class="avatar">${esc((v.voter_name || '?')[0].toUpperCase())}</span>
+          <div class="note__body-wrap">
+            <div class="note__meta">
+              <span class="note__author">${esc(v.voter_name || 'Housemate')}</span>
+              <span class="note__time">${v.veto ? '<span class="vote-score vote-score--veto">Veto</span>' : `<span class="vote-score">${v.score}/5</span>`} · ${relTime(v.updated_at || v.created_at)}</span>
+            </div>
+            ${v.note ? `<p class="note__body">${esc(v.note)}</p>` : ''}
+          </div>
+        </li>`).join('')}</ul>`;
+  }
+  return `<section class="review__section notes">
+    <div class="notes__head"><h3 class="review__section-title">House votes</h3></div>
+    ${body}
+  </section>`;
+}
+
+/* Contextual footer: vote bar in review, recruiter actions for candidates,
+   reopen for archived. */
+function renderReviewFoot(a) {
+  const foot = document.getElementById('review-foot');
+  if (!foot) return;
+  const keepNote = document.getElementById('vote-note')?.value ?? null;
+  if (a.stage === 'review') {
+    const mine = myVote(a.id);
+    const sel = pendingVote || (mine ? { score: mine.score, veto: mine.veto } : { score: null, veto: false });
+    foot.innerHTML = `
+      <div class="vote-bar">
+        <span class="vote-bar__q">Would you live with them?</span>
+        <span class="vote-bar__scores">
+          ${[1, 2, 3, 4, 5].map(n =>
+            `<button type="button" class="vote-bar__score ${!sel.veto && sel.score === n ? 'is-on' : ''}" data-vote-score="${n}" aria-label="Vote ${n}">${n}</button>`).join('')}
+        </span>
+        <button type="button" class="vote-bar__veto ${sel.veto ? 'is-on' : ''}" data-vote-veto>${sel.veto ? 'Veto — tap to undo' : 'Veto'}</button>
+        <input type="text" class="listing-status vote-bar__note" id="vote-note" maxlength="500"
+          placeholder="${sel.veto ? 'Why the veto? (required)' : 'One line on why (optional)'}"
+          value="${esc(keepNote ?? mine?.note ?? '')}">
+        <button type="button" class="btn btn--accent vote-bar__cast" data-cast-vote>${mine ? 'Update vote' : 'Cast vote'}</button>
+      </div>`;
+  } else if (a.stage === 'candidate') {
+    foot.innerHTML = `
+      <button class="btn review__btn review__btn--notfit" data-open-decision="pass">Not a fit</button>
+      <button class="btn review__btn review__btn--place" data-open-decision="outreach">${decisions[a.id]?.d === 'outreach' ? 'Move listing' : 'Add to listing'}</button>`;
+  } else {
+    foot.innerHTML = `<button class="btn review__btn" data-reopen="${a.id}">Reopen — back to Review</button>`;
+  }
+}
+
+async function reopenApplicant(id) {
+  const a = applicants.find(x => x.id === id);
+  if (!a) return;
+  if (await setStage(id, 'review')) {
+    const st = voteStats(id);
+    toast(st.veto ? `Reopened — note: ${st.veto.voter_name || 'a housemate'}'s veto still stands until they change their vote` : 'Reopened — back in Review');
+    renderRailCounts();
+    if (!document.getElementById('review').hidden) renderReview(); else render();
+  }
 }
 
 function renderNotes(applicantId) {
@@ -1778,7 +1994,7 @@ function hideDecisionSheet() {
 }
 const hideHoldSheet = hideDecisionSheet; // step()/openReview() call this on navigation
 
-function submitDecision() {
+async function submitDecision() {
   const a = applicants.find(x => x.id === queue[qIndex]);
   if (!a || !pendingDecision) return;
   const d = pendingDecision;
@@ -1789,8 +2005,12 @@ function submitDecision() {
   const editing = sheetMode === 'edit';
   hideDecisionSheet();
   saveDecision(a.id, d, reason, null, note, listingId);
-  toast(`${fullName(a)} → ${DECISION_LABELS[d]}${d === 'outreach' ? ` · ${attachmentLabel(decisions[a.id])}` : (reason ? ` (${reasonLabel(reason)})` : '')}`);
+  // Recruiter "not a fit" on a candidate auto-archives — the update email is
+  // owed, same as a veto; outreach keeps them a candidate.
+  if (d === 'pass' && a.stage !== 'archived') await setStage(a.id, 'rejected');
+  toast(`${fullName(a)} → ${d === 'pass' ? 'Archived — update email queued' : DECISION_LABELS[d]}${d === 'outreach' ? ` · ${attachmentLabel(decisions[a.id])}` : (reason ? ` (${reasonLabel(reason)})` : '')}`);
   if (d === 'outreach') computeMatch(a.id); // refresh the AI suggestion in the background
+  renderRailCounts();
   if (editing) { renderReview(); return; }
   if (qIndex === queue.length - 1) closeReview(); else step(1);
 }
@@ -1842,12 +2062,14 @@ function stopDictation() {
 /* ---------- export ---------- */
 function exportCsv() {
   const cols = ['first', 'last', 'email', 'ts_iso', 'residency', 'movein', 'budget', 'source'];
-  const head = [...cols, 'decision', 'reason', 'decision_note', 'decided_by', 'decided_at', 'notes'];
+  const head = [...cols, 'stage', 'votes', 'vote_avg', 'vetoed', 'decision', 'reason', 'decision_note', 'decided_by', 'decided_at', 'notes'];
   const q = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
   const lines = [head.join(',')];
   for (const a of applicants) {
     const rec = decisions[a.id] || {};
-    lines.push([...cols.map(c => q(a[c])), q(DECISION_LABELS[rec.d] || ''),
+    const st = voteStats(a.id);
+    lines.push([...cols.map(c => q(a[c])), q(a.stage), q(st.n || 0), q(st.avg ? st.avg.toFixed(2) : ''),
+      q(st.veto ? (st.veto.voter_name || 'yes') : ''), q(DECISION_LABELS[rec.d] || ''),
       q(rec.reason ? reasonLabel(rec.reason) : ''), q(rec.note || ''),
       q(rec.byName || ''), q(rec.at || ''), q(commentCounts[a.id] || 0)].join(','));
   }
@@ -2055,15 +2277,16 @@ async function _checkMembershipAndEnter() {
     });
     resolveAvatars(); // background — server resolves any unchecked profile photos
     scanInbox();      // background — badge replies without opening each thread
-    const autoPassed = await applyAutoPass();
+    const autoFlagged = await applyAutoFlags();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;
     renderRailUser();
     handleGmailCallback();
-    view = new URLSearchParams(location.search).get('view') || 'inbox';
-    if (!VIEWS[view]) view = 'inbox';
+    view = new URLSearchParams(location.search).get('view') || 'review';
+    view = LEGACY_VIEWS[view] || view;
+    if (!VIEWS[view]) view = 'review';
     render();
-    if (autoPassed) toast(`${autoPassed} applicant${autoPassed === 1 ? '' : 's'} auto-archived (budget under $1,500)`);
+    if (autoFlagged) toast(`${autoFlagged} applicant${autoFlagged === 1 ? '' : 's'} auto-archived (budget under $1,500) — update emails queued`);
     const deep = new URLSearchParams(location.search).get('a');
     if (deep && applicants.some(x => x.id === deep)) openReview(deep);
   } catch (e) {
@@ -2121,8 +2344,40 @@ function init() {
     if (fclear) { filters = { track: 'all', month: 'any', budget: 'any' }; renderApplicants(); return; }
     const review = e.target.closest('[data-review]');
     if (review) { openReview(review.dataset.review); return; }
+    const vs = e.target.closest('[data-vote-score]');
+    if (vs) {
+      pendingVote = { score: +vs.dataset.voteScore, veto: false };
+      renderReviewFoot(applicants.find(x => x.id === queue[qIndex]));
+      return;
+    }
+    const vv = e.target.closest('[data-vote-veto]');
+    if (vv) {
+      pendingVote = { score: pendingVote?.score || null, veto: !(pendingVote?.veto ?? myVote(queue[qIndex])?.veto) };
+      renderReviewFoot(applicants.find(x => x.id === queue[qIndex]));
+      return;
+    }
+    const cv = e.target.closest('[data-cast-vote]');
+    if (cv) {
+      if (!pendingVote) {
+        const mine = myVote(queue[qIndex]);
+        pendingVote = mine ? { score: mine.score, veto: mine.veto } : null;
+      }
+      castVote(queue[qIndex]);
+      return;
+    }
+    const od = e.target.closest('[data-open-decision]');
+    if (od) { openDecisionSheet(od.dataset.openDecision); return; }
+    const ro = e.target.closest('[data-reopen]');
+    if (ro) { reopenApplicant(ro.dataset.reopen); return; }
     const clear = e.target.closest('[data-clear]');
-    if (clear) { saveDecision(clear.dataset.clear, null); renderReview(); return; }
+    if (clear) {
+      const a = applicants.find(x => x.id === clear.dataset.clear);
+      saveDecision(clear.dataset.clear, null);
+      // undoing an auto/manual archive puts them back in front of the house
+      if (a && a.stage === 'rejected') setStage(a.id, 'review').then(() => { renderRailCounts(); renderReview(); });
+      renderReview();
+      return;
+    }
     const cps = e.target.closest('[data-copy-schedule]');
     if (cps) {
       const a = applicants.find(x => x.id === cps.dataset.copySchedule);
@@ -2241,7 +2496,7 @@ function init() {
   });
 
   window.addEventListener('popstate', () => {
-    const v = new URLSearchParams(location.search).get('view') || 'inbox';
+    const v = new URLSearchParams(location.search).get('view') || 'review';
     setView(v, false);
   });
 
@@ -2301,9 +2556,6 @@ function init() {
   document.getElementById('review-close').onclick = closeReview;
   document.getElementById('review-prev').onclick = () => step(-1);
   document.getElementById('review-next').onclick = () => step(1);
-  document.getElementById('btn-pass').onclick = () => openDecisionSheet('pass');
-  document.getElementById('btn-outreach').onclick = () => openDecisionSheet('outreach');
-  document.getElementById('btn-hold').onclick = () => openDecisionSheet('hold');
   document.getElementById('decision-cancel').onclick = hideDecisionSheet;
   document.getElementById('decision-submit').onclick = submitDecision;
   document.getElementById('decision-mic').onclick = toggleDictation;

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -1,0 +1,48 @@
+# Agape recruiting funnel — collective review + staged pipeline
+
+**One line:** `/applications` moves from single-decider triage (Inbox → Outreach/Hold/Archive) to a staged funnel — Review (collective votes) → Candidates → Openings → Screening → Archive — with server-side stage computation.
+
+Status: **Phase A shipped (v3.0.0, migration 120)** · Phases B–D planned.
+
+---
+
+## The funnel
+
+1. **Someone applies** → lands in Review (`stage = 'review'`).
+2. **Application review** — quality of character + culture fit, judged collectively:
+   - 3+ Recruiting Society members score 1–5 ("would you live with them?").
+   - A single veto rejects — **auto-archived** immediately, update email owed.
+   - Auto-flags (budget < $1,500/mo; disqualifiers like pets as they're added) also auto-archive.
+   - Score ≥ threshold (avg ≥ 3.5 across ≥ 3 votes) → Candidates.
+   - Everyone who doesn't pass **receives an update email** (Phase B queue).
+3. **Room openings** — listings generated from the occupancy calendar; candidates bucketed into the listing that fits best (move-in date weighted heaviest). Same-date openings share one general pool; the room is assigned later. A Recruiting member sends the screening request from the listing shortlist.
+4. **Screening request** — availability asked in natural language; replies trigger the claim flow in `#recruiting-interviews` (see [agape-screening-claim-automation.md](./agape-screening-claim-automation.md), built in a parallel effort — `recruit-discord` is shared infrastructure).
+
+Out of scope for now (manual): post-screening accept/vote, house tour, onboarding (Notion, Google permissions, buddy matching).
+
+## Decisions taken (2026-07-22)
+
+| Question | Decision |
+|---|---|
+| Where do residents vote? | Hybrid — Discord ping links into the app; Discord-native voting revisited after the claim endpoint ships. |
+| Veto semantics | Separate toggle from the 1–5 scale; note required; tally blind until you cast your own vote. Veto/auto-flag → **immediate auto-archive**, no confirmation step. |
+| Rejection emails | Queued with one-click batch send (Phase B); flip to full-auto after a clean month. |
+| Auto-generated listings | Created as drafts from occupancy; one click to open; bucketing only sees `open` listings (Phase C). |
+
+## Technical shape
+
+**Migration 120** (`supabase/migrations/120_recruit_votes.sql`):
+- `recruit_applicants.stage` — `review | candidate | rejected | archived`. `rejected` = archived with an update email owed; `archived` = closed, nothing owed (historical backfill).
+- `recruit_votes` — one row per (applicant, voter); `score 1–5`, explicit `veto` (note required), RLS: members read all, write own.
+- Thresholds in `recruit_settings` (`vote_min_count = 3`, `vote_pass_avg = 3.5`).
+- Trigger `recruit_recompute_stage` on vote writes is the single source of truth; manual moves via `recruit_set_stage(applicant, stage)` RPC (applicants table stays read-only to clients).
+- Backfill: old decisions map outreach/hold → candidate, pass → archived.
+
+**Client (v3.0.0):** rail = Review / Candidates / Openings / Screening / Archive (+ Occupancy). Review overlay footer is contextual — vote bar (1–5 + veto + note) in Review, Not a fit / Add to listing for Candidates, Reopen for archived. Legacy URLs (`?view=inbox|outreach|hold`) redirect.
+
+## Phasing
+
+- **A (done):** voting core, stage machine, rail restructure.
+- **B:** Discord ping on new application; rejection-email queue + template in Archive (`recruit-gmail` gains a `rejection` kind; needs a `update_email_sent_at` marker).
+- **C:** auto-generate draft listings from occupancy gaps (`recruit_listings.source='auto'`, `pool_key` for same-date grouping); auto-bucket candidates via `recruit-match` on pool entry.
+- **D:** "Request screening" action + integration with the screening-claim automation.

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -4,6 +4,11 @@
 
 This is the "claim" model from the recruiting pipeline doc (first-to-claim runs the interview — no rotation, no paid round-robin), wired to plumbing that already exists in `/applications`.
 
+> Funnel context: this is step 4 of the staged pipeline in
+> [agape-recruiting-funnel.md](./agape-recruiting-funnel.md) (v3 funnel, migration 120).
+> The `recruit-discord` fn proposed below is shared infrastructure — the funnel's
+> Phase B new-application ping will post through the same function.
+
 ---
 
 ## What already exists (build on, don't rebuild)

--- a/supabase/migrations/120_recruit_votes.sql
+++ b/supabase/migrations/120_recruit_votes.sql
@@ -1,0 +1,137 @@
+-- ============================================
+-- Migration 120: application-review voting + applicant stage machine
+--
+-- Restructures review from one shared decision into collective voting:
+-- 3+ recruiting members score each applicant 1–5 ("would you live with
+-- them?"); a single veto rejects. Thresholds live in recruit_settings so
+-- the house can tune them without a deploy.
+--
+-- 1. recruit_applicants.stage — the funnel position, recomputed server-side
+--    by a trigger on votes (single source of truth; clients never write it
+--    directly, they call recruit_set_stage for manual overrides).
+--      review    — gathering votes (the old Inbox)
+--      candidate — passed review; waiting for / attached to a listing
+--      rejected  — vetoed, voted down, or auto-flagged; owes an update
+--                  email (queued surface lands in a later migration)
+--      archived  — closed out with nothing owed (historical imports,
+--                  manual archive)
+-- 2. recruit_votes — one row per (applicant, voter). Veto is explicit and
+--    separate from the 1–5 scale, and requires a note.
+-- 3. Threshold settings + trigger + recruit_set_stage RPC.
+-- 4. Backfill: existing shared decisions map onto stages
+--    (outreach/hold → candidate, pass → archived — no email owed for
+--    historical passes).
+-- ============================================
+
+ALTER TABLE recruit_applicants
+  ADD COLUMN IF NOT EXISTS stage TEXT NOT NULL DEFAULT 'review'
+  CHECK (stage IN ('review', 'candidate', 'rejected', 'archived'));
+CREATE INDEX IF NOT EXISTS idx_recruit_applicants_stage ON recruit_applicants(stage);
+
+CREATE TABLE IF NOT EXISTS recruit_votes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  voter_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  voter_name TEXT,
+  score SMALLINT CHECK (score BETWEEN 1 AND 5),
+  veto BOOLEAN NOT NULL DEFAULT false,
+  note TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (applicant_id, voter_id),
+  CHECK (veto OR score IS NOT NULL),           -- a non-veto vote needs a score
+  CHECK (NOT veto OR char_length(note) >= 3)   -- a veto needs a why
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_votes_applicant ON recruit_votes(applicant_id);
+
+ALTER TABLE recruit_votes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Recruiting members read votes" ON recruit_votes
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members insert own vote" ON recruit_votes
+  FOR INSERT TO authenticated
+  WITH CHECK (is_recruiting_member() AND voter_id = auth.uid());
+CREATE POLICY "Recruiting members update own vote" ON recruit_votes
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member() AND voter_id = auth.uid())
+  WITH CHECK (is_recruiting_member() AND voter_id = auth.uid());
+CREATE POLICY "Recruiting members delete own vote" ON recruit_votes
+  FOR DELETE TO authenticated
+  USING (is_recruiting_member() AND voter_id = auth.uid());
+
+INSERT INTO recruit_settings (key, value) VALUES
+  ('vote_min_count', '3'::jsonb),
+  ('vote_pass_avg', '3.5'::jsonb)
+  ON CONFLICT (key) DO NOTHING;
+
+-- Stage recompute — fires on any vote write. A veto rejects immediately
+-- (auto-archive per house rule); enough passing votes promote to candidate;
+-- otherwise the applicant stays in review. Manual 'archived' is never
+-- overridden by vote math.
+CREATE OR REPLACE FUNCTION recruit_recompute_stage()
+RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  aid TEXT := COALESCE(NEW.applicant_id, OLD.applicant_id);
+  cur TEXT;
+  min_count NUMERIC;
+  pass_avg NUMERIC;
+  n_scores INT;
+  avg_score NUMERIC;
+  any_veto BOOLEAN;
+  next_stage TEXT;
+BEGIN
+  SELECT stage INTO cur FROM recruit_applicants WHERE id = aid;
+  IF cur IS NULL OR cur = 'archived' THEN RETURN NULL; END IF;
+
+  SELECT COALESCE((value #>> '{}')::numeric, 3) INTO min_count FROM recruit_settings WHERE key = 'vote_min_count';
+  SELECT COALESCE((value #>> '{}')::numeric, 3.5) INTO pass_avg FROM recruit_settings WHERE key = 'vote_pass_avg';
+  min_count := COALESCE(min_count, 3);
+  pass_avg := COALESCE(pass_avg, 3.5);
+
+  SELECT COUNT(*) FILTER (WHERE NOT veto AND score IS NOT NULL),
+         AVG(score) FILTER (WHERE NOT veto),
+         COALESCE(BOOL_OR(veto), false)
+    INTO n_scores, avg_score, any_veto
+    FROM recruit_votes WHERE applicant_id = aid;
+
+  IF any_veto THEN next_stage := 'rejected';
+  ELSIF n_scores >= min_count AND avg_score >= pass_avg THEN next_stage := 'candidate';
+  ELSE next_stage := 'review';
+  END IF;
+
+  UPDATE recruit_applicants SET stage = next_stage
+    WHERE id = aid AND stage IS DISTINCT FROM next_stage;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_recruit_votes_stage ON recruit_votes;
+CREATE TRIGGER trg_recruit_votes_stage
+  AFTER INSERT OR UPDATE OR DELETE ON recruit_votes
+  FOR EACH ROW EXECUTE FUNCTION recruit_recompute_stage();
+
+-- Manual overrides (auto-flag disqualifiers, reopen from archive) go through
+-- this RPC — recruit_applicants itself stays read-only to clients.
+CREATE OR REPLACE FUNCTION recruit_set_stage(p_applicant TEXT, p_stage TEXT)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  IF p_stage NOT IN ('review', 'candidate', 'rejected', 'archived') THEN
+    RAISE EXCEPTION 'unknown stage %', p_stage;
+  END IF;
+  UPDATE recruit_applicants SET stage = p_stage WHERE id = p_applicant;
+END;
+$$;
+
+-- Backfill from the single-decision era. Historical passes owe no email.
+UPDATE recruit_applicants a SET stage = CASE d.decision
+    WHEN 'outreach' THEN 'candidate'
+    WHEN 'hold' THEN 'candidate'
+    ELSE 'archived'
+  END
+  FROM recruit_decisions d
+  WHERE d.applicant_id = a.id AND a.stage = 'review';


### PR DESCRIPTION
## Summary
- **Migration 120**: `recruit_votes` (1–5 score + explicit veto with required note), `recruit_applicants.stage` (`review/candidate/rejected/archived`), vote thresholds in `recruit_settings` (3 votes, avg ≥ 3.5), server-side stage trigger + `recruit_set_stage` RPC, backfill from legacy decisions.
- **App v3.0.0**: rail becomes the funnel — Review / Candidates / Openings / Screening / Archive. Review overlay footer is contextual: vote bar (tally blind until you cast), recruiter actions for candidates, reopen for archived.
- **Auto-archive**: a veto or an auto-flag (budget under $1,500) goes straight to Archive as `rejected` (update email owed — the Phase B queue reads this state).
- PRD: `docs/strategy/prds/agape-recruiting-funnel.md`; screening-claim PRD cross-referenced (shared `recruit-discord`).

## Test plan
- Migration applied to Boards project after merge.
- `node --check` on app.js; manual smoke of the five views + vote flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)