### PR TITLE
Occupancy: per-room costs + globally editable food & dues (v3.1.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1043,3 +1043,18 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .vote-summary { margin: 0 0 var(--space-3); font-size: var(--font-size-small); font-weight: var(--fw-semibold); color: var(--fg-muted); }
 .vote-score { font-weight: var(--fw-semibold); color: var(--fg); }
 .vote-score--veto { color: var(--error); }
+
+/* --- v3.1: room costs in the drawer --- */
+.occ-drawer__section {
+  margin-top: var(--space-2);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+  color: var(--fg-subtle); text-transform: uppercase; letter-spacing: 0.04em;
+}
+.occ-drawer__fact--sub dt { font-size: var(--font-size-caption); color: var(--fg-subtle); }
+.occ-drawer__fact--total { border-top: 1px solid var(--border); padding-top: var(--space-2); }
+.occ-drawer__fact--total dd { font-weight: var(--fw-semibold); }
+.occ-drawer__global {
+  display: block; font-size: var(--font-size-caption);
+  color: var(--fg-subtle); font-weight: 400;
+}
+.occ-drawer__cost { width: 90px; height: 32px; text-align: right; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.0.0">
+  <link rel="stylesheet" href="css/app.css?v=3.1.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -141,6 +141,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.0.1"></script>
+  <script src="js/app.js?v=3.1.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -7,7 +7,7 @@
    Openings (listing shortlists) → Screening → Archive. The applicant's
    stage column is recomputed server-side by a trigger on recruit_votes;
    manual moves go through the recruit_set_stage RPC. */
-const VERSION = '3.0.1';
+const VERSION = '3.1.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1174,10 +1174,26 @@ function roomDetailsHtml(r) {
     ['Share of private space', r.pct_private ? `${(+r.pct_private).toFixed(2)}%` : null],
   ].filter(([, v]) => v);
   const open = listings.filter(l => l.room_id === r.id && l.status === 'open');
+  const money = n => n != null && n !== '' ? '$' + Number(n).toLocaleString('en-US') : null;
+  const food = settings.food_monthly, dues = settings.dues_monthly;
+  const allIn = r.rent_monthly != null && food != null && dues != null
+    ? r.rent_monthly + Number(food) + Number(dues) : null;
+  const costsHtml = r.rent_monthly != null ? `
+    <div class="occ-drawer__section">Monthly costs</div>
+    <dl class="occ-drawer__facts">
+      <div class="occ-drawer__fact"><dt>Room (lease share)</dt><dd>${money(r.rent_monthly)}</dd></div>
+      ${r.rent_private != null && r.rent_public ? `<div class="occ-drawer__fact occ-drawer__fact--sub"><dt>${money(r.rent_private)} private + ${money(r.rent_public)} shared</dt><dd></dd></div>` : ''}
+      <div class="occ-drawer__fact"><dt>Food <span class="occ-drawer__global">per person · global</span></dt>
+        <dd><input type="number" class="listing-status occ-drawer__cost" data-cost-setting="food_monthly" value="${food ?? ''}" min="0" max="2000" step="5"></dd></div>
+      <div class="occ-drawer__fact"><dt>Communal dues <span class="occ-drawer__global">per person · global</span></dt>
+        <dd><input type="number" class="listing-status occ-drawer__cost" data-cost-setting="dues_monthly" value="${dues ?? ''}" min="0" max="5000" step="5"></dd></div>
+      ${allIn != null ? `<div class="occ-drawer__fact occ-drawer__fact--total"><dt>All-in, one person</dt><dd>${money(allIn)}/mo</dd></div>` : ''}
+    </dl>` : '';
   return `
     <dl class="occ-drawer__facts">
       ${facts.map(([k, v]) => `<div class="occ-drawer__fact"><dt>${k}</dt><dd>${esc(String(v))}</dd></div>`).join('')}
     </dl>
+    ${costsHtml}
     ${r.details_notes ? `<p class="occ-drawer__note">${esc(r.details_notes)}</p>` : ''}
     ${open.length ? `<div class="occ-drawer__listings">
       ${open.map(l => `<p class="occ-drawer__note">Open listing: ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}
@@ -2463,6 +2479,20 @@ function init() {
   document.addEventListener('change', e => {
     const sel = e.target.closest('[data-listing-status]');
     if (sel) updateListingStatus(sel.dataset.listingStatus, sel.value);
+    const cost = e.target.closest('[data-cost-setting]');
+    if (cost) {
+      const key = cost.dataset.costSetting;
+      const value = cost.value === '' ? null : Math.round(+cost.value);
+      if (value === null || value < 0) return;
+      settings[key] = value;
+      sb.from('recruit_settings').upsert({
+        key, value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+      }).then(({ error }) => {
+        if (error) toast(`Save failed: ${error.message}`);
+        else toast('Global cost updated — applies to everyone');
+      });
+      renderOccDrawer();
+    }
   });
 
   // Re-fit the timeline when the viewport crosses the phone breakpoint.

--- a/supabase/migrations/122_recruit_room_costs.sql
+++ b/supabase/migrations/122_recruit_room_costs.sql
@@ -1,0 +1,41 @@
+-- ============================================
+-- Agape recruiting: room costs + global per-person dues
+-- Migration 122
+--
+-- Per-room lease contribution from the "Agape Occupancy & Rent Calculator"
+-- sheet (Current System tab, effective July 2026): private share (by sq ft)
+-- + public share (equal per room). Food and communal membership dues are the
+-- same for every person, so they live in recruit_settings and are editable
+-- from the room drawer.
+-- ============================================
+
+ALTER TABLE recruit_rooms
+  ADD COLUMN IF NOT EXISTS rent_monthly INT,    -- lease total (private + public)
+  ADD COLUMN IF NOT EXISTS rent_private INT,    -- sq-ft-weighted share
+  ADD COLUMN IF NOT EXISTS rent_public INT;     -- equal per-room share
+
+UPDATE recruit_rooms AS r SET
+  rent_monthly = v.lease, rent_private = v.priv, rent_public = v.pub
+FROM (VALUES
+  (1,  1221, 519,  702),
+  (2,  1163, 461,  702),
+  (3,  1376, 675,  702),
+  (4,  1508, 806,  702),
+  (5,  1265, 563,  702),
+  (6,  1200, 499,  702),
+  (7,  1608, 907,  702),
+  (8,  1210, 508,  702),
+  (9,  1329, 627,  702),
+  (10, 1712, 1011, 702),
+  (11, 1294, 592,  702),
+  (12, 1519, 817,  702),
+  (13, 3112, 2411, 702),
+  (14, 984,  984,  0)
+) AS v(id, lease, priv, pub)
+WHERE r.id = v.id;
+
+-- Global per-person monthly costs (same for everyone).
+INSERT INTO recruit_settings (key, value) VALUES
+  ('food_monthly', '250'::jsonb),
+  ('dues_monthly', '450'::jsonb)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Room drawer gains a **Monthly costs** section:
- **Room (lease share)** per room from the Current System tab of the rent-calculator sheet (private sq-ft share + $702 public share), stored on `recruit_rooms` — migration 122, already applied and seeded.
- **Food ($250)** and **communal dues ($450)** are per-person and the same for everyone — stored once in `recruit_settings`, editable inline from any room's drawer (change saves globally with a toast).
- **All-in, one person** total (lease + food + dues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)