### PR TITLE
Recruiting v3.2.1: placements require dates to line up

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.2.0">
+  <link rel="stylesheet" href="css/app.css?v=3.2.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -140,6 +140,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.2.0"></script>
+  <script src="js/app.js?v=3.2.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.2.0';
+const VERSION = '3.2.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -454,17 +454,29 @@ function qualifiesFor(a, l) {
   if (isSublet(a) !== (l.kind === 'sublet')) return false;
   const bm = budgetMax(a.budget);
   if (bm !== null && l.rent_monthly != null && bm < l.rent_monthly) return false;
+  // Dates have to line up. Only an explicit "flexible" rides any window;
+  // ASAP only fits a room opening within the month after now; stated dates
+  // must fall inside the listing's actual window (a resident trial's window
+  // is its start month — that's when the room is free).
+  const norm = normalizeMoveIn(a);
+  if (/flexible/i.test(norm || '')) return true;
+  const startMonth = l.starts_on.slice(0, 7);
+  const endMonth = l.ends_on ? l.ends_on.slice(0, 7) : startMonth;
+  if (/^ASAP/.test(norm || '')) {
+    const now = new Date();
+    const cur = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    return startMonth >= cur && startMonth <= monthShift(cur, 1);
+  }
   const range = moveInRange(a);
-  if (!range) return true;
-  const listLo = monthShift(l.starts_on.slice(0, 7), -1); // a month early is fine
-  const listHi = l.ends_on ? l.ends_on.slice(0, 7) : monthShift(l.starts_on.slice(0, 7), 2);
-  return range.hi >= listLo && range.lo <= listHi;
+  if (!range) return false; // no parseable dates — can't confirm they line up
+  return range.hi >= startMonth && range.lo <= endMonth;
 }
 
 const activePlacements = id => placements.filter(p => p.applicant_id === id && p.status === 'active');
 
-/* Insert missing placements for every candidate; never resurrects rows a
-   recruiter removed (tombstones stay). Returns how many were added. */
+/* Insert missing placements for every candidate AND prune auto rows that no
+   longer qualify (rule changes, edited listings, stage moves). Never touches
+   manual placements or tombstones a recruiter removed. Returns adds. */
 async function syncAutoPlacements() {
   if (!houseLoaded) return 0;
   const have = new Set(placements.map(p => `${p.applicant_id}:${p.listing_id}`));
@@ -474,6 +486,20 @@ async function syncAutoPlacements() {
       if (!have.has(`${a.id}:${l.id}`) && qualifiesFor(a, l)) {
         fresh.push({ applicant_id: a.id, listing_id: l.id, source: 'auto' });
       }
+    }
+  }
+  const stale = placements.filter(p => {
+    if (p.source !== 'auto' || p.status !== 'active') return false;
+    const a = applicants.find(x => x.id === p.applicant_id);
+    const l = listings.find(x => x.id === p.listing_id);
+    return !a || !l || a.stage !== 'candidate' || !qualifiesFor(a, l);
+  });
+  if (stale.length) {
+    const { error } = await sb.from('recruit_listing_candidates').delete().in('id', stale.map(r => r.id));
+    if (error) console.warn('placement prune failed', error.message);
+    else {
+      const gone = new Set(stale.map(r => r.id));
+      placements = placements.filter(p => !gone.has(p.id));
     }
   }
   if (!fresh.length) return 0;

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -7,7 +7,7 @@ Status: **Phase A shipped (v3.0.0, migration 120); auto-placement shipped early 
 ### v3.2.0 amendments (2026-07-22)
 - "Review" is named **Inbox**; Openings sits in the House rail group under Occupancy.
 - Legacy Hold applicants went back to Inbox — hold ≠ passed review.
-- **AI listing suggestions removed** from profiles. Replaced by deterministic auto-placement: candidates land in **every** open listing they qualify for (`recruit_listing_candidates`; qualification = track match, budget ≥ rent when both known, move-in window overlaps listing window ±1 month; flexible/unknown move-in qualifies on track). Recruiter removals are tombstoned so the sweep never re-adds them. This delivers most of old Phase C — remaining Phase C scope is only auto-*generating* draft listings from occupancy gaps.
+- **AI listing suggestions removed** from profiles. Replaced by deterministic auto-placement: candidates land in **every** open listing they qualify for (`recruit_listing_candidates`; qualification = track match, budget ≥ rent when both known, move-in dates must fall inside the listing window — no padding; only explicit "flexible" rides any window, ASAP fits rooms opening within a month, unparseable dates never auto-place). Recruiter removals are tombstoned so the sweep never re-adds them. This delivers most of old Phase C — remaining Phase C scope is only auto-*generating* draft listings from occupancy gaps.
 
 ---
 


### PR DESCRIPTION
Tightens auto-placement qualification per house feedback (candidates in listings whose dates don't match):
- Stated move-in must fall **inside** the listing window — the ±1 month padding is gone; a resident trial's window is its start month.
- ASAP only matches rooms opening within a month of today; unparseable move-ins never auto-place; explicit "flexible" still qualifies anywhere on its track.
- The sweep now also **prunes** stale auto-placements that fail the rule, so existing wrong rows clean themselves up on next load. Manual placements and recruiter tombstones are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)