### PR TITLE
Per-pipeline Anthropic key for events functions

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -226,7 +226,9 @@ Accessed via `Deno.env.get('KEY')`:
 
 | Variable | Required By |
 |----------|-------------|
-| `ANTHROPIC_API_KEY` | enrich-link, generate-widget, categorize, agent-handler |
+| `ANTHROPIC_API_KEY` | enrich-link, generate-widget, categorize, agent-handler (shared fallback; console key `taste-graph`) |
+| `EVENTS_ANTHROPIC_API_KEY` | enrich-event, scrape-discord-events, recommend-events, add-event (console key `events-pipeline`; falls back to `ANTHROPIC_API_KEY` if unset) |
+| `LADDER_ANTHROPIC_API_KEY` | Ladder functions (console key `ladder-jobs`; falls back to `ANTHROPIC_API_KEY` if unset) |
 | `OPENAI_API_KEY` | generate-widget (fallback) |
 | `SUPABASE_URL` | All functions (auto-set by Supabase) |
 | `SUPABASE_SERVICE_ROLE_KEY` | enrich-link, notion-sync (bypasses RLS) |
@@ -241,7 +243,7 @@ Set in repository Settings → Secrets:
 | `SUPABASE_URL` | notion-sync job |
 | `SUPABASE_SERVICE_KEY` | notion-sync job |
 | `NOTION_API_KEY` | notion-sync job |
-| `ANTHROPIC_API_KEY` | agent jobs |
+| `ANTHROPIC_API_KEY` | agent jobs (console key `agents-automation`) |
 
 ### Client-Side
 

--- a/supabase/functions/add-event/index.ts
+++ b/supabase/functions/add-event/index.ts
@@ -13,7 +13,7 @@
 // Body: { url: string }
 // Returns: { event, visibility, merged: boolean }
 
-const VERSION = '1.0.1'
+const VERSION = '1.0.2'
 console.log(`[add-event] v${VERSION} - PT-local date anchor + Z-timestamp handling`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -184,7 +184,7 @@ serve(async (req: Request) => {
     let extracted = extractJsonLd(html)
     let method = 'json-ld'
     if (!extracted) {
-      const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+      const apiKey = Deno.env.get('EVENTS_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
       if (!apiKey) return json({ error: 'No structured event data found on page' }, 422)
       extracted = await extractWithAI(html, url, apiKey)
       method = 'ai'

--- a/supabase/functions/enrich-event/index.ts
+++ b/supabase/functions/enrich-event/index.ts
@@ -204,7 +204,7 @@ async function classifyWithAI(event: {
   name: string, venue: string, genre: string, content_type: string,
   description: string, tags: string[]
 }): Promise<{ genre: string, content_type: string, music_type: string | null } | null> {
-  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  const apiKey = Deno.env.get('EVENTS_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
   if (!apiKey) {
     console.log('[enrich-event] ANTHROPIC_API_KEY not set, skipping AI classification')
     return null

--- a/supabase/functions/recommend-events/index.ts
+++ b/supabase/functions/recommend-events/index.ts
@@ -10,7 +10,7 @@
 // Body: { profile: { categories, artists, genres, keywords, domains, contentTypes, tasteContext? }, filters? }
 // Returns: { events: [...], meta: { eventsScanned, profileSignals, algorithm } }
 
-const VERSION = '1.2.0'
+const VERSION = '1.2.1'
 console.log(`[recommend-events] v${VERSION} — taste-engine DB context`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -300,7 +300,7 @@ async function rankEventsWithAI(
   profile: EventProfile,
   maxResults: number
 ): Promise<{ rankings: Array<{ event_index: number; score: number; reasons: string[] }>, confidence: number }> {
-  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  const apiKey = Deno.env.get('EVENTS_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
   if (!apiKey) {
     console.warn('[recommend-events] No ANTHROPIC_API_KEY, falling back to keyword-only')
     return { rankings: [], confidence: 0 }

--- a/supabase/functions/scrape-discord-events/index.ts
+++ b/supabase/functions/scrape-discord-events/index.ts
@@ -517,7 +517,7 @@ async function scrapeAndCache(
 ): Promise<{ events: ExtractedEvent[]; meta: Record<string, unknown> }> {
   const botToken = Deno.env.get('DISCORD_BOT_TOKEN')
   if (!botToken) throw new Error('DISCORD_BOT_TOKEN not configured')
-  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  const apiKey = Deno.env.get('EVENTS_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured')
 
   console.log(`Scraping channel ${channelId} (${lookbackDays}d lookback)`)


### PR DESCRIPTION
Splits events-pipeline Claude usage onto its own API key for cost visibility.

- `enrich-event` v1.3.2, `scrape-discord-events` v1.5.1, `recommend-events` v1.2.1, `add-event` v1.0.2 now read `EVENTS_ANTHROPIC_API_KEY` first, falling back to the shared `ANTHROPIC_API_KEY` (same pattern as `LADDER_ANTHROPIC_API_KEY`)
- deployment.md documents the env-var → console-key mapping (taste-graph / events-pipeline / ladder-jobs / agents-automation)

Safe to merge before the secret exists — fallback keeps current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)