### PR TITLE
feat(recruiting): claim-post copy, real names, interview DM reminders

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -57,6 +57,11 @@ export function slotLabel(d: Date): string {
   return `${day} · ${time}`
 }
 
+// Prose variant for sentences: "Thu, Jul 23 at 9:30a"
+export function slotWhen(d: Date): string {
+  return slotLabel(d).replace(' · ', ' at ')
+}
+
 export interface Slot { start: string; label: string }
 
 // Windows → up to 8 concrete 30-min slots. Round-robin across windows so one
@@ -188,14 +193,18 @@ export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promis
   return row
 }
 
-// Close a claimed post: strip buttons, green "claimed" embed.
+// Close a claimed post: strip buttons, green interview announcement.
 export async function editClaimMessageClaimed(
-  channelId: string, messageId: string, claimerDiscordId: string, label: string,
+  channelId: string, messageId: string, claimerDiscordId: string,
+  applicantName: string, applicantId: string, when: string,
 ): Promise<void> {
   await discordFetch(`/channels/${channelId}/messages/${messageId}`, {
     method: 'PATCH',
     body: JSON.stringify({
-      embeds: [{ description: `✅ **Claimed by <@${claimerDiscordId}>** — ${label} · invite sent`, color: 0x2ecc71 }],
+      embeds: [{
+        description: `✅ <@${claimerDiscordId}> will be interviewing **${applicantName}** on ${when} — [see the candidate background here](${appLink(applicantId)}).`,
+        color: 0x2ecc71,
+      }],
       components: [],
     }),
   })
@@ -203,12 +212,16 @@ export async function editClaimMessageClaimed(
 
 // Mark a claimed post that hit an error downstream (calendar etc.).
 export async function editClaimMessageFailed(
-  channelId: string, messageId: string, claimerDiscordId: string, label: string,
+  channelId: string, messageId: string, claimerDiscordId: string,
+  applicantId: string, when: string,
 ): Promise<void> {
   await discordFetch(`/channels/${channelId}/messages/${messageId}`, {
     method: 'PATCH',
     body: JSON.stringify({
-      embeds: [{ description: `⚠️ **Claimed by <@${claimerDiscordId}>** — ${label}, but the calendar invite failed. Book manually in the app.`, color: 0xe74c3c }],
+      embeds: [{
+        description: `⚠️ <@${claimerDiscordId}> claimed this interview (${when}) but the calendar invite failed — [book manually in the app](${appLink(applicantId)}).`,
+        color: 0xe74c3c,
+      }],
       components: [],
     }),
   })

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,13 +13,13 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.0.0'
-console.log(`[recruit-discord] v${VERSION} — screening-claim interactions endpoint`)
+const VERSION = '1.1.0'
+console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { scheduleScreening, sendApplicantConfirmation } from '../_shared/recruit-schedule.ts'
-import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel } from '../_shared/discord.ts'
+import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
 
@@ -100,14 +100,18 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
       applicantId, startsAt, housemateUserId: opts.userId, housemateName, housemateEmail,
     })
 
-    await editClaimMessageClaimed(claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId, label)
+    const applicantName = `${applicant.first_name} ${applicant.last_name || ''}`.trim()
+    await editClaimMessageClaimed(
+      claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId,
+      applicantName, applicantId, slotWhen(startsAt),
+    )
 
     const platform = claimPost.platform as { kind?: string; handle?: string } | null
     const platformLine = platform?.kind
       ? `\nHeads up: they asked for ${platform.kind}${platform.handle ? ` (@${platform.handle})` : ''} — default is the Meet link, but feel free to DM them about it.`
       : ''
     await dmUser(opts.discordUserId,
-      `✅ You claimed **${applicant.first_name}**'s screening call — ${label}.\n` +
+      `✅ You claimed **${applicantName}**'s screening call — ${slotWhen(startsAt)}.\n` +
       `Calendar invites are out to you both. Meet: ${meetLink || '(see calendar invite)'}${platformLine}`)
 
     try {
@@ -120,7 +124,7 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     // Never reopen the post (avoids double-booking) — flag it and tell the claimer.
     console.error(`[recruit-discord] claim finish failed for ${applicantId}: ${(err as Error).message}`)
     try {
-      await editClaimMessageFailed(claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId, label)
+      await editClaimMessageFailed(claimPost.discord_channel_id, claimPost.discord_message_id, opts.discordUserId, applicantId, slotWhen(startsAt))
     } catch { /* best effort */ }
     try {
       await dmUser(opts.discordUserId,
@@ -176,8 +180,50 @@ async function handleClaim(interaction: Record<string, any>): Promise<Response> 
   return json(DEFERRED_UPDATE)
 }
 
+// DM each claimer ~an hour before their interview. Invoked by pg_cron every
+// 15 min via POST /recruit-discord/remind with X-Cron-Secret (migration 122).
+async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
+  const now = Date.now()
+  const { data: upcoming } = await client.from('recruit_screenings')
+    .select('id, applicant_id, housemate_user_id, starts_at, meet_link')
+    .eq('status', 'scheduled').is('reminder_sent_at', null)
+    .gte('starts_at', new Date(now).toISOString())
+    .lte('starts_at', new Date(now + 65 * 60000).toISOString())
+  let sent = 0
+  for (const s of (upcoming || [])) {
+    try {
+      const [{ data: applicant }, { data: dm }] = await Promise.all([
+        client.from('recruit_applicants').select('first_name, last_name').eq('id', s.applicant_id).maybeSingle(),
+        client.from('user_discord_membership').select('discord_user_id').eq('user_id', s.housemate_user_id).maybeSingle(),
+      ])
+      if (dm?.discord_user_id && applicant) {
+        const name = `${applicant.first_name} ${applicant.last_name || ''}`.trim()
+        await dmUser(dm.discord_user_id,
+          `⏰ Coming up: you're interviewing **${name}** at ${slotWhen(new Date(s.starts_at))} PT.\n` +
+          `Meet: ${s.meet_link || '(see calendar invite)'}\n` +
+          `Background: https://ctrl.rodeo/applications/?id=${encodeURIComponent(s.applicant_id)}`)
+        sent++
+      }
+      // Stamp even without a Discord id so we don't retry forever.
+      await client.from('recruit_screenings').update({ reminder_sent_at: new Date().toISOString() }).eq('id', s.id)
+    } catch (err) {
+      console.warn(`[recruit-discord] reminder failed for screening ${s.id}: ${(err as Error).message}`)
+    }
+  }
+  return sent
+}
+
 serve(async (req) => {
   try {
+    // Cron path: interview reminders (header auth, not Discord-signed).
+    if (new URL(req.url).pathname.endsWith('/remind')) {
+      const secret = Deno.env.get('CRON_SECRET')
+      if (!secret || req.headers.get('x-cron-secret') !== secret) return json({ error: 'unauthorized' }, 401)
+      const sent = await remindUpcoming(db())
+      console.log(`[recruit-discord] reminder sweep: ${sent} DM(s) sent`)
+      return json({ reminded: sent })
+    }
+
     const body = await req.text()
     if (!(await verifySignature(req, body))) {
       return json({ error: 'invalid request signature' }, 401)

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.4.0'
+const VERSION = '1.4.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendApplicantConfirmation, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel } from '../_shared/discord.ts'
+import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -345,7 +345,10 @@ serve(async (req) => {
         if (post) {
           const { data: dm } = await client.from('user_discord_membership')
             .select('discord_user_id').eq('user_id', userData.user.id).maybeSingle()
-          if (dm?.discord_user_id) await editClaimMessageClaimed(post.discord_channel_id, post.discord_message_id, dm.discord_user_id, label)
+          if (dm?.discord_user_id) {
+            const applicantName = `${result.applicant.first_name} ${result.applicant.last_name || ''}`.trim()
+            await editClaimMessageClaimed(post.discord_channel_id, post.discord_message_id, dm.discord_user_id, applicantName, applicantId, slotWhen(startsAt))
+          }
         }
       } catch (err) {
         console.warn(`claim post close failed for ${applicantId}: ${(err as Error).message}`)

--- a/supabase/migrations/122_screening_reminders.sql
+++ b/supabase/migrations/122_screening_reminders.sql
@@ -1,0 +1,34 @@
+-- ============================================
+-- Migration 122: interview DM reminders
+--
+-- pg_cron pings recruit-discord/remind every 15 min; the fn DMs each
+-- claimer ~an hour before their screening call. reminder_sent_at makes
+-- the DM once-only. Auth mirrors pull-recommendations: X-Cron-Secret
+-- header = app.cron_secret DB setting = CRON_SECRET fn env.
+-- ============================================
+
+ALTER TABLE recruit_screenings ADD COLUMN IF NOT EXISTS reminder_sent_at TIMESTAMPTZ;
+
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'recruit_screening_reminder_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end$$;
+
+select cron.schedule(
+  'recruit_screening_reminder_tick',
+  '*/15 * * * *',
+  $$
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord/remind',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'X-Cron-Secret', current_setting('app.cron_secret', true)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+  $$
+);


### PR DESCRIPTION
Follow-up to #1179 from live testing.

- **Claimed-post copy**: now "✅ @claimer will be interviewing **{Applicant Name}** on Thu, Jul 23 at 9:30a — see the candidate background here" (links to the applicant in /applications). Failure variant updated to match.
- **Real names**: applicant full name everywhere; resident names resolve from `recruit_profiles.display_name` (Ian's set to his real name via SQL — other residents can set theirs in the app; Discord username stays the fallback).
- **Interview reminders**: `recruit-discord` v1.1.0 adds a `/remind` endpoint (X-Cron-Secret auth, mirroring pull-recommendations); migration 122 adds `reminder_sent_at` + a pg_cron tick every 15 min. Claimers get a DM ~an hour before with the Meet link + candidate background link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)