### PR TITLE
fix(recruiting): secretless nonce auth for the reminder cron

### DIFF
--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -216,10 +216,22 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
 serve(async (req) => {
   try {
     // Cron path: interview reminders (header auth, not Discord-signed).
+    // Auth: X-Cron-Secret when CRON_SECRET is configured, else the one-time
+    // nonce minted by the pg_cron tick (migration 123) — delete-on-use.
     if (new URL(req.url).pathname.endsWith('/remind')) {
+      const client = db()
       const secret = Deno.env.get('CRON_SECRET')
-      if (!secret || req.headers.get('x-cron-secret') !== secret) return json({ error: 'unauthorized' }, 401)
-      const sent = await remindUpcoming(db())
+      let authorized = Boolean(secret) && req.headers.get('x-cron-secret') === secret
+      const nonce = req.headers.get('x-cron-nonce')
+      if (!authorized && nonce && /^[0-9a-f-]{36}$/i.test(nonce)) {
+        const { data: burned } = await client.from('recruit_cron_nonce')
+          .delete().eq('nonce', nonce)
+          .gte('created_at', new Date(Date.now() - 10 * 60000).toISOString())
+          .select().maybeSingle()
+        authorized = Boolean(burned)
+      }
+      if (!authorized) return json({ error: 'unauthorized' }, 401)
+      const sent = await remindUpcoming(client)
       console.log(`[recruit-discord] reminder sweep: ${sent} DM(s) sent`)
       return json({ reminded: sent })
     }

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.1.0'
+const VERSION = '1.1.1'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/migrations/123_cron_nonce_auth.sql
+++ b/supabase/migrations/123_cron_nonce_auth.sql
@@ -1,0 +1,46 @@
+-- ============================================
+-- Migration 123: nonce auth for the reminder cron
+--
+-- CRON_SECRET / app.cron_secret are not configured on this project, so the
+-- X-Cron-Secret path in migration 122 never authenticates. Replace it with a
+-- secretless one-time-nonce handshake: each tick INSERTs a UUID into a
+-- service-role-only table and sends it as X-Cron-Nonce; recruit-discord
+-- consumes it (delete-on-use, 10-minute expiry). If CRON_SECRET is ever set,
+-- the fn still accepts X-Cron-Secret as an alternative.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_cron_nonce (
+  nonce UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE recruit_cron_nonce ENABLE ROW LEVEL SECURITY;
+-- No policies on purpose: only service role (the edge fn) and postgres (cron) touch it.
+
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'recruit_screening_reminder_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end$$;
+
+select cron.schedule(
+  'recruit_screening_reminder_tick',
+  '*/15 * * * *',
+  $$
+  with purge as (
+    delete from recruit_cron_nonce where created_at < now() - interval '1 hour'
+  ), n as (
+    insert into recruit_cron_nonce default values returning nonce
+  )
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord/remind',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'X-Cron-Nonce', (select nonce::text from n)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+  $$
+);


### PR DESCRIPTION
CRON_SECRET / app.cron_secret turn out to be unset on the Boards project (pull-recommendations only enforces its secret when the env var exists), so migration 122's reminder tick could never authenticate — the /remind endpoint correctly 401'd.

Migration 123 replaces the tick's auth with a one-time nonce: each pg_cron run INSERTs a UUID into service-role-only `recruit_cron_nonce` and sends it as `X-Cron-Nonce`; recruit-discord v1.1.1 burns it on use (delete-on-use, 10-min expiry, hourly purge). `X-Cron-Secret` still accepted if CRON_SECRET is ever configured.

No secrets created or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)