### PR TITLE
Recruiting v3.5: row-state polish + design documentation

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1107,3 +1107,40 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .listing-allin { font-weight: var(--fw-semibold); cursor: help; }
 .listing-others { margin-top: var(--space-2); }
 .listing-others summary { color: var(--fg-subtle); font-size: var(--font-size-small); cursor: pointer; }
+
+/* --- v3.5.0: row-state polish — response dot, note bubble, ✕, see-more bar --- */
+.inbox-row { position: relative; }
+.replied-dot {
+  position: absolute; left: 5px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent);
+}
+.note-bubble {
+  position: relative; width: 22px; height: 22px;
+  color: var(--accent); flex-shrink: 0; display: inline-block;
+}
+.note-bubble svg { width: 100%; height: 100%; display: block; }
+.note-bubble__n {
+  position: absolute; left: 0; right: 0; top: 2px; height: 14px;
+  display: grid; place-items: center;
+  font-size: 10px; font-weight: var(--fw-bold);
+  color: var(--accent-fg);
+}
+.row-x {
+  border: 0; background: none; padding: 4px 8px;
+  color: var(--fg-subtle); font-size: 14px; line-height: 1;
+  cursor: pointer; border-radius: var(--radius-pill);
+}
+.row-x:hover { color: var(--error); background: var(--bg-overlay); }
+.listing-others { margin-top: 0; }
+.listing-others > summary {
+  list-style: none;
+  display: flex; justify-content: center; align-items: center; gap: 8px;
+  width: 100%; padding: 10px 0 var(--space-2);
+  color: var(--fg-muted); font-size: var(--font-size-small); font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+.listing-others > summary::-webkit-details-marker { display: none; }
+.listing-others > summary:hover { color: var(--fg); }
+.listing-others__chev { font-size: 12px; transition: transform 120ms ease; }
+.listing-others[open] .listing-others__chev { transform: rotate(180deg); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.4.0">
+  <link rel="stylesheet" href="css/app.css?v=3.5.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -140,6 +140,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.4.0"></script>
+  <script src="js/app.js?v=3.5.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.4.0';
+const VERSION = '3.5.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -343,6 +343,25 @@ function avatarHtml(a, large) {
   const px = large ? 112 : 56;
   const src = `https://images.weserv.nl/?url=${encodeURIComponent(a.avatarUrl.replace(/^https:\/\//, ''))}&w=${px}&h=${px}&fit=cover`;
   return `<span class="${cls}">${esc(initials(a))}<img class="avatar__img" src="${esc(src)}" alt="" loading="lazy" onerror="this.remove()"></span>`;
+}
+
+/* Blue response dot in the row's left gutter — sits beside the avatar,
+   never on top of it. */
+function repliedDot(a) {
+  const st = emailState[a.id];
+  if (st?.lastDir !== 'in') return '';
+  return `<span class="replied-dot" title="They replied — ${relTime(st.lastAt)}"></span>`;
+}
+
+/* Filled square speech bubble (tail centered on the bottom) with the note
+   count inside — louder than the old pencil count. */
+function noteBubble(id) {
+  const n = commentCounts[id];
+  if (!n) return '';
+  return `<span class="note-bubble" title="${n} house note${n === 1 ? '' : 's'}">
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 3h14a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-4.6L12 21l-2.4-4H5a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3z"/></svg>
+    <b class="note-bubble__n">${n}</b>
+  </span>`;
 }
 
 /* Kick server-side resolution for anyone not yet checked (fire-and-forget;
@@ -865,10 +884,19 @@ function screeningChip(a) {
   return `<span class="decision-chip decision-chip--vote">Availability received</span>`;
 }
 
+/* One pill per room they're placed in, with the room's open date. Falls
+   back to a count before house data lands. */
 function placementChip(a) {
-  const n = activePlacements(a.id).length;
-  if (!n) return '';
-  return `<span class="decision-chip decision-chip--outreach" title="Placed in ${n} open listing${n === 1 ? '' : 's'} — see Openings">In ${n} listing${n === 1 ? '' : 's'}</span>`;
+  const active = activePlacements(a.id);
+  if (!active.length) return '';
+  if (!houseLoaded) return `<span class="decision-chip decision-chip--outreach">In ${active.length} listing${active.length === 1 ? '' : 's'}</span>`;
+  return active.map(p => {
+    const l = listings.find(x => x.id === p.listing_id);
+    if (!l || l.status !== 'open') return '';
+    const room = rooms.find(r => r.id === l.room_id);
+    const d = new Date(l.starts_on + 'T12:00');
+    return `<span class="decision-chip decision-chip--outreach" title="${esc(`${room?.name || 'Room'} — ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}`)}">${esc(room?.name || 'Room')} · ${d.getMonth() + 1}/${d.getDate()}</span>`;
+  }).join('');
 }
 
 function rowBadge(a) {
@@ -982,6 +1010,7 @@ function renderApplicants() {
         ${g.items.map(a => `
           <li class="inbox-row" ${view === 'openings' ? `draggable="true" data-row-id="${a.id}" data-row-group="${esc(g.key)}"` : ''}>
             ${view === 'openings' ? '<span class="inbox-row__grip" title="Drag to reorder">⠿</span>' : ''}
+            ${repliedDot(a)}
             <button class="inbox-row__main" data-review="${a.id}">
               ${avatarHtml(a)}
               <span class="inbox-row__text">
@@ -990,9 +1019,11 @@ function renderApplicants() {
               </span>
             </button>
             <span class="inbox-row__actions">
-              ${emailState[a.id]?.lastDir === 'in' ? `<span class="decision-chip decision-chip--replied" title="They replied — last message ${relTime(emailState[a.id].lastAt)}">↙ Replied</span>` : (view === 'openings' && emailState[a.id]?.lastDir === 'out' ? `<span class="note-count" title="Waiting on their reply">sent ${relTime(emailState[a.id].lastAt)}</span>` : '')}
-              ${commentCounts[a.id] ? `<span class="note-count" title="${commentCounts[a.id]} house note${commentCounts[a.id] === 1 ? '' : 's'}">✎ ${commentCounts[a.id]}</span>` : ''}
-              ${view === 'openings' ? `<button class="btn btn--sm inbox-row__review" data-remove-placement="${a.id}|${esc(g.key)}" title="Pull them out of this listing (the auto-sweep won't re-add)">Remove</button><button class="btn inbox-row__review" data-email="${a.id}">Send email</button>` : `${rowBadge(a)}<button class="btn inbox-row__review" data-review="${a.id}">${view === 'inbox' && !myVote(a.id) ? 'Vote' : 'Open'}</button>`}
+              ${view === 'openings' && emailState[a.id]?.lastDir === 'out' ? `<span class="note-count" title="Waiting on their reply">sent ${relTime(emailState[a.id].lastAt)}</span>` : ''}
+              ${noteBubble(a.id)}
+              ${view === 'openings'
+                ? `<button class="btn inbox-row__review" data-email="${a.id}">Send email</button><button class="row-x" data-remove-placement="${a.id}|${esc(g.key)}" title="Remove from this listing — the auto-sweep won't re-add them" aria-label="Remove from listing">✕</button>`
+                : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn inbox-row__review" data-review="${a.id}">Vote</button>` : ''}`}
             </span>
           </li>`).join('')}
       </ul>`}
@@ -1006,12 +1037,13 @@ function renderApplicants() {
 function othersAccordion(listingId) {
   const others = otherQualified(listingId);
   if (!others.length) return '';
-  return `<details class="occupants__past listing-others">
-    <summary>See other qualified applicants (${others.length})</summary>
+  return `<details class="listing-others">
+    <summary>See other qualified applicants (${others.length}) <span class="listing-others__chev" aria-hidden="true">▾</span></summary>
     <ul class="inbox-card">
       ${others.map(a => {
         const removed = placements.some(p => p.applicant_id === a.id && p.listing_id === listingId && p.status === 'removed');
         return `<li class="inbox-row">
+          ${repliedDot(a)}
           <button class="inbox-row__main" data-review="${a.id}">
             ${avatarHtml(a)}
             <span class="inbox-row__text">
@@ -1021,9 +1053,7 @@ function othersAccordion(listingId) {
           </button>
           <span class="inbox-row__actions">
             ${a.stage === 'review' ? (voteChip(a) || '<span class="note-count">gathering votes</span>') : (removed ? '<span class="note-count" title="Removed from this listing by a recruiter">removed</span>' : '')}
-            ${a.stage === 'candidate'
-              ? `<button class="btn btn--sm inbox-row__review" data-add-placement="${a.id}|${esc(listingId)}">Add</button>`
-              : `<button class="btn btn--sm inbox-row__review" data-review="${a.id}">Open</button>`}
+            ${a.stage === 'candidate' ? `<button class="btn btn--sm inbox-row__review" data-add-placement="${a.id}|${esc(listingId)}">Add</button>` : ''}
           </span>
         </li>`;
       }).join('')}

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -54,3 +54,6 @@ Out of scope for now (manual): post-screening accept/vote, house tour, onboardin
 
 ### v3.3.0 (2026-07-22): recruiter-confirmed move-in
 Structured `move_in_from`/`move_in_to` window on the applicant (migration 124, set via `recruit_set_move_in` RPC, attributed). Editable from the profile's Move-in fact — the applicant's typed answer stays on top, the confirmed window sits underneath. When set it is exact (no "flexible" escape hatch) and overrides the parsed text in sublines, filters, and placement qualification; saving re-runs the placement sweep.
+
+### Design reference
+Row states, chip taxonomy, and subcopy grammar for Inbox/Candidates/Openings: [docs/ux/recruiting-row-states.md](../../ux/recruiting-row-states.md) (v3.5.0 — response dot, room pills, note bubble, ✕ removal, see-more bar).

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -1,0 +1,89 @@
+# Recruiting app — row states & subcopy reference
+
+Design documentation for `/applications` list rows (v3.5.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
+
+## Shared row anatomy
+
+```
+[response dot?] [avatar] [name / subline] ......... [chips] [note bubble?] [action?] [✕?]
+```
+
+- **Row tap always opens the review overlay.** There is never an "Open" button; the only row-level action buttons are verbs that do something else (Vote, Send email, Add).
+- **Response dot** — 8px blue (`--accent`) dot in the row's left gutter, vertically centered, *beside* the avatar (never on top of it). Meaning: their last email to the house is unanswered-by-us / newest. Tooltip carries recency ("They replied — 3h ago"). Replaces the old "↙ Replied" chip in every view.
+- **Note bubble** — filled square speech bubble (rounded rect, tail centered on the bottom edge), accent-colored, with the note count inside in knockout text. Tooltip: "N house notes". Replaces the old "✎ N" text count.
+- **Chips** are pills, 24px tall. Color taxonomy: gray = informational (vote progress), blue = placement, green = positive/confirmed, red/amber reserved for Archive states.
+
+## Inbox (`stage = 'review'`)
+
+| State | Visual | Logic |
+|---|---|---|
+| Fresh | no chip · **Vote** button | zero votes |
+| Others voted, you haven't | gray chip `2/3 votes` (count only — **average stays blind until you cast**) · **Vote** | votes > 0, `myVote` null |
+| You voted, below threshold | gray chip `2/3 · avg 3.5` · no button | `myVote` set; scored < `vote_min_count` or avg < `vote_pass_avg` |
+| They replied | blue response dot (stacks with any chip) | last email direction = in |
+| Has notes | note bubble with count | comment count > 0 |
+
+Exit paths are instant and server-side (rows never render in these states): any veto → Archive (update queued) · 3+ votes with avg ≥ 3.5 → Candidates · budget under $1,500 → auto-archived at load. The "Vetoed" and passing-blue chips exist in code but are unreachable in the Inbox.
+
+## Candidates (`stage = 'candidate'`)
+
+| State | Visual | Logic |
+|---|---|---|
+| Placed | **one pill per room**: `Priest · 9/1` (room name · open date M/D), tooltip = full listing line | one pill per active placement in an open listing |
+| Waiting | no pills, no button | no open listing passes `qualifiesFor` (dates/track/budget) |
+| Replied / notes | dot and bubble stack as everywhere | email/comment state |
+
+Pills fall back to `In N listings` for the beat before house data loads.
+
+## Openings (rows = active placements, grouped per open listing)
+
+| State | Visual | Logic |
+|---|---|---|
+| On the shortlist | grip ⠿ + rank · **Send email** · **✕** at the far right | placement `status='active'`; the same person can appear under several listings |
+| Awaiting their reply | muted `sent 3h ago` before the buttons | last email direction = out |
+| They replied | blue response dot | last email direction = in |
+
+**✕** removes from *this* listing only — tombstones the placement so the auto-sweep never re-adds; tooltip says so.
+
+### "See other qualified applicants (N)" — full-width see-more bar
+
+Ladder-style expander (`.inbox-more__btn` pattern): full-width, centered, muted, chevron ▾ that flips when open. Sits between the shortlist card and the next listing. Rows inside:
+
+| State | Visual | Logic |
+|---|---|---|
+| Still in the Inbox | `gathering votes` (or their vote chip) · no button, row tap opens review | `stage='review'` and qualifies |
+| Removed by a recruiter | `removed` · **Add** (re-activates the tombstoned placement) | `stage='candidate'`, tombstoned |
+
+Because the sweep places every qualifying candidate, this set is provably {still in review} ∪ {tombstoned} — no third case.
+
+## Row subcopy grammar
+
+`[pronouns] · [track] · [move-in] · [stay] · applied [date]` — segments drop out when unknown, never render placeholders.
+
+| Segment | Values |
+|---|---|
+| pronouns | lowercase, only when given — `she/her` |
+| track | `Full-time` \| `Sublet` (from the residency answer) |
+| move-in (parsed) | `Sep 2026` · `Sep 5, 2026` · `Aug–Sep 2026` · `ASAP` · `Flexible` · any + `· flexible` · omitted when unparseable |
+| move-in (confirmed) | recruiter-confirmed window **replaces** the parsed value everywhere: `Sep 1, 2026` or `Sep 1 – Oct 15, 2026` (green + ✓ on the profile only; plain in sublines) |
+| stay (sublets) | `6-week stay`; under 21 days `12-day stay` — from the confirmed window when set, else the parsed range |
+| applied | `applied Jul 1` — main rows only; accordion rows omit it |
+| email recency | Openings, awaiting state only: `sent 3h ago` → `2d ago` → date |
+
+## Empty states & page subtitles
+
+| Surface | Copy |
+|---|---|
+| Inbox empty | "All caught up — every application has its votes." |
+| Any view, filters active | "No applicants match these filters." |
+| Listing with no one placed | "No qualifying candidates yet — they land here automatically when they pass review." |
+| Other views empty | "Nothing here yet." |
+| Inbox subtitle | "N applicants gathering votes · 3 needed, one veto rejects" |
+| Candidates subtitle | "N applicants passed review — waiting for a room" |
+| Elsewhere | "N applicants" (with "X of Y" when filtered) |
+
+## Known gaps (accepted for now)
+
+1. Waiting candidates don't say *why* nothing fits (dates vs budget vs no open listing).
+2. Openings rows don't surface a booked screening — that lives only in the Screening view.
+3. Auto vs manual placements are visually identical.


### PR DESCRIPTION
Applies the audited row-state design across Inbox / Candidates / Openings:
- Replied chip → **blue response dot** left of the avatar (row gutter, tooltip has recency)
- Placement chip → **per-room pills** (`Priest · 9/1`)
- Notes count → **filled square speech bubble** (bottom-center tail) with the count inside
- **No Open buttons** — row tap always opens review; Vote remains the only Inbox CTA
- Openings Remove → **✕** at the far right
- Qualified-others → **full-width see-more bar** with chevron (Ladder pattern)
- New design doc: `docs/ux/recruiting-row-states.md` — every row state with logic + the full subcopy grammar (move-in variants, empty states, subtitles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)