### PR TITLE
Recruiting v3.6: subcopy grammar + contextual Openings CTA

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1144,3 +1144,9 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .listing-others > summary:hover { color: var(--fg); }
 .listing-others__chev { font-size: 12px; transition: transform 120ms ease; }
 .listing-others[open] .listing-others__chev { transform: rotate(180deg); }
+
+/* --- v3.6.0: subcopy cleanup — track badge in sublines --- */
+.listing-kind--xs {
+  height: 16px; padding: 0 6px; margin: 0 6px 0 0;
+  font-size: 10px; vertical-align: text-bottom;
+}

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.5.0">
+  <link rel="stylesheet" href="css/app.css?v=3.6.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -140,6 +140,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.5.0"></script>
+  <script src="js/app.js?v=3.6.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.5.0';
+const VERSION = '3.6.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -106,23 +106,36 @@ const relTime = iso => {
 
 /* Recruiter-confirmed move-in window (set after emailing them) — when
    present it beats the parsed free text everywhere dates matter. */
+const fmtMD = iso => new Date(iso + 'T12:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 const confirmedMoveIn = a => a.moveinFrom
-  ? (a.moveinTo ? `${fmtDay(a.moveinFrom)} – ${fmtDay(a.moveinTo)}` : fmtDay(a.moveinFrom))
+  ? (a.moveinTo ? `${fmtMD(a.moveinFrom)} → ${fmtMD(a.moveinTo)}` : fmtDay(a.moveinFrom))
   : '';
 const effectiveMoveIn = a => confirmedMoveIn(a) || normalizeMoveIn(a);
 
-/* Row subline stays clean: track + move-in (+ stay length for sublets).
+/* The canonical, simplified move-in display. One of:
+   "Sep 1, 2026" · "Sep 2026" · "Aug–Sep 2026" · "ASAP" · "Flexible" ·
+   "Jul 28 → Aug 29" (a known in→out window) · '' (unparseable).
+   The "· flexible" suffix never renders in sublines — the raw answer lives
+   behind the profile info-dot. */
+function displayMoveIn(a) {
+  const conf = confirmedMoveIn(a);
+  if (conf) return conf;
+  const win = parsedStayWindow(a);
+  if (win) return `${fmtMD(win[0])} → ${fmtMD(win[1])}`;
+  return normalizeMoveIn(a).replace(/ · flexible$/, '');
+}
+
+/* Track badge — same pill component as the listing headers. */
+const trackBadge = a =>
+  `<span class="listing-kind listing-kind--${isSublet(a) ? 'sublet' : 'resident'} listing-kind--xs">${trackLabel(a)}</span>`;
+
+/* Row subline (text after the track badge): pronouns · move-in dates.
    Budget lives on the review page. */
 function subLine(a) {
   const bits = [];
   if (a.pronouns) bits.push(a.pronouns.toLowerCase());
-  bits.push(trackLabel(a));
-  const mi = effectiveMoveIn(a);
+  const mi = displayMoveIn(a);
   if (mi) bits.push(mi);
-  if (isSublet(a)) {
-    const len = stayLength(a);
-    if (len) bits.push(len);
-  }
   return bits.join(' · ');
 }
 
@@ -203,11 +216,10 @@ function normalizeBudget(raw) {
 
 /* Day-level stay length for sublets, when the move-in text carries two dates
    ("July 28 - Aug 29", "June 21st - Sept 4th"). Null when not parseable. */
-function stayLength(a) {
-  if (a.moveinFrom && a.moveinTo) {
-    const days = Math.round((new Date(a.moveinTo) - new Date(a.moveinFrom)) / 86400000);
-    if (days > 0 && days <= 366) return days < 21 ? `${days}-day stay` : `${Math.round(days / 7)}-week stay`;
-  }
+/* A stated in→out window parsed from the free text ("July 28 - Aug 29"),
+   as a pair of ISO dates. Null when the answer doesn't carry two dates. */
+function parsedStayWindow(a) {
+  if (!isSublet(a)) return null;
   const raw = (a.movein || '');
   const rx = new RegExp(`\\b(${MONTH_ABBR.join('|')})[a-z]*\\.?\\s+(\\d{1,2})(?:st|nd|rd|th)?\\b`, 'gi');
   const dates = [];
@@ -220,7 +232,7 @@ function stayLength(a) {
   if (dates[1] < dates[0]) dates[1].setFullYear(dates[1].getFullYear() + 1);
   const days = Math.round((dates[1] - dates[0]) / 86400000);
   if (days <= 0 || days > 366) return null;
-  return days < 21 ? `${days}-day stay` : `${Math.round(days / 7)}-week stay`;
+  return dates.map(d => d.toISOString().slice(0, 10));
 }
 
 /* Human length of a listing window. */
@@ -345,6 +357,24 @@ function avatarHtml(a, large) {
   return `<span class="${cls}">${esc(initials(a))}<img class="avatar__img" src="${esc(src)}" alt="" loading="lazy" onerror="this.remove()"></span>`;
 }
 
+/* The one CTA an Openings row needs right now, from its funnel micro-state:
+   nothing sent yet → Reach out · waiting on them → Follow up · they wrote
+   back → Reply · availability in hand → Pick a time · call booked → the
+   slot chip (+ Join when there's a Meet link). */
+function openingsCta(a) {
+  const sc = screeningState[a.id];
+  if (sc?.at) {
+    const chip = `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
+    const join = sc.link ? `<a class="btn btn--sm inbox-row__review" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';
+    return chip + join;
+  }
+  if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review" data-pick-time="${a.id}">Pick a time</button>`;
+  const st = emailState[a.id];
+  if (st?.lastDir === 'in') return `<button class="btn btn--sm inbox-row__review" data-pick-time="${a.id}">Reply</button>`;
+  if (st?.lastDir === 'out') return `<span class="note-count" title="Waiting on their reply">sent ${relTime(st.lastAt)}</span><button class="btn btn--sm inbox-row__review" data-email="${a.id}">Follow up</button>`;
+  return `<button class="btn inbox-row__review" data-email="${a.id}">Reach out</button>`;
+}
+
 /* Blue response dot in the row's left gutter — sits beside the avatar,
    never on top of it. */
 function repliedDot(a) {
@@ -397,7 +427,7 @@ async function loadAll() {
     sb.from('recruit_comments').select('applicant_id'),
     sb.from('recruit_emails').select('applicant_id, direction, sent_at').order('sent_at'),
     sb.from('recruit_votes').select('*').order('created_at'),
-    sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name').order('starts_at'),
+    sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, meet_link').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
   ]);
@@ -406,7 +436,7 @@ async function loadAll() {
   for (const v of (vRes.data || [])) (votes[v.applicant_id] ||= []).push(v);
   screeningState = {};
   for (const s of (scRes.data || [])) {
-    if (s.status === 'scheduled') screeningState[s.applicant_id] = { at: s.starts_at, with: s.housemate_name };
+    if (s.status === 'scheduled') screeningState[s.applicant_id] = { at: s.starts_at, with: s.housemate_name, link: s.meet_link };
   }
   for (const av of (avRes.data || [])) screeningState[av.applicant_id] ||= { availability: true };
   emailState = {};
@@ -1015,14 +1045,13 @@ function renderApplicants() {
               ${avatarHtml(a)}
               <span class="inbox-row__text">
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
-                <span class="inbox-row__sub">${esc(subLine(a))} · applied ${fmtDate(a.ts_iso)}</span>
+                <span class="inbox-row__sub">${trackBadge(a)}${subLine(a) ? `${esc(subLine(a))} · ` : ''}applied ${fmtDate(a.ts_iso)}</span>
               </span>
             </button>
             <span class="inbox-row__actions">
-              ${view === 'openings' && emailState[a.id]?.lastDir === 'out' ? `<span class="note-count" title="Waiting on their reply">sent ${relTime(emailState[a.id].lastAt)}</span>` : ''}
               ${noteBubble(a.id)}
               ${view === 'openings'
-                ? `<button class="btn inbox-row__review" data-email="${a.id}">Send email</button><button class="row-x" data-remove-placement="${a.id}|${esc(g.key)}" title="Remove from this listing — the auto-sweep won't re-add them" aria-label="Remove from listing">✕</button>`
+                ? `${openingsCta(a)}<button class="row-x" data-remove-placement="${a.id}|${esc(g.key)}" title="Remove from this listing — the auto-sweep won't re-add them" aria-label="Remove from listing">✕</button>`
                 : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn inbox-row__review" data-review="${a.id}">Vote</button>` : ''}`}
             </span>
           </li>`).join('')}
@@ -1048,7 +1077,7 @@ function othersAccordion(listingId) {
             ${avatarHtml(a)}
             <span class="inbox-row__text">
               <span class="inbox-row__title">${esc(fullName(a))}</span>
-              <span class="inbox-row__sub">${esc(subLine(a))}</span>
+              <span class="inbox-row__sub">${trackBadge(a)}${esc(subLine(a))}</span>
             </span>
           </button>
           <span class="inbox-row__actions">
@@ -1892,10 +1921,9 @@ function moveInFactHtml(a, miNorm) {
     </span>`;
   }
   const conf = confirmedMoveIn(a);
-  const shown = conf || miNorm || a.movein || '—';
-  const stay = isSublet(a) && stayLength(a) ? ` · ${stayLength(a)}` : '';
+  const shown = conf || displayMoveIn(a) || a.movein || '—';
   return `<span class="review__fact-value ${conf ? 'is-confirmed' : ''}">
-    ${esc(shown)}${stay}
+    ${esc(shown)}
     ${conf ? `<span class="movein-check" title="Confirmed by ${esc(a.moveinSetBy || 'the house')} — their stated answer is behind the (i)">✓</span>` : ''}
     ${infoDot(a.movein, conf || miNorm)}
     <button type="button" class="fact-edit" data-movein-edit title="${conf ? 'Edit the confirmed date' : 'Confirm their real date'}" aria-label="Edit move-in date">✎</button>
@@ -2642,6 +2670,13 @@ function init() {
     if (em) { openEmailModal(em.dataset.email); return; }
     const so = e.target.closest('[data-second-opinion]');
     if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
+    const pt = e.target.closest('[data-pick-time]');
+    if (pt) {
+      openReview(pt.dataset.pickTime);
+      reviewTab = 'emails';
+      renderReview();
+      return;
+    }
     const miEdit = e.target.closest('[data-movein-edit]');
     if (miEdit) { moveinEditing = true; renderReview(); return; }
     const miSave = e.target.closest('[data-movein-save]');

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -1,6 +1,6 @@
 # Recruiting app — row states & subcopy reference
 
-Design documentation for `/applications` list rows (v3.5.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
+Design documentation for `/applications` list rows (v3.6.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
 
 ## Shared row anatomy
 
@@ -37,11 +37,15 @@ Pills fall back to `In N listings` for the beat before house data loads.
 
 ## Openings (rows = active placements, grouped per open listing)
 
-| State | Visual | Logic |
+Every row carries grip ⠿ + rank, **one contextual CTA**, and **✕** at the far right. The CTA is a state machine — never a generic "Send email":
+
+| Micro-state | CTA | Logic |
 |---|---|---|
-| On the shortlist | grip ⠿ + rank · **Send email** · **✕** at the far right | placement `status='active'`; the same person can appear under several listings |
-| Awaiting their reply | muted `sent 3h ago` before the buttons | last email direction = out |
-| They replied | blue response dot | last email direction = in |
+| Nothing sent yet | **Reach out** (primary) — opens the AI email draft | no email either direction |
+| Waiting on them | muted `sent 3h ago` + **Follow up** | last email direction = out |
+| They replied | blue response dot + **Reply** — opens the Emails tab to read first | last email direction = in, no availability parsed |
+| Availability in hand | **Pick a time** (accent) — opens the Emails tab slot picker | `recruit_availability` has windows, no screening booked |
+| Call booked | slot chip `Fri, Jul 25, 9:00 AM` + **Join call** when a Meet link exists | scheduled row in `recruit_screenings` |
 
 **✕** removes from *this* listing only — tombstones the placement so the auto-sweep never re-adds; tooltip says so.
 
@@ -58,17 +62,17 @@ Because the sweep places every qualifying candidate, this set is provably {still
 
 ## Row subcopy grammar
 
-`[pronouns] · [track] · [move-in] · [stay] · applied [date]` — segments drop out when unknown, never render placeholders.
+`[track badge] [pronouns] · [move-in] · applied [date]` — segments drop out when unknown, never render placeholders.
 
 | Segment | Values |
 |---|---|
+| track badge | The same `listing-kind` pill as listing headers, xs size: `Full-time` (resident tint) \| `Sublet` (sublet tint). Always first; never plain text. |
 | pronouns | lowercase, only when given — `she/her` |
-| track | `Full-time` \| `Sublet` (from the residency answer) |
-| move-in (parsed) | `Sep 2026` · `Sep 5, 2026` · `Aug–Sep 2026` · `ASAP` · `Flexible` · any + `· flexible` · omitted when unparseable |
-| move-in (confirmed) | recruiter-confirmed window **replaces** the parsed value everywhere: `Sep 1, 2026` or `Sep 1 – Oct 15, 2026` (green + ✓ on the profile only; plain in sublines) |
-| stay (sublets) | `6-week stay`; under 21 days `12-day stay` — from the confirmed window when set, else the parsed range |
+| move-in | **One canonical set:** `Sep 5, 2026` (day known) · `Sep 2026` (month) · `Aug–Sep 2026` (month range) · `Jul 28 → Aug 29` (known in→out window — replaces the old "N-week stay") · `ASAP` · `Flexible` · omitted when unparseable. The `· flexible` suffix never renders in sublines (the raw answer lives behind the profile info-dot). A recruiter-confirmed window replaces the parsed value everywhere: `Sep 1, 2026` or `Sep 1 → Oct 15`. |
 | applied | `applied Jul 1` — main rows only; accordion rows omit it |
 | email recency | Openings, awaiting state only: `sent 3h ago` → `2d ago` → date |
+
+There is no stay-length segment — sublet durations read as move-in → move-out dates.
 
 ## Empty states & page subtitles
 


### PR DESCRIPTION
- **Track badge**: sublines lead with the same `listing-kind` pill used on listing headers (xs size) — no more plain-text Full-time/Sublet.
- **Move-in, one canonical set**: `Sep 5, 2026` · `Sep 2026` · `Aug–Sep 2026` · `Jul 28 → Aug 29` · `ASAP` · `Flexible`. The `· flexible` suffix is display-noise (kept for qualification logic only) and stay-lengths are replaced by in→out dates.
- **Openings CTA state machine** replaces flat Send email: Reach out → Follow up (`sent 3h ago`) → Reply → **Pick a time** (accent, opens the slot picker) → slot chip + Join call (Meet link).
- Design doc `docs/ux/recruiting-row-states.md` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)