### PR TITLE
Recruiting v3.6.1: neutral Full-time badge

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1150,3 +1150,6 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   height: 16px; padding: 0 6px; margin: 0 6px 0 0;
   font-size: 10px; vertical-align: text-bottom;
 }
+
+/* --- v3.6.1: neutral Full-time badge — blends with the row background --- */
+.listing-kind--fulltime { background: var(--resident-tint); color: var(--fg-muted); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.6.0">
+  <link rel="stylesheet" href="css/app.css?v=3.6.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -140,6 +140,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.6.0"></script>
+  <script src="js/app.js?v=3.6.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.6.0';
+const VERSION = '3.6.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -125,9 +125,11 @@ function displayMoveIn(a) {
   return normalizeMoveIn(a).replace(/ · flexible$/, '');
 }
 
-/* Track badge — same pill component as the listing headers. */
+/* Track badge — same pill component as the listing headers. Full-time is
+   the default track, so it stays neutral (blends with the background);
+   Sublet keeps its tint as the exception worth noticing. */
 const trackBadge = a =>
-  `<span class="listing-kind listing-kind--${isSublet(a) ? 'sublet' : 'resident'} listing-kind--xs">${trackLabel(a)}</span>`;
+  `<span class="listing-kind listing-kind--${isSublet(a) ? 'sublet' : 'fulltime'} listing-kind--xs">${trackLabel(a)}</span>`;
 
 /* Row subline (text after the track badge): pronouns · move-in dates.
    Budget lives on the review page. */


### PR DESCRIPTION
Full-time is the default track, so its badge now uses the neutral resident tint (blends with the row background); Sublet keeps its amber tint as the exception worth noticing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)