### PR TITLE
Recruiting v3.7: thread-matched replies + openings chrome cleanup

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1111,7 +1111,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 /* --- v3.5.0: row-state polish — response dot, note bubble, ✕, see-more bar --- */
 .inbox-row { position: relative; }
 .replied-dot {
-  position: absolute; left: 5px; top: 50%; transform: translateY(-50%);
+  position: absolute; left: -13px; top: 50%; transform: translateY(-50%);
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--accent);
 }
@@ -1153,3 +1153,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 
 /* --- v3.6.1: neutral Full-time badge — blends with the row background --- */
 .listing-kind--fulltime { background: var(--resident-tint); color: var(--fg-muted); }
+
+/* --- v3.7.0: openings chrome cleanup + standardized CTA column --- */
+.page__head-action { margin-left: var(--space-3); margin-top: 6px; }
+.cta-std { min-width: 108px; justify-content: center; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.6.1">
+  <link rel="stylesheet" href="css/app.css?v=3.7.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -70,6 +70,7 @@
           <h1 class="page__title" id="page-title">Inbox</h1>
           <p class="page__sub" id="page-sub"></p>
         </div>
+        <div class="page__head-action" id="page-head-action"></div>
       </header>
       <div id="view-root"></div>
     </main>
@@ -140,6 +141,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.6.1"></script>
+  <script src="js/app.js?v=3.7.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.6.1';
+const VERSION = '3.7.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -367,14 +367,14 @@ function openingsCta(a) {
   const sc = screeningState[a.id];
   if (sc?.at) {
     const chip = `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
-    const join = sc.link ? `<a class="btn btn--sm inbox-row__review" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';
+    const join = sc.link ? `<a class="btn btn--sm inbox-row__review cta-std" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';
     return chip + join;
   }
-  if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review" data-pick-time="${a.id}">Pick a time</button>`;
+  if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Pick a time</button>`;
   const st = emailState[a.id];
-  if (st?.lastDir === 'in') return `<button class="btn btn--sm inbox-row__review" data-pick-time="${a.id}">Reply</button>`;
-  if (st?.lastDir === 'out') return `<span class="note-count" title="Waiting on their reply">sent ${relTime(st.lastAt)}</span><button class="btn btn--sm inbox-row__review" data-email="${a.id}">Follow up</button>`;
-  return `<button class="btn inbox-row__review" data-email="${a.id}">Reach out</button>`;
+  if (st?.lastDir === 'in') return `<button class="btn btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Reply</button>`;
+  if (st?.lastDir === 'out') return `<span class="note-count" title="Waiting on their reply">sent ${relTime(st.lastAt)}</span><button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Follow up</button>`;
+  return `<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`;
 }
 
 /* Blue response dot in the row's left gutter — sits beside the avatar,
@@ -790,6 +790,8 @@ async function render() {
   const def = VIEWS[view];
   document.getElementById('page-title').textContent = def.title;
   document.getElementById('mobile-title').textContent = def.title;
+  const headAction = document.getElementById('page-head-action');
+  if (headAction) headAction.innerHTML = view === 'openings' ? `<button class="btn btn--sm" data-new-listing>New listing</button>` : '';
   document.querySelectorAll('[data-view-link]').forEach(el =>
     el.classList.toggle('is-current', el.dataset.viewLink === view && el.classList.contains('rail-nav__row')));
   renderRailCounts();
@@ -951,7 +953,7 @@ function renderApplicants() {
 
   const host = document.getElementById('view-root');
   host.className = 'inbox';
-  const bar = view === 'inbox' ? '' : renderFilterBar(viewList); // the inbox stays clean
+  const bar = view === 'inbox' || view === 'openings' ? '' : renderFilterBar(viewList); // inbox + openings stay clean
   if (!list.length) {
     host.innerHTML = bar + `<p class="inbox-empty">${filtered ? 'No applicants match these filters.' : (view === 'inbox' ? 'All caught up — every application has its votes.' : 'Nothing here yet.')}</p>`;
     return;
@@ -1003,11 +1005,7 @@ function renderApplicants() {
       <span class="listing-head__actions">${listingMenuHtml(l)}</span>`;
   };
 
-  const outreachChrome = view === 'openings' ? `
-    <div class="listing-toolbar">
-      <span class="notes__empty">Each open listing is a ranked shortlist — drag rows to reorder.</span>
-      <button class="btn btn--sm" data-new-listing>New listing</button>
-    </div>` : '';
+  const outreachChrome = '';
   const doneListings = view === 'openings' ? listings.filter(l => l.status !== 'open') : [];
   const doneDrawer = doneListings.length ? `
     <details class="occupants__past">

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.4.1'
+const VERSION = '1.5.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -372,6 +372,13 @@ serve(async (req) => {
       const byEmail = new Map((allApplicants || [])
         .filter((a) => a.email?.includes('@'))
         .map((a) => [a.email.toLowerCase(), a.id]))
+      // Thread fallback: people reply from addresses other than the one on
+      // their application. Any message in a thread we've already matched
+      // belongs to that applicant, regardless of From/To.
+      const { data: knownThreads } = await client.from('recruit_emails').select('thread_id, applicant_id')
+      const byThread = new Map((knownThreads || [])
+        .filter((r) => r.thread_id)
+        .map((r) => [r.thread_id, r.applicant_id]))
       const list = await (await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages?q=' + encodeURIComponent('newer_than:14d') + '&maxResults=60', {
         headers: { Authorization: `Bearer ${at}` },
       })).json()
@@ -389,7 +396,9 @@ serve(async (req) => {
         const direction = from.toLowerCase().includes(SHARED_EMAIL) ? 'out' : 'in'
         const counterpart = (direction === 'in' ? from : to).toLowerCase()
         const applicantId = [...byEmail.entries()].find(([em]) => counterpart.includes(em))?.[1]
+          || byThread.get(msg.threadId)
         if (!applicantId) continue
+        if (!byThread.has(msg.threadId)) byThread.set(msg.threadId, applicantId)
         let bodyText = ''
         // deno-lint-ignore no-explicit-any
         const walk = (part: any) => {


### PR DESCRIPTION
- **Reply matching by thread**: Katie replied from a different address than her application email, so the address-only scan match dropped her reply (and the house's response). The scan now falls back to the Gmail thread id — any message in an already-matched thread belongs to that applicant. recruit-gmail v1.5.0.
- **Dot overlap fixed**: the response dot sits in the card's padding gutter, clear of the Openings drag grip.
- **Openings chrome**: ranked-shortlist hint removed, New listing button moved beside the page header, filter chips removed.
- **Standardized CTA column**: right-rail buttons share a min-width so Reach out / Follow up / Reply / Pick a time / Join call + ✕ align.

🤖 Generated with [Claude Code](https://claude.com/claude-code)