### PR TITLE
Recruiting v3.8: notes tooltip + manual-scheduling pickup

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1157,3 +1157,19 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 /* --- v3.7.0: openings chrome cleanup + standardized CTA column --- */
 .page__head-action { margin-left: var(--space-3); margin-top: 6px; }
 .cta-std { min-width: 108px; justify-content: center; }
+
+/* --- v3.8.0: note-bubble tooltip (same mechanics as the info-dot) --- */
+.note-bubble { cursor: help; }
+.note-bubble::after {
+  content: attr(data-tip);
+  position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%);
+  width: max-content; max-width: min(340px, 80vw);
+  background: var(--fg); color: var(--bg);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm); box-shadow: var(--shadow-md);
+  font-size: var(--font-size-caption); font-weight: 400;
+  line-height: var(--lh-tight); text-align: left; white-space: normal;
+  opacity: 0; visibility: hidden; transition: opacity 120ms ease;
+  pointer-events: none; z-index: 90;
+}
+.note-bubble:hover::after { opacity: 1; visibility: visible; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.7.0">
+  <link rel="stylesheet" href="css/app.css?v=3.8.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -141,6 +141,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.7.0"></script>
+  <script src="js/app.js?v=3.8.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.7.0';
+const VERSION = '3.8.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -69,6 +69,7 @@ let placements = [];          // recruit_listing_candidates rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
 let pendingVote = null;       // { score, veto } while the vote bar is open
 let commentCounts = {};       // applicant_id -> n
+let latestNotes = {};         // applicant_id -> { author, body }
 let comments = [];            // comments for the applicant open in review
 let view = 'inbox';           // current rail view
 let filters = { track: 'all', month: 'any', budget: 'any' }; // shared across applicant views
@@ -373,7 +374,14 @@ function openingsCta(a) {
   if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Pick a time</button>`;
   const st = emailState[a.id];
   if (st?.lastDir === 'in') return `<button class="btn btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Reply</button>`;
-  if (st?.lastDir === 'out') return `<span class="note-count" title="Waiting on their reply">sent ${relTime(st.lastAt)}</span><button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Follow up</button>`;
+  if (st?.lastDir === 'out') {
+    // A human saying "I'll send an invite" reads as manual scheduling — say
+    // so instead of nagging Follow up. Calendar invites from the shared
+    // account get picked up automatically by the scan's calendar sweep.
+    const promised = /\b(invite|calendar|schedul|let'?s (chat|talk|meet)|talk (soon|then|tomorrow))\b/i.test(st.lastSnippet || '');
+    if (promised) return `<span class="decision-chip decision-chip--vote" title="The last email reads like manual scheduling — an invite from the shared account will be picked up automatically">Invite promised</span><button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Follow up</button>`;
+    return `<span class="note-count" title="Waiting on their reply">sent ${relTime(st.lastAt)}</span><button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Follow up</button>`;
+  }
   return `<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`;
 }
 
@@ -390,7 +398,9 @@ function repliedDot(a) {
 function noteBubble(id) {
   const n = commentCounts[id];
   if (!n) return '';
-  return `<span class="note-bubble" title="${n} house note${n === 1 ? '' : 's'}">
+  const latest = latestNotes[id];
+  const tip = `${n} house note${n === 1 ? '' : 's'}${latest ? ` · latest — ${latest.author}: “${latest.body.replace(/\s+/g, ' ').slice(0, 140)}${latest.body.length > 140 ? '…' : ''}”` : ''}`;
+  return `<span class="note-bubble" data-tip="${esc(tip)}">
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 3h14a3 3 0 0 1 3 3v8a3 3 0 0 1-3 3h-4.6L12 21l-2.4-4H5a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3z"/></svg>
     <b class="note-bubble__n">${n}</b>
   </span>`;
@@ -426,8 +436,8 @@ async function loadAll() {
   const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
-    sb.from('recruit_comments').select('applicant_id'),
-    sb.from('recruit_emails').select('applicant_id, direction, sent_at').order('sent_at'),
+    sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
+    sb.from('recruit_emails').select('applicant_id, direction, sent_at, snippet').order('sent_at'),
     sb.from('recruit_votes').select('*').order('created_at'),
     sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, meet_link').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, updated_at'),
@@ -443,8 +453,8 @@ async function loadAll() {
   for (const av of (avRes.data || [])) screeningState[av.applicant_id] ||= { availability: true };
   emailState = {};
   for (const e of (eRes.data || [])) {
-    const st = (emailState[e.applicant_id] ||= { lastDir: null, lastAt: null, replies: 0 });
-    st.lastDir = e.direction; st.lastAt = e.sent_at;
+    const st = (emailState[e.applicant_id] ||= { lastDir: null, lastAt: null, lastSnippet: '', replies: 0 });
+    st.lastDir = e.direction; st.lastAt = e.sent_at; st.lastSnippet = e.snippet || '';
     if (e.direction === 'in') st.replies++;
   }
   sb.from('recruit_settings').select('*').then(({ data }) => {
@@ -467,7 +477,11 @@ async function loadAll() {
     decisions[d.applicant_id] = { d: d.decision, reason: d.reason, note: d.note || '', listingId: d.listing_id || null, byName: d.decided_by_name, at: d.decided_at };
   }
   commentCounts = {};
-  for (const c of (cRes.data || [])) commentCounts[c.applicant_id] = (commentCounts[c.applicant_id] || 0) + 1;
+  latestNotes = {};
+  for (const c of (cRes.data || [])) {
+    commentCounts[c.applicant_id] = (commentCounts[c.applicant_id] || 0) + 1;
+    latestNotes[c.applicant_id] = { author: c.author_name || 'Housemate', body: c.body || '' }; // rows are created_at-ordered
+  }
 }
 
 async function saveDecision(id, d, reason, byName, note, listingId) {

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -1,6 +1,6 @@
 # Recruiting app — row states & subcopy reference
 
-Design documentation for `/applications` list rows (v3.6.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
+Design documentation for `/applications` list rows (v3.8.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
 
 ## Shared row anatomy
 
@@ -10,7 +10,7 @@ Design documentation for `/applications` list rows (v3.6.0). One row = one appli
 
 - **Row tap always opens the review overlay.** There is never an "Open" button; the only row-level action buttons are verbs that do something else (Vote, Send email, Add).
 - **Response dot** — 8px blue (`--accent`) dot in the row's left gutter, vertically centered, *beside* the avatar (never on top of it). Meaning: their last email to the house is unanswered-by-us / newest. Tooltip carries recency ("They replied — 3h ago"). Replaces the old "↙ Replied" chip in every view.
-- **Note bubble** — filled square speech bubble (rounded rect, tail centered on the bottom edge), accent-colored, with the note count inside in knockout text. Tooltip: "N house notes". Replaces the old "✎ N" text count.
+- **Note bubble** — filled square speech bubble (rounded rect, tail centered on the bottom edge), accent-colored, with the note count inside in knockout text. Hover shows a styled tooltip (same mechanics as the info-dot): "N house notes · latest — Author: 'first 140 chars…'". Replaces the old "✎ N" text count.
 - **Chips** are pills, 24px tall. Color taxonomy: gray = informational (vote progress), blue = placement, green = positive/confirmed, red/amber reserved for Archive states.
 
 ## Inbox (`stage = 'review'`)
@@ -43,9 +43,10 @@ Every row carries grip ⠿ + rank, **one contextual CTA**, and **✕** at the fa
 |---|---|---|
 | Nothing sent yet | **Reach out** (primary) — opens the AI email draft | no email either direction |
 | Waiting on them | muted `sent 3h ago` + **Follow up** | last email direction = out |
+| Invite promised | gray chip `Invite promised` + **Follow up** | last outbound reads like manual scheduling ("I'll send an invite", "let's chat tomorrow") — regex on the snippet |
 | They replied | blue response dot + **Reply** — opens the Emails tab to read first | last email direction = in, no availability parsed |
 | Availability in hand | **Pick a time** (accent) — opens the Emails tab slot picker | `recruit_availability` has windows, no screening booked |
-| Call booked | slot chip `Fri, Jul 25, 9:00 AM` + **Join call** when a Meet link exists | scheduled row in `recruit_screenings` |
+| Call booked | slot chip `Fri, Jul 25, 9:00 AM` + **Join call** when a Meet link exists | scheduled row in `recruit_screenings` — booked in-app **or picked up from the shared calendar**: the scan sweeps upcoming events and matches attendees to applicants (application address or any address they've replied from), so manually-sent invites become screening rows automatically |
 
 **✕** removes from *this* listing only — tombstones the placement so the auto-sweep never re-adds; tooltip says so.
 
@@ -89,5 +90,4 @@ There is no stay-length segment — sublet durations read as move-in → move-ou
 ## Known gaps (accepted for now)
 
 1. Waiting candidates don't say *why* nothing fits (dates vs budget vs no open listing).
-2. Openings rows don't surface a booked screening — that lives only in the Screening view.
 3. Auto vs manual placements are visually identical.

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.5.0'
+const VERSION = '1.6.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -432,9 +432,54 @@ serve(async (req) => {
           }
         }
       }
+      // Manual-scheduling pickup: a human who jumps in and sends a calendar
+      // invite from the shared account bypasses the app's schedule action.
+      // Sweep upcoming events; any attendee matching an applicant — by their
+      // application address OR any address they've written from — becomes a
+      // screenings row (deduped by event id, so app-booked calls are skipped).
+      let manualPickups = 0
+      try {
+        const { data: altRows } = await client.from('recruit_emails').select('applicant_id, from_email').eq('direction', 'in')
+        const altByEmail = new Map<string, string>()
+        for (const r of (altRows || [])) {
+          const m = String(r.from_email || '').toLowerCase().match(/[a-z0-9._%+-]+@[a-z0-9.-]+/)
+          if (m) altByEmail.set(m[0], r.applicant_id)
+        }
+        const timeMin = new Date().toISOString()
+        const timeMax = new Date(Date.now() + 45 * 86400000).toISOString()
+        const cal = await (await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=${encodeURIComponent(timeMin)}&timeMax=${encodeURIComponent(timeMax)}&singleEvents=true&maxResults=100`, {
+          headers: { Authorization: `Bearer ${at}` },
+        })).json()
+        for (const ev of (cal.items || [])) {
+          if (!ev.attendees?.length || !ev.start?.dateTime) continue
+          let aid: string | null = null
+          for (const att of ev.attendees) {
+            const em = String(att.email || '').toLowerCase()
+            aid = byEmail.get(em) || altByEmail.get(em) || null
+            if (aid) break
+          }
+          if (!aid) continue
+          const { data: existingEv } = await client.from('recruit_screenings').select('id').eq('gcal_event_id', ev.id).maybeSingle()
+          if (existingEv) continue
+          await client.from('recruit_screenings').insert({
+            applicant_id: aid,
+            starts_at: ev.start.dateTime,
+            ends_at: ev.end?.dateTime || ev.start.dateTime,
+            gcal_event_id: ev.id,
+            meet_link: ev.hangoutLink || null,
+            housemate_name: ev.organizer?.displayName || (ev.organizer?.email === SHARED_EMAIL ? 'the house' : ev.organizer?.email) || 'scheduled manually',
+            status: 'scheduled',
+          })
+          manualPickups++
+          console.log(`manual screening picked up: ${aid} @ ${ev.start.dateTime}`)
+        }
+      } catch (err) {
+        console.warn(`calendar sweep failed: ${(err as Error).message}`)
+      }
+
       await remindStuckPosts(client)
-      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied`)
-      return json({ matched, replied: [...replied] })
+      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up`)
+      return json({ matched, replied: [...replied], manualPickups })
     }
 
     return json({ error: 'Unknown action' }, 400)


### PR DESCRIPTION
- **Note bubble tooltip**: hover shows "N house notes · latest — Author: 'preview…'" (info-dot mechanics).
- **Invite promised**: when the last outbound reads like manual scheduling, the Openings row says so instead of a bare waiting state.
- **Manual scheduling pickup** (recruit-gmail v1.6.0): the scan now sweeps the shared account's calendar (next 45 days); events whose attendees match an applicant — by application address or any address they've written from — become `recruit_screenings` rows, deduped by event id. A human sending an invite by hand now flows into Screening + the Openings slot chip automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)