### PR TITLE
Recruiting v3.9: time-proposal pickup + manual Discord trigger with preview

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1179,3 +1179,15 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .foot-pills { display: inline-flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
 .placement-pill { border: 0; cursor: pointer; }
 .placement-pill:hover { filter: brightness(1.1); box-shadow: inset 0 0 0 1.5px currentColor; }
+
+/* --- v3.9.0: Discord claim preview (embed-styled card) --- */
+.avail-card__discord { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; margin: var(--space-3) 0 0; font-size: var(--font-size-small); color: var(--fg-muted); }
+.claim-preview {
+  border-left: 4px solid #3498db; border-radius: var(--radius-xs);
+  background: var(--bg-surface); padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.claim-preview--manual { border-left-color: #e67e22; }
+.claim-preview__title { margin: 0 0 var(--space-2); font-weight: var(--fw-bold); }
+.claim-preview__desc { margin: 0; font-size: var(--font-size-small); line-height: var(--lh-body); white-space: normal; }
+.claim-preview__slots { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.8.1">
+  <link rel="stylesheet" href="css/app.css?v=3.9.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -139,8 +139,24 @@
     </div>
   </div>
 
+  <!-- Discord claim-post preview — manual trigger for now; auto later. -->
+  <div class="email-modal" id="claim-modal" hidden>
+    <div class="email-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title">Post to #recruiting-interviews</h3>
+        <button class="review__close email-modal__close" id="claim-close" aria-label="Close">✕</button>
+      </div>
+      <p class="email-modal__status" id="claim-status"></p>
+      <div id="claim-preview-body"></div>
+      <div class="decision-sheet__actions">
+        <button class="hold-sheet__cancel" id="claim-cancel" type="button">Cancel</button>
+        <button class="btn btn--accent btn--sm" id="claim-post-btn" type="button" disabled>Post to Discord</button>
+      </div>
+    </div>
+  </div>
+
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.8.1"></script>
+  <script src="js/app.js?v=3.9.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.8.1';
+const VERSION = '3.9.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -440,7 +440,7 @@ async function loadAll() {
     sb.from('recruit_emails').select('applicant_id, direction, sent_at, snippet').order('sent_at'),
     sb.from('recruit_votes').select('*').order('created_at'),
     sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, meet_link').order('starts_at'),
-    sb.from('recruit_availability').select('applicant_id, updated_at'),
+    sb.from('recruit_availability').select('applicant_id, windows, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
   ]);
   placements = pRes.data || [];
@@ -450,7 +450,10 @@ async function loadAll() {
   for (const s of (scRes.data || [])) {
     if (s.status === 'scheduled') screeningState[s.applicant_id] = { at: s.starts_at, with: s.housemate_name, link: s.meet_link };
   }
-  for (const av of (avRes.data || [])) screeningState[av.applicant_id] ||= { availability: true };
+  for (const av of (avRes.data || [])) {
+    // empty windows = a processed non-scheduling reply — no Pick a time
+    if (Array.isArray(av.windows) && av.windows.length) screeningState[av.applicant_id] ||= { availability: true };
+  }
   emailState = {};
   for (const e of (eRes.data || [])) {
     const st = (emailState[e.applicant_id] ||= { lastDir: null, lastAt: null, lastSnippet: '', replies: 0 });
@@ -2184,11 +2187,59 @@ function schedulingHtml(a) {
           <span class="avail-card__slots">${windowSlots(w).map(d =>
             `<button type="button" class="chip" data-slot="${d.toISOString()}" data-slot-applicant="${a.id}">${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</button>`).join('') || '<span class="notes__empty">window already passed</span>'}</span>
         </div>`).join('')}
+      <p class="avail-card__discord">…or hand it to the house: <button type="button" class="btn btn--sm" data-claim-preview="${a.id}">Post to Discord…</button>
+        <span class="notes__empty">first housemate to claim a slot runs the call (manual for now)</span></p>
     </div>`);
   } else if (!screenings.length) {
-    parts.push(`<p class="notes__empty">No availability captured yet — when they reply with days/times, windows appear here automatically.</p>`);
+    parts.push(`<p class="notes__empty">No availability captured yet — when they reply with days/times, windows appear here automatically.${emailState[a.id]?.lastDir === 'in' ? ` <button type="button" class="btn btn--sm" data-claim-preview="${a.id}">Post to Discord…</button>` : ''}</p>`);
   }
   return parts.join('');
+}
+
+/* ---------- manual Discord claim trigger (preview → post) ---------- */
+let claimCtx = null; // { applicantId, extraction } while the modal is open
+
+async function openClaimPreview(applicantId) {
+  claimCtx = { applicantId, extraction: null };
+  document.getElementById('claim-modal').hidden = false;
+  document.getElementById('claim-status').textContent = 'Reading their reply and composing the post…';
+  document.getElementById('claim-preview-body').innerHTML = '';
+  document.getElementById('claim-post-btn').disabled = true;
+  try {
+    const out = await gmailCall({ action: 'claim-preview', applicantId });
+    if (claimCtx?.applicantId !== applicantId) return; // closed meanwhile
+    claimCtx.extraction = out.extraction;
+    const emb = out.preview?.embeds?.[0] || {};
+    document.getElementById('claim-status').textContent = 'This exact message goes to #recruiting-interviews:';
+    document.getElementById('claim-preview-body').innerHTML = `
+      <div class="claim-preview ${out.slotLabels?.length ? '' : 'claim-preview--manual'}">
+        <p class="claim-preview__title">${esc(emb.title || '')}</p>
+        <p class="claim-preview__desc">${esc(emb.description || '').replace(/\n/g, '<br>')}</p>
+        ${out.slotLabels?.length ? `<div class="claim-preview__slots">${out.slotLabels.map(l => `<span class="chip">${esc(l)}</span>`).join('')}<span class="chip">Other time…</span></div>` : ''}
+      </div>`;
+    document.getElementById('claim-post-btn').disabled = false;
+  } catch (e) {
+    document.getElementById('claim-status').textContent = `Preview failed: ${e.message}`;
+  }
+}
+
+function closeClaimModal() {
+  claimCtx = null;
+  document.getElementById('claim-modal').hidden = true;
+}
+
+async function postClaimFromModal() {
+  if (!claimCtx?.extraction) return;
+  const btn = document.getElementById('claim-post-btn');
+  btn.disabled = true; btn.textContent = 'Posting…';
+  try {
+    const out = await gmailCall({ action: 'claim-post', applicantId: claimCtx.applicantId, extraction: claimCtx.extraction });
+    toast(out.posted ? 'Posted to #recruiting-interviews — first claim wins' : 'Already claimed — not reposted');
+    closeClaimModal();
+  } catch (e) {
+    toast(`Post failed: ${e.message}`);
+  }
+  btn.disabled = false; btn.textContent = 'Post to Discord';
 }
 
 async function scheduleSlot(applicantId, iso, btn) {
@@ -2692,6 +2743,8 @@ function init() {
     if (em) { openEmailModal(em.dataset.email); return; }
     const so = e.target.closest('[data-second-opinion]');
     if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
+    const cp = e.target.closest('[data-claim-preview]');
+    if (cp) { openClaimPreview(cp.dataset.claimPreview); return; }
     const pt = e.target.closest('[data-pick-time]');
     if (pt) {
       openReview(pt.dataset.pickTime);
@@ -2825,6 +2878,9 @@ function init() {
     else toast(value ? 'House preference: open to couples' : 'House preference: not open to couples');
   };
 
+  document.getElementById('claim-close').onclick = closeClaimModal;
+  document.getElementById('claim-cancel').onclick = closeClaimModal;
+  document.getElementById('claim-post-btn').onclick = postClaimFromModal;
   document.getElementById('email-close').onclick = closeEmailModal;
   document.getElementById('email-regen').onclick = () => emailApplicantId && generateEmail(emailApplicantId);
   document.getElementById('email-send').onclick = async () => {
@@ -2869,6 +2925,7 @@ function init() {
     if (e.target instanceof Element && e.target.matches('input, textarea')) return;
     if (e.key === 'Escape') {
       if (!document.getElementById('email-modal').hidden) closeEmailModal();
+      else if (!document.getElementById('claim-modal').hidden) closeClaimModal();
       else if (!document.getElementById('listing-modal').hidden) closeListingModal();
       else if (!document.getElementById('decision-sheet').hidden) hideDecisionSheet();
       else closeReview();

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -107,7 +107,9 @@ function appLink(applicantId: string): string {
   return `https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`
 }
 
-function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<string, unknown> {
+// Exported so the app can render a faithful preview before a human
+// triggers the post (auto-posting is off for now — manual first).
+export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<string, unknown> {
   const why = (input.whyLine || '').trim().replace(/\s+/g, ' ').slice(0, 140)
   const manual = input.needsHuman || !slots.length
 

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.6.0'
+const VERSION = '1.7.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendApplicantConfirmation, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen } from '../_shared/discord.ts'
+import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -299,7 +299,9 @@ serve(async (req) => {
                 updated_at: new Date().toISOString(),
               })
             }
-            await postClaim(client, applicant.id, extraction)
+            // Auto-post to Discord is off for now — a recruiter triggers the
+            // claim post from the app (claim-preview/claim-post actions).
+            // await postClaim(client, applicant.id, extraction)
           }
         }
       }
@@ -362,6 +364,39 @@ serve(async (req) => {
 
       console.log(`screening ${applicantId} x ${housemateName} @ ${startsAt.toISOString()}`)
       return json({ scheduled: true, screening: result.screening })
+    }
+
+    if (action === 'claim-preview' || action === 'claim-post') {
+      // Manual Discord trigger: preview composes the exact message; post
+      // sends it. The extraction rides back from preview to post so Haiku
+      // runs once. Future cutover: re-enable the auto postClaim calls.
+      const applicantId = String(body.applicantId || '')
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('id, first_name, why_agape').eq('id', applicantId).maybeSingle()
+      if (!applicant) return json({ error: 'unknown applicant' }, 404)
+      let extraction: Extraction = body.extraction && Array.isArray(body.extraction.windows)
+        ? body.extraction as Extraction
+        : NO_EXTRACTION
+      if (!body.extraction) {
+        const { data: latest } = await client.from('recruit_emails')
+          .select('body_text').eq('applicant_id', applicantId).eq('direction', 'in')
+          .order('sent_at', { ascending: false }).limit(1).maybeSingle()
+        if (!latest?.body_text?.trim()) return json({ error: 'no inbound email to read times from' }, 400)
+        extraction = await extractAvailability(latest.body_text)
+        if (!extraction.windows.length && !extraction.needs_human) extraction = { ...extraction, needs_human: true }
+      }
+      const input = {
+        applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape,
+        windows: extraction.windows, platform: extraction.platform,
+        timezoneNote: extraction.timezone_note, needsHuman: extraction.needs_human,
+      }
+      const slots = extraction.needs_human ? [] : deriveSlots(extraction.windows)
+      const message = buildMessage(input, slots)
+      if (action === 'claim-preview') {
+        return json({ preview: message, slotLabels: slots.map((sl) => sl.label), extraction })
+      }
+      const row = await upsertClaimMessage(client, input)
+      return json({ posted: !!row, alreadyClaimed: !row })
     }
 
     if (action === 'scan') {
@@ -428,10 +463,47 @@ serve(async (req) => {
                 updated_at: new Date().toISOString(),
               })
             }
-            await postClaim(client, applicantId, extraction)
+            // manual-trigger era: no auto post (see claim-preview/claim-post)
+            // await postClaim(client, applicantId, extraction)
           }
         }
       }
+      // Availability backfill: extraction normally runs when a message first
+      // lands, but replies matched late (thread fallback) or from before an
+      // extraction fix slip through. For each applicant whose LATEST inbound
+      // was never extracted, run it from the stored body. Empty extractions
+      // are stored too (windows []) so a non-scheduling reply is marked
+      // processed and Haiku doesn't re-read it every scan. Capped per scan.
+      let backfilled = 0
+      try {
+        const { data: avRows } = await client.from('recruit_availability').select('applicant_id, source_gmail_id')
+        const avBy = new Map((avRows || []).map((r) => [r.applicant_id, r.source_gmail_id]))
+        const { data: inbound } = await client.from('recruit_emails')
+          .select('applicant_id, gmail_id, body_text, sent_at')
+          .eq('direction', 'in').order('sent_at', { ascending: false }).limit(60)
+        const seen = new Set<string>()
+        for (const r of (inbound || [])) {
+          if (seen.has(r.applicant_id)) continue
+          seen.add(r.applicant_id)
+          if (backfilled >= 5) break
+          if (avBy.get(r.applicant_id) === r.gmail_id) continue // latest already processed
+          if (!r.body_text?.trim()) continue
+          const { data: sched } = await client.from('recruit_screenings')
+            .select('id').eq('applicant_id', r.applicant_id).eq('status', 'scheduled').limit(1).maybeSingle()
+          if (sched) continue // call already booked — nothing to extract for
+          const extraction = await extractAvailability(r.body_text)
+          await client.from('recruit_availability').upsert({
+            applicant_id: r.applicant_id, windows: extraction.windows,
+            source_gmail_id: r.gmail_id, updated_at: new Date().toISOString(),
+          })
+          // manual-trigger era: no auto post (see claim-preview/claim-post)
+          backfilled++
+          console.log(`availability backfill: ${r.applicant_id} → ${extraction.windows.length} windows`)
+        }
+      } catch (err) {
+        console.warn(`availability backfill failed: ${(err as Error).message}`)
+      }
+
       // Manual-scheduling pickup: a human who jumps in and sends a calendar
       // invite from the shared account bypasses the app's schedule action.
       // Sweep upcoming events; any attendee matching an applicant — by their
@@ -478,8 +550,8 @@ serve(async (req) => {
       }
 
       await remindStuckPosts(client)
-      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up`)
-      return json({ matched, replied: [...replied], manualPickups })
+      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up, ${backfilled} availability backfills`)
+      return json({ matched, replied: [...replied], manualPickups, backfilled })
     }
 
     return json({ error: 'Unknown action' }, 400)


### PR DESCRIPTION
- **Time proposals picked up**: replies that suggest a screening time (e.g. Marisa's "July 25, morning your time") were skipped when the message matched late via thread fallback — the scan now backfills extraction from the stored body for each applicant's latest inbound (capped per scan; non-scheduling replies stored as processed markers so Haiku doesn't loop).
- **Pick a time** now requires actual windows.
- **Manual Discord trigger**: automatic claim posts are off. The Emails tab gets *Post to Discord…* → an in-app preview of the exact embed (title, description, slot buttons) → confirm to post to #recruiting-interviews. Cutover to auto later is re-enabling two calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)