### PR TITLE
Recruiting v3.9.1: expandable email rows

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -901,7 +901,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .review-tabs__tab.is-on { color: var(--fg); font-weight: var(--fw-semibold); border-bottom-color: var(--accent); }
 .emails-toolbar { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--space-3); }
 .email-list { padding-inline: var(--space-4); }
-.email-row { display: flex; align-items: flex-start; gap: var(--space-3); padding: var(--space-3) 0; position: relative; }
+.email-row { display: flex; flex-direction: column; padding: var(--space-3) 0; position: relative; }
 .email-row::after { content: ''; position: absolute; left: 28px; right: 0; bottom: 0; border-bottom: 1px solid var(--border); }
 .email-row:last-child::after { display: none; }
 .email-row__dir { flex-shrink: 0; width: 20px; text-align: center; font-weight: var(--fw-bold); }
@@ -1191,3 +1191,23 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .claim-preview__title { margin: 0 0 var(--space-2); font-weight: var(--fw-bold); }
 .claim-preview__desc { margin: 0; font-size: var(--font-size-small); line-height: var(--lh-body); white-space: normal; }
 .claim-preview__slots { display: flex; flex-wrap: wrap; gap: var(--space-2); margin-top: var(--space-3); }
+
+/* --- v3.9.1: expandable email rows --- */
+.email-row__head {
+  display: flex; align-items: flex-start; gap: var(--space-3);
+  width: 100%; border: 0; background: none; padding: 0;
+  font: inherit; color: inherit; text-align: left; cursor: pointer;
+}
+.email-row__head:disabled { cursor: default; }
+.email-row__head:not(:disabled):hover .inbox-row__title { text-decoration: underline; }
+.email-row__chev { margin-left: auto; color: var(--fg-subtle); font-size: 12px; transition: transform 120ms ease; flex-shrink: 0; }
+.email-row.is-open .email-row__chev { transform: rotate(180deg); }
+.email-row__body {
+  margin: var(--space-3) 0 0 28px;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface); border-radius: var(--radius-sm);
+  font-size: var(--font-size-small); line-height: var(--lh-body);
+  white-space: pre-wrap; overflow-wrap: anywhere;
+  max-height: 420px; overflow-y: auto;
+}
+.email-row__body[hidden] { display: none; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.9.0">
+  <link rel="stylesheet" href="css/app.css?v=3.9.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -157,6 +157,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.9.0"></script>
+  <script src="js/app.js?v=3.9.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.9.0';
+const VERSION = '3.9.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2102,15 +2102,21 @@ function section(title, text) {
 }
 
 /* ---------- emails panel ---------- */
+/* Each row expands in place to the full message body. */
 function emailRow(m) {
   const arrow = m.direction === 'out' ? '↗' : '↙';
   const who = m.direction === 'out' ? `Agape${m.sent_by_name ? ` (${esc(m.sent_by_name)})` : ''}` : esc(m.from_email.replace(/<.*>/, '').trim() || m.from_email);
+  const body = (m.body_text || '').trim();
   return `<li class="email-row email-row--${m.direction}">
-    <span class="email-row__dir" title="${m.direction === 'out' ? 'Sent by the house' : 'Received'}">${arrow}</span>
-    <span class="inbox-row__text">
-      <span class="inbox-row__title">${esc(m.subject || '(no subject)')}</span>
-      <span class="inbox-row__sub">${who} · ${new Date(m.sent_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}${m.snippet ? ` — ${esc(m.snippet.slice(0, 110))}` : ''}</span>
-    </span>
+    <button type="button" class="email-row__head" data-email-toggle aria-expanded="false" ${body ? '' : 'disabled title="No text body stored for this message"'}>
+      <span class="email-row__dir" title="${m.direction === 'out' ? 'Sent by the house' : 'Received'}">${arrow}</span>
+      <span class="inbox-row__text">
+        <span class="inbox-row__title">${esc(m.subject || '(no subject)')}</span>
+        <span class="inbox-row__sub">${who} · ${new Date(m.sent_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}${m.snippet ? ` — ${esc(m.snippet.slice(0, 110))}` : ''}</span>
+      </span>
+      ${body ? '<span class="email-row__chev" aria-hidden="true">▾</span>' : ''}
+    </button>
+    ${body ? `<div class="email-row__body" hidden>${esc(body.slice(0, 8000))}</div>` : ''}
   </li>`;
 }
 
@@ -2743,6 +2749,16 @@ function init() {
     if (em) { openEmailModal(em.dataset.email); return; }
     const so = e.target.closest('[data-second-opinion]');
     if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
+    const et = e.target.closest('[data-email-toggle]');
+    if (et) {
+      const bodyEl = et.parentElement.querySelector('.email-row__body');
+      if (bodyEl) {
+        bodyEl.hidden = !bodyEl.hidden;
+        et.setAttribute('aria-expanded', String(!bodyEl.hidden));
+        et.parentElement.classList.toggle('is-open', !bodyEl.hidden);
+      }
+      return;
+    }
     const cp = e.target.closest('[data-claim-preview]');
     if (cp) { openClaimPreview(cp.dataset.claimPreview); return; }
     const pt = e.target.closest('[data-pick-time]');


### PR DESCRIPTION
Each row in a profile's Emails tab now expands in place to the full message body (chevron flips, body scrolls past 420px). Rows without a stored text body are inert with a tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)