### PR TITLE
Recruiting v3.10: dedicated API key + Discord-first row CTA

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -371,7 +371,7 @@ function openingsCta(a) {
     const join = sc.link ? `<a class="btn btn--sm inbox-row__review cta-std" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';
     return chip + join;
   }
-  if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Pick a time</button>`;
+  if (sc?.availability) return `<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-claim-preview="${a.id}">Post to Discord</button><button class="btn btn--sm inbox-row__review" data-pick-time="${a.id}">Pick a time</button>`;
   const st = emailState[a.id];
   if (st?.lastDir === 'in') return `<button class="btn btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Reply</button>`;
   if (st?.lastDir === 'out') {
@@ -1066,7 +1066,7 @@ function renderApplicants() {
               ${avatarHtml(a)}
               <span class="inbox-row__text">
                 <span class="inbox-row__title">${esc(fullName(a))}</span>
-                <span class="inbox-row__sub">${trackBadge(a)}${subLine(a) ? `${esc(subLine(a))} · ` : ''}applied ${fmtDate(a.ts_iso)}</span>
+                <span class="inbox-row__sub">${trackBadge(a)}${esc(subLine(a))}</span>
               </span>
             </button>
             <span class="inbox-row__actions">
@@ -1583,7 +1583,7 @@ function listingPricing(l) {
 function listingMeta(l) {
   const bits = [];
   if (l.kind === 'resident') {
-    bits.push(`Opens ${fmtDay(l.starts_on)}`, '3-month trial, then house vote');
+    bits.push(`Opens ${fmtDay(l.starts_on)}`);
   } else {
     bits.push(l.ends_on ? `${fmtDay(l.starts_on)} – ${fmtDay(l.ends_on)}` : `From ${fmtDay(l.starts_on)} · end date TBD`);
     const len = windowLength(l.starts_on, l.ends_on);

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -1,6 +1,6 @@
 # Recruiting app — row states & subcopy reference
 
-Design documentation for `/applications` list rows (v3.8.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
+Design documentation for `/applications` list rows (v3.10.0). One row = one applicant; every visual state derives from four inputs: `stage` (server-owned), `placements`, `email state`, and `your vote`. Nothing else may add chrome to a row.
 
 ## Shared row anatomy
 
@@ -45,7 +45,7 @@ Every row carries grip ⠿ + rank, **one contextual CTA**, and **✕** at the fa
 | Waiting on them | muted `sent 3h ago` + **Follow up** | last email direction = out |
 | Invite promised | gray chip `Invite promised` + **Follow up** | last outbound reads like manual scheduling ("I'll send an invite", "let's chat tomorrow") — regex on the snippet |
 | They replied | blue response dot + **Reply** — opens the Emails tab to read first | last email direction = in, no availability parsed |
-| Availability in hand | **Pick a time** (accent) — opens the Emails tab slot picker | `recruit_availability` has windows, no screening booked |
+| Availability in hand | **Post to Discord** (accent, primary — opens the claim-post preview modal) + **Pick a time** (secondary, Emails-tab slot picker) | `recruit_availability` has windows, no screening booked. Discord claim is the primary route; posts are manual-with-preview for now |
 | Call booked | slot chip `Fri, Jul 25, 9:00 AM` + **Join call** when a Meet link exists | scheduled row in `recruit_screenings` — booked in-app **or picked up from the shared calendar**: the scan sweeps upcoming events and matches attendees to applicants (application address or any address they've replied from), so manually-sent invites become screening rows automatically |
 
 **✕** removes from *this* listing only — tombstones the placement so the auto-sweep never re-adds; tooltip says so.
@@ -63,14 +63,13 @@ Because the sweep places every qualifying candidate, this set is provably {still
 
 ## Row subcopy grammar
 
-`[track badge] [pronouns] · [move-in] · applied [date]` — segments drop out when unknown, never render placeholders.
+`[track badge] [pronouns] · [move-in]` — segments drop out when unknown, never render placeholders.
 
 | Segment | Values |
 |---|---|
 | track badge | The same `listing-kind` pill as listing headers, xs size: `Full-time` (resident tint) \| `Sublet` (sublet tint). Always first; never plain text. |
 | pronouns | lowercase, only when given — `she/her` |
 | move-in | **One canonical set:** `Sep 5, 2026` (day known) · `Sep 2026` (month) · `Aug–Sep 2026` (month range) · `Jul 28 → Aug 29` (known in→out window — replaces the old "N-week stay") · `ASAP` · `Flexible` · omitted when unparseable. The `· flexible` suffix never renders in sublines (the raw answer lives behind the profile info-dot). A recruiter-confirmed window replaces the parsed value everywhere: `Sep 1, 2026` or `Sep 1 → Oct 15`. |
-| applied | `applied Jul 1` — main rows only; accordion rows omit it |
 | email recency | Openings, awaiting state only: `sent 3h ago` → `2d ago` → date |
 
 There is no stay-length segment — sublet durations read as move-in → move-out dates.

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -58,7 +58,9 @@ const NO_EXTRACTION: Extraction = { windows: [], platform: null, timezone_note: 
 // availability windows in PT, platform requests (IG/WhatsApp/phone),
 // timezone conversions, and a needs_human flag for unparseable replies.
 async function extractAvailability(text: string): Promise<Extraction> {
-  const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
+  // Recruiting has its own key (own workspace + cap); shared/Ladder keys are
+  // emergency fallbacks only.
+  const key = Deno.env.get('RECRUIT_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
   if (!key || !text.trim()) return NO_EXTRACTION
   const prompt = `Today is ${new Date().toLocaleDateString('en-CA', { timeZone: TZ })} (${TZ}). You are extracting scheduling information from an email a housing applicant sent to Agape (San Francisco, Pacific time).
 

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.7.0'
+const VERSION = '1.7.1'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -32,7 +32,9 @@ function db() {
 }
 
 async function callClaudeRaw(model: string, system: string, prompt: string, maxTokens = 500): Promise<string> {
-  const key = Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
+  // Recruiting has its own key (own workspace + cap); shared/Ladder keys are
+  // emergency fallbacks only.
+  const key = Deno.env.get('RECRUIT_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
   if (!key) throw new Error('No Anthropic API key configured')
   const resp = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',


### PR DESCRIPTION
- **Key hygiene**: recruiting fns prefer `RECRUIT_ANTHROPIC_API_KEY` — a new key in its own `agape-recruiting` Console workspace (created + secret set); the shared Boards and Ladder keys remain as fallbacks only.
- **Discord-first**: when availability is in hand, the Openings row's primary CTA is **Post to Discord** (preview modal); Pick a time is secondary.
- Listing subheader drops the trial boilerplate; `applied [date]` removed from row sublines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)