### PR TITLE
feat(recruiting): Agape Intro Call rename + thread-reply intro email

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -117,7 +117,7 @@ export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<strin
   if (manual) {
     description += `Couldn't extract concrete times from their reply — read their thread and coordinate by email.\n\n[Open in the app](${appLink(input.applicantId)})`
   } else {
-    description += `Offered times for a screening call — tap one to claim it.`
+    description += `Offered times for an Agape Intro Call — tap one to claim it.`
   }
   const warnings: string[] = []
   if (input.timezoneNote) warnings.push(`⚠️ ${input.timezoneNote}`)
@@ -141,7 +141,7 @@ export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<strin
 
   return {
     embeds: [{
-      title: `${input.firstName} — screening call`,
+      title: `${input.firstName} — Agape Intro Call`,
       description,
       color: manual ? 0xe67e22 : 0x3498db,
     }],
@@ -244,7 +244,7 @@ export async function notifyStuck(channelId: string, messageId: string, firstNam
   await discordFetch(`/channels/${channelId}/messages`, {
     method: 'POST',
     body: JSON.stringify({
-      content: `⏰ **${firstName}**'s screening call has been unclaimed for 4 days — anyone free? https://discord.com/channels/${guildId}/${channelId}/${messageId}`,
+      content: `⏰ **${firstName}**'s Agape Intro Call has been unclaimed for 4 days — anyone free? https://discord.com/channels/${guildId}/${channelId}/${messageId}`,
     }),
   })
 }

--- a/supabase/functions/_shared/recruit-schedule.ts
+++ b/supabase/functions/_shared/recruit-schedule.ts
@@ -56,8 +56,8 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
 
   const at = await sharedAccessToken(db)
   const event = {
-    summary: `Agape screening call — ${applicant.first_name} ${applicant.last_name} × ${opts.housemateName}`,
-    description: `Get-to-know-you call with ${applicant.first_name} (Agape application), scheduled from their offered availability.`,
+    summary: `Agape Intro Call — ${applicant.first_name} ${applicant.last_name} × ${opts.housemateName}`,
+    description: `A get-to-know-you Agape Intro Call with ${applicant.first_name}, scheduled from their offered availability.`,
     start: { dateTime: opts.startsAt.toISOString(), timeZone: TZ },
     end: { dateTime: endsAt.toISOString(), timeZone: TZ },
     attendees: [
@@ -86,21 +86,35 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
   return { screening: row, meetLink: meet, applicant }
 }
 
-// Short plain-text confirmation so the booking isn't missed if the bare
-// calendar invite is. Logged to recruit_emails as an automated send.
-export async function sendApplicantConfirmation(
-  db: Db, applicant: any, housemateName: string, startsAt: Date, meetLink: string | null,
+// Introduction email: replies in the applicant's existing thread from the
+// shared inbox, introducing the resident (CC'd on their real email) so the
+// two are directly connected. Falls back to a fresh email when the applicant
+// has no thread yet (picker-only applicants). Logged to recruit_emails.
+export async function sendIntroEmail(
+  db: Db, applicant: any, residentName: string, residentEmail: string, startsAt: Date, meetLink: string | null,
 ): Promise<void> {
   const when = startsAt.toLocaleString('en-US', {
     weekday: 'long', month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ,
   })
-  const subject = `You're confirmed — Agape call with ${housemateName}`
+  // Latest thread with this applicant, if any — reply there so the intro
+  // lands in the conversation they already have open.
+  const { data: lastMail } = await db.from('recruit_emails')
+    .select('thread_id, subject').eq('applicant_id', applicant.id)
+    .not('thread_id', 'is', null)
+    .order('sent_at', { ascending: false }).limit(1).maybeSingle()
+  const subject = lastMail?.subject
+    ? (/^re:/i.test(lastMail.subject) ? lastMail.subject : `Re: ${lastMail.subject}`)
+    : `You're confirmed — Agape Intro Call with ${residentName}`
+
+  const cc = residentEmail.includes('@') ? residentEmail : null
   const text = [
     `Hi ${applicant.first_name},`,
     '',
-    `You're confirmed for a call with ${housemateName} on ${when} (Pacific time).`,
+    cc
+      ? `Meet ${residentName} (cc'd here) — you two are set for your Agape Intro Call on ${when} (Pacific time).`
+      : `You're set for your Agape Intro Call with ${residentName} on ${when} (Pacific time).`,
     meetLink ? `Google Meet link: ${meetLink}` : `The Google Meet link is in your calendar invite.`,
-    `A calendar invite from ${SHARED_EMAIL} is on its way to this address.`,
+    `A calendar invite from ${SHARED_EMAIL} is on its way too.`,
     '',
     `Looking forward to it!`,
     `— Agape`,
@@ -111,6 +125,7 @@ export async function sendApplicantConfirmation(
   const raw = [
     `From: Agape <${SHARED_EMAIL}>`,
     `To: ${applicant.email}`,
+    ...(cc ? [`Cc: ${cc}`] : []),
     `Subject: ${encSubject}`,
     'MIME-Version: 1.0',
     'Content-Type: text/plain; charset=UTF-8',
@@ -120,14 +135,22 @@ export async function sendApplicantConfirmation(
   const resp = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
     method: 'POST',
     headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ raw: b64url(raw) }),
+    body: JSON.stringify({ raw: b64url(raw), ...(lastMail?.thread_id ? { threadId: lastMail.thread_id } : {}) }),
   })
   const sent = await resp.json()
-  if (!resp.ok) throw new Error(`Confirmation send failed: ${JSON.stringify(sent).slice(0, 180)}`)
+  if (!resp.ok) throw new Error(`Intro send failed: ${JSON.stringify(sent).slice(0, 180)}`)
   await db.from('recruit_emails').upsert({
     applicant_id: applicant.id, gmail_id: sent.id, thread_id: sent.threadId,
     direction: 'out', subject, snippet: text.slice(0, 180), body_text: text,
     from_email: SHARED_EMAIL, to_email: applicant.email,
     sent_by_name: 'auto', sent_at: new Date().toISOString(),
   }, { onConflict: 'gmail_id' })
+}
+
+// Resolve the email a resident should be CC'd/invited on: the Google Group
+// email from their profile when set, else their ctrl.rodeo login email.
+export async function residentEmailFor(db: Db, userId: string, fallback: string): Promise<string> {
+  const { data: rp } = await db.from('recruit_profiles').select('group_email').eq('user_id', userId).maybeSingle()
+  const email = (rp?.group_email || fallback || '').toLowerCase().trim()
+  return email
 }

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,12 +13,12 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.1.1'
+const VERSION = '1.2.0'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { scheduleScreening, sendApplicantConfirmation } from '../_shared/recruit-schedule.ts'
+import { scheduleScreening, sendIntroEmail } from '../_shared/recruit-schedule.ts'
 import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
@@ -90,10 +90,11 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
 }): Promise<void> {
   const { claimPost, applicantId, startsAt, label } = opts
   try {
-    const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', opts.userId).maybeSingle()
+    const { data: rp } = await client.from('recruit_profiles').select('display_name, group_email').eq('user_id', opts.userId).maybeSingle()
     const housemateName = rp?.display_name || opts.discordUsername || 'an Agape housemate'
     const { data: authUser, error: authErr } = await client.auth.admin.getUserById(opts.userId)
-    const housemateEmail = (authUser?.user?.email || '').toLowerCase()
+    // Google Group address preferred — it's the email residents actually read.
+    const housemateEmail = (rp?.group_email || authUser?.user?.email || '').toLowerCase().trim()
     if (authErr || !housemateEmail.includes('@')) throw new Error('Could not resolve your account email')
 
     const { screening, meetLink, applicant } = await scheduleScreening(client, {
@@ -111,13 +112,13 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
       ? `\nHeads up: they asked for ${platform.kind}${platform.handle ? ` (@${platform.handle})` : ''} — default is the Meet link, but feel free to DM them about it.`
       : ''
     await dmUser(opts.discordUserId,
-      `✅ You claimed **${applicantName}**'s screening call — ${slotWhen(startsAt)}.\n` +
+      `✅ You claimed **${applicantName}**'s Agape Intro Call — ${slotWhen(startsAt)}.\n` +
       `Calendar invites are out to you both. Meet: ${meetLink || '(see calendar invite)'}${platformLine}`)
 
     try {
-      await sendApplicantConfirmation(client, applicant, housemateName, startsAt, meetLink)
+      await sendIntroEmail(client, applicant, housemateName, housemateEmail, startsAt, meetLink)
     } catch (err) {
-      console.warn(`[recruit-discord] confirmation email failed for ${applicantId}: ${(err as Error).message}`)
+      console.warn(`[recruit-discord] intro email failed for ${applicantId}: ${(err as Error).message}`)
     }
     console.log(`[recruit-discord] claim complete: ${applicantId} × ${housemateName} @ ${startsAt.toISOString()} (screening ${screening.id})`)
   } catch (err) {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,12 +16,12 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.7.1'
+const VERSION = '1.8.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendApplicantConfirmation, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
+import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
 import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage } from '../_shared/discord.ts'
 
 const corsHeaders = {
@@ -320,9 +320,10 @@ serve(async (req) => {
       const startsAt = new Date(String(body.startsAt || ''))
       if (isNaN(startsAt.getTime()) || startsAt < new Date()) return json({ error: 'Pick a future start time' }, 400)
 
-      const { data: rp } = await client.from('recruit_profiles').select('display_name').eq('user_id', userData.user.id).maybeSingle()
+      const { data: rp } = await client.from('recruit_profiles').select('display_name, group_email').eq('user_id', userData.user.id).maybeSingle()
       const housemateName = rp?.display_name || membership.discord_username || 'an Agape housemate'
-      const housemateEmail = (userData.user.email || '').toLowerCase()
+      // Google Group address preferred — it's the email residents actually read.
+      const housemateEmail = (rp?.group_email || userData.user.email || '').toLowerCase().trim()
 
       let result
       try {
@@ -359,9 +360,9 @@ serve(async (req) => {
       }
 
       try {
-        await sendApplicantConfirmation(client, result.applicant, housemateName, startsAt, result.meetLink)
+        await sendIntroEmail(client, result.applicant, housemateName, housemateEmail, startsAt, result.meetLink)
       } catch (err) {
-        console.warn(`confirmation email failed for ${applicantId}: ${(err as Error).message}`)
+        console.warn(`intro email failed for ${applicantId}: ${(err as Error).message}`)
       }
 
       console.log(`screening ${applicantId} x ${housemateName} @ ${startsAt.toISOString()}`)

--- a/supabase/migrations/125_recruit_profiles_group_email.sql
+++ b/supabase/migrations/125_recruit_profiles_group_email.sql
@@ -1,0 +1,4 @@
+-- Migration 125: residents' Google Group email on recruit_profiles.
+-- CC'd on Agape Intro Call intro emails and preferred as the GCal invite
+-- address; the ctrl.rodeo login email is the fallback when unset.
+ALTER TABLE recruit_profiles ADD COLUMN IF NOT EXISTS group_email TEXT;


### PR DESCRIPTION
## What

1. **Terminology**: all human-facing copy now says **Agape Intro Call** — Discord post title/body, stuck nudge, claimer DM, and the GCal event (`Agape Intro Call — {Applicant} × {Resident}`).
2. **Intro email replaces the confirmation email**: on claim (Discord or app), the shared inbox now **replies in the applicant's existing thread**, introducing the resident by name with them **CC'd** — so the two are directly connected. Picker-only applicants with no thread get a fresh `You're confirmed — Agape Intro Call with {Resident}` email.
3. **Resident real emails**: new `recruit_profiles.group_email` (migration 125, already applied) holds each resident's Google Group address; it's preferred for the CC and the calendar invite, falling back to their ctrl.rodeo login email. Seed it once from the group roster.

recruit-gmail → 1.8.0, recruit-discord → 1.2.0. `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)