### PR TITLE
feat(recruiting): group-roster autofill + Recall.ai recording pipeline

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -152,6 +152,8 @@ supabase functions deploy {function-name}
 | `recruit-availability` | Boards | Public applicant schedule picker backend (schedule_token auth) | — |
 | `recruit-discord` | Boards | Discord interactions endpoint for screening-claim buttons | — |
 
+**Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notetaker" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-interviews, and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
+
 **recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-interviews` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
 
 ---

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -238,6 +238,29 @@ export async function dmUser(discordUserId: string, content: string): Promise<vo
   })
 }
 
+// Post the recording + summary back to the claims channel after a call ends.
+export async function postRecordingNote(
+  firstName: string, applicantId: string, residentName: string,
+  summary: string | null, videoUrl: string | null,
+): Promise<void> {
+  const lines = [
+    summary || '_No transcript captured (captions may have been off)._',
+    '',
+    videoUrl ? `🎥 [Recording](${videoUrl}) _(link expires — grab it soon)_` : '🎥 Recording unavailable.',
+    `📋 [Full profile](${appLink(applicantId)})`,
+  ]
+  await discordFetch(`/channels/${CLAIMS_CHANNEL_ID}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({
+      embeds: [{
+        title: `${firstName} × ${residentName} — Intro Call notes`,
+        description: lines.join('\n').slice(0, 4000),
+        color: 0x9b59b6,
+      }],
+    }),
+  })
+}
+
 // One channel nudge for a post nobody claimed within 96h.
 export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {
   const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -1,0 +1,120 @@
+// _shared/recall.ts
+// Recall.ai meeting-recording bot for Agape Intro Calls. Entirely inert until
+// RECALL_API_KEY is set. The bot ("Agape Notetaker") joins the Meet at start
+// time, records, and captures the transcript via Meet's own captions (free
+// tier — no per-minute transcription cost).
+//
+// RECALL_API_BASE defaults to the us-west-2 region; set it if the account
+// lives in another region (the key is region-scoped).
+
+// deno-lint-ignore-file no-explicit-any
+
+const RECALL_API_BASE = Deno.env.get('RECALL_API_BASE') || 'https://us-west-2.recall.ai'
+
+export function recallEnabled(): boolean {
+  return Boolean(Deno.env.get('RECALL_API_KEY'))
+}
+
+async function recallFetch(path: string, options: RequestInit = {}): Promise<any> {
+  const key = Deno.env.get('RECALL_API_KEY')
+  if (!key) throw new Error('RECALL_API_KEY not set')
+  const resp = await fetch(`${RECALL_API_BASE}${path}`, {
+    ...options,
+    headers: { Authorization: `Token ${key}`, 'Content-Type': 'application/json' },
+  })
+  const text = await resp.text()
+  if (!resp.ok) throw new Error(`Recall ${resp.status} ${options.method || 'GET'} ${path}: ${text.slice(0, 200)}`)
+  return text ? JSON.parse(text) : null
+}
+
+// Create a bot that joins the meeting at start time. Returns the bot id.
+export async function createRecordingBot(meetingUrl: string, joinAtISO: string): Promise<string> {
+  const bot = await recallFetch('/api/v1/bot/', {
+    method: 'POST',
+    body: JSON.stringify({
+      meeting_url: meetingUrl,
+      bot_name: 'Agape Notetaker',
+      join_at: joinAtISO,
+      recording_config: {
+        transcript: { provider: { meeting_captions: {} } },
+      },
+    }),
+  })
+  if (!bot?.id) throw new Error(`Recall bot create returned no id: ${JSON.stringify(bot).slice(0, 150)}`)
+  return bot.id
+}
+
+export interface BotResult {
+  done: boolean
+  failed: boolean
+  statusCode: string
+  videoUrl: string | null
+  transcriptUrl: string | null
+}
+
+// Poll a bot: done once its lifecycle ended; URLs come from media_shortcuts.
+export async function getBotResult(botId: string): Promise<BotResult> {
+  const bot = await recallFetch(`/api/v1/bot/${botId}/`)
+  const changes = bot.status_changes || []
+  const statusCode = String(changes[changes.length - 1]?.code || bot.status?.code || 'unknown')
+  const terminal = ['done', 'fatal', 'call_ended', 'media_expired'].includes(statusCode)
+  const rec = (bot.recordings || [])[0]
+  const videoUrl = rec?.media_shortcuts?.video_mixed?.data?.download_url || bot.video_url || null
+  const transcriptUrl = rec?.media_shortcuts?.transcript?.data?.download_url || null
+  return {
+    done: terminal && statusCode !== 'fatal',
+    failed: statusCode === 'fatal',
+    statusCode,
+    videoUrl,
+    transcriptUrl,
+  }
+}
+
+// Download a transcript and flatten it to "Speaker: text" lines. Recall's
+// transcript JSON is a list of participant segments with word arrays.
+export async function fetchTranscriptText(transcriptUrl: string): Promise<string> {
+  const resp = await fetch(transcriptUrl)
+  if (!resp.ok) throw new Error(`transcript download ${resp.status}`)
+  const data = await resp.json()
+  const lines: string[] = []
+  for (const seg of (Array.isArray(data) ? data : [])) {
+    const speaker = seg.participant?.name || seg.speaker || 'Speaker'
+    const words = (seg.words || []).map((w: any) => w.text).join(' ').trim()
+    if (words) lines.push(`${speaker}: ${words}`)
+  }
+  return lines.join('\n')
+}
+
+// Haiku summary of the call — the "screener representation" that rides back
+// to Discord and the applicant's profile.
+export async function summarizeIntroCall(transcript: string, applicantName: string, residentName: string): Promise<string | null> {
+  const key = Deno.env.get('RECRUIT_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
+  if (!key || !transcript.trim()) return null
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001', max_tokens: 700,
+      system: 'You summarize housing-community intro calls for the housemates deciding on an applicant. Be concrete and neutral; quote sparingly.',
+      messages: [{
+        role: 'user',
+        content: `This is the transcript of an Agape Intro Call between resident ${residentName} and applicant ${applicantName}. Write a summary for the house:
+
+**Vibe** — one sentence on how the conversation felt.
+**About them** — 3-5 bullets: work, background, why they want co-op living, logistics (move-in, budget) if mentioned.
+**Highlights** — anything that stood out, positive or concerning.
+**Follow-ups** — open questions the house should still ask.
+
+Keep it under 250 words. Transcript:
+
+${transcript.slice(0, 24000)}`,
+      }],
+    }),
+  })
+  if (!resp.ok) {
+    console.warn(`summarizeIntroCall: anthropic ${resp.status} ${(await resp.text()).slice(0, 200)}`)
+    return null
+  }
+  const data = await resp.json()
+  return (data.content || []).filter((b: any) => b.type === 'text').map((b: any) => b.text).join('').trim() || null
+}

--- a/supabase/functions/_shared/recruit-schedule.ts
+++ b/supabase/functions/_shared/recruit-schedule.ts
@@ -83,6 +83,23 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
     gcal_event_id: created.id, meet_link: meet, status: 'scheduled',
   }).select().single()
   if (error) throw new Error(error.message)
+
+  // Recording bot: "Agape Notetaker" joins the Meet at start time. Warn-only
+  // and inert until RECALL_API_KEY is set — never blocks scheduling.
+  if (meet) {
+    try {
+      const { recallEnabled, createRecordingBot } = await import('./recall.ts')
+      if (recallEnabled()) {
+        const botId = await createRecordingBot(meet, opts.startsAt.toISOString())
+        await db.from('recruit_screenings').update({ recall_bot_id: botId, recall_status: 'scheduled' }).eq('id', row.id)
+        row.recall_bot_id = botId
+        console.log(`[recall] bot ${botId} scheduled for screening ${row.id}`)
+      }
+    } catch (err) {
+      console.warn(`[recall] bot scheduling failed for screening ${row.id}: ${(err as Error).message}`)
+    }
+  }
+
   return { screening: row, meetLink: meet, applicant }
 }
 

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,7 +20,7 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.1.2'
+const VERSION = '1.2.0'
 console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -155,6 +155,35 @@ async function verifyAndCache(userId: string, identity: DiscordIdentity) {
     .from('user_discord_membership')
     .upsert(row, { onConflict: 'user_id' })
   if (error) throw new Error(`Cache write failed: ${error.message}`)
+
+  // First-sign-in nicety: when the login email is on the AgapeSF group
+  // roster, seed recruit_profiles with their real name + group email so
+  // Intro Call invites and intro emails use real identities from day one.
+  if (isRecruiting) {
+    try {
+      const db = getSupabase()
+      const { data: au } = await db.auth.admin.getUserById(userId)
+      const email = (au?.user?.email || '').toLowerCase()
+      const { data: roster } = email
+        ? await db.from('recruit_group_roster').select('full_name, email').eq('email', email).maybeSingle()
+        : { data: null }
+      if (roster) {
+        const { data: prof } = await db.from('recruit_profiles')
+          .select('user_id, display_name, group_email').eq('user_id', userId).maybeSingle()
+        if (!prof) {
+          await db.from('recruit_profiles').insert({ user_id: userId, display_name: roster.full_name, group_email: roster.email })
+        } else if (!prof.display_name || !prof.group_email) {
+          await db.from('recruit_profiles').update({
+            display_name: prof.display_name || roster.full_name,
+            group_email: prof.group_email || roster.email,
+          }).eq('user_id', userId)
+        }
+      }
+    } catch (err) {
+      console.warn('roster autofill failed:', (err as Error).message)
+    }
+  }
+
   console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember} recruiting=${isRecruiting}`)
   return row
 }

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.2.1'
+const VERSION = '1.3.0'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -245,6 +245,53 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
   return sent
 }
 
+// Harvest finished Recall recordings: after a call ends, pull the transcript,
+// summarize with Haiku, post notes + recording link to #recruiting-interviews,
+// and store the summary on the screening row (the app reads it from there).
+// Runs on the same 15-min cron tick as reminders; inert without RECALL_API_KEY.
+async function processRecordings(client: ReturnType<typeof db>): Promise<number> {
+  const { recallEnabled, getBotResult, fetchTranscriptText, summarizeIntroCall } = await import('../_shared/recall.ts')
+  if (!recallEnabled()) return 0
+  const { postRecordingNote } = await import('../_shared/discord.ts')
+  const { data: rows } = await client.from('recruit_screenings')
+    .select('id, applicant_id, housemate_name, recall_bot_id, ends_at')
+    .not('recall_bot_id', 'is', null).is('recording_posted_at', null)
+    .lt('ends_at', new Date(Date.now() - 5 * 60000).toISOString())
+    .limit(5)
+  let posted = 0
+  for (const s of (rows || [])) {
+    try {
+      const bot = await getBotResult(s.recall_bot_id)
+      if (!bot.done && !bot.failed) continue // still recording or processing
+      if (bot.failed) {
+        await client.from('recruit_screenings')
+          .update({ recall_status: 'failed', recording_posted_at: new Date().toISOString() }).eq('id', s.id)
+        console.warn(`[recall] bot ${s.recall_bot_id} failed (${bot.statusCode}) for screening ${s.id}`)
+        continue
+      }
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('first_name, last_name').eq('id', s.applicant_id).maybeSingle()
+      const applicantName = `${applicant?.first_name || 'Applicant'} ${applicant?.last_name || ''}`.trim()
+      let summary: string | null = null
+      if (bot.transcriptUrl) {
+        const transcript = await fetchTranscriptText(bot.transcriptUrl)
+        summary = await summarizeIntroCall(transcript, applicantName, s.housemate_name || 'a resident')
+      }
+      await postRecordingNote(applicant?.first_name || 'Applicant', s.applicant_id, s.housemate_name || 'resident', summary, bot.videoUrl)
+      await client.from('recruit_screenings').update({
+        recall_status: 'done',
+        recording_summary: summary,
+        recording_posted_at: new Date().toISOString(),
+      }).eq('id', s.id)
+      posted++
+      console.log(`[recall] notes posted for screening ${s.id}`)
+    } catch (err) {
+      console.warn(`[recall] processing failed for screening ${s.id}: ${(err as Error).message}`)
+    }
+  }
+  return posted
+}
+
 serve(async (req) => {
   try {
     // Cron path: interview reminders (header auth, not Discord-signed).
@@ -264,8 +311,9 @@ serve(async (req) => {
       }
       if (!authorized) return json({ error: 'unauthorized' }, 401)
       const sent = await remindUpcoming(client)
-      console.log(`[recruit-discord] reminder sweep: ${sent} DM(s) sent`)
-      return json({ reminded: sent })
+      const recorded = await processRecordings(client)
+      console.log(`[recruit-discord] tick: ${sent} reminder(s), ${recorded} recording(s) posted`)
+      return json({ reminded: sent, recorded })
     }
 
     const body = await req.text()

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.8.0'
+const VERSION = '1.8.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/migrations/127_recruit_recall_recording.sql
+++ b/supabase/migrations/127_recruit_recall_recording.sql
@@ -1,0 +1,9 @@
+-- Migration 127: Recall.ai recording bot tracking on recruit_screenings.
+-- recall_bot_id set at schedule time (bot joins the Meet as "Agape Notetaker");
+-- the 15-min recruit-discord tick harvests finished recordings, summarizes the
+-- transcript, posts to #recruiting-interviews, and stamps recording_posted_at.
+ALTER TABLE recruit_screenings
+  ADD COLUMN IF NOT EXISTS recall_bot_id TEXT,
+  ADD COLUMN IF NOT EXISTS recall_status TEXT,
+  ADD COLUMN IF NOT EXISTS recording_summary TEXT,
+  ADD COLUMN IF NOT EXISTS recording_posted_at TIMESTAMPTZ;


### PR DESCRIPTION
## What

**1. AgapeSF roster → real identities** (migrations 126, applied)
- `recruit_group_roster` seeded with the 15 humans from groups.google.com/g/AgapeSF
- `discord-membership` v1.2.0: when a rostered resident first signs into ctrl.rodeo, their `recruit_profiles` row is auto-created with their **real name** and **group email** — so Intro Call invites, intro emails, and Discord copy use real identities with zero manual setup
- Ian's profile backfilled

**2. Recall.ai recording pipeline** (migration 127, applied — inert until `RECALL_API_KEY` is set)
- On claim, `scheduleScreening` sends an **Agape Notetaker** bot to the Meet at start time (transcript via free Meet captions)
- The existing 15-min cron tick polls finished bots: downloads the transcript, generates a Haiku **intro-call summary** (vibe / about them / highlights / follow-ups), posts it with the recording link to #recruiting-interviews, and stores it on `recruit_screenings.recording_summary` for the app
- Bot failures and missing transcripts degrade gracefully; nothing ever blocks scheduling

To activate: sign up at recall.ai, then `supabase secrets set RECALL_API_KEY=...` (+ `RECALL_API_BASE` if not us-west-2).

`deno check` clean across all four functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)