### PR TITLE
chore(recruiting): rename recording bot to 'Agape Notes'

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -152,7 +152,7 @@ supabase functions deploy {function-name}
 | `recruit-availability` | Boards | Public applicant schedule picker backend (schedule_token auth) | — |
 | `recruit-discord` | Boards | Discord interactions endpoint for screening-claim buttons | — |
 
-**Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notetaker" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-interviews, and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
+**Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notes" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-interviews, and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
 
 **recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-interviews` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
 

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -1,6 +1,6 @@
 // _shared/recall.ts
 // Recall.ai meeting-recording bot for Agape Intro Calls. Entirely inert until
-// RECALL_API_KEY is set. The bot ("Agape Notetaker") joins the Meet at start
+// RECALL_API_KEY is set. The bot ("Agape Notes") joins the Meet at start
 // time, records, and captures the transcript via Meet's own captions (free
 // tier — no per-minute transcription cost).
 //
@@ -33,7 +33,7 @@ export async function createRecordingBot(meetingUrl: string, joinAtISO: string):
     method: 'POST',
     body: JSON.stringify({
       meeting_url: meetingUrl,
-      bot_name: 'Agape Notetaker',
+      bot_name: 'Agape Notes',
       join_at: joinAtISO,
       recording_config: {
         transcript: { provider: { meeting_captions: {} } },

--- a/supabase/functions/_shared/recruit-schedule.ts
+++ b/supabase/functions/_shared/recruit-schedule.ts
@@ -84,7 +84,7 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
   }).select().single()
   if (error) throw new Error(error.message)
 
-  // Recording bot: "Agape Notetaker" joins the Meet at start time. Warn-only
+  // Recording bot: "Agape Notes" joins the Meet at start time. Warn-only
   // and inert until RECALL_API_KEY is set — never blocks scheduling.
   if (meet) {
     try {

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.3.0'
+const VERSION = '1.3.1'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.8.1'
+const VERSION = '1.8.2'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/migrations/127_recruit_recall_recording.sql
+++ b/supabase/migrations/127_recruit_recall_recording.sql
@@ -1,5 +1,5 @@
 -- Migration 127: Recall.ai recording bot tracking on recruit_screenings.
--- recall_bot_id set at schedule time (bot joins the Meet as "Agape Notetaker");
+-- recall_bot_id set at schedule time (bot joins the Meet as "Agape Notes");
 -- the 15-min recruit-discord tick harvests finished recordings, summarizes the
 -- transcript, posts to #recruiting-interviews, and stamps recording_posted_at.
 ALTER TABLE recruit_screenings


### PR DESCRIPTION
The Meet recording bot now joins as **Agape Notes** (was Agape Notetaker). Patch bumps for both functions bundling the shared module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)