### PR TITLE
feat(recruiting): Intro Call notes → #recruiting-society

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -152,7 +152,7 @@ supabase functions deploy {function-name}
 | `recruit-availability` | Boards | Public applicant schedule picker backend (schedule_token auth) | — |
 | `recruit-discord` | Boards | Discord interactions endpoint for screening-claim buttons | — |
 
-**Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notes" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-interviews, and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
+**Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notes" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-society (`1503490895469609211`; `SCREENING_NOTES_CHANNEL_ID` overrides), and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
 
 **recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-interviews` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
 

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -10,6 +10,8 @@ import { TZ } from './recruit-schedule.ts'
 const DISCORD_API = 'https://discord.com/api/v10'
 // #recruiting-interviews in the Agape guild (952961396121931838)
 export const CLAIMS_CHANNEL_ID = Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || '1529576830514762029'
+// #recruiting-society — where finished Intro Call notes/recordings post
+export const NOTES_CHANNEL_ID = Deno.env.get('SCREENING_NOTES_CHANNEL_ID') || '1503490895469609211'
 
 function botHeaders(): Record<string, string> {
   const token = Deno.env.get('DISCORD_BOT_TOKEN')
@@ -249,7 +251,7 @@ export async function postRecordingNote(
     videoUrl ? `🎥 [Recording](${videoUrl}) _(link expires — grab it soon)_` : '🎥 Recording unavailable.',
     `📋 [Full profile](${appLink(applicantId)})`,
   ]
-  await discordFetch(`/channels/${CLAIMS_CHANNEL_ID}/messages`, {
+  await discordFetch(`/channels/${NOTES_CHANNEL_ID}/messages`, {
     method: 'POST',
     body: JSON.stringify({
       embeds: [{

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.3.1'
+const VERSION = '1.3.2'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
Recording notes (Haiku summary + recording link) now post to **#recruiting-society** (`1503490895469609211`, env `SCREENING_NOTES_CHANNEL_ID` overrides) instead of #recruiting-interviews. Claim posts and the claim flow are unchanged.

Needs the bot to have View/Send/Embed in #recruiting-society.

🤖 Generated with [Claude Code](https://claude.com/claude-code)