### PR TITLE
feat(recruiting): claim post copy refresh

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -99,6 +99,7 @@ export interface ClaimPostInput {
   applicantId: string
   firstName: string
   whyLine: string | null
+  pronouns?: string | null
   windows: Array<{ date: string; start: string; end: string }>
   platform: { kind: string; handle?: string } | null
   timezoneNote: string | null
@@ -109,26 +110,45 @@ function appLink(applicantId: string): string {
   return `https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`
 }
 
+// "her/his/their application" from the applicant's own pronouns field;
+// neutral "their" whenever unstated or ambiguous.
+function possessive(pronouns: string | null | undefined): string {
+  const p = (pronouns || '').toLowerCase()
+  if (/she/.test(p) && !/he\/|\bhe\b/.test(p.replace(/she/g, ''))) return 'her'
+  if (/\bhe\b|he\/him/.test(p) && !/she/.test(p)) return 'his'
+  return 'their'
+}
+
 // Exported so the app can render a faithful preview before a human
 // triggers the post (auto-posting is off for now — manual first).
 export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<string, unknown> {
-  const why = (input.whyLine || '').trim().replace(/\s+/g, ' ').slice(0, 140)
   const manual = input.needsHuman || !slots.length
+  const poss = possessive(input.pronouns)
 
-  let description = why ? `_${why}_\n\n` : ''
-  if (manual) {
-    description += `Couldn't extract concrete times from their reply — read their thread and coordinate by email.\n\n[Open in the app](${appLink(input.applicantId)})`
-  } else {
-    description += `Offered times for an Agape Intro Call — tap one to claim it.`
-  }
-  const warnings: string[] = []
-  if (input.timezoneNote) warnings.push(`⚠️ ${input.timezoneNote}`)
+  const considerations: string[] = []
+  if (input.timezoneNote) considerations.push(`⚠️ ${input.timezoneNote}`)
   if (input.platform?.kind) {
     const handle = input.platform.handle ? ` (@${input.platform.handle})` : ''
-    warnings.push(`⚠️ Asked for ${input.platform.kind}${handle} — default is Meet; claimer can DM them about it.`)
+    considerations.push(`⚠️ Asked for ${input.platform.kind}${handle} — default is Meet; the resident can DM them about it.`)
   }
-  if (warnings.length) description += `\n\n${warnings.join('\n')}`
-  if (!manual) description += `\n\n_Tap a time to claim the call — you'll both get a calendar invite._`
+  // Considerations section only exists when there is something to flag.
+  const considerationsBlock = considerations.length
+    ? `**Considerations:**\n${considerations.join('\n')}\n\n`
+    : ''
+
+  let description: string
+  if (manual) {
+    description =
+      `**${input.firstName}** replied about scheduling, but no concrete times could be read.\n\n` +
+      considerationsBlock +
+      `See ${poss} [application](${appLink(input.applicantId)}) — read the thread and coordinate by email.`
+  } else {
+    description =
+      `Can someone take this Intro Call with **${input.firstName}**?\n\n` +
+      considerationsBlock +
+      `See ${poss} [application](${appLink(input.applicantId)}).\n\n` +
+      `_Tap a time below to claim the call — you'll both receive an invite._`
+  }
 
   const components: Array<Record<string, unknown>> = []
   if (!manual) {
@@ -143,7 +163,6 @@ export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<strin
 
   return {
     embeds: [{
-      title: `${input.firstName} — Agape Intro Call`,
       description,
       color: manual ? 0xe67e22 : 0x3498db,
     }],

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -7,7 +7,7 @@
 // POST { token }                      → { firstName, windows }
 // POST { token, windows: [...] }      → save; { saved: true, windows }
 
-const VERSION = '1.2.0'
+const VERSION = '1.2.1'
 console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint + Discord claim post`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -61,10 +61,10 @@ serve(async (req) => {
       // Warn-only: Discord being down never blocks the applicant's save.
       try {
         const { data: full } = await client.from('recruit_applicants')
-          .select('why_agape').eq('id', applicant.id).maybeSingle()
+          .select('why_agape, pronouns').eq('id', applicant.id).maybeSingle()
         await upsertClaimMessage(client, {
           applicantId: applicant.id, firstName: applicant.first_name,
-          whyLine: full?.why_agape || null,
+          whyLine: full?.why_agape || null, pronouns: full?.pronouns || null,
           windows, platform: null, timezoneNote: null, needsHuman: false,
         })
       } catch (err) {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.9.0'
+const VERSION = '1.9.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -111,10 +111,10 @@ async function postClaim(client: ReturnType<typeof db>, applicantId: string, ext
   if (!extraction.windows.length && !extraction.needs_human) return
   try {
     const { data: applicant } = await client.from('recruit_applicants')
-      .select('first_name, why_agape').eq('id', applicantId).maybeSingle()
+      .select('first_name, why_agape, pronouns').eq('id', applicantId).maybeSingle()
     if (!applicant) return
     await upsertClaimMessage(client, {
-      applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape,
+      applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape, pronouns: applicant.pronouns,
       windows: extraction.windows, platform: extraction.platform,
       timezoneNote: extraction.timezone_note, needsHuman: extraction.needs_human,
     })
@@ -375,7 +375,7 @@ serve(async (req) => {
       // runs once. Future cutover: re-enable the auto postClaim calls.
       const applicantId = String(body.applicantId || '')
       const { data: applicant } = await client.from('recruit_applicants')
-        .select('id, first_name, why_agape').eq('id', applicantId).maybeSingle()
+        .select('id, first_name, why_agape, pronouns').eq('id', applicantId).maybeSingle()
       if (!applicant) return json({ error: 'unknown applicant' }, 404)
       let extraction: Extraction = body.extraction && Array.isArray(body.extraction.windows)
         ? body.extraction as Extraction
@@ -389,7 +389,7 @@ serve(async (req) => {
         if (!extraction.windows.length && !extraction.needs_human) extraction = { ...extraction, needs_human: true }
       }
       const input = {
-        applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape,
+        applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape, pronouns: applicant.pronouns,
         windows: extraction.windows, platform: extraction.platform,
         timezoneNote: extraction.timezone_note, needsHuman: extraction.needs_human,
       }


### PR DESCRIPTION
Restructures the claim card per Ian's sketch:

```
Can someone take this Intro Call with **Marisa**?

**Considerations:**
⚠️ applicant is in Europe, +9h from PT — windows converted
⚠️ Asked for instagram (@aroundwespin) — default is Meet; the resident can DM them about it.

See her [application](link).

_Tap a time below to claim the call — you'll both receive an invite._
```

- **Considerations section renders only when there's something to flag** — no header, no empty block otherwise.
- Possessive ("her/his/their application") derives from the applicant's own pronouns field; neutral "their" when unstated.
- Embed title and the why-they-applied quote are dropped; the application link carries that context.
- needs_human posts restructured to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)