### PR TITLE
feat(recruiting): record all shared-account Meets + liveness cancel fix

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -147,7 +147,7 @@ export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<strin
       `Can someone take this Intro Call with **${input.firstName}**?\n\n` +
       considerationsBlock +
       `See ${poss} [application](${appLink(input.applicantId)}).\n\n` +
-      `_Tap a time below to claim the call — you'll both receive an invite._`
+      `_Tap a time below to claim the call — you'll both receive an invite and be added to the email thread._`
   }
 
   const components: Array<Record<string, unknown>> = []
@@ -311,6 +311,23 @@ export async function postRecordingNote(
         description: lines.join('\n').slice(0, 4000),
         color: 0x9b59b6,
       }],
+    }),
+  })
+}
+
+// Notes for a non-applicant meeting hosted by the shared account.
+export async function postMeetingNote(
+  title: string, summary: string | null, videoUrl: string | null,
+): Promise<void> {
+  const lines = [
+    summary || '_No transcript captured (captions may have been off)._',
+    '',
+    videoUrl ? `🎥 [Recording](${videoUrl}) _(link expires — grab it soon)_` : '🎥 Recording unavailable.',
+  ]
+  await discordFetch(`/channels/${NOTES_CHANNEL_ID}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({
+      embeds: [{ title: `${title} — meeting notes`, description: lines.join('\n').slice(0, 4000), color: 0x9b59b6 }],
     }),
   })
 }

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -85,6 +85,31 @@ export async function fetchTranscriptText(transcriptUrl: string): Promise<string
   return lines.join('\n')
 }
 
+// Generic meeting summary for non-applicant calls hosted by the shared account.
+export async function summarizeMeeting(transcript: string, title: string): Promise<string | null> {
+  const key = Deno.env.get('RECRUIT_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY')
+  if (!key || !transcript.trim()) return null
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001', max_tokens: 700,
+      system: 'You summarize meetings for the Agape co-op house. Be concrete and neutral.',
+      messages: [{
+        role: 'user',
+        content: `Summarize this meeting ("${title}") for housemates who missed it: what was discussed, decisions made, and open follow-ups. Under 250 words, bullets welcome. Transcript:\n\n${transcript.slice(0, 24000)}`,
+      }],
+    }),
+  })
+  if (!resp.ok) {
+    console.warn(`summarizeMeeting: anthropic ${resp.status} ${(await resp.text()).slice(0, 200)}`)
+    return null
+  }
+  const data = await resp.json()
+  // deno-lint-ignore no-explicit-any
+  return (data.content || []).filter((b: any) => b.type === 'text').map((b: any) => b.text).join('').trim() || null
+}
+
 // Haiku summary of the call — the "screener representation" that rides back
 // to Discord and the applicant's profile.
 export async function summarizeIntroCall(transcript: string, applicantName: string, residentName: string): Promise<string | null> {

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -7,7 +7,7 @@
 // POST { token }                      → { firstName, windows }
 // POST { token, windows: [...] }      → save; { saved: true, windows }
 
-const VERSION = '1.2.1'
+const VERSION = '1.2.2'
 console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint + Discord claim post`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.4.0'
+const VERSION = '1.5.0'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -205,11 +205,15 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
           let dead = resp.status === 404 || resp.status === 410
           if (resp.ok) {
             const ev = await resp.json()
+            const myEmail = (s.housemate_email || '').toLowerCase()
             // deno-lint-ignore no-explicit-any
-            const me = (ev.attendees || []).find((a: any) => (a.email || '').toLowerCase() === (s.housemate_email || '').toLowerCase())
+            const me = (ev.attendees || []).find((a: any) => (a.email || '').toLowerCase() === myEmail)
+            // Missing-attendee only signals a release when we actually know the
+            // resident's email — calendar-pickup rows have none (housemate_email
+            // null) and must not be treated as declined (the Katie 10am bug).
             dead = ev.status === 'cancelled'
               || me?.responseStatus === 'declined'
-              || (!me && (ev.attendees || []).length > 0)
+              || (Boolean(myEmail) && !me && (ev.attendees || []).length > 0)
           }
           if (dead) {
             await client.from('recruit_screenings')
@@ -246,6 +250,118 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
 // summarize with Haiku, post notes + recording link to #recruiting-interviews,
 // and store the summary on the screening row (the app reads it from there).
 // Runs on the same 15-min cron tick as reminders; inert without RECALL_API_KEY.
+// Every scheduled screening with a Meet link gets a recording bot — including
+// calls created by hand on the shared calendar (picked up by scan) and calls
+// booked before RECALL_API_KEY existed. Runs on the 15-min tick.
+async function scheduleMissingBots(client: ReturnType<typeof db>): Promise<number> {
+  const { recallEnabled, createRecordingBot } = await import('../_shared/recall.ts')
+  if (!recallEnabled()) return 0
+  const { data: rows } = await client.from('recruit_screenings')
+    .select('id, meet_link, starts_at')
+    .eq('status', 'scheduled').is('recall_bot_id', null)
+    .not('meet_link', 'is', null)
+    .gt('starts_at', new Date().toISOString()).limit(10)
+  let created = 0
+  for (const s of (rows || [])) {
+    try {
+      const botId = await createRecordingBot(s.meet_link, s.starts_at)
+      await client.from('recruit_screenings')
+        .update({ recall_bot_id: botId, recall_status: 'scheduled' }).eq('id', s.id)
+      created++
+      console.log(`[recall] backfilled bot ${botId} for screening ${s.id} (${s.starts_at})`)
+    } catch (err) {
+      console.warn(`[recall] backfill failed for screening ${s.id}: ${(err as Error).message}`)
+    }
+  }
+  return created
+}
+
+// Default: record EVERY Meet hosted by the shared account. Sweep the shared
+// calendar for upcoming Meet-bearing events it organizes; applicant calls are
+// covered via recruit_screenings, anything else lands in recruit_recorded_events.
+async function scheduleCalendarBots(client: ReturnType<typeof db>): Promise<number> {
+  const { recallEnabled, createRecordingBot } = await import('../_shared/recall.ts')
+  if (!recallEnabled()) return 0
+  let token: string
+  try { token = await sharedAccessToken(client) } catch { return 0 }
+  const now = new Date()
+  const timeMax = new Date(now.getTime() + 7 * 24 * 3600 * 1000)
+  const resp = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events?singleEvents=true&orderBy=startTime&maxResults=50&timeMin=${encodeURIComponent(now.toISOString())}&timeMax=${encodeURIComponent(timeMax.toISOString())}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (!resp.ok) { console.warn(`[recall] calendar sweep failed: ${resp.status}`); return 0 }
+  const events = (await resp.json()).items || []
+  // deno-lint-ignore no-explicit-any
+  const meetOf = (ev: any) => ev.hangoutLink || ev.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || null
+  // deno-lint-ignore no-explicit-any
+  const candidates = events.filter((ev: any) => ev.status !== 'cancelled' && ev.organizer?.self && meetOf(ev) && ev.start?.dateTime)
+  if (!candidates.length) return 0
+
+  // deno-lint-ignore no-explicit-any
+  const ids = candidates.map((ev: any) => ev.id)
+  const [{ data: screenings }, { data: tracked }] = await Promise.all([
+    client.from('recruit_screenings').select('gcal_event_id').in('gcal_event_id', ids),
+    client.from('recruit_recorded_events').select('gcal_event_id').in('gcal_event_id', ids),
+  ])
+  // deno-lint-ignore no-explicit-any
+  const known = new Set([...(screenings || []), ...(tracked || [])].map((r: any) => r.gcal_event_id))
+
+  let created = 0
+  for (const ev of candidates) {
+    if (known.has(ev.id)) continue
+    try {
+      const meet = meetOf(ev)
+      const botId = await createRecordingBot(meet, ev.start.dateTime)
+      await client.from('recruit_recorded_events').upsert({
+        gcal_event_id: ev.id, title: (ev.summary || 'Agape call').slice(0, 200),
+        starts_at: ev.start.dateTime, ends_at: ev.end?.dateTime || null,
+        meet_link: meet, recall_bot_id: botId, recall_status: 'scheduled',
+      })
+      created++
+      console.log(`[recall] calendar bot ${botId} for "${ev.summary}" (${ev.start.dateTime})`)
+    } catch (err) {
+      console.warn(`[recall] calendar bot failed for ${ev.id}: ${(err as Error).message}`)
+    }
+  }
+  return created
+}
+
+// Harvest finished non-applicant meeting recordings.
+async function processMeetingRecordings(client: ReturnType<typeof db>): Promise<number> {
+  const { recallEnabled, getBotResult, fetchTranscriptText, summarizeMeeting } = await import('../_shared/recall.ts')
+  if (!recallEnabled()) return 0
+  const { postMeetingNote } = await import('../_shared/discord.ts')
+  const { data: rows } = await client.from('recruit_recorded_events')
+    .select('gcal_event_id, title, recall_bot_id, ends_at')
+    .not('recall_bot_id', 'is', null).is('recording_posted_at', null)
+    .lt('ends_at', new Date(Date.now() - 5 * 60000).toISOString()).limit(5)
+  let posted = 0
+  for (const m of (rows || [])) {
+    try {
+      const bot = await getBotResult(m.recall_bot_id)
+      if (!bot.done && !bot.failed) continue
+      if (bot.failed) {
+        await client.from('recruit_recorded_events')
+          .update({ recall_status: 'failed', recording_posted_at: new Date().toISOString() }).eq('gcal_event_id', m.gcal_event_id)
+        continue
+      }
+      let summary: string | null = null
+      if (bot.transcriptUrl) {
+        summary = await summarizeMeeting(await fetchTranscriptText(bot.transcriptUrl), m.title || 'Agape call')
+      }
+      await postMeetingNote(m.title || 'Agape call', summary, bot.videoUrl)
+      await client.from('recruit_recorded_events').update({
+        recall_status: 'done', recording_summary: summary, recording_posted_at: new Date().toISOString(),
+      }).eq('gcal_event_id', m.gcal_event_id)
+      posted++
+    } catch (err) {
+      console.warn(`[recall] meeting processing failed for ${m.gcal_event_id}: ${(err as Error).message}`)
+    }
+  }
+  return posted
+}
+
 async function processRecordings(client: ReturnType<typeof db>): Promise<number> {
   const { recallEnabled, getBotResult, fetchTranscriptText, summarizeIntroCall } = await import('../_shared/recall.ts')
   if (!recallEnabled()) return 0
@@ -307,10 +423,11 @@ serve(async (req) => {
         authorized = Boolean(burned)
       }
       if (!authorized) return json({ error: 'unauthorized' }, 401)
+      const bots = await scheduleMissingBots(client) + await scheduleCalendarBots(client)
       const sent = await remindUpcoming(client)
-      const recorded = await processRecordings(client)
-      console.log(`[recruit-discord] tick: ${sent} reminder(s), ${recorded} recording(s) posted`)
-      return json({ reminded: sent, recorded })
+      const recorded = await processRecordings(client) + await processMeetingRecordings(client)
+      console.log(`[recruit-discord] tick: ${bots} bot(s) backfilled, ${sent} reminder(s), ${recorded} recording(s) posted`)
+      return json({ bots, reminded: sent, recorded })
     }
 
     const body = await req.text()

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.9.1'
+const VERSION = '1.9.2'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/migrations/129_recruit_recorded_events.sql
+++ b/supabase/migrations/129_recruit_recorded_events.sql
@@ -1,0 +1,20 @@
+-- Migration 129: record ALL Meets hosted by the shared account.
+-- The recruit-discord tick sweeps the shared Google calendar; any upcoming
+-- Meet-bearing event organized by live.at.agapesf gets an Agape Notes bot.
+-- Events tied to an applicant live in recruit_screenings; everything else
+-- (manually created calls) is tracked here.
+CREATE TABLE IF NOT EXISTS recruit_recorded_events (
+  gcal_event_id TEXT PRIMARY KEY,
+  title TEXT,
+  starts_at TIMESTAMPTZ NOT NULL,
+  ends_at TIMESTAMPTZ,
+  meet_link TEXT,
+  recall_bot_id TEXT,
+  recall_status TEXT,
+  recording_summary TEXT,
+  recording_posted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE recruit_recorded_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read recorded events" ON recruit_recorded_events
+  FOR SELECT TO authenticated USING (is_recruiting_member());


### PR DESCRIPTION
## Fixes

**The Katie 10am bug**: the reminder tick's calendar-liveness check treated rows with no `housemate_email` (manual calendar pickups) as "resident removed themselves" and cancelled real calls. Missing-attendee now only counts when we actually know the resident's email. (Katie's call was un-cancelled and given a bot directly in the DB before this PR.)

## Recording policy: everything the shared account hosts

- **scheduleMissingBots**: any `scheduled` screening with a Meet link and no bot gets one on the next 15-min tick — covers calendar-pickup rows and calls booked before the key existed (e.g. today's 2pm Timothy call).
- **scheduleCalendarBots** (+ migration 129, applied): the tick sweeps the shared Google calendar (7-day window) and sends Agape Notes to **every Meet-bearing event it organizes**, applicant or not. Non-applicant meetings land in `recruit_recorded_events` and their notes post to #recruiting-society as "{title} — meeting notes" with a generic discussion/decisions/follow-ups summary.

## Copy

Claim line: "_Tap a time below to claim the call — you'll both receive an invite and be added to the email thread._"

`deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)