### PR TITLE
fix(recruiting): profile deep links + summary format

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -107,7 +107,7 @@ export interface ClaimPostInput {
 }
 
 function appLink(applicantId: string): string {
-  return `https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`
+  return `https://ctrl.rodeo/applications/?a=${encodeURIComponent(applicantId)}`
 }
 
 // "her/his/their application" from the applicant's own pronouns field;

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -128,9 +128,8 @@ export async function summarizeIntroCall(transcript: string, applicantName: stri
 **Vibe** — one sentence on how the conversation felt.
 **About them** — 3-5 bullets: work, background, why they want co-op living, logistics (move-in, budget) if mentioned.
 **Highlights** — anything that stood out, positive or concerning.
-**Follow-ups** — open questions the house should still ask.
 
-Keep it under 250 words. Transcript:
+Keep it under 200 words. Transcript:
 
 ${transcript.slice(0, 24000)}`,
       }],

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -7,7 +7,7 @@
 // POST { token }                      → { firstName, windows }
 // POST { token, windows: [...] }      → save; { saved: true, windows }
 
-const VERSION = '1.2.2'
+const VERSION = '1.2.3'
 console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint + Discord claim post`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.7.0'
+const VERSION = '1.7.1'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -127,7 +127,7 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     try {
       await dmUser(opts.discordUserId,
         `⚠️ You claimed the call with this applicant (${label}), but scheduling hit an error: ${(err as Error).message.slice(0, 200)}\n` +
-        `Please book it manually in the app: https://ctrl.rodeo/applications/?id=${encodeURIComponent(applicantId)}`)
+        `Please book it manually in the app: https://ctrl.rodeo/applications/?a=${encodeURIComponent(applicantId)}`)
     } catch { /* best effort */ }
   }
 }
@@ -234,7 +234,7 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
         await dmUser(dm.discord_user_id,
           `⏰ Coming up: you're interviewing **${name}** at ${slotWhen(new Date(s.starts_at))} PT.\n` +
           `Meet: ${s.meet_link || '(see calendar invite)'}\n` +
-          `Background: https://ctrl.rodeo/applications/?id=${encodeURIComponent(s.applicant_id)}`)
+          `Background: https://ctrl.rodeo/applications/?a=${encodeURIComponent(s.applicant_id)}`)
         sent++
       }
       // Stamp even without a Discord id so we don't retry forever.

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.10.0'
+const VERSION = '1.10.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
1. **Profile links landed on the inbox**: the app's applicant deep-link param is `?a=` (read at app.js:2634); every generated link (claim cards, notes cards, DMs, reminders) used `?id=`. All link sites fixed.
2. **Intro-call summaries**: Follow-ups section removed per house preference; now Vibe / About them / Highlights, ≤200 words.

`deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)