### PR TITLE
feat(applications): ▶ Watch state for recorded Intro Calls

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.10.2">
+  <link rel="stylesheet" href="css/app.css?v=3.11.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -157,6 +157,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.10.2"></script>
+  <script src="js/app.js?v=3.11.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.10.2';
+const VERSION = '3.11.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -439,7 +439,7 @@ async function loadAll() {
     sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
     sb.from('recruit_emails').select('applicant_id, direction, sent_at, snippet').order('sent_at'),
     sb.from('recruit_votes').select('*').order('created_at'),
-    sb.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, meet_link').order('starts_at'),
+    sb.from('recruit_screenings').select('id, applicant_id, starts_at, status, housemate_name, meet_link, recall_status').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, windows, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
   ]);
@@ -448,7 +448,9 @@ async function loadAll() {
   for (const v of (vRes.data || [])) (votes[v.applicant_id] ||= []).push(v);
   screeningState = {};
   for (const s of (scRes.data || [])) {
-    if (s.status === 'scheduled') screeningState[s.applicant_id] = { at: s.starts_at, with: s.housemate_name, link: s.meet_link };
+    if (s.status === 'scheduled') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), at: s.starts_at, with: s.housemate_name, link: s.meet_link };
+    // A finished recording adds a Watch state to the row (fresh link on click).
+    if (s.recall_status === 'done') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), watch: s.id };
   }
   for (const av of (avRes.data || [])) {
     // empty windows = a processed non-scheduling reply — no Pick a time
@@ -934,8 +936,23 @@ function stageChip(a) {
 function screeningChip(a) {
   const sc = screeningState[a.id];
   if (!sc) return '';
-  if (sc.at) return `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
+  const watch = sc.watch
+    ? `<span class="decision-chip decision-chip--pass" style="cursor:pointer" title="Watch the recorded Intro Call" onclick="event.stopPropagation();watchRecording('${sc.watch}')">▶ Watch</span>`
+    : '';
+  if (sc.at) return `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>` + watch;
+  if (watch) return watch;
   return `<span class="decision-chip decision-chip--vote">Availability received</span>`;
+}
+
+/* Watch a recorded Intro Call: Recall links expire, so fetch a fresh one. */
+async function watchRecording(screeningId) {
+  try {
+    toast('Fetching recording…');
+    const out = await gmailCall({ action: 'recording-link', screeningId });
+    if (out.url) window.open(out.url, '_blank'); else toast('Recording not available');
+  } catch (e) {
+    toast(`Recording: ${e.message}`);
+  }
 }
 
 /* One pill per room they're placed in, with the room's open date. Falls

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -97,7 +97,7 @@ export async function summarizeMeeting(transcript: string, title: string): Promi
       system: 'You summarize meetings for the Agape co-op house. Be concrete and neutral.',
       messages: [{
         role: 'user',
-        content: `Summarize this meeting ("${title}") for housemates who missed it: what was discussed, decisions made, and open follow-ups. Under 250 words, bullets welcome. Transcript:\n\n${transcript.slice(0, 24000)}`,
+        content: `Summarize this meeting ("${title}") for housemates who missed it: what was discussed and any decisions made. Under 250 words, bullets welcome. Never include follow-ups, action items, open questions, or recommended next steps — describe the meeting only. Transcript:\n\n${transcript.slice(0, 24000)}`,
       }],
     }),
   })
@@ -129,7 +129,7 @@ export async function summarizeIntroCall(transcript: string, applicantName: stri
 **About them** — 3-5 bullets: work, background, why they want co-op living, logistics (move-in, budget) if mentioned.
 **Highlights** — anything that stood out, positive or concerning.
 
-Keep it under 200 words. Transcript:
+Keep it under 200 words. Never include follow-ups, action items, suggested questions, or next steps of any kind — describe the call only. Transcript:
 
 ${transcript.slice(0, 24000)}`,
       }],

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.10.1'
+const VERSION = '1.11.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -400,6 +400,17 @@ serve(async (req) => {
       }
       const row = await upsertClaimMessage(client, input)
       return json({ posted: !!row, alreadyClaimed: !row })
+    }
+
+    if (action === 'recording-link') {
+      // Fresh Recall download URL for a finished recording (links expire).
+      const { data: s } = await client.from('recruit_screenings')
+        .select('id, recall_bot_id').eq('id', String(body.screeningId || '')).maybeSingle()
+      if (!s?.recall_bot_id) return json({ error: 'No recording for this call' }, 404)
+      const { getBotResult } = await import('../_shared/recall.ts')
+      const bot = await getBotResult(s.recall_bot_id)
+      if (!bot.videoUrl) return json({ error: 'Recording not ready (or has been purged)' }, 404)
+      return json({ url: bot.videoUrl })
     }
 
     if (action === 'scan') {


### PR DESCRIPTION
1. **Watch**: applicant rows in the Screening view get a **▶ Watch** chip when their Intro Call has a finished recording. Clicking fetches a *fresh* Recall download link via a new `recording-link` action in recruit-gmail (Recall links expire after a few hours, so they're never stored) and opens it in a new tab. Applicants whose call is done-and-recorded now also appear in the Screening view even with nothing scheduled.
2. **Summaries**: both prompts (intro calls + generic meetings) now explicitly prohibit follow-ups, action items, open questions, and next steps.

`deno check` + `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)