### PR TITLE
fix(recruiting): Watch chip precedence + Join-first live post

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.11.0">
+  <link rel="stylesheet" href="css/app.css?v=3.11.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -157,6 +157,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.11.0"></script>
+  <script src="js/app.js?v=3.11.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.11.0';
+const VERSION = '3.11.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -366,6 +366,9 @@ function avatarHtml(a, large) {
    slot chip (+ Join when there's a Meet link). */
 function openingsCta(a) {
   const sc = screeningState[a.id];
+  if (!sc?.at && sc?.watch) {
+    return `<span class="decision-chip decision-chip--pass" style="cursor:pointer" title="Watch the recorded Intro Call" onclick="event.stopPropagation();watchRecording('${sc.watch}')">▶ Watch</span>`;
+  }
   if (sc?.at) {
     const chip = `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
     const join = sc.link ? `<a class="btn btn--sm inbox-row__review cta-std" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -338,7 +338,7 @@ export async function postLiveCall(title: string, when: string, meetLink: string
     method: 'POST',
     body: JSON.stringify({
       embeds: [{
-        description: `🔴 **Happening now:** ${title} — ${when}${meetLink ? `\n[Join the call](${meetLink}) if you'd like to sit in.` : ''}`,
+        description: `🎥 **Join — ${title}** · ${when}${meetLink ? `\n[▶ Tap to join the call](${meetLink})` : ''}`,
         color: 0xe74c3c,
       }],
     }),

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.8.0'
+const VERSION = '1.8.1'
 console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
1. **Katie showed 'Invite promised'**: the Openings view CTA never learned the completed/recorded state — with no upcoming slot it fell through to email-snippet heuristics. Recorded calls now short-circuit to the **▶ Watch** chip.
2. **Live post**: `🎥 Join — {title} · {when}` with a **▶ Tap to join the call** link, replacing 'Happening now'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)