### PR TITLE
feat(ladder): Outdoor sector recognition (add-role v0.7.0)

### DIFF
--- a/supabase/functions/_shared/sector-tags.ts
+++ b/supabase/functions/_shared/sector-tags.ts
@@ -28,6 +28,10 @@ const CANONICAL: Record<string, string> = {
   'SaaS - Productivity': 'Productivity',
   'AI / Consumer Hardware': 'Consumer',
   'Consumer Hardware': 'Consumer',
+  'Outdoor Recreation': 'Outdoor',
+  'Outdoor Industry': 'Outdoor',
+  'Outdoor Gear': 'Outdoor',
+  'Sporting Goods': 'Outdoor',
 };
 
 function splitToken(token: string): string[] {

--- a/supabase/functions/add-role/index.ts
+++ b/supabase/functions/add-role/index.ts
@@ -12,11 +12,11 @@ import { computeFit } from '../jobs-pipe/fit.ts';
 import { scoreOne } from '../_shared/job-fit-haiku.ts';
 import { compClears } from '../_shared/comp.ts';
 
-const VERSION = '0.6.0';
+const VERSION = '0.7.0';
 // Status default: 'Saved' (post-taxonomy collapse).
 // Source-email-link: stash payload.gmailApiId as a Gmail web URL when
 // the rec came from Gmail.
-console.log(`[add-role] v${VERSION} - comp_acceptable computed deterministically from the salary range (compClears)`);
+console.log(`[add-role] v${VERSION} - Outdoor sector recognition (inferSector + canonical tags)`);
 
 const URL_RE = /^https?:\/\//i;
 const TITLE_RE = /<title[^>]*>([\s\S]*?)<\/title>/i;
@@ -218,6 +218,7 @@ function inferSector(text: string, company: string): string {
     [/\b(fintech|banking|consumer\s+lending|payments?\s+platform|insurtech)\b/, 'Fintech'],
     [/saas/, 'SaaS'],
     [/marketplace/, 'Marketplace'],
+    [/\b(outdoor|outdoors|camping|hiking|climbing|backpacks?|ski|snowboard|surf|cycling|apparel|sporting goods|gear for)\b/, 'Outdoor'],
     [/consumer|retail|e-?commerce/, 'Consumer'],
     [/hardware|robotics/, 'Hardware'],
     [/productivity|workflow|automation/, 'Productivity'],


### PR DESCRIPTION
Companion to the outdoor-industry profile update (vision fields updated in DB): `inferSector` now recognizes outdoor/gear/apparel JDs and the sector-tag canonicalizer maps Outdoor Recreation / Outdoor Gear / Sporting Goods → **Outdoor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)