### PR TITLE
feat(applications): in-app recording viewer + Watch/Join button styles

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1220,3 +1220,20 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .btn--discord { background: #5865F2; border-color: #5865F2; color: #fff; gap: 6px; }
 .btn--discord:hover { filter: brightness(1.08); border-color: #5865F2; }
 .btn-discord__icon { width: 16px; height: 16px; flex-shrink: 0; }
+
+/* Watch / Join row buttons + recording viewer (v3.12.0) */
+.btn--watch { background: #1D9E75; border-color: #1D9E75; color: #fff; gap: 6px; }
+.btn--watch:hover { filter: brightness(1.08); border-color: #1D9E75; }
+.btn--join { background: #378ADD; border-color: #378ADD; color: #fff; gap: 6px; }
+.btn--join:hover { filter: brightness(1.08); border-color: #378ADD; }
+.watch-modal__card { max-width: 1060px; width: min(1060px, 94vw); }
+.watch-modal__grid { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 20px; align-items: start; }
+.watch-modal__player video { width: 100%; border-radius: 8px; background: #000; min-height: 300px; display: block; }
+.watch-modal__side { display: flex; flex-direction: column; gap: 16px; min-width: 0; max-height: 72vh; overflow-y: auto; padding-right: 2px; }
+.watch-modal__side-title { margin: 0 0 8px; font-size: var(--font-size-small); text-transform: uppercase; letter-spacing: 0.04em; opacity: 0.7; }
+.watch-modal__summary { font-size: 13.5px; line-height: 1.55; }
+.watch-md__h { display: block; margin: 10px 0 4px; }
+.watch-md__li { display: block; padding-left: 6px; }
+.watch-modal__note-form { display: flex; gap: 8px; align-items: flex-end; margin-top: 8px; }
+.watch-modal__note-form .notes__input { flex: 1; }
+@media (max-width: 900px) { .watch-modal__grid { grid-template-columns: 1fr; } .watch-modal__side { max-height: none; } }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.11.1">
+  <link rel="stylesheet" href="css/app.css?v=3.12.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -155,8 +155,38 @@
     </div>
   </div>
 
+  <!-- Recording viewer — video with the call summary + house notes beside it. -->
+  <div class="email-modal" id="watch-modal" hidden>
+    <div class="email-modal__card watch-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title" id="watch-title">Agape Intro Call</h3>
+        <button class="review__close email-modal__close" aria-label="Close" onclick="closeWatch()">✕</button>
+      </div>
+      <div class="watch-modal__grid">
+        <div class="watch-modal__player">
+          <video id="watch-video" controls playsinline preload="metadata"></video>
+          <p class="email-modal__status" id="watch-status"></p>
+        </div>
+        <aside class="watch-modal__side">
+          <div>
+            <h4 class="watch-modal__side-title">Call summary</h4>
+            <div class="watch-modal__summary" id="watch-summary"></div>
+          </div>
+          <div>
+            <h4 class="watch-modal__side-title">House notes</h4>
+            <div id="watch-notes"></div>
+            <div class="watch-modal__note-form">
+              <textarea class="notes__input" id="watch-note-input" rows="2" placeholder="Add a note for the house…"></textarea>
+              <button class="btn btn--accent btn--sm" type="button" onclick="postWatchNote()">Post</button>
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </div>
+
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.11.1"></script>
+  <script src="js/app.js?v=3.12.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.11.1';
+const VERSION = '3.12.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -367,11 +367,11 @@ function avatarHtml(a, large) {
 function openingsCta(a) {
   const sc = screeningState[a.id];
   if (!sc?.at && sc?.watch) {
-    return `<span class="decision-chip decision-chip--pass" style="cursor:pointer" title="Watch the recorded Intro Call" onclick="event.stopPropagation();watchRecording('${sc.watch}')">▶ Watch</span>`;
+    return `<button class="btn btn--sm inbox-row__review cta-std btn--watch" title="Watch the recorded Intro Call" onclick="event.stopPropagation();openWatch('${sc.watch}')"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button>`;
   }
   if (sc?.at) {
     const chip = `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`;
-    const join = sc.link ? `<a class="btn btn--sm inbox-row__review cta-std" href="${esc(sc.link)}" target="_blank" rel="noopener">Join call</a>` : '';
+    const join = sc.link ? `<a class="btn btn--sm inbox-row__review cta-std btn--join" href="${esc(sc.link)}" target="_blank" rel="noopener" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M17 10.5V7a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-3.5l4 4v-11l-4 4z"/></svg>Join</a>` : '';
     return chip + join;
   }
   if (sc?.availability) return `<button class="btn btn--sm btn--discord inbox-row__review cta-std" data-claim-preview="${a.id}"><svg class="btn-discord__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Post to Discord</button><button class="btn btn--sm inbox-row__review" data-pick-time="${a.id}">Pick a time</button>`;
@@ -939,23 +939,91 @@ function stageChip(a) {
 function screeningChip(a) {
   const sc = screeningState[a.id];
   if (!sc) return '';
-  const watch = sc.watch
-    ? `<span class="decision-chip decision-chip--pass" style="cursor:pointer" title="Watch the recorded Intro Call" onclick="event.stopPropagation();watchRecording('${sc.watch}')">▶ Watch</span>`
-    : '';
+  const watch = sc.watch ? `<button class="btn btn--sm inbox-row__review cta-std btn--watch" title="Watch the recorded Intro Call" onclick="event.stopPropagation();openWatch('${sc.watch}')"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button>` : '';
   if (sc.at) return `<span class="decision-chip decision-chip--outreach" title="Screening call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>` + watch;
   if (watch) return watch;
   return `<span class="decision-chip decision-chip--vote">Availability received</span>`;
 }
 
-/* Watch a recorded Intro Call: Recall links expire, so fetch a fresh one. */
-async function watchRecording(screeningId) {
+/* ---------- recording viewer: video + call notes + house comments ---------- */
+let watchApplicantId = null;
+
+/* Tiny renderer for the Haiku summary (headings, bold, bullets). */
+function mdLite(md) {
+  return esc(md)
+    .replace(/^#+\s*(.+)$/gm, '<strong class="watch-md__h">$1</strong>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/^[-*]\s+(.+)$/gm, '<span class="watch-md__li">• $1</span>')
+    .replace(/\n{2,}/g, '<br><br>').replace(/\n/g, '<br>');
+}
+
+function renderWatchNotes() {
+  const host = document.getElementById('watch-notes');
+  if (!host) return;
+  if (!comments.length) { host.innerHTML = `<p class="notes__empty">No notes yet — be the first.</p>`; return; }
+  host.innerHTML = `<ul class="notes__list">${comments.map(c => `
+    <li class="note">
+      <span class="avatar">${esc((c.author_name || '?')[0].toUpperCase())}</span>
+      <div class="note__body-wrap">
+        <div class="note__meta">
+          <span class="note__author">${esc(c.author_name || 'Housemate')}</span>
+          <span class="note__time">${relTime(c.created_at)}</span>
+        </div>
+        <p class="note__body">${esc(c.body)}</p>
+      </div>
+    </li>`).join('')}</ul>`;
+}
+
+async function postWatchNote() {
+  const input = document.getElementById('watch-note-input');
+  const body = (input.value || '').trim();
+  if (!body || !watchApplicantId) return;
+  input.value = '';
+  const { data, error } = await sb.from('recruit_comments')
+    .insert({ applicant_id: watchApplicantId, user_id: me.id, author_name: me.name, body })
+    .select().single();
+  if (error) { toast(`Note failed: ${error.message}`); input.value = body; return; }
+  comments.push(data);
+  commentCounts[watchApplicantId] = comments.length;
+  renderWatchNotes();
+}
+
+async function openWatch(screeningId) {
+  const modal = document.getElementById('watch-modal');
+  const video = document.getElementById('watch-video');
+  const status = document.getElementById('watch-status');
+  modal.hidden = false;
+  video.removeAttribute('src');
+  status.textContent = 'Fetching recording…';
+  document.getElementById('watch-summary').innerHTML = '';
+  document.getElementById('watch-notes').innerHTML = '';
   try {
-    toast('Fetching recording…');
+    const { data: sRow } = await sb.from('recruit_screenings')
+      .select('applicant_id, housemate_name, starts_at, recording_summary')
+      .eq('id', screeningId).maybeSingle();
+    const a = applicants.find(x => x.id === sRow?.applicant_id);
+    watchApplicantId = sRow?.applicant_id || null;
+    document.getElementById('watch-title').textContent =
+      `${a ? fullName(a) : 'Agape Intro Call'}${sRow?.housemate_name ? ` × ${sRow.housemate_name}` : ''} · ${sRow?.starts_at ? fmtSlot(sRow.starts_at) : ''}`;
+    document.getElementById('watch-summary').innerHTML =
+      sRow?.recording_summary ? mdLite(sRow.recording_summary) : '<p class="notes__empty">No summary was captured for this call.</p>';
+    if (watchApplicantId) { await loadComments(watchApplicantId); renderWatchNotes(); }
     const out = await gmailCall({ action: 'recording-link', screeningId });
-    if (out.url) window.open(out.url, '_blank'); else toast('Recording not available');
+    if (!out.url) throw new Error('recording not available');
+    video.src = out.url;
+    status.textContent = '';
   } catch (e) {
-    toast(`Recording: ${e.message}`);
+    status.textContent = `Recording unavailable: ${e.message}`;
   }
+}
+
+function closeWatch() {
+  const modal = document.getElementById('watch-modal');
+  const video = document.getElementById('watch-video');
+  try { video.pause(); } catch { /* not started */ }
+  video.removeAttribute('src');
+  modal.hidden = true;
+  watchApplicantId = null;
 }
 
 /* One pill per room they're placed in, with the room's open date. Falls


### PR DESCRIPTION
1. **Buttons**: ▶ Watch now matches the standard row-button style with a green fill; Join is blue with a camera icon. Both in Screening and Openings views.
2. **Watch experience**: clicking Watch opens a viewer modal — video player on the left (fetches a fresh Recall link on every open, since links expire), **call summary** and **house notes** on the right. Notes are `recruit_comments`, so anything written in the viewer also shows in the applicant's regular notes and its count bubble.

`node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)