### PR TITLE
Recruiting v3.13.3: downstyle copy rule

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -159,7 +159,7 @@
   <div class="email-modal" id="watch-modal" hidden>
     <div class="email-modal__card watch-modal__card">
       <div class="email-modal__head">
-        <h3 class="hold-sheet__title" id="watch-title">Agape Intro Call</h3>
+        <h3 class="hold-sheet__title" id="watch-title">Agape intro call</h3>
         <button class="review__close email-modal__close" aria-label="Close" onclick="closeWatch()">✕</button>
       </div>
       <div class="watch-modal__grid">

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -1037,7 +1037,7 @@ async function openWatch(screeningId) {
     const a = applicants.find(x => x.id === sRow?.applicant_id);
     watchApplicantId = sRow?.applicant_id || null;
     document.getElementById('watch-title').textContent =
-      `${a ? fullName(a) : 'Agape Intro Call'}${sRow?.housemate_name ? ` × ${sRow.housemate_name}` : ''} · ${sRow?.starts_at ? fmtSlot(sRow.starts_at) : ''}`;
+      `${a ? fullName(a) : 'Agape intro call'}${sRow?.housemate_name ? ` × ${sRow.housemate_name}` : ''} · ${sRow?.starts_at ? fmtSlot(sRow.starts_at) : ''}`;
     document.getElementById('watch-summary').innerHTML =
       sRow?.recording_summary ? mdLite(sRow.recording_summary) : '<p class="notes__empty">No summary was captured for this call.</p>';
     if (watchApplicantId) { await loadComments(watchApplicantId); renderWatchNotes(); }
@@ -1977,7 +1977,7 @@ function renderReview() {
         <span class="decision-banner__meta">${esc(why)}</span>
       </div>
       <span class="decision-banner__actions">
-        <button class="decision-banner__undo" data-reopen="${a.id}">Reopen — back to Review</button>
+        <button class="decision-banner__undo" data-reopen="${a.id}">Reopen — back to Inbox</button>
       </span>
     </div>`;
   };
@@ -2168,7 +2168,7 @@ function renderReviewFoot(a) {
       <button class="btn review__btn review__btn--notfit" data-open-decision="pass">Not a fit</button>
       <button class="btn review__btn review__btn--place" data-open-decision="outreach">${activePlacements(a.id).length ? 'Add to another listing' : 'Add to listing'}</button>`;
   } else {
-    foot.innerHTML = `<button class="btn review__btn" data-reopen="${a.id}">Reopen — back to Review</button>`;
+    foot.innerHTML = `<button class="btn review__btn" data-reopen="${a.id}">Reopen — back to Inbox</button>`;
   }
 }
 
@@ -2177,7 +2177,7 @@ async function reopenApplicant(id) {
   if (!a) return;
   if (await setStage(id, 'review')) {
     const st = voteStats(id);
-    toast(st.veto ? `Reopened — note: ${st.veto.voter_name || 'a housemate'}'s veto still stands until they change their vote` : 'Reopened — back in Review');
+    toast(st.veto ? `Reopened — note: ${st.veto.voter_name || 'a housemate'}'s veto still stands until they change their vote` : 'Reopened — back in the Inbox');
     renderRailCounts();
     if (!document.getElementById('review').hidden) renderReview(); else render();
   }

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -90,3 +90,6 @@ There is no stay-length segment — sublet durations read as move-in → move-ou
 
 1. Waiting candidates don't say *why* nothing fits (dates vs budget vs no open listing).
 3. Auto vs manual placements are visually identical.
+
+## Copy rule (2026-07-22)
+Downstyle (sentence case) everywhere in buttons, banners, badges, and chips; capitalize proper nouns only (Discord, Agape, Gmail, view names like Inbox). "Post to Discord" ✓ · "Post To Discord" ✗ · "Agape intro call" ✓.


### PR DESCRIPTION
Sentence case in all buttons/banners/badges with proper nouns capitalized, recorded in the design doc. Fixes "Agape Intro Call" → "Agape intro call" and "Reopen — back to Review" → "Reopen — back to Inbox" (also stale view name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)