### PR TITLE
Recruiting v3.16: state-colored CTAs + comments column

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -408,7 +408,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   width: 100%;
 }
 .review__inner {
-  max-width: 720px; width: 100%; margin: 0 auto;
+  max-width: 1060px; width: 100%; margin: 0 auto;
   padding: 0 var(--space-4) var(--space-6);
 }
 .review__card {
@@ -493,7 +493,7 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   background: var(--bg-elevated); flex-shrink: 0;
 }
 .review__foot[hidden] { display: none; }
-@media (min-width: 721px) { .review__foot { max-width: 760px; width: 100%; margin-inline: auto; border-inline: 1px solid var(--border); border-radius: var(--radius-lg) var(--radius-lg) 0 0; } }
+@media (min-width: 721px) { .review__foot { max-width: 1060px; width: 100%; margin-inline: auto; border-inline: 1px solid var(--border); border-radius: var(--radius-lg) var(--radius-lg) 0 0; } }
 .review__btn { flex: 1; height: 48px; border-radius: var(--radius-pill); }
 .review__btn--pass, .review__btn--hold { background: var(--bg-surface); border: 0; }
 .review__btn--pass:hover, .review__btn--hold:hover { background: var(--bg-overlay); }
@@ -1251,3 +1251,21 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .cta-stack { display: flex; flex-direction: column; align-items: flex-end; gap: 3px; }
 .cta-context { font-size: var(--font-size-caption); color: var(--fg-subtle); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .call-video { width: 100%; max-height: 420px; border-radius: var(--radius-md); background: #000; margin-bottom: var(--space-3); }
+
+/* --- v3.16.0: state-colored rounded-rect primaries + comments column --- */
+.cta-std { border-radius: var(--radius-sm); }
+.cta--blue { background: var(--accent-strong); border-color: var(--accent-strong); color: var(--accent-strong-fg); }
+.cta--blue:hover { filter: brightness(0.95); border-color: var(--accent-strong); }
+.cta--green { background: #9FE870; border-color: #9FE870; color: #163300; }
+.cta--green:hover { filter: brightness(0.95); border-color: #9FE870; }
+.cta--amber { background: #EDC843; border-color: #EDC843; color: #3a2c00; }
+.cta--amber:hover { filter: brightness(0.97); border-color: #EDC843; }
+.btn--discord.cta-std, .btn--watch.cta-std, .btn--join.cta-std { border-radius: var(--radius-sm); }
+
+.review-cols { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: var(--space-6); align-items: start; }
+.review-cols__side .notes {
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: var(--space-4);
+  position: sticky; top: var(--space-3);
+}
+@media (max-width: 900px) { .review-cols { grid-template-columns: 1fr; } .review-cols__side .notes { position: static; } }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.15.0">
+  <link rel="stylesheet" href="css/app.css?v=3.16.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -187,6 +187,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.15.0"></script>
+  <script src="js/app.js?v=3.16.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.15.0';
+const VERSION = '3.16.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -409,18 +409,18 @@ function openingsCta(a) {
     return stack(`<span class="decision-chip decision-chip--outreach" title="Intro call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`, sc.with ? `with ${esc(sc.with)}` : '');
   }
   if (sc?.availability) return stack(
-    `<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Pick a time</button>`,
+    `<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-pick-time="${a.id}">Pick a time</button>`,
     `<button type="button" class="cta-link" data-claim-preview="${a.id}">Ask for coverage</button>`);
   const st = emailState[a.id];
-  if (st?.lastDir === 'in') return stack(`<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-pick-time="${a.id}">Reply</button>`, `replied ${relTime(st.lastAt)}`);
+  if (st?.lastDir === 'in') return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--green" data-pick-time="${a.id}">Reply</button>`, `replied ${relTime(st.lastAt)}`);
   if (st?.lastDir === 'out') {
     // "I'll send an invite" reads as manual scheduling — say so instead of
     // nagging; a shared-account invite gets picked up by the calendar sweep.
     const promised = /\b(invite|calendar|schedul|let'?s (chat|talk|meet)|talk (soon|then|tomorrow))\b/i.test(st.lastSnippet || '');
-    return stack(`<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Follow up</button>`,
+    return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--amber" data-email="${a.id}">Follow up</button>`,
       `${promised ? 'invite promised · ' : ''}sent ${relTime(st.lastAt)}`);
   }
-  return stack(`<button class="btn btn--accent btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`, '');
+  return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}">Reach out</button>`, '');
 }
 
 /* Blue response dot in the row's left gutter — sits beside the avatar,
@@ -2083,21 +2083,27 @@ function renderReview() {
       ${(screeningState[a.id]?.watch || screeningState[a.id]?.at) ? `<button class="review-tabs__tab ${reviewTab === 'call' ? 'is-on' : ''}" data-review-tab="call">Call</button>` : ''}
     </div>
     ${reviewTab === 'emails' ? `<div id="emails-panel"><p class="notes__empty">Loading emails…</p></div>` : reviewTab === 'call' ? `<div id="call-panel"><p class="notes__empty">Loading the call…</p></div>` : `
-    ${voteSectionHtml(a)}
-    ${section('About them', a.about)}
-    ${section('Why Agape', a.why)}
-    ${section('Gifts to share', a.gifts)}
-    <section class="review__section notes" id="notes">
-      <div class="notes__head">
-        <h3 class="review__section-title">House notes</h3>
-        <button type="button" class="btn btn--sm" id="second-opinion" data-second-opinion="${a.id}">Second opinion</button>
+    <div class="review-cols">
+      <div class="review-cols__main">
+        ${voteSectionHtml(a)}
+        ${section('About them', a.about)}
+        ${section('Why Agape', a.why)}
+        ${section('Gifts to share', a.gifts)}
       </div>
-      <div id="notes-body"><p class="notes__empty">Loading notes…</p></div>
-      <form class="notes__form" id="notes-form">
-        <textarea class="notes__input" id="notes-input" placeholder="Add an internal note for the house — only Recruiting Society members see these." maxlength="4000"></textarea>
-        <button class="btn btn--accent btn--sm notes__submit" type="submit">Add note</button>
-      </form>
-    </section>`}
+      <aside class="review-cols__side">
+        <section class="review__section notes" id="notes">
+          <div class="notes__head">
+            <h3 class="review__section-title">Comments</h3>
+            <button type="button" class="btn btn--sm" id="second-opinion" data-second-opinion="${a.id}">Second opinion</button>
+          </div>
+          <div id="notes-body"><p class="notes__empty">Loading comments…</p></div>
+          <form class="notes__form" id="notes-form">
+            <textarea class="notes__input" id="notes-input" placeholder="Comment for the house — only Recruiting Society members see these." maxlength="4000"></textarea>
+            <button class="btn btn--accent btn--sm notes__submit" type="submit">Add comment</button>
+          </form>
+        </section>
+      </aside>
+    </div>`}
   `;
 
   renderReviewFoot(a);


### PR DESCRIPTION
- Right-rail primary buttons are now rounded rectangles colored by state: blue = start/schedule (Reach out, Pick a time), green = respond/attend (Reply; Watch/Join already green/blue family), amber = nudge (Follow up), blurple = Discord.
- Profile comments move into their own sticky right column beside the main content (stacks on mobile); overlay widened to fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)