### PR TITLE
Recruiting v3.16.2: accessible CTA palette

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1222,10 +1222,10 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .btn-discord__icon { width: 16px; height: 16px; flex-shrink: 0; }
 
 /* Watch / Join row buttons + recording viewer (v3.12.0) */
-.btn--watch { background: #1D9E75; border-color: #1D9E75; color: #fff; gap: 6px; }
-.btn--watch:hover { background: #0F6E56; border-color: #0F6E56; color: #fff; }
-.btn--join { background: #378ADD; border-color: #378ADD; color: #fff; gap: 6px; }
-.btn--join:hover { background: #185FA5; border-color: #185FA5; color: #fff; }
+.btn--watch { background: #0F6E56; border-color: #0F6E56; color: #fff; gap: 6px; }
+.btn--watch:hover { background: #085041; border-color: #085041; color: #fff; }
+.btn--join { background: #185FA5; border-color: #185FA5; color: #fff; gap: 6px; }
+.btn--join:hover { background: #0C447C; border-color: #0C447C; color: #fff; }
 .watch-modal__card { max-width: 1060px; width: min(1060px, 94vw); }
 .watch-modal__grid { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 20px; align-items: start; }
 .watch-modal__player video { width: 100%; border-radius: 8px; background: #000; min-height: 300px; display: block; }
@@ -1254,11 +1254,11 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 
 /* --- v3.16.0: state-colored rounded-rect primaries + comments column --- */
 .cta-std { border-radius: var(--radius-sm); }
-.cta--blue { background: var(--accent-strong); border-color: var(--accent-strong); color: var(--accent-strong-fg); }
-.cta--blue:hover { filter: brightness(0.95); border-color: var(--accent-strong); }
-.cta--green { background: #9FE870; border-color: #9FE870; color: #163300; }
-.cta--green:hover { filter: brightness(0.95); border-color: #9FE870; }
-.cta--amber { background: #EDC843; border-color: #EDC843; color: #3a2c00; }
-.cta--amber:hover { filter: brightness(0.97); border-color: #EDC843; }
+.cta--blue { background: #185FA5; border-color: #185FA5; color: #fff; }
+.cta--blue:hover { filter: brightness(1.12); border-color: #185FA5; color: #fff; }
+.cta--green { background: #0F6E56; border-color: #0F6E56; color: #fff; }
+.cta--green:hover { filter: brightness(1.12); border-color: #0F6E56; color: #fff; }
+.cta--amber { background: #B45309; border-color: #B45309; color: #fff; }
+.cta--amber:hover { filter: brightness(1.1); border-color: #B45309; color: #fff; }
 .btn--discord.cta-std, .btn--watch.cta-std, .btn--join.cta-std { border-radius: var(--radius-sm); }
 

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.16.1">
+  <link rel="stylesheet" href="css/app.css?v=3.16.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -187,6 +187,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.16.1"></script>
+  <script src="js/app.js?v=3.16.2"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.16.1';
+const VERSION = '3.16.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -420,7 +420,7 @@ function openingsCta(a) {
     return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--amber" data-email="${a.id}">Follow up</button>`,
       `${promised ? 'invite promised · ' : ''}sent ${relTime(st.lastAt)}`);
   }
-  return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}">Reach out</button>`, '');
+  return stack(`<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`, '');
 }
 
 /* Blue response dot in the row's left gutter — sits beside the avatar,


### PR DESCRIPTION
Reach out returns to the default grey; every other colored CTA uses white text on AA-compliant darkened backgrounds (blue #185FA5, green #0F6E56, amber #B45309, blurple #5865F2). Watch/Join aligned to the same shades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)