### PR TITLE
Recruiting v3.17.1: snippet entity decode

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.17.0">
+  <link rel="stylesheet" href="css/app.css?v=3.17.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -201,6 +201,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.17.0"></script>
+  <script src="js/app.js?v=3.17.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.17.0';
+const VERSION = '3.17.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2487,7 +2487,9 @@ async function openAvailModal(applicantId) {
     const windows = av?.windows || [];
     const ex = out.extraction || {};
     const bullets = [];
-    if (srcEmail?.snippet) bullets.push(`They wrote${srcEmail.sent_at ? ` on ${fmtDate(srcEmail.sent_at)}` : ''}: “${esc(srcEmail.snippet.slice(0, 180))}”`);
+    // Gmail snippets arrive HTML-escaped — decode before our own escaping.
+    const deent = (t) => String(t || '').replace(/&#39;/g, "'").replace(/&quot;/g, '"').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+    if (srcEmail?.snippet) bullets.push(`They wrote${srcEmail.sent_at ? ` on ${fmtDate(srcEmail.sent_at)}` : ''}: “${esc(deent(srcEmail.snippet).slice(0, 180))}”`);
     if (ex.timezone_note) bullets.push(esc(ex.timezone_note));
     if (ex.platform?.kind) bullets.push(`They asked for ${esc(ex.platform.kind)}${ex.platform.handle ? ` (@${esc(ex.platform.handle)})` : ''} — the default is Google Meet.`);
     bullets.push('Vague day-parts map to morning 9:00–12:00, afternoon 12:00–17:00, evening 17:00–21:00 PT; windows under 30 minutes are dropped.');


### PR DESCRIPTION
Gmail snippets arrive HTML-escaped; the availability modal's quote bullet now decodes before rendering (no more `&#39;`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)