### PR TITLE
Recruiting v3.19.1: footer pair sizing

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1283,3 +1283,8 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .avail-foot__go { display: inline-flex; align-items: center; gap: var(--space-3); margin-left: auto; }
 .avail-foot__note { font-size: var(--font-size-caption); color: var(--fg-subtle); max-width: 260px; text-align: right; }
 .avail-card__slots .chip.is-on { background: var(--accent-strong); border-color: var(--accent-strong); color: var(--accent-strong-fg); }
+
+/* --- v3.19.1: footer CTA pair sizing --- */
+.foot-cta .cta-pair { display: flex; width: 100%; gap: 6px; }
+.foot-cta .cta-pair .cta-std { width: auto; flex: 1; }
+.foot-cta .cta-pair .cta-icon { width: auto; flex: 0 0 auto; }


### PR DESCRIPTION
The Schedule a visit + ▶ pair collapsed inside the profile footer; scoped flex sizing fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)