### PR TITLE
fix(auth): pin search_path in handle_new_user (new Discord sign-ups 500'd)

### DIFF
--- a/supabase/migrations/131_fix_handle_new_user_search_path.sql
+++ b/supabase/migrations/131_fix_handle_new_user_search_path.sql
@@ -1,0 +1,21 @@
+-- 131: fix handle_new_user failing for brand-new OAuth users.
+-- GoTrue inserts into auth.users with search_path = auth, so the unqualified
+-- `profiles` reference in handle_new_user() (025_profiles.sql) raised
+-- `relation "profiles" does not exist`, aborting the whole sign-up with a
+-- 500 at /callback. Pin the search_path and schema-qualify the table.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, username)
+  VALUES (
+    NEW.id,
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'username'), '')
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Why
Last night's failed Discord sign-in on /applications: OAuth redirect succeeded, but GoTrue's /callback returned **500: Database error saving new user** — `relation "profiles" does not exist`.

## Root cause
`handle_new_user()` (025_profiles.sql) is the AFTER INSERT trigger on `auth.users`. It references `profiles` unqualified with no pinned `search_path`. GoTrue runs with `search_path=auth`, so for any **first-time** user the trigger fails and aborts the whole sign-up transaction. Existing users are unaffected.

## Fix
Migration 131: `SET search_path = public` + schema-qualify `public.profiles`.

**Note:** remote apply was permission-blocked in the session — run `supabase db push` (or apply 131 manually) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)