### PR TITLE
feat(applications): bot-issued magic-link sign-in + in-app-browser nudge (v3.20.0)

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.19.1';
+const VERSION = '3.20.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2810,6 +2810,44 @@ async function connectSharedGmail() {
 }
 
 /* ---------- auth + boot ---------- */
+
+/* Webview sandboxes (Discord/Instagram/FB in-app browsers, Android wv) break
+   OAuth round-trips: isolated short-lived storage, and the PKCE verifier is
+   lost if the flow hops out and back. Nudge toward the real browser or the
+   bot's one-time link instead. */
+function inAppBrowser() {
+  const ua = navigator.userAgent || '';
+  return /discord|instagram|fban|fbav|; wv\)/i.test(ua);
+}
+
+/* One-time sign-in link from the Discord "Get sign-in link" button:
+   ?signin=<token> → recruit-discord /redeem → verifyOtp mints the session
+   (CtrlAuth then fires signedin and the normal gate flow takes over). */
+async function redeemSigninToken() {
+  const params = new URLSearchParams(location.search);
+  const token = params.get('signin');
+  if (!token) return;
+  const clean = new URL(location.href);
+  clean.searchParams.delete('signin');
+  history.replaceState(null, '', clean);
+  setGate('Signing you in…', null);
+  try {
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-discord/redeem`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+      body: JSON.stringify({ token }),
+    });
+    const out = await resp.json();
+    if (!resp.ok) throw new Error(out.error || 'redeem failed');
+    const { error } = await sb.auth.verifyOtp({ type: 'email', token_hash: out.token_hash, email: out.email });
+    if (error) throw error;
+  } catch (e) {
+    setGate(e.message || 'Sign-in link failed.', 'Continue with Discord',
+      'Get a fresh link from the "Get sign-in link" button on Discord, or sign in with Discord here.');
+    document.getElementById('gate-btn').onclick = signInWithDiscord;
+  }
+}
+
 /* Direct Discord OAuth — the gate's primary action goes straight to Discord
    rather than through the multi-provider modal. */
 async function signInWithDiscord() {
@@ -2931,7 +2969,11 @@ function init() {
     document.body.dataset.authState = 'out';
     document.getElementById('app').hidden = true;
     document.getElementById('gate').hidden = false;
-    setGate('Sign in with Discord to open the applicant inbox.', 'Continue with Discord');
+    if (new URLSearchParams(location.search).get('signin')) return; // redeem in flight
+    setGate('Sign in with Discord to open the applicant inbox.', 'Continue with Discord',
+      inAppBrowser()
+        ? 'Heads up: you\'re in an in-app browser, where Discord sign-in often loops. Use ⋯ → "Open in browser", or tap "Get sign-in link" in the recruiting channel for a one-tap link.'
+        : null);
     document.getElementById('gate-btn').onclick = signInWithDiscord;
   });
 
@@ -2942,6 +2984,7 @@ function init() {
     mountTo: '#ctrl-auth-root',
   });
   sb = window.CtrlAuth.getSupabaseClient();
+  redeemSigninToken(); // no-op without ?signin=
 
   document.getElementById('gate-btn').onclick = signInWithDiscord;
   document.getElementById('gate-alt').onclick = () => window.CtrlAuth.openLoginModal();

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -118,3 +118,13 @@ Expected: `windows: [{date: 2026-07-25, start: 09:00, end: 12:00}]`, `platform: 
 - Claim is first-write-wins via `UPDATE ... WHERE status='open'`; the 3s interaction deadline is met by ACKing with DEFERRED_UPDATE_MESSAGE and doing GCal/edit/DM/email in `EdgeRuntime.waitUntil`. Calendar failure after a claim never reopens the post (no double-booking) — the post flips to a ⚠️ state and the claimer is DM'd to book manually.
 - App-side booking (`schedule` action in /applications) also closes any open claim post for that applicant.
 - The 96h stuck nudge piggybacks on `recruit-gmail scan` (no new cron).
+
+## Mobile sign-in: bot-issued magic links (v1.9.0, 2026-07-28)
+
+Browser Discord OAuth is hostile on phones (users aren't logged into discord.com in Safari) and structurally broken in in-app webviews (sandboxed storage kills the PKCE round-trip). Housemates already live in the Discord app, so the bot now issues sign-in links directly:
+
+- **"Get sign-in link" button** — persistent message in the recruiting channel (posted via `POST recruit-discord/signin-post`, recruiting-member JWT). Tap → ephemeral one-time link (`?signin=<token>`, 10-min TTL, single use, sha256-at-rest in `recruit_signin_tokens`, migration 132).
+- **Redeem** — `POST recruit-discord/redeem` exchanges the token for `{token_hash, email}`; the app calls `verifyOtp` to mint the session. Existing accounts (past desktop OAuth) are matched via `user_discord_membership`; first-timers get a shadow account (`discord-<id>@signin.ctrl.rodeo`) with the Discord id in `app_metadata`.
+- **Gate unchanged** — `discord-membership` v1.3.0 reads the Discord id from provider identity *or* `app_metadata`, then runs the same guild + channel-permission check. The link only mints a session; access is still decided by the Recruiting Society channel gate.
+- **Guard** — shadow emails never receive calendar invites; claims from a shadow account without a real profile email fail into the existing ⚠️ manual-booking DM path.
+- **Webview nudge** — the app gate detects Discord/Instagram/FB/Android-webview UAs and points users to "Open in browser" or the bot button (app v3.20.0).

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -345,6 +345,26 @@ export async function postLiveCall(title: string, when: string, meetLink: string
   })
 }
 
+// Persistent "Get sign-in link" helper message for phone sign-in — tapping
+// the button gets an ephemeral one-time link (handled in recruit-discord).
+export async function postSigninMessage(channelId: string): Promise<any> {
+  return await discordFetch(`/channels/${channelId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({
+      embeds: [{
+        description: '📱 **Applicant inbox — sign in from your phone**\n' +
+          'Tap below for a one-time sign-in link. No password, no Discord OAuth dance — ' +
+          'works in any browser. Links expire after 10 minutes.',
+        color: 0x5865f2,
+      }],
+      components: [{
+        type: 1,
+        components: [{ type: 2, style: 1, label: 'Get sign-in link', custom_id: 'signin' }],
+      }],
+    }),
+  })
+}
+
 // One channel nudge for a post nobody claimed within 96h.
 export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {
   const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,8 +20,8 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.2.0'
-console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification`)
+const VERSION = '1.3.0'
+console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification (OAuth or bot magic-link)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -51,7 +51,15 @@ interface DiscordIdentity {
 function findDiscordIdentity(user: Record<string, unknown>): DiscordIdentity | null {
   const identities = (user.identities || []) as Array<Record<string, unknown>>
   const identity = identities.find(i => i.provider === 'discord')
-  if (!identity) return null
+  if (!identity) {
+    // Bot magic-link accounts (recruit-discord /redeem) carry their Discord id
+    // in app_metadata instead of a provider identity.
+    const meta = (user.app_metadata || {}) as Record<string, unknown>
+    if (meta.discord_user_id) {
+      return { discordUserId: String(meta.discord_user_id), username: meta.discord_username ? String(meta.discord_username) : null }
+    }
+    return null
+  }
   const data = (identity.identity_data || {}) as Record<string, unknown>
   const discordUserId = String(identity.id || data.provider_id || data.sub || '')
   if (!discordUserId) return null

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,8 +13,8 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.8.2'
-console.log(`[recruit-discord] v${VERSION} — screening-claim interactions + DM reminders`)
+const VERSION = '1.9.0'
+console.log(`[recruit-discord] v${VERSION} — screening claims + bot-issued magic-link sign-in`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -23,8 +23,14 @@ import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel, slo
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
 
+// CORS needed only by the browser-facing routes (/redeem, /signin-post);
+// harmless on Discord-signed interaction responses.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
 const json = (data: unknown, status = 200) =>
-  new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+  new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
 
 function db() {
   return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
@@ -95,7 +101,10 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     const { data: authUser, error: authErr } = await client.auth.admin.getUserById(opts.userId)
     // Google Group address preferred — it's the email residents actually read.
     const housemateEmail = (rp?.group_email || authUser?.user?.email || '').toLowerCase().trim()
-    if (authErr || !housemateEmail.includes('@')) throw new Error('Could not resolve your account email')
+    // Shadow magic-link accounts have a synthetic email — invites would bounce.
+    if (authErr || !housemateEmail.includes('@') || housemateEmail.endsWith('@signin.ctrl.rodeo')) {
+      throw new Error('Could not resolve your real email — set your name/email in the app profile first')
+    }
 
     const { screening, meetLink, applicant } = await scheduleScreening(client, {
       applicantId, startsAt, housemateUserId: opts.userId, housemateName, housemateEmail,
@@ -176,6 +185,98 @@ async function handleClaim(interaction: Record<string, any>): Promise<Response> 
   else work.catch(() => { /* logged inside */ })
 
   return json(DEFERRED_UPDATE)
+}
+
+// ---- bot-issued magic-link sign-in ----
+// The "Get sign-in link" button (posted via /signin-post) lives in a
+// recruiting channel, so tapping it proves channel access; the link itself
+// only mints a session — the app's discord-membership gate still runs the
+// real channel-permission check afterwards.
+
+const SIGNIN_TTL_MS = 10 * 60_000
+const APP_URL = 'https://ctrl.rodeo/applications/'
+// Shadow email for members who've never OAuth'd on desktop; deterministic so
+// repeat sign-ins land on the same account.
+const shadowEmail = (discordUserId: string) => `discord-${discordUserId}@signin.ctrl.rodeo`
+
+async function sha256Hex(s: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(s))
+  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function handleSigninButton(interaction: Record<string, any>): Promise<Response> {
+  const discordUserId = interaction.member?.user?.id || interaction.user?.id
+  const discordUsername = interaction.member?.user?.username || interaction.user?.username || null
+  if (!discordUserId || !interaction.guild_id) return json(ephemeral('Could not identify you.'))
+
+  const raw = crypto.randomUUID().replaceAll('-', '') + crypto.randomUUID().replaceAll('-', '')
+  const client = db()
+  const { error } = await client.from('recruit_signin_tokens').insert({
+    token_hash: await sha256Hex(raw), discord_user_id: discordUserId, discord_username: discordUsername,
+  })
+  if (error) return json(ephemeral('Could not mint a link — try again in a minute.'))
+
+  return json(ephemeral(
+    `🔑 Your one-time sign-in link (10 min, single use):\n${APP_URL}?signin=${raw}\n` +
+    `Opens the applicant inbox already signed in — any browser works.`,
+  ))
+}
+
+// POST /redeem  { token } → { token_hash, email } for supabase-js verifyOtp.
+// Unauthenticated by design: the token is the credential (single-use, 10-min).
+async function handleRedeem(req: Request): Promise<Response> {
+  const { token } = await req.json().catch(() => ({} as Record<string, unknown>))
+  if (typeof token !== 'string' || token.length < 32) return json({ error: 'bad token' }, 400)
+  const client = db()
+  const { data: row } = await client.from('recruit_signin_tokens')
+    .update({ used_at: new Date().toISOString() })
+    .eq('token_hash', await sha256Hex(token)).is('used_at', null)
+    .gte('created_at', new Date(Date.now() - SIGNIN_TTL_MS).toISOString())
+    .select().maybeSingle()
+  if (!row) return json({ error: 'Link expired or already used — get a fresh one from the Discord button.' }, 401)
+
+  // Prefer the member's existing account (from a past desktop OAuth sign-in).
+  const { data: membership } = await client.from('user_discord_membership')
+    .select('user_id').eq('discord_user_id', row.discord_user_id).maybeSingle()
+
+  let email: string | null = null
+  if (membership?.user_id) {
+    const { data: au } = await client.auth.admin.getUserById(membership.user_id)
+    email = au?.user?.email || null
+  }
+  if (!email) {
+    email = shadowEmail(row.discord_user_id)
+    const { error: createErr } = await client.auth.admin.createUser({
+      email, email_confirm: true,
+      app_metadata: { discord_user_id: row.discord_user_id, discord_username: row.discord_username },
+      user_metadata: { username: row.discord_username },
+    })
+    // "already registered" is fine — repeat shadow sign-in.
+    if (createErr && !/already/i.test(createErr.message)) return json({ error: createErr.message }, 500)
+  }
+
+  const { data: link, error: linkErr } = await client.auth.admin.generateLink({ type: 'magiclink', email })
+  if (linkErr || !link?.properties?.hashed_token) return json({ error: linkErr?.message || 'link generation failed' }, 500)
+  return json({ token_hash: link.properties.hashed_token, email })
+}
+
+// POST /signin-post  (user JWT, recruiting member) → post the button message.
+async function handleSigninPost(req: Request): Promise<Response> {
+  const client = db()
+  const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+  const { data: userData, error: userErr } = await client.auth.getUser(token)
+  if (userErr || !userData?.user) return json({ error: 'Not authenticated' }, 401)
+  const { data: membership } = await client.from('user_discord_membership')
+    .select('is_recruiting_member').eq('user_id', userData.user.id).maybeSingle()
+  if (!membership?.is_recruiting_member) return json({ error: 'Not a recruiting member' }, 403)
+
+  const { postSigninMessage, NOTES_CHANNEL_ID } = await import('../_shared/discord.ts')
+  const body = await req.json().catch(() => ({} as Record<string, unknown>))
+  const channelId = typeof body.channelId === 'string' && body.channelId
+    ? body.channelId
+    : (Deno.env.get('RECRUITING_CHANNEL_ID') || NOTES_CHANNEL_ID)
+  const message = await postSigninMessage(channelId)
+  return json({ posted: true, channelId, messageId: message?.id || null })
 }
 
 // DM each claimer ~an hour before their interview. Invoked by pg_cron every
@@ -483,6 +584,7 @@ async function processRecordings(client: ReturnType<typeof db>): Promise<number>
 }
 
 serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
   try {
     // Cron path: interview reminders (header auth, not Discord-signed).
     // Auth: X-Cron-Secret when CRON_SECRET is configured, else the one-time
@@ -509,13 +611,20 @@ serve(async (req) => {
       return json({ bots, live, reminded: sent, recorded })
     }
 
+    const pathname = new URL(req.url).pathname
+    if (pathname.endsWith('/redeem')) return await handleRedeem(req)
+    if (pathname.endsWith('/signin-post')) return await handleSigninPost(req)
+
     const body = await req.text()
     if (!(await verifySignature(req, body))) {
       return json({ error: 'invalid request signature' }, 401)
     }
     const interaction = JSON.parse(body)
     if (interaction.type === 1) return json(PONG)
-    if (interaction.type === 3) return await handleClaim(interaction)
+    if (interaction.type === 3) {
+      if (String(interaction.data?.custom_id || '') === 'signin') return await handleSigninButton(interaction)
+      return await handleClaim(interaction)
+    }
     return json(ephemeral('Unsupported interaction.'))
   } catch (err) {
     console.error('[recruit-discord] error:', (err as Error).message)

--- a/supabase/migrations/132_recruit_signin_tokens.sql
+++ b/supabase/migrations/132_recruit_signin_tokens.sql
@@ -1,0 +1,18 @@
+-- 132: one-time sign-in tokens for the bot-issued magic-link flow.
+-- A "Get sign-in link" button in the recruiting channel mints a short-lived
+-- single-use token (recruit-discord); redeeming it at /redeem exchanges the
+-- token for a Supabase session via auth.admin.generateLink + verifyOtp.
+-- Service-role only: RLS on, no policies.
+CREATE TABLE IF NOT EXISTS recruit_signin_tokens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  token_hash text UNIQUE NOT NULL,          -- sha256 of the raw token; raw never stored
+  discord_user_id text NOT NULL,
+  discord_username text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  used_at timestamptz
+);
+
+ALTER TABLE recruit_signin_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Hygiene: tokens are 10-minute single-use; anything older is dead weight.
+CREATE INDEX IF NOT EXISTS recruit_signin_tokens_created_idx ON recruit_signin_tokens (created_at);


### PR DESCRIPTION
## Why
Phone sign-in via Discord OAuth is hostile (users aren't logged into discord.com in Safari) and structurally broken inside Discord's in-app webview (sandboxed storage kills the PKCE round-trip). Housemates live in the Discord app — so the bot now issues sign-in links there.

## What
- **recruit-discord v1.9.0** — `signin` button interaction → ephemeral one-time link (10-min TTL, single use, sha256 at rest); `POST /redeem` exchanges token → `verifyOtp` token_hash; `POST /signin-post` (recruiting-member JWT) posts the button message; CORS on browser routes; shadow-email guard in finishClaim.
- **discord-membership v1.3.0** — Discord id fallback to `app_metadata` for magic-link shadow accounts; same guild + Recruiting-Society channel gate still decides access.
- **Migration 132** — `recruit_signin_tokens` (RLS, service-role only).
- **App v3.20.0** — `?signin=` redemption on boot; in-app-browser UA nudge on the gate.
- PRD updated: docs/strategy/prds/agape-screening-claim-automation.md.

## Post-merge
Deploy `recruit-discord` + `discord-membership`, apply migration 132, post the button via /signin-post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)