### PR TITLE
fix(applications): bump asset cache-bust to 3.20.1

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.19.1">
+  <link rel="stylesheet" href="css/app.css?v=3.20.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -205,6 +205,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.19.1"></script>
+  <script src="js/app.js?v=3.20.1"></script>
 </body>
 </html>


### PR DESCRIPTION
index.html pinned `app.js?v=3.19.1`, so clients never picked up v3.20.0/3.20.1 — this is why the phone test ran the old code. Bumps both asset pins to 3.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)