### PR TITLE
feat(recruiting): attach out-of-band recordings to applicants (v3.21.0)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.20.1">
+  <link rel="stylesheet" href="css/app.css?v=3.21.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -155,6 +155,19 @@
     </div>
   </div>
 
+  <!-- Link an orphaned recording to an applicant (?link=<gcal event id>). -->
+  <div class="email-modal" id="link-modal" hidden>
+    <div class="email-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title" id="link-title">Link recording to an applicant</h3>
+        <button class="review__close email-modal__close" id="link-close" aria-label="Close">✕</button>
+      </div>
+      <p class="email-modal__status" id="link-status"></p>
+      <input type="text" class="listing-status" id="link-search" placeholder="Search applicants…" autocomplete="off">
+      <div id="link-results" style="max-height:280px;overflow:auto;margin-top:8px"></div>
+    </div>
+  </div>
+
   <!-- Recording viewer — video with the call summary + house notes beside it. -->
   <div class="email-modal" id="watch-modal" hidden>
     <div class="email-modal__card watch-modal__card">
@@ -205,6 +218,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.20.1"></script>
+  <script src="js/app.js?v=3.21.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.20.1';
+const VERSION = '3.21.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2809,6 +2809,50 @@ async function connectSharedGmail() {
   } catch (e) { toast(`Couldn't start Gmail connect: ${e.message}`); }
 }
 
+/* ---------- link orphaned recording to applicant (?link=<gcal id>) ---------- */
+async function openLinkRecording(gcalEventId) {
+  const clean = new URL(location.href);
+  clean.searchParams.delete('link');
+  history.replaceState(null, '', clean);
+  const modal = document.getElementById('link-modal');
+  const { data: rec } = await sb.from('recruit_recorded_events')
+    .select('gcal_event_id, title, starts_at, applicant_id').eq('gcal_event_id', gcalEventId).maybeSingle();
+  if (!rec) { toast('Recording not found — it may already be linked.'); return; }
+  if (rec.applicant_id) { toast('Already linked.'); openReview(rec.applicant_id); return; }
+  document.getElementById('link-title').textContent = `Link "${rec.title || 'Agape call'}" to an applicant`;
+  document.getElementById('link-status').textContent =
+    new Date(rec.starts_at).toLocaleString([], { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+  const results = document.getElementById('link-results');
+  const search = document.getElementById('link-search');
+  const renderRows = q => {
+    const needle = (q || '').toLowerCase();
+    const rows = applicants
+      .filter(a => !needle || `${a.first_name} ${a.last_name || ''} ${a.email || ''}`.toLowerCase().includes(needle))
+      .slice(0, 30);
+    results.innerHTML = rows.map(a =>
+      `<button type="button" class="hold-sheet__cancel" style="display:block;width:100%;text-align:left;margin-top:4px" data-link-pick="${esc(a.id)}">
+        ${esc(`${a.first_name} ${a.last_name || ''}`.trim())} <span style="opacity:.6">${esc(a.email || '')}</span>
+      </button>`).join('') || '<p class="email-modal__status">No matches.</p>';
+  };
+  search.value = ''; renderRows('');
+  search.oninput = () => renderRows(search.value);
+  results.onclick = async e => {
+    const btn = e.target.closest('[data-link-pick]');
+    if (!btn) return;
+    btn.disabled = true;
+    try {
+      const out = await gmailCall({ action: 'link-recording', gcalEventId, applicantId: btn.dataset.linkPick });
+      modal.hidden = true;
+      toast(`Linked to ${out.firstName} — notes will land on their profile`);
+      await loadAll(); render();
+      openReview(btn.dataset.linkPick);
+    } catch (err) { toast(`Link failed: ${err.message}`); btn.disabled = false; }
+  };
+  document.getElementById('link-close').onclick = () => { modal.hidden = true; };
+  modal.hidden = false;
+  search.focus();
+}
+
 /* ---------- auth + boot ---------- */
 
 /* Webview sandboxes (Discord/Instagram/FB in-app browsers, Android wv) break
@@ -2950,6 +2994,8 @@ async function _checkMembershipAndEnter() {
     if (autoFlagged) toast(`${autoFlagged} applicant${autoFlagged === 1 ? '' : 's'} auto-archived (budget under $1,500) — update emails queued`);
     const deep = new URLSearchParams(location.search).get('a');
     if (deep && applicants.some(x => x.id === deep)) openReview(deep);
+    const linkEv = new URLSearchParams(location.search).get('link');
+    if (linkEv) openLinkRecording(linkEv);
   } catch (e) {
     setGate('Something went wrong checking access.', 'Try again');
     document.getElementById('gate-btn').onclick = checkMembershipAndEnter;

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -128,3 +128,10 @@ Browser Discord OAuth is hostile on phones (users aren't logged into discord.com
 - **Gate unchanged** — `discord-membership` v1.3.0 reads the Discord id from provider identity *or* `app_metadata`, then runs the same guild + channel-permission check. The link only mints a session; access is still decided by the Recruiting Society channel gate.
 - **Guard** — shadow emails never receive calendar invites; claims from a shadow account without a real profile email fail into the existing ⚠️ manual-booking DM path.
 - **Webview nudge** — the app gate detects Discord/Instagram/FB/Android-webview UAs and points users to "Open in browser" or the bot button (app v3.20.0).
+
+## Out-of-band call attachment (v1.10.0 / app v3.21.0, 2026-07-28)
+
+Calls scheduled outside the app already get picked up and recorded when the shared calendar is involved; the remaining gap was silent non-attachment. Now:
+
+- **Unmatched-call DM** — the cron sweep DMs housemate attendees when an upcoming swept call has a guest that matches no applicant ("link it" + deep link). House-internal meetings (all attendees known) are stamped and never nag. One DM per event (`unmatched_notified_at`, migration 133).
+- **Link modal** — `?link=<gcal_event_id>` opens an applicant picker; linking clones the recorded event into `recruit_screenings` (Watch chip, notes land on the profile) via `recruit-gmail link-recording`, and stamps `applicant_id` on the recorded event.

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,8 +13,8 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.9.0'
-console.log(`[recruit-discord] v${VERSION} — screening claims + bot-issued magic-link sign-in`)
+const VERSION = '1.10.0'
+console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -449,6 +449,73 @@ async function scheduleCalendarBots(client: ReturnType<typeof db>): Promise<numb
   return created
 }
 
+// DM housemates on swept calls with an unrecognized external guest: the call
+// got a recording bot but no applicant attachment, so someone should either
+// link it or know it's house-internal. One DM per event (unmatched_notified_at).
+async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<number> {
+  const { dmUser } = await import('../_shared/discord.ts')
+  const { SHARED_EMAIL } = await import('../_shared/recruit-schedule.ts')
+  const { data: rows } = await client.from('recruit_recorded_events')
+    .select('gcal_event_id, title, starts_at, meet_link')
+    .is('applicant_id', null).is('unmatched_notified_at', null)
+    .gt('starts_at', new Date().toISOString()).limit(10)
+  if (!rows?.length) return 0
+
+  let token: string
+  try { token = await sharedAccessToken(client) } catch { return 0 }
+  const botEmail = (Deno.env.get('RECALL_BOT_EMAIL') || '').toLowerCase()
+  // Known internal addresses: profile group emails + login emails of members.
+  const { data: profs } = await client.from('recruit_profiles').select('user_id, group_email')
+  const { data: members } = await client.from('user_discord_membership').select('user_id, discord_user_id')
+  const discordByUser = new Map((members || []).map(m => [m.user_id, m.discord_user_id]))
+  const internal = new Map<string, string | null>() // email -> discord id (null = internal, not DM-able)
+  internal.set(SHARED_EMAIL.toLowerCase(), null)
+  if (botEmail) internal.set(botEmail, null)
+  for (const p of (profs || [])) {
+    if (p.group_email) internal.set(String(p.group_email).toLowerCase(), discordByUser.get(p.user_id) || null)
+  }
+  for (const m of (members || [])) {
+    try {
+      const { data: au } = await client.auth.admin.getUserById(m.user_id)
+      const em = (au?.user?.email || '').toLowerCase()
+      if (em.includes('@') && !em.endsWith('@signin.ctrl.rodeo')) internal.set(em, m.discord_user_id)
+    } catch { /* best effort */ }
+  }
+
+  let notified = 0
+  for (const r of (rows || [])) {
+    try {
+      const resp = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(r.gcal_event_id)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!resp.ok) continue
+      const ev = await resp.json()
+      // deno-lint-ignore no-explicit-any
+      const emails = ((ev.attendees || []) as any[]).map(a => String(a.email || '').toLowerCase()).filter(Boolean)
+      const hasGuest = emails.some(e => !internal.has(e))
+      if (!hasGuest) {
+        // House-internal meeting — nothing to link, never notify.
+        await client.from('recruit_recorded_events')
+          .update({ unmatched_notified_at: new Date().toISOString() }).eq('gcal_event_id', r.gcal_event_id)
+        continue
+      }
+      const housemateDiscordIds = [...new Set(emails.map(e => internal.get(e)).filter(Boolean))] as string[]
+      for (const did of housemateDiscordIds.slice(0, 3)) {
+        await dmUser(did,
+          `🔗 Your call **${r.title || 'Agape call'}** (${slotWhen(new Date(r.starts_at))}) has a guest I can't match to an applicant.\n` +
+          `It'll be recorded either way — if it's an applicant call, link it so notes land on their profile:\n` +
+          `https://ctrl.rodeo/applications/?link=${encodeURIComponent(r.gcal_event_id)}`)
+      }
+      await client.from('recruit_recorded_events')
+        .update({ unmatched_notified_at: new Date().toISOString() }).eq('gcal_event_id', r.gcal_event_id)
+      if (housemateDiscordIds.length) notified++
+    } catch (err) {
+      console.warn(`[unmatched] notify failed for ${r.gcal_event_id}: ${(err as Error).message}`)
+    }
+  }
+  return notified
+}
+
 // Calls whose end time passed flip scheduled -> completed so the app stops
 // showing them as upcoming (the Watch chip takes over once notes land).
 async function completePastCalls(client: ReturnType<typeof db>): Promise<number> {
@@ -603,6 +670,8 @@ serve(async (req) => {
       }
       if (!authorized) return json({ error: 'unauthorized' }, 401)
       const bots = await scheduleMissingBots(client) + await scheduleCalendarBots(client)
+      const unmatched = await notifyUnmatchedCalls(client)
+      if (unmatched) console.log(`[unmatched] ${unmatched} link-nudge DM(s) sent`)
       const live = await announceLiveCalls(client)
       await completePastCalls(client)
       const sent = await remindUpcoming(client)

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.11.0'
+const VERSION = '1.12.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -367,6 +367,52 @@ serve(async (req) => {
 
       console.log(`screening ${applicantId} x ${housemateName} @ ${startsAt.toISOString()}`)
       return json({ scheduled: true, screening: result.screening })
+    }
+
+    if (action === 'link-recording') {
+      // Attach an orphaned recorded call to an applicant: clone it into
+      // recruit_screenings (the surface the app already renders — Watch chip,
+      // notes) and stamp the recorded-event row so it stops counting as
+      // unlinked. Idempotent per event via the gcal_event_id dedup.
+      const gcalEventId = String(body.gcalEventId || '')
+      const applicantId = String(body.applicantId || '')
+      const { data: rec } = await client.from('recruit_recorded_events')
+        .select('*').eq('gcal_event_id', gcalEventId).maybeSingle()
+      if (!rec) return json({ error: 'unknown recorded event' }, 404)
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('id, first_name').eq('id', applicantId).maybeSingle()
+      if (!applicant) return json({ error: 'unknown applicant' }, 404)
+      const { data: dupe } = await client.from('recruit_screenings')
+        .select('id').eq('gcal_event_id', gcalEventId).maybeSingle()
+      if (!dupe) {
+        const past = new Date(rec.ends_at || rec.starts_at) < new Date()
+        const { error: insErr } = await client.from('recruit_screenings').insert({
+          applicant_id: applicantId,
+          starts_at: rec.starts_at,
+          ends_at: rec.ends_at || rec.starts_at,
+          gcal_event_id: rec.gcal_event_id,
+          meet_link: rec.meet_link,
+          housemate_name: 'linked manually',
+          status: past ? 'completed' : 'scheduled',
+          recall_bot_id: rec.recall_bot_id,
+          recall_status: rec.recall_status,
+          recording_summary: rec.recording_summary,
+          recording_posted_at: rec.recording_posted_at,
+        })
+        if (insErr) return json({ error: insErr.message }, 500)
+      }
+      await client.from('recruit_recorded_events')
+        .update({ applicant_id: applicantId }).eq('gcal_event_id', gcalEventId)
+      return json({ linked: true, applicantId, firstName: applicant.first_name })
+    }
+
+    if (action === 'unlinked-recordings') {
+      // Feed for the app's link modal: swept calls with no applicant.
+      const { data } = await client.from('recruit_recorded_events')
+        .select('gcal_event_id, title, starts_at, recording_summary')
+        .is('applicant_id', null)
+        .order('starts_at', { ascending: false }).limit(25)
+      return json({ recordings: data || [] })
     }
 
     if (action === 'claim-preview' || action === 'claim-post') {

--- a/supabase/migrations/133_recorded_events_attach.sql
+++ b/supabase/migrations/133_recorded_events_attach.sql
@@ -1,0 +1,8 @@
+-- 133: attach out-of-band recordings to applicants.
+-- recruit_recorded_events rows are calendar-swept calls with no applicant
+-- match. applicant_id records a manual link (recruit-gmail link-recording);
+-- unmatched_notified_at stamps the one-time "couldn't match this call" DM
+-- so the cron never nags twice.
+ALTER TABLE recruit_recorded_events
+  ADD COLUMN IF NOT EXISTS applicant_id UUID REFERENCES recruit_applicants(id),
+  ADD COLUMN IF NOT EXISTS unmatched_notified_at TIMESTAMPTZ;


### PR DESCRIPTION
## Why
Off-flow calls already get recorded via the shared-calendar sweep, but when the guest's email matches no applicant the recording lands unattached — silently. This closes the loop.

## What
- **Unmatched-call DM**: the 15-min cron DMs housemate attendees when an upcoming swept call has a guest we can't match ('link it' + deep link). All-internal meetings are stamped, never nagged. One DM per event.
- **Link flow**: `?link=<gcal_event_id>` opens an applicant picker; linking clones the recorded event into `recruit_screenings` (Watch chip + notes on the profile) and stamps the recorded event.
- Migration 133, recruit-gmail v1.12.0, recruit-discord v1.10.0, app v3.21.0. PRD updated.

## Post-merge
Deploy `recruit-gmail` + `recruit-discord`, apply migration 133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)