### PR TITLE
fix(migrations): 133 applicant_id TEXT to match recruit_applicants.id

### DIFF
--- a/supabase/migrations/133_recorded_events_attach.sql
+++ b/supabase/migrations/133_recorded_events_attach.sql
@@ -4,5 +4,5 @@
 -- unmatched_notified_at stamps the one-time "couldn't match this call" DM
 -- so the cron never nags twice.
 ALTER TABLE recruit_recorded_events
-  ADD COLUMN IF NOT EXISTS applicant_id UUID REFERENCES recruit_applicants(id),
+  ADD COLUMN IF NOT EXISTS applicant_id TEXT REFERENCES recruit_applicants(id),
   ADD COLUMN IF NOT EXISTS unmatched_notified_at TIMESTAMPTZ;


### PR DESCRIPTION
FK failed on prod apply: recruit_applicants.id is TEXT, not UUID. Applied corrected version to prod directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)