### PR TITLE
feat(applications): Openings as home + mobile row fix (v3.22.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -543,6 +543,12 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   .inbox-row__review { display: none; } /* whole row is tappable on phones */
   .review__foot { gap: var(--space-2); }
   .review__btn { padding-inline: var(--space-2); font-size: var(--font-size-small); }
+  /* Openings rows: the fixed 172px CTA column (its buttons are hidden here
+     anyway) starved the name column into one-letter-per-line wraps. */
+  .inbox-row__actions .cta-stack { width: auto; }
+  .inbox-row__actions .cta-context { display: none; }
+  .inbox-row__grip { display: none; } /* drag-reorder is a desktop affordance */
+  .inbox-row__title { overflow-wrap: break-word; }
 }
 
 /* Social profile photo layered over the initials; broken loads self-remove. */

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.21.0">
+  <link rel="stylesheet" href="css/app.css?v=3.22.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -40,13 +40,13 @@
     </header>
 
     <aside class="app__rail" id="rail">
-      <a class="brand" href="?view=inbox" data-view-link="inbox">
+      <a class="brand" href="?view=openings" data-view-link="openings">
         <span class="brand__text">Agape recruiting</span>
       </a>
       <nav class="rail-nav" id="rail-nav">
         <div class="rail-nav__group">House</div>
-        <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
         <a class="rail-nav__row" href="?view=openings" data-view-link="openings">Openings <span class="rail-nav__count" id="count-openings"></span></a>
+        <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
         <div class="rail-nav__group">Funnel</div>
         <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Inbox <span class="rail-nav__count" id="count-inbox"></span></a>
         <a class="rail-nav__row" href="?view=candidates" data-view-link="candidates">Candidates <span class="rail-nav__count" id="count-candidates"></span></a>
@@ -218,6 +218,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.21.0"></script>
+  <script src="js/app.js?v=3.22.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.21.0';
+const VERSION = '3.22.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2986,9 +2986,9 @@ async function _checkMembershipAndEnter() {
     document.getElementById('app').hidden = false;
     renderRailUser();
     handleGmailCallback();
-    view = new URLSearchParams(location.search).get('view') || 'inbox';
+    view = new URLSearchParams(location.search).get('view') || 'openings';
     view = LEGACY_VIEWS[view] || view;
-    if (!VIEWS[view]) view = 'inbox';
+    if (!VIEWS[view]) view = 'openings';
     pendingOccRoom = view === 'occupancy' ? +new URLSearchParams(location.search).get('room') || null : null;
     render();
     if (autoFlagged) toast(`${autoFlagged} applicant${autoFlagged === 1 ? '' : 's'} auto-archived (budget under $1,500) — update emails queued`);


### PR DESCRIPTION
## What
- **Openings is home**: default view when no `?view=` param (and unknown-view fallback), brand click, and first row in the rail. Deep links (`?view=inbox` etc.) unchanged.
- **Mobile Openings fix**: the CTA column reserved a fixed 172px on phones even though its buttons are hidden ≤480px, starving names into one-letter-per-line wraps (see Timothy S. screenshot). Column now auto-sizes; drag grip and CTA context line hidden on phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)