### PR TITLE
fix(applications): mobile CTA width override lost the cascade (v3.22.1)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1307,3 +1307,10 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .foot-cta .cta-pair { display: flex; width: 100%; gap: 6px; }
 .foot-cta .cta-pair .cta-std { width: auto; flex: 1; }
 .foot-cta .cta-pair .cta-icon { width: auto; flex: 0 0 auto; }
+
+/* --- v3.22.1: mobile CTA-column fix, placed AFTER the 172px rule above so
+   the cascade resolves in its favor (equal specificity, later wins). --- */
+@media (max-width: 480px) {
+  .inbox-row__actions .cta-stack { width: auto; align-items: flex-end; }
+  .inbox-row__actions .cta-pair { width: auto; }
+}

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.22.0">
+  <link rel="stylesheet" href="css/app.css?v=3.22.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -218,6 +218,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.22.0"></script>
+  <script src="js/app.js?v=3.22.1"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.22.0';
+const VERSION = '3.22.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';


### PR DESCRIPTION
v3.22.0's `width: auto` override was declared before the `width: 172px` rule it needed to beat — same specificity, later wins, so phones kept the fixed column and names still wrapped one-letter-per-line. Re-declared at end of sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)