### PR TITLE
Recruiting v3.23: everything outstanding

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1329,3 +1329,10 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .chip-line { color: var(--fg-muted); }
 .cta--green.btn { background: #1D9E75; border-color: #1D9E75; color: #fff; }
 .gd-no { color: var(--error); border-color: var(--error); background: transparent; }
+
+/* --- v3.22.1 (restored post-rebase): mobile CTA-column fix — must stay
+   LAST so the cascade resolves in its favor. --- */
+@media (max-width: 480px) {
+  .inbox-row__actions .cta-stack { width: auto; align-items: flex-end; }
+  .inbox-row__actions .cta-pair { width: auto; }
+}

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1308,9 +1308,24 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .foot-cta .cta-pair .cta-std { width: auto; flex: 1; }
 .foot-cta .cta-pair .cta-icon { width: auto; flex: 0 0 auto; }
 
-/* --- v3.22.1: mobile CTA-column fix, placed AFTER the 172px rule above so
-   the cascade resolves in its favor (equal specificity, later wins). --- */
-@media (max-width: 480px) {
-  .inbox-row__actions .cta-stack { width: auto; align-items: flex-end; }
-  .inbox-row__actions .cta-pair { width: auto; }
+/* --- v3.23.0: update tray, draft cards, decisions --- */
+.update-tray {
+  background: var(--hold-tint); border: 1px solid rgba(237,200,67,0.4);
+  border-radius: var(--radius-md); padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
 }
+.update-tray__head { display: flex; justify-content: space-between; align-items: center; gap: var(--space-3); margin-bottom: var(--space-2); color: var(--hold-fg); }
+.update-tray__row { display: flex; align-items: center; gap: var(--space-3); padding: 7px 0; border-top: 1px solid rgba(237,200,67,0.3); font-size: var(--font-size-small); color: var(--hold-fg); }
+.update-tray__who { font-weight: var(--fw-semibold); }
+.update-tray__why { flex: 1; min-width: 0; opacity: 0.8; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.draft-card {
+  display: flex; justify-content: space-between; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  border: 1px dashed var(--border-strong); border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4); margin-bottom: var(--space-3);
+}
+.draft-card__text { display: flex; flex-direction: column; gap: 2px; font-size: var(--font-size-small); color: var(--fg-muted); }
+.draft-card__actions { display: inline-flex; align-items: center; gap: var(--space-3); }
+.gd-tally { display: flex; flex-direction: column; gap: 6px; margin-bottom: var(--space-3); font-size: var(--font-size-small); }
+.chip-line { color: var(--fg-muted); }
+.cta--green.btn { background: #1D9E75; border-color: #1D9E75; color: #fff; }
+.gd-no { color: var(--error); border-color: var(--error); background: transparent; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.22.1">
+  <link rel="stylesheet" href="css/app.css?v=3.23.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -56,6 +56,7 @@
       <div class="rail-foot">
         <span class="rail-foot__user" id="rail-user"></span>
         <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
+        <label class="rail-foot__pref" title="When on, coverage asks post to #recruiting-interviews automatically as availability lands"><input type="checkbox" id="pref-autopost"> Auto-post coverage asks</label>
         <button class="rail-foot__link rail-foot__gmail" id="gmail-conn" type="button">Checking shared Gmail…</button>
         <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
         <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
@@ -216,8 +217,26 @@
     </div>
   </div>
 
+  <!-- Post-screening decision: would you accept them? -->
+  <div class="email-modal" id="gd-modal" hidden>
+    <div class="email-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title" id="gd-title">Would you accept them?</h3>
+        <button class="review__close email-modal__close" id="gd-close" aria-label="Close">✕</button>
+      </div>
+      <div id="gd-tally" class="gd-tally"></div>
+      <label class="listing-form__field">A line for the house (optional)
+        <input type="text" class="listing-status" id="gd-note" maxlength="500">
+      </label>
+      <div class="decision-sheet__actions">
+        <button class="btn btn--sm gd-no" id="gd-no" type="button">No</button>
+        <button class="btn btn--sm cta--green" id="gd-yes" type="button">Yes — accept</button>
+      </div>
+    </div>
+  </div>
+
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.22.1"></script>
+  <script src="js/app.js?v=3.23.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.22.1';
+const VERSION = '3.23.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -66,6 +66,8 @@ let applicants = [];          // newest first; each carries .stage
 let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
 let votes = {};               // applicant_id -> recruit_votes rows
 let placements = [];          // recruit_listing_candidates rows
+let claimPosts = {};          // applicant_id -> { status, posted_at }
+let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
 let pendingVote = null;       // { score, veto } while the vote bar is open
 let commentCounts = {};       // applicant_id -> n
@@ -403,12 +405,26 @@ function openingsCta(a) {
   const phase = callPhase(sc);
   const stack = (top, ctx) => `<span class="cta-stack">${top}${ctx ? `<span class="cta-context">${ctx}</span>` : ''}</span>`;
   const when = sc?.at ? `${fmtSlot(sc.at)}${sc.with ? ` · ${esc(sc.with)}` : ''}` : '';
-  if (phase === 'watch') return stack(
-    `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Watch the recorded intro call" data-open-call="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`, when);
+  if (phase === 'watch') {
+    const dv = decisionVotes[a.id] || [];
+    const mine = dv.find(v => v.voter_id === me?.id);
+    const decCtx = mine
+      ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
+      : `<button type="button" class="cta-link" data-give-decision="${a.id}">give your decision</button>${dv.length ? ` · ${dv.length} in` : ''}`;
+    return stack(
+      `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Watch the recorded intro call" data-open-call="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
+      `${decCtx}${when ? ` · ${when}` : ''}`);
+  }
   if (phase === 'processing') return stack(processingChip(), when);
   if (phase === 'live') return stack(joinBtn(sc) || processingChip(), when);
   if (phase === 'scheduled') {
     return stack(`<span class="decision-chip decision-chip--outreach" title="Intro call${sc.with ? ` with ${esc(sc.with)}` : ''}">${fmtSlot(sc.at)}</span>`, sc.with ? `with ${esc(sc.with)}` : '');
+  }
+  const claim = claimPosts[a.id];
+  if (sc?.availability && claim && (claim.status === 'open' || claim.status === 'manual')) {
+    const days = Math.max(0, Math.round((Date.now() - new Date(claim.postedAt).getTime()) / 86400000));
+    return stack(`<span class="decision-chip decision-chip--outreach">◆ sent to housemates</span>`,
+      `unclaimed ${days === 0 ? 'today' : `${days}d`} · <button type="button" class="cta-link" data-avail-review="${a.id}">book it yourself</button>`);
   }
   if (sc?.availability) return stack(
     `<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-avail-review="${a.id}">Review availability</button>`,
@@ -419,7 +435,9 @@ function openingsCta(a) {
     // "I'll send an invite" reads as manual scheduling — say so instead of
     // nagging; a shared-account invite gets picked up by the calendar sweep.
     const promised = /\b(invite|calendar|schedul|let'?s (chat|talk|meet)|talk (soon|then|tomorrow))\b/i.test(st.lastSnippet || '');
-    return stack(`<button class="btn btn--sm inbox-row__review cta-std cta--amber" data-email="${a.id}">Follow up</button>`,
+    // Waiting is passive until ~3 quiet days; then the clock arms Follow up.
+    const stale = Date.now() - new Date(st.lastAt).getTime() > 3 * 86400000;
+    return stack(`<button class="btn btn--sm inbox-row__review cta-std ${stale ? 'cta--amber' : ''}" data-email="${a.id}">Follow up</button>`,
       `${promised ? 'invite promised · ' : ''}sent ${relTime(st.lastAt)}`);
   }
   return stack(`<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`, '');
@@ -473,7 +491,7 @@ async function resolveAvatars() {
 
 /* ---------- data ---------- */
 async function loadAll() {
-  const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes] = await Promise.all([
+  const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes, cpRes, dvRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
     sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
@@ -482,8 +500,14 @@ async function loadAll() {
     sb.from('recruit_screenings').select('id, applicant_id, starts_at, ends_at, status, housemate_name, meet_link, recall_status').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, windows, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
+    sb.from('recruit_claim_posts').select('applicant_id, status, posted_at'),
+    sb.from('recruit_decision_votes').select('*'),
   ]);
   placements = pRes.data || [];
+  claimPosts = {};
+  for (const c of (cpRes.data || [])) claimPosts[c.applicant_id] = { status: c.status, postedAt: c.posted_at };
+  decisionVotes = {};
+  for (const d of (dvRes.data || [])) (decisionVotes[d.applicant_id] ||= []).push(d);
   votes = {};
   for (const v of (vRes.data || [])) (votes[v.applicant_id] ||= []).push(v);
   screeningState = {};
@@ -506,6 +530,8 @@ async function loadAll() {
     for (const row of (data || [])) settings[row.key] = row.value;
     const box = document.getElementById('pref-couples');
     if (box) box.checked = settings.open_to_couples !== false;
+    const ap = document.getElementById('pref-autopost');
+    if (ap) ap.checked = settings.discord_auto_post === true;
   });
   if (aRes.error) throw aRes.error;
   applicants = (aRes.data || []).map(r => ({
@@ -516,6 +542,7 @@ async function loadAll() {
     movein: r.move_in, budget: r.budget, avatarUrl: r.avatar_url, scheduleToken: r.schedule_token,
     stage: r.stage || 'review',
     moveinFrom: r.move_in_from, moveinTo: r.move_in_to, moveinSetBy: r.move_in_set_by_name,
+    updateSentAt: r.update_email_sent_at, updateSkippedAt: r.update_email_skipped_at,
   }));
   decisions = {};
   for (const d of (dRes.data || [])) {
@@ -592,7 +619,8 @@ function qualifiesFor(a, l) {
     return r.hi >= startMonth && r.lo <= endMonth;
   }
   const norm = normalizeMoveIn(a);
-  if (/flexible/i.test(norm || '')) return true;
+  // Bare "Flexible" rides any window; "month + flexible" means that month ±1.
+  if (/^Flexible$/i.test(norm || '')) return true;
   if (/^ASAP/.test(norm || '')) {
     const now = new Date();
     const cur = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
@@ -600,7 +628,8 @@ function qualifiesFor(a, l) {
   }
   const range = moveInRange(a);
   if (!range) return false; // no parseable dates — can't confirm they line up
-  return range.hi >= startMonth && range.lo <= endMonth;
+  const flexPad = /flexible/i.test(norm || '') ? 1 : 0;
+  return monthShift(range.hi, flexPad) >= startMonth && monthShift(range.lo, -flexPad) <= endMonth;
 }
 
 const activePlacements = id => placements.filter(p => p.applicant_id === id && p.status === 'active');
@@ -667,16 +696,83 @@ async function removePlacement(applicantId, listingId) {
 /* ---------- outreach email drafts ---------- */
 let emailApplicantId = null;
 
-async function openEmailModal(applicantId) {
+let emailMode = 'outreach';   // 'outreach' | 'update' (rejection queue)
+let emailKind = null;         // typed draft override, e.g. 'visit'
+
+async function openEmailModal(applicantId, kind) {
   const a = applicants.find(x => x.id === applicantId);
   if (!a) return;
   emailApplicantId = applicantId;
-  document.getElementById('email-title').textContent = `Email ${fullName(a)}`;
+  emailMode = 'outreach';
+  emailKind = kind || null;
+  document.getElementById('email-send').textContent = 'Send via Agape Gmail';
+  document.getElementById('email-title').textContent = kind === 'visit' ? `Invite ${a.first} to visit` : `Email ${fullName(a)}`;
   document.getElementById('email-subject').value = '';
   document.getElementById('email-body').value = '';
   document.getElementById('email-status').textContent = 'Drafting from their application, the listing, and any flags…';
   document.getElementById('email-modal').hidden = false;
   await generateEmail(applicantId);
+}
+
+/* Rejection-queue editor: drafts via draft_update, sends via send-update
+   (which stamps the queue state server-side). */
+/* Batch: draft + send every pending update, sequentially with progress. */
+async function sendAllUpdates(btn) {
+  const pending = applicants.filter(x => x.stage === 'rejected' && !x.updateSentAt && !x.updateSkippedAt);
+  if (!pending.length) return;
+  if (!confirm(`Send update emails to ${pending.length} applicant${pending.length === 1 ? '' : 's'}? Each gets an individually drafted community note.`)) return;
+  btn.disabled = true;
+  let done = 0;
+  const { data } = await sb.auth.getSession();
+  const token = data?.session?.access_token;
+  for (const a of pending) {
+    try {
+      btn.textContent = `Sending ${done + 1}/${pending.length}…`;
+      const dr = await (await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ action: 'draft_update', applicantId: a.id }),
+      })).json();
+      if (dr.error) throw new Error(dr.error);
+      await gmailCall({ action: 'send-update', applicantId: a.id, subject: dr.subject, body: dr.body });
+      a.updateSentAt = new Date().toISOString(); a.stage = 'archived';
+      done++;
+    } catch (e) {
+      toast(`${fullName(a)}: ${e.message}`);
+    }
+  }
+  toast(`${done}/${pending.length} update${pending.length === 1 ? '' : 's'} sent`);
+  renderRailCounts(); renderApplicants();
+}
+
+async function openUpdateEmail(applicantId) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  emailApplicantId = applicantId;
+  emailMode = 'update';
+  emailKind = null;
+  document.getElementById('email-title').textContent = `Update for ${fullName(a)}`;
+  document.getElementById('email-subject').value = '';
+  document.getElementById('email-body').value = '';
+  document.getElementById('email-send').textContent = 'Send update';
+  document.getElementById('email-status').textContent = 'Drafting the community update…';
+  document.getElementById('email-modal').hidden = false;
+  try {
+    const { data } = await sb.auth.getSession();
+    const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${data?.session?.access_token}` },
+      body: JSON.stringify({ action: 'draft_update', applicantId }),
+    });
+    const out = await resp.json();
+    if (out.error) throw new Error(out.error);
+    if (emailApplicantId !== applicantId) return;
+    document.getElementById('email-subject').value = out.subject || 'An update from Agape';
+    document.getElementById('email-body').value = out.body || '';
+    document.getElementById('email-status').textContent = 'Edit freely, then send.';
+  } catch (e) {
+    document.getElementById('email-status').textContent = `Draft failed: ${e.message}`;
+  }
 }
 
 async function generateEmail(applicantId) {
@@ -687,7 +783,7 @@ async function generateEmail(applicantId) {
     const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-match`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-      body: JSON.stringify({ action: 'draft_email', applicantId }),
+      body: JSON.stringify({ action: 'draft_email', applicantId, ...(emailKind ? { emailType: emailKind } : {}) }),
     });
     const out = await resp.json();
     if (out.error) throw new Error(out.error);
@@ -972,6 +1068,7 @@ function stageChip(a) {
     const why = st.veto ? `Vetoed by ${st.veto.voter_name || 'a housemate'}` : (decisions[a.id]?.note || 'Did not pass review');
     return `<span class="decision-chip decision-chip--hold" title="${esc(why)}">Update queued</span>`;
   }
+  if (a.updateSentAt) return `<span class="decision-chip decision-chip--outreach" title="Update email sent">Update sent ${fmtDate(a.updateSentAt)}</span>`;
   return `<span class="decision-chip decision-chip--pass">Archived</span>`;
 }
 
@@ -1212,7 +1309,42 @@ function renderApplicants() {
       <span class="listing-head__actions">${listingMenuHtml(l)}</span>`;
   };
 
-  const outreachChrome = '';
+  // Archive: the update-email tray sits above the list. Openings: draft
+  // listings detected from occupancy gaps sit above the shortlists.
+  let outreachChrome = '';
+  if (view === 'archive') {
+    const pending = applicants.filter(x => x.stage === 'rejected' && !x.updateSentAt && !x.updateSkippedAt);
+    if (pending.length) {
+      outreachChrome = `<div class="update-tray">
+        <div class="update-tray__head">
+          <b>${pending.length} applicant${pending.length === 1 ? '' : 's'} haven't been told yet</b>
+          <button type="button" class="btn btn--sm cta--amber" data-send-all-updates>Send all ${pending.length}</button>
+        </div>
+        ${pending.map(x => `<div class="update-tray__row">
+          <span class="update-tray__who">${esc(fullName(x))}</span>
+          <span class="update-tray__why">${voteStats(x.id).veto ? `vetoed by ${esc(voteStats(x.id).veto.voter_name || 'a housemate')}` : (decisions[x.id]?.note || 'did not pass review')}</span>
+          <button type="button" class="cta-link" data-update-edit="${x.id}">Edit email</button>
+          <button type="button" class="cta-link" data-update-skip="${x.id}">Skip</button>
+        </div>`).join('')}
+      </div>`;
+    }
+  }
+  if (view === 'openings') {
+    const drafts = listings.filter(l => l.status === 'draft');
+    if (drafts.length) {
+      outreachChrome = drafts.map(l => {
+        const room = rooms.find(r => r.id === l.room_id);
+        return `<div class="draft-card">
+          <span class="draft-card__text"><b>Draft — ${esc(room?.name || 'Room')}, ${l.kind === 'resident' ? `opens ${fmtDay(l.starts_on)}` : `${fmtDay(l.starts_on)} – ${l.ends_on ? fmtDay(l.ends_on) : 'TBD'}`}</b>
+          <span>Detected from the occupancy calendar · invisible to bucketing until opened</span></span>
+          <span class="draft-card__actions">
+            <button type="button" class="cta-link" data-delete-listing="${l.id}">Dismiss</button>
+            <button type="button" class="btn btn--sm" data-open-draft="${l.id}">Open listing</button>
+          </span>
+        </div>`;
+      }).join('');
+    }
+  }
   const doneListings = view === 'openings' ? listings.filter(l => l.status !== 'open') : [];
   const doneDrawer = doneListings.length ? `
     <details class="occupants__past">
@@ -1308,9 +1440,82 @@ function rowMenuHtml(a, listingId) {
       <button type="button" class="listing-menu__item" data-review="${a.id}">Open profile</button>
       ${a.scheduleToken ? `<button type="button" class="listing-menu__item" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
       <button type="button" class="listing-menu__item" data-remove-placement="${a.id}|${esc(listingId)}">Remove from this listing</button>
+      ${screeningState[a.id]?.watch ? `<button type="button" class="listing-menu__item" data-give-decision="${a.id}">Give decision…</button>` : ''}
       <button type="button" class="listing-menu__item listing-menu__item--danger" data-pass-row="${a.id}">Pass on ${esc(a.first)}…</button>
     </span>
   </span>`;
+}
+
+/* Occupancy-gap sweep: stretches of 28+ days with nothing scheduled in the
+   next six months become DRAFT listings (invisible to bucketing until a
+   human opens them). Dedup: skip when any listing for the room starts
+   within 21 days of the gap. */
+async function syncDraftListings() {
+  if (!houseLoaded) return 0;
+  const today = new Date().toISOString().slice(0, 10);
+  const horizon = addMonthsIso(today.slice(0, 7) + '-01', 6);
+  let created = 0;
+  for (const r of rooms) {
+    const covered = stays.filter(x => x.room_id === r.id)
+      .map(x => [x.starts_on, x.ends_on || '9999-12-31'])
+      .filter(([a, b]) => a <= horizon && b >= today)
+      .sort((x, y) => x[0].localeCompare(y[0]));
+    const gaps = [];
+    let cursor = today;
+    for (const [a, b] of covered) {
+      if (a > cursor) gaps.push([cursor, isoAddDays(a, -1)]);
+      if (b >= cursor) cursor = isoAddDays(b, 1);
+      if (cursor > horizon) break;
+    }
+    if (cursor <= horizon) gaps.push([cursor, null]); // open-ended
+    for (const [gs, ge] of gaps) {
+      const days = ge ? Math.round((new Date(ge) - new Date(gs)) / 86400000) : 999;
+      if (days < 28) continue;
+      const near = listings.some(l => l.room_id === r.id &&
+        Math.abs(new Date(l.starts_on) - new Date(gs)) < 21 * 86400000);
+      if (near) continue;
+      const rec = {
+        room_id: r.id, kind: ge && days <= 95 ? 'sublet' : 'resident',
+        starts_on: gs, ends_on: ge && days <= 95 ? ge : null,
+        status: 'draft', source: 'gap',
+        notes: `Auto-detected occupancy gap (${fmtDay(gs)}${ge ? ` – ${fmtDay(ge)}` : ' onward'}).`,
+        created_by: me.id, created_by_name: 'auto',
+      };
+      const { data, error } = await sb.from('recruit_listings').insert(rec).select().single();
+      if (!error && data) { listings.push(data); created++; }
+    }
+  }
+  return created;
+}
+
+/* Post-screening decision sheet: yes / no + note, one row per housemate. */
+async function giveDecision(applicantId, verdict) {
+  const note = (document.getElementById('gd-note')?.value || '').trim();
+  const { data, error } = await sb.from('recruit_decision_votes').upsert({
+    applicant_id: applicantId, voter_id: me.id, voter_name: me.name,
+    verdict, note, updated_at: new Date().toISOString(),
+  }, { onConflict: 'applicant_id,voter_id' }).select().single();
+  if (error) { toast(`Decision failed: ${error.message}`); return; }
+  decisionVotes[applicantId] = [...(decisionVotes[applicantId] || []).filter(v => v.voter_id !== me.id), data];
+  document.getElementById('gd-modal').hidden = true;
+  toast(`Decision saved — ${(decisionVotes[applicantId] || []).length} in`);
+  if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+  if (!document.getElementById('review').hidden) renderReview();
+}
+
+function openGiveDecision(applicantId) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  const modal = document.getElementById('gd-modal');
+  const dv = decisionVotes[applicantId] || [];
+  const mine = dv.find(v => v.voter_id === me?.id);
+  document.getElementById('gd-title').textContent = `Would you accept ${a.first}?`;
+  document.getElementById('gd-tally').innerHTML = mine || dv.length
+    ? dv.map(v => `<span class="chip-line">${esc(v.voter_name || 'Housemate')} · <b>${v.verdict}</b>${v.note ? ` — ${esc(v.note)}` : ''}</span>`).join('')
+    : '<span class="notes__empty">You\'re first — others see the tally after they decide.</span>';
+  document.getElementById('gd-note').value = mine?.note || '';
+  modal.dataset.applicant = applicantId;
+  modal.hidden = false;
 }
 
 /* Drag-to-reorder applicants inside each listing group; shared house state. */
@@ -2976,6 +3181,8 @@ async function _checkMembershipAndEnter() {
     loadHouse().then(async () => {
       const added = await syncAutoPlacements();
       if (added) toast(`${added} auto-placement${added === 1 ? '' : 's'} added across open listings`);
+      const drafted = await syncDraftListings();
+      if (drafted) toast(`${drafted} draft listing${drafted === 1 ? '' : 's'} detected from occupancy gaps`);
       renderRailCounts();
       if (VIEWS[view]?.kind === 'applicants') renderApplicants();
     });
@@ -3133,7 +3340,7 @@ function init() {
     const rtab = e.target.closest('[data-review-tab]');
     if (rtab) { reviewTab = rtab.dataset.reviewTab; renderReview(); return; }
     const em = e.target.closest('[data-email]');
-    if (em) { openEmailModal(em.dataset.email); return; }
+    if (em) { openEmailModal(em.dataset.email, em.dataset.emailKind || null); return; }
     const so = e.target.closest('[data-second-opinion]');
     if (so) { requestSecondOpinion(so.dataset.secondOpinion, so); return; }
     const et = e.target.closest('[data-email-toggle]');
@@ -3180,6 +3387,27 @@ function init() {
     }
     const ar = e.target.closest('[data-avail-review]');
     if (ar) { openAvailModal(ar.dataset.availReview); return; }
+    const gd = e.target.closest('[data-give-decision]');
+    if (gd) { openGiveDecision(gd.dataset.giveDecision); return; }
+    const ue = e.target.closest('[data-update-edit]');
+    if (ue) { openUpdateEmail(ue.dataset.updateEdit); return; }
+    const us = e.target.closest('[data-update-skip]');
+    if (us) {
+      const a = applicants.find(x => x.id === us.dataset.updateSkip);
+      if (a && confirm(`Skip the update email for ${fullName(a)}? They're archived without one.`)) {
+        sb.rpc('recruit_skip_update', { p_applicant: a.id }).then(({ error }) => {
+          if (error) { toast(`Skip failed: ${error.message}`); return; }
+          a.updateSkippedAt = new Date().toISOString(); a.stage = 'archived';
+          toast(`${fullName(a)} archived without an update`);
+          renderRailCounts(); renderApplicants();
+        });
+      }
+      return;
+    }
+    const sa = e.target.closest('[data-send-all-updates]');
+    if (sa) { sendAllUpdates(sa); return; }
+    const od2 = e.target.closest('[data-open-draft]');
+    if (od2) { updateListingStatus(od2.dataset.openDraft, 'open'); return; }
     const oc = e.target.closest('[data-open-call]');
     if (oc) {
       openReview(oc.dataset.openCall);
@@ -3312,6 +3540,18 @@ function init() {
   document.getElementById('menu-theme').onclick = () =>
     applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
   document.getElementById('menu-signout').onclick = () => window.CtrlAuth.signOut();
+  document.getElementById('pref-autopost').onchange = async (e) => {
+    const value = e.target.checked;
+    settings.discord_auto_post = value;
+    const { error } = await sb.from('recruit_settings').upsert({
+      key: 'discord_auto_post', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+    });
+    if (error) { toast(`Save failed: ${error.message}`); e.target.checked = !value; settings.discord_auto_post = !value; }
+    else toast(value ? 'Coverage asks now post to Discord automatically' : 'Coverage asks are manual again');
+  };
+  document.getElementById('gd-close').onclick = () => { document.getElementById('gd-modal').hidden = true; };
+  document.getElementById('gd-yes').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'yes');
+  document.getElementById('gd-no').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'no');
   document.getElementById('pref-couples').onchange = async (e) => {
     const value = e.target.checked;
     settings.open_to_couples = value;
@@ -3338,16 +3578,25 @@ function init() {
     const btn = document.getElementById('email-send');
     btn.disabled = true; btn.textContent = 'Sending…';
     try {
+      const sentFor = emailApplicantId;
       await gmailCall({
-        action: 'send', applicantId: emailApplicantId,
+        action: emailMode === 'update' ? 'send-update' : 'send', applicantId: sentFor,
         subject: document.getElementById('email-subject').value,
         body: document.getElementById('email-body').value,
       });
-      toast('Sent from live.at.agapesf@gmail.com');
-      delete emailsCache[emailApplicantId];
+      if (emailMode === 'update') {
+        const a = applicants.find(x => x.id === sentFor);
+        if (a) { a.updateSentAt = new Date().toISOString(); a.stage = 'archived'; }
+        toast('Update sent — archived clean');
+        renderRailCounts();
+        if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+      } else {
+        toast('Sent from live.at.agapesf@gmail.com');
+      }
+      delete emailsCache[sentFor];
       closeEmailModal();
     } catch (e) { toast(`Send failed: ${e.message}`); }
-    btn.disabled = false; btn.textContent = 'Send via Agape Gmail';
+    btn.disabled = false; btn.textContent = emailMode === 'update' ? 'Send update' : 'Send via Agape Gmail';
   };
   document.getElementById('email-copy').onclick = async () => {
     const text = `Subject: ${document.getElementById('email-subject').value}\n\n${document.getElementById('email-body').value}`;

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -166,7 +166,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>design system · v3.19</span><a href="/design-system/">← all design systems</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>design system · v3.23</span><a href="/design-system/">← all design systems</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -256,7 +256,8 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
       <div class="dec"><span class="d">Jul 22</span><br><b>Pick-a-time beat the Discord post as the schedule primary.</b><p>Self-serve booking is the fast path; coverage is the fallback, so it reads as one ("Ask for coverage").</p></div>
       <div class="dec"><span class="d">Jul 22</span><br><b>The rail became two tiers with a fixed-width column.</b><p>One primary, quiet context beneath, every edge aligned. The alternative — badges, timestamps, and two buttons jostling inline — is where the old design died.</p></div>
       <div class="dec"><span class="d">Jul 22</span><br><b>Accessible-dark palette softened to friendly mid-tones.</b><p>Strict AA darks read as heavy. The system trades measured contrast for warmth at semibold sizes — a deliberate, documented exception.</p></div>
-      <div class="dec"><span class="d">Jul 22</span><br><b>The profile footer joined the state machine.</b><p>The lime/red decision pills were the last pre-v3 survivors; the footer now shows the same primary as the person's row.</p></div>
+      <div class="dec"><span class="d">Jul 27</span><br><b>The outstanding list shipped in one pass.</b><p>Phase B (new-application pings + the update-email tray), draft listings from occupancy gaps, awaiting-claim and give-decision states, follow-up staleness, visit drafts, the flexible ±1 month dial, and auto-posting as a settings toggle rather than a deploy.</p></div>
+<div class="dec"><span class="d">Jul 22</span><br><b>The profile footer joined the state machine.</b><p>The lime/red decision pills were the last pre-v3 survivors; the footer now shows the same primary as the person's row.</p></div>
     </div>
   </section>
 

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -108,3 +108,14 @@ Watch opens a **Call** tab on the applicant profile (not a modal): recording pla
 - **Review availability** (blue) replaces Pick a time; context tier shows `N windows offered`. Opens a modal: bookable slot chips per window, a **How we read it** bullet list (their verbatim snippet + date, timezone conversion note, platform request, the day-part mapping rules), and the secondary path at the bottom: *"Doesn't work with your schedule? Ask the house on Discord"* (→ claim-post preview).
 - **Post-screening primary is Schedule a visit** (blue, opens the email draft); Watch demotes to a small inline green ▶ icon beside it — an icon secondary doesn't violate the one-primary rule.
 - **Row ⋯ menu** (grip back on the left edge): Open profile · Copy availability link · Remove from this listing · **Pass on [name]…** (confirm → stage `rejected`, update email queued — passing always requires outreach).
+
+
+## v3.23 (2026-07-27) — the outstanding list
+- **Phase B live**: scan pings the recruiting channel about new review-stage applicants (one post each; 4+ collapse to a digest; `discord_ping_at` dedup). Archive shows the **update tray** — pending rejections with Edit email / Skip and **Send all** (individually drafted community notes via `draft_update`, sent via `send-update` which stamps `update_email_sent_at` and archives clean).
+- **Draft listings**: 28+ day occupancy gaps in the next six months become `status='draft'` listings (dashed cards atop Openings; Open listing / Dismiss). Bucketing only sees `open`.
+- **Awaiting claim** is a real row state: coverage ask posted → `◆ sent to housemates` chip + `unclaimed Nd · book it yourself` context.
+- **Give decision**: post-screening yes/no + note per housemate (`recruit_decision_votes`); the watch-state context tier carries `give your decision` / `N decisions in`; also in the row ⋮. Tally is advisory — moving the person stays human.
+- **Follow-up staleness** implemented: grey under 3 quiet days, amber after.
+- **Schedule a visit** drafts a visit-specific invite (`emailType: 'visit'`).
+- **Flexible dial**: bare "Flexible" rides any window; "month + flexible" = that month ±1.
+- **Auto-post toggle**: `discord_auto_post` setting (rail footer checkbox) — the manual→auto claim cutover without a deploy.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -393,6 +393,14 @@ export async function postSigninMessage(channelId: string): Promise<any> {
 }
 
 // One channel nudge for a post nobody claimed within 96h.
+// Plain embed post to any channel (new-application pings etc.).
+export async function postChannelEmbed(channelId: string, description: string, color = 0x378add): Promise<any> {
+  return await discordFetch(`/channels/${channelId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({ embeds: [{ description, color }] }),
+  })
+}
+
 export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {
   const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
   await postResilient(channelId, {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.12.1'
+const VERSION = '1.13.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage } from '../_shared/discord.ts'
+import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -103,6 +103,14 @@ Return one JSON object: {"windows":..., "platform":..., "timezone_note":..., "ne
       needs_human: Boolean(obj.needs_human) && !windows.length,
     }
   } catch { return NO_EXTRACTION }
+}
+
+// The manual→auto claim cutover is a settings toggle, not a deploy.
+async function autoPostEnabled(client: ReturnType<typeof db>): Promise<boolean> {
+  try {
+    const { data } = await client.from('recruit_settings').select('value').eq('key', 'discord_auto_post').maybeSingle()
+    return data?.value === true
+  } catch { return false }
 }
 
 // After availability lands, post/refresh the claimable message in
@@ -213,6 +221,44 @@ serve(async (req) => {
       return json(acct ? { connected: true, ...acct } : { connected: false })
     }
 
+    if (action === 'send-update') {
+      // Rejection-queue send: same pipe as 'send', plus stamps
+      // update_email_sent_at and closes the stage to 'archived'.
+      const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
+      if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      const subject = String(body.subject || '').slice(0, 300)
+      const text = String(body.body || '').slice(0, 10000)
+      if (!subject || !text) return json({ error: 'Subject and body required' }, 400)
+      const at = await accessToken(client)
+      const encSubject = `=?UTF-8?B?${b64url(subject).replace(/-/g, '+').replace(/_/g, '/')}?=`
+      const raw = [
+        `From: Agape <${SHARED_EMAIL}>`,
+        `To: ${applicant.email}`,
+        `Subject: ${encSubject}`,
+        'MIME-Version: 1.0',
+        'Content-Type: text/plain; charset=UTF-8',
+        '',
+        text,
+      ].join('\r\n')
+      const resp = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ raw: b64url(raw) }),
+      })
+      const sent = await resp.json()
+      if (!resp.ok) return json({ error: `Send failed: ${JSON.stringify(sent).slice(0, 180)}` }, 500)
+      await client.from('recruit_emails').upsert({
+        applicant_id: applicant.id, gmail_id: sent.id, thread_id: sent.threadId,
+        direction: 'out', subject, snippet: text.slice(0, 180), body_text: text,
+        from_email: SHARED_EMAIL, to_email: applicant.email,
+        sent_by_name: 'update queue', sent_at: new Date().toISOString(),
+      }, { onConflict: 'gmail_id' })
+      await client.from('recruit_applicants')
+        .update({ update_email_sent_at: new Date().toISOString(), stage: 'archived' })
+        .eq('id', applicant.id)
+      return json({ sent: true })
+    }
+
     if (action === 'send') {
       const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
       if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
@@ -301,9 +347,7 @@ serve(async (req) => {
                 updated_at: new Date().toISOString(),
               })
             }
-            // Auto-post to Discord is off for now — a recruiter triggers the
-            // claim post from the app (claim-preview/claim-post actions).
-            // await postClaim(client, applicant.id, extraction)
+            if (await autoPostEnabled(client)) await postClaim(client, applicant.id, extraction)
           }
         }
       }
@@ -523,8 +567,7 @@ serve(async (req) => {
                 updated_at: new Date().toISOString(),
               })
             }
-            // manual-trigger era: no auto post (see claim-preview/claim-post)
-            // await postClaim(client, applicantId, extraction)
+            if (await autoPostEnabled(client)) await postClaim(client, applicantId, extraction)
           }
         }
       }
@@ -556,7 +599,7 @@ serve(async (req) => {
             applicant_id: r.applicant_id, windows: extraction.windows,
             source_gmail_id: r.gmail_id, updated_at: new Date().toISOString(),
           })
-          // manual-trigger era: no auto post (see claim-preview/claim-post)
+          if ((extraction.windows.length || extraction.needs_human) && await autoPostEnabled(client)) await postClaim(client, r.applicant_id, extraction)
           backfilled++
           console.log(`availability backfill: ${r.applicant_id} → ${extraction.windows.length} windows`)
         }
@@ -609,9 +652,48 @@ serve(async (req) => {
         console.warn(`calendar sweep failed: ${(err as Error).message}`)
       }
 
+      // Phase B: ping the Recruiting Society channel about new applications —
+      // stage 'review', no votes yet, never pinged. One post per applicant;
+      // a batch of 4+ collapses into a single digest.
+      let pinged = 0
+      try {
+        const pingChannel = Deno.env.get('RECRUITING_PING_CHANNEL_ID') || Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || ''
+        if (pingChannel) {
+          const { data: fresh } = await client.from('recruit_applicants')
+            .select('id, first_name, last_name, residency, move_in, why_agape')
+            .eq('stage', 'review').is('discord_ping_at', null)
+            .order('submitted_at', { ascending: false }).limit(12)
+          const { data: votedRows } = await client.from('recruit_votes').select('applicant_id')
+          const voted = new Set((votedRows || []).map((v) => v.applicant_id))
+          const toPing = (fresh || []).filter((a) => !voted.has(a.id))
+          const appLink = (id: string) => `https://ctrl.rodeo/applications/?a=${encodeURIComponent(id)}`
+          if (toPing.length > 3) {
+            const lines = toPing.map((a) => `• [${a.first_name} ${a.last_name || ''}](${appLink(a.id)})`).join('\n')
+            await postChannelEmbed(pingChannel, `📥 **${toPing.length} new applications** are ready for votes:\n${lines}`)
+          } else {
+            for (const a of toPing) {
+              const track = /short/i.test(a.residency || '') ? 'Sublet' : 'Full-time'
+              const why = (a.why_agape || '').trim().replace(/\s+/g, ' ').slice(0, 140)
+              await postChannelEmbed(pingChannel,
+                `📥 **${a.first_name} ${a.last_name || ''}** applied — ${track}${a.move_in ? ` · ${String(a.move_in).slice(0, 60)}` : ''}\n` +
+                (why ? `_${why}_\n` : '') +
+                `[Read + vote](${appLink(a.id)})`)
+            }
+          }
+          if (toPing.length) {
+            await client.from('recruit_applicants')
+              .update({ discord_ping_at: new Date().toISOString() })
+              .in('id', toPing.map((a) => a.id))
+            pinged = toPing.length
+          }
+        }
+      } catch (err) {
+        console.warn(`new-application ping failed: ${(err as Error).message}`)
+      }
+
       await remindStuckPosts(client)
       console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up, ${backfilled} availability backfills`)
-      return json({ matched, replied: [...replied], manualPickups, backfilled })
+      return json({ matched, replied: [...replied], manualPickups, backfilled, pinged })
     }
 
     return json({ error: 'Unknown action' }, 400)

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.8.0'
+const VERSION = '1.9.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -222,6 +222,7 @@ async function draftEmail(applicant: any, listing: any, room: any, flags: any[],
       reply: `They wrote back last — respond directly and concretely to what they said (use the listing details below for pricing/dates if asked). If no call is booked yet, close with the call CTA — ${cta}. Under 140 words.`,
       post_call: `Their Intro Call with ${ctx.screening?.housemate_name || 'a housemate'} just happened. Thank them warmly, one specific human touch, and say the house will be in touch about next steps soon. Do NOT promise an outcome or timeline beyond "soon". Under 80 words.`,
       reschedule: `Their scheduled call fell through. Own it lightly (no blame either way) and reopen scheduling — ${cta}. Under 90 words.`,
+      visit: `Their intro call went well and we want to invite them to VISIT THE HOUSE in person (a house tour + hang, usually an evening; they'll meet more housemates). Warm and concrete: propose that they come by, ask for 2–3 evenings that work for them in the next two weeks. Do NOT promise an outcome — a visit is the next step, not an offer. Under 110 words.`,
     }
     const situationBrief = briefs[ctx.type] || briefs.follow_up
     const ctxPrompt = `Write the NEXT email in an ongoing thread from ${senderName} at Agape (13-bedroom co-op near Dolores Park, SF) to applicant ${applicant.first_name}.
@@ -325,6 +326,32 @@ serve(async (req) => {
       const draft = await draftEmail(applicant, listing, room, sug?.flags || [], prof?.discord_username || 'a housemate',
         { type, emails: emails || [], screening })
       return new Response(JSON.stringify({ ...draft, emailType: type, reason: cls.reason }), { headers: jsonHeaders })
+    }
+
+    if (body.action === 'draft_update' && body.applicantId) {
+      // Rejection-queue draft. Unsigned community voice; never discloses
+      // votes, vetoes, or auto-flags.
+      const { data: applicant } = await client.from('recruit_applicants').select('first_name, why_agape').eq('id', String(body.applicantId)).maybeSingle()
+      if (!applicant) return new Response(JSON.stringify({ error: 'Unknown applicant' }), { status: 404, headers: jsonHeaders })
+      const why = (applicant.why_agape || '').replace(/\s+/g, ' ').slice(0, 300)
+      const prompt = `Write a short, kind update email from the Agape community (a 13-bedroom co-op near Dolores Park, SF) to ${applicant.first_name}, who applied to live here and will not be moving forward.
+
+Hard rules:
+- Warm, human, and brief (under 100 words). Thank them genuinely for the care in their application${why ? ` (they wrote: "${why}")` : ''}.
+- Do NOT give reasons, feedback, or specifics about the decision. Do not say "unfortunately" more than once, do not apologize repeatedly.
+- Leave the door open gently (things shift; they're welcome to apply again down the road) without promising anything.
+- Sign off as "the Agape community" — no individual name.
+- Subject: short and neutral, e.g. "An update from Agape".
+
+Return exactly:
+SUBJECT: <subject>
+BODY:
+<body>`
+      const text = await callClaudeRaw('claude-haiku-4-5-20251001', 'You write brief, warm community emails. Follow the format exactly.', prompt, 400)
+      const m = text.match(/SUBJECT:\s*(.+)\n+BODY:\n?([\s\S]+)/)
+      const subject = (m?.[1] || 'An update from Agape').trim().slice(0, 200)
+      const bodyText = (m?.[2] || text).trim().slice(0, 4000)
+      return new Response(JSON.stringify({ subject, body: bodyText }), { headers: jsonHeaders })
     }
 
     if (body.action === 'second_opinion' && body.applicantId) {

--- a/supabase/migrations/130_recruit_phase_b.sql
+++ b/supabase/migrations/130_recruit_phase_b.sql
@@ -1,0 +1,62 @@
+-- ============================================
+-- Migration 130: Phase B + post-screening decisions + draft listings
+--
+-- 1. New-application Discord ping tracking (auto ping rides the scan;
+--    one post per applicant, digest guard client of the column).
+-- 2. Rejection-email queue state: rejected applicants owe an update email
+--    until sent or skipped. Sent is stamped server-side by recruit-gmail's
+--    send-update; skip goes through the RPC below.
+-- 3. recruit_decision_votes — the post-screening house decision (yes/no +
+--    note, one row per voter per applicant). Tally is advisory; moving the
+--    person remains a human action.
+-- 4. recruit_listings gains a 'draft' status — auto-generated from
+--    occupancy gaps; bucketing only ever sees 'open'.
+-- 5. Settings: discord_auto_post (default false) — the manual→auto claim
+--    cutover is a toggle, not a deploy.
+-- ============================================
+
+ALTER TABLE recruit_applicants
+  ADD COLUMN IF NOT EXISTS discord_ping_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS update_email_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS update_email_skipped_at TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS recruit_decision_votes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  voter_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  voter_name TEXT,
+  verdict TEXT NOT NULL CHECK (verdict IN ('yes', 'no')),
+  note TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (applicant_id, voter_id)
+);
+ALTER TABLE recruit_decision_votes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Recruiting members read decision votes" ON recruit_decision_votes
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+CREATE POLICY "Recruiting members write own decision vote" ON recruit_decision_votes
+  FOR INSERT TO authenticated WITH CHECK (is_recruiting_member() AND voter_id = auth.uid());
+CREATE POLICY "Recruiting members update own decision vote" ON recruit_decision_votes
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member() AND voter_id = auth.uid())
+  WITH CHECK (is_recruiting_member() AND voter_id = auth.uid());
+
+-- Listings: allow drafts (auto-detected occupancy gaps awaiting a human open).
+ALTER TABLE recruit_listings DROP CONSTRAINT IF EXISTS recruit_listings_status_check;
+ALTER TABLE recruit_listings ADD CONSTRAINT recruit_listings_status_check
+  CHECK (status IN ('draft', 'open', 'filled', 'closed'));
+
+-- Skip marker for the update-email queue (applicants table is client-read-only).
+CREATE OR REPLACE FUNCTION recruit_skip_update(p_applicant TEXT)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT is_recruiting_member() THEN RAISE EXCEPTION 'recruiting members only'; END IF;
+  UPDATE recruit_applicants
+    SET update_email_skipped_at = NOW(), stage = 'archived'
+    WHERE id = p_applicant AND stage = 'rejected';
+END;
+$$;
+
+INSERT INTO recruit_settings (key, value) VALUES ('discord_auto_post', 'false'::jsonb)
+  ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
One pass over the whole outstanding list:
- **Phase B**: auto Discord pings for new applications (per-applicant, digest at 4+, `discord_ping_at` dedup) + the Archive **update tray** — Edit email / Skip per applicant and **Send all** with individually drafted, unsigned community notes; sends stamp `update_email_sent_at` and archive clean.
- **Draft listings** from 28+ day occupancy gaps (dashed cards in Openings, Open/Dismiss; bucketing only sees open).
- **Awaiting claim** and **Give decision** become real row states (`recruit_decision_votes`, advisory tally, blind-until-you-vote).
- **Follow-up staleness** (grey <3 quiet days, amber after), **visit-typed email drafts**, **flexible = stated month ±1**, and **auto-post as a settings toggle** (rail footer) instead of a deploy cutover.
- Migration 130; recruit-gmail v1.13; recruit-match v1.9; docs + design-system site updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)