### PR TITLE
feat(recruiting): permanent recording archive in Supabase storage

### DIFF
--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -135,3 +135,7 @@ Calls scheduled outside the app already get picked up and recorded when the shar
 
 - **Unmatched-call DM** — the cron sweep DMs housemate attendees when an upcoming swept call has a guest that matches no applicant ("link it" + deep link). House-internal meetings (all attendees known) are stamped and never nag. One DM per event (`unmatched_notified_at`, migration 133).
 - **Link modal** — `?link=<gcal_event_id>` opens an applicant picker; linking clones the recorded event into `recruit_screenings` (Watch chip, notes land on the profile) via `recruit-gmail link-recording`, and stamps `applicant_id` on the recorded event.
+
+## Permanent recording archive (v1.11.0 / recruit-gmail v1.14.0, 2026-07-29)
+
+Recall.ai purges bot media ~7 days after a call and its download links are short-lived presigned URLs — old Discord links died and older calls became unwatchable. Now every finished recording is streamed into the private `recruit-recordings` storage bucket (migration 134: `recording_path` on both recording tables). `recording-link` serves a 6-hour signed URL from the archive first, Recall as fallback; a backfill sweep on the cron tick rescues recordings processed before the archive existed and marks Recall-purged ones `media_expired`. Discord recording posts remain convenience links — the app is the durable viewer.

--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -70,6 +70,28 @@ export async function getBotResult(botId: string): Promise<BotResult> {
   }
 }
 
+// Copy a finished recording into the permanent recruit-recordings bucket.
+// Streams straight from Recall's presigned URL into Storage (no buffering —
+// hour-long Meets exceed edge-function memory). Returns the storage path.
+export async function archiveVideoToStorage(videoUrl: string, path: string): Promise<string> {
+  const src = await fetch(videoUrl)
+  if (!src.ok || !src.body) throw new Error(`video download ${src.status}`)
+  const resp = await fetch(
+    `${Deno.env.get('SUPABASE_URL')}/storage/v1/object/recruit-recordings/${path}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`,
+        'Content-Type': src.headers.get('content-type') || 'video/mp4',
+        'x-upsert': 'true',
+      },
+      body: src.body,
+    },
+  )
+  if (!resp.ok) throw new Error(`storage upload ${resp.status}: ${(await resp.text()).slice(0, 150)}`)
+  return path
+}
+
 // Download a transcript and flatten it to "Speaker: text" lines. Recall's
 // transcript JSON is a list of participant segments with word arrays.
 export async function fetchTranscriptText(transcriptUrl: string): Promise<string> {

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.10.1'
+const VERSION = '1.11.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -516,6 +516,41 @@ async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<numb
   return notified
 }
 
+// Backfill archive: recordings processed before the archive existed (or whose
+// upload failed) get copied to storage while Recall still has the media.
+// media_expired marks the permanently lost so we stop retrying.
+async function archiveMissingRecordings(client: ReturnType<typeof db>): Promise<number> {
+  const { recallEnabled, getBotResult, archiveVideoToStorage } = await import('../_shared/recall.ts')
+  if (!recallEnabled()) return 0
+  let archived = 0
+  const sweep = async (table: string, idCol: string, pathPrefix: string, limit: number) => {
+    const { data: rows } = await client.from(table)
+      .select(`${idCol}, recall_bot_id`)
+      .eq('recall_status', 'done').is('recording_path', null)
+      .not('recall_bot_id', 'is', null).limit(limit)
+    // deno-lint-ignore no-explicit-any
+    for (const r of ((rows || []) as any[])) {
+      try {
+        const bot = await getBotResult(r.recall_bot_id)
+        if (bot.videoUrl) {
+          const path = await archiveVideoToStorage(bot.videoUrl, `${pathPrefix}/${r[idCol]}.mp4`)
+          await client.from(table).update({ recording_path: path }).eq(idCol, r[idCol])
+          archived++
+          console.log(`[archive] backfilled ${table} ${r[idCol]}`)
+        } else if (bot.statusCode === 'media_expired' || bot.done) {
+          await client.from(table).update({ recall_status: 'media_expired' }).eq(idCol, r[idCol])
+          console.warn(`[archive] ${table} ${r[idCol]} media gone (${bot.statusCode})`)
+        }
+      } catch (err) {
+        console.warn(`[archive] backfill ${table} ${r[idCol]}: ${(err as Error).message}`)
+      }
+    }
+  }
+  await sweep('recruit_screenings', 'id', 'screenings', 2)
+  await sweep('recruit_recorded_events', 'gcal_event_id', 'events', 1)
+  return archived
+}
+
 // Calls whose end time passed flip scheduled -> completed so the app stops
 // showing them as upcoming (the Watch chip takes over once notes land).
 async function completePastCalls(client: ReturnType<typeof db>): Promise<number> {
@@ -592,8 +627,16 @@ async function processMeetingRecordings(client: ReturnType<typeof db>): Promise<
         summary = await summarizeMeeting(await fetchTranscriptText(bot.transcriptUrl), m.title || 'Agape call')
       }
       await postMeetingNote(m.title || 'Agape call', summary, bot.videoUrl)
+      let recordingPath: string | null = null
+      if (bot.videoUrl) {
+        try {
+          const { archiveVideoToStorage } = await import('../_shared/recall.ts')
+          recordingPath = await archiveVideoToStorage(bot.videoUrl, `events/${m.gcal_event_id}.mp4`)
+        } catch (err) { console.warn(`[archive] event ${m.gcal_event_id}: ${(err as Error).message}`) }
+      }
       await client.from('recruit_recorded_events').update({
         recall_status: 'done', recording_summary: summary, recording_posted_at: new Date().toISOString(),
+        recording_path: recordingPath,
       }).eq('gcal_event_id', m.gcal_event_id)
       posted++
     } catch (err) {
@@ -636,10 +679,20 @@ async function processRecordings(client: ReturnType<typeof db>): Promise<number>
         summary = await summarizeIntroCall(transcript, applicantName, s.housemate_name || 'a resident')
       }
       await postRecordingNote(applicant?.first_name || 'Applicant', s.applicant_id, s.housemate_name || 'resident', summary, bot.videoUrl)
+      // Permanent copy — Recall purges media in ~7 days. Failure is fine:
+      // recording_path stays null and the backfill sweep retries next tick.
+      let recordingPath: string | null = null
+      if (bot.videoUrl) {
+        try {
+          const { archiveVideoToStorage } = await import('../_shared/recall.ts')
+          recordingPath = await archiveVideoToStorage(bot.videoUrl, `screenings/${s.id}.mp4`)
+        } catch (err) { console.warn(`[archive] screening ${s.id}: ${(err as Error).message}`) }
+      }
       await client.from('recruit_screenings').update({
         recall_status: 'done',
         recording_summary: summary,
         recording_posted_at: new Date().toISOString(),
+        recording_path: recordingPath,
       }).eq('id', s.id)
       posted++
       console.log(`[recall] notes posted for screening ${s.id}`)
@@ -676,6 +729,8 @@ serve(async (req) => {
       await completePastCalls(client)
       const sent = await remindUpcoming(client)
       const recorded = await processRecordings(client) + await processMeetingRecordings(client)
+      const archived = await archiveMissingRecordings(client)
+      if (archived) console.log(`[archive] ${archived} recording(s) copied to storage`)
       console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${recorded} recording(s)`)
       return json({ bots, live, reminded: sent, recorded })
     }

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.13.0'
+const VERSION = '1.14.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -493,14 +493,20 @@ serve(async (req) => {
     }
 
     if (action === 'recording-link') {
-      // Fresh Recall download URL for a finished recording (links expire).
+      // Our permanent storage copy first; Recall (short-lived presigned URL)
+      // only as fallback for recordings not yet archived.
       const { data: s } = await client.from('recruit_screenings')
-        .select('id, recall_bot_id').eq('id', String(body.screeningId || '')).maybeSingle()
-      if (!s?.recall_bot_id) return json({ error: 'No recording for this call' }, 404)
+        .select('id, recall_bot_id, recording_path').eq('id', String(body.screeningId || '')).maybeSingle()
+      if (!s?.recall_bot_id && !s?.recording_path) return json({ error: 'No recording for this call' }, 404)
+      if (s.recording_path) {
+        const { data: signed, error: signErr } = await client.storage
+          .from('recruit-recordings').createSignedUrl(s.recording_path, 6 * 3600)
+        if (!signErr && signed?.signedUrl) return json({ url: signed.signedUrl, source: 'archive' })
+      }
       const { getBotResult } = await import('../_shared/recall.ts')
       const bot = await getBotResult(s.recall_bot_id)
       if (!bot.videoUrl) return json({ error: 'Recording not ready (or has been purged)' }, 404)
-      return json({ url: bot.videoUrl })
+      return json({ url: bot.videoUrl, source: 'recall' })
     }
 
     if (action === 'scan') {

--- a/supabase/migrations/134_recording_archive.sql
+++ b/supabase/migrations/134_recording_archive.sql
@@ -1,0 +1,10 @@
+-- 134: permanent recording archive.
+-- Recall.ai purges bot media after ~7 days and its download links are
+-- short-lived presigned URLs. Archive every finished video into the private
+-- recruit-recordings storage bucket; recording_path points at the copy.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('recruit-recordings', 'recruit-recordings', false)
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE recruit_screenings ADD COLUMN IF NOT EXISTS recording_path TEXT;
+ALTER TABLE recruit_recorded_events ADD COLUMN IF NOT EXISTS recording_path TEXT;


### PR DESCRIPTION
## Why
Kate SF's 'old videos' report: Recall.ai purges bot media ~7 days after a call, and both the Discord-posted links and API download URLs are short-lived presigned URLs. We never kept our own copy.

## What
- Migration 134: private `recruit-recordings` bucket, `recording_path` on `recruit_screenings` + `recruit_recorded_events`
- `archiveVideoToStorage`: streams the Recall video straight into storage (no memory buffering)
- recruit-discord v1.11.0: archives at processing time + a backfill sweep each cron tick (rescues the two Jul 23 recordings while Recall still has them); purged media marked `media_expired`
- recruit-gmail v1.14.0: `recording-link` prefers the archive (6-hour signed URL), falls back to Recall

## Post-merge
Deploy both fns, apply migration 134. Backfill runs automatically on the next 15-min tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)