### PR TITLE
fix(recruiting): archive uploads via signed URL, force video/mp4

### DIFF
--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -71,23 +71,30 @@ export async function getBotResult(botId: string): Promise<BotResult> {
 }
 
 // Copy a finished recording into the permanent recruit-recordings bucket.
-// Streams straight from Recall's presigned URL into Storage (no buffering —
-// hour-long Meets exceed edge-function memory). Returns the storage path.
-export async function archiveVideoToStorage(videoUrl: string, path: string): Promise<string> {
+// Uses a signed upload URL (the token authenticates, so this works whether the
+// project's service key is a JWT or an sb_secret) and streams Recall's bytes
+// straight through — hour-long Meets exceed edge-function memory if buffered.
+export async function archiveVideoToStorage(
+  // deno-lint-ignore no-explicit-any
+  client: any,
+  videoUrl: string,
+  path: string,
+): Promise<string> {
+  const { data: signed, error: signErr } = await client.storage
+    .from('recruit-recordings').createSignedUploadUrl(path, { upsert: true })
+  if (signErr || !signed?.signedUrl) throw new Error(`signed upload url: ${signErr?.message || 'none'}`)
+
   const src = await fetch(videoUrl)
   if (!src.ok || !src.body) throw new Error(`video download ${src.status}`)
-  const resp = await fetch(
-    `${Deno.env.get('SUPABASE_URL')}/storage/v1/object/recruit-recordings/${path}`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')}`,
-        'Content-Type': src.headers.get('content-type') || 'video/mp4',
-        'x-upsert': 'true',
-      },
-      body: src.body,
-    },
-  )
+  const resp = await fetch(signed.signedUrl, {
+    method: 'PUT',
+    // Force video/mp4 — Recall serves binary/octet-stream, which Safari/iOS
+    // refuses to play in a <video> tag.
+    headers: { 'Content-Type': 'video/mp4', 'x-upsert': 'true' },
+    body: src.body,
+    // Deno requires duplex on a streamed request body; without it fetch throws.
+    duplex: 'half',
+  } as RequestInit & { duplex: string })
   if (!resp.ok) throw new Error(`storage upload ${resp.status}: ${(await resp.text()).slice(0, 150)}`)
   return path
 }

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -533,7 +533,7 @@ async function archiveMissingRecordings(client: ReturnType<typeof db>): Promise<
       try {
         const bot = await getBotResult(r.recall_bot_id)
         if (bot.videoUrl) {
-          const path = await archiveVideoToStorage(bot.videoUrl, `${pathPrefix}/${r[idCol]}.mp4`)
+          const path = await archiveVideoToStorage(client, bot.videoUrl, `${pathPrefix}/${r[idCol]}.mp4`)
           await client.from(table).update({ recording_path: path }).eq(idCol, r[idCol])
           archived++
           console.log(`[archive] backfilled ${table} ${r[idCol]}`)
@@ -631,7 +631,7 @@ async function processMeetingRecordings(client: ReturnType<typeof db>): Promise<
       if (bot.videoUrl) {
         try {
           const { archiveVideoToStorage } = await import('../_shared/recall.ts')
-          recordingPath = await archiveVideoToStorage(bot.videoUrl, `events/${m.gcal_event_id}.mp4`)
+          recordingPath = await archiveVideoToStorage(client, bot.videoUrl, `events/${m.gcal_event_id}.mp4`)
         } catch (err) { console.warn(`[archive] event ${m.gcal_event_id}: ${(err as Error).message}`) }
       }
       await client.from('recruit_recorded_events').update({
@@ -685,7 +685,7 @@ async function processRecordings(client: ReturnType<typeof db>): Promise<number>
       if (bot.videoUrl) {
         try {
           const { archiveVideoToStorage } = await import('../_shared/recall.ts')
-          recordingPath = await archiveVideoToStorage(bot.videoUrl, `screenings/${s.id}.mp4`)
+          recordingPath = await archiveVideoToStorage(client, bot.videoUrl, `screenings/${s.id}.mp4`)
         } catch (err) { console.warn(`[archive] screening ${s.id}: ${(err as Error).message}`) }
       }
       await client.from('recruit_screenings').update({

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -492,6 +492,28 @@ serve(async (req) => {
       return json({ posted: !!row, alreadyClaimed: !row })
     }
 
+    if (action === 'archive-now') {
+      // Force the archive for unarchived recordings and surface real errors
+      // (the cron sweep only logs them).
+      const { data: rows } = await client.from('recruit_screenings')
+        .select('id, recall_bot_id').eq('recall_status', 'done').is('recording_path', null)
+        .not('recall_bot_id', 'is', null)
+      const { getBotResult, archiveVideoToStorage } = await import('../_shared/recall.ts')
+      const out = []
+      for (const r of (rows || [])) {
+        try {
+          const bot = await getBotResult(r.recall_bot_id)
+          if (!bot.videoUrl) { out.push({ id: r.id, skipped: bot.statusCode }); continue }
+          const path = await archiveVideoToStorage(client, bot.videoUrl, `screenings/${r.id}.mp4`)
+          await client.from('recruit_screenings').update({ recording_path: path }).eq('id', r.id)
+          out.push({ id: r.id, archived: path })
+        } catch (err) {
+          out.push({ id: r.id, error: (err as Error).message })
+        }
+      }
+      return json({ results: out })
+    }
+
     if (action === 'recording-link') {
       // Our permanent storage copy first; Recall (short-lived presigned URL)
       // only as fallback for recordings not yet archived.


### PR DESCRIPTION
Follow-up to the archive PR — the first implementation failed silently in prod.

## Three bugs, all found by forcing the archive and reading real errors
1. **`Invalid Compact JWS`** — the raw Storage REST call sent `SUPABASE_SERVICE_ROLE_KEY` as a Bearer JWT, but this project issues an `sb_secret` key. Now uses a signed upload URL (the token authenticates, works with either key format), still streaming.
2. **`EntityTooLarge`** — project storage `fileSizeLimit` was 50MB; recordings are 195MB and 387MB. Raised to 5GB.
3. **`binary/octet-stream`** — Recall's content type, which Safari/iOS refuse to play in a `<video>`. Pinned to `video/mp4`.

Also adds an authenticated `archive-now` action for forcing/retrying.

## Verified in prod
Both Jul 23 recordings archived (195MB + 387MB), `recording-link` returns `source: archive`, range request returns 206 `video/mp4` (seeking works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)