### PR TITLE
feat(recruiting): Discord posts link to app watch page, not doomed Recall URLs

### DIFF
--- a/applications/watch/index.html
+++ b/applications/watch/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Agape call recording</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root { --bg: #0f1115; --surface: #171a21; --border: #262b36; --fg: #e8eaf0; --fg-muted: #9aa3b2; --accent: #5865f2; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; padding: 24px 16px 48px; background: var(--bg); color: var(--fg);
+      font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6;
+    }
+    .wrap { max-width: 900px; margin: 0 auto; }
+    .brand { font-size: 13px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--fg-muted); margin: 0 0 16px; }
+    h1 { font-size: 22px; font-weight: 600; margin: 0 0 4px; }
+    .when { color: var(--fg-muted); font-size: 14px; margin: 0 0 20px; }
+    video { width: 100%; border-radius: 12px; background: #000; display: block; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 16px 20px; margin-top: 24px; }
+    .card h2 { font-size: 15px; font-weight: 600; margin: 0 0 10px; }
+    .summary { white-space: pre-wrap; font-size: 15px; }
+    .muted { color: var(--fg-muted); }
+    .foot { margin-top: 28px; font-size: 13px; color: var(--fg-muted); }
+    .foot a { color: var(--accent); }
+    .state { padding: 40px 0; text-align: center; color: var(--fg-muted); }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <p class="brand">Agape recruiting</p>
+    <div id="root"><p class="state">Loading recording…</p></div>
+  </div>
+
+  <script>
+    const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+    const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+    function fmtWhen(iso) {
+      if (!iso) return '';
+      try {
+        return new Date(iso).toLocaleString([], {
+          weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+        });
+      } catch { return ''; }
+    }
+
+    // Light markdown: the Haiku summaries use ## headings, **bold**, - bullets.
+    function mdLite(src) {
+      return esc(src)
+        .replace(/^#+\s*(.+)$/gm, '<strong>$1</strong>')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/^[-*]\s+(.+)$/gm, '• $1');
+    }
+
+    (async () => {
+      const root = document.getElementById('root');
+      const token = new URLSearchParams(location.search).get('t') || '';
+      if (!token) { root.innerHTML = '<p class="state">This link is missing its recording code.</p>'; return; }
+      try {
+        const resp = await fetch(`${SUPABASE_URL}/functions/v1/recruit-watch?t=${encodeURIComponent(token)}`);
+        const data = await resp.json();
+        if (!resp.ok) {
+          root.innerHTML = '<p class="state">This recording link is no longer valid. Ask in the Recruiting Society channel for a fresh one.</p>';
+          return;
+        }
+        root.innerHTML = `
+          <h1>${esc(data.title)}</h1>
+          <p class="when">${esc(fmtWhen(data.when))}</p>
+          ${data.url
+            ? `<video controls playsinline preload="metadata" src="${esc(data.url)}"></video>`
+            : `<p class="state">${esc(data.reason || 'No recording available for this call.')}</p>`}
+          ${data.summary ? `<div class="card"><h2>Call summary</h2><div class="summary">${mdLite(data.summary)}</div></div>` : ''}
+          <p class="foot">Anyone with this link can watch. Housemates: open the
+            <a href="/applications/">applicant inbox</a> for notes, votes, and the full profile.</p>`;
+      } catch {
+        root.innerHTML = '<p class="state">Couldn’t load the recording. Try again in a minute.</p>';
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -139,3 +139,12 @@ Calls scheduled outside the app already get picked up and recorded when the shar
 ## Permanent recording archive (v1.11.0 / recruit-gmail v1.14.0, 2026-07-29)
 
 Recall.ai purges bot media ~7 days after a call and its download links are short-lived presigned URLs — old Discord links died and older calls became unwatchable. Now every finished recording is streamed into the private `recruit-recordings` storage bucket (migration 134: `recording_path` on both recording tables). `recording-link` serves a 6-hour signed URL from the archive first, Recall as fallback; a backfill sweep on the cron tick rescues recordings processed before the archive existed and marks Recall-purged ones `media_expired`. Discord recording posts remain convenience links — the app is the durable viewer.
+
+## Capability watch links (recruit-watch v1.0.0, 2026-07-29)
+
+Discord recording posts carried Recall's presigned URL, which expired within hours ("old videos don't work"). Posts now link to `ctrl.rodeo/applications/watch/?t=<share_token>` — a public page that plays our archived copy.
+
+- **Token is the credential** (migration 135): 32 random bytes, unique index, minted when a recording archives; backfilled for existing calls. Revoke any link by setting `share_token = NULL`.
+- **`recruit-watch`** (`verify_jwt = false`) validates the token shape, resolves screening *or* recorded event, and returns title/when/summary plus a 6-hour signed URL. Bad, revoked, and unknown tokens are all a flat 404.
+- **Deliberate trade-off:** anyone with the link can watch, with no Discord sign-in — chosen so links work from phones and forwarded messages. The app's own Watch button remains membership-gated; only the shared link bypasses it.
+- Ordering matters: the archive upload now happens *before* the Discord post, since the post links to our copy.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -10,3 +10,8 @@ verify_jwt = false
 # Ed25519 request signatures, not JWTs.
 [functions.recruit-discord]
 verify_jwt = false
+
+# recruit-watch serves recordings by capability link (the share_token is the
+# credential) — no user JWT involved.
+[functions.recruit-watch]
+verify_jwt = false

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -110,6 +110,12 @@ function appLink(applicantId: string): string {
   return `https://ctrl.rodeo/applications/?a=${encodeURIComponent(applicantId)}`
 }
 
+// Capability link to our archived copy — Recall's presigned URLs died within
+// hours, so recording posts point here instead. The token is the credential.
+function watchLink(shareToken: string): string {
+  return `https://ctrl.rodeo/applications/watch/?t=${encodeURIComponent(shareToken)}`
+}
+
 // "her/his/their application" from the applicant's own pronouns field;
 // neutral "their" whenever unstated or ambiguous.
 function possessive(pronouns: string | null | undefined): string {
@@ -331,12 +337,12 @@ export async function postResilient(channelId: string, payload: Record<string, u
 // Post the recording + summary back to the claims channel after a call ends.
 export async function postRecordingNote(
   firstName: string, applicantId: string, residentName: string,
-  summary: string | null, videoUrl: string | null,
+  summary: string | null, shareToken: string | null,
 ): Promise<void> {
   const lines = [
     summary || '_No transcript captured (captions may have been off)._',
     '',
-    videoUrl ? `🎥 [Recording](${videoUrl}) _(link expires — grab it soon)_` : '🎥 Recording unavailable.',
+    shareToken ? `🎥 [Watch the recording](${watchLink(shareToken)})` : '🎥 Recording unavailable.',
     `📋 [Full profile](${appLink(applicantId)})`,
   ]
   await postResilient(NOTES_CHANNEL_ID, {
@@ -350,12 +356,12 @@ export async function postRecordingNote(
 
 // Notes for a non-applicant meeting hosted by the shared account.
 export async function postMeetingNote(
-  title: string, summary: string | null, videoUrl: string | null,
+  title: string, summary: string | null, shareToken: string | null,
 ): Promise<void> {
   const lines = [
     summary || '_No transcript captured (captions may have been off)._',
     '',
-    videoUrl ? `🎥 [Recording](${videoUrl}) _(link expires — grab it soon)_` : '🎥 Recording unavailable.',
+    shareToken ? `🎥 [Watch the recording](${watchLink(shareToken)})` : '🎥 Recording unavailable.',
   ]
   await postResilient(NOTES_CHANNEL_ID, {
     embeds: [{ title: `${title} — meeting notes`, description: lines.join('\n').slice(0, 4000), color: 0x9b59b6 }],

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.11.0'
+const VERSION = '1.12.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -516,6 +516,13 @@ async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<numb
   return notified
 }
 
+// Capability token for a recording's public watch link — 32 random bytes, so
+// links are unguessable. Revoke by nulling share_token.
+function newShareToken(): string {
+  return Array.from(crypto.getRandomValues(new Uint8Array(32)))
+    .map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
 // Backfill archive: recordings processed before the archive existed (or whose
 // upload failed) get copied to storage while Recall still has the media.
 // media_expired marks the permanently lost so we stop retrying.
@@ -525,7 +532,7 @@ async function archiveMissingRecordings(client: ReturnType<typeof db>): Promise<
   let archived = 0
   const sweep = async (table: string, idCol: string, pathPrefix: string, limit: number) => {
     const { data: rows } = await client.from(table)
-      .select(`${idCol}, recall_bot_id`)
+      .select(`${idCol}, recall_bot_id, share_token`)
       .eq('recall_status', 'done').is('recording_path', null)
       .not('recall_bot_id', 'is', null).limit(limit)
     // deno-lint-ignore no-explicit-any
@@ -534,7 +541,10 @@ async function archiveMissingRecordings(client: ReturnType<typeof db>): Promise<
         const bot = await getBotResult(r.recall_bot_id)
         if (bot.videoUrl) {
           const path = await archiveVideoToStorage(client, bot.videoUrl, `${pathPrefix}/${r[idCol]}.mp4`)
-          await client.from(table).update({ recording_path: path }).eq(idCol, r[idCol])
+          await client.from(table).update({
+            recording_path: path,
+            ...(r.share_token ? {} : { share_token: newShareToken() }),
+          }).eq(idCol, r[idCol])
           archived++
           console.log(`[archive] backfilled ${table} ${r[idCol]}`)
         } else if (bot.statusCode === 'media_expired' || bot.done) {
@@ -626,7 +636,7 @@ async function processMeetingRecordings(client: ReturnType<typeof db>): Promise<
       if (bot.transcriptUrl) {
         summary = await summarizeMeeting(await fetchTranscriptText(bot.transcriptUrl), m.title || 'Agape call')
       }
-      await postMeetingNote(m.title || 'Agape call', summary, bot.videoUrl)
+      // Archive before posting — the Discord link resolves to our copy.
       let recordingPath: string | null = null
       if (bot.videoUrl) {
         try {
@@ -634,10 +644,13 @@ async function processMeetingRecordings(client: ReturnType<typeof db>): Promise<
           recordingPath = await archiveVideoToStorage(client, bot.videoUrl, `events/${m.gcal_event_id}.mp4`)
         } catch (err) { console.warn(`[archive] event ${m.gcal_event_id}: ${(err as Error).message}`) }
       }
+      const shareToken = recordingPath ? newShareToken() : null
       await client.from('recruit_recorded_events').update({
         recall_status: 'done', recording_summary: summary, recording_posted_at: new Date().toISOString(),
         recording_path: recordingPath,
+        ...(shareToken ? { share_token: shareToken } : {}),
       }).eq('gcal_event_id', m.gcal_event_id)
+      await postMeetingNote(m.title || 'Agape call', summary, shareToken)
       posted++
     } catch (err) {
       console.warn(`[recall] meeting processing failed for ${m.gcal_event_id}: ${(err as Error).message}`)
@@ -678,9 +691,9 @@ async function processRecordings(client: ReturnType<typeof db>): Promise<number>
         const transcript = await fetchTranscriptText(bot.transcriptUrl)
         summary = await summarizeIntroCall(transcript, applicantName, s.housemate_name || 'a resident')
       }
-      await postRecordingNote(applicant?.first_name || 'Applicant', s.applicant_id, s.housemate_name || 'resident', summary, bot.videoUrl)
-      // Permanent copy — Recall purges media in ~7 days. Failure is fine:
-      // recording_path stays null and the backfill sweep retries next tick.
+      // Archive BEFORE posting — the Discord link points at our copy, so it
+      // has to exist first. Recall purges media in ~7 days; if the upload
+      // fails, recording_path stays null and the backfill sweep retries.
       let recordingPath: string | null = null
       if (bot.videoUrl) {
         try {
@@ -688,12 +701,15 @@ async function processRecordings(client: ReturnType<typeof db>): Promise<number>
           recordingPath = await archiveVideoToStorage(client, bot.videoUrl, `screenings/${s.id}.mp4`)
         } catch (err) { console.warn(`[archive] screening ${s.id}: ${(err as Error).message}`) }
       }
+      const shareToken = recordingPath ? newShareToken() : null
       await client.from('recruit_screenings').update({
         recall_status: 'done',
         recording_summary: summary,
         recording_posted_at: new Date().toISOString(),
         recording_path: recordingPath,
+        ...(shareToken ? { share_token: shareToken } : {}),
       }).eq('id', s.id)
+      await postRecordingNote(applicant?.first_name || 'Applicant', s.applicant_id, s.housemate_name || 'resident', summary, shareToken)
       posted++
       console.log(`[recall] notes posted for screening ${s.id}`)
     } catch (err) {

--- a/supabase/functions/recruit-watch/index.ts
+++ b/supabase/functions/recruit-watch/index.ts
@@ -1,0 +1,75 @@
+// Supabase Edge Function: recruit-watch
+// Public playback for a recording, by capability link (verify_jwt=false in
+// config.toml). Discord posts link here instead of Recall's presigned URL,
+// which died within hours.
+//
+// GET /recruit-watch?t=<share_token>        → { title, when, summary, url }
+//   url is a 6-hour signed URL for the archived copy in recruit-recordings.
+//
+// The token IS the credential: 32 random bytes from migration 135, unique,
+// and revocable by setting share_token = NULL. No applicant identifiers are
+// returned beyond what the recording itself shows, and a bad or revoked
+// token is indistinguishable from a missing one (404 either way).
+
+const VERSION = '1.0.0'
+console.log(`[recruit-watch] v${VERSION} — capability-link recording playback`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  try {
+    const token = new URL(req.url).searchParams.get('t') || ''
+    // Shape check first — never let a malformed token reach a query.
+    if (!/^[0-9a-f]{64}$/.test(token)) return json({ error: 'Not found' }, 404)
+
+    const client = db()
+    const { data: screening } = await client.from('recruit_screenings')
+      .select('id, applicant_id, housemate_name, starts_at, recording_summary, recording_path')
+      .eq('share_token', token).maybeSingle()
+
+    let title: string, when: string | null, summary: string | null, path: string | null
+    if (screening) {
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('first_name, last_name').eq('id', screening.applicant_id).maybeSingle()
+      const name = `${applicant?.first_name || 'Applicant'} ${applicant?.last_name || ''}`.trim()
+      title = `${name} × ${screening.housemate_name || 'Agape'} — Intro Call`
+      when = screening.starts_at
+      summary = screening.recording_summary
+      path = screening.recording_path
+    } else {
+      const { data: event } = await client.from('recruit_recorded_events')
+        .select('title, starts_at, recording_summary, recording_path')
+        .eq('share_token', token).maybeSingle()
+      if (!event) return json({ error: 'Not found' }, 404)
+      title = event.title || 'Agape call'
+      when = event.starts_at
+      summary = event.recording_summary
+      path = event.recording_path
+    }
+
+    if (!path) {
+      return json({ title, when, summary, url: null, reason: 'Recording is still processing, or was lost before we archived it.' })
+    }
+    const { data: signed, error } = await client.storage
+      .from('recruit-recordings').createSignedUrl(path, 6 * 3600)
+    if (error || !signed?.signedUrl) return json({ error: 'Could not open the recording' }, 500)
+
+    return json({ title, when, summary, url: signed.signedUrl })
+  } catch (err) {
+    console.error('[recruit-watch] error:', (err as Error).message)
+    return json({ error: 'Something went wrong' }, 500)
+  }
+})

--- a/supabase/migrations/135_recording_share_tokens.sql
+++ b/supabase/migrations/135_recording_share_tokens.sql
@@ -1,0 +1,21 @@
+-- 135: capability links for recordings.
+-- Discord recording posts used to carry Recall's presigned URL, which dies
+-- within hours. They now point at /applications/watch/?t=<share_token>, a
+-- page that plays the archived copy without a sign-in — the token IS the
+-- credential, so it must be unguessable (32 random bytes, hex) and revocable
+-- (set share_token = NULL to kill every link that was ever shared).
+ALTER TABLE recruit_screenings ADD COLUMN IF NOT EXISTS share_token TEXT;
+ALTER TABLE recruit_recorded_events ADD COLUMN IF NOT EXISTS share_token TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS recruit_screenings_share_token_idx
+  ON recruit_screenings (share_token) WHERE share_token IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS recruit_recorded_events_share_token_idx
+  ON recruit_recorded_events (share_token) WHERE share_token IS NOT NULL;
+
+-- Backfill anything already recorded so old calls get shareable links too.
+UPDATE recruit_screenings
+  SET share_token = encode(gen_random_bytes(32), 'hex')
+  WHERE share_token IS NULL AND recall_bot_id IS NOT NULL;
+UPDATE recruit_recorded_events
+  SET share_token = encode(gen_random_bytes(32), 'hex')
+  WHERE share_token IS NULL AND recall_bot_id IS NOT NULL;


### PR DESCRIPTION
## What
Recording posts in Discord now link to `ctrl.rodeo/applications/watch/?t=<token>` — our archived copy — instead of Recall's presigned URL that expired within hours.

Playback needs **no sign-in**: the token is the credential (32 random bytes, unique-indexed, minted on archive, backfilled for existing calls). Revoke any shared link with `UPDATE ... SET share_token = NULL`.

## Verified in prod
- Unauthenticated GET returns title + summary + 6h signed URL; video range request → 206 `video/mp4`
- Malformed/unknown token → flat 404

## Note
This is intentionally a capability URL: anyone the link reaches can watch an applicant's interview. The app's own Watch button stays membership-gated — only the shared link bypasses the Discord check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)