### PR TITLE
Recruiting: #recruiting-automation audit mirror

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -56,7 +56,7 @@
       <div class="rail-foot">
         <span class="rail-foot__user" id="rail-user"></span>
         <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
-        <label class="rail-foot__pref" title="When on, coverage asks post to #recruiting-interviews automatically as availability lands"><input type="checkbox" id="pref-autopost"> Auto-post coverage asks</label>
+        <label class="rail-foot__pref" title="When on, coverage asks post to #recruiting-automation automatically as availability lands"><input type="checkbox" id="pref-autopost"> Auto-post coverage asks</label>
         <button class="rail-foot__link rail-foot__gmail" id="gmail-conn" type="button">Checking shared Gmail…</button>
         <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
         <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -2642,7 +2642,7 @@ async function openClaimPreview(applicantId) {
     if (claimCtx?.applicantId !== applicantId) return; // closed meanwhile
     claimCtx.extraction = out.extraction;
     const emb = out.preview?.embeds?.[0] || {};
-    document.getElementById('claim-status').textContent = 'This exact message goes to #recruiting-interviews:';
+    document.getElementById('claim-status').textContent = 'This exact message goes to #recruiting-automation:';
     document.getElementById('claim-preview-body').innerHTML = `
       <div class="claim-preview ${out.slotLabels?.length ? '' : 'claim-preview--manual'}">
         <p class="claim-preview__title">${esc(emb.title || '')}</p>
@@ -2666,7 +2666,7 @@ async function postClaimFromModal() {
   btn.disabled = true; btn.textContent = 'Posting…';
   try {
     const out = await gmailCall({ action: 'claim-post', applicantId: claimCtx.applicantId, extraction: claimCtx.extraction });
-    toast(out.posted ? 'Posted to #recruiting-interviews — first claim wins' : 'Already claimed — not reposted');
+    toast(out.posted ? 'Posted to #recruiting-automation — first claim wins' : 'Already claimed — not reposted');
     closeClaimModal();
   } catch (e) {
     toast(`Post failed: ${e.message}`);

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -166,7 +166,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>design system · v3.24</span><a href="/design-system/">← all design systems</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>design system · v3.25</span><a href="/design-system/">← all design systems</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -205,6 +205,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
       <a href="#listing-header" data-story="listing-header">Listing header</a>
       <a href="#profile" data-story="profile">Profile</a>
       <a href="#stage-machine" data-story="stage-machine">Stage machine</a>
+      <a href="#automation-audit" data-story="automation-audit">Automation audit</a>
     </div>
   </div>
 </aside>
@@ -562,6 +563,27 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
         <li>Long answers clamp to six lines with More/Less; heard-from is a quiet "Via" fact, not a bubble.</li>
         <li>The Call tab holds the recording, AI summary, and comments with "comment at current time" stamps.</li>
         <li>Confirmed move-in replaces the parsed date outright — green, ✓, attributed — with the raw answer on hover.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="story" id="s-automation-audit">
+    <h1>Automation audit</h1>
+    <p class="lede">Every automated message the app sends is visible in one channel, so the house can audit the robot and subgroups can be given access to just that channel.</p>
+    <div class="canvas">
+      <div style="background:var(--elevated);border:1px solid var(--line);border-radius:var(--r-sm);padding:14px 16px;max-width:520px;">
+        <p style="margin:0 0 4px;font-size:13px;">🤖 <b>New application — Marisa</b> → #recruiting-society</p>
+        <p style="margin:0;font-size:12px;color:var(--ink-3);">📥 Marisa Maccaro applied — Full-time · Sep 2026</p>
+      </div>
+    </div>
+    <div class="notes">
+      <h3>Notes</h3>
+      <ul>
+        <li><b>#recruiting-automation</b> is the audit hub (formerly #recruiting-interviews — same channel, renamed). Claim posts live here; everything else is mirrored here.</li>
+        <li><b>#recruiting-society</b> is the members channel: new-application pings, Intro Call notes and recordings, live-call announcements.</li>
+        <li>Mirrors are one compact line — label, target channel, first line of the real message. Best-effort: an audit failure never breaks the automation it describes, and messages that already went to the automation channel aren't echoed.</li>
+        <li><b>DMs are audited too</b> — the house sees that a claimer confirmation went out without seeing the thread.</li>
+        <li>New-application pings only cover the last 14 days, so turning them on never dumps the backlog.</li>
       </ul>
     </div>
   </section>

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -148,7 +148,7 @@ supabase functions deploy {function-name}
 
 **Intro Call recording (Recall.ai):** optional; enabled by setting `RECALL_API_KEY` (Boards project). When set, `scheduleScreening` sends an "Agape Notes" bot to each Meet at start time; the 15-min recruit-discord cron tick harvests finished recordings, summarizes the transcript with Haiku, posts notes + recording link to #recruiting-society (`1503490895469609211`; `SCREENING_NOTES_CHANNEL_ID` overrides), and stores the summary on `recruit_screenings.recording_summary`. `RECALL_API_BASE` overrides the region (default us-west-2).
 
-**recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-interviews` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
+**recruit-discord setup:** point the Discord application's *Interactions Endpoint URL* at `https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-discord`. It verifies Ed25519 request signatures using the app's `verify_key`, fetched at runtime via `DISCORD_BOT_TOKEN` (`DISCORD_PUBLIC_KEY` env overrides). Claim posts go to `#recruiting-automation` (`1529576830514762029`; `SCREENING_CLAIMS_CHANNEL_ID` env overrides). No extra secrets required.
 
 ---
 

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -21,7 +21,7 @@ Status: **Phase A shipped (v3.0.0, migration 120); auto-placement shipped early 
    - Score ≥ threshold (avg ≥ 3.5 across ≥ 3 votes) → Candidates.
    - Everyone who doesn't pass **receives an update email** (Phase B queue).
 3. **Room openings** — listings generated from the occupancy calendar; candidates bucketed into the listing that fits best (move-in date weighted heaviest). Same-date openings share one general pool; the room is assigned later. A Recruiting member sends the screening request from the listing shortlist.
-4. **Screening request** — availability asked in natural language; replies trigger the claim flow in `#recruiting-interviews` (see [agape-screening-claim-automation.md](./agape-screening-claim-automation.md), built in a parallel effort — `recruit-discord` is shared infrastructure).
+4. **Screening request** — availability asked in natural language; replies trigger the claim flow in `#recruiting-automation` (see [agape-screening-claim-automation.md](./agape-screening-claim-automation.md), built in a parallel effort — `recruit-discord` is shared infrastructure).
 
 Out of scope for now (manual): post-screening accept/vote, house tour, onboarding (Notion, Google permissions, buddy matching).
 

--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -34,7 +34,7 @@ Applicant uses the /schedule picker ───────────┤
                                                ▼
                         recruit_availability updated (existing)
                                                ▼
-                 NEW: post to #recruiting-interviews (bot message)
+                 NEW: post to #recruiting-automation (bot message)
                  One message per applicant. Buttons = concrete
                  30-min slots derived from their windows (max ~8,
                  spread across days) + "Other time…"
@@ -56,7 +56,7 @@ Dedup rules: one open post per applicant (re-availability edits the existing pos
 
 ## Channel
 
-**`#recruiting-interviews`** (ID `1529576830514762029`) — bot-writable, visible to the Recruiting Society role. Keep it single-purpose: posts and claims only, discussion goes to the applicant thread in `#recruiting`.
+**`#recruiting-automation`** (ID `1529576830514762029`) — bot-writable, visible to the Recruiting Society role. Keep it single-purpose: posts and claims only, discussion goes to the applicant thread in `#recruiting`.
 
 ## Hosting
 

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -122,3 +122,6 @@ Watch opens a **Call** tab on the applicant profile (not a modal): recording pla
 
 ## v3.24 — dropped out
 Row ⋮ in Openings gains **"[name] dropped out…"**. A withdrawal is not a rejection: it archives clean (`stage='archived'`, **no update email owed**), pulls them off every listing with tombstones so the auto-sweep can't re-add them, and records `reason='dropped-out'` for the CSV. Archive shows a neutral **Dropped out** chip instead of "Update queued".
+
+## v3.25 — automation audit channel
+`#recruiting-interviews` was renamed **`#recruiting-automation`** (same channel id). It is now the audit hub: `auditMirror()` in `_shared/discord.ts` posts a one-line record of **every** automation — channel posts, pings, notes, recordings, live-call announcements, and DMs — alongside the real message at its intended target. Skipped when the target already is the automation channel; failures are logged, never propagated. New-application pings target **#recruiting-society** (the members channel) with a 14-day floor so enabling them never dumps the backlog.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -1,17 +1,39 @@
 // _shared/discord.ts
-// Discord REST helpers for the screening-claim flow: post/edit the claimable
-// message in #recruiting-interviews, DM the claimer, nudge stuck posts.
-// Used by recruit-gmail, recruit-availability, and recruit-discord.
+// Discord REST helpers for the recruiting automations: claim posts, notes,
+// pings, DMs. Used by recruit-gmail, recruit-availability, recruit-discord.
+//
+// Channel roles:
+//   #recruiting-automation — every automated message the app sends lands
+//     here as well as at its intended target, so the house has one audit
+//     trail and subgroups can be granted access to just this channel.
+//     (Formerly #recruiting-automation — same channel id, renamed 2026-07.)
+//   #recruiting-society — the members channel: new-application pings,
+//     Intro Call notes/recordings, live-call announcements.
 
 // deno-lint-ignore-file no-explicit-any
 
 import { TZ } from './recruit-schedule.ts'
 
 const DISCORD_API = 'https://discord.com/api/v10'
-// #recruiting-interviews in the Agape guild (952961396121931838)
-export const CLAIMS_CHANNEL_ID = Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || '1529576830514762029'
-// #recruiting-society — where finished Intro Call notes/recordings post
+// #recruiting-automation in the Agape guild (952961396121931838) — claim
+// posts live here AND it is the audit mirror for every other automation.
+export const AUTOMATION_CHANNEL_ID = Deno.env.get('RECRUITING_AUTOMATION_CHANNEL_ID')
+  || Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || '1529576830514762029'
+// Kept for callers that still speak in claim terms — same channel.
+export const CLAIMS_CHANNEL_ID = AUTOMATION_CHANNEL_ID
+// #recruiting-society — the members channel (pings, notes, recordings)
 export const NOTES_CHANNEL_ID = Deno.env.get('SCREENING_NOTES_CHANNEL_ID') || '1503490895469609211'
+
+// Compact one-liner for the audit trail: the embed's title/description or
+// the plain content, whichever the payload carries.
+function summarize(payload: Record<string, unknown>): string {
+  const embeds = payload.embeds as Array<Record<string, string>> | undefined
+  if (embeds?.length) {
+    const e = embeds[0]
+    return [e.title, (e.description || '').split('\n')[0]].filter(Boolean).join(' — ')
+  }
+  return String(payload.content || '(no text)').split('\n')[0]
+}
 
 function botHeaders(): Record<string, string> {
   const token = Deno.env.get('DISCORD_BOT_TOKEN')
@@ -194,7 +216,7 @@ async function postOrPatch(channelId: string, messageId: string | null, payload:
 }
 
 // Post (or edit, per the one-open-post-per-applicant rule) the claim message —
-// in BOTH #recruiting-interviews and #recruiting-society. Either copy is
+// in BOTH #recruiting-automation and #recruiting-society. Either copy is
 // claimable; both carry the same custom_ids so the claim handler is agnostic.
 // Returns the recruit_claim_posts row, or null when posting was skipped.
 export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promise<any | null> {
@@ -222,7 +244,7 @@ export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promis
   const { data: row, error } = await db.from('recruit_claim_posts').upsert({
     applicant_id: input.applicantId,
     discord_message_id: message.id,
-    discord_channel_id: message.channel_id || CLAIMS_CHANNEL_ID,
+    discord_channel_id: message.channel_id || AUTOMATION_CHANNEL_ID,
     mirror_message_id: mirror?.id || null,
     mirror_channel_id: mirror ? (mirror.channel_id || NOTES_CHANNEL_ID) : null,
     slots, platform: input.platform, timezone_note: input.timezoneNote,
@@ -289,6 +311,8 @@ export async function editClaimMessageFailed(
   })
 }
 
+/* DMs are audited as well: a claimer's confirmation is an automation the
+   house should be able to see happened, without exposing the DM thread. */
 export async function dmUser(discordUserId: string, content: string): Promise<void> {
   const channel = await discordFetch('/users/@me/channels', {
     method: 'POST', body: JSON.stringify({ recipient_id: discordUserId }),
@@ -296,6 +320,34 @@ export async function dmUser(discordUserId: string, content: string): Promise<vo
   await discordFetch(`/channels/${channel.id}/messages`, {
     method: 'POST', body: JSON.stringify({ content }),
   })
+  await auditMirror('Direct message', content.split('\n')[0], { dmTo: discordUserId })
+}
+
+/* Audit mirror: a one-line record of every automated message, posted to
+   #recruiting-automation alongside the real thing. Best-effort by design —
+   an audit failure must never break (or double-report) the automation it
+   describes, and messages that already went to the automation channel are
+   skipped so the trail stays readable. */
+export async function auditMirror(
+  label: string, summary: string, target: { channelId?: string; dmTo?: string } = {},
+): Promise<void> {
+  try {
+    if (target.channelId && target.channelId === AUTOMATION_CHANNEL_ID) return
+    const where = target.dmTo ? `DM → <@${target.dmTo}>`
+      : target.channelId ? `→ <#${target.channelId}>`
+      : '→ (no channel)'
+    await discordFetch(`/channels/${AUTOMATION_CHANNEL_ID}/messages`, {
+      method: 'POST',
+      body: JSON.stringify({
+        embeds: [{
+          description: `🤖 **${label}** ${where}\n${summary.slice(0, 900)}`,
+          color: 0x6a6c6a,
+        }],
+      }),
+    })
+  } catch (err) {
+    console.warn(`[discord] audit mirror for "${label}" failed: ${(err as Error).message}`)
+  }
 }
 
 // Ops contact for last-resort alerts when Discord posting fails everywhere.
@@ -307,9 +359,10 @@ const ALERT_DISCORD_USER_ID = Deno.env.get('ALERT_DISCORD_USER_ID') || '85378260
 // the other recruiting channel with a ⚠️ prefix → DM the ops contact.
 // Throws if every rung fails, so callers don't stamp state as posted.
 export async function postResilient(channelId: string, payload: Record<string, unknown>, label: string): Promise<void> {
-  const fallback = channelId === NOTES_CHANNEL_ID ? CLAIMS_CHANNEL_ID : NOTES_CHANNEL_ID
+  const fallback = channelId === NOTES_CHANNEL_ID ? AUTOMATION_CHANNEL_ID : NOTES_CHANNEL_ID
   try {
     await discordFetch(`/channels/${channelId}/messages`, { method: 'POST', body: JSON.stringify(payload) })
+    await auditMirror(label, summarize(payload), { channelId })
     return
   } catch (err) {
     console.warn(`[discord] ${label}: post to ${channelId} failed: ${(err as Error).message}`)
@@ -381,6 +434,7 @@ export async function postLiveCall(title: string, when: string, meetLink: string
 // Persistent "Get sign-in link" helper message for phone sign-in — tapping
 // the button gets an ephemeral one-time link (handled in recruit-discord).
 export async function postSigninMessage(channelId: string): Promise<any> {
+  await auditMirror('Sign-in helper posted', 'Persistent phone sign-in message', { channelId })
   return await discordFetch(`/channels/${channelId}/messages`, {
     method: 'POST',
     body: JSON.stringify({
@@ -400,11 +454,13 @@ export async function postSigninMessage(channelId: string): Promise<any> {
 
 // One channel nudge for a post nobody claimed within 96h.
 // Plain embed post to any channel (new-application pings etc.).
-export async function postChannelEmbed(channelId: string, description: string, color = 0x378add): Promise<any> {
-  return await discordFetch(`/channels/${channelId}/messages`, {
+export async function postChannelEmbed(channelId: string, description: string, color = 0x378add, label = 'Automated post'): Promise<any> {
+  const msg = await discordFetch(`/channels/${channelId}/messages`, {
     method: 'POST',
     body: JSON.stringify({ embeds: [{ description, color }] }),
   })
+  await auditMirror(label, description.split('\n')[0], { channelId })
+  return msg
 }
 
 export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -57,7 +57,7 @@ serve(async (req) => {
       if (error) return json({ error: 'Could not save — try again' }, 500)
       console.log(`availability saved for ${applicant.id} (${windows.length} windows)`)
 
-      // Post/refresh the claimable message in #recruiting-interviews.
+      // Post/refresh the claimable message in #recruiting-automation.
       // Warn-only: Discord being down never blocks the applicant's save.
       try {
         const { data: full } = await client.from('recruit_applicants')

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -348,7 +348,7 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
 }
 
 // Harvest finished Recall recordings: after a call ends, pull the transcript,
-// summarize with Haiku, post notes + recording link to #recruiting-interviews,
+// summarize with Haiku, post notes + recording link to #recruiting-automation,
 // and store the summary on the screening row (the app reads it from there).
 // Runs on the same 15-min cron tick as reminders; inert without RECALL_API_KEY.
 // Every scheduled screening with a Meet link gets a recording bot — including

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.14.0'
+const VERSION = '1.15.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed } from '../_shared/discord.ts'
+import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -114,7 +114,7 @@ async function autoPostEnabled(client: ReturnType<typeof db>): Promise<boolean> 
 }
 
 // After availability lands, post/refresh the claimable message in
-// #recruiting-interviews. Warn-only: Discord being down never breaks a scan.
+// #recruiting-automation. Warn-only: Discord being down never breaks a scan.
 async function postClaim(client: ReturnType<typeof db>, applicantId: string, extraction: Extraction): Promise<void> {
   if (!extraction.windows.length && !extraction.needs_human) return
   try {
@@ -685,11 +685,16 @@ serve(async (req) => {
       // a batch of 4+ collapses into a single digest.
       let pinged = 0
       try {
-        const pingChannel = Deno.env.get('RECRUITING_PING_CHANNEL_ID') || Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID') || ''
+        // New applications go to the members channel; the audit copy lands in
+        // #recruiting-automation automatically.
+        const pingChannel = Deno.env.get('RECRUITING_PING_CHANNEL_ID') || NOTES_CHANNEL_ID
         if (pingChannel) {
+          // Only genuinely new applications — a 14-day floor keeps switching
+          // this on from dumping the historical backlog into the channel.
+          const pingFloor = new Date(Date.now() - 14 * 86400000).toISOString()
           const { data: fresh } = await client.from('recruit_applicants')
             .select('id, first_name, last_name, residency, move_in, why_agape')
-            .eq('stage', 'review').is('discord_ping_at', null)
+            .eq('stage', 'review').is('discord_ping_at', null).gte('submitted_at', pingFloor)
             .order('submitted_at', { ascending: false }).limit(12)
           const { data: votedRows } = await client.from('recruit_votes').select('applicant_id')
           const voted = new Set((votedRows || []).map((v) => v.applicant_id))
@@ -697,7 +702,7 @@ serve(async (req) => {
           const appLink = (id: string) => `https://ctrl.rodeo/applications/?a=${encodeURIComponent(id)}`
           if (toPing.length > 3) {
             const lines = toPing.map((a) => `• [${a.first_name} ${a.last_name || ''}](${appLink(a.id)})`).join('\n')
-            await postChannelEmbed(pingChannel, `📥 **${toPing.length} new applications** are ready for votes:\n${lines}`)
+            await postChannelEmbed(pingChannel, `📥 **${toPing.length} new applications** are ready for votes:\n${lines}`, 0x378add, `${toPing.length} new applications`)
           } else {
             for (const a of toPing) {
               const track = /short/i.test(a.residency || '') ? 'Sublet' : 'Full-time'
@@ -705,7 +710,7 @@ serve(async (req) => {
               await postChannelEmbed(pingChannel,
                 `📥 **${a.first_name} ${a.last_name || ''}** applied — ${track}${a.move_in ? ` · ${String(a.move_in).slice(0, 60)}` : ''}\n` +
                 (why ? `_${why}_\n` : '') +
-                `[Read + vote](${appLink(a.id)})`)
+                `[Read + vote](${appLink(a.id)})`, 0x378add, `New application — ${a.first_name}`)
             }
           }
           if (toPing.length) {


### PR DESCRIPTION
**Rename**: `#recruiting-interviews` → `#recruiting-automation` (Discord keeps the channel id, so nothing breaks) — code comments, docs, and in-app copy updated.

**Audit mirror**: `auditMirror()` posts a compact one-line record of *every* automation — claim posts, new-application pings, Intro Call notes, recordings, live-call announcements, and **DMs** — into #recruiting-automation alongside the intended target channel. Best-effort by design: it's skipped when the target already is that channel, and an audit failure is logged rather than breaking the automation it describes. This gives the house one audit trail and lets subgroups be granted access to just that channel.

**Ping target**: new-application pings go to #recruiting-society (the members channel) with a **14-day floor**, so switching them on never dumps the 50-applicant backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)