### PR TITLE
feat(recruiting): four-outcome Remove sheet, transparency exits, cross-listing drag

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1330,6 +1330,65 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .cta--green.btn { background: #1D9E75; border-color: #1D9E75; color: #fff; }
 .gd-no { color: var(--error); border-color: var(--error); background: transparent; }
 
+/* --- v3.24.0: the Remove sheet, transparency exits, cross-listing drag --- */
+
+/* Menu rule: navigation above, removal below. */
+.listing-menu__rule {
+  height: 1px; margin: 4px 6px;
+  background: var(--border);
+}
+
+/* Each option carries its consequence, so it's a two-line target. */
+.remove-sheet__options { display: flex; flex-direction: column; gap: var(--space-2); }
+.remove-sheet__option {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 10px 12px; text-align: left; cursor: pointer;
+  background: var(--bg-surface); color: var(--fg);
+  border: 1px solid var(--border); border-radius: var(--radius-sm);
+}
+.remove-sheet__option:hover { background: var(--bg-overlay); border-color: var(--border-strong); }
+.remove-sheet__option.is-selected { border-color: currentColor; background: var(--bg-overlay); }
+.remove-sheet__option--danger { color: var(--error); }
+.remove-sheet__option-label { font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.remove-sheet__option-hint { font-size: var(--font-size-caption); color: var(--fg-subtle); }
+.remove-sheet__option--danger .remove-sheet__option-hint { color: inherit; opacity: 0.75; }
+.remove-sheet__until { margin-top: var(--space-3); }
+.remove-sheet__note { margin-top: var(--space-3); width: 100%; }
+/* --bg tracks the theme, so the label stays legible against both the light
+   theme's dark red and the dark theme's salmon. */
+.btn--danger { background: var(--error); border-color: var(--error); color: var(--bg); }
+
+/* Exit state: transparency, never strike-through. 0.45 is the same value
+   .inbox-row.is-dragging uses — "in motion, not settled".
+   The fade applies to WHO is leaving, not to the chip saying so or the way
+   back — dimming the Undo would hide the one control that still matters. */
+.inbox-row.is-exiting .inbox-row__main,
+.inbox-row.is-exiting .inbox-row__grip,
+.inbox-row.is-exiting .replied-dot,
+.inbox-row.is-exiting .note-bubble { opacity: 0.45; }
+.inbox-row.is-exiting .inbox-row__main { pointer-events: none; }
+.exit-chip {
+  display: inline-flex; align-items: center; height: 24px; padding: 0 10px;
+  border-radius: var(--radius-pill); background: var(--pass-tint);
+  color: var(--fg-subtle); font-size: var(--font-size-caption);
+  font-weight: var(--fw-semibold); white-space: nowrap;
+}
+.exit-undo { margin-left: var(--space-2); }
+/* Colored by how final the exit was: amber = coming back, gray = they left,
+   red = our no. */
+.decision-chip--exit-future { background: var(--hold-tint); color: var(--hold-fg); }
+.decision-chip--exit-opted_out { background: var(--pass-tint); color: var(--fg-subtle); }
+.decision-chip--exit-not_a_fit { background: var(--pass-tint); color: var(--error); }
+
+/* Cross-listing drop target — the whole section lights up, so a listing
+   with no rows yet is still reachable. */
+.inbox-group.is-drop-target {
+  outline: 2px dashed var(--accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+.inbox-group.is-drop-target .inbox-empty--group { color: var(--accent); }
+
 /* --- v3.22.1 (restored post-rebase): mobile CTA-column fix — must stay
    LAST so the cascade resolves in its favor. --- */
 @media (max-width: 480px) {

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1354,9 +1354,10 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 .remove-sheet__option--danger .remove-sheet__option-hint { color: inherit; opacity: 0.75; }
 .remove-sheet__until { margin-top: var(--space-3); }
 .remove-sheet__note { margin-top: var(--space-3); width: 100%; }
-/* --bg tracks the theme, so the label stays legible against both the light
-   theme's dark red and the dark theme's salmon. */
-.btn--danger { background: var(--error); border-color: var(--error); color: var(--bg); }
+/* Matches design-system/components.css .btn--danger (and the app's own
+   .gd-no): outline until hover, never a filled red sitting in a sheet. */
+.btn--danger { background: transparent; border-color: var(--error); color: var(--error); }
+.btn--danger:hover { background: var(--error); color: var(--bg); }
 
 /* Exit state: transparency, never strike-through. 0.45 is the same value
    .inbox-row.is-dragging uses — "in motion, not settled".

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.23.0">
+  <link rel="stylesheet" href="css/app.css?v=3.24.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -217,6 +217,27 @@
     </div>
   </div>
 
+  <!-- Remove from a listing: one sheet, four outcomes. Scope (this listing
+       only) sits apart from the three that take them out of the funnel. -->
+  <div class="email-modal" id="remove-modal" hidden>
+    <div class="email-modal__card remove-sheet">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title" id="remove-title">Remove</h3>
+        <button class="review__close email-modal__close" id="remove-close" aria-label="Close">✕</button>
+      </div>
+      <div class="remove-sheet__options" id="remove-options"></div>
+      <label class="listing-form__field remove-sheet__until" id="remove-until-wrap" hidden>Bring them back on
+        <input type="date" class="listing-status" id="remove-until">
+      </label>
+      <textarea class="notes__input remove-sheet__note" id="remove-note" rows="2"
+        placeholder="Optional context for the house…" maxlength="2000"></textarea>
+      <div class="decision-sheet__actions">
+        <button class="hold-sheet__cancel" id="remove-cancel" type="button">Cancel</button>
+        <button class="btn btn--accent btn--sm" id="remove-submit" type="button" disabled>Remove</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Post-screening decision: would you accept them? -->
   <div class="email-modal" id="gd-modal" hidden>
     <div class="email-modal__card">
@@ -237,6 +258,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.23.0"></script>
+  <script src="js/app.js?v=3.24.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.23.0';
+const VERSION = '3.24.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -48,6 +48,39 @@ function reasonLabel(id) {
 const HOLD_REASONS = DECISION_REASONS.hold; // legacy references
 // DB keeps 'pass'; the surface calls it Archive.
 const DECISION_LABELS = { outreach: 'Outreach', hold: 'Hold', pass: 'Archive' };
+
+/* Removing someone is one gesture with four outcomes. 'listing' is scope
+   (recruit_listing_candidates tombstone); the other three are exits from the
+   funnel (recruit_applicants.exit_reason, migration 135). Ordered least →
+   most final — only the last one is destructive. */
+const REMOVE_OPTIONS = [
+  {
+    id: 'listing', label: 'From this listing',
+    hint: 'still a candidate for other rooms',
+    chip: 'removed', scope: true,
+  },
+  {
+    id: 'future', label: 'Save for future',
+    hint: 'right person, wrong time — pick when to bring them back',
+    chip: 'saved for future', stage: 'candidate', needsDate: true,
+  },
+  {
+    id: 'opted_out', label: 'Opted out',
+    hint: 'they withdrew — no update email owed',
+    chip: 'opted out', stage: 'archived',
+  },
+  {
+    id: 'not_a_fit', label: 'Not a fit',
+    hint: 'our no — queues an update email',
+    chip: 'not a fit', stage: 'rejected', danger: true,
+  },
+];
+const removeOption = id => REMOVE_OPTIONS.find(o => o.id === id) || null;
+// Default return date for Save for future: three months out, month start.
+function defaultReturnDate() {
+  const d = new Date();
+  return new Date(d.getFullYear(), d.getMonth() + 3, 1).toISOString().slice(0, 10);
+}
 
 const VIEWS = {
   inbox: { title: 'Inbox', kind: 'applicants' },
@@ -543,6 +576,8 @@ async function loadAll() {
     stage: r.stage || 'review',
     moveinFrom: r.move_in_from, moveinTo: r.move_in_to, moveinSetBy: r.move_in_set_by_name,
     updateSentAt: r.update_email_sent_at, updateSkippedAt: r.update_email_skipped_at,
+    exitReason: r.exit_reason || null, exitUntil: r.exit_until || null,
+    exitNote: r.exit_note || '', exitBy: r.exit_by_name || null,
   }));
   decisions = {};
   for (const d of (dRes.data || [])) {
@@ -641,7 +676,9 @@ async function syncAutoPlacements() {
   if (!houseLoaded) return 0;
   const have = new Set(placements.map(p => `${p.applicant_id}:${p.listing_id}`));
   const fresh = [];
-  for (const a of applicants.filter(x => x.stage === 'candidate')) {
+  // A saved-for-future candidate keeps the stage but is off the board until
+  // their date lands, so they're excluded here as well as in matchesView.
+  for (const a of applicants.filter(x => x.stage === 'candidate' && !x.exitReason)) {
     for (const l of listings.filter(l => l.status === 'open')) {
       if (!have.has(`${a.id}:${l.id}`) && qualifiesFor(a, l)) {
         fresh.push({ applicant_id: a.id, listing_id: l.id, source: 'auto' });
@@ -652,7 +689,7 @@ async function syncAutoPlacements() {
     if (p.source !== 'auto' || p.status !== 'active') return false;
     const a = applicants.find(x => x.id === p.applicant_id);
     const l = listings.find(x => x.id === p.listing_id);
-    return !a || !l || a.stage !== 'candidate' || !qualifiesFor(a, l);
+    return !a || !l || a.stage !== 'candidate' || a.exitReason || !qualifiesFor(a, l);
   });
   if (stale.length) {
     const { error } = await sb.from('recruit_listing_candidates').delete().in('id', stale.map(r => r.id));
@@ -691,6 +728,184 @@ async function removePlacement(applicantId, listingId) {
   renderRailCounts();
   if (!document.getElementById('review').hidden) renderReview();
   else if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+}
+
+/* ---------- funnel exits (migration 135) ----------
+   The three non-scope removals. Each writes exit_reason via the RPC and
+   moves the stage; 'not_a_fit' additionally records a pass decision so the
+   update-email tray picks them up. Passing reason=null is the Undo. */
+async function setExit(applicantId, reason, until = null, note = '') {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return false;
+  const { error } = await sb.rpc('recruit_set_exit', {
+    p_applicant: applicantId, p_reason: reason,
+    p_until: reason === 'future' ? until : null,
+    p_note: note || null, p_name: me?.name || null,
+  });
+  if (error) { toast(`Remove failed: ${error.message}`); return false; }
+  a.exitReason = reason;
+  a.exitUntil = reason === 'future' ? until : null;
+  a.exitNote = reason ? note : '';
+  a.exitBy = reason ? (me?.name || null) : null;
+  return true;
+}
+
+/* A future-fit exit hides them from Openings, so their auto placements have
+   to go too — otherwise the sweep and the view disagree about who's live. */
+async function clearActivePlacements(applicantId) {
+  const live = activePlacements(applicantId);
+  if (!live.length) return;
+  const { error } = await sb.from('recruit_listing_candidates')
+    .delete().in('id', live.map(p => p.id));
+  if (error) { console.warn('placement clear failed', error.message); return; }
+  const gone = new Set(live.map(p => p.id));
+  placements = placements.filter(p => !gone.has(p.id));
+}
+
+/* Saved-for-future people come back on their own — that's the whole reason
+   Save for future isn't just Archive. Anyone whose date has arrived has the
+   exit cleared on load; syncAutoPlacements then re-places them normally. */
+async function returnDueCandidates() {
+  const today = new Date().toISOString().slice(0, 10);
+  const due = applicants.filter(x => x.exitReason === 'future' && x.exitUntil && x.exitUntil <= today);
+  if (!due.length) return 0;
+  for (const a of due) {
+    if (await setExit(a.id, null)) a.returnedFromFuture = true;
+  }
+  return due.length;
+}
+
+/* ---------- the Remove sheet ----------
+   One ⋯ item, four outcomes. Opened from an Openings row (listingId set) or
+   from a profile (listingId null, so the scope option is hidden — there's no
+   "this listing" to scope to). */
+let removeTarget = null;   // { applicantId, listingId }
+let removePick = null;     // REMOVE_OPTIONS id
+
+function openRemoveSheet(applicantId, listingId = null) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  removeTarget = { applicantId, listingId: listingId || null };
+  removePick = null;
+  document.getElementById('remove-title').textContent = `Remove ${fullName(a)}`;
+  document.getElementById('remove-note').value = '';
+  document.getElementById('remove-until').value = defaultReturnDate();
+  document.getElementById('remove-until-wrap').hidden = true;
+  renderRemoveOptions();
+  document.getElementById('remove-submit').disabled = true;
+  document.getElementById('remove-submit').classList.remove('btn--danger');
+  document.getElementById('remove-modal').hidden = false;
+}
+
+function renderRemoveOptions() {
+  const listingId = removeTarget?.listingId;
+  document.getElementById('remove-options').innerHTML = REMOVE_OPTIONS
+    .filter(o => !o.scope || listingId)
+    .map(o => `<button type="button" class="remove-sheet__option${removePick === o.id ? ' is-selected' : ''}${o.danger ? ' remove-sheet__option--danger' : ''}" data-remove-pick="${o.id}">
+      <span class="remove-sheet__option-label">${esc(o.label)}</span>
+      <span class="remove-sheet__option-hint">${esc(o.hint)}</span>
+    </button>`).join('');
+}
+
+function pickRemoveOption(id) {
+  const opt = removeOption(id);
+  if (!opt) return;
+  removePick = id;
+  renderRemoveOptions();
+  document.getElementById('remove-until-wrap').hidden = !opt.needsDate;
+  const submit = document.getElementById('remove-submit');
+  submit.disabled = false;
+  submit.textContent = opt.scope ? 'Remove' : opt.label;
+  submit.classList.toggle('btn--danger', !!opt.danger);
+}
+
+function hideRemoveSheet() {
+  document.getElementById('remove-modal').hidden = true;
+  removeTarget = null;
+  removePick = null;
+}
+
+async function submitRemove() {
+  if (!removeTarget || !removePick) return;
+  const { applicantId, listingId } = removeTarget;
+  const opt = removeOption(removePick);
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a || !opt) return;
+  const note = document.getElementById('remove-note').value.trim();
+  const until = opt.needsDate ? document.getElementById('remove-until').value : null;
+  if (opt.needsDate && !until) { toast('Pick a date to bring them back'); return; }
+
+  hideRemoveSheet();
+  // Fade the row and hold it — nothing is written until the window closes,
+  // so Undo is a no-op rather than a compensating write.
+  beginRowExit(applicantId, listingId, opt, async () => {
+    if (opt.scope) { await removePlacement(applicantId, listingId); return; }
+    if (!await setExit(applicantId, opt.id, until, note)) return;
+    // Their listing slots go with them — all three exits leave the board.
+    await clearActivePlacements(applicantId);
+    if (opt.id === 'not_a_fit') await saveDecision(applicantId, 'pass', null, null, note);
+    if (a.stage !== opt.stage) await setStage(applicantId, opt.stage);
+    toast(opt.id === 'not_a_fit'
+      ? `${fullName(a)} → Archived — update email queued`
+      : opt.id === 'opted_out'
+        ? `${fullName(a)} → Archived — no update email owed`
+        : `${fullName(a)} saved for ${fmtDay(until)} — they'll come back on their own`);
+    renderRailCounts();
+    if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+    if (!document.getElementById('review').hidden) renderReview();
+  });
+}
+
+/* ---------- transparency exit ----------
+   The row fades to the same 0.45 the drag state uses, swaps its actions for
+   the outcome chip + Undo, and holds for EXIT_HOLD_MS before the write runs.
+   It never moves while the window is open — no reflow under the cursor. */
+const EXIT_HOLD_MS = 6000;
+const pendingExits = new Map(); // rowKey -> { timer, commit }
+
+const exitRowKey = (applicantId, listingId) => `${applicantId}|${listingId || ''}`;
+
+function beginRowExit(applicantId, listingId, opt, commit) {
+  const key = exitRowKey(applicantId, listingId);
+  if (pendingExits.has(key)) clearTimeout(pendingExits.get(key).timer);
+  const row = document.querySelector(
+    listingId
+      ? `.inbox-row[data-row-id="${CSS.escape(applicantId)}"][data-row-group="${CSS.escape(listingId)}"]`
+      : `.inbox-row[data-row-id="${CSS.escape(applicantId)}"]`);
+  if (!row) { commit(); return; } // row isn't on screen — just do it
+
+  const actions = row.querySelector('.inbox-row__actions');
+  const restore = actions ? actions.innerHTML : null;
+  row.classList.add('is-exiting');
+  if (actions) {
+    actions.innerHTML = `<span class="exit-chip">${esc(opt.chip)}</span>
+      <button type="button" class="cta-link exit-undo" data-undo-exit="${esc(key)}">Undo</button>`;
+  }
+  const timer = setTimeout(() => {
+    pendingExits.delete(key);
+    commit();
+  }, EXIT_HOLD_MS);
+  pendingExits.set(key, { timer, commit, row, actions, restore });
+}
+
+function undoRowExit(key) {
+  const held = pendingExits.get(key);
+  if (!held) return;
+  clearTimeout(held.timer);
+  pendingExits.delete(key);
+  held.row.classList.remove('is-exiting');
+  if (held.actions && held.restore !== null) held.actions.innerHTML = held.restore;
+  toast('Kept them where they were');
+}
+
+/* Any re-render drops the held rows, so commit them first — otherwise the
+   fade silently disappears and the write never happens. */
+function flushPendingExits() {
+  for (const [key, held] of pendingExits) {
+    clearTimeout(held.timer);
+    pendingExits.delete(key);
+    held.commit();
+  }
 }
 
 /* ---------- outreach email drafts ---------- */
@@ -970,8 +1185,10 @@ async function render() {
 function matchesView(a) {
   const out = a.stage !== 'rejected' && a.stage !== 'archived';
   if (view === 'inbox') return a.stage === 'review';
+  // Saved for future stays a candidate — visible in Candidates with its chip,
+  // absent from Openings until the return date brings them back.
   if (view === 'candidates') return a.stage === 'candidate';
-  if (view === 'openings') return activePlacements(a.id).length > 0 && out;
+  if (view === 'openings') return activePlacements(a.id).length > 0 && out && !a.exitReason;
   if (view === 'screening') return !!screeningState[a.id] && out;
   if (view === 'archive') return !out;
   return false;
@@ -1238,13 +1455,21 @@ function placementChip(a) {
 
 function rowBadge(a) {
   if (view === 'inbox') return voteChip(a);
-  if (view === 'archive') return stageChip(a);
+  // Archive carries two facts: which kind of no, and whether they've been
+  // told. The email chip only earns its place when an email is actually
+  // owed or sent — "opted out · Archived" is noise.
+  if (view === 'archive') {
+    const owed = a.stage === 'rejected' || a.updateSentAt;
+    return exitChip(a) + (owed || !a.exitReason ? stageChip(a) : '');
+  }
   if (view === 'screening') return screeningChip(a);
-  if (view === 'candidates') return placementChip(a);
+  if (view === 'candidates') return exitChip(a) || placementChip(a);
   return decisionChip(a.id);
 }
 
 function renderApplicants() {
+  // Held rows die on re-render, so their writes have to land first.
+  flushPendingExits();
   const viewList = applicants.filter(matchesView);
   const list = viewList.filter(matchesFilters);
   const filtered = list.length !== viewList.length;
@@ -1380,7 +1605,7 @@ function renderApplicants() {
         ${g.items.map(a => `
           <li class="inbox-row" ${view === 'openings' ? `draggable="true" data-row-id="${a.id}" data-row-group="${esc(g.key)}"` : ''}>
             ${repliedDot(a)}
-            ${view === 'openings' ? '<span class="inbox-row__grip" title="Drag to reorder">⠿</span>' : ''}
+            ${view === 'openings' ? '<span class="inbox-row__grip" title="Drag to reorder — or drop on another listing to move them">⠿</span>' : ''}
             <button class="inbox-row__main" data-review="${a.id}">
               ${avatarHtml(a)}
               <span class="inbox-row__text">
@@ -1430,8 +1655,9 @@ function othersAccordion(listingId) {
   </details>`;
 }
 
-/* Row-level ⋯: profile, availability link, remove, and Pass (archives +
-   queues the update email — passing always requires outreach). */
+/* Row-level ⋯: navigation up top, one Remove… below the rule. The four
+   removal outcomes live in the sheet rather than the menu — each needs a
+   consequence line ("queues an update email") that a menu can't carry. */
 function rowMenuHtml(a, listingId) {
   const mid = `row-${a.id}-${listingId}`;
   return `<span class="listing-menu-wrap">
@@ -1439,11 +1665,22 @@ function rowMenuHtml(a, listingId) {
     <span class="listing-menu" data-menu-for="${esc(mid)}" hidden>
       <button type="button" class="listing-menu__item" data-review="${a.id}">Open profile</button>
       ${a.scheduleToken ? `<button type="button" class="listing-menu__item" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
-      <button type="button" class="listing-menu__item" data-remove-placement="${a.id}|${esc(listingId)}">Remove from this listing</button>
       ${screeningState[a.id]?.watch ? `<button type="button" class="listing-menu__item" data-give-decision="${a.id}">Give decision…</button>` : ''}
-      <button type="button" class="listing-menu__item listing-menu__item--danger" data-pass-row="${a.id}">Pass on ${esc(a.first)}…</button>
+      <span class="listing-menu__rule" aria-hidden="true"></span>
+      <button type="button" class="listing-menu__item" data-open-remove="${a.id}|${esc(listingId)}">Remove…</button>
     </span>
   </span>`;
+}
+
+/* Exit state on a row outside Openings — Candidates shows saved-for-future
+   with its return date, Archive shows which kind of no it was. */
+function exitChip(a) {
+  if (!a.exitReason) return '';
+  const opt = removeOption(a.exitReason);
+  if (!opt) return '';
+  const when = a.exitReason === 'future' && a.exitUntil ? ` · ${fmtDay(a.exitUntil)}` : '';
+  const who = a.exitBy ? ` by ${a.exitBy}` : '';
+  return `<span class="decision-chip decision-chip--exit decision-chip--exit-${esc(a.exitReason)}" title="${esc(opt.hint)}${esc(who)}">${esc(opt.chip)}${esc(when)}</span>`;
 }
 
 /* Occupancy-gap sweep: stretches of 28+ days with nothing scheduled in the
@@ -1518,33 +1755,101 @@ function openGiveDecision(applicantId) {
   modal.hidden = false;
 }
 
-/* Drag-to-reorder applicants inside each listing group; shared house state. */
+/* Drag applicants inside a listing group to reorder, or across groups to
+   move them to another opening. Same-group drops write shared row order;
+   cross-group drops are a real placement move (drop the source, add the
+   target) so the auto-sweep won't undo either half. */
 let dragRow = null; // { id, group }
+
+function saveRowOrder(group, ids) {
+  const rowOrder = (settings.outreach_row_order && typeof settings.outreach_row_order === 'object') ? settings.outreach_row_order : {};
+  rowOrder[group] = ids;
+  settings.outreach_row_order = rowOrder;
+  sb.from('recruit_settings').upsert({
+    key: 'outreach_row_order', value: rowOrder,
+    updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+  }).then(({ error }) => { if (error) toast(`Order save failed: ${error.message}`); });
+}
+
+/* Move a placement between listings. The source row is deleted rather than
+   tombstoned: a 'removed' tombstone is a recruiter saying "never here
+   again", which isn't what a move means — they may well qualify later. */
+async function movePlacement(applicantId, fromListingId, toListingId) {
+  const a = applicants.find(x => x.id === applicantId);
+  const to = listings.find(l => l.id === toListingId);
+  if (!a || !to) return;
+  if (activePlacements(applicantId).some(p => p.listing_id === toListingId)) {
+    toast(`${a.first} is already on that listing`);
+    return;
+  }
+  const added = await addPlacement(applicantId, toListingId, 'manual');
+  if (!added) return;
+  const src = placements.find(p => p.applicant_id === applicantId && p.listing_id === fromListingId);
+  if (src) {
+    const { error } = await sb.from('recruit_listing_candidates').delete().eq('id', src.id);
+    if (error) { toast(`Move half-finished: ${error.message}`); }
+    else placements = placements.filter(p => p.id !== src.id);
+  }
+  const room = rooms.find(r => r.id === to.room_id);
+  toast(`${a.first} moved to ${room?.name || 'the other listing'}${qualifiesFor(a, to) ? '' : " — they don't auto-qualify there, so it'll stick"}`);
+  renderRailCounts();
+  renderApplicants();
+}
+
 function wireRowDrag(host) {
+  const clearTargets = () => host.querySelectorAll('.is-drop-target')
+    .forEach(el => el.classList.remove('is-drop-target'));
+
   host.querySelectorAll('.inbox-row[data-row-id]').forEach(row => {
     row.addEventListener('dragstart', e => {
       dragRow = { id: row.dataset.rowId, group: row.dataset.rowGroup };
       row.classList.add('is-dragging');
       e.dataTransfer.effectAllowed = 'move';
+      // Firefox won't start a drag without payload.
+      try { e.dataTransfer.setData('text/plain', row.dataset.rowId); } catch { /* */ }
     });
-    row.addEventListener('dragend', () => { row.classList.remove('is-dragging'); dragRow = null; });
+    row.addEventListener('dragend', () => {
+      row.classList.remove('is-dragging');
+      clearTargets();
+      dragRow = null;
+    });
     row.addEventListener('dragover', e => {
-      if (dragRow && row.dataset.rowGroup === dragRow.group) { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; }
+      if (!dragRow) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
     });
     row.addEventListener('drop', e => {
+      if (!dragRow) return;
       e.preventDefault();
-      if (!dragRow || row.dataset.rowGroup !== dragRow.group || row.dataset.rowId === dragRow.id) return;
-      const group = dragRow.group;
+      e.stopPropagation(); // don't also fire the section handler underneath
+      const { id, group } = dragRow;
+      clearTargets();
+      if (row.dataset.rowGroup !== group) { movePlacement(id, group, row.dataset.rowGroup); return; }
+      if (row.dataset.rowId === id) return;
       const ids = [...host.querySelectorAll(`.inbox-row[data-row-group="${CSS.escape(group)}"]`)].map(x => x.dataset.rowId);
-      ids.splice(ids.indexOf(row.dataset.rowId), 0, ids.splice(ids.indexOf(dragRow.id), 1)[0]);
-      const rowOrder = (settings.outreach_row_order && typeof settings.outreach_row_order === 'object') ? settings.outreach_row_order : {};
-      rowOrder[group] = ids;
-      settings.outreach_row_order = rowOrder;
-      sb.from('recruit_settings').upsert({
-        key: 'outreach_row_order', value: rowOrder,
-        updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
-      }).then(({ error }) => { if (error) toast(`Order save failed: ${error.message}`); });
+      ids.splice(ids.indexOf(row.dataset.rowId), 0, ids.splice(ids.indexOf(id), 1)[0]);
+      saveRowOrder(group, ids);
       renderApplicants();
+    });
+  });
+
+  // Whole-section targets — the only way to reach a listing with no rows yet.
+  host.querySelectorAll('.inbox-group[data-group-key]').forEach(section => {
+    section.addEventListener('dragover', e => {
+      if (!dragRow || section.dataset.groupKey === dragRow.group) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      section.classList.add('is-drop-target');
+    });
+    section.addEventListener('dragleave', e => {
+      if (!section.contains(e.relatedTarget)) section.classList.remove('is-drop-target');
+    });
+    section.addEventListener('drop', e => {
+      if (!dragRow || section.dataset.groupKey === dragRow.group) return;
+      e.preventDefault();
+      const { id, group } = dragRow;
+      clearTargets();
+      movePlacement(id, group, section.dataset.groupKey);
     });
   });
 }
@@ -2448,13 +2753,24 @@ function renderReviewFoot(a) {
       const room = rooms.find(r => r.id === l.room_id);
       return `<button type="button" class="decision-chip decision-chip--outreach placement-pill" data-remove-placement="${a.id}|${p.listing_id}" title="Remove from ${esc(room?.name || 'this listing')} — the auto-sweep won't re-add them">${esc(room?.name || 'Room')} ✕</button>`;
     }).join('');
-    foot.innerHTML = `
-      ${pills ? `<span class="foot-pills">${pills}</span>` : ''}
-      <span class="foot-cta">${openingsCta(a)}</span>
-      <span class="foot-links">
-        <button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Add to another listing' : 'Add to a listing'}</button>
-        <button type="button" class="cta-link cta-link--danger" data-open-decision="pass">Not a fit…</button>
-      </span>`;
+    // Saved for future: they're off the board, so the outreach CTA would be
+    // a lie. Show the standing date and a way back instead.
+    if (a.exitReason === 'future') {
+      foot.innerHTML = `
+        <span class="foot-cta"><span class="decision-chip decision-chip--exit decision-chip--exit-future">saved for future · ${esc(fmtDay(a.exitUntil))}</span></span>
+        <span class="foot-links">
+          <button type="button" class="cta-link" data-bring-back="${a.id}">Bring back now</button>
+          <button type="button" class="cta-link cta-link--danger" data-open-remove="${a.id}|">Remove…</button>
+        </span>`;
+    } else {
+      foot.innerHTML = `
+        ${pills ? `<span class="foot-pills">${pills}</span>` : ''}
+        <span class="foot-cta">${openingsCta(a)}</span>
+        <span class="foot-links">
+          <button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Add to another listing' : 'Add to a listing'}</button>
+          <button type="button" class="cta-link cta-link--danger" data-open-remove="${a.id}|">Remove…</button>
+        </span>`;
+    }
   } else {
     foot.innerHTML = `<button class="btn review__btn" data-reopen="${a.id}">Reopen — back to Inbox</button>`;
   }
@@ -3179,6 +3495,10 @@ async function _checkMembershipAndEnter() {
     // background — outreach attachment labels + rail badges need house data;
     // re-render the open view once it lands so labels don't show stale fallbacks
     loadHouse().then(async () => {
+      // Saved-for-future people whose date has landed come back first, so the
+      // placement sweep below re-places them in the same pass.
+      const back = await returnDueCandidates();
+      if (back) toast(`${back} saved candidate${back === 1 ? ' is' : 's are'} back — their date arrived`);
       const added = await syncAutoPlacements();
       if (added) toast(`${added} auto-placement${added === 1 ? '' : 's'} added across open listings`);
       const drafted = await syncDraftListings();
@@ -3360,17 +3680,28 @@ function init() {
       proseT.textContent = clamped ? 'More' : 'Less';
       return;
     }
-    const pr = e.target.closest('[data-pass-row]');
-    if (pr) {
-      const a = applicants.find(x => x.id === pr.dataset.passRow);
-      if (a && confirm(`Pass on ${fullName(a)}? They move to the Archive and get queued for an update email.`)) {
-        saveDecision(a.id, 'pass', null, null, '');
-        setStage(a.id, 'rejected').then(() => {
-          toast(`${fullName(a)} → Archived — update email queued`);
-          renderRailCounts();
-          if (VIEWS[view]?.kind === 'applicants') renderApplicants();
-        });
-      }
+    const orm = e.target.closest('[data-open-remove]');
+    if (orm) {
+      const [aid, lid] = orm.dataset.openRemove.split('|');
+      openRemoveSheet(aid, lid || null);
+      return;
+    }
+    const rpick = e.target.closest('[data-remove-pick]');
+    if (rpick) { pickRemoveOption(rpick.dataset.removePick); return; }
+    const undo = e.target.closest('[data-undo-exit]');
+    if (undo) { undoRowExit(undo.dataset.undoExit); return; }
+    const bb = e.target.closest('[data-bring-back]');
+    if (bb) {
+      const id = bb.dataset.bringBack;
+      setExit(id, null).then(async ok => {
+        if (!ok) return;
+        if (!houseLoaded) await loadHouse();
+        const added = await syncAutoPlacements();
+        toast(`Back on the board${added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : ''}`);
+        renderRailCounts();
+        if (!document.getElementById('review').hidden) renderReview();
+        else if (VIEWS[view]?.kind === 'applicants') renderApplicants();
+      });
       return;
     }
     const sp = e.target.closest('[data-slot-pick]');
@@ -3561,6 +3892,10 @@ function init() {
     if (error) { toast(`Preference save failed: ${error.message}`); e.target.checked = !value; settings.open_to_couples = !value; }
     else toast(value ? 'House preference: open to couples' : 'House preference: not open to couples');
   };
+
+  document.getElementById('remove-close').onclick = hideRemoveSheet;
+  document.getElementById('remove-cancel').onclick = hideRemoveSheet;
+  document.getElementById('remove-submit').onclick = submitRemove;
 
   document.getElementById('claim-close').onclick = closeClaimModal;
   document.getElementById('claim-cancel').onclick = closeClaimModal;

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -818,7 +818,10 @@ function pickRemoveOption(id) {
   const submit = document.getElementById('remove-submit');
   submit.disabled = false;
   submit.textContent = opt.scope ? 'Remove' : opt.label;
+  // Danger is an outline style — it replaces the accent fill, never stacks
+  // on top of it (design-system/components.css .btn--danger).
   submit.classList.toggle('btn--danger', !!opt.danger);
+  submit.classList.toggle('btn--accent', !opt.danger);
 }
 
 function hideRemoveSheet() {

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -52,6 +52,7 @@ The CTRL Design System provides a unified visual language across all ctrl.rodeo 
 - **Minimal** — Borders over fills, function over decoration
 - **Dark-first** — Dark mode default with optional light mode
 - **Accessible** — Clear visual hierarchy, readable text
+- **Transparency, never strike-through** — Removed, deferred, archived, and disabled things are expressed by reducing opacity. `text-decoration: line-through` is not used anywhere in this system. See [Removed & deferred states](#removed--deferred-states).
 
 ## Quick Start
 
@@ -565,6 +566,99 @@ Button group for admin panel sections.
 - Flexbox with gap spacing
 - Wraps on narrow screens
 - Buttons match admin panel style
+
+### Removed & deferred states
+
+**Rule: transparency, never strike-through.** Nothing in this system uses `text-decoration: line-through`. A thing on its way out is dimmed, not defaced — strike-through reads as "wrong/invalid", while these states mean "no longer here", which is a different fact.
+
+Two opacity values, both already load-bearing:
+
+| Value | Meaning | Existing users |
+|---|---|---|
+| `0.45` | **In motion, not settled** — mid-drag, mid-exit, pending a write | `.inbox-row.is-dragging`, `.inbox-row.is-exiting` |
+| `0.5` | **Settled but inactive** — closed, filled, archived, disabled | `.listing-row.is-done`, disabled buttons (`0.35`) |
+
+Do not introduce a third value for "faded" without a reason the table can't cover.
+
+**Dim the subject, not the controls.** When a row is mid-exit it still carries an outcome chip and an Undo. Those must stay at full opacity — dimming the way back hides the one control that still matters.
+
+```html
+<li class="inbox-row is-exiting">
+  <span class="inbox-row__grip">⠿</span>              <!-- dimmed -->
+  <button class="inbox-row__main">…name, avatar…</button>  <!-- dimmed -->
+  <span class="inbox-row__actions">                    <!-- full opacity -->
+    <span class="exit-chip">not a fit</span>
+    <button class="cta-link exit-undo">Undo</button>
+  </span>
+</li>
+```
+
+```css
+.inbox-row.is-exiting .inbox-row__main,
+.inbox-row.is-exiting .inbox-row__grip { opacity: 0.45; }
+.inbox-row.is-exiting .inbox-row__main { pointer-events: none; }
+```
+
+**Hold before committing.** A destructive action fades the row and waits (~6s) before writing. The row does **not** move during the hold — nothing reflows under the cursor. Undo is therefore a no-op rather than a compensating write, and any re-render must flush held rows so a pending write can't be silently dropped.
+
+*Reference implementation: `applications/js/app.js` — `beginRowExit()` / `undoRowExit()` / `flushPendingExits()`.*
+
+### Reason Sheet
+
+A destructive or branching action with **more than two outcomes** opens a sheet, not a submenu. Each option carries a one-line consequence; menus can't show that, and hover submenus fail on touch.
+
+```html
+<div class="email-modal__card remove-sheet">
+  <div class="email-modal__head">
+    <h3 class="hold-sheet__title">Remove Marisa Chen</h3>
+    <button class="review__close email-modal__close">✕</button>
+  </div>
+  <div class="remove-sheet__options">
+    <button class="remove-sheet__option">
+      <span class="remove-sheet__option-label">From this listing</span>
+      <span class="remove-sheet__option-hint">still a candidate for other rooms</span>
+    </button>
+    <button class="remove-sheet__option is-selected">…</button>
+    <button class="remove-sheet__option remove-sheet__option--danger">
+      <span class="remove-sheet__option-label">Not a fit</span>
+      <span class="remove-sheet__option-hint">our no — queues an update email</span>
+    </button>
+  </div>
+  <!-- optional: a field an option reveals inline, never a second layer -->
+  <label class="listing-form__field remove-sheet__until" hidden>…</label>
+  <textarea class="notes__input remove-sheet__note" rows="2"></textarea>
+  <div class="decision-sheet__actions">
+    <button class="hold-sheet__cancel">Cancel</button>
+    <button class="btn btn--accent btn--sm btn--danger">Not a fit</button>
+  </div>
+</div>
+```
+
+**Reason sheet rules:**
+- Options ordered **least → most final**; at most one `--danger`
+- Every option gets a hint line stating its consequence (what's written, what's sent)
+- An option needing extra input expands **inline** — never a second sheet
+- The submit button's label mirrors the chosen option, not a generic "Confirm"
+- `btn--danger` **replaces** `btn--accent` rather than stacking on it — danger is an outline style that fills on hover, so the two together produce an accent fill with a red border
+- The parent menu keeps a single entry (`Remove…`), with a `.listing-menu__rule` separating navigation from destructive items
+
+### Drop Target
+
+Whole-container drop zone for drag-and-drop between groups. Highlighting the **container** rather than an insertion line is what makes an empty group reachable.
+
+```html
+<section class="inbox-group is-drop-target" data-group-key="listing-42">…</section>
+```
+
+```css
+.inbox-group.is-drop-target { outline: 2px dashed var(--accent); outline-offset: 4px; }
+```
+
+**Drop target behavior:**
+- `outline`, not `border` — no layout shift when it appears
+- Applied on `dragover`, cleared on `dragleave` and `dragend` (guard `dragleave` with `!el.contains(e.relatedTarget)` so child elements don't flicker it off)
+- Row-level `drop` handlers must `stopPropagation()` so the container handler doesn't also fire
+- Set `dataTransfer.setData('text/plain', …)` on `dragstart` — Firefox won't start a drag without a payload
 
 ### AI Widget System (`widgets.css`)
 

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -107,7 +107,7 @@ Watch opens a **Call** tab on the applicant profile (not a modal): recording pla
 ## v3.17 amendments
 - **Review availability** (blue) replaces Pick a time; context tier shows `N windows offered`. Opens a modal: bookable slot chips per window, a **How we read it** bullet list (their verbatim snippet + date, timezone conversion note, platform request, the day-part mapping rules), and the secondary path at the bottom: *"Doesn't work with your schedule? Ask the house on Discord"* (→ claim-post preview).
 - **Post-screening primary is Schedule a visit** (blue, opens the email draft); Watch demotes to a small inline green ▶ icon beside it — an icon secondary doesn't violate the one-primary rule.
-- **Row ⋯ menu** (grip back on the left edge): Open profile · Copy availability link · Remove from this listing · **Pass on [name]…** (confirm → stage `rejected`, update email queued — passing always requires outreach).
+- **Row ⋯ menu** (grip back on the left edge): Open profile · Copy availability link · Remove from this listing · **Pass on [name]…** (confirm → stage `rejected`, update email queued — passing always requires outreach). *Superseded in v3.24 — see below.*
 
 
 ## v3.23 (2026-07-27) — the outstanding list
@@ -119,3 +119,61 @@ Watch opens a **Call** tab on the applicant profile (not a modal): recording pla
 - **Schedule a visit** drafts a visit-specific invite (`emailType: 'visit'`).
 - **Flexible dial**: bare "Flexible" rides any window; "month + flexible" = that month ±1.
 - **Auto-post toggle**: `discord_auto_post` setting (rail footer checkbox) — the manual→auto claim cutover without a deploy.
+
+## v3.24 (2026-07-29) — removing someone
+
+`Pass` collapsed three different outcomes into one destructive action that always archived **and** queued a rejection email. They're now four, behind one gesture.
+
+### The ⋯ menu
+
+Navigation on top, a rule, then one item:
+
+```
+Open profile
+Copy availability link
+Give decision…            (only when a recording exists)
+──────────────────────
+Remove…
+```
+
+The four outcomes live in a **sheet**, not a submenu — each needs a consequence line that a menu can't carry, and hover submenus are unreliable on a touch surface where the row is already a drag handle.
+
+### The Remove sheet
+
+| Option | Hint | Stage | Placements | Email owed |
+|---|---|---|---|---|
+| **From this listing** | still a candidate for other rooms | unchanged | tombstones *this* one | none |
+| **Save for future** | right person, wrong time — pick when to bring them back | `candidate` | all cleared | none |
+| **Opted out** | they withdrew — no update email owed | `archived` | all cleared | **none** |
+| **Not a fit** | our no — queues an update email | `rejected` | all cleared | queued in the update tray |
+
+*From this listing* only appears when the sheet is opened from an Openings row — there's no "this listing" to scope to from a profile. *Save for future* expands a date field inline (defaults to three months out).
+
+Ordered least → most final; only *Not a fit* is red.
+
+### Where they show up afterward
+
+| Outcome | Openings | Candidates | Archive |
+|---|---|---|---|
+| From this listing | leaves that group; reachable under "See other qualified applicants" with `removed` + **Add** | unchanged | — |
+| Save for future | gone until the date | `saved for future · Mar 1, 2027` chip; foot offers **Bring back now** | — |
+| Opted out | gone | — | `opted out` chip |
+| Not a fit | gone | — | `not a fit` chip |
+
+**Save for future auto-returns.** `returnDueCandidates()` runs at load: anyone whose `exit_until` has passed has the exit cleared, and the placement sweep re-places them in the same pass. Without the return trip it would just be Archive with extra steps.
+
+### Transparency exit (never strike-through)
+
+Picking an option doesn't write immediately. The row fades to `opacity: .45` — the same value `.inbox-row.is-dragging` uses, i.e. "in motion, not settled" — swaps its actions for the outcome chip plus **Undo**, and holds 6s. It never moves while the window is open, so nothing reflows under the cursor. Undo is a no-op rather than a compensating write; any re-render flushes held rows so a pending write can't be silently lost.
+
+**Strike-through is not used anywhere in this design system.** Removed, deferred, and archived states are all expressed with transparency.
+
+### Cross-listing drag
+
+Dragging a row onto **another** listing moves the placement (add target, delete source). Dropping inside the same group still reorders. The whole `.inbox-group` is a drop target, so a listing with no rows yet is reachable; it outlines while hovered.
+
+The source placement is **deleted, not tombstoned** — a tombstone means "never here again", which isn't what a move means. If the person doesn't auto-qualify for the target, the toast says so (the manual placement will stick).
+
+### Schema
+
+Migration 135: `recruit_applicants.exit_reason` (`future` | `opted_out` | `not_a_fit`), `exit_until` (DATE, only valid with `future`), `exit_note`, `exit_by_name`, `exit_at`. Writes go through the `recruit_set_exit` RPC — the table stays client-read-only, same pattern as `recruit_set_stage`. Passing a NULL reason clears the exit (that's Bring back now). "From this listing" is *not* recorded here — `recruit_listing_candidates.status` already holds that tombstone.

--- a/supabase/migrations/135_recruit_exit_reason.sql
+++ b/supabase/migrations/135_recruit_exit_reason.sql
@@ -1,0 +1,99 @@
+-- ============================================
+-- Migration 135: why someone left a listing
+--
+-- "Pass" used to collapse three different outcomes into one destructive
+-- action that always archived AND queued a rejection email. They're
+-- distinct facts and the house needs to tell them apart:
+--
+--   listing      removed from THIS listing only — still a candidate elsewhere
+--   future       right person, wrong time — comes back on exit_until
+--   opted_out    they withdrew — archived, no update email owed
+--   not_a_fit    our no — archived, update email owed (today's 'pass')
+--
+-- Only 'future' uses exit_until: the client's auto-return sweep filters on
+-- it, so it has to be a real DATE rather than a note. The other three leave
+-- it NULL.
+--
+-- 'listing' is deliberately NOT recorded here — it's per-listing, and
+-- recruit_listing_candidates.status already holds that tombstone. This
+-- column answers "why are they out of the funnel", not "which room".
+--
+-- Writes go through an RPC (recruit_applicants stays client-read-only, same
+-- pattern as recruit_set_stage / recruit_set_move_in). Passing a NULL reason
+-- clears the exit — that's the Undo path.
+-- ============================================
+
+ALTER TABLE recruit_applicants
+  ADD COLUMN IF NOT EXISTS exit_reason TEXT,
+  ADD COLUMN IF NOT EXISTS exit_until DATE,
+  ADD COLUMN IF NOT EXISTS exit_note TEXT,
+  ADD COLUMN IF NOT EXISTS exit_by_name TEXT,
+  ADD COLUMN IF NOT EXISTS exit_at TIMESTAMPTZ;
+
+DO $$
+BEGIN
+  ALTER TABLE recruit_applicants
+    ADD CONSTRAINT recruit_applicants_exit_reason_chk
+    CHECK (exit_reason IS NULL OR exit_reason IN ('future', 'opted_out', 'not_a_fit'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- A return date only means something for 'future'.
+DO $$
+BEGIN
+  ALTER TABLE recruit_applicants
+    ADD CONSTRAINT recruit_applicants_exit_until_chk
+    CHECK (exit_until IS NULL OR exit_reason = 'future');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Partial index: the auto-return sweep asks "who's due back?" on every load.
+CREATE INDEX IF NOT EXISTS recruit_applicants_exit_until_idx
+  ON recruit_applicants (exit_until)
+  WHERE exit_reason = 'future';
+
+CREATE OR REPLACE FUNCTION recruit_set_exit(
+  p_applicant TEXT,
+  p_reason TEXT,
+  p_until DATE,
+  p_note TEXT,
+  p_name TEXT
+)
+RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  IF p_reason IS NOT NULL AND p_reason NOT IN ('future', 'opted_out', 'not_a_fit') THEN
+    RAISE EXCEPTION 'unknown exit reason %', p_reason;
+  END IF;
+  IF p_until IS NOT NULL AND p_reason IS DISTINCT FROM 'future' THEN
+    RAISE EXCEPTION 'only a future-fit exit carries a return date';
+  END IF;
+  IF p_reason = 'future' AND p_until IS NULL THEN
+    RAISE EXCEPTION 'a future-fit exit needs a return date';
+  END IF;
+
+  UPDATE recruit_applicants SET
+    exit_reason  = p_reason,
+    exit_until   = p_until,
+    exit_note    = CASE WHEN p_reason IS NULL THEN NULL ELSE p_note END,
+    exit_by_name = CASE WHEN p_reason IS NULL THEN NULL ELSE p_name END,
+    exit_at      = CASE WHEN p_reason IS NULL THEN NULL ELSE NOW() END
+  WHERE id = p_applicant;
+END;
+$$;
+
+-- Backfill: everyone already archived by a recruiter 'pass' decision was,
+-- under the old single-verb model, always our no. Historical rows keep
+-- their attribution; the update-email state is untouched either way.
+UPDATE recruit_applicants a
+  SET exit_reason = 'not_a_fit',
+      exit_by_name = d.decided_by_name,
+      exit_at = d.decided_at
+  FROM recruit_decisions d
+  WHERE d.applicant_id = a.id
+    AND d.decision = 'pass'
+    AND a.stage IN ('rejected', 'archived')
+    AND a.exit_reason IS NULL;


### PR DESCRIPTION
## What

`Pass` collapsed three different outcomes into one destructive action that always archived **and** queued a rejection email. Now four, behind one gesture.

### The ⋯ menu

```
Open profile
Copy availability link
Give decision…
──────────────────────
Remove…
```

Navigation on top, a rule, one removal item. The outcomes live in a **sheet**, not a submenu — each needs a consequence line a menu can't carry, and hover submenus are unreliable on a touch surface where the row is already a drag handle.

### The Remove sheet

| Option | Hint | Stage | Placements | Email owed |
|---|---|---|---|---|
| From this listing | still a candidate for other rooms | unchanged | tombstones *this* one | none |
| Save for future | right person, wrong time | `candidate` | all cleared | none |
| Opted out | they withdrew | `archived` | all cleared | **none** |
| Not a fit | our no | `rejected` | all cleared | queued in update tray |

*From this listing* only appears when opened from an Openings row. *Save for future* expands a date field inline (defaults three months out). Ordered least → most final; only *Not a fit* is red.

**Save for future auto-returns** — `returnDueCandidates()` clears the exit at load once the date passes, and the placement sweep re-places them in the same pass. Without the return trip it's just Archive with extra steps.

### Transparency exit

The row fades to `opacity: .45` — the same value `.inbox-row.is-dragging` uses — swaps its actions for the outcome chip plus **Undo**, and holds 6s before anything is written. Undo is a no-op, not a compensating write. The row never moves while the window is open, so nothing reflows under the cursor. The chip and Undo stay at full opacity; only the person's name and avatar fade.

**Strike-through is not used anywhere in this design system** and isn't introduced here (`grep line-through` was and stays zero).

### Cross-listing drag

Dropping a row on another listing moves the placement. Same-group drops still reorder. Whole `.inbox-group` sections are drop targets, so a listing with no rows yet is reachable. The source placement is deleted rather than tombstoned — a tombstone means "never here again", which a move isn't.

### Schema

Migration 135: `exit_reason` (`future` | `opted_out` | `not_a_fit`), `exit_until` (DATE, only valid with `future`), `exit_note`, `exit_by_name`, `exit_at`, behind a `recruit_set_exit` RPC so `recruit_applicants` stays client-read-only. Backfills historical `pass` decisions to `not_a_fit`. "From this listing" isn't recorded here — `recruit_listing_candidates.status` already holds that tombstone.

## Verification

- `node --check` clean.
- New sheet, exit states, chips, menu, and drop target rendered in Chrome against the real `app.css`; two contrast bugs found and fixed in the process (danger button label, and the exit chip/Undo being dimmed by the row fade).
- Not exercised end-to-end behind the Discord gate — needs the deploy.

## Docs

`docs/ux/recruiting-row-states.md` — new v3.24 section; the v3.17 ⋯ menu entry marked superseded.

`VERSION` → 3.24.0 (app.js + both cache-busting query strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)