### PR TITLE
Recruiting: 'claim' → screener scheduler

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.26.0">
+  <link rel="stylesheet" href="css/app.css?v=3.27.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -144,14 +144,14 @@
   <div class="email-modal" id="claim-modal" hidden>
     <div class="email-modal__card">
       <div class="email-modal__head">
-        <h3 class="hold-sheet__title">Send to housemates to claim</h3>
+        <h3 class="hold-sheet__title">Ask housemates for coverage</h3>
         <button class="review__close email-modal__close" id="claim-close" aria-label="Close">✕</button>
       </div>
       <p class="email-modal__status" id="claim-status"></p>
       <div id="claim-preview-body"></div>
       <div class="decision-sheet__actions">
         <button class="hold-sheet__cancel" id="claim-cancel" type="button">Cancel</button>
-        <button class="btn btn--accent btn--sm" id="claim-post-btn" type="button" disabled>Send to housemates</button>
+        <button class="btn btn--accent btn--sm" id="claim-post-btn" type="button" disabled>Post the scheduler</button>
       </div>
     </div>
   </div>
@@ -258,6 +258,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.26.0"></script>
+  <script src="js/app.js?v=3.27.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.26.0';
+const VERSION = '3.27.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -458,7 +458,7 @@ function openingsCta(a) {
   if (sc?.availability && claim && (claim.status === 'open' || claim.status === 'manual')) {
     const days = Math.max(0, Math.round((Date.now() - new Date(claim.postedAt).getTime()) / 86400000));
     return stack(`<span class="decision-chip decision-chip--outreach">◆ sent to housemates</span>`,
-      `unclaimed ${days === 0 ? 'today' : `${days}d`} · <button type="button" class="cta-link" data-avail-review="${a.id}">book it yourself</button>`);
+      `no screener yet · ${days === 0 ? 'sent today' : `${days}d`} · <button type="button" class="cta-link" data-avail-review="${a.id}">book it yourself</button>`);
   }
   if (sc?.availability) return stack(
     `<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-avail-review="${a.id}">Review availability</button>`,
@@ -2937,28 +2937,28 @@ function schedulingHtml(a) {
           <span class="avail-card__slots">${windowSlots(w).map(d =>
             `<button type="button" class="chip" data-slot="${d.toISOString()}" data-slot-applicant="${a.id}">${d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</button>`).join('') || '<span class="notes__empty">window already passed</span>'}</span>
         </div>`).join('')}
-      <p class="avail-card__discord">…or <button type="button" class="btn btn--sm btn--discord" data-claim-preview="${a.id}"><svg class="btn-discord__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Send to housemates to claim…</button>
-        <span class="notes__empty">first housemate to claim a slot runs the call (manual for now)</span></p>
+      <p class="avail-card__discord">…or <button type="button" class="btn btn--sm btn--discord" data-claim-preview="${a.id}"><svg class="btn-discord__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Ask for coverage…</button>
+        <span class="notes__empty">first housemate to sign up runs the screener (manual for now)</span></p>
     </div>`);
   } else if (!screenings.length) {
-    parts.push(`<p class="notes__empty">No availability captured yet — when they reply with days/times, windows appear here automatically.${emailState[a.id]?.lastDir === 'in' ? ` <button type="button" class="btn btn--sm btn--discord" data-claim-preview="${a.id}"><svg class="btn-discord__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Send to housemates to claim…</button>` : ''}</p>`);
+    parts.push(`<p class="notes__empty">No availability captured yet — when they reply with days/times, windows appear here automatically.${emailState[a.id]?.lastDir === 'in' ? ` <button type="button" class="btn btn--sm btn--discord" data-claim-preview="${a.id}"><svg class="btn-discord__icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Ask for coverage…</button>` : ''}</p>`);
   }
   return parts.join('');
 }
 
-/* ---------- manual Discord claim trigger (preview → post) ---------- */
-let claimCtx = null; // { applicantId, extraction } while the modal is open
+/* ---------- screener scheduler: manual Discord trigger (preview → post) ---------- */
+let schedulerCtx = null; // { applicantId, extraction } while the modal is open
 
-async function openClaimPreview(applicantId) {
-  claimCtx = { applicantId, extraction: null };
+async function openSchedulerPreview(applicantId) {
+  schedulerCtx = { applicantId, extraction: null };
   document.getElementById('claim-modal').hidden = false;
-  document.getElementById('claim-status').textContent = 'Reading their reply and composing the post…';
+  document.getElementById('claim-status').textContent = 'Reading their reply and composing the screener scheduler…';
   document.getElementById('claim-preview-body').innerHTML = '';
   document.getElementById('claim-post-btn').disabled = true;
   try {
-    const out = await gmailCall({ action: 'claim-preview', applicantId });
-    if (claimCtx?.applicantId !== applicantId) return; // closed meanwhile
-    claimCtx.extraction = out.extraction;
+    const out = await gmailCall({ action: 'scheduler-preview', applicantId });
+    if (schedulerCtx?.applicantId !== applicantId) return; // closed meanwhile
+    schedulerCtx.extraction = out.extraction;
     const emb = out.preview?.embeds?.[0] || {};
     document.getElementById('claim-status').textContent = 'This exact message goes to #recruiting-automation:';
     document.getElementById('claim-preview-body').innerHTML = `
@@ -2973,19 +2973,19 @@ async function openClaimPreview(applicantId) {
   }
 }
 
-function closeClaimModal() {
-  claimCtx = null;
+function closeSchedulerModal() {
+  schedulerCtx = null;
   document.getElementById('claim-modal').hidden = true;
 }
 
-async function postClaimFromModal() {
-  if (!claimCtx?.extraction) return;
+async function postSchedulerFromModal() {
+  if (!schedulerCtx?.extraction) return;
   const btn = document.getElementById('claim-post-btn');
   btn.disabled = true; btn.textContent = 'Posting…';
   try {
-    const out = await gmailCall({ action: 'claim-post', applicantId: claimCtx.applicantId, extraction: claimCtx.extraction });
-    toast(out.posted ? 'Posted to #recruiting-automation — first claim wins' : 'Already claimed — not reposted');
-    closeClaimModal();
+    const out = await gmailCall({ action: 'scheduler-post', applicantId: schedulerCtx.applicantId, extraction: schedulerCtx.extraction });
+    toast(out.posted ? 'Screener scheduler posted — first housemate to sign up runs it' : 'A screener already signed up — not reposted');
+    closeSchedulerModal();
   } catch (e) {
     toast(`Post failed: ${e.message}`);
   }
@@ -3010,7 +3010,7 @@ async function openAvailModal(applicantId) {
   try {
     const [avRes, out] = await Promise.all([
       sb.from('recruit_availability').select('windows, source_gmail_id, updated_at').eq('applicant_id', applicantId).maybeSingle(),
-      gmailCall({ action: 'claim-preview', applicantId }).catch(() => ({})),
+      gmailCall({ action: 'scheduler-preview', applicantId }).catch(() => ({})),
     ]);
     const av = avRes.data;
     let srcEmail = null;
@@ -3753,7 +3753,7 @@ function init() {
       return;
     }
     const cp = e.target.closest('[data-claim-preview]');
-    if (cp) { openClaimPreview(cp.dataset.claimPreview); return; }
+    if (cp) { openSchedulerPreview(cp.dataset.claimPreview); return; }
     const pt = e.target.closest('[data-pick-time]');
     if (pt) {
       openReview(pt.dataset.pickTime);
@@ -3903,14 +3903,14 @@ function init() {
   document.getElementById('remove-cancel').onclick = hideRemoveSheet;
   document.getElementById('remove-submit').onclick = submitRemove;
 
-  document.getElementById('claim-close').onclick = closeClaimModal;
-  document.getElementById('claim-cancel').onclick = closeClaimModal;
-  document.getElementById('claim-post-btn').onclick = postClaimFromModal;
+  document.getElementById('claim-close').onclick = closeSchedulerModal;
+  document.getElementById('claim-cancel').onclick = closeSchedulerModal;
+  document.getElementById('claim-post-btn').onclick = postSchedulerFromModal;
   document.getElementById('avail-close').onclick = closeAvailModal;
   document.getElementById('avail-ask-coverage').onclick = () => {
     const id = availApplicantId;
     closeAvailModal();
-    if (id) openClaimPreview(id);
+    if (id) openSchedulerPreview(id);
   };
   document.getElementById('email-close').onclick = closeEmailModal;
   document.getElementById('email-regen').onclick = () => emailApplicantId && generateEmail(emailApplicantId);
@@ -3965,7 +3965,7 @@ function init() {
     if (e.target instanceof Element && e.target.matches('input, textarea')) return;
     if (e.key === 'Escape') {
       if (!document.getElementById('email-modal').hidden) closeEmailModal();
-      else if (!document.getElementById('claim-modal').hidden) closeClaimModal();
+      else if (!document.getElementById('claim-modal').hidden) closeSchedulerModal();
       else if (!document.getElementById('listing-modal').hidden) closeListingModal();
       else if (!document.getElementById('decision-sheet').hidden) hideDecisionSheet();
       else closeReview();

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -166,7 +166,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>design system · v3.25</span><a href="/design-system/">← all design systems</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>design system · v3.27</span><a href="/design-system/">← all design systems</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -579,7 +579,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <div class="notes">
       <h3>Notes</h3>
       <ul>
-        <li><b>#recruiting-automation</b> is the audit hub (formerly #recruiting-interviews — same channel, renamed). Claim posts live here; everything else is mirrored here.</li>
+        <li><b>#recruiting-automation</b> is the audit hub (formerly #recruiting-interviews — same channel, renamed). Screener schedulers live here; everything else is mirrored here.</li>
         <li><b>#recruiting-society</b> is the members channel: new-application pings, Intro Call notes and recordings, live-call announcements.</li>
         <li>Mirrors are one compact line — label, target channel, first line of the real message. Best-effort: an audit failure never breaks the automation it describes, and messages that already went to the automation channel aren't echoed.</li>
         <li><b>DMs are audited too</b> — the house sees that a claimer confirmation went out without seeing the thread.</li>

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -185,3 +185,8 @@ The source placement is **deleted, not tombstoned** — a tombstone means "never
 ### Schema
 
 Migration 135: `recruit_applicants.exit_reason` (`future` | `opted_out` | `not_a_fit`), `exit_until` (DATE, only valid with `future`), `exit_note`, `exit_by_name`, `exit_at`. Writes go through the `recruit_set_exit` RPC — the table stays client-read-only, same pattern as `recruit_set_stage`. Passing a NULL reason clears the exit (that's Bring back now). "From this listing" is *not* recorded here — `recruit_listing_candidates.status` already holds that tombstone.
+
+## v3.27 — "claim" becomes "screener scheduler"
+The Discord post that offers an applicant's open times is a **screener scheduler**; a housemate **signs up** for a slot and becomes the **screener**. Row copy reads *"no screener yet · 2d"*, the app action stays **Ask for coverage**, and the preview modal is *"Ask housemates for coverage"* → **Post the scheduler**.
+
+"Claim" survives only where changing it would break things: the `recruit_claim_posts` table and `claimed_*` columns (a rename buys nothing), and Discord `custom_id`s — **live posted buttons carry `claim|…`, so that wire format is frozen**. The edge function accepts both `scheduler-preview`/`scheduler-post` and the legacy `claim-*` action names so a cached browser keeps working.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -1,6 +1,12 @@
 // _shared/discord.ts
-// Discord REST helpers for the recruiting automations: claim posts, notes,
-// pings, DMs. Used by recruit-gmail, recruit-availability, recruit-discord.
+// Discord REST helpers for the recruiting automations: screener schedulers,
+// notes, pings, DMs. Used by recruit-gmail, recruit-availability, recruit-discord.
+//
+// Vocabulary (2026-07): the post that offers an applicant's open times is a
+// SCREENER SCHEDULER; a housemate SIGNS UP for a slot and becomes the
+// SCREENER. "Claim" survives only in storage (recruit_claim_posts, claimed_*)
+// and in Discord custom_ids — live posted buttons carry `claim|…`, so the
+// wire format is frozen for compatibility.
 //
 // Channel roles:
 //   #recruiting-automation — every automated message the app sends lands
@@ -117,7 +123,7 @@ export function deriveSlots(windows: Array<{ date: string; start: string; end: s
 
 // ---- claim message --------------------------------------------------------
 
-export interface ClaimPostInput {
+export interface ScreenerSchedulerInput {
   applicantId: string
   firstName: string
   whyLine: string | null
@@ -149,7 +155,7 @@ function possessive(pronouns: string | null | undefined): string {
 
 // Exported so the app can render a faithful preview before a human
 // triggers the post (auto-posting is off for now — manual first).
-export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<string, unknown> {
+export function buildMessage(input: ScreenerSchedulerInput, slots: Slot[]): Record<string, unknown> {
   const manual = input.needsHuman || !slots.length
   const poss = possessive(input.pronouns)
 
@@ -175,7 +181,7 @@ export function buildMessage(input: ClaimPostInput, slots: Slot[]): Record<strin
       `Can someone take this Intro Call with **${input.firstName}**?\n\n` +
       considerationsBlock +
       `See ${poss} [application](${appLink(input.applicantId)}).\n\n` +
-      `_Tap a time below to claim the call — you'll both receive an invite and be added to the email thread._`
+      `_Tap a time to sign up — you'll both receive an invite and be added to the email thread._`
   }
 
   const components: Array<Record<string, unknown>> = []
@@ -219,11 +225,11 @@ async function postOrPatch(channelId: string, messageId: string | null, payload:
 // in BOTH #recruiting-automation and #recruiting-society. Either copy is
 // claimable; both carry the same custom_ids so the claim handler is agnostic.
 // Returns the recruit_claim_posts row, or null when posting was skipped.
-export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promise<any | null> {
+export async function upsertScreenerScheduler(db: any, input: ScreenerSchedulerInput): Promise<any | null> {
   const { data: existing } = await db.from('recruit_claim_posts')
     .select('*').eq('applicant_id', input.applicantId).maybeSingle()
   if (existing?.status === 'claimed') {
-    console.log(`[discord] claim post for ${input.applicantId} already claimed — skipping repost`)
+    console.log(`[discord] screener scheduler for ${input.applicantId} already signed up — skipping repost`)
     return null
   }
 
@@ -253,12 +259,12 @@ export async function upsertClaimMessage(db: any, input: ClaimPostInput): Promis
     reminded_at: null,
     updated_at: new Date().toISOString(),
   }).select().single()
-  if (error) throw new Error(`claim post upsert failed: ${error.message}`)
-  console.log(`[discord] claim post ${existing ? 'updated' : 'created'} for ${input.applicantId} (${slots.length} slots, ${status}, mirror=${Boolean(mirror)})`)
+  if (error) throw new Error(`screener scheduler upsert failed: ${error.message}`)
+  console.log(`[discord] screener scheduler ${existing ? 'updated' : 'created'} for ${input.applicantId} (${slots.length} slots, ${status}, mirror=${Boolean(mirror)})`)
   return row
 }
 
-// A claim post row's message targets: primary + mirror when present.
+// A scheduler row's message targets: primary + mirror when present.
 // deno-lint-ignore no-explicit-any
 function postTargets(post: any): Array<{ channelId: string; messageId: string }> {
   const targets = [{ channelId: post.discord_channel_id, messageId: post.discord_message_id }]
@@ -269,7 +275,7 @@ function postTargets(post: any): Array<{ channelId: string; messageId: string }>
 }
 
 // deno-lint-ignore no-explicit-any
-async function editClaimPostEverywhere(post: any, payload: Record<string, unknown>): Promise<void> {
+async function editSchedulerEverywhere(post: any, payload: Record<string, unknown>): Promise<void> {
   for (const t of postTargets(post)) {
     try {
       await discordFetch(`/channels/${t.channelId}/messages/${t.messageId}`, {
@@ -283,35 +289,35 @@ async function editClaimPostEverywhere(post: any, payload: Record<string, unknow
 
 // Close a claimed post (both copies): strip buttons, green announcement.
 // deno-lint-ignore no-explicit-any
-export async function editClaimMessageClaimed(
-  post: any, claimerDiscordId: string,
+export async function editSchedulerSignedUp(
+  post: any, screenerDiscordId: string,
   applicantName: string, applicantId: string, when: string,
 ): Promise<void> {
-  await editClaimPostEverywhere(post, {
+  await editSchedulerEverywhere(post, {
     embeds: [{
-      description: `✅ <@${claimerDiscordId}> will be interviewing **${applicantName}** on ${when} — [see the candidate background here](${appLink(applicantId)}).`,
+      description: `✅ <@${screenerDiscordId}> is screening **${applicantName}** on ${when} — [see the candidate background here](${appLink(applicantId)}).`,
       color: 0x2ecc71,
     }],
     components: [],
   })
 }
 
-// Mark a claimed post (both copies) that hit an error downstream.
+// Mark a signed-up scheduler (both copies) that hit an error downstream.
 // deno-lint-ignore no-explicit-any
-export async function editClaimMessageFailed(
-  post: any, claimerDiscordId: string,
+export async function editSchedulerFailed(
+  post: any, screenerDiscordId: string,
   applicantId: string, when: string,
 ): Promise<void> {
-  await editClaimPostEverywhere(post, {
+  await editSchedulerEverywhere(post, {
     embeds: [{
-      description: `⚠️ <@${claimerDiscordId}> claimed this interview (${when}) but the calendar invite failed — [book manually in the app](${appLink(applicantId)}).`,
+      description: `⚠️ <@${screenerDiscordId}> signed up for this screener (${when}) but the calendar invite failed — [book manually in the app](${appLink(applicantId)}).`,
       color: 0xe74c3c,
     }],
     components: [],
   })
 }
 
-/* DMs are audited as well: a claimer's confirmation is an automation the
+/* DMs are audited as well: a screener's confirmation is an automation the
    house should be able to see happened, without exposing the DM thread. */
 export async function dmUser(discordUserId: string, content: string): Promise<void> {
   const channel = await discordFetch('/users/@me/channels', {
@@ -466,6 +472,6 @@ export async function postChannelEmbed(channelId: string, description: string, c
 export async function notifyStuck(channelId: string, messageId: string, firstName: string): Promise<void> {
   const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
   await postResilient(channelId, {
-    content: `⏰ **${firstName}**'s Agape Intro Call has been unclaimed for 4 days — anyone free? https://discord.com/channels/${guildId}/${channelId}/${messageId}`,
+    content: `⏰ **${firstName}**'s Agape intro call still needs a screener after 4 days — anyone free? https://discord.com/channels/${guildId}/${channelId}/${messageId}`,
   }, `stuck nudge (${firstName})`)
 }

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -12,7 +12,7 @@ console.log(`[recruit-availability] v${VERSION} — public applicant availabilit
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { upsertClaimMessage } from '../_shared/discord.ts'
+import { upsertScreenerScheduler } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -62,7 +62,7 @@ serve(async (req) => {
       try {
         const { data: full } = await client.from('recruit_applicants')
           .select('why_agape, pronouns').eq('id', applicant.id).maybeSingle()
-        await upsertClaimMessage(client, {
+        await upsertScreenerScheduler(client, {
           applicantId: applicant.id, firstName: applicant.first_name,
           whyLine: full?.why_agape || null, pronouns: full?.pronouns || null,
           windows, platform: null, timezoneNote: null, needsHuman: false,

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -19,7 +19,7 @@ console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sig
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { scheduleScreening, sendIntroEmail, sharedAccessToken } from '../_shared/recruit-schedule.ts'
-import { editClaimMessageClaimed, editClaimMessageFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
+import { editSchedulerSignedUp, editSchedulerFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
 
@@ -111,14 +111,14 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     })
 
     const applicantName = `${applicant.first_name} ${applicant.last_name || ''}`.trim()
-    await editClaimMessageClaimed(claimPost, opts.discordUserId, applicantName, applicantId, slotWhen(startsAt))
+    await editSchedulerSignedUp(claimPost, opts.discordUserId, applicantName, applicantId, slotWhen(startsAt))
 
     const platform = claimPost.platform as { kind?: string; handle?: string } | null
     const platformLine = platform?.kind
       ? `\nHeads up: they asked for ${platform.kind}${platform.handle ? ` (@${platform.handle})` : ''} — default is the Meet link, but feel free to DM them about it.`
       : ''
     await dmUser(opts.discordUserId,
-      `✅ You claimed **${applicantName}**'s Agape Intro Call — ${slotWhen(startsAt)}.\n` +
+      `✅ You're screening **${applicantName}** — Agape intro call — ${slotWhen(startsAt)}.\n` +
       `Calendar invites are out to you both. Meet: ${meetLink || '(see calendar invite)'}${platformLine}`)
 
     try {
@@ -131,7 +131,7 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     // Never reopen the post (avoids double-booking) — flag it and tell the claimer.
     console.error(`[recruit-discord] claim finish failed for ${applicantId}: ${(err as Error).message}`)
     try {
-      await editClaimMessageFailed(claimPost, opts.discordUserId, applicantId, slotWhen(startsAt))
+      await editSchedulerFailed(claimPost, opts.discordUserId, applicantId, slotWhen(startsAt))
     } catch { /* best effort */ }
     try {
       await dmUser(opts.discordUserId,

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.15.0'
+const VERSION = '1.16.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID } from '../_shared/discord.ts'
+import { upsertScreenerScheduler, editSchedulerSignedUp, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID } from '../_shared/discord.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -121,7 +121,7 @@ async function postClaim(client: ReturnType<typeof db>, applicantId: string, ext
     const { data: applicant } = await client.from('recruit_applicants')
       .select('first_name, why_agape, pronouns').eq('id', applicantId).maybeSingle()
     if (!applicant) return
-    await upsertClaimMessage(client, {
+    await upsertScreenerScheduler(client, {
       applicantId, firstName: applicant.first_name, whyLine: applicant.why_agape, pronouns: applicant.pronouns,
       windows: extraction.windows, platform: extraction.platform,
       timezoneNote: extraction.timezone_note, needsHuman: extraction.needs_human,
@@ -396,7 +396,7 @@ serve(async (req) => {
             .select('discord_user_id').eq('user_id', userData.user.id).maybeSingle()
           if (dm?.discord_user_id) {
             const applicantName = `${result.applicant.first_name} ${result.applicant.last_name || ''}`.trim()
-            await editClaimMessageClaimed(post, dm.discord_user_id, applicantName, applicantId, slotWhen(startsAt))
+            await editSchedulerSignedUp(post, dm.discord_user_id, applicantName, applicantId, slotWhen(startsAt))
           }
         }
       } catch (err) {
@@ -459,7 +459,10 @@ serve(async (req) => {
       return json({ recordings: data || [] })
     }
 
-    if (action === 'claim-preview' || action === 'claim-post') {
+    // 'scheduler-*' is the current vocabulary; 'claim-*' stays accepted so a
+    // browser holding a cached app.js keeps working after this rename.
+    if (action === 'scheduler-preview' || action === 'scheduler-post' || action === 'claim-preview' || action === 'claim-post') {
+      const isPreview = action === 'scheduler-preview' || action === 'claim-preview'
       // Manual Discord trigger: preview composes the exact message; post
       // sends it. The extraction rides back from preview to post so Haiku
       // runs once. Future cutover: re-enable the auto postClaim calls.
@@ -485,11 +488,11 @@ serve(async (req) => {
       }
       const slots = extraction.needs_human ? [] : deriveSlots(extraction.windows)
       const message = buildMessage(input, slots)
-      if (action === 'claim-preview') {
+      if (isPreview) {
         return json({ preview: message, slotLabels: slots.map((sl) => sl.label), extraction })
       }
-      const row = await upsertClaimMessage(client, input)
-      return json({ posted: !!row, alreadyClaimed: !row })
+      const row = await upsertScreenerScheduler(client, input)
+      return json({ posted: !!row, alreadySignedUp: !row, alreadyClaimed: !row })
     }
 
     if (action === 'archive-now') {


### PR DESCRIPTION
Renames the domain vocabulary: the Discord post offering an applicant's open times is a **screener scheduler**, a housemate **signs up** for a slot, and they become the **screener**.

Copy: *"Tap a time to sign up"* · *"✅ @name is screening Marisa"* · row context *"no screener yet · 2d"* · modal *"Ask housemates for coverage" → "Post the scheduler"*. Identifiers renamed to match.

**Frozen on purpose:** the `recruit_claim_posts` table/`claimed_*` columns (rename buys nothing) and Discord `custom_id`s — live posted buttons carry `claim|…`, so changing that would break every message already in the channel. The function also still accepts the legacy `claim-preview`/`claim-post` action names so a browser on a cached app.js keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)