### PR TITLE
Recruiting: automated application ingest from the sheet

### DIFF
--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -229,3 +229,9 @@ Hardcoded in `boards/index.html` (public, by design):
 ---
 
 *Last updated: 2026-02-05*
+
+## recruit-ingest (application sheet → Inbox)
+```bash
+supabase functions deploy recruit-ingest --project-ref yfhudwakpgzswiylhfbh --no-verify-jwt
+```
+`--no-verify-jwt` is required: the caller is a Google Apps Script, authenticated by the `RECRUIT_INGEST_SECRET` header instead of a user JWT. Setup + the script to paste into the sheet: [recruiting-sheet-ingest.md](./recruiting-sheet-ingest.md).

--- a/docs/infrastructure/recruiting-sheet-ingest.md
+++ b/docs/infrastructure/recruiting-sheet-ingest.md
@@ -1,0 +1,87 @@
+# Application sheet → Inbox (automated ingest)
+
+**One line:** the application spreadsheet pushes each new row to the `recruit-ingest` edge function on submit, so applicants appear in `/applications` Inbox without a manual import.
+
+Status: **endpoint live** (`recruit-ingest` v1.0.1) · **one setup step left in the sheet** (below).
+
+---
+
+## Why push, not pull
+
+Google Sheets has no native webhook. The two real options:
+
+| Approach | Latency | Cost to set up | Notes |
+|---|---|---|---|
+| **Apps Script trigger → our endpoint** ✅ chosen | seconds | paste one script into the sheet, once | No new OAuth scopes. The sheet already has permission to read itself. |
+| Scheduled pull via pg_cron + Sheets API | up to an hour | reconnect the shared Google account with an added `spreadsheets.readonly` scope, or share the sheet with a service account | More moving parts, and a scope change re-triggers the OAuth consent dance. |
+
+Push wins because it needs no new Google permissions and lands applicants while the applicant is still warm — the Discord ping and the vote can happen the same hour.
+
+## The endpoint
+
+```
+POST https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-ingest
+headers: x-ingest-secret: <RECRUIT_INGEST_SECRET>   (Supabase secret, already set)
+body:    { "rows": [ { "<sheet header>": "<value>", ... } ] }
+         { "rows": [ ... ], "dryRun": true }   → returns the mapping, writes nothing
+```
+
+- **Header mapping is by intent, not exact text** — "Full Name", "Email Address", "Why Agape?", "When are you hoping to move in?" etc. all resolve. Reword a column and it keeps working; an unrecognized long answer lands in About.
+- **Idempotent.** The row id is `name-slug + YYYYMMDDHHMMSS` from the submission timestamp — the same shape the original manual import produced — and inserts ignore duplicates. **Resending the whole sheet is a safe backfill**, not a pile of copies.
+- Rows with no email or no name are skipped and reported in the response.
+- New rows land at `stage='review'`, so the funnel picks them up: the `recruit-gmail` scan pings #recruiting-society (14-day floor, digest at 4+) and the house votes.
+- Each ingest posts one audit line to #recruiting-automation.
+
+## Setup: the Apps Script (one time, in the sheet)
+
+1. Open the application spreadsheet → **Extensions → Apps Script**.
+2. Paste this, replacing `PASTE_SECRET_HERE` with the `RECRUIT_INGEST_SECRET` value (ask Ian / read it from Supabase → Edge Functions → Secrets):
+
+```javascript
+const INGEST_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-ingest';
+const INGEST_SECRET = 'PASTE_SECRET_HERE';
+
+// Reads the header row + one data row into { header: value } and posts it.
+function sendRow_(sheet, rowIndex) {
+  const lastCol = sheet.getLastColumn();
+  const headers = sheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  const values = sheet.getRange(rowIndex, 1, 1, lastCol).getValues()[0];
+  const row = {};
+  headers.forEach((h, i) => { if (h) row[String(h)] = values[i]; });
+  const resp = UrlFetchApp.fetch(INGEST_URL, {
+    method: 'post',
+    contentType: 'application/json',
+    headers: { 'x-ingest-secret': INGEST_SECRET },
+    payload: JSON.stringify({ rows: [row] }),
+    muteHttpExceptions: true,
+  });
+  console.log(rowIndex + ': ' + resp.getResponseCode() + ' ' + resp.getContentText());
+}
+
+// Fires on every form submission into this sheet.
+function onFormSubmit(e) {
+  const sheet = e.range.getSheet();
+  sendRow_(sheet, e.range.getRow());
+}
+
+// Run manually to backfill everything (safe — duplicates are ignored).
+function backfillAll() {
+  const sheet = SpreadsheetApp.getActiveSheet();
+  for (let r = 2; r <= sheet.getLastRow(); r++) sendRow_(sheet, r);
+}
+```
+
+3. **Triggers** (clock icon) → *Add trigger* → function `onFormSubmit`, event source **From spreadsheet**, event type **On form submit** → Save. Approve the one-time authorization prompt.
+4. Optional: run `backfillAll` once to push history. Safe to repeat.
+
+If the form is a Fillout/Typeform rather than a Google Form, point its native webhook at the same URL with the same header — the body just needs to be `{ "rows": [ { header: value } ] }`.
+
+## Verifying
+
+```bash
+curl -s -X POST https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-ingest \
+  -H "Content-Type: application/json" -H "x-ingest-secret: $RECRUIT_INGEST_SECRET" \
+  -d '{"dryRun":true,"rows":[{"Timestamp":"7/29/2026 14:22:05","Full Name":"Test Person","Email Address":"t@example.com"}]}'
+```
+
+`dryRun` shows exactly what would be written, including the derived id, and touches nothing.

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -13,7 +13,7 @@ Status: **Phase A shipped (v3.0.0, migration 120); auto-placement shipped early 
 
 ## The funnel
 
-1. **Someone applies** → lands in Review (`stage = 'review'`).
+1. **Someone applies** → the sheet pushes the row to `recruit-ingest` on submit and they land in the Inbox (`stage = 'review'`) automatically — see [recruiting-sheet-ingest.md](../../infrastructure/recruiting-sheet-ingest.md).
 2. **Application review** — quality of character + culture fit, judged collectively:
    - 3+ Recruiting Society members score 1–5 ("would you live with them?").
    - A single veto rejects — **auto-archived** immediately, update email owed.

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -1,0 +1,150 @@
+// Supabase Edge Function: recruit-ingest
+// Application intake. The application sheet pushes rows here on submit (an
+// Apps Script trigger — Sheets has no native webhook), so new applicants
+// land in the Inbox without a manual import.
+//
+// Deployed with --no-verify-jwt: the caller is a Google Apps Script, not a
+// signed-in user, so it authenticates with a shared secret header instead.
+//
+// POST /functions/v1/recruit-ingest
+//   headers: x-ingest-secret: <RECRUIT_INGEST_SECRET>
+//   body:    { rows: [ { "<sheet header>": "<value>", ... } ], dryRun?: true }
+//
+// Idempotent: the row's id is derived from the applicant's name + submission
+// timestamp, and inserts ignore duplicates — so resending the whole sheet is
+// a safe backfill, not a mess of copies.
+
+const VERSION = '1.0.1'
+console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { postChannelEmbed, AUTOMATION_CHANNEL_ID } from '../_shared/discord.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-ingest-secret',
+}
+const json = (data: unknown, status = 200) =>
+  new Response(JSON.stringify(data), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+
+// Sheet headers drift (they get reworded, columns get added), so map by
+// intent rather than exact string. First matching pattern wins.
+const FIELD_PATTERNS: Array<[string, RegExp]> = [
+  ['submitted_at', /^(timestamp|submitted|date submitted|submission)/i],
+  ['first_name', /^(first name|first)/i],
+  ['last_name', /^(last name|last|surname)/i],
+  ['full_name', /^(full name|your name|name)$/i],
+  ['email', /e-?mail/i],
+  ['pronouns', /pronoun/i],
+  ['social', /(social|instagram|links?|handle)/i],
+  ['residency', /(residency|full.?time|short.?term|length of stay|type of stay)/i],
+  ['move_in', /(move.?in|when.*(move|start)|availability)/i],
+  ['budget', /budget|rent range|afford/i],
+  ['why_agape', /(why agape|why.*interested|why do you want)/i],
+  ['gifts', /(gift|offer|contribute|share with the house)/i],
+  ['about', /(about you|tell us about|introduce)/i],
+  ['heard_from', /(how did you hear|hear about|referred|find us)/i],
+]
+
+function mapRow(row: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [rawKey, rawVal] of Object.entries(row)) {
+    const key = String(rawKey || '').trim()
+    const val = rawVal == null ? '' : String(rawVal).trim()
+    if (!key || !val) continue
+    let matched = false
+    for (const [field, rx] of FIELD_PATTERNS) {
+      if (rx.test(key)) { matched = true; if (!out[field]) out[field] = val; break }
+    }
+    // Long free-text under a header we don't recognize still deserves a home:
+    // the first orphan paragraph becomes "about", the next one "gifts".
+    if (!matched && val.length > 120) {
+      if (!out.about) out.about = val
+      else if (!out.gifts) out.gifts = val
+    }
+  }
+  if (!out.first_name && out.full_name) {
+    const parts = out.full_name.split(/\s+/)
+    out.first_name = parts[0]
+    out.last_name = parts.slice(1).join(' ')
+  }
+  return out
+}
+
+const slug = (s: string) =>
+  s.toLowerCase().normalize('NFKD').replace(/[^\w\s-]/g, '').trim().replace(/\s+/g, '-').slice(0, 48)
+
+// Same id shape the original import produced: name-slug + YYYYMMDDHHMMSS,
+// so a row ingested here can never duplicate one already in the table.
+function deriveId(first: string, last: string, submittedAt: Date): string {
+  const p = (n: number, w = 2) => String(n).padStart(w, '0')
+  const stamp = `${submittedAt.getFullYear()}${p(submittedAt.getMonth() + 1)}${p(submittedAt.getDate())}` +
+    `${p(submittedAt.getHours())}${p(submittedAt.getMinutes())}${p(submittedAt.getSeconds())}`
+  return `${slug([first, last].filter(Boolean).join(' ')) || 'applicant'}-${stamp}`
+}
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  try {
+    const secret = Deno.env.get('RECRUIT_INGEST_SECRET')
+    if (!secret) return json({ error: 'RECRUIT_INGEST_SECRET not configured' }, 500)
+    if (req.headers.get('x-ingest-secret') !== secret) return json({ error: 'bad or missing x-ingest-secret' }, 401)
+
+    const body = await req.json().catch(() => ({}))
+    const rows: Array<Record<string, unknown>> = Array.isArray(body.rows) ? body.rows
+      : body.row && typeof body.row === 'object' ? [body.row] : []
+    if (!rows.length) return json({ error: 'send { rows: [ {header: value} ] }' }, 400)
+    const dryRun = body.dryRun === true
+
+    const client = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+    const prepared: Array<Record<string, string>> = []
+    const skipped: string[] = []
+
+    for (const raw of rows.slice(0, 200)) {
+      const m = mapRow(raw)
+      if (!m.email?.includes('@')) { skipped.push(`no email: ${JSON.stringify(raw).slice(0, 80)}`); continue }
+      if (!m.first_name) { skipped.push(`no name: ${m.email}`); continue }
+      const when = m.submitted_at ? new Date(m.submitted_at) : new Date()
+      const submittedAt = isNaN(when.getTime()) ? new Date() : when
+      prepared.push({
+        id: deriveId(m.first_name, m.last_name || '', submittedAt),
+        submitted_at: submittedAt.toISOString(),
+        first_name: m.first_name, last_name: m.last_name || '',
+        pronouns: m.pronouns || '', email: m.email, social: m.social || '',
+        about: m.about || '', why_agape: m.why_agape || '', gifts: m.gifts || '',
+        heard_from: m.heard_from || '', residency: m.residency || '',
+        move_in: m.move_in || '', budget: m.budget || '',
+      })
+    }
+
+    if (dryRun) return json({ dryRun: true, wouldInsert: prepared, skipped })
+    if (!prepared.length) return json({ inserted: 0, skipped })
+
+    // ignoreDuplicates: resending the sheet is a backfill, not a mess.
+    const { data, error } = await client.from('recruit_applicants')
+      .upsert(prepared, { onConflict: 'id', ignoreDuplicates: true })
+      .select('id, first_name, last_name')
+    if (error) return json({ error: `insert failed: ${error.message}` }, 500)
+
+    const created = data || []
+    if (created.length) {
+      // Ingest is an automation too — it belongs in the audit channel. The
+      // #recruiting-society ping about these applicants follows from the
+      // recruit-gmail scan, which owns ping dedup.
+      try {
+        const names = created.map((c) => `${c.first_name} ${c.last_name || ''}`.trim()).join(', ')
+        await postChannelEmbed(AUTOMATION_CHANNEL_ID,
+          `📥 **${created.length} application${created.length === 1 ? '' : 's'} ingested** from the sheet\n${names.slice(0, 800)}`,
+          0x6a6c6a, `${created.length} applications ingested`)
+      } catch (err) {
+        console.warn(`[recruit-ingest] audit post failed: ${(err as Error).message}`)
+      }
+    }
+    console.log(`[recruit-ingest] ${created.length} created, ${prepared.length - created.length} already present, ${skipped.length} skipped`)
+    return json({ inserted: created.length, ids: created.map((c) => c.id), duplicates: prepared.length - created.length, skipped })
+  } catch (err) {
+    console.error(`[recruit-ingest] ${(err as Error).message}`)
+    return json({ error: (err as Error).message }, 500)
+  }
+})


### PR DESCRIPTION
**Recommendation implemented: push, not pull.** Google Sheets has no native webhook, so the sheet's own Apps Script fires on form submit and POSTs the row to a new `recruit-ingest` edge function. That avoids adding a `spreadsheets` OAuth scope to the shared Google account (which would force a reconnect) and lands applicants in seconds instead of on a cron.

- **Idempotent**: id = name-slug + submission timestamp, same shape as the original manual import; inserts ignore duplicates, so re-sending the whole sheet is a safe backfill (`backfillAll()` in the script).
- **Header mapping by intent**, not exact text — reword a column and it keeps working; an unrecognized long answer lands in About.
- **`dryRun: true`** returns the exact mapping without writing (verified against a realistic row).
- Auth by `x-ingest-secret` (secret created); unsigned calls get 401 (verified).
- New rows land at `stage='review'`, so the #recruiting-society ping and the house vote follow automatically. Each ingest posts one audit line to #recruiting-automation.

**One setup step left, in the sheet:** Extensions → Apps Script → paste the script from `docs/infrastructure/recruiting-sheet-ingest.md`, add the on-form-submit trigger. I can't do that part — it lives in the spreadsheet's script editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)