### PR TITLE
feat(recruiting): stable emails, scan cron, house calendar, external recordings

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1390,6 +1390,31 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 }
 .inbox-group.is-drop-target .inbox-empty--group { color: var(--accent); }
 
+/* Quiet background-sync note beside the message count. Never a spinner and
+   never a blank panel — the thread is already on screen. */
+.emails-note { color: var(--fg-subtle); font-style: italic; }
+.emails-note:not(:empty)::before { content: ' · '; font-style: normal; }
+
+/* --- v3.27.0: house-calendar events + external recordings --- */
+
+/* Calendar events that aren't intro calls: read-only profile context. */
+.house-events { margin-top: var(--space-4); }
+.house-events__title {
+  margin: 0 0 var(--space-2); font-size: var(--font-size-small);
+  text-transform: uppercase; letter-spacing: 0.04em; color: var(--fg-subtle);
+}
+.house-events__row {
+  display: flex; align-items: center; gap: var(--space-2);
+  padding: 6px 0; font-size: var(--font-size-small);
+  border-bottom: 1px solid var(--border);
+}
+.house-events__row:last-child { border-bottom: 0; }
+.house-events__what { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.house-events__when { color: var(--fg-subtle); white-space: nowrap; }
+
+/* Recording hosted elsewhere — a link out, never a fake inline player. */
+.external-rec { display: flex; flex-direction: column; gap: 6px; align-items: flex-start; }
+
 /* --- v3.22.1 (restored post-rebase): mobile CTA-column fix — must stay
    LAST so the cascade resolves in its favor. --- */
 @media (max-width: 480px) {

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.26.0">
+  <link rel="stylesheet" href="css/app.css?v=3.27.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -258,6 +258,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.26.0"></script>
+  <script src="js/app.js?v=3.27.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.26.0';
+const VERSION = '3.27.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -103,6 +103,7 @@ let placements = [];          // recruit_listing_candidates rows
 let claimPosts = {};          // applicant_id -> { status, posted_at }
 let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
+let houseEvents = {};         // applicant_id -> non-intro_call calendar rows
 let pendingVote = null;       // { score, veto } while the vote bar is open
 let commentCounts = {};       // applicant_id -> n
 let latestNotes = {};         // applicant_id -> { author, body }
@@ -529,9 +530,13 @@ async function loadAll() {
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
     sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
-    sb.from('recruit_emails').select('applicant_id, direction, sent_at, snippet').order('sent_at'),
+    // Full rows, not just the state columns: this is also what hydrates
+    // emailsCache so a profile can render its thread before any Gmail
+    // round-trip. body_text is the one heavy column and stays out — the
+    // background sync fills it in.
+    sb.from('recruit_emails').select('id, applicant_id, gmail_id, thread_id, direction, subject, snippet, from_email, to_email, sent_at').order('sent_at'),
     sb.from('recruit_votes').select('*').order('created_at'),
-    sb.from('recruit_screenings').select('id, applicant_id, starts_at, ends_at, status, housemate_name, meet_link, recall_status').order('starts_at'),
+    sb.from('recruit_screenings').select('id, applicant_id, starts_at, ends_at, status, housemate_name, meet_link, recall_status, kind, title, calendar_id').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, windows, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
     sb.from('recruit_claim_posts').select('applicant_id, status, posted_at'),
@@ -545,7 +550,16 @@ async function loadAll() {
   votes = {};
   for (const v of (vRes.data || [])) (votes[v.applicant_id] ||= []).push(v);
   screeningState = {};
+  houseEvents = {};
   for (const s of (scRes.data || [])) {
+    // Only intro calls drive the row state machine. Visits and house events
+    // come off the house calendar (migration 137) and belong on the profile,
+    // not in the Screening funnel — a dinner must never render a Watch chip
+    // or arm "Notes on the way…".
+    if ((s.kind || 'intro_call') !== 'intro_call') {
+      (houseEvents[s.applicant_id] ||= []).push(s);
+      continue;
+    }
     if (s.status === 'scheduled') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), at: s.starts_at, ends: s.ends_at, with: s.housemate_name, link: s.meet_link };
     // A finished recording adds a Watch state to the row (fresh link on click).
     if (s.recall_status === 'done') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), watch: s.id };
@@ -555,11 +569,20 @@ async function loadAll() {
     if (Array.isArray(av.windows) && av.windows.length) screeningState[av.applicant_id] ||= { availability: true, nWindows: av.windows.length };
   }
   emailState = {};
+  emailsCache = {};
   for (const e of (eRes.data || [])) {
     const st = (emailState[e.applicant_id] ||= { lastDir: null, lastAt: null, lastSnippet: '', replies: 0 });
     st.lastDir = e.direction; st.lastAt = e.sent_at; st.lastSnippet = e.snippet || '';
     if (e.direction === 'in') st.replies++;
+    // Newest-first, matching what the sync action returns.
+    (emailsCache[e.applicant_id] ||= []).unshift(e);
   }
+  // Availability and screenings ride along too, so the Emails tab can draw
+  // its scheduling card from the first paint rather than after the sync.
+  availCache = {};
+  for (const av of (avRes.data || [])) availCache[av.applicant_id] = av;
+  screeningsCache = {};
+  for (const s of (scRes.data || [])) (screeningsCache[s.applicant_id] ||= []).push(s);
   sb.from('recruit_settings').select('*').then(({ data }) => {
     for (const row of (data || [])) settings[row.key] = row.value;
     const box = document.getElementById('pref-couples');
@@ -775,6 +798,60 @@ async function returnDueCandidates() {
     if (await setExit(a.id, null)) a.returnedFromFuture = true;
   }
   return due.length;
+}
+
+/* ---------- external recordings ----------
+   Calls recorded outside the pipeline (tldv, Zoom, Drive). Stored as a link,
+   opened in a new tab: none of these hosts allow cross-origin embedding, so
+   an inline player would just be a broken black box. */
+async function promptRecordingLink(applicantId) {
+  const a = applicants.find(x => x.id === applicantId);
+  if (!a) return;
+  const url = prompt(`Recording link for ${fullName(a)} (tldv, Zoom, Drive…):`, '');
+  if (url === null) return;                       // cancelled
+  const clean = url.trim();
+  if (clean && !/^https?:\/\//i.test(clean)) { toast('Link must start with http:// or https://'); return; }
+  try {
+    await gmailCall({ action: 'attach-recording', applicantId, url: clean || null });
+    toast(clean ? `Recording linked to ${a.first}` : 'Recording link removed');
+    if (!document.getElementById('review').hidden) renderReview();
+  } catch (e) { toast(`Couldn't attach: ${e.message}`); }
+}
+
+/* Links harvested from the recruiting channels that nobody has filed yet.
+   Suggestions only — a wrong recording on a profile is worse than none, so
+   attaching always takes a human confirming who it belongs to. */
+let recordingLeads = [];
+async function loadRecordingLeads() {
+  if (!gmailStatus.connected) return;
+  try {
+    const out = await gmailCall({ action: 'recording-leads' });
+    recordingLeads = out.leads || [];
+    if (view === 'screening') renderApplicants();
+  } catch (e) { console.warn('recording leads failed', e); }
+}
+
+function recordingLeadsHtml() {
+  if (view !== 'screening' || !recordingLeads.length) return '';
+  return `<div class="update-tray">
+    <div class="update-tray__head">
+      <b>${recordingLeads.length} recording link${recordingLeads.length === 1 ? '' : 's'} posted in Discord, unfiled</b>
+      <button type="button" class="btn btn--sm" data-rescan-recordings>Rescan</button>
+    </div>
+    ${recordingLeads.map(l => {
+      const who = l.suggested_applicant_id
+        ? applicants.find(x => x.id === l.suggested_applicant_id) : null;
+      return `<div class="update-tray__row">
+        <span class="update-tray__who">${esc(l.source || 'link')}${l.author_name ? ` · ${esc(l.author_name)}` : ''}</span>
+        <span class="update-tray__why">${esc(l.context || l.url)}</span>
+        ${who
+          ? `<button type="button" class="cta-link" data-file-lead="${esc(l.id)}|${esc(who.id)}">File under ${esc(who.first)}</button>`
+          : `<span class="note-count">no match — open a profile and use Add recording link</span>`}
+        <a class="cta-link" href="${esc(l.url)}" target="_blank" rel="noopener">Open</a>
+        <button type="button" class="cta-link" data-dismiss-lead="${esc(l.id)}">Dismiss</button>
+      </div>`;
+    }).join('')}
+  </div>`;
 }
 
 /* ---------- the Remove sheet ----------
@@ -1358,18 +1435,29 @@ async function loadCallPanel(a) {
   let row = null;
   if (sc.watch) {
     ({ data: row } = await sb.from('recruit_screenings')
-      .select('id, housemate_name, starts_at, recording_summary')
+      .select('id, housemate_name, starts_at, recording_summary, external_recording_url, external_recording_source, external_recording_by_name')
       .eq('id', sc.watch).maybeSingle());
   } else {
     ({ data: row } = await sb.from('recruit_screenings')
-      .select('id, housemate_name, starts_at, recording_summary')
+      .select('id, housemate_name, starts_at, recording_summary, external_recording_url, external_recording_source, external_recording_by_name')
       .eq('applicant_id', a.id).order('starts_at', { ascending: false }).limit(1).maybeSingle());
   }
   if (queue[qIndex] !== a.id || reviewTab !== 'call' || !host()) return;
-  if (!row) { host().innerHTML = '<p class="notes__empty">No intro call yet.</p>'; return; }
+  if (!row) {
+    host().innerHTML = `<p class="notes__empty">No intro call yet.</p>
+      <p class="notes__empty"><button type="button" class="cta-link" data-add-recording="${a.id}">Add a recording link</button> — if the call happened on tldv or elsewhere.</p>`;
+    return;
+  }
   host().innerHTML = `
     <p class="notes__empty">${esc(`${row.housemate_name ? `${row.housemate_name} × ` : ''}${fullName(a)}`)} · ${row.starts_at ? fmtSlot(row.starts_at) : ''}</p>
-    ${sc.watch ? `<video id="call-video" class="call-video" controls playsinline></video><p class="email-modal__status" id="call-status">Fetching recording…</p>` : `<p class="notes__empty">The recording lands here after the call.</p>`}
+    ${sc.watch
+      ? `<video id="call-video" class="call-video" controls playsinline></video><p class="email-modal__status" id="call-status">Fetching recording…</p>`
+      : row.external_recording_url
+        // These hosts block cross-origin embedding, so this opens out rather
+        // than pretending to be a player.
+        ? `<p class="external-rec"><a class="btn btn--sm btn--watch" href="${esc(row.external_recording_url)}" target="_blank" rel="noopener">Watch on ${esc(row.external_recording_source || 'the host')}</a>
+             <span class="notes__empty">added${row.external_recording_by_name ? ` by ${esc(row.external_recording_by_name)}` : ''} · <button type="button" class="cta-link" data-add-recording="${a.id}">replace</button></span></p>`
+        : `<p class="notes__empty">The recording lands here after the call. <button type="button" class="cta-link" data-add-recording="${a.id}">Add a link</button> if it was recorded elsewhere.</p>`}
     ${row.recording_summary ? `<section class="review__section"><h3 class="review__section-title">Call summary</h3>${mdLite(row.recording_summary)}</section>` : ''}
     <section class="review__section notes">
       <div class="notes__head">
@@ -1542,7 +1630,7 @@ function renderApplicants() {
 
   // Archive: the update-email tray sits above the list. Openings: draft
   // listings detected from occupancy gaps sit above the shortlists.
-  let outreachChrome = '';
+  let outreachChrome = recordingLeadsHtml();
   if (view === 'archive') {
     const pending = applicants.filter(x => x.stage === 'rejected' && !x.updateSentAt && !x.updateSkippedAt);
     if (pending.length) {
@@ -1672,6 +1760,7 @@ function rowMenuHtml(a, listingId) {
       <button type="button" class="listing-menu__item" data-review="${a.id}">Open profile</button>
       ${a.scheduleToken ? `<button type="button" class="listing-menu__item" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
       ${screeningState[a.id]?.watch ? `<button type="button" class="listing-menu__item" data-give-decision="${a.id}">Give decision…</button>` : ''}
+      <button type="button" class="listing-menu__item" data-add-recording="${a.id}">Add recording link…</button>
       <span class="listing-menu__rule" aria-hidden="true"></span>
       <button type="button" class="listing-menu__item" data-open-remove="${a.id}|${esc(listingId)}">Remove…</button>
     </span>
@@ -2518,6 +2607,7 @@ function openReview(id) {
   hideHoldSheet();
   renderReview();
   resetScroll();
+  prefetchNextEmails();
 }
 
 function closeReview() {
@@ -2537,6 +2627,7 @@ function step(delta) {
   hideHoldSheet();
   renderReview();
   resetScroll();
+  prefetchNextEmails();
 }
 
 function resetScroll() {
@@ -2615,6 +2706,7 @@ function renderReview() {
     ${section('About them', a.about)}
     ${section('Why Agape', a.why)}
     ${section('Gifts to share', a.gifts)}
+    ${houseEventsHtml(a)}
     <section class="review__section notes" id="notes">
       <div class="notes__head">
         <h3 class="review__section-title">House notes</h3>
@@ -2878,27 +2970,66 @@ async function loadEmailsPanel(a) {
     document.getElementById('gmail-connect').onclick = connectSharedGmail;
     return;
   }
-  host().innerHTML = `<p class="notes__empty">Syncing with the shared inbox…</p>`;
-  try {
-    const out = await gmailCall({ action: 'sync', applicantId: a.id });
-    emailsCache[a.id] = out.emails || [];
-    availCache[a.id] = out.availability || null;
-    screeningsCache[a.id] = out.screenings || [];
-    if (queue[qIndex] !== a.id || reviewTab !== 'emails' || !host()) return;
-    host().innerHTML = `
-      ${schedulingHtml(a)}
-      <div class="emails-toolbar">
-        <span class="notes__empty">${emailsCache[a.id].length} message${emailsCache[a.id].length === 1 ? '' : 's'} with ${esc(a.email)}</span>
-        <span class="emails-toolbar__actions">
-          ${a.scheduleToken ? `<button type="button" class="btn btn--sm" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
-          <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
-        </span>
-      </div>
-      ${emailsCache[a.id].length ? `<ul class="inbox-card email-list">${emailsCache[a.id].map(emailRow).join('')}</ul>`
-        : `<p class="inbox-empty">No emails yet — Compose starts the thread through the shared account.</p>`}`;
-  } catch (e) {
-    if (host()) host().innerHTML = `<p class="notes__empty">Email sync failed: ${esc(e.message)}</p>`;
-  }
+  // Cache-first: past emails are already in memory from loadAll, so the
+  // thread paints immediately and the Gmail round-trip only ever ADDS to
+  // what's on screen. The old behaviour blanked the panel and blocked on
+  // the network every single time the tab was opened.
+  paintEmailsPanel(a, emailSyncing.has(a.id) ? 'checking' : '');
+  syncEmails(a.id).then(changed => {
+    if (changed && queue[qIndex] === a.id && reviewTab === 'emails' && host()) paintEmailsPanel(a, '');
+    else if (queue[qIndex] === a.id && reviewTab === 'emails' && host()) setEmailsNote('');
+  }).catch(e => setEmailsNote(`couldn't reach the inbox — showing what we have (${e.message})`));
+}
+
+function setEmailsNote(text) {
+  const el = document.getElementById('emails-note');
+  if (el) el.textContent = text;
+}
+
+function paintEmailsPanel(a, note) {
+  const host = document.getElementById('emails-panel');
+  if (!host) return;
+  const rows = emailsCache[a.id] || [];
+  host.innerHTML = `
+    ${schedulingHtml(a)}
+    <div class="emails-toolbar">
+      <span class="notes__empty">${rows.length ? `${rows.length} message${rows.length === 1 ? '' : 's'} with ${esc(a.email)}` : esc(a.email || '')}
+        <span class="emails-note" id="emails-note">${esc(note === 'checking' ? 'checking for new…' : note)}</span></span>
+      <span class="emails-toolbar__actions">
+        ${a.scheduleToken ? `<button type="button" class="btn btn--sm" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
+        <button type="button" class="btn btn--sm" data-email="${a.id}">Compose</button>
+      </span>
+    </div>
+    ${rows.length ? `<ul class="inbox-card email-list">${rows.map(emailRow).join('')}</ul>`
+      : `<p class="inbox-empty">No emails yet — Compose starts the thread through the shared account.</p>`}`;
+}
+
+/* One in-flight sync per applicant; resolves true when anything changed.
+   Callers that just want the data warm can ignore the result. */
+const emailSyncing = new Map(); // applicant_id -> Promise<boolean>
+function syncEmails(applicantId) {
+  if (emailSyncing.has(applicantId)) return emailSyncing.get(applicantId);
+  const p = (async () => {
+    if (!gmailStatus.connected) return false;
+    const before = (emailsCache[applicantId] || []).length;
+    const out = await gmailCall({ action: 'sync', applicantId });
+    emailsCache[applicantId] = out.emails || emailsCache[applicantId] || [];
+    availCache[applicantId] = out.availability || null;
+    screeningsCache[applicantId] = out.screenings || [];
+    return (out.synced || 0) > 0 || emailsCache[applicantId].length !== before;
+  })();
+  emailSyncing.set(applicantId, p);
+  p.catch(() => {}).finally(() => emailSyncing.delete(applicantId));
+  return p;
+}
+
+/* Warm the next applicant in the queue while you read the current one, so
+   stepping through review never waits on Gmail. Silent by design. */
+function prefetchNextEmails() {
+  const next = queue[qIndex + 1];
+  if (!next || !gmailStatus.connected) return;
+  const a = applicants.find(x => x.id === next);
+  if (a?.email?.includes('@')) syncEmails(next).catch(() => {});
 }
 
 /* ---------- screening scheduler ---------- */
@@ -2917,8 +3048,30 @@ function windowSlots(w) {
   return slots.slice(0, 16);
 }
 
+/* Visits and house events swept off the house calendar. Read-only context:
+   "they came to dinner on the 4th" is exactly the thing that used to live
+   only in someone's head. Newest first, past ones included. */
+function houseEventsHtml(a) {
+  const evs = (houseEvents[a.id] || []).slice()
+    .sort((x, y) => (y.starts_at || '').localeCompare(x.starts_at || ''));
+  if (!evs.length) return '';
+  const label = { visit: 'Visited the house', house_event: 'House event' };
+  return `<div class="house-events">
+    <h4 class="house-events__title">On the house calendar</h4>
+    ${evs.map(e => {
+      const past = new Date(e.ends_at || e.starts_at) < new Date();
+      return `<div class="house-events__row">
+        <span class="decision-chip decision-chip--vote">${esc(label[e.kind] || 'Event')}</span>
+        <span class="house-events__what">${esc(e.title || 'Untitled')}</span>
+        <span class="house-events__when">${past ? '' : 'upcoming · '}${esc(fmtSlot(e.starts_at))}</span>
+      </div>`;
+    }).join('')}
+  </div>`;
+}
+
 function schedulingHtml(a) {
-  const screenings = (screeningsCache[a.id] || []).filter(x => x.status === 'scheduled');
+  const screenings = (screeningsCache[a.id] || [])
+    .filter(x => x.status === 'scheduled' && (x.kind || 'intro_call') === 'intro_call');
   const avail = availCache[a.id];
   const parts = [];
   for (const sc of screenings) {
@@ -3514,6 +3667,7 @@ async function _checkMembershipAndEnter() {
     });
     resolveAvatars(); // background — server resolves any unchecked profile photos
     scanInbox();      // background — badge replies without opening each thread
+    loadRecordingLeads(); // background — unfiled Discord recording links
     const autoFlagged = await applyAutoFlags();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;
@@ -3686,6 +3840,38 @@ function init() {
       proseT.textContent = clamped ? 'More' : 'Less';
       return;
     }
+    const fileLead = e.target.closest('[data-file-lead]');
+    if (fileLead) {
+      const [leadId, aid] = fileLead.dataset.fileLead.split('|');
+      const lead = recordingLeads.find(l => l.id === leadId);
+      if (lead) {
+        gmailCall({ action: 'attach-recording', applicantId: aid, url: lead.url })
+          .then(() => {
+            recordingLeads = recordingLeads.filter(l => l.id !== leadId);
+            toast('Recording filed');
+            renderApplicants();
+          })
+          .catch(err => toast(`Couldn't file: ${err.message}`));
+      }
+      return;
+    }
+    const dismissLead = e.target.closest('[data-dismiss-lead]');
+    if (dismissLead) {
+      const id = dismissLead.dataset.dismissLead;
+      gmailCall({ action: 'dismiss-lead', leadId: id }).catch(() => {});
+      recordingLeads = recordingLeads.filter(l => l.id !== id);
+      renderApplicants();
+      return;
+    }
+    if (e.target.closest('[data-rescan-recordings]')) {
+      toast('Scanning the recruiting channels…');
+      gmailCall({ action: 'scan-recordings' })
+        .then(out => { toast(out.found ? `${out.found} new link${out.found === 1 ? '' : 's'}` : 'No new links'); return loadRecordingLeads(); })
+        .catch(err => toast(`Scan failed: ${err.message}`));
+      return;
+    }
+    const addRec = e.target.closest('[data-add-recording]');
+    if (addRec) { promptRecordingLink(addRec.dataset.addRecording); return; }
     const orm = e.target.closest('[data-open-remove]');
     if (orm) {
       const [aid, lid] = orm.dataset.openRemove.split('|');
@@ -3934,7 +4120,12 @@ function init() {
       } else {
         toast('Sent from live.at.agapesf@gmail.com');
       }
-      delete emailsCache[sentFor];
+      // Pull the sent message in rather than dropping the cache — clearing
+      // it would blank a thread the user is looking at.
+      syncEmails(sentFor).then(() => {
+        const a = applicants.find(x => x.id === sentFor);
+        if (a && queue[qIndex] === sentFor && reviewTab === 'emails') paintEmailsPanel(a, '');
+      }).catch(() => {});
       closeEmailModal();
     } catch (e) { toast(`Send failed: ${e.message}`); }
     btn.disabled = false; btn.textContent = emailMode === 'update' ? 'Send update' : 'Send via Agape Gmail';

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -358,6 +358,32 @@ const ALERT_DISCORD_USER_ID = Deno.env.get('ALERT_DISCORD_USER_ID') || '85378260
 // because alerts posted into the channel that was broken): primary channel →
 // the other recruiting channel with a ⚠️ prefix → DM the ops contact.
 // Throws if every rung fails, so callers don't stamp state as posted.
+/* Read recent messages from a channel. Needs the bot to hold "Read Message
+   History" there — it already posts to both recruiting channels, so this is
+   normally granted. Paginates backwards via `before`. */
+export async function fetchChannelMessages(
+  channelId: string,
+  opts: { limit?: number; sinceIso?: string } = {},
+): Promise<any[]> {
+  const want = Math.min(opts.limit ?? 200, 1000)
+  const since = opts.sinceIso ? new Date(opts.sinceIso).getTime() : 0
+  const out: any[] = []
+  let before = ''
+  while (out.length < want) {
+    const page: any[] = await discordFetch(
+      `/channels/${channelId}/messages?limit=100${before ? `&before=${before}` : ''}`,
+    )
+    if (!page.length) break
+    for (const m of page) {
+      if (since && new Date(m.timestamp).getTime() < since) return out
+      out.push(m)
+    }
+    before = page[page.length - 1].id
+    if (page.length < 100) break
+  }
+  return out
+}
+
 export async function postResilient(channelId: string, payload: Record<string, unknown>, label: string): Promise<void> {
   const fallback = channelId === NOTES_CHANNEL_ID ? AUTOMATION_CHANNEL_ID : NOTES_CHANNEL_ID
   try {

--- a/supabase/functions/_shared/recruit-schedule.ts
+++ b/supabase/functions/_shared/recruit-schedule.ts
@@ -12,6 +12,22 @@ export const TZ = 'America/Los_Angeles'
 const CLIENT_ID = Deno.env.get('GOOGLE_CALENDAR_CLIENT_ID')!
 const CLIENT_SECRET = Deno.env.get('GOOGLE_CALENDAR_CLIENT_SECRET')!
 
+// The shared Agape house calendar. Screenings land here so residents see
+// them on the calendar they actually read, instead of only on the shared
+// account's private primary. Overridable per-environment; 'primary' turns
+// the whole behaviour off and restores the old placement.
+export const HOUSE_CALENDAR_ID = Deno.env.get('AGAPE_HOUSE_CALENDAR_ID') ||
+  'knl4pjtdvea5kk80jf1lfuvcpk@group.calendar.google.com'
+
+// Calendars the sweep reads when matching events to applicants. 'primary'
+// stays in the list: invites a housemate sent from the shared account still
+// live there, and so does everything booked before this change.
+export function sweepCalendars(): string[] {
+  const extra = (Deno.env.get('AGAPE_EXTRA_CALENDAR_IDS') || '')
+    .split(',').map((s) => s.trim()).filter(Boolean)
+  return [...new Set(['primary', HOUSE_CALENDAR_ID, ...extra])]
+}
+
 // Minimal structural type so we don't pin a supabase-js version here.
 type Db = any
 
@@ -70,11 +86,26 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
     conferenceData: { createRequest: { requestId: crypto.randomUUID(), conferenceSolutionKey: { type: 'hangoutsMeet' } } },
     reminders: { useDefault: true },
   }
-  const resp = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates=all&conferenceDataVersion=1', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(event),
-  })
+  // Post to the house calendar so residents see the call on the calendar
+  // they actually read. If the shared account only has read access there,
+  // fall back to its own primary rather than failing the booking outright —
+  // a screening that exists on the wrong calendar beats one that never got
+  // scheduled. The fallback is logged loudly so the permission gap surfaces.
+  const post = (calendarId: string) =>
+    fetch(`https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?sendUpdates=all&conferenceDataVersion=1`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${at}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(event),
+    })
+
+  let calendarUsed = HOUSE_CALENDAR_ID
+  let resp = await post(calendarUsed)
+  if (!resp.ok && calendarUsed !== 'primary' && (resp.status === 403 || resp.status === 404)) {
+    const why = await resp.text()
+    console.warn(`[calendar] house calendar ${calendarUsed} rejected the event (${resp.status}) — falling back to primary. Grant "Make changes to events" to ${SHARED_EMAIL}. ${why.slice(0, 200)}`)
+    calendarUsed = 'primary'
+    resp = await post(calendarUsed)
+  }
   const created = await resp.json()
   if (!resp.ok) throw new Error(`Calendar failed: ${JSON.stringify(created).slice(0, 200)} — if this mentions scopes, reconnect the shared Gmail to grant calendar access`)
   const meet = created.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || created.hangoutLink || null
@@ -84,6 +115,7 @@ export async function scheduleScreening(db: Db, opts: ScheduleOpts): Promise<{
     housemate_name: opts.housemateName, housemate_email: opts.housemateEmail,
     starts_at: opts.startsAt.toISOString(), ends_at: endsAt.toISOString(),
     gcal_event_id: created.id, meet_link: meet, status: 'scheduled',
+    kind: 'intro_call', calendar_id: calendarUsed, title: event.summary,
   }).select().single()
   if (error) throw new Error(error.message)
 

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.12.0'
+const VERSION = '1.13.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -285,6 +285,9 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
   const now = Date.now()
   const { data: upcoming } = await client.from('recruit_screenings')
     .select('id, applicant_id, housemate_user_id, housemate_email, starts_at, meet_link, gcal_event_id')
+    // Only intro calls get reminders — a swept house dinner is not a call
+    // anyone needs paging about (migration 137).
+    .eq('kind', 'intro_call')
     .eq('status', 'scheduled').is('reminder_sent_at', null)
     .gte('starts_at', new Date(now).toISOString())
     .lte('starts_at', new Date(now + 65 * 60000).toISOString())
@@ -359,6 +362,8 @@ async function scheduleMissingBots(client: ReturnType<typeof db>): Promise<numbe
   if (!recallEnabled()) return 0
   const { data: rows } = await client.from('recruit_screenings')
     .select('id, meet_link, starts_at')
+    // Never send a recording bot into a house event (migration 137).
+    .eq('kind', 'intro_call')
     .eq('status', 'scheduled').is('recall_bot_id', null)
     .not('meet_link', 'is', null)
     .gt('starts_at', new Date().toISOString()).limit(10)
@@ -583,6 +588,7 @@ async function announceLiveCalls(client: ReturnType<typeof db>): Promise<number>
   let posted = 0
   const { data: screenings } = await client.from('recruit_screenings')
     .select('id, applicant_id, housemate_name, starts_at, meet_link')
+    .eq('kind', 'intro_call')
     .eq('status', 'scheduled').is('live_posted_at', null)
     .gte('starts_at', from).lte('starts_at', to)
   for (const s of (screenings || [])) {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,12 +16,12 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.15.0'
+const VERSION = '1.16.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
+import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, sweepCalendars, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
 import { upsertClaimMessage, editClaimMessageClaimed, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID } from '../_shared/discord.ts'
 
 const corsHeaders = {
@@ -153,6 +153,54 @@ async function remindStuckPosts(client: ReturnType<typeof db>): Promise<void> {
   }
 }
 
+/* Which kind of recruit_screenings row a calendar event becomes.
+   Only 'intro_call' drives the row state machine (Watch chips, recording
+   bots, coverage reminders), so the default has to be the inert one — a
+   house dinner misfiled as a call is a worse failure than a call misfiled
+   as an event, which a human can reclassify.
+
+   A video link is the strongest signal: intro calls are remote and
+   everything on the house calendar that isn't is, by definition, in person. */
+function classifyEvent(ev: any): 'intro_call' | 'visit' | 'house_event' {
+  const title = String(ev.summary || '').toLowerCase()
+  if (/\b(intro call|screening|phone screen|intro chat)\b/.test(title)) return 'intro_call'
+  if (/\b(visit|tour|open house|walkthrough|come by|stop by)\b/.test(title)) return 'visit'
+  if (ev.hangoutLink || ev.conferenceData) return 'intro_call'
+  return 'house_event'
+}
+
+/* Hosts we recognise as "this is a recording". Deliberately a allowlist:
+   scanning a chat channel for bare URLs would drag in every article anyone
+   ever shared. tldv is the one the house actually uses. */
+const RECORDING_HOSTS: Array<[RegExp, string]> = [
+  [/(^|\.)tldv\.io$/i, 'tldv'],
+  [/(^|\.)zoom\.us$/i, 'zoom'],
+  [/(^|\.)fathom\.video$/i, 'fathom'],
+  [/(^|\.)grain\.com$/i, 'grain'],
+  [/(^|\.)loom\.com$/i, 'loom'],
+  [/(^|\.)otter\.ai$/i, 'otter'],
+  [/(^|\.)drive\.google\.com$/i, 'drive'],
+  [/(^|\.)vimeo\.com$/i, 'vimeo'],
+]
+
+function sourceOf(url: string): string {
+  try {
+    const host = new URL(url).hostname
+    return RECORDING_HOSTS.find(([re]) => re.test(host))?.[1] || host.replace(/^www\./, '')
+  } catch { return 'link' }
+}
+
+function extractRecordingUrls(text: string): string[] {
+  const out = new Set<string>()
+  for (const raw of (text.match(/https?:\/\/[^\s<>()\[\]"']+/g) || [])) {
+    const url = raw.replace(/[.,;:]+$/, '')
+    try {
+      if (RECORDING_HOSTS.some(([re]) => re.test(new URL(url).hostname))) out.add(url)
+    } catch { /* not a URL we can parse */ }
+  }
+  return [...out]
+}
+
 function header(headers: Array<{ name: string; value: string }>, name: string): string {
   return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value || ''
 }
@@ -161,16 +209,43 @@ serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
 
   try {
-    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
     const client = db()
-    const { data: userData, error: userErr } = await client.auth.getUser(token)
-    if (userErr || !userData?.user) return json({ error: 'Not authenticated' }, 401)
-    const { data: membership } = await client.from('user_discord_membership')
-      .select('is_recruiting_member, discord_username').eq('user_id', userData.user.id).maybeSingle()
-    if (!membership?.is_recruiting_member) return json({ error: 'Not a recruiting member' }, 403)
 
-    const body = await req.json().catch(() => ({}))
-    const action = body.action
+    // Cron path: /scan runs the same inbox+calendar sweep the app triggers,
+    // but on a schedule so row states stay current when nobody has the app
+    // open. Same secretless handshake recruit-discord/remind uses — a
+    // one-time nonce minted by the pg_cron tick, delete-on-use (migration
+    // 123), with X-Cron-Secret honoured if CRON_SECRET is ever configured.
+    const isCron = new URL(req.url).pathname.endsWith('/scan')
+    if (isCron) {
+      const secret = Deno.env.get('CRON_SECRET')
+      let authorized = Boolean(secret) && req.headers.get('x-cron-secret') === secret
+      const nonce = req.headers.get('x-cron-nonce')
+      if (!authorized && nonce && /^[0-9a-f-]{36}$/i.test(nonce)) {
+        const { data: burned } = await client.from('recruit_cron_nonce')
+          .delete().eq('nonce', nonce)
+          .gte('created_at', new Date(Date.now() - 10 * 60000).toISOString())
+          .select().maybeSingle()
+        authorized = Boolean(burned)
+      }
+      if (!authorized) return json({ error: 'unauthorized' }, 401)
+    }
+
+    const token = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+    let userData: any = null
+    let membership: any = null
+    if (!isCron) {
+      const u = await client.auth.getUser(token)
+      if (u.error || !u.data?.user) return json({ error: 'Not authenticated' }, 401)
+      userData = u.data
+      const m = await client.from('user_discord_membership')
+        .select('is_recruiting_member, discord_username').eq('user_id', userData.user.id).maybeSingle()
+      membership = m.data
+      if (!membership?.is_recruiting_member) return json({ error: 'Not a recruiting member' }, 403)
+    }
+
+    const body = isCron ? {} as Record<string, unknown> : await req.json().catch(() => ({}))
+    const action = isCron ? 'scan' : (body as any).action
 
     if (action === 'auth-url') {
       const url = 'https://accounts.google.com/o/oauth2/v2/auth?' + new URLSearchParams({
@@ -450,6 +525,108 @@ serve(async (req) => {
       return json({ linked: true, applicantId, firstName: applicant.first_name })
     }
 
+    if (action === 'attach-recording') {
+      // Paste a tldv/Zoom/Drive link onto an applicant. p_url null detaches.
+      const url = body.url === null ? null : String(body.url || '').trim()
+      const applicantId = String(body.applicantId || '')
+      if (url && !/^https?:\/\//i.test(url)) return json({ error: 'Recording link must start with http(s)://' }, 400)
+      const { data: rp } = await client.from('recruit_profiles')
+        .select('display_name').eq('user_id', userData.user.id).maybeSingle()
+      const { data: screeningId, error } = await client.rpc('recruit_attach_recording', {
+        p_applicant: applicantId,
+        p_url: url,
+        p_source: url ? sourceOf(url) : null,
+        p_name: rp?.display_name || membership.discord_username || null,
+        p_screening: body.screeningId ? String(body.screeningId) : null,
+      })
+      if (error) return json({ error: error.message }, 400)
+      // Close out any Discord lead that pointed at this URL.
+      if (url) {
+        await client.from('recruit_recording_leads')
+          .update({ resolved_applicant_id: applicantId }).eq('url', url)
+      }
+      return json({ attached: true, screeningId })
+    }
+
+    if (action === 'recording-leads') {
+      const { data } = await client.from('recruit_recording_leads')
+        .select('*').is('resolved_applicant_id', null).is('dismissed_at', null)
+        .order('posted_at', { ascending: false }).limit(50)
+      return json({ leads: data || [] })
+    }
+
+    if (action === 'dismiss-lead') {
+      await client.from('recruit_recording_leads')
+        .update({ dismissed_at: new Date().toISOString() }).eq('id', String(body.leadId || ''))
+      return json({ dismissed: true })
+    }
+
+    if (action === 'scan-recordings') {
+      // Harvest recording links posted in the recruiting channels and guess
+      // who each one is about. Guesses are SUGGESTIONS — a wrong recording
+      // on someone's profile is worse than no recording, so nothing attaches
+      // without a human picking the applicant.
+      const { fetchChannelMessages, NOTES_CHANNEL_ID: NOTES, AUTOMATION_CHANNEL_ID } =
+        await import('../_shared/discord.ts')
+      const channels = [...new Set([
+        Deno.env.get('RECRUITING_PING_CHANNEL_ID') || NOTES,
+        AUTOMATION_CHANNEL_ID,
+      ].filter(Boolean))] as string[]
+      const sinceIso = new Date(Date.now() - 180 * 86400000).toISOString()
+
+      const { data: people } = await client.from('recruit_applicants')
+        .select('id, first_name, last_name')
+      const { data: existingLeads } = await client.from('recruit_recording_leads').select('url')
+      const seen = new Set((existingLeads || []).map((r) => r.url))
+      const { data: attached } = await client.from('recruit_screenings')
+        .select('external_recording_url').not('external_recording_url', 'is', null)
+      for (const r of (attached || [])) seen.add(r.external_recording_url)
+
+      let found = 0
+      for (const channelId of channels) {
+        let messages: any[] = []
+        try {
+          messages = await fetchChannelMessages(channelId, { limit: 400, sinceIso })
+        } catch (err) {
+          console.warn(`[recordings] cannot read channel ${channelId}: ${(err as Error).message}`)
+          continue
+        }
+        for (const m of messages) {
+          const text = [m.content || '', ...(m.embeds || []).flatMap((e: any) =>
+            [e.title, e.description, e.url, ...((e.fields || []).map((f: any) => `${f.name} ${f.value}`))])]
+            .filter(Boolean).join('\n')
+          for (const url of extractRecordingUrls(text)) {
+            if (seen.has(url)) continue
+            seen.add(url)
+            // Match on a full name first, then a distinctive first name —
+            // "Sam" in a channel with two Sams stays unattributed on purpose.
+            const hay = text.toLowerCase()
+            let suggested: string | null = null
+            for (const p of (people || [])) {
+              const full = `${p.first_name || ''} ${p.last_name || ''}`.trim().toLowerCase()
+              if (full && full.includes(' ') && hay.includes(full)) { suggested = p.id; break }
+            }
+            if (!suggested) {
+              const firstHits = (people || []).filter((p) => {
+                const f = String(p.first_name || '').toLowerCase()
+                return f.length > 2 && new RegExp(`\\b${f.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(hay)
+              })
+              if (firstHits.length === 1) suggested = firstHits[0].id
+            }
+            await client.from('recruit_recording_leads').upsert({
+              url, source: sourceOf(url), channel_id: channelId, message_id: m.id,
+              posted_at: m.timestamp, author_name: m.author?.global_name || m.author?.username || null,
+              context: text.replace(/\s+/g, ' ').slice(0, 400),
+              suggested_applicant_id: suggested,
+            }, { onConflict: 'url' })
+            found++
+          }
+        }
+      }
+      console.log(`[recordings] ${found} new link(s) across ${channels.length} channel(s)`)
+      return json({ found })
+    }
+
     if (action === 'unlinked-recordings') {
       // Feed for the app's link modal: swept calls with no applicant.
       const { data } = await client.from('recruit_recorded_events')
@@ -542,18 +719,33 @@ serve(async (req) => {
       // Thread fallback: people reply from addresses other than the one on
       // their application. Any message in a thread we've already matched
       // belongs to that applicant, regardless of From/To.
-      const { data: knownThreads } = await client.from('recruit_emails').select('thread_id, applicant_id')
+      const { data: knownThreads } = await client.from('recruit_emails').select('thread_id, applicant_id, gmail_id')
       const byThread = new Map((knownThreads || [])
         .filter((r) => r.thread_id)
         .map((r) => [r.thread_id, r.applicant_id]))
-      const list = await (await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages?q=' + encodeURIComponent('newer_than:14d') + '&maxResults=60', {
-        headers: { Authorization: `Bearer ${at}` },
-      })).json()
+      // One set instead of a SELECT per message. This is what makes a wider
+      // window affordable: the old per-message existence check meant 60 round
+      // trips a run, so the cap had to stay small and mail older than the cap
+      // was simply never seen.
+      const knownIds = new Set((knownThreads || []).map((r) => r.gmail_id).filter(Boolean))
+      // Cron runs sweep wider than the app's opportunistic scan: a quiet
+      // stretch with nobody opening the app used to leave a permanent hole.
+      const windowDays = isCron ? 60 : 14
+      const pageCap = isCron ? 400 : 100
+      const messages: Array<{ id: string }> = []
+      let pageToken = ''
+      do {
+        const url = 'https://gmail.googleapis.com/gmail/v1/users/me/messages?q=' +
+          encodeURIComponent(`newer_than:${windowDays}d`) + '&maxResults=100' +
+          (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : '')
+        const page = await (await fetch(url, { headers: { Authorization: `Bearer ${at}` } })).json()
+        messages.push(...(page.messages || []))
+        pageToken = page.nextPageToken || ''
+      } while (pageToken && messages.length < pageCap)
       let matched = 0
       const replied = new Set<string>()
-      for (const m of (list.messages || [])) {
-        const { data: existing } = await client.from('recruit_emails').select('id').eq('gmail_id', m.id).maybeSingle()
-        if (existing) continue
+      for (const m of messages) {
+        if (knownIds.has(m.id)) continue
         const msg = await (await fetch(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${m.id}?format=full`, {
           headers: { Authorization: `Bearer ${at}` },
         })).json()
@@ -648,33 +840,53 @@ serve(async (req) => {
           const m = String(r.from_email || '').toLowerCase().match(/[a-z0-9._%+-]+@[a-z0-9.-]+/)
           if (m) altByEmail.set(m[0], r.applicant_id)
         }
-        const timeMin = new Date().toISOString()
+        // Look back as well as forward: an event that already happened is
+        // exactly the thing the app failed to notice at the time.
+        const timeMin = new Date(Date.now() - 60 * 86400000).toISOString()
         const timeMax = new Date(Date.now() + 45 * 86400000).toISOString()
-        const cal = await (await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=${encodeURIComponent(timeMin)}&timeMax=${encodeURIComponent(timeMax)}&singleEvents=true&maxResults=100`, {
-          headers: { Authorization: `Bearer ${at}` },
-        })).json()
-        for (const ev of (cal.items || [])) {
-          if (!ev.attendees?.length || !ev.start?.dateTime) continue
-          let aid: string | null = null
-          for (const att of ev.attendees) {
-            const em = String(att.email || '').toLowerCase()
-            aid = byEmail.get(em) || altByEmail.get(em) || null
-            if (aid) break
-          }
-          if (!aid) continue
-          const { data: existingEv } = await client.from('recruit_screenings').select('id').eq('gcal_event_id', ev.id).maybeSingle()
-          if (existingEv) continue
-          await client.from('recruit_screenings').insert({
-            applicant_id: aid,
-            starts_at: ev.start.dateTime,
-            ends_at: ev.end?.dateTime || ev.start.dateTime,
-            gcal_event_id: ev.id,
-            meet_link: ev.hangoutLink || null,
-            housemate_name: ev.organizer?.displayName || (ev.organizer?.email === SHARED_EMAIL ? 'the house' : ev.organizer?.email) || 'scheduled manually',
-            status: 'scheduled',
+        const { data: seenEvents } = await client.from('recruit_screenings')
+          .select('gcal_event_id').not('gcal_event_id', 'is', null)
+        const seenIds = new Set((seenEvents || []).map((r) => r.gcal_event_id))
+
+        for (const calendarId of sweepCalendars()) {
+          const resp = await fetch(`https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?timeMin=${encodeURIComponent(timeMin)}&timeMax=${encodeURIComponent(timeMax)}&singleEvents=true&maxResults=250`, {
+            headers: { Authorization: `Bearer ${at}` },
           })
-          manualPickups++
-          console.log(`manual screening picked up: ${aid} @ ${ev.start.dateTime}`)
+          if (!resp.ok) {
+            // A calendar the shared account can't read shouldn't kill the
+            // sweep for the ones it can.
+            console.warn(`[calendar] cannot read ${calendarId} (${resp.status}) — skipping`)
+            continue
+          }
+          const cal = await resp.json()
+          for (const ev of (cal.items || [])) {
+            if (!ev.attendees?.length || !ev.start?.dateTime) continue
+            if (ev.status === 'cancelled') continue
+            let aid: string | null = null
+            for (const att of ev.attendees) {
+              const em = String(att.email || '').toLowerCase()
+              aid = byEmail.get(em) || altByEmail.get(em) || null
+              if (aid) break
+            }
+            if (!aid) continue
+            if (seenIds.has(ev.id)) continue
+            seenIds.add(ev.id)
+            const past = new Date(ev.end?.dateTime || ev.start.dateTime) < new Date()
+            await client.from('recruit_screenings').insert({
+              applicant_id: aid,
+              starts_at: ev.start.dateTime,
+              ends_at: ev.end?.dateTime || ev.start.dateTime,
+              gcal_event_id: ev.id,
+              calendar_id: calendarId,
+              title: String(ev.summary || '').slice(0, 300),
+              kind: classifyEvent(ev),
+              meet_link: ev.hangoutLink || null,
+              housemate_name: ev.organizer?.displayName || (ev.organizer?.email === SHARED_EMAIL ? 'the house' : ev.organizer?.email) || 'scheduled manually',
+              status: past ? 'completed' : 'scheduled',
+            })
+            manualPickups++
+            console.log(`calendar pickup [${classifyEvent(ev)}] on ${calendarId}: ${aid} @ ${ev.start.dateTime}`)
+          }
         }
       } catch (err) {
         console.warn(`calendar sweep failed: ${(err as Error).message}`)

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.16.0'
+const VERSION = '1.16.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -165,7 +165,13 @@ function classifyEvent(ev: any): 'intro_call' | 'visit' | 'house_event' {
   const title = String(ev.summary || '').toLowerCase()
   if (/\b(intro call|screening|phone screen|intro chat)\b/.test(title)) return 'intro_call'
   if (/\b(visit|tour|open house|walkthrough|come by|stop by)\b/.test(title)) return 'visit'
-  if (ev.hangoutLink || ev.conferenceData) return 'intro_call'
+  // A video link is NOT sufficient on its own — the house calendar is full
+  // of social events that happen to have a Meet link, and one of them
+  // ("Peloton man doing what he Peloton can") sailed straight through the
+  // first version of this rule. A screening is a small meeting: applicant,
+  // a housemate or two, maybe the recording bot.
+  const attendees = (ev.attendees || []).filter((x: any) => !x.resource).length
+  if ((ev.hangoutLink || ev.conferenceData) && attendees > 0 && attendees <= 4) return 'intro_call'
   return 'house_event'
 }
 
@@ -834,6 +840,11 @@ serve(async (req) => {
       // screenings row (deduped by event id, so app-booked calls are skipped).
       let manualPickups = 0
       try {
+        // People who left the funnel don't need their calendar mined. This
+        // also stops long-dead test records from collecting house events.
+        const { data: goneRows } = await client.from('recruit_applicants')
+          .select('id').in('stage', ['rejected', 'archived'])
+        const gone = new Set((goneRows || []).map((r) => r.id))
         const { data: altRows } = await client.from('recruit_emails').select('applicant_id, from_email').eq('direction', 'in')
         const altByEmail = new Map<string, string>()
         for (const r of (altRows || [])) {
@@ -868,7 +879,7 @@ serve(async (req) => {
               aid = byEmail.get(em) || altByEmail.get(em) || null
               if (aid) break
             }
-            if (!aid) continue
+            if (!aid || gone.has(aid)) continue
             if (seenIds.has(ev.id)) continue
             seenIds.add(ev.id)
             const past = new Date(ev.end?.dateTime || ev.start.dateTime) < new Date()

--- a/supabase/migrations/136_recruit_gmail_scan_cron.sql
+++ b/supabase/migrations/136_recruit_gmail_scan_cron.sql
@@ -1,0 +1,50 @@
+-- ============================================
+-- Migration 136: schedule the inbox + calendar sweep
+--
+-- Why row states go stale: recruit-gmail's `scan` action — the thing that
+-- matches inbound mail to applicants, picks up manually-booked calls off the
+-- calendar, and backfills availability — only ever ran from the browser.
+-- scanInbox() is throttled to one run per 10 minutes per device and skipped
+-- entirely when nobody has /applications open. A week of nobody opening the
+-- app meant a week of replies and bookings the surface never learned about.
+--
+-- This ticks it every 20 minutes regardless. Same secretless handshake as
+-- migration 123's reminder cron: mint a one-time nonce into the
+-- service-role-only recruit_cron_nonce table, send it as X-Cron-Nonce, and
+-- the function burns it on use (10-minute expiry).
+--
+-- The cron path is /scan (recruit-gmail v1.16.0), which forces action='scan'
+-- and skips the Discord-membership gate the app's calls go through.
+--
+-- 20 minutes, not 15: it shares the shared-Gmail token and Google's quota
+-- with the reminder tick, and offsetting them keeps the two off each other.
+-- ============================================
+
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'recruit_gmail_scan_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end$$;
+
+select cron.schedule(
+  'recruit_gmail_scan_tick',
+  '*/20 * * * *',
+  $$
+  with purge as (
+    delete from recruit_cron_nonce where created_at < now() - interval '1 hour'
+  ), n as (
+    insert into recruit_cron_nonce default values returning nonce
+  )
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-gmail/scan',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'X-Cron-Nonce', (select nonce::text from n)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+  $$
+);

--- a/supabase/migrations/136_recruit_gmail_scan_cron.sql
+++ b/supabase/migrations/136_recruit_gmail_scan_cron.sql
@@ -16,6 +16,15 @@
 -- The cron path is /scan (recruit-gmail v1.16.0), which forces action='scan'
 -- and skips the Discord-membership gate the app's calls go through.
 --
+-- The Authorization header is the PUBLIC anon key, and it is not the auth
+-- for this endpoint — the nonce is. Supabase's function gateway rejects any
+-- request with no Authorization header before the function ever runs
+-- (UNAUTHORIZED_NO_AUTH_HEADER), so a nonce-only request never arrives.
+-- recruit-discord sidesteps this with verify_jwt = false; recruit-gmail
+-- can't take that route, because every one of its other actions relies on
+-- a real user JWT plus the Discord-membership gate. Sending the anon key
+-- satisfies the gateway and changes nothing about who can run the sweep.
+--
 -- 20 minutes, not 15: it shares the shared-Gmail token and Google's quota
 -- with the reminder tick, and offsetting them keeps the two off each other.
 -- ============================================
@@ -41,6 +50,9 @@ select cron.schedule(
     url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-gmail/scan',
     headers := jsonb_build_object(
       'Content-Type', 'application/json',
+      -- Public anon key: satisfies the function gateway only. The nonce below
+      -- is what actually authorizes the sweep.
+      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI',
       'X-Cron-Nonce', (select nonce::text from n)
     ),
     body := '{}'::jsonb,

--- a/supabase/migrations/137_recruit_screening_kind.sql
+++ b/supabase/migrations/137_recruit_screening_kind.sql
@@ -1,0 +1,42 @@
+-- ============================================
+-- Migration 137: what kind of event is this?
+--
+-- recruit_screenings has always modelled exactly one thing — the intro call
+-- — and the calendar sweep inserted anything it could match into it. That
+-- was safe only because the sweep read the shared account's own calendar,
+-- where the only applicant-attended events ARE intro calls.
+--
+-- Pointing the sweep at the house calendar breaks that assumption: house
+-- dinners, tours, and second visits all carry applicant invitees. Without a
+-- kind, every one of them would arm the intro-call state machine — Watch
+-- chips, "Notes on the way…", coverage reminders, recording bots.
+--
+--   intro_call   the screening call; the only kind that drives row states
+--   visit        they came to the house
+--   house_event  anything else they were invited to
+--
+-- Existing rows are intro_call: that's all the table has ever held.
+-- ============================================
+
+ALTER TABLE recruit_screenings
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'intro_call',
+  ADD COLUMN IF NOT EXISTS calendar_id TEXT,
+  ADD COLUMN IF NOT EXISTS title TEXT;
+
+DO $$
+BEGIN
+  ALTER TABLE recruit_screenings
+    ADD CONSTRAINT recruit_screenings_kind_chk
+    CHECK (kind IN ('intro_call', 'visit', 'house_event'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- The state machine reads "scheduled intro calls" constantly.
+CREATE INDEX IF NOT EXISTS recruit_screenings_kind_idx
+  ON recruit_screenings (kind, status);
+
+-- Recording bots must never be scheduled for a dinner. The sweep sets these
+-- explicitly, but a NULL-safe guard here documents the invariant.
+CREATE INDEX IF NOT EXISTS recruit_screenings_gcal_idx
+  ON recruit_screenings (gcal_event_id)
+  WHERE gcal_event_id IS NOT NULL;

--- a/supabase/migrations/138_recruit_external_recording.sql
+++ b/supabase/migrations/138_recruit_external_recording.sql
@@ -1,0 +1,112 @@
+-- ============================================
+-- Migration 138: recordings we didn't make
+--
+-- Calls get recorded outside the pipeline all the time — someone runs the
+-- intro on tldv, or Zoom, or records to Drive. Today the only recordings the
+-- app can show are ones Recall's bot captured (recall_bot_id) or ones we
+-- archived to storage (recording_path). Everything else is a link pasted
+-- into Discord that nobody can find two weeks later.
+--
+-- external_recording_url holds that link on the screening row, so the Watch
+-- affordance works regardless of who did the recording. It is a LINK, not a
+-- stream: tldv and friends refuse to embed cross-origin, so the UI opens it
+-- in a new tab rather than pretending it can play inline.
+-- ============================================
+
+ALTER TABLE recruit_screenings
+  ADD COLUMN IF NOT EXISTS external_recording_url TEXT,
+  ADD COLUMN IF NOT EXISTS external_recording_source TEXT,
+  ADD COLUMN IF NOT EXISTS external_recording_by_name TEXT,
+  ADD COLUMN IF NOT EXISTS external_recording_at TIMESTAMPTZ;
+
+-- Only http(s). Cheap guard against a javascript: URL reaching an href.
+DO $$
+BEGIN
+  ALTER TABLE recruit_screenings
+    ADD CONSTRAINT recruit_screenings_external_url_chk
+    CHECK (external_recording_url IS NULL OR external_recording_url ~* '^https?://');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Attach a recording link to an applicant. Creates a bare screening row when
+-- there's nothing to hang it on — a call that happened entirely outside the
+-- app still deserves a record. Kind stays intro_call: someone bothered to
+-- record it, so it was a call.
+CREATE OR REPLACE FUNCTION recruit_attach_recording(
+  p_applicant TEXT,
+  p_url TEXT,
+  p_source TEXT,
+  p_name TEXT,
+  p_screening UUID DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  target UUID;
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  IF p_url IS NOT NULL AND p_url !~* '^https?://' THEN
+    RAISE EXCEPTION 'recording link must be an http(s) URL';
+  END IF;
+
+  target := p_screening;
+  IF target IS NULL THEN
+    -- Most recent call for this applicant that has no recording yet.
+    SELECT id INTO target FROM recruit_screenings
+      WHERE applicant_id = p_applicant
+        AND kind = 'intro_call'
+        AND external_recording_url IS NULL
+        AND recall_bot_id IS NULL
+      ORDER BY starts_at DESC LIMIT 1;
+  END IF;
+
+  IF target IS NULL THEN
+    INSERT INTO recruit_screenings (applicant_id, starts_at, ends_at, status, kind, housemate_name)
+      VALUES (p_applicant, NOW(), NOW(), 'completed', 'intro_call', 'recorded elsewhere')
+      RETURNING id INTO target;
+  END IF;
+
+  UPDATE recruit_screenings SET
+    external_recording_url = p_url,
+    external_recording_source = CASE WHEN p_url IS NULL THEN NULL ELSE p_source END,
+    external_recording_by_name = CASE WHEN p_url IS NULL THEN NULL ELSE p_name END,
+    external_recording_at = CASE WHEN p_url IS NULL THEN NULL ELSE NOW() END
+  WHERE id = target;
+
+  RETURN target;
+END;
+$$;
+
+-- Links harvested from Discord that we couldn't confidently attribute. The
+-- app offers them as suggestions; a human picks the applicant. Never
+-- auto-attached: a wrong recording on a profile is worse than none.
+CREATE TABLE IF NOT EXISTS recruit_recording_leads (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  url TEXT NOT NULL UNIQUE,
+  source TEXT,
+  channel_id TEXT,
+  message_id TEXT,
+  posted_at TIMESTAMPTZ,
+  author_name TEXT,
+  context TEXT,
+  suggested_applicant_id TEXT REFERENCES recruit_applicants(id) ON DELETE SET NULL,
+  resolved_applicant_id TEXT REFERENCES recruit_applicants(id) ON DELETE SET NULL,
+  dismissed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE recruit_recording_leads ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS recruit_recording_leads_read ON recruit_recording_leads;
+CREATE POLICY recruit_recording_leads_read ON recruit_recording_leads
+  FOR SELECT USING (is_recruiting_member());
+
+DROP POLICY IF EXISTS recruit_recording_leads_write ON recruit_recording_leads;
+CREATE POLICY recruit_recording_leads_write ON recruit_recording_leads
+  FOR UPDATE USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+
+CREATE INDEX IF NOT EXISTS recruit_recording_leads_open_idx
+  ON recruit_recording_leads (posted_at DESC)
+  WHERE resolved_applicant_id IS NULL AND dismissed_at IS NULL;


### PR DESCRIPTION
Closes the remaining four items. Migrations 136–138 are **already applied** and all three edge functions **already deployed** — this PR is the code of record.

## 1. Stable email loading

`loadEmailsPanel` blanked the panel and blocked on a Gmail round-trip on *every* open. Now `loadAll` pulls full email rows (minus the heavy `body_text`) and hydrates `emailsCache` / `availCache` / `screeningsCache` at boot, so a thread paints from memory and the network only ever **adds**. One in-flight sync per applicant, a quiet `checking for new…` note instead of a blank panel, and the next applicant in the queue prefetches while you read the current one. Sending folds the sent message in rather than dropping the cache out from under an open thread.

## 2. Scan cron — the actual "why aren't Marisa & Keerti reflected" fix

The sweep that matches inbound mail and picks up manually-booked calls **only ever ran from a browser** — throttled to 10 min per device, skipped entirely when nobody had the app open. Migration 136 ticks `recruit-gmail/scan` every 20 minutes. Cron runs sweep 60 days and paginate to 400 messages (vs the app's 14/100), affordable because the per-message existence `SELECT` became one prefetched id set.

## 3. House calendar

Screenings posted to the shared account's **private primary**, so residents never saw them. They now post to the house calendar, falling back to primary with a loud log if the account only has read access — a call on the wrong calendar beats a booking that failed. The sweep reads every calendar in the list, looks 60 days **back** as well as forward, and tolerates one unreadable calendar without dying.

Migration 137 adds `recruit_screenings.kind`, and this is the part that matters: the table only ever modelled intro calls, which was safe only while the sweep read a calendar where applicant-attended events *are* intro calls. On the house calendar a dinner would have armed Watch chips, recording bots, and coverage reminders. Only `kind='intro_call'` drives row states; visits and house events render as read-only profile context. `recruit-discord`'s reminder, bot, and live-announce queries are gated to `intro_call` too.

## 4. External recordings

Migration 138 adds `external_recording_url` behind a `recruit_attach_recording` RPC, plus `recruit_recording_leads`. **Add recording link…** sits in the row ⋯ and on the Call tab; `scan-recordings` harvests tldv/Zoom/Fathom/Loom/Grain/Otter/Drive/Vimeo links from the recruiting channels and guesses the applicant from a full-name match (or an unambiguous first name). Guesses are **suggestions** in a tray on Screening — nothing auto-attaches, because a wrong recording on a profile is worse than no recording. Links open out; none of these hosts allow cross-origin embedding.

## Two bugs caught by running it

- **The cron would never have fired.** Supabase's gateway rejects requests with no `Authorization` header before the function runs. `recruit-discord` escapes this via `verify_jwt = false`; `recruit-gmail` can't, since its other actions need a real user JWT. The tick now sends the public anon key to satisfy the gateway; the nonce remains the actual authorization. Verified: no nonce → 401, valid nonce → runs.
- **"Has a video link" was too loose a signal for an intro call.** A social event named *"Peloton man doing what he Peloton can"* got filed as a screening. A video link now only implies `intro_call` for a small meeting (1–4 attendees). The sweep also skips rejected/archived applicants.

## Verification

First real cron-path run found what the app had been missing: **3 unseen emails, 3 availability backfills, 3 calendar pickups** — two of them `keerti-agape` and `marisa-agape`. Those calls sat on the house calendar the whole time and nothing read it.

Also confirmed live: both check constraints reject bad input, the `recruit_attach_recording` RPC exists, `recruit_gmail_scan_tick` is scheduled and active alongside the reminder tick, and the house calendar is readable by the shared account.

**Not verified:** whether the shared account can *write* to the house calendar — that only exercises on the next booking, and the code falls back to primary with a log if not.

`app v3.27.0` · `recruit-gmail v1.16.1` · `recruit-discord v1.13.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)