### PR TITLE
Recruiting: hourly Sheets-API ingest (replaces Apps Script as primary)

### DIFF
--- a/docs/infrastructure/recruiting-sheet-ingest.md
+++ b/docs/infrastructure/recruiting-sheet-ingest.md
@@ -2,20 +2,25 @@
 
 **One line:** the application spreadsheet pushes each new row to the `recruit-ingest` edge function on submit, so applicants appear in `/applications` Inbox without a manual import.
 
-Status: **endpoint live** (`recruit-ingest` v1.0.1) · **one setup step left in the sheet** (below).
+Status: **live, API pull on an hourly cron** (`recruit-ingest` v1.1.0, migration 131) · one blocker: the shared Google account needs a reconnect to grant the Sheets scope.
 
 ---
 
-## Why push, not pull
+## Why the API pull is primary
 
-Google Sheets has no native webhook. The two real options:
+Google Sheets has no native webhook, so the two options are an Apps Script trigger inside the sheet (push) or a scheduled read through the Sheets API (pull). **Pull is the primary path** because it's more stable in the ways that matter here:
 
-| Approach | Latency | Cost to set up | Notes |
-|---|---|---|---|
-| **Apps Script trigger → our endpoint** ✅ chosen | seconds | paste one script into the sheet, once | No new OAuth scopes. The sheet already has permission to read itself. |
-| Scheduled pull via pg_cron + Sheets API | up to an hour | reconnect the shared Google account with an added `spreadsheets.readonly` scope, or share the sheet with a service account | More moving parts, and a scope change re-triggers the OAuth consent dance. |
+| | API pull ✅ primary | Apps Script push |
+|---|---|---|
+| Where the code lives | our repo, deployed + versioned | inside the spreadsheet, editable by anyone with edit access |
+| Secret exposure | none — the shared account's OAuth token | the ingest secret sits in plaintext in the script |
+| Failure visibility | edge-function logs + the audit channel | Apps Script disables triggers after repeated errors, silently |
+| Works for hand-added rows | yes (it reads the whole tab) | no (only fires on form submit) |
+| Latency | up to an hour | seconds |
 
-Push wins because it needs no new Google permissions and lands applicants while the applicant is still warm — the Discord ping and the vote can happen the same hour.
+An hour of latency costs nothing: the applicant has just filled in a form and isn't waiting on us. The push endpoint stays available for a Fillout-style webhook if real-time ever matters.
+
+Because the pull is **idempotent**, re-reading the entire sheet every hour is free: ids derive from name + submission timestamp and inserts ignore duplicates.
 
 ## The endpoint
 
@@ -32,7 +37,13 @@ body:    { "rows": [ { "<sheet header>": "<value>", ... } ] }
 - New rows land at `stage='review'`, so the funnel picks them up: the `recruit-gmail` scan pings #recruiting-society (14-day floor, digest at 4+) and the house votes.
 - Each ingest posts one audit line to #recruiting-automation.
 
-## Setup: the Apps Script (one time, in the sheet)
+## What runs
+
+- **Cron** (migration 131): `recruit_application_ingest_tick`, hourly at :07, one-time-nonce auth (same handshake as the reminder cron).
+- **Endpoint**: `POST /functions/v1/recruit-ingest/pull` — reads `RECRUIT_SHEET_ID` / `RECRUIT_SHEET_RANGE` (defaults to the Jan 2026+ responses sheet, tab `Form Responses 1`) with the shared account's token.
+- **Prereqs**: the sheet is shared with `live.at.agapesf@gmail.com` (already true), and that account has granted `spreadsheets.readonly` — added to recruit-gmail's consent screen, so **reconnecting the shared Gmail from the /applications rail footer grants it**. Until then the pull returns a plain-English 502 saying exactly that.
+
+## Optional: real-time push via Apps Script
 
 1. Open the application spreadsheet → **Extensions → Apps Script**.
 2. Paste this, replacing `PASTE_SECRET_HERE` with the `RECRUIT_INGEST_SECRET` value (ask Ian / read it from Supabase → Edge Functions → Secrets):

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.16.0'
+const VERSION = '1.17.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -40,6 +40,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/calendar.events', // screening-call invites
+  'https://www.googleapis.com/auth/spreadsheets.readonly', // application-sheet ingest
 ]
 
 function db() {

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -6,20 +6,60 @@
 // Deployed with --no-verify-jwt: the caller is a Google Apps Script, not a
 // signed-in user, so it authenticates with a shared secret header instead.
 //
-// POST /functions/v1/recruit-ingest
-//   headers: x-ingest-secret: <RECRUIT_INGEST_SECRET>
-//   body:    { rows: [ { "<sheet header>": "<value>", ... } ], dryRun?: true }
+// Two ways in:
+//   PULL (primary, hourly cron) — POST /functions/v1/recruit-ingest/pull
+//     auth: X-Cron-Nonce (cron) or x-ingest-secret (manual). Reads the sheet
+//     with the shared Google account's token, so no secret lives in the sheet.
+//   PUSH (optional, real-time) — POST /functions/v1/recruit-ingest
+//     auth: x-ingest-secret. body { rows: [ { "<header>": "<value>" } ] }
+//     For a Fillout/Apps Script webhook when seconds matter.
+//   dryRun: true on either reports the mapping and writes nothing.
 //
 // Idempotent: the row's id is derived from the applicant's name + submission
 // timestamp, and inserts ignore duplicates — so resending the whole sheet is
 // a safe backfill, not a mess of copies.
 
-const VERSION = '1.0.1'
+const VERSION = '1.1.0'
 console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { postChannelEmbed, AUTOMATION_CHANNEL_ID } from '../_shared/discord.ts'
+import { sharedAccessToken } from '../_shared/recruit-schedule.ts'
+
+// The application spreadsheet + tab, overridable so a new form or season
+// doesn't need a deploy.
+const SHEET_ID = Deno.env.get('RECRUIT_SHEET_ID') || '1dyDpPv7LhFSjL2Nz2E_2GMBIR-qGZg4qW4TjEkt7Epg'
+const SHEET_RANGE = Deno.env.get('RECRUIT_SHEET_RANGE') || 'Form Responses 1'
+
+/* Read the sheet as rows of { header: value } with the shared account's OAuth
+   token. Needs the spreadsheets.readonly scope; until the account is
+   reconnected Google answers 403, and we say exactly that rather than
+   failing quietly. */
+// deno-lint-ignore no-explicit-any
+async function readSheet(client: any): Promise<Array<Record<string, unknown>>> {
+  const at = await sharedAccessToken(client)
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${encodeURIComponent(SHEET_RANGE)}`
+  const resp = await fetch(url, { headers: { Authorization: `Bearer ${at}` } })
+  const text = await resp.text()
+  if (!resp.ok) {
+    if (resp.status === 403 && /insufficient|scope|ACCESS_TOKEN_SCOPE/i.test(text)) {
+      throw new Error('the shared Google account has not granted the Sheets scope yet — reconnect it from the /applications rail footer')
+    }
+    if (resp.status === 403 || resp.status === 404) {
+      throw new Error(`the shared account cannot read the sheet — share it with live.at.agapesf@gmail.com as Viewer (HTTP ${resp.status})`)
+    }
+    throw new Error(`Sheets API ${resp.status}: ${text.slice(0, 200)}`)
+  }
+  const values: string[][] = JSON.parse(text).values || []
+  if (values.length < 2) return []
+  const headers = values[0]
+  return values.slice(1).map((row) => {
+    const obj: Record<string, unknown> = {}
+    headers.forEach((h, i) => { if (h) obj[String(h)] = row[i] ?? '' })
+    return obj
+  })
+}
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -87,21 +127,41 @@ function deriveId(first: string, last: string, submittedAt: Date): string {
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
   try {
-    const secret = Deno.env.get('RECRUIT_INGEST_SECRET')
-    if (!secret) return json({ error: 'RECRUIT_INGEST_SECRET not configured' }, 500)
-    if (req.headers.get('x-ingest-secret') !== secret) return json({ error: 'bad or missing x-ingest-secret' }, 401)
-
+    const isPull = new URL(req.url).pathname.endsWith('/pull')
+    const client = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
     const body = await req.json().catch(() => ({}))
-    const rows: Array<Record<string, unknown>> = Array.isArray(body.rows) ? body.rows
-      : body.row && typeof body.row === 'object' ? [body.row] : []
-    if (!rows.length) return json({ error: 'send { rows: [ {header: value} ] }' }, 400)
     const dryRun = body.dryRun === true
 
-    const client = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+    // The hourly cron presents a one-time nonce (same handshake the reminder
+    // cron uses); humans and webhooks present the shared secret.
+    const secret = Deno.env.get('RECRUIT_INGEST_SECRET')
+    const nonce = req.headers.get('x-cron-nonce')
+    let authed = Boolean(secret) && req.headers.get('x-ingest-secret') === secret
+    if (!authed && nonce) {
+      const { data: burned } = await client.from('recruit_cron_nonce')
+        .delete().eq('nonce', nonce).gte('created_at', new Date(Date.now() - 10 * 60000).toISOString())
+        .select('nonce').maybeSingle()
+      authed = Boolean(burned)
+    }
+    if (!authed) return json({ error: 'bad or missing x-ingest-secret / x-cron-nonce' }, 401)
+
+    let rows: Array<Record<string, unknown>>
+    if (isPull) {
+      try {
+        rows = await readSheet(client)
+      } catch (err) {
+        console.error(`[recruit-ingest] pull failed: ${(err as Error).message}`)
+        return json({ error: (err as Error).message }, 502)
+      }
+    } else {
+      rows = Array.isArray(body.rows) ? body.rows
+        : body.row && typeof body.row === 'object' ? [body.row] : []
+      if (!rows.length) return json({ error: 'send { rows: [ {header: value} ] }' }, 400)
+    }
     const prepared: Array<Record<string, string>> = []
     const skipped: string[] = []
 
-    for (const raw of rows.slice(0, 200)) {
+    for (const raw of rows.slice(0, 500)) {
       const m = mapRow(raw)
       if (!m.email?.includes('@')) { skipped.push(`no email: ${JSON.stringify(raw).slice(0, 80)}`); continue }
       if (!m.first_name) { skipped.push(`no name: ${m.email}`); continue }
@@ -118,7 +178,7 @@ serve(async (req) => {
       })
     }
 
-    if (dryRun) return json({ dryRun: true, wouldInsert: prepared, skipped })
+    if (dryRun) return json({ dryRun: true, source: isPull ? 'sheet' : 'push', rowsRead: rows.length, wouldInsert: prepared, skipped })
     if (!prepared.length) return json({ inserted: 0, skipped })
 
     // ignoreDuplicates: resending the sheet is a backfill, not a mess.
@@ -142,7 +202,7 @@ serve(async (req) => {
       }
     }
     console.log(`[recruit-ingest] ${created.length} created, ${prepared.length - created.length} already present, ${skipped.length} skipped`)
-    return json({ inserted: created.length, ids: created.map((c) => c.id), duplicates: prepared.length - created.length, skipped })
+    return json({ inserted: created.length, source: isPull ? 'sheet' : 'push', rowsRead: rows.length, ids: created.map((c) => c.id), duplicates: prepared.length - created.length, skipped })
   } catch (err) {
     console.error(`[recruit-ingest] ${(err as Error).message}`)
     return json({ error: (err as Error).message }, 500)

--- a/supabase/migrations/131_recruit_ingest_cron.sql
+++ b/supabase/migrations/131_recruit_ingest_cron.sql
@@ -1,0 +1,41 @@
+-- ============================================
+-- Migration 131: hourly application-sheet ingest
+--
+-- Pulls the application spreadsheet through the Sheets API with the shared
+-- Google account's token (recruit-ingest/pull) instead of relying on an Apps
+-- Script trigger living inside the sheet. Same one-time-nonce handshake as
+-- the reminder cron (migration 123): each tick inserts a nonce and sends it
+-- as X-Cron-Nonce; the function burns it on use.
+--
+-- Ingest is idempotent (id = name-slug + submission timestamp, duplicates
+-- ignored), so re-reading the whole sheet every hour costs nothing.
+-- ============================================
+
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'recruit_application_ingest_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end$$;
+
+select cron.schedule(
+  'recruit_application_ingest_tick',
+  '7 * * * *',   -- hourly, off the hour so it doesn't collide with other jobs
+  $$
+  with purge as (
+    delete from recruit_cron_nonce where created_at < now() - interval '1 hour'
+  ), n as (
+    insert into recruit_cron_nonce default values returning nonce
+  )
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/recruit-ingest/pull',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'X-Cron-Nonce', (select nonce::text from n)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+  $$
+);


### PR DESCRIPTION
You were right that the API is more stable. Switched the primary path to a **scheduled Sheets-API pull**:

| | API pull ✅ | Apps Script push |
|---|---|---|
| Code location | our repo, versioned | inside the spreadsheet |
| Secret exposure | none (OAuth token) | plaintext in the script |
| Failure visibility | fn logs + audit channel | triggers silently disable after errors |
| Hand-added rows | picked up | ignored (form-submit only) |
| Latency | ≤ 1 hour | seconds |

- `recruit-ingest/pull` (v1.1.0) reads the sheet with the shared account's token; sheet id/range are env-overridable.
- `recruit-gmail` v1.17.0 adds `spreadsheets.readonly` to the shared-account consent screen. A missing scope returns a plain-English 502 rather than failing quietly.
- **Migration 131**: hourly cron at :07 using the existing one-time-nonce handshake.
- Push endpoint kept for a Fillout webhook if real-time ever matters.

Verified: the sheet is already shared with live.at.agapesf@gmail.com, and the pull currently returns the exact scope error it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)