### PR TITLE
feat(recruiting): relink-recordings repairs stale Discord recording links

### DIFF
--- a/docs/strategy/prds/agape-screening-claim-automation.md
+++ b/docs/strategy/prds/agape-screening-claim-automation.md
@@ -148,3 +148,5 @@ Discord recording posts carried Recall's presigned URL, which expired within hou
 - **`recruit-watch`** (`verify_jwt = false`) validates the token shape, resolves screening *or* recorded event, and returns title/when/summary plus a 6-hour signed URL. Bad, revoked, and unknown tokens are all a flat 404.
 - **Deliberate trade-off:** anyone with the link can watch, with no Discord sign-in — chosen so links work from phones and forwarded messages. The app's own Watch button remains membership-gated; only the shared link bypasses it.
 - Ordering matters: the archive upload now happens *before* the Discord post, since the post links to our copy.
+
+**Repairing old posts:** `recruit-gmail relink-recordings` (recruiting-member JWT) scans the notes channel and rewrites any 🎥 line still pointing at an expired Recall URL, editing the message in place so notes keep their position in channel history. Matching is by profile link, then applicant first name, then recorded-event title; posts with no archived recording are reported in `skipped` and left untouched. Idempotent — a second run updates nothing.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -427,6 +427,43 @@ export async function postMeetingNote(
   }, `meeting notes (${title})`)
 }
 
+// One-shot repair for notes posted before capability links existed: their
+// 🎥 line still points at a Recall presigned URL that expired within hours.
+// Rewrites that line in place (editing beats reposting — the notes keep their
+// position in channel history). resolve() maps an applicant id to its share
+// token; posts we can't resolve are left untouched.
+export async function relinkRecordingPosts(
+  // Meeting-style notes carry no profile link, so the title is the only
+  // handle we have on them — the resolver gets both.
+  resolve: (applicantId: string | null, title: string) => Promise<string | null>,
+  limit = 100,
+): Promise<{ scanned: number; updated: number; skipped: string[] }> {
+  const messages = await discordFetch(`/channels/${NOTES_CHANNEL_ID}/messages?limit=${limit}`, { method: 'GET' })
+  const skipped: string[] = []
+  let updated = 0
+  for (const msg of (messages || [])) {
+    const embed = (msg.embeds || [])[0]
+    const desc: string = embed?.description || ''
+    // Only touch posts whose recording line is a stale non-watch link.
+    if (!/🎥 \[Recording\]\(/.test(desc)) continue
+    const idMatch = desc.match(/\/applications\/\?a=([0-9a-zA-Z-]+)/)?.[1]
+    const applicantId = idMatch ? decodeURIComponent(idMatch) : null
+    const token = await resolve(applicantId, String(embed?.title || ''))
+    if (!token) { skipped.push(`${msg.id}: ${embed?.title || 'untitled'} — no archived recording`); continue }
+    const fixed = desc.replace(
+      /🎥 \[Recording\]\([^)]*\)(\s*_\([^)]*\)_)?/,
+      `🎥 [Watch the recording](${watchLink(token)})`,
+    )
+    if (fixed === desc) { skipped.push(`${msg.id}: line not matched`); continue }
+    await discordFetch(`/channels/${NOTES_CHANNEL_ID}/messages/${msg.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ embeds: [{ ...embed, description: fixed.slice(0, 4000) }] }),
+    })
+    updated++
+  }
+  return { scanned: (messages || []).length, updated, skipped }
+}
+
 // "Happening now" — announce a starting call so housemates can drop in.
 export async function postLiveCall(title: string, when: string, meetLink: string | null): Promise<void> {
   await postResilient(NOTES_CHANNEL_ID, {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.16.0'
+const VERSION = '1.17.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -515,6 +515,42 @@ serve(async (req) => {
         }
       }
       return json({ results: out })
+    }
+
+    if (action === 'relink-recordings') {
+      // Repair old notes whose 🎥 link is an expired Recall URL.
+      const { relinkRecordingPosts } = await import('../_shared/discord.ts')
+      const out = await relinkRecordingPosts(async (applicantId, title) => {
+        if (applicantId) {
+          const { data } = await client.from('recruit_screenings')
+            .select('share_token').eq('applicant_id', applicantId)
+            .not('share_token', 'is', null).not('recording_path', 'is', null)
+            .order('starts_at', { ascending: false }).limit(1).maybeSingle()
+          if (data?.share_token) return data.share_token
+        }
+        // No profile link: "<First> × <Resident> — Intro Call notes" or
+        // "<Title> — meeting notes". Try the applicant's first name, then
+        // the recorded-event title.
+        const stem = title.replace(/ — (Intro Call|meeting) notes$/, '').trim()
+        const first = stem.split('×')[0].trim().replace(/'s Intro Call$/, '')
+        if (first) {
+          const { data: app } = await client.from('recruit_applicants')
+            .select('id').ilike('first_name', first).limit(2)
+          if (app?.length === 1) {
+            const { data } = await client.from('recruit_screenings')
+              .select('share_token').eq('applicant_id', app[0].id)
+              .not('share_token', 'is', null).not('recording_path', 'is', null)
+              .order('starts_at', { ascending: false }).limit(1).maybeSingle()
+            if (data?.share_token) return data.share_token
+          }
+        }
+        const { data: ev } = await client.from('recruit_recorded_events')
+          .select('share_token').eq('title', stem)
+          .not('share_token', 'is', null).not('recording_path', 'is', null)
+          .limit(1).maybeSingle()
+        return ev?.share_token || null
+      })
+      return json(out)
     }
 
     if (action === 'recording-link') {


### PR DESCRIPTION
Old notes in the channel still linked to Recall presigned URLs that expired within hours. `relink-recordings` rewrites those 🎥 lines in place to point at the archived copy.

Editing beats reposting: the notes keep their position in channel history and nobody gets duplicate pings.

Matching cascade: profile link → applicant first name → recorded-event title. Anything with no archived recording is reported in `skipped` and left alone.

## Verified in prod
Ran against #recruiting notes: scanned 69, both stale posts updated, zero skips. A repeat run reports `updated: 0` — idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)