### PR TITLE
feat(recruiting): playback speed + docking mini player (v3.29.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1421,3 +1421,14 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   .inbox-row__actions .cta-stack { width: auto; align-items: flex-end; }
   .inbox-row__actions .cta-pair { width: auto; }
 }
+
+/* --- v3.29.0: playback-speed row under call recordings --- */
+.speed-bar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-top: var(--space-2); }
+.speed-bar__label { font-size: var(--font-size-caption); color: var(--fg-subtle); margin-right: 2px; }
+.speed-bar__btn {
+  background: transparent; color: var(--fg-subtle);
+  border: 1px solid var(--border); border-radius: 999px;
+  padding: 4px 10px; font: inherit; font-size: var(--font-size-caption); cursor: pointer;
+}
+.speed-bar__btn:hover { border-color: var(--border-strong); color: var(--fg); }
+.speed-bar__btn[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: var(--accent-fg, #fff); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.28.0">
+  <link rel="stylesheet" href="css/app.css?v=3.29.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -179,6 +179,15 @@
       <div class="watch-modal__grid">
         <div class="watch-modal__player">
           <video id="watch-video" controls playsinline preload="metadata"></video>
+          <div class="speed-bar" data-speed-for="watch-video">
+            <span class="speed-bar__label">Speed</span>
+            <button type="button" class="speed-bar__btn" data-rate="0.75">0.75×</button>
+            <button type="button" class="speed-bar__btn" data-rate="1" aria-pressed="true">1×</button>
+            <button type="button" class="speed-bar__btn" data-rate="1.25">1.25×</button>
+            <button type="button" class="speed-bar__btn" data-rate="1.5">1.5×</button>
+            <button type="button" class="speed-bar__btn" data-rate="1.75">1.75×</button>
+            <button type="button" class="speed-bar__btn" data-rate="2">2×</button>
+          </div>
           <p class="email-modal__status" id="watch-status"></p>
         </div>
         <aside class="watch-modal__side">
@@ -258,6 +267,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.28.0"></script>
+  <script src="js/app.js?v=3.29.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.28.0';
+const VERSION = '3.29.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1383,6 +1383,43 @@ function screeningChip(a) {
   return `<span class="decision-chip decision-chip--vote">Availability received</span>`;
 }
 
+/* Playback-speed row for a <video>. Browsers bury speed in a menu (and iOS
+   omits it), so surface it; the choice sticks across calls. */
+const PLAY_RATES = [0.75, 1, 1.25, 1.5, 1.75, 2];
+const RATE_KEY = 'agape:watchRate';
+
+function savedRate() {
+  const r = parseFloat(localStorage.getItem(RATE_KEY));
+  return PLAY_RATES.includes(r) ? r : 1;
+}
+
+function speedBarHtml(videoId) {
+  const cur = savedRate();
+  return `<div class="speed-bar" data-speed-for="${videoId}">
+    <span class="speed-bar__label">Speed</span>
+    ${PLAY_RATES.map(r => `<button type="button" class="speed-bar__btn" data-rate="${r}" aria-pressed="${r === cur}">${r}×</button>`).join('')}
+  </div>`;
+}
+
+function wireSpeedBar(videoId) {
+  const bar = document.querySelector(`[data-speed-for="${videoId}"]`);
+  const video = document.getElementById(videoId);
+  if (!bar || !video) return;
+  const apply = rate => {
+    video.playbackRate = rate;
+    localStorage.setItem(RATE_KEY, String(rate));
+    bar.querySelectorAll('.speed-bar__btn').forEach(b =>
+      b.setAttribute('aria-pressed', String(parseFloat(b.dataset.rate) === rate)));
+  };
+  bar.addEventListener('click', e => {
+    const btn = e.target.closest('.speed-bar__btn');
+    if (btn) apply(parseFloat(btn.dataset.rate));
+  });
+  // Setting src resets playbackRate, so re-apply once metadata lands.
+  video.addEventListener('loadedmetadata', () => { video.playbackRate = savedRate(); });
+  apply(savedRate());
+}
+
 /* ---------- recording viewer: video + call notes + house comments ---------- */
 let watchApplicantId = null;
 
@@ -1451,7 +1488,9 @@ async function loadCallPanel(a) {
   host().innerHTML = `
     <p class="notes__empty">${esc(`${row.housemate_name ? `${row.housemate_name} × ` : ''}${fullName(a)}`)} · ${row.starts_at ? fmtSlot(row.starts_at) : ''}</p>
     ${sc.watch
-      ? `<video id="call-video" class="call-video" controls playsinline></video><p class="email-modal__status" id="call-status">Fetching recording…</p>`
+      ? `<video id="call-video" class="call-video" controls playsinline></video>
+         ${speedBarHtml('call-video')}
+         <p class="email-modal__status" id="call-status">Fetching recording…</p>`
       : row.external_recording_url
         // These hosts block cross-origin embedding, so this opens out rather
         // than pretending to be a player.
@@ -1471,6 +1510,7 @@ async function loadCallPanel(a) {
       </form>
     </section>`;
   loadComments(a.id).then(() => { if (queue[qIndex] === a.id && reviewTab === 'call') renderNotes(a.id); });
+  wireSpeedBar('call-video');
   document.getElementById('notes-form-call')?.addEventListener('submit', (ev) => { ev.preventDefault(); postNote(a.id); });
   document.getElementById('call-stamp')?.addEventListener('click', () => {
     const v = document.getElementById('call-video');
@@ -1518,6 +1558,7 @@ async function openWatch(screeningId) {
     if (!out.url) throw new Error('recording not available');
     video.src = out.url;
     status.textContent = '';
+    wireSpeedBar('watch-video');
   } catch (e) {
     status.textContent = `Recording unavailable: ${e.message}`;
   }

--- a/applications/watch/index.html
+++ b/applications/watch/index.html
@@ -22,10 +22,43 @@
     .card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 16px 20px; margin-top: 24px; }
     .card h2 { font-size: 15px; font-weight: 600; margin: 0 0 10px; }
     .summary { white-space: pre-wrap; font-size: 15px; }
-    .muted { color: var(--fg-muted); }
     .foot { margin-top: 28px; font-size: 13px; color: var(--fg-muted); }
     .foot a { color: var(--accent); }
     .state { padding: 40px 0; text-align: center; color: var(--fg-muted); }
+
+    /* Playback controls: browsers bury (or omit) speed on mobile, so surface it. */
+    .tools { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .tools__label { font-size: 13px; color: var(--fg-muted); margin-right: 2px; }
+    .rate {
+      background: transparent; color: var(--fg-muted); border: 1px solid var(--border);
+      border-radius: 999px; padding: 5px 11px; font: inherit; font-size: 13px; cursor: pointer;
+    }
+    .rate:hover { border-color: #3a4150; color: var(--fg); }
+    .rate[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .pip { margin-left: auto; }
+
+    /* Mini player: the shell goes fixed, a placeholder holds the page height
+       so nothing jumps. Scrolling back up re-docks it inline. */
+    .player { position: relative; }
+    .player.is-mini {
+      position: fixed; right: 16px; bottom: 16px; z-index: 60;
+      width: min(360px, 62vw); border-radius: 12px; overflow: hidden;
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55); border: 1px solid var(--border);
+    }
+    .player.is-mini video { border-radius: 0; }
+    .player.is-mini .tools { display: none; }
+    .mini-bar {
+      display: none; align-items: center; gap: 8px;
+      background: var(--surface); padding: 6px 8px 6px 12px; font-size: 12px; color: var(--fg-muted);
+    }
+    .player.is-mini .mini-bar { display: flex; }
+    .mini-bar__title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .mini-bar button {
+      background: transparent; border: 0; color: var(--fg-muted); cursor: pointer;
+      font: inherit; font-size: 12px; padding: 3px 7px; border-radius: 6px;
+    }
+    .mini-bar button:hover { background: #222732; color: var(--fg); }
+    @media (max-width: 520px) { .player.is-mini { width: min(260px, 70vw); right: 10px; bottom: 10px; } }
   </style>
 </head>
 <body>
@@ -36,6 +69,8 @@
 
   <script>
     const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+    const RATES = [0.75, 1, 1.25, 1.5, 1.75, 2];
+    const RATE_KEY = 'agape:watchRate';
     const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 
     function fmtWhen(iso) {
@@ -55,6 +90,82 @@
         .replace(/^[-*]\s+(.+)$/gm, '• $1');
     }
 
+    function wirePlayer(title) {
+      const video = document.getElementById('v');
+      const player = document.getElementById('player');
+      const placeholder = document.getElementById('player-slot');
+      if (!video) return;
+
+      // ---- speed ----
+      const saved = parseFloat(localStorage.getItem(RATE_KEY));
+      const startRate = RATES.includes(saved) ? saved : 1;
+      const buttons = [...document.querySelectorAll('.rate')];
+      const applyRate = rate => {
+        video.playbackRate = rate;
+        localStorage.setItem(RATE_KEY, String(rate));
+        buttons.forEach(b => b.setAttribute('aria-pressed', String(parseFloat(b.dataset.rate) === rate)));
+      };
+      buttons.forEach(b => b.addEventListener('click', () => applyRate(parseFloat(b.dataset.rate))));
+      applyRate(startRate);
+      // Some browsers reset rate when new media loads.
+      video.addEventListener('loadedmetadata', () => { video.playbackRate = startRate; });
+
+      // ---- mini player ----
+      let dismissed = false;
+      const setMini = on => {
+        if (player.classList.contains('is-mini') === on) return;
+        if (on) {
+          placeholder.style.height = `${player.offsetHeight}px`;
+          player.classList.add('is-mini');
+        } else {
+          player.classList.remove('is-mini');
+          placeholder.style.height = '';
+        }
+      };
+      const observer = new IntersectionObserver(([entry]) => {
+        // Dock only while actually watching — a paused video scrolling away
+        // is just a page you've moved past.
+        const watching = !video.paused && !video.ended;
+        setMini(!entry.isIntersecting && watching && !dismissed);
+      }, { threshold: 0.35 });
+      observer.observe(placeholder);
+
+      // Pausing in the mini player returns it inline; so does scrolling back.
+      video.addEventListener('pause', () => setMini(false));
+      video.addEventListener('play', () => { dismissed = false; });
+
+      document.getElementById('mini-expand').addEventListener('click', () => {
+        setMini(false);
+        placeholder.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      });
+      document.getElementById('mini-close').addEventListener('click', () => {
+        dismissed = true;
+        video.pause();
+        setMini(false);
+      });
+      document.getElementById('mini-title').textContent = title;
+
+      // ---- picture-in-picture: keeps playing when you leave the tab ----
+      const pipBtn = document.getElementById('pip');
+      if (!document.pictureInPictureEnabled || video.disablePictureInPicture) {
+        pipBtn.hidden = true;
+      } else {
+        pipBtn.addEventListener('click', async () => {
+          try {
+            if (document.pictureInPictureElement) await document.exitPictureInPicture();
+            else await video.requestPictureInPicture();
+          } catch { /* browser declined — the inline player still works */ }
+        });
+        // Leaving the tab mid-play pops out automatically where allowed;
+        // browsers that require a gesture just decline and nothing breaks.
+        document.addEventListener('visibilitychange', async () => {
+          if (document.hidden && !video.paused && !document.pictureInPictureElement) {
+            try { await video.requestPictureInPicture(); } catch { /* declined */ }
+          }
+        });
+      }
+    }
+
     (async () => {
       const root = document.getElementById('root');
       const token = new URLSearchParams(location.search).get('t') || '';
@@ -66,15 +177,32 @@
           root.innerHTML = '<p class="state">This recording link is no longer valid. Ask in the Recruiting Society channel for a fresh one.</p>';
           return;
         }
+        const rateButtons = RATES.map(r =>
+          `<button type="button" class="rate" data-rate="${r}" aria-pressed="false">${r}×</button>`).join('');
         root.innerHTML = `
           <h1>${esc(data.title)}</h1>
           <p class="when">${esc(fmtWhen(data.when))}</p>
-          ${data.url
-            ? `<video controls playsinline preload="metadata" src="${esc(data.url)}"></video>`
+          ${data.url ? `
+            <div id="player-slot">
+              <div class="player" id="player">
+                <div class="mini-bar">
+                  <span class="mini-bar__title" id="mini-title"></span>
+                  <button type="button" id="mini-expand">Back to page</button>
+                  <button type="button" id="mini-close" aria-label="Close mini player">✕</button>
+                </div>
+                <video id="v" controls playsinline preload="metadata" src="${esc(data.url)}"></video>
+                <div class="tools">
+                  <span class="tools__label">Speed</span>
+                  ${rateButtons}
+                  <button type="button" class="rate pip" id="pip">Pop out</button>
+                </div>
+              </div>
+            </div>`
             : `<p class="state">${esc(data.reason || 'No recording available for this call.')}</p>`}
           ${data.summary ? `<div class="card"><h2>Call summary</h2><div class="summary">${mdLite(data.summary)}</div></div>` : ''}
           <p class="foot">Anyone with this link can watch. Housemates: open the
             <a href="/applications/">applicant inbox</a> for notes, votes, and the full profile.</p>`;
+        if (data.url) wirePlayer(data.title || 'Agape call');
       } catch {
         root.innerHTML = '<p class="state">Couldn’t load the recording. Try again in a minute.</p>';
       }


### PR DESCRIPTION
## Watch page
- **Speed**: 0.75× / 1× / 1.25× / 1.5× / 1.75× / 2× pills under the player, remembered in localStorage across calls (browsers bury speed in a menu; iOS omits it).
- **Mini player**: scroll the video out of view *while playing* and it docks bottom-right so you can read the summary while listening. A placeholder holds the page height so nothing jumps. Scrolling back, pausing, or "Back to page" re-docks it inline; ✕ dismisses.
- **Pop out**: native picture-in-picture button; leaving the tab mid-play pops out automatically where the browser permits (declines are caught — nothing breaks).

## In-app
Same speed row on the profile Call tab and the watch modal, sharing the stored preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)