### PR TITLE
feat(recruiting): speed control on the player, not below it (v3.30.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1422,13 +1422,27 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
   .inbox-row__actions .cta-pair { width: auto; }
 }
 
-/* --- v3.29.0: playback-speed row under call recordings --- */
-.speed-bar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-top: var(--space-2); }
-.speed-bar__label { font-size: var(--font-size-caption); color: var(--fg-subtle); margin-right: 2px; }
-.speed-bar__btn {
-  background: transparent; color: var(--fg-subtle);
-  border: 1px solid var(--border); border-radius: 999px;
-  padding: 4px 10px; font: inherit; font-size: var(--font-size-caption); cursor: pointer;
+/* --- v3.30.0: speed control on the player, not a row beneath it --- */
+.video-wrap { position: relative; }
+.vspeed { position: absolute; top: 8px; right: 8px; z-index: 2; opacity: 0; transition: opacity 140ms ease; }
+.video-wrap:hover .vspeed, .video-wrap:focus-within .vspeed { opacity: 1; }
+.vspeed__btn {
+  background: rgba(12, 14, 19, 0.78); color: #fff; border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 8px; padding: 4px 9px; font: inherit; font-size: var(--font-size-caption);
+  line-height: 1.2; cursor: pointer;
 }
-.speed-bar__btn:hover { border-color: var(--border-strong); color: var(--fg); }
-.speed-bar__btn[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: var(--accent-fg, #fff); }
+.vspeed__btn:hover { background: rgba(12, 14, 19, 0.95); }
+.vspeed__menu {
+  position: absolute; top: calc(100% + 6px); right: 0; min-width: 88px;
+  background: rgba(12, 14, 19, 0.96); border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px; padding: 4px; display: none; flex-direction: column;
+}
+.vspeed__menu.is-open { display: flex; }
+.vspeed__menu button {
+  background: transparent; border: 0; color: #cfd5e1; text-align: left;
+  padding: 6px 10px; border-radius: 6px; font: inherit; font-size: var(--font-size-caption); cursor: pointer;
+}
+.vspeed__menu button:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
+.vspeed__menu button[aria-checked="true"] { color: #fff; font-weight: var(--fw-medium); }
+/* Touch has no hover — keep it visible on small screens. */
+@media (hover: none) { .vspeed { opacity: 1; } }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.29.0">
+  <link rel="stylesheet" href="css/app.css?v=3.30.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -178,15 +178,19 @@
       </div>
       <div class="watch-modal__grid">
         <div class="watch-modal__player">
-          <video id="watch-video" controls playsinline preload="metadata"></video>
-          <div class="speed-bar" data-speed-for="watch-video">
-            <span class="speed-bar__label">Speed</span>
-            <button type="button" class="speed-bar__btn" data-rate="0.75">0.75×</button>
-            <button type="button" class="speed-bar__btn" data-rate="1" aria-pressed="true">1×</button>
-            <button type="button" class="speed-bar__btn" data-rate="1.25">1.25×</button>
-            <button type="button" class="speed-bar__btn" data-rate="1.5">1.5×</button>
-            <button type="button" class="speed-bar__btn" data-rate="1.75">1.75×</button>
-            <button type="button" class="speed-bar__btn" data-rate="2">2×</button>
+          <div class="video-wrap">
+            <div class="vspeed" data-speed-for="watch-video">
+              <button type="button" class="vspeed__btn" aria-haspopup="true" aria-expanded="false">1&times;</button>
+              <div class="vspeed__menu" role="menu">
+                <button type="button" role="menuitemradio" data-rate="0.75">0.75&times;</button>
+                <button type="button" role="menuitemradio" data-rate="1" aria-checked="true">1&times;</button>
+                <button type="button" role="menuitemradio" data-rate="1.25">1.25&times;</button>
+                <button type="button" role="menuitemradio" data-rate="1.5">1.5&times;</button>
+                <button type="button" role="menuitemradio" data-rate="1.75">1.75&times;</button>
+                <button type="button" role="menuitemradio" data-rate="2">2&times;</button>
+              </div>
+            </div>
+            <video id="watch-video" controls playsinline preload="metadata"></video>
           </div>
           <p class="email-modal__status" id="watch-status"></p>
         </div>
@@ -267,6 +271,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.29.0"></script>
+  <script src="js/app.js?v=3.30.0"></script>
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.29.0';
+const VERSION = '3.30.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1393,28 +1393,44 @@ function savedRate() {
   return PLAY_RATES.includes(r) ? r : 1;
 }
 
-function speedBarHtml(videoId) {
+/* Speed rides on the player itself (top-right), not as a row beneath it. */
+function speedOverlayHtml(videoId) {
   const cur = savedRate();
-  return `<div class="speed-bar" data-speed-for="${videoId}">
-    <span class="speed-bar__label">Speed</span>
-    ${PLAY_RATES.map(r => `<button type="button" class="speed-bar__btn" data-rate="${r}" aria-pressed="${r === cur}">${r}×</button>`).join('')}
+  return `<div class="vspeed" data-speed-for="${videoId}">
+    <button type="button" class="vspeed__btn" aria-haspopup="true" aria-expanded="false">${cur}×</button>
+    <div class="vspeed__menu" role="menu">
+      ${PLAY_RATES.map(r => `<button type="button" role="menuitemradio" data-rate="${r}" aria-checked="${r === cur}">${r}×</button>`).join('')}
+    </div>
   </div>`;
 }
 
 function wireSpeedBar(videoId) {
-  const bar = document.querySelector(`[data-speed-for="${videoId}"]`);
+  const wrap = document.querySelector(`[data-speed-for="${videoId}"]`);
   const video = document.getElementById(videoId);
-  if (!bar || !video) return;
+  if (!wrap || !video) return;
+  const trigger = wrap.querySelector('.vspeed__btn');
+  const menu = wrap.querySelector('.vspeed__menu');
   const apply = rate => {
     video.playbackRate = rate;
     localStorage.setItem(RATE_KEY, String(rate));
-    bar.querySelectorAll('.speed-bar__btn').forEach(b =>
-      b.setAttribute('aria-pressed', String(parseFloat(b.dataset.rate) === rate)));
+    trigger.textContent = `${rate}×`;
+    menu.querySelectorAll('[data-rate]').forEach(b =>
+      b.setAttribute('aria-checked', String(parseFloat(b.dataset.rate) === rate)));
   };
-  bar.addEventListener('click', e => {
-    const btn = e.target.closest('.speed-bar__btn');
-    if (btn) apply(parseFloat(btn.dataset.rate));
+  const close = () => { menu.classList.remove('is-open'); trigger.setAttribute('aria-expanded', 'false'); };
+  trigger.addEventListener('click', e => {
+    e.stopPropagation();
+    const open = menu.classList.toggle('is-open');
+    trigger.setAttribute('aria-expanded', String(open));
   });
+  menu.addEventListener('click', e => {
+    const btn = e.target.closest('[data-rate]');
+    if (!btn) return;
+    e.stopPropagation();
+    apply(parseFloat(btn.dataset.rate));
+    close();
+  });
+  document.addEventListener('click', close);
   // Setting src resets playbackRate, so re-apply once metadata lands.
   video.addEventListener('loadedmetadata', () => { video.playbackRate = savedRate(); });
   apply(savedRate());
@@ -1488,8 +1504,7 @@ async function loadCallPanel(a) {
   host().innerHTML = `
     <p class="notes__empty">${esc(`${row.housemate_name ? `${row.housemate_name} × ` : ''}${fullName(a)}`)} · ${row.starts_at ? fmtSlot(row.starts_at) : ''}</p>
     ${sc.watch
-      ? `<video id="call-video" class="call-video" controls playsinline></video>
-         ${speedBarHtml('call-video')}
+      ? `<div class="video-wrap">${speedOverlayHtml('call-video')}<video id="call-video" class="call-video" controls playsinline></video></div>
          <p class="email-modal__status" id="call-status">Fetching recording…</p>`
       : row.external_recording_url
         // These hosts block cross-origin embedding, so this opens out rather

--- a/applications/watch/index.html
+++ b/applications/watch/index.html
@@ -26,16 +26,33 @@
     .foot a { color: var(--accent); }
     .state { padding: 40px 0; text-align: center; color: var(--fg-muted); }
 
-    /* Playback controls: browsers bury (or omit) speed on mobile, so surface it. */
-    .tools { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
-    .tools__label { font-size: 13px; color: var(--fg-muted); margin-right: 2px; }
-    .rate {
-      background: transparent; color: var(--fg-muted); border: 1px solid var(--border);
-      border-radius: 999px; padding: 5px 11px; font: inherit; font-size: 13px; cursor: pointer;
+    /* Playback controls ride on the player itself — browsers bury speed in a
+       menu and iOS omits it. Fade with the native controls on hover/touch. */
+    .overlay {
+      position: absolute; top: 10px; right: 10px; z-index: 2;
+      display: flex; gap: 6px; opacity: 0; transition: opacity 140ms ease;
     }
-    .rate:hover { border-color: #3a4150; color: var(--fg); }
-    .rate[aria-pressed="true"] { background: var(--accent); border-color: var(--accent); color: #fff; }
-    .pip { margin-left: auto; }
+    .player:hover .overlay, .player:focus-within .overlay, .player.is-touched .overlay { opacity: 1; }
+    .ov-btn {
+      background: rgba(12, 14, 19, 0.78); color: #fff; border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 8px; padding: 5px 10px; font: inherit; font-size: 13px; line-height: 1.2;
+      cursor: pointer; backdrop-filter: blur(6px);
+    }
+    .ov-btn:hover { background: rgba(12, 14, 19, 0.95); }
+    .speed { position: relative; }
+    .speed-menu {
+      position: absolute; top: calc(100% + 6px); right: 0; min-width: 92px;
+      background: rgba(12, 14, 19, 0.96); border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 10px; padding: 4px; display: none; flex-direction: column;
+      backdrop-filter: blur(6px);
+    }
+    .speed-menu.is-open { display: flex; }
+    .speed-menu button {
+      background: transparent; border: 0; color: #cfd5e1; text-align: left;
+      padding: 6px 10px; border-radius: 6px; font: inherit; font-size: 13px; cursor: pointer;
+    }
+    .speed-menu button:hover { background: rgba(255, 255, 255, 0.1); color: #fff; }
+    .speed-menu button[aria-checked="true"] { color: #fff; font-weight: 600; }
 
     /* Mini player: the shell goes fixed, a placeholder holds the page height
        so nothing jumps. Scrolling back up re-docks it inline. */
@@ -46,7 +63,7 @@
       box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55); border: 1px solid var(--border);
     }
     .player.is-mini video { border-radius: 0; }
-    .player.is-mini .tools { display: none; }
+    .player.is-mini .overlay { display: none; }
     .mini-bar {
       display: none; align-items: center; gap: 8px;
       background: var(--surface); padding: 6px 8px 6px 12px; font-size: 12px; color: var(--fg-muted);
@@ -99,13 +116,33 @@
       // ---- speed ----
       const saved = parseFloat(localStorage.getItem(RATE_KEY));
       const startRate = RATES.includes(saved) ? saved : 1;
-      const buttons = [...document.querySelectorAll('.rate')];
+      const speedBtn = document.getElementById('speed-btn');
+      const speedMenu = document.getElementById('speed-menu');
+      const buttons = [...speedMenu.querySelectorAll('[data-rate]')];
       const applyRate = rate => {
         video.playbackRate = rate;
         localStorage.setItem(RATE_KEY, String(rate));
-        buttons.forEach(b => b.setAttribute('aria-pressed', String(parseFloat(b.dataset.rate) === rate)));
+        speedBtn.textContent = `${rate}\u00d7`;
+        buttons.forEach(b => b.setAttribute('aria-checked', String(parseFloat(b.dataset.rate) === rate)));
       };
-      buttons.forEach(b => b.addEventListener('click', () => applyRate(parseFloat(b.dataset.rate))));
+      const closeMenu = () => { speedMenu.classList.remove('is-open'); speedBtn.setAttribute('aria-expanded', 'false'); };
+      speedBtn.addEventListener('click', e => {
+        e.stopPropagation();
+        const open = speedMenu.classList.toggle('is-open');
+        speedBtn.setAttribute('aria-expanded', String(open));
+      });
+      buttons.forEach(b => b.addEventListener('click', e => {
+        e.stopPropagation();
+        applyRate(parseFloat(b.dataset.rate));
+        closeMenu();
+      }));
+      document.addEventListener('click', closeMenu);
+      // Touch has no hover: reveal the overlay on tap, hide it with the menu.
+      player.addEventListener('touchstart', () => {
+        player.classList.add('is-touched');
+        clearTimeout(player._ovTimer);
+        player._ovTimer = setTimeout(() => player.classList.remove('is-touched'), 3500);
+      }, { passive: true });
       applyRate(startRate);
       // Some browsers reset rate when new media loads.
       video.addEventListener('loadedmetadata', () => { video.playbackRate = startRate; });
@@ -178,7 +215,7 @@
           return;
         }
         const rateButtons = RATES.map(r =>
-          `<button type="button" class="rate" data-rate="${r}" aria-pressed="false">${r}×</button>`).join('');
+          `<button type="button" role="menuitemradio" data-rate="${r}" aria-checked="false">${r}×</button>`).join('');
         root.innerHTML = `
           <h1>${esc(data.title)}</h1>
           <p class="when">${esc(fmtWhen(data.when))}</p>
@@ -190,12 +227,14 @@
                   <button type="button" id="mini-expand">Back to page</button>
                   <button type="button" id="mini-close" aria-label="Close mini player">✕</button>
                 </div>
-                <video id="v" controls playsinline preload="metadata" src="${esc(data.url)}"></video>
-                <div class="tools">
-                  <span class="tools__label">Speed</span>
-                  ${rateButtons}
-                  <button type="button" class="rate pip" id="pip">Pop out</button>
+                <div class="overlay">
+                  <span class="speed">
+                    <button type="button" class="ov-btn" id="speed-btn" aria-haspopup="true" aria-expanded="false">1&times;</button>
+                    <span class="speed-menu" id="speed-menu" role="menu">${rateButtons}</span>
+                  </span>
+                  <button type="button" class="ov-btn" id="pip" title="Pop out into a floating window">&#9974;</button>
                 </div>
+                <video id="v" controls playsinline preload="metadata" src="${esc(data.url)}"></video>
               </div>
             </div>`
             : `<p class="state">${esc(data.reason || 'No recording available for this call.')}</p>`}


### PR DESCRIPTION
Follow-up to v3.29.0: the speed pills sat in a row under the video. They now ride on the player itself — a small rate button in the top-right that opens a menu, fading in with hover/focus and staying visible on touch devices (no hover there).

Applies to all three players: watch page, profile Call tab, watch modal. Rate still persists across calls. On the watch page the pop-out button moved into the same overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)