### PR TITLE
fix(recruiting): post-call row state, house-calendar bots, email-agreed times

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -408,6 +408,13 @@ function avatarHtml(a, large) {
 function callPhase(sc) {
   if (!sc) return null;
   if (sc.watch) return 'watch';
+  // Finished, nothing to watch. Distinct from 'processing' (which means a
+  // recording is still landing) — this call may simply never have been
+  // recorded, so the row should move on rather than wait forever.
+  if (sc.done && !sc.at) {
+    const overFor = Date.now() - new Date(sc.doneAt).getTime();
+    return overFor > 6 * 3600000 ? 'done' : 'processing';
+  }
   if (sc.at) {
     const now = Date.now();
     const start = new Date(sc.at).getTime();
@@ -449,6 +456,18 @@ function openingsCta(a) {
     return stack(
       `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Watch the recorded intro call" data-open-call="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
       `${decCtx}${when ? ` · ${when}` : ''}`);
+  }
+  if (phase === 'done') {
+    // Same move as after a watched call — the decision is the point, the
+    // recording was only ever an aid — plus a way to supply one.
+    const dv = decisionVotes[a.id] || [];
+    const mine = dv.find(v => v.voter_id === me?.id);
+    const decCtx = mine
+      ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
+      : `<button type="button" class="cta-link" data-give-decision="${a.id}">give your decision</button>${dv.length ? ` · ${dv.length} in` : ''}`;
+    return stack(
+      `<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button>`,
+      `${decCtx} · no recording — <button type="button" class="cta-link" data-add-recording="${a.id}">add a link</button>`);
   }
   if (phase === 'processing') return stack(processingChip(), when);
   if (phase === 'live') return stack(joinBtn(sc) || processingChip(), when);
@@ -561,12 +580,32 @@ async function loadAll() {
       continue;
     }
     if (s.status === 'scheduled') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), at: s.starts_at, ends: s.ends_at, with: s.housemate_name, link: s.meet_link };
-    // A finished recording adds a Watch state to the row (fresh link on click).
+    // A call that already happened. Calendar-swept rows land here directly
+    // (the sweep inserts past events as 'completed'), and without this the
+    // row falls through to the availability branch below and offers to book
+    // a call that is already over.
+    if (s.status === 'completed') screeningState[s.applicant_id] = {
+      ...(screeningState[s.applicant_id] || {}),
+      done: s.id, doneAt: s.ends_at || s.starts_at, with: s.housemate_name,
+    };
+    // A finished recording adds a Watch state to the row (fresh link on
+    // click). Recall's own capture and a pasted link (tldv etc.) are equally
+    // watchable — the Call tab knows which player to use.
     if (s.recall_status === 'done') screeningState[s.applicant_id] = { ...(screeningState[s.applicant_id] || {}), watch: s.id };
+    if (s.external_recording_url) screeningState[s.applicant_id] = {
+      ...(screeningState[s.applicant_id] || {}),
+      watch: s.id, watchExternal: s.external_recording_url,
+    };
   }
   for (const av of (avRes.data || [])) {
-    // empty windows = a processed non-scheduling reply — no Pick a time
-    if (Array.isArray(av.windows) && av.windows.length) screeningState[av.applicant_id] ||= { availability: true, nWindows: av.windows.length };
+    // Availability is the weakest signal there is — it must never overwrite
+    // a booked or finished call. `||=` guards the object, but a row whose
+    // only state is `done` still needs the windows recorded without the
+    // availability CTA winning.
+    if (!Array.isArray(av.windows) || !av.windows.length) continue;
+    const st = screeningState[av.applicant_id];
+    if (!st) { screeningState[av.applicant_id] = { availability: true, nWindows: av.windows.length }; continue; }
+    if (!st.at && !st.done && !st.watch) { st.availability = true; st.nWindows = av.windows.length; }
   }
   emailState = {};
   emailsCache = {};
@@ -1469,6 +1508,9 @@ async function loadCallPanel(a) {
   const host = () => document.getElementById('call-panel');
   if (!host()) return;
   const sc = screeningState[a.id] || {};
+  // sc.watch covers both our own captures and pasted links; only the former
+  // can actually be played inline.
+  const streamable = Boolean(sc.watch) && !sc.watchExternal;
   let row = null;
   if (sc.watch) {
     ({ data: row } = await sb.from('recruit_screenings')
@@ -1487,7 +1529,7 @@ async function loadCallPanel(a) {
   }
   host().innerHTML = `
     <p class="notes__empty">${esc(`${row.housemate_name ? `${row.housemate_name} × ` : ''}${fullName(a)}`)} · ${row.starts_at ? fmtSlot(row.starts_at) : ''}</p>
-    ${sc.watch
+    ${streamable
       ? `<video id="call-video" class="call-video" controls playsinline></video>
          ${speedBarHtml('call-video')}
          <p class="email-modal__status" id="call-status">Fetching recording…</p>`
@@ -1501,7 +1543,7 @@ async function loadCallPanel(a) {
     <section class="review__section notes">
       <div class="notes__head">
         <h3 class="review__section-title">Comments</h3>
-        ${sc.watch ? `<button type="button" class="btn btn--sm" id="call-stamp" title="Prefix your comment with the video's current time">Comment at current time</button>` : ''}
+        ${streamable ? `<button type="button" class="btn btn--sm" id="call-stamp" title="Prefix your comment with the video's current time">Comment at current time</button>` : ''}
       </div>
       <div id="notes-body"><p class="notes__empty">Loading comments…</p></div>
       <form class="notes__form" id="notes-form-call">
@@ -1520,7 +1562,7 @@ async function loadCallPanel(a) {
     if (input && !input.value.startsWith(stamp)) input.value = stamp + input.value;
     input?.focus();
   });
-  if (sc.watch) {
+  if (streamable) {
     try {
       const out = await gmailCall({ action: 'recording-link', screeningId: sc.watch });
       const v = document.getElementById('call-video');
@@ -2740,7 +2782,7 @@ function renderReview() {
     <div class="review-tabs">
       <button class="review-tabs__tab ${reviewTab === 'profile' ? 'is-on' : ''}" data-review-tab="profile">Profile</button>
       <button class="review-tabs__tab ${reviewTab === 'emails' ? 'is-on' : ''}" data-review-tab="emails">Emails${(emailsCache[a.id] || []).length ? ` (${emailsCache[a.id].length})` : ''}</button>
-      ${(screeningState[a.id]?.watch || screeningState[a.id]?.at) ? `<button class="review-tabs__tab ${reviewTab === 'call' ? 'is-on' : ''}" data-review-tab="call">Call</button>` : ''}
+      ${(screeningState[a.id]?.watch || screeningState[a.id]?.at || screeningState[a.id]?.done) ? `<button class="review-tabs__tab ${reviewTab === 'call' ? 'is-on' : ''}" data-review-tab="call">Call</button>` : ''}
     </div>
     ${reviewTab === 'emails' ? `<div id="emails-panel"><p class="notes__empty">Loading emails…</p></div>` : reviewTab === 'call' ? `<div id="call-panel"><p class="notes__empty">Loading the call…</p></div>` : `
     ${voteSectionHtml(a)}

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,12 +13,12 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.13.0'
+const VERSION = '1.14.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { scheduleScreening, sendIntroEmail, sharedAccessToken } from '../_shared/recruit-schedule.ts'
+import { scheduleScreening, sendIntroEmail, sharedAccessToken, sweepCalendars, HOUSE_CALENDAR_ID, SHARED_EMAIL } from '../_shared/recruit-schedule.ts'
 import { editSchedulerSignedUp, editSchedulerFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
@@ -408,16 +408,29 @@ async function scheduleCalendarBots(client: ReturnType<typeof db>): Promise<numb
   try { token = await sharedAccessToken(client) } catch { return 0 }
   const now = new Date()
   const timeMax = new Date(now.getTime() + 7 * 24 * 3600 * 1000)
-  const resp = await fetch(
-    `https://www.googleapis.com/calendar/v3/calendars/primary/events?singleEvents=true&orderBy=startTime&maxResults=50&timeMin=${encodeURIComponent(now.toISOString())}&timeMax=${encodeURIComponent(timeMax.toISOString())}`,
-    { headers: { Authorization: `Bearer ${token}` } },
-  )
-  if (!resp.ok) { console.warn(`[recall] calendar sweep failed: ${resp.status}`); return 0 }
-  const events = (await resp.json()).items || []
+  // Every calendar we book on, not just primary. Screenings now land on the
+  // house calendar, and a bot sweep that only watched primary would silently
+  // stop recording the moment bookings moved.
+  const events: any[] = []
+  for (const calendarId of sweepCalendars()) {
+    const resp = await fetch(
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events?singleEvents=true&orderBy=startTime&maxResults=50&timeMin=${encodeURIComponent(now.toISOString())}&timeMax=${encodeURIComponent(timeMax.toISOString())}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    if (!resp.ok) { console.warn(`[recall] calendar sweep failed for ${calendarId}: ${resp.status}`); continue }
+    events.push(...((await resp.json()).items || []))
+  }
   // deno-lint-ignore no-explicit-any
   const meetOf = (ev: any) => ev.hangoutLink || ev.conferenceData?.entryPoints?.find((e: any) => e.entryPointType === 'video')?.uri || null
+  // organizer.self is only true on the account's own calendar — on a shared
+  // group calendar the organizer is the calendar itself, so ours would all
+  // be filtered out. Accept either.
   // deno-lint-ignore no-explicit-any
-  const candidates = events.filter((ev: any) => ev.status !== 'cancelled' && ev.organizer?.self && meetOf(ev) && ev.start?.dateTime)
+  const isOurs = (ev: any) => ev.organizer?.self ||
+    String(ev.organizer?.email || '').toLowerCase() === HOUSE_CALENDAR_ID.toLowerCase() ||
+    String(ev.creator?.email || '').toLowerCase() === SHARED_EMAIL.toLowerCase()
+  // deno-lint-ignore no-explicit-any
+  const candidates = events.filter((ev: any) => ev.status !== 'cancelled' && isOurs(ev) && meetOf(ev) && ev.start?.dateTime)
   if (!candidates.length) return 0
 
   // deno-lint-ignore no-explicit-any

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.17.0'
+const VERSION = '1.18.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -104,6 +104,154 @@ Return one JSON object: {"windows":..., "platform":..., "timezone_note":..., "ne
       needs_human: Boolean(obj.needs_human) && !windows.length,
     }
   } catch { return NO_EXTRACTION }
+}
+
+/* Some calls get agreed entirely in the email thread — "Tuesday at 3 works!"
+   — and no invite is ever sent. Nothing downstream sees them: no calendar
+   event, so no Meet link, so no recording bot, and the row keeps showing
+   "Review availability" for a call that's already on the books.
+
+   This reads the tail of a thread and reports a time only when BOTH sides
+   have converged on one. Deliberately strict: the cost of a false positive
+   is a wrong calendar invite landing in an applicant's inbox. */
+interface AgreedTime {
+  agreed: boolean
+  starts_at: string | null   // ISO 8601 with offset
+  minutes: number | null
+  quote: string | null       // the sentence that settles it
+  confidence: 'high' | 'medium' | 'low'
+}
+const NO_AGREEMENT: AgreedTime = { agreed: false, starts_at: null, minutes: null, quote: null, confidence: 'low' }
+
+async function detectAgreedTime(thread: Array<{ direction: string; sent_at: string; body_text: string | null; snippet: string | null }>): Promise<AgreedTime> {
+  const key = Deno.env.get('RECRUIT_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY') || Deno.env.get('LADDER_ANTHROPIC_API_KEY')
+  if (!key || thread.length < 2) return NO_AGREEMENT
+  const transcript = thread.map((m) =>
+    `[${m.direction === 'out' ? 'AGAPE' : 'APPLICANT'} · ${m.sent_at}]\n${(m.body_text || m.snippet || '').slice(0, 1500)}`,
+  ).join('\n\n---\n\n')
+
+  const prompt = `Today is ${new Date().toLocaleDateString('en-CA', { timeZone: TZ })} (${TZ}). Below is an email thread between Agape (a San Francisco co-living house) and a housing applicant.
+
+Decide whether they have MUTUALLY AGREED on one specific date and time for a call, with no invite yet sent.
+
+Say agreed=true ONLY when all of these hold:
+- One specific date AND clock time is settled (not a range, not "sometime Tuesday", not a list of options).
+- Both sides have expressed assent — one proposed it and the other accepted, or one confirmed a time the other named.
+- The time is in the future.
+Say agreed=false for: offered availability nobody accepted yet, a proposal with no reply, a time that already passed, vague agreement ("looking forward to chatting!"), or anything you are unsure about. When in doubt, false — a wrong answer sends a real applicant a wrong calendar invite.
+
+Return JSON:
+{"agreed": bool,
+ "starts_at": "YYYY-MM-DDTHH:MM:SS-07:00" (Pacific offset) or null,
+ "minutes": integer duration if stated, else 30,
+ "quote": the exact sentence that settles it, or null,
+ "confidence": "high" | "medium" | "low"}
+
+THREAD START
+${transcript.slice(0, 12000)}
+THREAD END
+One JSON object. No prose.`
+
+  const resp = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5-20251001', max_tokens: 400,
+      system: 'You detect firmly-agreed meeting times in email threads. You are conservative: unless both parties clearly settled on one specific date and time, you answer agreed=false. Respond with a single JSON object only.',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+  if (!resp.ok) { console.warn(`detectAgreedTime: anthropic ${resp.status}`); return NO_AGREEMENT }
+  const data = await resp.json()
+  const out = (data.content || []).filter((b: any) => b.type === 'text').map((b: any) => b.text).join('')
+  try {
+    const o = JSON.parse(out.trim().replace(/^```json?\s*|\s*```$/g, ''))
+    if (!o.agreed || !o.starts_at) return NO_AGREEMENT
+    const when = new Date(o.starts_at)
+    if (isNaN(when.getTime())) return NO_AGREEMENT
+    return {
+      agreed: true,
+      starts_at: when.toISOString(),
+      minutes: Number(o.minutes) > 0 && Number(o.minutes) <= 180 ? Number(o.minutes) : 30,
+      quote: o.quote ? String(o.quote).slice(0, 300) : null,
+      confidence: ['high', 'medium', 'low'].includes(o.confidence) ? o.confidence : 'low',
+    }
+  } catch { return NO_AGREEMENT }
+}
+
+/* Turn email-agreed times into real calendar events, so the Meet link
+   exists and the recording bot has something to join. Runs inside the scan,
+   which the 20-minute cron drives.
+
+   OFF until switched on, because the invite is a real email to a real
+   applicant chosen by a model. Enable with:
+     insert into recruit_settings(key, value) values ('email_autoschedule', 'true')
+       on conflict (key) do update set value = 'true';
+   Pass dryRun to see what it WOULD book without touching anything. */
+async function scheduleFromEmail(client: ReturnType<typeof db>, dryRun = false): Promise<{ made: number; proposals: any[] }> {
+  const { data: flag } = await client.from('recruit_settings')
+    .select('value').eq('key', 'email_autoschedule').maybeSingle()
+  if (!dryRun && flag?.value !== true) return { made: 0, proposals: [] }
+
+  // Live applicants with inbound mail and no call on the books.
+  const { data: live } = await client.from('recruit_applicants')
+    .select('id, first_name, last_name, email')
+    .in('stage', ['review', 'candidate'])
+  if (!live?.length) return { made: 0, proposals: [] }
+  const { data: booked } = await client.from('recruit_screenings')
+    .select('applicant_id').eq('kind', 'intro_call').in('status', ['scheduled', 'completed'])
+  const haveCall = new Set((booked || []).map((r) => r.applicant_id))
+
+  let made = 0
+  const proposals: any[] = []
+  for (const a of live) {
+    if (haveCall.has(a.id) || !a.email?.includes('@')) continue
+    const { data: thread } = await client.from('recruit_emails')
+      .select('direction, sent_at, body_text, snippet')
+      .eq('applicant_id', a.id).order('sent_at', { ascending: false }).limit(6)
+    if (!thread?.length) continue
+    const msgs = thread.slice().reverse()
+    // Needs a real back-and-forth: one side talking to itself isn't a deal.
+    if (!msgs.some((m) => m.direction === 'in') || !msgs.some((m) => m.direction === 'out')) continue
+
+    const hit = await detectAgreedTime(msgs)
+    if (!hit.agreed || hit.confidence === 'low' || !hit.starts_at) continue
+    const when = new Date(hit.starts_at)
+    if (when.getTime() < Date.now() || when.getTime() > Date.now() + 60 * 86400000) continue
+    proposals.push({ applicant: `${a.first_name} ${a.last_name || ''}`.trim(), startsAt: when.toISOString(), minutes: hit.minutes, confidence: hit.confidence, quote: hit.quote })
+    if (dryRun) continue
+
+    try {
+      const result = await scheduleScreening(client, {
+        applicantId: a.id,
+        startsAt: when,
+        minutes: hit.minutes || 30,
+        housemateUserId: null as unknown as string,
+        housemateName: 'agreed by email',
+        housemateEmail: '',
+      })
+      made++
+      console.log(`[autoschedule] ${a.first_name} @ ${when.toISOString()} (${hit.confidence}) — ${hit.quote || 'no quote'}`)
+      try {
+        const { postResilient, NOTES_CHANNEL_ID: NOTES } = await import('../_shared/discord.ts')
+        await postResilient(NOTES, {
+          embeds: [{
+            title: `Calendar invite sent — ${a.first_name} ${a.last_name || ''}`.trim(),
+            description: [
+              `A time was agreed over email, so the call is now on the house calendar and the recording bot will join.`,
+              hit.quote ? `> ${hit.quote}` : null,
+              result.meetLink ? `[Meet link](${result.meetLink})` : null,
+              `If this is wrong, cancel the event on the calendar — nothing else was sent.`,
+            ].filter(Boolean).join('\n\n'),
+            color: 0x1D9E75,
+          }],
+        }, 'autoschedule')
+      } catch { /* Discord down never blocks scheduling */ }
+    } catch (err) {
+      console.warn(`[autoschedule] ${a.id} failed: ${(err as Error).message}`)
+    }
+  }
+  return { made, proposals }
 }
 
 // The manual→auto claim cutover is a settings toggle, not a deploy.
@@ -223,7 +371,12 @@ serve(async (req) => {
     // open. Same secretless handshake recruit-discord/remind uses — a
     // one-time nonce minted by the pg_cron tick, delete-on-use (migration
     // 123), with X-Cron-Secret honoured if CRON_SECRET is ever configured.
-    const isCron = new URL(req.url).pathname.endsWith('/scan')
+    const reqUrl = new URL(req.url)
+    const isCron = reqUrl.pathname.endsWith('/scan')
+    // /scan?dry=1 — report what email-autoschedule WOULD book and change
+    // nothing else. Read-only, same nonce gate; exists so the detector can be
+    // audited before anyone turns it on.
+    const cronDryRun = isCron && reqUrl.searchParams.get('dry') === '1'
     if (isCron) {
       const secret = Deno.env.get('CRON_SECRET')
       let authorized = Boolean(secret) && req.headers.get('x-cron-secret') === secret
@@ -252,7 +405,7 @@ serve(async (req) => {
     }
 
     const body = isCron ? {} as Record<string, unknown> : await req.json().catch(() => ({}))
-    const action = isCron ? 'scan' : (body as any).action
+    const action = isCron ? (cronDryRun ? 'autoschedule-preview' : 'scan') : (body as any).action
 
     if (action === 'auth-url') {
       const url = 'https://accounts.google.com/o/oauth2/v2/auth?' + new URLSearchParams({
@@ -553,6 +706,12 @@ serve(async (req) => {
           .update({ resolved_applicant_id: applicantId }).eq('url', url)
       }
       return json({ attached: true, screeningId })
+    }
+
+    if (action === 'autoschedule-preview') {
+      // What the email-agreed-time detector WOULD book. Reads only.
+      const out = await scheduleFromEmail(client, true)
+      return json({ proposals: out.proposals })
     }
 
     if (action === 'recording-leads') {
@@ -988,8 +1147,15 @@ serve(async (req) => {
       }
 
       await remindStuckPosts(client)
-      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up, ${backfilled} availability backfills`)
-      return json({ matched, replied: [...replied], manualPickups, backfilled, pinged })
+      // Last: calls agreed purely in email get a real calendar event, so the
+      // Meet link exists and the bot cron has something to join. Runs after
+      // the calendar sweep so anything already on a calendar is known.
+      let autoScheduled = 0
+      try { autoScheduled = (await scheduleFromEmail(client)).made } catch (err) {
+        console.warn(`email autoschedule failed: ${(err as Error).message}`)
+      }
+      console.log(`scan: ${matched} new messages matched, ${replied.size} applicants replied, ${manualPickups} manual screenings picked up, ${backfilled} availability backfills, ${autoScheduled} scheduled from email`)
+      return json({ matched, replied: [...replied], manualPickups, backfilled, pinged, autoScheduled })
     }
 
     return json({ error: 'Unknown action' }, 400)


### PR DESCRIPTION
Functions already deployed; this is the code of record.

## The regression you spotted

Marisa and Keerti sat on **Review availability** for calls that had already happened.

A `completed` intro call set *nothing* in `screeningState`, so the availability loop's `||=` fired and the row offered to book a call that was over. This state never existed before — the old sweep only ever inserted `scheduled` rows; mine inserts past events as `completed`. My bug.

- `completed` intro calls now set `{ done, doneAt }`
- `external_recording_url` counts as watchable, same as a Recall capture
- availability can no longer overwrite a booked **or** finished call
- new **`done`** phase (finished, nothing to watch) shows the post-call move — *Schedule a visit* + *give your decision* + *add a link* — instead of waiting forever on a recording that may never arrive
- the Call tab distinguishes streamable captures from pasted links (which open out), and now appears for a finished call with no recording, because the notes still matter

**Both recordings are attached.** The mapping wasn't a guess — tldv meeting ids are Mongo ObjectIds, and their embedded timestamps (`17:18:52`, `18:07:14`) land a few minutes into each call (`17:15`, `18:00`).

## House-calendar bots — a second thing I broke

`scheduleCalendarBots` only ever read `primary`. Moving bookings to the house calendar would have **silently stopped recording every call**. It now sweeps every calendar we book on. Also relaxed `organizer.self`, which is false on a shared group calendar and would have filtered out exactly the events we care about.

## Email-agreed meetings → calendar + bot

Calls settled purely in a thread never reached a calendar, so no Meet link and no bot. A conservative Haiku pass over the last six messages reports a time only when both sides converged on one specific slot; hits become real calendar events (Meet + recording bot) and post to Discord.

Guards: traffic in both directions, medium/high confidence only, future, inside 60 days, and it skips anyone who already has a call.

**Shipped OFF.** It emails real applicants based on a model's judgment, so turning it on should be deliberate:

```sql
insert into recruit_settings(key, value) values ('email_autoschedule', 'true')
  on conflict (key) do update set value = 'true';
```

`/scan?dry=1` (nonce-gated, read-only) reports what it *would* book. First dry run returned zero proposals — nothing pending, and nothing invented from the existing corpus.

`app v3.29.0` · `recruit-gmail v1.18.1` · `recruit-discord v1.14.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)