### PR TITLE
Recruiting: ingest dedupes by email (verified on real data)

### DIFF
--- a/docs/infrastructure/recruiting-sheet-ingest.md
+++ b/docs/infrastructure/recruiting-sheet-ingest.md
@@ -2,7 +2,7 @@
 
 **One line:** the application spreadsheet pushes each new row to the `recruit-ingest` edge function on submit, so applicants appear in `/applications` Inbox without a manual import.
 
-Status: **live, API pull on an hourly cron** (`recruit-ingest` v1.1.0, migration 131) · one blocker: the shared Google account needs a reconnect to grant the Sheets scope.
+Status: **live and verified** — `recruit-ingest` v1.2.0, migration 131, hourly at :07. First real run (2026-07-29) read 119 rows, ingested the 7 applications that arrived after the last manual import, and recognized 109 as already present.
 
 ---
 
@@ -20,7 +20,9 @@ Google Sheets has no native webhook, so the two options are an Apps Script trigg
 
 An hour of latency costs nothing: the applicant has just filled in a form and isn't waiting on us. The push endpoint stays available for a Fillout-style webhook if real-time ever matters.
 
-Because the pull is **idempotent**, re-reading the entire sheet every hour is free: ids derive from name + submission timestamp and inserts ignore duplicates.
+Because the pull is **idempotent**, re-reading the entire sheet every hour is free.
+
+**Dedupe is by email, not just by id.** Id-only dedupe turned out to be unsafe on real data: the original manual import slugged accents and apostrophes differently (Lagelée, D'Avignon, Prud'homme, O'Brien), so those rows would have been ingested a second time under new ids. People also re-apply — the same address appears twice in the sheet. One row per email is the model the funnel wants; the trade-off is that a genuine re-applicant in a later season is skipped and reported in `skipped[]` rather than creating a second row that competes with the first. A recruiter reopening the existing row is the intended path.
 
 ## The endpoint
 
@@ -41,7 +43,7 @@ body:    { "rows": [ { "<sheet header>": "<value>", ... } ] }
 
 - **Cron** (migration 131): `recruit_application_ingest_tick`, hourly at :07, one-time-nonce auth (same handshake as the reminder cron).
 - **Endpoint**: `POST /functions/v1/recruit-ingest/pull` — reads `RECRUIT_SHEET_ID` / `RECRUIT_SHEET_RANGE` (defaults to the Jan 2026+ responses sheet, tab `Form Responses 1`) with the shared account's token.
-- **Prereqs**: the sheet is shared with `live.at.agapesf@gmail.com` (already true), and that account has granted `spreadsheets.readonly` — added to recruit-gmail's consent screen, so **reconnecting the shared Gmail from the /applications rail footer grants it**. Until then the pull returns a plain-English 502 saying exactly that.
+- **Prereqs, all satisfied 2026-07-29**: the sheet is shared with `live.at.agapesf@gmail.com`; that account has granted `spreadsheets.readonly` (reconnect from the /applications rail footer re-grants it if the token is ever lost); and **the Google Sheets API is enabled in the `add-to-calendar-477919` GCP project** (project number 845688740681 — the one the shared account's OAuth client lives in). That last one is the non-obvious failure: without it every call returns 403 with a message about the API being disabled, which reads like a sharing problem.
 
 ## Optional: real-time push via Apps Script
 

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -19,7 +19,7 @@
 // timestamp, and inserts ignore duplicates — so resending the whole sheet is
 // a safe backfill, not a mess of copies.
 
-const VERSION = '1.1.0'
+const VERSION = '1.2.0'
 console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -47,7 +47,9 @@ async function readSheet(client: any): Promise<Array<Record<string, unknown>>> {
       throw new Error('the shared Google account has not granted the Sheets scope yet — reconnect it from the /applications rail footer')
     }
     if (resp.status === 403 || resp.status === 404) {
-      throw new Error(`the shared account cannot read the sheet — share it with live.at.agapesf@gmail.com as Viewer (HTTP ${resp.status})`)
+      // Include Google's own words — "cannot read the sheet" and "wrong
+      // account" look identical from the outside otherwise.
+      throw new Error(`sheet unreadable by the shared account (HTTP ${resp.status}): ${text.slice(0, 220)}`)
     }
     throw new Error(`Sheets API ${resp.status}: ${text.slice(0, 200)}`)
   }
@@ -178,12 +180,40 @@ serve(async (req) => {
       })
     }
 
-    if (dryRun) return json({ dryRun: true, source: isPull ? 'sheet' : 'push', rowsRead: rows.length, wouldInsert: prepared, skipped })
-    if (!prepared.length) return json({ inserted: 0, skipped })
+    /* Dedupe by EMAIL, not just by id. Two things make id-only dedupe unsafe:
+       the original manual import slugged accents and apostrophes differently
+       (Lagelée, D'Avignon, Prud'homme), and people re-apply — the same person
+       appears twice in the sheet. One row per email address is the model the
+       funnel actually wants; a genuine re-applicant is better handled by a
+       recruiter reopening the existing row than by a second row competing with
+       it. Within a batch, the most recent application wins. */
+    const byEmail = new Map<string, Record<string, string>>()
+    for (const r of prepared.sort((a, b) => b.submitted_at.localeCompare(a.submitted_at))) {
+      const key = r.email.toLowerCase()
+      if (!byEmail.has(key)) byEmail.set(key, r)
+      else skipped.push(`re-application in the same batch: ${r.email}`)
+    }
+    const { data: existing } = await client.from('recruit_applicants').select('id, email')
+    const knownEmails = new Set((existing || []).map((e) => String(e.email || '').toLowerCase()))
+    const knownIds = new Set((existing || []).map((e) => e.id))
+    const fresh: Array<Record<string, string>> = []
+    for (const r of byEmail.values()) {
+      if (knownEmails.has(r.email.toLowerCase())) { skipped.push(`already an applicant: ${r.email}`); continue }
+      if (knownIds.has(r.id)) { skipped.push(`already an applicant (id): ${r.id}`); continue }
+      fresh.push(r)
+    }
+
+    if (dryRun) {
+      return json({
+        dryRun: true, source: isPull ? 'sheet' : 'push', rowsRead: rows.length,
+        wouldInsert: fresh, alreadyPresent: byEmail.size - fresh.length, skipped,
+      })
+    }
+    if (!fresh.length) return json({ inserted: 0, rowsRead: rows.length, alreadyPresent: byEmail.size, skipped })
 
     // ignoreDuplicates: resending the sheet is a backfill, not a mess.
     const { data, error } = await client.from('recruit_applicants')
-      .upsert(prepared, { onConflict: 'id', ignoreDuplicates: true })
+      .upsert(fresh, { onConflict: 'id', ignoreDuplicates: true })
       .select('id, first_name, last_name')
     if (error) return json({ error: `insert failed: ${error.message}` }, 500)
 
@@ -201,8 +231,8 @@ serve(async (req) => {
         console.warn(`[recruit-ingest] audit post failed: ${(err as Error).message}`)
       }
     }
-    console.log(`[recruit-ingest] ${created.length} created, ${prepared.length - created.length} already present, ${skipped.length} skipped`)
-    return json({ inserted: created.length, source: isPull ? 'sheet' : 'push', rowsRead: rows.length, ids: created.map((c) => c.id), duplicates: prepared.length - created.length, skipped })
+    console.log(`[recruit-ingest] ${created.length} created, ${byEmail.size - fresh.length} already present, ${skipped.length} skipped`)
+    return json({ inserted: created.length, source: isPull ? 'sheet' : 'push', rowsRead: rows.length, ids: created.map((c) => c.id), alreadyPresent: byEmail.size - fresh.length, skipped })
   } catch (err) {
     console.error(`[recruit-ingest] ${(err as Error).message}`)
     return json({ error: (err as Error).message }, 500)


### PR DESCRIPTION
Dry-running the pull against the real sheet caught a bug that would have created **6 duplicate applicants**: the original manual import slugged accents and apostrophes differently (Lagelée, D'Avignon, Prud'homme, O'Brien), so id-only dedupe treated them as new. Isabel also appears twice in the sheet itself.

Now deduped **by email**: one row per address, most recent application wins within a batch, everything skipped is reported. Trade-off documented — a genuine re-applicant in a later season is skipped rather than creating a competing row.

**First live run:** 119 rows read → 7 genuinely new applications ingested (Sam Kaplan, Grace Reed, Victor Cui, Rania Ahmed, malak el baz, Linda Green, Alexander Perkins — all arrived after the last manual import), 109 recognized as already present, 0 duplicates created. Table went 111 → 118, Inbox 53 → 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)