### PR TITLE
feat(recruiting): app-level player that survives navigation (v3.33.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1447,23 +1447,35 @@ body[data-auth-state="loading"] .gate { visibility: hidden; }
 /* Touch has no hover — keep it visible on small screens. */
 @media (hover: none) { .vspeed { opacity: 1; } }
 
-/* --- v3.31.0: pop-out + docking mini player on the in-app players --- */
+/* --- v3.33.0: app-level player (survives navigation) --- */
 .vchrome { position: absolute; top: 8px; right: 8px; z-index: 2; display: flex; gap: 6px; opacity: 0; transition: opacity 140ms ease; }
-.video-wrap:hover .vchrome, .video-wrap:focus-within .vchrome { opacity: 1; }
+.gplayer__stage:hover .vchrome, .gplayer__stage:focus-within .vchrome { opacity: 1; }
 @media (hover: none) { .vchrome { opacity: 1; } }
 .vspeed { position: static; }
 .vspeed__menu { right: 0; }
 .vpip { line-height: 1.2; }
 
-/* Docked player: fixed bottom-right while the call keeps playing. The
-   placeholder height keeps the Call tab from collapsing underneath it. */
-.video-wrap.is-mini { position: fixed; right: 16px; bottom: 16px; z-index: 90; width: min(340px, 60vw); border-radius: var(--radius-lg); overflow: hidden; box-shadow: 0 18px 40px rgba(0,0,0,.5); border: 1px solid var(--border-strong); background: #000; }
-.video-wrap.is-mini::after { content: ''; }
-.video-wrap.is-mini + * { margin-top: 0; }
-.video-wrap.is-mini .vchrome { display: none; }
-.mini-bar { display: none; align-items: center; gap: 8px; background: var(--bg-surface); padding: 5px 6px 5px 10px; font-size: var(--font-size-caption); color: var(--fg-subtle); }
-.video-wrap.is-mini .mini-bar { display: flex; }
-.mini-bar__title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.mini-bar button { background: transparent; border: 0; color: var(--fg-subtle); cursor: pointer; font: inherit; padding: 2px 6px; border-radius: 6px; }
-.mini-bar button:hover { background: var(--bg-overlay); color: var(--fg); }
-@media (max-width: 520px) { .video-wrap.is-mini { width: min(250px, 68vw); right: 10px; bottom: 10px; } }
+.gplayer__stage { position: relative; }
+.gplayer video { display: block; width: 100%; background: #000; }
+.gplayer.is-hidden { display: none; }
+
+/* Inline: sits in the Call tab like any other block. */
+.gplayer.is-inline { position: static; width: 100%; }
+.gplayer.is-inline .gplayer__bar { display: none; }
+.gplayer.is-inline video { border-radius: var(--radius-lg); }
+.call-player-mount { display: block; }
+
+/* Docked: fixed bottom-right, above the review overlay, with a title bar
+   carrying Expand (opens the Call tab) and close. */
+.gplayer.is-mini {
+  position: fixed; right: 16px; bottom: 16px; z-index: 120;
+  width: min(340px, 62vw); border-radius: var(--radius-lg); overflow: hidden;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, .5); border: 1px solid var(--border-strong); background: #000;
+}
+.gplayer.is-mini .gplayer__bar { display: flex; }
+.gplayer__bar { display: none; align-items: center; gap: 6px; background: var(--bg-surface); padding: 5px 6px 5px 10px; }
+.gplayer__title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--font-size-caption); color: var(--fg); }
+.gplayer__btn { background: transparent; border: 0; color: var(--fg-subtle); cursor: pointer; font: inherit; font-size: var(--font-size-caption); padding: 3px 7px; border-radius: 6px; }
+.gplayer__btn:hover { background: var(--bg-overlay); color: var(--fg); }
+.gplayer.is-mini .vchrome { display: none; }
+@media (max-width: 520px) { .gplayer.is-mini { width: min(250px, 70vw); right: 10px; bottom: 10px; } }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.32.1">
+  <link rel="stylesheet" href="css/app.css?v=3.33.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -274,6 +274,35 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.32.1"></script>
+  <script src="js/app.js?v=3.33.0"></script>
+
+  <!-- App-level player: one <video> that outlives the Call tab. It is moved
+       into the Call tab's mount when that tab is open and docked bottom-right
+       otherwise, so playback survives navigating anywhere in the app. -->
+  <div class="gplayer is-hidden" id="gplayer">
+    <div class="gplayer__bar">
+      <span class="gplayer__title" id="gp-title"></span>
+      <button type="button" class="gplayer__btn" id="gp-expand">Expand</button>
+      <button type="button" class="gplayer__btn" id="gp-close" aria-label="Close player">&#10005;</button>
+    </div>
+    <div class="gplayer__stage">
+      <div class="vchrome">
+        <div class="vspeed" data-speed-for="gp-video">
+          <button type="button" class="vspeed__btn" aria-haspopup="true" aria-expanded="false">1&times;</button>
+          <div class="vspeed__menu" role="menu">
+            <button type="button" role="menuitemradio" data-rate="0.75">0.75&times;</button>
+            <button type="button" role="menuitemradio" data-rate="1" aria-checked="true">1&times;</button>
+            <button type="button" role="menuitemradio" data-rate="1.25">1.25&times;</button>
+            <button type="button" role="menuitemradio" data-rate="1.5">1.5&times;</button>
+            <button type="button" role="menuitemradio" data-rate="1.75">1.75&times;</button>
+            <button type="button" role="menuitemradio" data-rate="2">2&times;</button>
+          </div>
+        </div>
+        <button type="button" class="vspeed__btn vpip" data-pip-for="gp-video" title="Pop out into a floating window">&#9186;</button>
+      </div>
+      <video id="gp-video" class="call-video" controls playsinline preload="metadata"></video>
+    </div>
+  </div>
+
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.32.1';
+const VERSION = '3.33.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -434,7 +434,7 @@ function processingChip() {
 function watchBtn(sc, applicantId) {
   // Opens the Call tab on their profile (video + summary + comments) —
   // not a detached modal.
-  if (applicantId) return `<button class="btn btn--sm inbox-row__review cta-std btn--watch" title="Watch the recorded intro call" data-open-call="${applicantId}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button>`;
+  if (applicantId) return `<button class="btn btn--sm inbox-row__review cta-std btn--watch" title="Watch the recorded intro call" data-play-mini="${applicantId}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button>`;
   return `<button class="btn btn--sm inbox-row__review cta-std btn--watch" title="Watch the recorded intro call" onclick="event.stopPropagation();openWatch('${sc.watch}')"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button>`;
 }
 
@@ -454,7 +454,7 @@ function openingsCta(a) {
       ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
       : `<button type="button" class="cta-link" data-give-decision="${a.id}">give your decision</button>${dv.length ? ` · ${dv.length} in` : ''}`;
     return stack(
-      `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Watch the recorded intro call" data-open-call="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
+      `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Play in the docked player — Expand opens the Call tab" data-play-mini="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
       `${decCtx}${when ? ` · ${when}` : ''}`);
   }
   if (phase === 'done') {
@@ -1462,61 +1462,6 @@ function wirePip(videoId) {
   });
 }
 
-/* Dock the player bottom-right once it scrolls out of its container while
-   playing, so the call keeps running while you read notes and comment on it.
-   A placeholder holds the layout height so nothing jumps. */
-function wireMiniPlayer(videoId, scrollRoot) {
-  const video = document.getElementById(videoId);
-  const wrap = video?.closest('.video-wrap');
-  if (!video || !wrap) return;
-  let dismissed = false;
-  const setMini = on => {
-    if (wrap.classList.contains('is-mini') === on) return;
-    if (on) {
-      const ph = document.createElement('div');
-      ph.className = 'video-slot';
-      ph.style.height = `${wrap.offsetHeight}px`;
-      wrap.parentNode.insertBefore(ph, wrap);
-      wrap.classList.add('is-mini');
-    } else {
-      wrap.classList.remove('is-mini');
-      const ph = wrap.previousElementSibling;
-      if (ph?.classList.contains('video-slot')) ph.remove();
-    }
-  };
-  // Rect-based rather than IntersectionObserver: the observer is suspended
-  // while a tab is backgrounded and its thresholds never report the
-  // fully-scrolled-past state, so geometry on scroll is more predictable.
-  const bounds = () => (scrollRoot ? scrollRoot.getBoundingClientRect() : { top: 0, bottom: window.innerHeight });
-  const evaluate = () => {
-    if (wrap.classList.contains('is-mini')) {
-      // While docked the wrap is fixed; the placeholder it left behind is
-      // what tells us whether we've scrolled back to it.
-      const ph = wrap.previousElementSibling?.classList.contains('video-slot') ? wrap.previousElementSibling : null;
-      const pr = ph?.getBoundingClientRect();
-      const b = bounds();
-      if (pr && pr.bottom > b.top + 56 && pr.top < b.bottom - 56) setMini(false);
-      if (video.paused || video.ended) setMini(false);
-      return;
-    }
-    const r = wrap.getBoundingClientRect();
-    const b = bounds();
-    const gone = r.bottom < b.top + 56 || r.top > b.bottom - 56;
-    setMini(gone && !video.paused && !video.ended && !dismissed);
-  };
-  (scrollRoot || window).addEventListener('scroll', evaluate, { passive: true });
-  window.addEventListener('resize', evaluate);
-  video.addEventListener('timeupdate', evaluate);
-  video.addEventListener('pause', () => setMini(false));
-  video.addEventListener('play', () => { dismissed = false; evaluate(); });
-  wrap.querySelector('[data-mini-close]')?.addEventListener('click', (e) => {
-    e.stopPropagation();
-    dismissed = true;
-    video.pause();
-    setMini(false);
-  });
-}
-
 function wireSpeedBar(videoId) {
   const wrap = document.querySelector(`[data-speed-for="${videoId}"]`);
   const video = document.getElementById(videoId);
@@ -1547,6 +1492,130 @@ function wireSpeedBar(videoId) {
   // Setting src resets playbackRate, so re-apply once metadata lands.
   video.addEventListener('loadedmetadata', () => { video.playbackRate = savedRate(); });
   apply(savedRate());
+}
+
+/* ---------- app-level player ----------------------------------------------
+   One <video> for the whole app. It is moved into the Call tab's mount while
+   that tab is open and docked bottom-right the rest of the time, so a call
+   keeps playing while you navigate. Moves are synchronous (remove + insert in
+   one task) — the spec only pauses a media element that stays detached. */
+
+const gp = { applicantId: null, screeningId: null, title: '', loading: false };
+
+function gpEl() { return document.getElementById('gplayer'); }
+function gpVideo() { return document.getElementById('gp-video'); }
+function gpPlaying() { const v = gpVideo(); return v && !v.paused && !v.ended && v.currentSrc; }
+
+function gpSetMode(mode) {
+  const el = gpEl();
+  if (!el) return;
+  el.classList.toggle('is-mini', mode === 'mini');
+  el.classList.toggle('is-inline', mode === 'inline');
+  el.classList.toggle('is-hidden', mode === 'hidden');
+}
+
+/* Where should the player live right now? Inline when its own applicant's
+   Call tab is open and scrolled into view; docked while it plays anywhere
+   else; hidden when nothing is playing. */
+function gpSyncPlacement() {
+  const el = gpEl();
+  if (!el || !gp.applicantId) return;
+  const mount = document.getElementById('call-player-mount');
+  const reviewOpen = !document.getElementById('review')?.hidden;
+  const onItsCallTab = reviewOpen && reviewTab === 'call' && queue[qIndex] === gp.applicantId && mount;
+
+  let inline = false;
+  if (onItsCallTab) {
+    const scroller = document.querySelector('.review__scroll');
+    const m = mount.getBoundingClientRect();
+    const b = scroller ? scroller.getBoundingClientRect() : { top: 0, bottom: window.innerHeight };
+    const visible = m.bottom > b.top + 56 && m.top < b.bottom - 56;
+    // Keep the mount's height while docked so the tab doesn't collapse.
+    if (mount.offsetHeight > 40) mount.style.minHeight = `${mount.offsetHeight}px`;
+    inline = visible || !gpPlaying();
+  }
+
+  if (inline) {
+    if (el.parentElement !== mount) mount.appendChild(el);
+    gpSetMode('inline');
+  } else {
+    if (el.parentElement !== document.body) document.body.appendChild(el);
+    gpSetMode(gpPlaying() ? 'mini' : 'hidden');
+  }
+}
+
+/* Point the player at an applicant's recording. Returns false when there is
+   nothing streamable. Does not autoplay unless asked. */
+async function gpLoad(applicantId, { autoplay = false } = {}) {
+  const sc = screeningState[applicantId] || {};
+  if (!sc.watch || sc.watchExternal) return false;
+  const a = applicants.find(x => x.id === applicantId);
+  const title = a ? fullName(a) : 'Intro call';
+  if (gp.screeningId === sc.watch && gpVideo()?.currentSrc) {
+    gp.applicantId = applicantId;
+    if (autoplay) { try { await gpVideo().play(); } catch { /* gesture required */ } }
+    gpSyncPlacement();
+    return true;
+  }
+  gp.applicantId = applicantId;
+  gp.screeningId = sc.watch;
+  gp.title = title;
+  gp.loading = true;
+  document.getElementById('gp-title').textContent = title;
+  gpSetMode(autoplay ? 'mini' : 'inline');
+  try {
+    const out = await gmailCall({ action: 'recording-link', screeningId: sc.watch });
+    const v = gpVideo();
+    if (!out.url || !v) throw new Error('Recording unavailable');
+    v.src = out.url;
+    v.playbackRate = savedRate();
+    if (autoplay) { try { await v.play(); } catch { /* gesture required */ } }
+  } catch (e) {
+    gp.loading = false;
+    toast(`Recording unavailable: ${e.message}`);
+    gpSetMode('hidden');
+    return false;
+  }
+  gp.loading = false;
+  gpSyncPlacement();
+  return true;
+}
+
+/* Row ▶ — start straight into the docked player, no navigation. */
+async function gpPlayMini(applicantId) {
+  const ok = await gpLoad(applicantId, { autoplay: true });
+  if (ok) gpSyncPlacement();
+}
+
+function gpStop() {
+  const v = gpVideo();
+  try { v.pause(); } catch { /* not started */ }
+  v?.removeAttribute('src');
+  gp.applicantId = null;
+  gp.screeningId = null;
+  document.body.appendChild(gpEl());
+  gpSetMode('hidden');
+}
+
+function initGlobalPlayer() {
+  const v = gpVideo();
+  if (!v) return;
+  wireSpeedBar('gp-video');
+  wirePip('gp-video');
+  v.addEventListener('play', gpSyncPlacement);
+  v.addEventListener('pause', gpSyncPlacement);
+  v.addEventListener('ended', gpSyncPlacement);
+  v.addEventListener('loadedmetadata', () => { v.playbackRate = savedRate(); });
+  window.addEventListener('resize', gpSyncPlacement);
+  // The review pane scrolls independently of the page.
+  document.addEventListener('scroll', gpSyncPlacement, { capture: true, passive: true });
+  document.getElementById('gp-close').addEventListener('click', gpStop);
+  document.getElementById('gp-expand').addEventListener('click', () => {
+    if (!gp.applicantId) return;
+    openReview(gp.applicantId);
+    reviewTab = 'call';
+    renderReview();
+  });
 }
 
 /* ---------- recording viewer: video + call notes + house comments ---------- */
@@ -1620,10 +1689,8 @@ async function loadCallPanel(a) {
   host().innerHTML = `
     <p class="notes__empty">${esc(`${row.housemate_name ? `${row.housemate_name} × ` : ''}${fullName(a)}`)} · ${row.starts_at ? fmtSlot(row.starts_at) : ''}</p>
     ${streamable
-      ? `<div class="video-wrap">
-           <div class="mini-bar"><span class="mini-bar__title">Intro call</span><button type="button" data-mini-close aria-label="Close mini player">✕</button></div>
-           ${speedOverlayHtml('call-video')}<video id="call-video" class="call-video" controls playsinline></video></div>
-         <p class="email-modal__status" id="call-status">Fetching recording…</p>`
+      ? `<div id="call-player-mount" class="call-player-mount"></div>
+         <p class="email-modal__status" id="call-status"></p>`
       : row.external_recording_url
         // These hosts block cross-origin embedding, so this opens out rather
         // than pretending to be a player.
@@ -1643,12 +1710,9 @@ async function loadCallPanel(a) {
       </form>
     </section>`;
   loadComments(a.id).then(() => { if (queue[qIndex] === a.id && reviewTab === 'call') renderNotes(a.id); });
-  wireSpeedBar('call-video');
-  wirePip('call-video');
-  wireMiniPlayer('call-video', document.querySelector('.review__scroll'));
   document.getElementById('notes-form-call')?.addEventListener('submit', (ev) => { ev.preventDefault(); postNote(a.id); });
   document.getElementById('call-stamp')?.addEventListener('click', () => {
-    const v = document.getElementById('call-video');
+    const v = gpVideo();
     const t = v?.currentTime || 0;
     const stamp = `[${Math.floor(t / 60)}:${String(Math.floor(t % 60)).padStart(2, '0')}] `;
     const input = document.getElementById('notes-input');
@@ -1656,16 +1720,13 @@ async function loadCallPanel(a) {
     input?.focus();
   });
   if (streamable) {
-    try {
-      const out = await gmailCall({ action: 'recording-link', screeningId: sc.watch });
-      const v = document.getElementById('call-video');
-      const st = document.getElementById('call-status');
-      if (v && out.url) { v.src = out.url; if (st) st.textContent = ''; }
-      else if (st) st.textContent = 'Recording unavailable';
-    } catch (e) {
-      const st = document.getElementById('call-status');
-      if (st) st.textContent = `Recording unavailable: ${e.message}`;
-    }
+    const st = document.getElementById('call-status');
+    if (gp.applicantId !== a.id) { if (st) st.textContent = 'Fetching recording…'; }
+    const ok = await gpLoad(a.id);
+    if (st) st.textContent = ok ? '' : 'Recording unavailable';
+  } else {
+    // Another call may be docked; leaving this tab must not strand it.
+    gpSyncPlacement();
   }
 }
 
@@ -2790,6 +2851,7 @@ function openReview(id) {
 function closeReview() {
   document.getElementById('review').hidden = true;
   document.body.style.overflow = '';
+  gpSyncPlacement(); // a playing call follows you out to the list
   const url = new URL(location); url.searchParams.delete('a');
   history.replaceState(null, '', url);
   render();
@@ -3995,7 +4057,7 @@ function init() {
     const slot = e.target.closest('[data-slot]');
     if (slot) { scheduleSlot(slot.dataset.slotApplicant, slot.dataset.slot, slot); return; }
     const rtab = e.target.closest('[data-review-tab]');
-    if (rtab) { reviewTab = rtab.dataset.reviewTab; renderReview(); return; }
+    if (rtab) { reviewTab = rtab.dataset.reviewTab; renderReview(); gpSyncPlacement(); return; }
     const em = e.target.closest('[data-email]');
     if (em) { openEmailModal(em.dataset.email, em.dataset.emailKind || null); return; }
     const so = e.target.closest('[data-second-opinion]');
@@ -4108,6 +4170,8 @@ function init() {
     if (sa) { sendAllUpdates(sa); return; }
     const od2 = e.target.closest('[data-open-draft]');
     if (od2) { updateListingStatus(od2.dataset.openDraft, 'open'); return; }
+    const pm = e.target.closest('[data-play-mini]');
+    if (pm) { e.stopPropagation(); gpPlayMini(pm.dataset.playMini); return; }
     const oc = e.target.closest('[data-open-call]');
     if (oc) {
       openReview(oc.dataset.openCall);


### PR DESCRIPTION
## What
A single `<video>` now lives at app level instead of inside the Call tab.

- **Playback survives navigation**: leave the Call tab, close the profile, switch views — the call shrinks into the docked player and keeps going.
- **Row ▶ plays straight into the dock**: clicking play in the Openings table starts the recording immediately with no navigation. The dock's **Expand** opens that applicant's Call tab and the video slots back inline.
- Placement is computed in one place (`gpSyncPlacement`): inline when its own Call tab is open and scrolled into view, docked while playing anywhere else, hidden when nothing is playing.
- Moves are synchronous remove+insert — the spec only pauses a media element left detached.

Replaces the per-tab `call-video` and the Call-tab-only mini player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)