### PR TITLE
fix(recruiting): docked player Expand reopened then closed the review (v3.33.1)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.33.0">
+  <link rel="stylesheet" href="css/app.css?v=3.33.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -274,7 +274,7 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.33.0"></script>
+  <script src="js/app.js?v=3.33.1"></script>
 
   <!-- App-level player: one <video> that outlives the Call tab. It is moved
        into the Call tab's mount when that tab is open and docked bottom-right

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.33.0';
+const VERSION = '3.33.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1609,12 +1609,17 @@ function initGlobalPlayer() {
   window.addEventListener('resize', gpSyncPlacement);
   // The review pane scrolls independently of the page.
   document.addEventListener('scroll', gpSyncPlacement, { capture: true, passive: true });
-  document.getElementById('gp-close').addEventListener('click', gpStop);
-  document.getElementById('gp-expand').addEventListener('click', () => {
+  // The docked player sits outside the review overlay, so its clicks would
+  // otherwise bubble to the outside-click handler that closes the review —
+  // reopening and immediately closing it.
+  document.getElementById('gp-close').addEventListener('click', (e) => { e.stopPropagation(); gpStop(); });
+  document.getElementById('gp-expand').addEventListener('click', (e) => {
+    e.stopPropagation();
     if (!gp.applicantId) return;
     openReview(gp.applicantId);
     reviewTab = 'call';
     renderReview();
+    gpSyncPlacement();
   });
 }
 


### PR DESCRIPTION
The docked player is a child of `body`, outside the review overlay, so clicking Expand bubbled to the outside-click handler that closes the review: it opened the Call tab and shut it again within the same event. Verified by running the same logic without a click event, which worked correctly.

`stopPropagation` on Expand and Close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)