### PR TITLE
Recruiting: no jargon in housemate-facing copy

### DIFF
--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -190,3 +190,16 @@ Migration 135: `recruit_applicants.exit_reason` (`future` | `opted_out` | `not_a
 The Discord post that offers an applicant's open times is a **screener scheduler**; a housemate **signs up** for a slot and becomes the **screener**. Row copy reads *"no screener yet · 2d"*, the app action stays **Ask for coverage**, and the preview modal is *"Ask housemates for coverage"* → **Post the scheduler**.
 
 "Claim" survives only where changing it would break things: the `recruit_claim_posts` table and `claimed_*` columns (a rename buys nothing), and Discord `custom_id`s — **live posted buttons carry `claim|…`, so that wire format is frozen**. The edge function accepts both `scheduler-preview`/`scheduler-post` and the legacy `claim-*` action names so a cached browser keeps working.
+
+## Copy rule: no jargon facing housemates
+Anything a housemate can read — Discord posts, DMs, audit lines, in-app copy — uses plain language. Never the words that only make sense inside the system: *ingested, extracted, payload, webhook, upsert, token, API, bot permissions, rejected*.
+
+| Was | Now |
+|---|---|
+| 7 applications ingested from the sheet | 7 new applications |
+| Direct message | Message sent |
+| Sign-in helper posted | Phone sign-in message posted |
+| Posted here because <#x> rejected it — check the bot's permissions | Posting this in <#x> didn't work, so it's here instead |
+| no concrete times could be read | didn't name specific times |
+
+Technical detail still belongs in two places: function logs, and the ops DM that fires when posting fails everywhere (that one is for whoever fixes it).

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -173,7 +173,7 @@ export function buildMessage(input: ScreenerSchedulerInput, slots: Slot[]): Reco
   let description: string
   if (manual) {
     description =
-      `**${input.firstName}** replied about scheduling, but no concrete times could be read.\n\n` +
+      `**${input.firstName}** wrote back about scheduling, but didn't name specific times.\n\n` +
       considerationsBlock +
       `See ${poss} [application](${appLink(input.applicantId)}) — read the thread and coordinate by email.`
   } else {
@@ -326,7 +326,7 @@ export async function dmUser(discordUserId: string, content: string): Promise<vo
   await discordFetch(`/channels/${channel.id}/messages`, {
     method: 'POST', body: JSON.stringify({ content }),
   })
-  await auditMirror('Direct message', content.split('\n')[0], { dmTo: discordUserId })
+  await auditMirror('Message sent', content.split('\n')[0], { dmTo: discordUserId })
 }
 
 /* Audit mirror: a one-line record of every automated message, posted to
@@ -404,7 +404,7 @@ export async function postResilient(channelId: string, payload: Record<string, u
       method: 'POST',
       body: JSON.stringify({
         ...payload,
-        content: `⚠️ Posted here because <#${channelId}> rejected it — check the bot's permissions there.${typeof payload.content === 'string' ? `\n${payload.content}` : ''}`,
+        content: `⚠️ Posting this in <#${channelId}> didn't work, so it's here instead.${typeof payload.content === 'string' ? `\n${payload.content}` : ''}`,
       }),
     })
     return
@@ -503,7 +503,7 @@ export async function postLiveCall(title: string, when: string, meetLink: string
 // Persistent "Get sign-in link" helper message for phone sign-in — tapping
 // the button gets an ephemeral one-time link (handled in recruit-discord).
 export async function postSigninMessage(channelId: string): Promise<any> {
-  await auditMirror('Sign-in helper posted', 'Persistent phone sign-in message', { channelId })
+  await auditMirror('Phone sign-in message posted', 'Housemates can get a sign-in link from it any time', { channelId })
   return await discordFetch(`/channels/${channelId}/messages`, {
     method: 'POST',
     body: JSON.stringify({

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -19,7 +19,7 @@
 // timestamp, and inserts ignore duplicates — so resending the whole sheet is
 // a safe backfill, not a mess of copies.
 
-const VERSION = '1.2.0'
+const VERSION = '1.2.1'
 console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -225,8 +225,8 @@ serve(async (req) => {
       try {
         const names = created.map((c) => `${c.first_name} ${c.last_name || ''}`.trim()).join(', ')
         await postChannelEmbed(AUTOMATION_CHANNEL_ID,
-          `📥 **${created.length} application${created.length === 1 ? '' : 's'} ingested** from the sheet\n${names.slice(0, 800)}`,
-          0x6a6c6a, `${created.length} applications ingested`)
+          `📥 **${created.length} new application${created.length === 1 ? '' : 's'}**\n${names.slice(0, 800)}`,
+          0x6a6c6a, `${created.length} new application${created.length === 1 ? '' : 's'}`)
       } catch (err) {
         console.warn(`[recruit-ingest] audit post failed: ${(err as Error).message}`)
       }


### PR DESCRIPTION
Fixes the string you flagged and sweeps the rest of what housemates can read.

| Was | Now |
|---|---|
| 7 applications ingested from the sheet | **7 new applications** |
| Direct message | Message sent |
| Sign-in helper posted | Phone sign-in message posted |
| Posted here because <#x> rejected it — check the bot's permissions | Posting this in <#x> didn't work, so it's here instead |
| no concrete times could be read | didn't name specific times |

Recorded as a standing rule in the design doc. Technical wording stays in function logs and the ops DM that fires when posting fails everywhere — that one is for whoever fixes it.

Downstyled to "7 new applications" per your standing sentence-case rule; say the word if you want the caps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)