### PR TITLE
Recruiting: keep the actionable half of the fallback notice

### DIFF
--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -199,7 +199,7 @@ Anything a housemate can read — Discord posts, DMs, audit lines, in-app copy �
 | 7 applications ingested from the sheet | 7 new applications |
 | Direct message | Message sent |
 | Sign-in helper posted | Phone sign-in message posted |
-| Posted here because <#x> rejected it — check the bot's permissions | Posting this in <#x> didn't work, so it's here instead |
+| Posted here because <#x> **rejected it** — check the bot's permissions | Posting this in <#x> didn't work, so it's here instead — check the bot's permissions there |
 | no concrete times could be read | didn't name specific times |
 
-Technical detail still belongs in two places: function logs, and the ops DM that fires when posting fails everywhere (that one is for whoever fixes it).
+**The test is whether the reader can act on it, not whether the word sounds technical.** "Check the bot's permissions" stays — it names the fix. "Rejected it" goes — it only describes our internals. Same logic keeps technical detail in function logs and in the ops DM that fires when posting fails everywhere.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -404,7 +404,7 @@ export async function postResilient(channelId: string, payload: Record<string, u
       method: 'POST',
       body: JSON.stringify({
         ...payload,
-        content: `⚠️ Posting this in <#${channelId}> didn't work, so it's here instead.${typeof payload.content === 'string' ? `\n${payload.content}` : ''}`,
+        content: `⚠️ Posting this in <#${channelId}> didn't work, so it's here instead — check the bot's permissions there.${typeof payload.content === 'string' ? `\n${payload.content}` : ''}`,
       }),
     })
     return


### PR DESCRIPTION
Per your call: "check the bot's permissions" is guidance someone can act on, so it belongs. "Rejected it" only described our internals, so it stays gone.

Now: *"⚠️ Posting this in <#x> didn't work, so it's here instead — check the bot's permissions there."*

Design doc rule sharpened accordingly: the test is whether the reader can act on it, not whether the word sounds technical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)