### PR TITLE
fix(recruiting): player markup must precede app.js (v3.33.3)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.33.2">
+  <link rel="stylesheet" href="css/app.css?v=3.33.3">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -274,8 +274,6 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.33.2"></script>
-
   <!-- App-level player: one <video> that outlives the Call tab. It is moved
        into the Call tab's mount when that tab is open and docked bottom-right
        otherwise, so playback survives navigating anywhere in the app. -->
@@ -303,6 +301,8 @@
       <video id="gp-video" class="call-video" controls playsinline preload="metadata"></video>
     </div>
   </div>
+
+  <script src="js/app.js?v=3.33.3"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.33.2';
+const VERSION = '3.33.3';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1599,7 +1599,9 @@ function gpStop() {
 
 function initGlobalPlayer() {
   const v = gpVideo();
-  if (!v) return;
+  // The markup must precede this script; a silent return here once cost an
+  // afternoon of "the button does nothing".
+  if (!v) { console.error('[applications] #gplayer missing at init — player disabled'); return; }
   wireSpeedBar('gp-video');
   wirePip('gp-video');
   v.addEventListener('play', gpSyncPlacement);


### PR DESCRIPTION
The `#gplayer` block was emitted after `<script src="js/app.js">`, so `initGlobalPlayer()` ran against a DOM that didn't contain it yet and hit its early return. No listeners were attached — View and ✕ silently did nothing, while playback itself (wired on demand) worked, which is what made it look like an event-bubbling problem.

Markup moved above the script; the early return now logs instead of failing silently.

Verified by re-running `initGlobalPlayer()` by hand in prod: View then opened the Call tab, mounted the player inline, and kept it playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)