### PR TITLE
fix(recruiting): actually call initGlobalPlayer (v3.33.4)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.36.0">
+  <link rel="stylesheet" href="css/app.css?v=3.36.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.36.0"></script>
+  <script src="js/app.js?v=3.36.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.36.0';
+const VERSION = '3.36.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -4006,6 +4006,7 @@ function init() {
   });
   sb = window.CtrlAuth.getSupabaseClient();
   redeemSigninToken(); // no-op without ?signin=
+  initGlobalPlayer();
 
   document.getElementById('gate-btn').onclick = signInWithDiscord;
   document.getElementById('gate-alt').onclick = () => window.CtrlAuth.openLoginModal();


### PR DESCRIPTION
`initGlobalPlayer()` was defined but never invoked, so the docked player's View and ✕ listeners were never bound — both buttons silently did nothing. Playback worked regardless (that path wires itself on demand), which is what masked it and sent me chasing event bubbling and script ordering first.

Proven by probe: the click reached the button, but no handler ran; calling `initGlobalPlayer()` by hand in prod made View work immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)