### PR TITLE
recruiting: Review label, veto archives for real, new-application dot, Discord inbox button (v3.34.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -129,7 +129,18 @@ button { font: inherit; cursor: pointer; }
 .gate[hidden] { display: none; }
 .page[hidden] { display: none; }
 /* No gate flash while CtrlAuth restores an existing session. */
-body[data-auth-state="loading"] .gate { visibility: hidden; }
+/* Restoring a session, or signed in and loading: show a quiet spinner, never
+   the sign-in card — a returning housemate should never see "Continue with
+   Discord" flash past on reload. */
+.gate__spinner { display: none; width: 26px; height: 26px; border-radius: 50%;
+  border: 2px solid var(--border); border-top-color: var(--fg-muted);
+  animation: gate-spin 0.7s linear infinite; }
+@keyframes gate-spin { to { transform: rotate(360deg); } }
+body[data-auth-state="loading"] .gate__card,
+body[data-auth-state="in"] .gate__card { display: none; }
+body[data-auth-state="loading"] .gate__spinner,
+body[data-auth-state="in"] .gate__spinner { display: block; }
+@media (prefers-reduced-motion: reduce) { .gate__spinner { animation-duration: 2.4s; } }
 .gate__card {
   width: 100%; max-width: 380px;
   background: var(--bg-elevated); border: 1px solid var(--border);

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.34.0">
+  <link rel="stylesheet" href="css/app.css?v=3.35.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -16,6 +16,7 @@
 
   <!-- Gate: Discord sign-in, then Recruiting Society channel verification. -->
   <div class="gate" id="gate">
+    <div class="gate__spinner" role="status" aria-label="Opening the applicant inbox"></div>
     <div class="gate__card">
       <h1 class="gate__title">Agape recruiting</h1>
       <p class="gate__sub" id="gate-sub">Sign in with Discord to open the applicant inbox.</p>
@@ -274,7 +275,7 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.34.0"></script>
+  <script src="js/app.js?v=3.35.0"></script>
 
   <!-- App-level player: one <video> that outlives the Call tab. It is moved
        into the Call tab's mount when that tab is open and docked bottom-right

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.33.2">
+  <link rel="stylesheet" href="css/app.css?v=3.34.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -274,7 +274,7 @@
 
   <div class="toast-host" id="toast-host"></div>
 
-  <script src="js/app.js?v=3.33.2"></script>
+  <script src="js/app.js?v=3.34.0"></script>
 
   <!-- App-level player: one <video> that outlives the Call tab. It is moved
        into the Call tab's mount when that tab is open and docked bottom-right

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.34.0';
+const VERSION = '3.35.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -3857,6 +3857,9 @@ async function signInWithDiscord() {
 }
 
 function setGate(sub, btnLabel, hint) {
+  // Showing a gate message means we've stopped: reveal the card even if we
+  // were mid-load, or the spinner would spin forever over a silent failure.
+  document.body.dataset.authState = 'out';
   document.getElementById('gate-sub').textContent = sub;
   const btn = document.getElementById('gate-btn');
   document.getElementById('gate-btn-label').textContent = btnLabel || '';
@@ -3991,6 +3994,14 @@ function init() {
 
   document.getElementById('gate-btn').onclick = signInWithDiscord;
   document.getElementById('gate-alt').onclick = () => window.CtrlAuth.openLoginModal();
+  // Nothing stored to restore and no redeem in flight? Then we're signed out
+  // for certain — show the card now instead of spinning for 2.5s.
+  const hasStoredSession = Object.keys(localStorage).some(k => /^sb-.*-auth-token$/.test(k));
+  if (!hasStoredSession && !new URLSearchParams(location.search).get('signin')
+      && !location.hash.includes('access_token')) {
+    document.body.dataset.authState = 'out';
+  }
+
   // If no signedin event lands shortly, we're signed out — show the gate.
   setTimeout(() => {
     if (document.body.dataset.authState === 'loading' && !window.CtrlAuth.getUser()) {

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.33.2';
+const VERSION = '3.34.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -100,6 +100,7 @@ let applicants = [];          // newest first; each carries .stage
 let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
 let votes = {};               // applicant_id -> recruit_votes rows
 let placements = [];          // recruit_listing_candidates rows
+let viewedIds = new Set();    // applicants I've opened (recruit_applicant_views)
 let claimPosts = {};          // applicant_id -> { status, posted_at }
 let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
@@ -500,6 +501,12 @@ function openingsCta(a) {
 /* Blue response dot in the row's left gutter — sits beside the avatar,
    never on top of it. */
 function repliedDot(a) {
+  // Same blue dot, two meanings by context: in the Inbox it marks an
+  // application nobody on your account has opened yet; elsewhere it marks
+  // their reply waiting on you.
+  if (view === 'inbox') {
+    return viewedIds.has(a.id) ? '' : `<span class="replied-dot" title="New — you haven't opened this application yet"></span>`;
+  }
   const st = emailState[a.id];
   if (st?.lastDir !== 'in') return '';
   return `<span class="replied-dot" title="They replied — ${relTime(st.lastAt)}"></span>`;
@@ -545,7 +552,7 @@ async function resolveAvatars() {
 
 /* ---------- data ---------- */
 async function loadAll() {
-  const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes, cpRes, dvRes] = await Promise.all([
+  const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes, cpRes, dvRes, vwRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
     sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
@@ -558,10 +565,12 @@ async function loadAll() {
     sb.from('recruit_screenings').select('id, applicant_id, starts_at, ends_at, status, housemate_name, meet_link, recall_status, kind, title, calendar_id').order('starts_at'),
     sb.from('recruit_availability').select('applicant_id, windows, updated_at'),
     sb.from('recruit_listing_candidates').select('*'),
+    sb.from('recruit_applicant_views').select('applicant_id'),
     sb.from('recruit_claim_posts').select('applicant_id, status, posted_at'),
     sb.from('recruit_decision_votes').select('*'),
   ]);
   placements = pRes.data || [];
+  viewedIds = new Set((vwRes.data || []).map(v => v.applicant_id));
   claimPosts = {};
   for (const c of (cpRes.data || [])) claimPosts[c.applicant_id] = { status: c.status, postedAt: c.posted_at };
   decisionVotes = {};
@@ -1305,7 +1314,8 @@ async function render() {
 /* ---------- applicants render ---------- */
 function matchesView(a) {
   const out = a.stage !== 'rejected' && a.stage !== 'archived';
-  if (view === 'inbox') return a.stage === 'review';
+  // A standing veto means archived — never show them here, whatever the stage says.
+  if (view === 'inbox') return a.stage === 'review' && !voteStats(a.id).veto;
   // Saved for future stays a candidate — visible in Candidates with its chip,
   // absent from Openings until the return date brings them back.
   if (view === 'candidates') return a.stage === 'candidate';
@@ -1954,7 +1964,7 @@ function renderApplicants() {
               ${noteBubble(a.id)}
               ${view === 'openings'
                 ? `${openingsCta(a)}${rowMenuHtml(a, g.key)}`
-                : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn inbox-row__review" data-review="${a.id}">Vote</button>` : ''}`}
+                : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn inbox-row__review" data-review="${a.id}">Review</button>` : ''}`}
             </span>
           </li>`).join('')}
       </ul>`}
@@ -2845,6 +2855,12 @@ function openReview(id) {
   reviewTab = 'profile';
   pendingVote = null;
   moveinEditing = false;
+  if (!viewedIds.has(id)) {
+    viewedIds.add(id);
+    sb.from('recruit_applicant_views')
+      .upsert({ applicant_id: id, user_id: me.id, viewed_at: new Date().toISOString() }, { onConflict: 'applicant_id,user_id' })
+      .then(({ error }) => { if (error) console.warn('view mark failed', error.message); });
+  }
   document.getElementById('review').hidden = false;
   document.body.style.overflow = 'hidden';
   hideHoldSheet();
@@ -3121,9 +3137,18 @@ function renderReviewFoot(a) {
 async function reopenApplicant(id) {
   const a = applicants.find(x => x.id === id);
   if (!a) return;
+  // A veto is archival, so reopening has to clear it — otherwise they'd sit in
+  // the Inbox with a standing veto that can never resolve.
+  const st0 = voteStats(id);
+  if (st0.veto) {
+    if (!confirm(`${fullName(a)} was vetoed by ${st0.veto.voter_name || 'a housemate'}. Reopening clears that veto so the house can review them again. Continue?`)) return;
+    const { error } = await sb.from('recruit_votes').delete().eq('applicant_id', id).eq('veto', true);
+    if (error) { toast(`Couldn't clear the veto: ${error.message}`); return; }
+    votes[id] = (votes[id] || []).filter(v => !v.veto);
+  }
   if (await setStage(id, 'review')) {
     const st = voteStats(id);
-    toast(st.veto ? `Reopened — note: ${st.veto.voter_name || 'a housemate'}'s veto still stands until they change their vote` : 'Reopened — back in the Inbox');
+    toast(st0.veto ? 'Reopened — the veto was cleared' : 'Reopened — back in the Inbox');
     renderRailCounts();
     if (!document.getElementById('review').hidden) renderReview(); else render();
   }

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -523,10 +523,16 @@ export async function postSigninMessage(channelId: string): Promise<any> {
 
 // One channel nudge for a post nobody claimed within 96h.
 // Plain embed post to any channel (new-application pings etc.).
-export async function postChannelEmbed(channelId: string, description: string, color = 0x378add, label = 'Automated post'): Promise<any> {
+export async function postChannelEmbed(
+  channelId: string, description: string, color = 0x378add, label = 'Automated post',
+  links: Array<{ label: string; url: string }> = [],
+): Promise<any> {
+  const components = links.length
+    ? [{ type: 1, components: links.slice(0, 5).map((l) => ({ type: 2, style: 5, label: l.label, url: l.url })) }]
+    : []
   const msg = await discordFetch(`/channels/${channelId}/messages`, {
     method: 'POST',
-    body: JSON.stringify({ embeds: [{ description, color }] }),
+    body: JSON.stringify({ embeds: [{ description, color }], components }),
   })
   await auditMirror(label, description.split('\n')[0], { channelId })
   return msg

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.18.1'
+const VERSION = '1.19.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -1124,7 +1124,9 @@ serve(async (req) => {
           const appLink = (id: string) => `https://ctrl.rodeo/applications/?a=${encodeURIComponent(id)}`
           if (toPing.length > 3) {
             const lines = toPing.map((a) => `• [${a.first_name} ${a.last_name || ''}](${appLink(a.id)})`).join('\n')
-            await postChannelEmbed(pingChannel, `📥 **${toPing.length} new applications** are ready for votes:\n${lines}`, 0x378add, `${toPing.length} new applications`)
+            await postChannelEmbed(pingChannel, `📥 **${toPing.length} new applications** are ready for votes:\n${lines}`,
+              0x378add, `${toPing.length} new applications`,
+              [{ label: 'Open the inbox', url: 'https://ctrl.rodeo/applications/?view=inbox' }])
           } else {
             for (const a of toPing) {
               const track = /short/i.test(a.residency || '') ? 'Sublet' : 'Full-time'
@@ -1132,7 +1134,9 @@ serve(async (req) => {
               await postChannelEmbed(pingChannel,
                 `📥 **${a.first_name} ${a.last_name || ''}** applied — ${track}${a.move_in ? ` · ${String(a.move_in).slice(0, 60)}` : ''}\n` +
                 (why ? `_${why}_\n` : '') +
-                `[Read + vote](${appLink(a.id)})`, 0x378add, `New application — ${a.first_name}`)
+                '', 0x378add, `New application — ${a.first_name}`,
+                [{ label: `Review ${a.first_name}`, url: appLink(a.id) },
+                 { label: 'Open the inbox', url: 'https://ctrl.rodeo/applications/?view=inbox' }])
             }
           }
           if (toPing.length) {

--- a/supabase/migrations/132_recruit_veto_invariant_views.sql
+++ b/supabase/migrations/132_recruit_veto_invariant_views.sql
@@ -1,0 +1,46 @@
+-- ============================================
+-- Migration 132: veto invariant, per-viewer read state, test-record cleanup
+--
+-- 1. A veto must always mean archived. Reopening a vetoed applicant used to
+--    drop them back into the Inbox with the veto still standing — the app even
+--    admitted it in a toast. Reconcile the existing drift here; the client now
+--    clears vetoes when a recruiter reopens, so the invariant holds going
+--    forward: a standing veto ⇒ stage 'rejected'.
+-- 2. recruit_applicant_views — which applicants each housemate has opened, so
+--    genuinely new rows can carry the blue dot. Per-viewer and durable, so it
+--    survives switching between phone and laptop.
+-- 3. Delete the 'test-claim-flow' record (Testy McTestface) used while wiring
+--    the screener scheduler. Cascades to its votes, emails, availability,
+--    scheduler post, and screenings.
+-- ============================================
+
+UPDATE recruit_applicants a SET stage = 'rejected'
+  WHERE a.stage NOT IN ('rejected', 'archived')
+    AND EXISTS (SELECT 1 FROM recruit_votes v WHERE v.applicant_id = a.id AND v.veto);
+
+CREATE TABLE IF NOT EXISTS recruit_applicant_views (
+  applicant_id TEXT NOT NULL REFERENCES recruit_applicants(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  viewed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (applicant_id, user_id)
+);
+ALTER TABLE recruit_applicant_views ENABLE ROW LEVEL SECURITY;
+
+-- Read state is personal: you see and write only your own.
+CREATE POLICY "Members read own views" ON recruit_applicant_views
+  FOR SELECT TO authenticated USING (is_recruiting_member() AND user_id = auth.uid());
+CREATE POLICY "Members write own views" ON recruit_applicant_views
+  FOR INSERT TO authenticated WITH CHECK (is_recruiting_member() AND user_id = auth.uid());
+CREATE POLICY "Members update own views" ON recruit_applicant_views
+  FOR UPDATE TO authenticated
+  USING (is_recruiting_member() AND user_id = auth.uid())
+  WITH CHECK (is_recruiting_member() AND user_id = auth.uid());
+
+-- Everything already in the funnel counts as seen, so switching this on
+-- doesn't light up 60 rows as "new".
+INSERT INTO recruit_applicant_views (applicant_id, user_id, viewed_at)
+  SELECT a.id, v.voter_id, NOW() FROM recruit_applicants a
+  JOIN recruit_votes v ON v.applicant_id = a.id
+  ON CONFLICT DO NOTHING;
+
+DELETE FROM recruit_applicants WHERE id = 'test-claim-flow';

--- a/supabase/migrations/133_recruit_seed_views.sql
+++ b/supabase/migrations/133_recruit_seed_views.sql
@@ -1,0 +1,14 @@
+-- ============================================
+-- Migration 133: seed read state so the blue dot only marks real arrivals
+--
+-- 132's backfill keyed off recruit_votes, which is empty (the single vote on
+-- record was Testy McTestface's veto, and it cascaded away with that row). Left
+-- as-is, every one of the 58 applicants already in the Inbox would light up as
+-- "new" the first time someone opened the app. Mark everything that exists
+-- right now as seen by everyone who has signed in, so the dot starts clean and
+-- only future applications carry it.
+-- ============================================
+
+INSERT INTO recruit_applicant_views (applicant_id, user_id, viewed_at)
+  SELECT a.id, u.id, NOW() FROM recruit_applicants a CROSS JOIN auth.users u
+  ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## What

- **"Vote" → "Review"** on Inbox rows, using Ladder's quiet surface-button style (the CSS already matched byte-for-byte, so this is label-only).
- **Veto genuinely archives.** Testy McTestface sat in the Inbox with 1 veto because Reopen returned vetoed applicants to `review` and its own toast admitted the veto still stood. Reopen now clears the veto behind a confirm, `matchesView('inbox')` filters any vetoed applicant defensively, and migration 132 reconciles existing drift and deletes the test record.
- **Blue dot for new applications.** In the Inbox the dot means "you haven't opened this yet", per-viewer via the new `recruit_applicant_views` table; elsewhere it keeps meaning "they replied". Opening a profile records the view for your account only (RLS: read/write own rows).
- **Discord pings get buttons** — "Open the inbox", plus "Review <name>" on single-applicant pings. `postChannelEmbed` takes optional link buttons.

## Versions
applications v3.34.0 · recruit-gmail v1.19.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)