### PR TITLE
fix(recruiting): give-decision lives in the ⋮ only

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.35.0">
+  <link rel="stylesheet" href="css/app.css?v=3.36.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -302,7 +302,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.35.0"></script>
+  <script src="js/app.js?v=3.36.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.35.0';
+const VERSION = '3.36.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -456,7 +456,7 @@ function openingsCta(a) {
     const mine = dv.find(v => v.voter_id === me?.id);
     const decCtx = mine
       ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
-      : `<button type="button" class="cta-link" data-give-decision="${a.id}">give your decision</button>${dv.length ? ` · ${dv.length} in` : ''}`;
+      : (dv.length ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours isn't` : 'no decisions yet');
     return stack(
       `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Play in the docked player — View opens the Call tab" data-play-mini="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
       `${decCtx}${when ? ` · ${when}` : ''}`);
@@ -468,7 +468,7 @@ function openingsCta(a) {
     const mine = dv.find(v => v.voter_id === me?.id);
     const decCtx = mine
       ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
-      : `<button type="button" class="cta-link" data-give-decision="${a.id}">give your decision</button>${dv.length ? ` · ${dv.length} in` : ''}`;
+      : (dv.length ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours isn't` : 'no decisions yet');
     return stack(
       `<button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button>`,
       `${decCtx} · no recording — <button type="button" class="cta-link" data-add-recording="${a.id}">add a link</button>`);
@@ -2017,7 +2017,7 @@ function rowMenuHtml(a, listingId) {
     <span class="listing-menu" data-menu-for="${esc(mid)}" hidden>
       <button type="button" class="listing-menu__item" data-review="${a.id}">Open profile</button>
       ${a.scheduleToken ? `<button type="button" class="listing-menu__item" data-copy-schedule="${a.id}">Copy availability link</button>` : ''}
-      ${screeningState[a.id]?.watch ? `<button type="button" class="listing-menu__item" data-give-decision="${a.id}">Give decision…</button>` : ''}
+      ${(screeningState[a.id]?.watch || screeningState[a.id]?.done) ? `<button type="button" class="listing-menu__item" data-give-decision="${a.id}">Give decision…</button>` : ''}
       <button type="button" class="listing-menu__item" data-add-recording="${a.id}">Add recording link…</button>
       <span class="listing-menu__rule" aria-hidden="true"></span>
       <button type="button" class="listing-menu__item" data-open-remove="${a.id}|${esc(listingId)}">Remove…</button>

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -114,7 +114,7 @@ Watch opens a **Call** tab on the applicant profile (not a modal): recording pla
 - **Phase B live**: scan pings the recruiting channel about new review-stage applicants (one post each; 4+ collapse to a digest; `discord_ping_at` dedup). Archive shows the **update tray** — pending rejections with Edit email / Skip and **Send all** (individually drafted community notes via `draft_update`, sent via `send-update` which stamps `update_email_sent_at` and archives clean).
 - **Draft listings**: 28+ day occupancy gaps in the next six months become `status='draft'` listings (dashed cards atop Openings; Open listing / Dismiss). Bucketing only sees `open`.
 - **Awaiting claim** is a real row state: coverage ask posted → `◆ sent to housemates` chip + `unclaimed Nd · book it yourself` context.
-- **Give decision**: post-screening yes/no + note per housemate (`recruit_decision_votes`); the watch-state context tier carries `give your decision` / `N decisions in`; also in the row ⋮. Tally is advisory — moving the person stays human.
+- **Give decision**: post-screening yes/no + note per housemate (`recruit_decision_votes`); the watch-state context tier carries `give your decision` / `N decisions in`; also in the row ⋮. Tally is advisory — moving the person stays human. *Amended in v3.36 — see below.*
 - **Follow-up staleness** implemented: grey under 3 quiet days, amber after.
 - **Schedule a visit** drafts a visit-specific invite (`emailType: 'visit'`).
 - **Flexible dial**: bare "Flexible" rides any window; "month + flexible" = that month ±1.
@@ -203,3 +203,11 @@ Anything a housemate can read — Discord posts, DMs, audit lines, in-app copy �
 | no concrete times could be read | didn't name specific times |
 
 **The test is whether the reader can act on it, not whether the word sounds technical.** "Check the bot's permissions" stays — it names the fix. "Rejected it" goes — it only describes our internals. Same logic keeps technical detail in function logs and in the ops DM that fires when posting fails everywhere.
+
+## v3.36 — one home per action
+
+`give your decision` sat in the row's context tier **and** in the row ⋮, which put the same action in two places a few pixels apart. The context tier now carries only the tally — `2 decisions in — yours counted` / `2 decisions in — yours isn't` / `no decisions yet` — and the action lives solely in the ⋮.
+
+This narrows the two-tier rule stated above: the context tier may hold a secondary action as a text link **only when that link is the tier's own explanation**. `no recording — add a link` earns its place, because the caption exists to say why there's no Watch button and the link is the remedy. A bare duplicate of a menu item does not.
+
+The ⋮ entry was gated on a recording existing (`screeningState.watch`); it now also shows for a finished call with no recording (`.done`), which is exactly the case where the row link used to be the only way in.


### PR DESCRIPTION
`give your decision` sat in the row's context tier **and** in the row ⋮ — the same action twice, a few pixels apart. The context tier now carries only the tally:

- `2 decisions in — yours counted`
- `2 decisions in — yours isn't`
- `no decisions yet`

**One thing this needed:** the ⋮ entry was gated on a recording existing (`screeningState.watch`), so on a finished call with no recording the row link was the *only* way in. Widened to `.done` as well — otherwise removing the link would have removed the affordance entirely.

Docs updated, narrowing the two-tier rule: the context tier may hold a secondary action as a text link **only when that link is the tier's own explanation**. `no recording — add a link` earns its place (the caption exists to explain the missing Watch button, and the link is the remedy). A bare duplicate of a menu item does not.

`app v3.36.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)