### PR TITLE
feat(recruiting): one listing per applicant

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.36.0">
+  <link rel="stylesheet" href="css/app.css?v=3.37.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.36.0"></script>
+  <script src="js/app.js?v=3.37.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.36.0';
+const VERSION = '3.37.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -748,6 +748,29 @@ function qualifiesFor(a, l) {
 }
 
 const activePlacements = id => placements.filter(p => p.applicant_id === id && p.status === 'active');
+const activePlacement = id => activePlacements(id)[0] || null;
+
+/* Of the open listings an applicant qualifies for, the one they actually fit
+   best: closest start date to their confirmed move-in, then earliest start,
+   then lowest id so the choice is stable run to run. Same ordering migration
+   139 used to reconcile the duplicates, so the sweep and the backfill agree.
+   A tombstoned listing is a recruiter's "not here" and is never re-picked. */
+function bestListingFor(a) {
+  const target = a.moveinFrom ? new Date(a.moveinFrom).getTime() : null;
+  const tombstoned = new Set(placements
+    .filter(p => p.applicant_id === a.id && p.status === 'removed')
+    .map(p => p.listing_id));
+  return listings
+    .filter(l => l.status === 'open' && !tombstoned.has(l.id) && qualifiesFor(a, l))
+    .sort((x, y) => {
+      if (target !== null) {
+        const dx = Math.abs(new Date(x.starts_on).getTime() - target);
+        const dy = Math.abs(new Date(y.starts_on).getTime() - target);
+        if (dx !== dy) return dx - dy;
+      }
+      return x.starts_on.localeCompare(y.starts_on) || String(x.id).localeCompare(String(y.id));
+    })[0] || null;
+}
 
 /* Insert missing placements for every candidate AND prune auto rows that no
    longer qualify (rule changes, edited listings, stage moves). Never touches
@@ -759,10 +782,12 @@ async function syncAutoPlacements() {
   // A saved-for-future candidate keeps the stage but is off the board until
   // their date lands, so they're excluded here as well as in matchesView.
   for (const a of applicants.filter(x => x.stage === 'candidate' && !x.exitReason)) {
-    for (const l of listings.filter(l => l.status === 'open')) {
-      if (!have.has(`${a.id}:${l.id}`) && qualifiesFor(a, l)) {
-        fresh.push({ applicant_id: a.id, listing_id: l.id, source: 'auto' });
-      }
+    // One listing each. Someone already placed is left alone — the sweep
+    // must never yank a person out from under whoever is working them.
+    if (activePlacements(a.id).length) continue;
+    const best = bestListingFor(a);
+    if (best && !have.has(`${a.id}:${best.id}`)) {
+      fresh.push({ applicant_id: a.id, listing_id: best.id, source: 'auto' });
     }
   }
   const stale = placements.filter(p => {
@@ -787,7 +812,21 @@ async function syncAutoPlacements() {
   return (data || []).length;
 }
 
+/* An applicant belongs to exactly ONE listing (migration 139). Placing them
+   somewhere therefore MOVES them — the previous active placement is dropped
+   first, or the unique index would reject the insert. Deleted rather than
+   tombstoned: a tombstone means "never here again", and a move says nothing
+   of the kind. */
 async function addPlacement(applicantId, listingId, source = 'manual') {
+  const prior = placements.filter(p =>
+    p.applicant_id === applicantId && p.status === 'active' && p.listing_id !== listingId);
+  if (prior.length) {
+    const { error: delErr } = await sb.from('recruit_listing_candidates')
+      .delete().in('id', prior.map(p => p.id));
+    if (delErr) { toast(`Couldn't move them: ${delErr.message}`); return null; }
+    const gone = new Set(prior.map(p => p.id));
+    placements = placements.filter(p => !gone.has(p.id));
+  }
   const { data, error } = await sb.from('recruit_listing_candidates').upsert({
     applicant_id: applicantId, listing_id: listingId, source,
     status: 'active', added_by_name: me?.name || null, updated_at: new Date().toISOString(),
@@ -2009,7 +2048,7 @@ function othersAccordion(listingId) {
           </button>
           <span class="inbox-row__actions">
             ${a.stage === 'review' ? (voteChip(a) || '<span class="note-count">gathering votes</span>') : (removed ? '<span class="note-count" title="Removed from this listing by a recruiter">removed</span>' : '')}
-            ${a.stage === 'candidate' ? `<button class="btn btn--sm inbox-row__review" data-add-placement="${a.id}|${esc(listingId)}">Add</button>` : ''}
+            ${a.stage === 'candidate' ? `<button class="btn btn--sm inbox-row__review" title="${activePlacements(a.id).length ? 'Moves them here from their current listing' : 'Place them on this listing'}" data-add-placement="${a.id}|${esc(listingId)}">${activePlacements(a.id).length ? 'Move here' : 'Add'}</button>` : ''}
           </span>
         </li>`;
       }).join('')}
@@ -2145,14 +2184,10 @@ async function movePlacement(applicantId, fromListingId, toListingId) {
     toast(`${a.first} is already on that listing`);
     return;
   }
+  // addPlacement clears the previous placement itself now — one listing per
+  // applicant is the invariant, so every placement is a move.
   const added = await addPlacement(applicantId, toListingId, 'manual');
   if (!added) return;
-  const src = placements.find(p => p.applicant_id === applicantId && p.listing_id === fromListingId);
-  if (src) {
-    const { error } = await sb.from('recruit_listing_candidates').delete().eq('id', src.id);
-    if (error) { toast(`Move half-finished: ${error.message}`); }
-    else placements = placements.filter(p => p.id !== src.id);
-  }
   const room = rooms.find(r => r.id === to.room_id);
   toast(`${a.first} moved to ${room?.name || 'the other listing'}${qualifiesFor(a, to) ? '' : " — they don't auto-qualify there, so it'll stick"}`);
   renderRailCounts();
@@ -3140,7 +3175,7 @@ function renderReviewFoot(a) {
         ${pills ? `<span class="foot-pills">${pills}</span>` : ''}
         <span class="foot-cta">${openingsCta(a)}</span>
         <span class="foot-links">
-          <button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Add to another listing' : 'Add to a listing'}</button>
+          <button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Move to a different listing' : 'Add to a listing'}</button>
           <button type="button" class="cta-link cta-link--danger" data-open-remove="${a.id}|">Remove…</button>
         </span>`;
     }
@@ -3535,7 +3570,7 @@ async function _openDecisionSheet(d) {
   const rec = decisions[a.id];
   pendingReason = (rec?.d === d ? rec.reason : null) || null;
   document.getElementById('decision-sheet-title').textContent =
-    d === 'outreach' ? 'Add to a listing' : d === 'hold' ? 'Future fit — why not now?' : 'Not a fit — why?';
+    d === 'outreach' ? 'Which listing?' : d === 'hold' ? 'Future fit — why not now?' : 'Not a fit — why?';
   renderDecisionOptions();
 
   // Outreach targets a specific open listing, or General interest.
@@ -4046,7 +4081,7 @@ function init() {
     if (addPl) {
       const [aid, lid] = addPl.dataset.addPlacement.split('|');
       addPlacement(aid, lid, 'manual').then(row => {
-        if (row) { toast('Added to the listing'); renderRailCounts(); renderApplicants(); }
+        if (row) { toast('Placed on this listing'); renderRailCounts(); renderApplicants(); }
       });
       return;
     }

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -211,3 +211,15 @@ Anything a housemate can read — Discord posts, DMs, audit lines, in-app copy �
 This narrows the two-tier rule stated above: the context tier may hold a secondary action as a text link **only when that link is the tier's own explanation**. `no recording — add a link` earns its place, because the caption exists to say why there's no Watch button and the link is the remedy. A bare duplicate of a menu item does not.
 
 The ⋮ entry was gated on a recording existing (`screeningState.watch`); it now also shows for a finished call with no recording (`.done`), which is exactly the case where the row link used to be the only way in.
+
+## v3.37 — one listing per applicant
+
+A candidate used to be auto-placed into **every** open listing they qualified for, so the same person appeared under three rooms and three housemates could each believe they were handling them. A shortlist that contains everyone isn't a shortlist.
+
+Now exactly one active placement per applicant, enforced by a partial unique index (`migration 139`) rather than by convention — the auto-sweep, the accordion, drag-and-drop, and the outreach sheet all write to this table, and only an index covers every path. Tombstones are exempt: a person may be `removed` from many listings over time, they just can't be **active** in more than one.
+
+**Which listing the sweep picks**, in order: closest start date to their confirmed move-in, then earliest start, then lowest id so the choice is stable run to run. A listing they've been tombstoned from is never re-picked. Anyone already placed is left alone — the sweep must never pull someone out from under whoever is working them.
+
+**Every placement is now a move.** `addPlacement()` drops the previous active row before inserting, which turns all four call sites into moves at once without each having to know. Copy follows: *Add* → **Move here** on the accordion when they're already placed, *Add to another listing* → **Move to a different listing** in the review foot.
+
+Reconciling the two existing duplicates preferred a manual placement over an auto one — a recruiter chose it — then fell back to the same date-fit ordering.

--- a/supabase/migrations/139_one_listing_per_applicant.sql
+++ b/supabase/migrations/139_one_listing_per_applicant.sql
@@ -1,0 +1,48 @@
+-- ============================================
+-- Migration 139: an applicant belongs to exactly one listing
+--
+-- Until now a candidate was auto-placed into EVERY open listing they
+-- qualified for, so the same person appeared under three rooms and three
+-- different housemates could each think they were handling them. Shortlists
+-- stopped meaning anything.
+--
+-- One active placement per applicant, enforced in the database rather than
+-- by convention — the client, the auto-sweep, and drag-and-drop all write
+-- here, and only an index catches every path.
+--
+-- Reconciling the existing duplicates, in order:
+--   1. a manual placement beats an auto one — a recruiter chose it
+--   2. otherwise the listing whose start date is closest to the applicant's
+--      confirmed move-in (the actual fit)
+--   3. otherwise the earliest-starting listing, then the lowest id, so the
+--      outcome is stable rather than whatever the planner returned first
+--
+-- Losers are deleted, not tombstoned: 'removed' means "a recruiter said
+-- never again here", and these were placed by a sweep, not by a person.
+-- ============================================
+
+WITH ranked AS (
+  SELECT
+    c.id,
+    c.applicant_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY c.applicant_id
+      ORDER BY
+        (c.source = 'manual') DESC,
+        ABS(EXTRACT(EPOCH FROM (l.starts_on::timestamp - COALESCE(a.move_in_from, l.starts_on)::timestamp))) ASC,
+        l.starts_on ASC,
+        c.id ASC
+    ) AS rn
+  FROM recruit_listing_candidates c
+  JOIN recruit_listings l ON l.id = c.listing_id
+  JOIN recruit_applicants a ON a.id = c.applicant_id
+  WHERE c.status = 'active'
+)
+DELETE FROM recruit_listing_candidates
+  WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- The guarantee. Tombstones are exempt: a person can be 'removed' from many
+-- listings over time, they just can't be ACTIVE in more than one.
+CREATE UNIQUE INDEX IF NOT EXISTS recruit_listing_candidates_one_active_idx
+  ON recruit_listing_candidates (applicant_id)
+  WHERE status = 'active';


### PR DESCRIPTION
Migration 139 **already applied**; this is the code of record.

## Why

A candidate was auto-placed into **every** open listing they qualified for, so the same person appeared under three rooms and three housemates could each believe they were handling them. A shortlist that contains everyone isn't a shortlist.

## What

Exactly one active placement per applicant, enforced by a **partial unique index** rather than by convention — the auto-sweep, the accordion, drag-and-drop and the outreach sheet all write this table, and only an index covers every path. Tombstones are exempt: a person may be `removed` from many listings over time, they just can't be *active* in more than one.

**Which listing the sweep picks**, in order: closest start date to their confirmed move-in → earliest start → lowest id, so the choice is stable run to run. A listing they've been tombstoned from is never re-picked. Anyone already placed is skipped — the sweep must not pull someone out from under whoever is working them.

**Every placement is now a move.** `addPlacement()` drops the previous active row before inserting, which turned all four call sites into moves at once without each needing to know; `movePlacement` collapsed to a wrapper. Copy follows: *Add* → **Move here** on the accordion when already placed, *Add to another listing* → **Move to a different listing**.

## Reconciling the two existing duplicates

Preferred a manual placement over an auto one (a recruiter chose it), then the same date-fit ordering the sweep uses, so backfill and runtime agree. Losers deleted rather than tombstoned — a tombstone means "never here again", and these were placed by a sweep, not a person.

Keerti and Laurie both kept their manual **Priest** placement.

## Verified live

- duplicates gone (`having count(*) > 1` → empty)
- a second active insert → `23505 recruit_listing_candidates_one_active_idx`
- three tombstones still coexist with the one active row

`app v3.37.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)