### PR TITLE
fix(applications): Inbox Review button matches Ladder (v3.36.2)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -363,6 +363,9 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   background: var(--bg-surface); border: 0;
 }
 .inbox-row__review:hover { background: var(--bg-overlay); }
+/* Ladder pairs btn--sm's small type with a 36px target; .btn--sm is declared
+   later in this file, so bind the height to the more specific selector. */
+.btn.inbox-row__review { height: 36px; }
 .inbox-empty { color: var(--fg-subtle); text-align: center; padding: var(--space-8) var(--space-4); }
 
 /* Avatars — initials on a neutral surface (28 list / 56 review). */

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.36.1">
+  <link rel="stylesheet" href="css/app.css?v=3.36.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.36.1"></script>
+  <script src="js/app.js?v=3.36.2"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.36.1';
+const VERSION = '3.36.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1979,7 +1979,7 @@ function renderApplicants() {
               ${noteBubble(a.id)}
               ${view === 'openings'
                 ? `${openingsCta(a)}${rowMenuHtml(a, g.key)}`
-                : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn inbox-row__review" data-review="${a.id}">Review</button>` : ''}`}
+                : `${rowBadge(a)}${view === 'inbox' && !myVote(a.id) ? `<button class="btn btn--sm inbox-row__review" data-review="${a.id}">Review <span aria-hidden="true">→</span></button>` : ''}`}
             </span>
           </li>`).join('')}
       </ul>`}

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -211,3 +211,11 @@ Anything a housemate can read — Discord posts, DMs, audit lines, in-app copy �
 This narrows the two-tier rule stated above: the context tier may hold a secondary action as a text link **only when that link is the tier's own explanation**. `no recording — add a link` earns its place, because the caption exists to say why there's no Watch button and the link is the remedy. A bare duplicate of a menu item does not.
 
 The ⋮ entry was gated on a recording existing (`screeningState.watch`); it now also shows for a finished call with no recording (`.done`), which is exactly the case where the row link used to be the only way in.
+
+## Amendment — v3.34–3.36
+
+- **Inbox action reads "Review →"** and matches Ladder's recommendation rows exactly: `btn btn--sm inbox-row__review`, small type, 36px target, quiet `--bg-surface` fill, and the trailing arrow (`aria-hidden`, so screen readers just hear "Review").
+- **The blue dot is context-dependent.** In the Inbox it means *you personally haven't opened this application yet* — tracked per housemate in `recruit_applicant_views`, so it clears on your account only and stays cleared across devices. Everywhere else it keeps its original meaning: *they replied and it's waiting on you*. Tooltips say which.
+- **A veto always means archived.** Vetoed applicants can never appear in the Inbox: the view filter drops them defensively, and Reopen clears the standing veto (with a confirm naming who vetoed) rather than returning someone to the Inbox with an unresolvable veto attached.
+- **Reload shows a spinner, never the sign-in card.** The gate card is hidden while a session is restoring or loading; any gate message reveals it again so a failure can't spin forever.
+- **New-application Discord pings carry buttons** — "Open the inbox", plus "Review <name>" on single-applicant pings.


### PR DESCRIPTION
Label-only wasn't enough: Ladder's row button is `btn btn--sm inbox-row__review` with a trailing `→`, so it reads at small type on a 36px target. Applications had the base `.btn` size and no arrow. Adds `btn--sm` + the arrow, and pins the 36px height via `.btn.inbox-row__review` because `.btn--sm` is declared later in this stylesheet than in Ladder's.

Also documents the v3.34–3.36 row-state changes in [recruiting-row-states.md](docs/ux/recruiting-row-states.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)