### PR TITLE
recruiting: trial check-in + decision dates with Discord reminders (v3.37.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1005,6 +1005,12 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .occ-drawer__form { display: flex; flex-direction: column; gap: var(--space-3); }
 .occ-drawer__dates { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
 .occ-drawer__ongoing { display: flex; align-items: center; gap: var(--space-2); font-size: var(--font-size-small); color: var(--fg-muted); }
+/* v3.37: trial check-in + decision dates — only shown for candidate stays */
+.occ-drawer__trial {
+  display: grid; gap: var(--space-2);
+  padding-top: var(--space-3); border-top: 1px solid var(--border);
+}
+.occ-drawer__trial[hidden] { display: none; }
 .occ-drawer__facts { margin: 0; display: flex; flex-direction: column; gap: var(--space-2); }
 .occ-drawer__fact { display: flex; justify-content: space-between; gap: var(--space-3); font-size: var(--font-size-small); }
 .occ-drawer__fact dt { color: var(--fg-subtle); }

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.36.1';
+const VERSION = '3.37.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2383,6 +2383,42 @@ function openOccDrawer(next) {
   renderOccDrawer();
 }
 
+/* Trial milestones. A trial candidate gets a check-in once they're a month
+   in, and a house decision a month before their sublet ends — far enough out
+   that either side can still make other plans. Both are suggestions the
+   drawer prefills; the house can move either date. */
+function trialCheckinDefault(startsOn) {
+  return startsOn ? addMonthsIso2(startsOn, 1) : '';
+}
+function trialDecisionDefault(endsOn) {
+  return endsOn ? addMonthsIso2(endsOn, -1) : '';
+}
+/* addMonthsIso() snaps to the first of the month (the timeline needs that);
+   milestones keep the day-of-month, clamped when the target month is short. */
+function addMonthsIso2(iso, n) {
+  const d = new Date(iso + 'T12:00');
+  const day = d.getDate();
+  d.setDate(1);
+  d.setMonth(d.getMonth() + n);
+  d.setDate(Math.min(day, new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate()));
+  return d.toISOString().slice(0, 10);
+}
+
+function trialFieldsHtml(s) {
+  return `<div class="occ-drawer__trial" data-trial-fields hidden>
+    <div class="occ-drawer__section">Trial milestones</div>
+    <div class="occ-drawer__dates">
+      <label class="listing-form__field">Check-in
+        <input type="date" name="checkin_on" class="listing-status" value="${s.checkin_on || ''}">
+      </label>
+      <label class="listing-form__field">Decision
+        <input type="date" name="decision_on" class="listing-status" value="${s.decision_on || ''}">
+      </label>
+    </div>
+    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. #recruiting-automation gets a reminder a week ahead of each.</p>
+  </div>`;
+}
+
 function stayFormHtml(s, roomId) {
   const isNew = !s.id;
   return `<form class="occ-drawer__form" data-stay-form="${s.id || 'new'}" data-stay-room="${roomId}">
@@ -2404,6 +2440,7 @@ function stayFormHtml(s, roomId) {
       </label>
     </div>
     <label class="occ-drawer__ongoing"><input type="checkbox" name="ongoing" ${s.id && !s.ends_on ? 'checked' : ''}> Ongoing — no move-out date yet</label>
+    ${trialFieldsHtml(s)}
     <p class="listing-form__error" data-form-error></p>
     <div class="decision-sheet__actions seg-form__actions">
       ${!isNew ? `<button type="button" class="listing-form__delete" data-stay-delete="${s.id}">Remove stay</button>` : ''}
@@ -2496,7 +2533,38 @@ function renderOccDrawer() {
     const ends = hostWrap.querySelector('input[name="ends_on"]');
     ends.disabled = e.target.checked;
     if (e.target.checked) ends.value = '';
+    syncTrialFields(hostWrap);
   });
+  const form = hostWrap.querySelector('[data-stay-form]');
+  if (form) {
+    for (const sel of ['select[name="kind"]', 'input[name="starts_on"]', 'input[name="ends_on"]']) {
+      form.querySelector(sel)?.addEventListener('change', () => syncTrialFields(hostWrap));
+    }
+    syncTrialFields(hostWrap);
+  }
+}
+
+/* Show the milestone block only for trial candidates, and keep the suggested
+   dates in step with the stay window until someone edits them by hand. */
+function syncTrialFields(hostWrap) {
+  const block = hostWrap.querySelector('[data-trial-fields]');
+  if (!block) return;
+  const kind = hostWrap.querySelector('select[name="kind"]')?.value;
+  block.hidden = kind !== 'candidate';
+  if (block.hidden) return;
+  const startsOn = hostWrap.querySelector('input[name="starts_on"]')?.value || '';
+  const endsOn = hostWrap.querySelector('input[name="ongoing"]')?.checked
+    ? '' : (hostWrap.querySelector('input[name="ends_on"]')?.value || '');
+  const checkin = block.querySelector('input[name="checkin_on"]');
+  const decision = block.querySelector('input[name="decision_on"]');
+  if (!checkin.dataset.touched) checkin.value = trialCheckinDefault(startsOn);
+  if (!decision.dataset.touched) decision.value = trialDecisionDefault(endsOn);
+  for (const el of [checkin, decision]) {
+    if (!el.dataset.wired) {
+      el.dataset.wired = '1';
+      el.addEventListener('input', () => { el.dataset.touched = '1'; });
+    }
+  }
 }
 
 async function onStaySave(e) {
@@ -2511,6 +2579,9 @@ async function onStaySave(e) {
     kind: fd.get('kind'),
     starts_on: fd.get('starts_on'),
     ends_on: fd.get('ongoing') ? null : (fd.get('ends_on') || null),
+    // Milestones belong to a trial; switching a stay to any other kind clears them.
+    checkin_on: fd.get('kind') === 'candidate' ? (fd.get('checkin_on') || null) : null,
+    decision_on: fd.get('kind') === 'candidate' ? (fd.get('decision_on') || null) : null,
   };
   if (!rec.starts_on) { err.textContent = 'Start date is required.'; return; }
   if (rec.ends_on && rec.ends_on < rec.starts_on) { err.textContent = '"Through" must be at or after "From".'; return; }
@@ -2519,6 +2590,21 @@ async function onStaySave(e) {
     if (rec.kind === 'resident' || rec.kind === 'shared') rec.ends_on = null; // residents default open-ended
     else { err.textContent = 'Sublets and trials need an end date (or tick "Ongoing").'; return; }
   }
+  for (const [field, label] of [['checkin_on', 'Check-in'], ['decision_on', 'Decision']]) {
+    const v = rec[field];
+    if (!v) continue;
+    if (v < rec.starts_on || (rec.ends_on && v > rec.ends_on)) {
+      err.textContent = `${label} has to fall inside the trial (${fmtDay(rec.starts_on)} – ${rec.ends_on ? fmtDay(rec.ends_on) : 'ongoing'}).`;
+      return;
+    }
+  }
+  if (rec.checkin_on && rec.decision_on && rec.decision_on < rec.checkin_on) {
+    err.textContent = 'The decision comes after the check-in.'; return;
+  }
+  // A moved milestone is a new milestone — let its reminder fire again.
+  const prev = stays.find(s => s.id === id);
+  if (prev && prev.checkin_on !== rec.checkin_on) rec.checkin_reminded_at = null;
+  if (prev && prev.decision_on !== rec.decision_on) rec.decision_reminded_at = null;
   if (id === 'new') {
     const { data, error } = await sb.from('recruit_stays').insert(rec).select().single();
     if (error) { err.textContent = error.message; return; }
@@ -2543,6 +2629,14 @@ async function deleteStay(id) {
   occDrawer = null;
   toast('Stay removed');
   renderOccupancy();
+}
+
+/* " · decision Oct 1" — the next unmet trial milestone, or nothing. */
+function nextMilestoneLabel(s, todayIso) {
+  if (s.kind !== 'candidate') return '';
+  const next = [['check-in', s.checkin_on], ['decision', s.decision_on]]
+    .filter(([, d]) => d && d >= todayIso).sort((a, b) => a[1].localeCompare(b[1]))[0];
+  return next ? ` · ${next[0]} ${fmtShort(next[1])}` : '';
 }
 
 /* --- current + past occupants --- */
@@ -2578,7 +2672,7 @@ function occupantsHtml() {
             <span class="avatar">${esc((s.occupant[0] || '?').toUpperCase())}</span>
             <span class="inbox-row__text">
               <span class="inbox-row__title">${esc(s.occupant)}</span>
-              <span class="inbox-row__sub">${esc(room?.name || '')} · ${esc(room?.floor || '')} · ${s.ends_on ? `through ${fmtShort(s.ends_on)}` : 'ongoing'}</span>
+              <span class="inbox-row__sub">${esc(room?.name || '')} · ${esc(room?.floor || '')} · ${s.ends_on ? `through ${fmtShort(s.ends_on)}` : 'ongoing'}${esc(nextMilestoneLabel(s, todayIso))}</span>
             </span>
             <span class="inbox-row__actions">
               <span class="listing-kind listing-kind--${s.kind === 'candidate' ? 'trial' : (s.kind === 'resident' ? 'resident' : 'sublet')}">${KIND_LABELS[s.kind]}</span>

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -55,5 +55,29 @@ Out of scope for now (manual): post-screening accept/vote, house tour, onboardin
 ### v3.3.0 (2026-07-22): recruiter-confirmed move-in
 Structured `move_in_from`/`move_in_to` window on the applicant (migration 124, set via `recruit_set_move_in` RPC, attributed). Editable from the profile's Move-in fact — the applicant's typed answer stays on top, the confirmed window sits underneath. When set it is exact (no "flexible" escape hatch) and overrides the parsed text in sublines, filters, and placement qualification; saving re-runs the placement sweep.
 
+### v3.37.0 (2026-07-29): trial check-in + decision dates
+A trial candidate's two decision moments now live on the stay (migration 139,
+`recruit_stays.checkin_on` / `decision_on`), not in someone's head:
+
+- **Check-in** — defaults to `starts_on + 1 month`. Far enough in to have signal,
+  early enough that a fixable problem is still fixable.
+- **Decision** — defaults to `ends_on - 1 month`, usually the end of month two of a
+  three-month sublet. Both sides need a month to make other plans.
+
+Both are prefilled in the occupancy drawer whenever the stay's type is **Trial
+candidate**, and both are editable — the defaults are a starting point, not a rule.
+Milestones must fall inside the trial window and the decision must follow the
+check-in. Changing a stay's type to anything else clears them.
+
+**Reminders.** `recruit-discord` v1.15.0 posts one embed per milestone to
+`#recruiting-automation`, seven days ahead, on the existing 15-minute `/remind`
+tick — no new cron. `checkin_reminded_at` / `decision_reminded_at` make each post
+once-only; moving a date in the app clears the stamp so the new date gets its own
+reminder. Milestones backdated more than 14 days are stamped silently — a date
+corrected after the fact isn't news.
+
+Backfilled on the two live trials (Alejandra, Sophia); Andy's finished Jan–Feb
+trial was left alone.
+
 ### Design reference
 Row states, chip taxonomy, and subcopy grammar for Inbox/Candidates/Openings: [docs/ux/recruiting-row-states.md](../../ux/recruiting-row-states.md) (v3.5.0 — response dot, room pills, note bubble, ✕ removal, see-more bar).

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,8 +13,8 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.14.0'
-console.log(`[recruit-discord] v${VERSION} — screening claims + magic-link sign-in + unmatched-call link nudges`)
+const VERSION = '1.15.0'
+console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial milestone reminders`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -534,6 +534,80 @@ async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<numb
   return notified
 }
 
+// Trial-candidate milestones (migration 139): a check-in a month into the
+// trial, a house decision a month before the sublet ends. Both post once to
+// #recruiting-automation, a week ahead, and stamp themselves so the 15-minute
+// tick can't repeat them. Moving a date in the app clears the stamp, which is
+// how a rescheduled milestone gets a fresh reminder.
+//
+// LEAD_DAYS of notice, but nothing older than STALE_DAYS: a date backdated in
+// the app is a correction, not a thing to announce, so it's stamped silently.
+const MILESTONE_LEAD_DAYS = 7
+const MILESTONE_STALE_DAYS = 14
+
+async function remindTrialMilestones(client: ReturnType<typeof db>): Promise<number> {
+  const { postResilient, AUTOMATION_CHANNEL_ID } = await import('../_shared/discord.ts')
+  const today = new Date()
+  const iso = (d: Date) => d.toISOString().slice(0, 10)
+  const todayIso = iso(today)
+  const horizon = iso(new Date(today.getTime() + MILESTONE_LEAD_DAYS * 86400000))
+  const floor = iso(new Date(today.getTime() - MILESTONE_STALE_DAYS * 86400000))
+
+  const { data: rows } = await client.from('recruit_stays')
+    .select('id, occupant, room_id, starts_on, ends_on, checkin_on, decision_on, checkin_reminded_at, decision_reminded_at')
+    .eq('kind', 'candidate')
+    .or(`and(checkin_on.lte.${horizon},checkin_reminded_at.is.null),and(decision_on.lte.${horizon},decision_reminded_at.is.null)`)
+  if (!rows?.length) return 0
+
+  const { data: rooms } = await client.from('recruit_rooms').select('id, name')
+  const roomName = new Map((rooms || []).map(r => [r.id, r.name as string]))
+
+  const fmt = (d: string) => new Date(d + 'T12:00Z')
+    .toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' })
+
+  let posted = 0
+  for (const s of rows) {
+    const kinds: Array<['checkin' | 'decision', string | null, string | null]> = [
+      ['checkin', s.checkin_on, s.checkin_reminded_at],
+      ['decision', s.decision_on, s.decision_reminded_at],
+    ]
+    for (const [which, on, remindedAt] of kinds) {
+      if (!on || remindedAt || on > horizon) continue
+      const stamp = { [`${which}_reminded_at`]: new Date().toISOString() }
+      // Backdated milestone: record it as handled, say nothing.
+      if (on < floor) {
+        await client.from('recruit_stays').update(stamp).eq('id', s.id)
+        continue
+      }
+      const who = s.occupant || 'Trial candidate'
+      const room = roomName.get(s.room_id) || 'their room'
+      const days = Math.round((new Date(on + 'T12:00Z').getTime() - new Date(todayIso + 'T12:00Z').getTime()) / 86400000)
+      const when = days > 1 ? `in ${days} days — ${fmt(on)}`
+        : days === 1 ? `tomorrow — ${fmt(on)}`
+        : days === 0 ? `today — ${fmt(on)}`
+        : `overdue since ${fmt(on)}`
+      const body = which === 'checkin'
+        ? `**${who}** is a month into their trial in ${room}. Time for the check-in: how is it going, both directions, while there's still runway to fix things.`
+        : `**${who}**'s trial in ${room} ends ${s.ends_on ? fmt(s.ends_on) : 'soon'}. The house decides now, so either side can still make other plans.`
+      try {
+        await postResilient(AUTOMATION_CHANNEL_ID, {
+          embeds: [{
+            title: which === 'checkin' ? `🌱 Trial check-in — ${who}` : `🗳️ Trial decision — ${who}`,
+            description: `${body}\n\nDue ${when}.\nhttps://ctrl.rodeo/applications/?view=occupancy&room=${s.room_id}`,
+            color: which === 'checkin' ? 0x4f8a6b : 0xb8863b,
+          }],
+        }, `Trial ${which} reminder`)
+        await client.from('recruit_stays').update(stamp).eq('id', s.id)
+        posted++
+      } catch (err) {
+        // Leave the stamp unset so the next tick retries rather than losing it.
+        console.warn(`[trial] ${which} reminder for stay ${s.id} failed: ${(err as Error).message}`)
+      }
+    }
+  }
+  return posted
+}
+
 // Capability token for a recording's public watch link — 32 random bytes, so
 // links are unguessable. Revoke by nulling share_token.
 function newShareToken(): string {
@@ -763,11 +837,13 @@ serve(async (req) => {
       const live = await announceLiveCalls(client)
       await completePastCalls(client)
       const sent = await remindUpcoming(client)
+      const trials = await remindTrialMilestones(client)
+      if (trials) console.log(`[trial] ${trials} milestone reminder(s) posted`)
       const recorded = await processRecordings(client) + await processMeetingRecordings(client)
       const archived = await archiveMissingRecordings(client)
       if (archived) console.log(`[archive] ${archived} recording(s) copied to storage`)
-      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${recorded} recording(s)`)
-      return json({ bots, live, reminded: sent, recorded })
+      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${trials} trial(s), ${recorded} recording(s)`)
+      return json({ bots, live, reminded: sent, trials, recorded })
     }
 
     const pathname = new URL(req.url).pathname

--- a/supabase/migrations/139_recruit_trial_milestones.sql
+++ b/supabase/migrations/139_recruit_trial_milestones.sql
@@ -1,0 +1,55 @@
+-- ============================================
+-- Migration 139: trial-candidate check-in + decision dates
+--
+-- A trial candidate ("candidate" stay) has two moments the house has to
+-- remember and currently doesn't: a check-in after their first month, and a
+-- decision a month before their sublet ends — late enough to have real
+-- signal, early enough that either side can still plan.
+--
+-- Both live on the stay itself, not on the applicant: the dates are derived
+-- from the stay's window, a person can trial twice, and the occupancy drawer
+-- is where the house already edits these people.
+--
+-- Reminders ride the existing 15-minute recruit-discord /remind tick
+-- (migration 122) rather than a cron of their own — the tick already runs
+-- every quarter hour and already owns Discord posting. The *_reminded_at
+-- stamps make each reminder once-only.
+-- ============================================
+
+ALTER TABLE recruit_stays
+  ADD COLUMN IF NOT EXISTS checkin_on DATE,
+  ADD COLUMN IF NOT EXISTS decision_on DATE,
+  ADD COLUMN IF NOT EXISTS checkin_reminded_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS decision_reminded_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN recruit_stays.checkin_on IS
+  'Trial candidates only: mid-trial check-in, defaults to starts_on + 1 month.';
+COMMENT ON COLUMN recruit_stays.decision_on IS
+  'Trial candidates only: house decision, defaults to ends_on - 1 month.';
+
+-- The reminder tick scans by due date; candidates are a handful of rows, but
+-- the partial index keeps the scan off the residents.
+CREATE INDEX IF NOT EXISTS idx_recruit_stays_milestones
+  ON recruit_stays (checkin_on, decision_on) WHERE kind = 'candidate';
+
+-- Backfill live trials only. Andy's Jan–Feb trial is five months finished;
+-- stamping dates on it would only create noise (and its two-month window
+-- puts "start + 1 month" after "end - 1 month" anyway).
+UPDATE recruit_stays SET
+  checkin_on = COALESCE(checkin_on, (starts_on + INTERVAL '1 month')::date),
+  decision_on = COALESCE(decision_on, (ends_on - INTERVAL '1 month')::date)
+WHERE kind = 'candidate'
+  AND ends_on IS NOT NULL
+  AND ends_on >= CURRENT_DATE
+  AND (starts_on + INTERVAL '1 month')::date < (ends_on - INTERVAL '1 month')::date;
+
+-- Milestones the backfill placed in the past already happened — the house
+-- doesn't need a Discord post about a check-in date three weeks gone.
+UPDATE recruit_stays
+   SET checkin_reminded_at = NOW()
+ WHERE kind = 'candidate' AND checkin_on IS NOT NULL
+   AND checkin_on < CURRENT_DATE AND checkin_reminded_at IS NULL;
+UPDATE recruit_stays
+   SET decision_reminded_at = NOW()
+ WHERE kind = 'candidate' AND decision_on IS NOT NULL
+   AND decision_on < CURRENT_DATE AND decision_reminded_at IS NULL;


### PR DESCRIPTION
Trial candidates in the Occupancy calendar now carry a **check-in** date (a month into the trial) and a **decision** date (a month before the sublet ends), with reminders posted to #recruiting-automation a week ahead of each.

## What changed
- **Migration 139** — `recruit_stays.checkin_on` / `decision_on` plus once-only reminder stamps. Backfilled the two live trials (Alejandra: check-in 7/1, decision 7/31; Sophia: check-in 7/1, decision 10/1). Andy's finished Jan–Feb trial was skipped — its two-month window puts the defaults out of order, and it ended five months ago.
- **Occupancy drawer** — milestone block appears only when the stay's type is Trial candidate. Both dates prefill from the stay window and stay in step until edited by hand. Validated to fall inside the trial, decision after check-in. Switching the stay to another type clears them.
- **recruit-discord v1.15.0** — `remindTrialMilestones()` rides the existing 15-minute `/remind` tick, so no new cron. One embed per milestone, 7 days of lead, stamped once-only; moving a date clears the stamp so the new date gets a fresh reminder. Milestones backdated 14+ days are stamped silently.
- Current-occupants list shows the next unmet milestone in the subline.

## Verification
Migration applied to the Boards project and the backfill read back correct. Alejandra's 7/31 decision is inside the 7-day window, so it posts on the first tick after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)