### PR TITLE
fix(applications): keep progress messages behind the gate spinner (v3.38.2)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.38.1">
+  <link rel="stylesheet" href="css/app.css?v=3.39.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.38.1"></script>
+  <script src="js/app.js?v=3.39.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -9,7 +9,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.39.0';
+const VERSION = '3.39.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -4001,9 +4001,11 @@ async function signInWithDiscord() {
 }
 
 function setGate(sub, btnLabel, hint) {
-  // Showing a gate message means we've stopped: reveal the card even if we
-  // were mid-load, or the spinner would spin forever over a silent failure.
-  document.body.dataset.authState = 'out';
+  // A gate message with a button is terminal — we've stopped and need the
+  // reader to act, so reveal the card even if we were mid-load. Progress
+  // messages pass no button and stay behind the spinner: a returning housemate
+  // should never watch the sign-in card narrate its own loading.
+  if (btnLabel) document.body.dataset.authState = 'out';
   document.getElementById('gate-sub').textContent = sub;
   const btn = document.getElementById('gate-btn');
   document.getElementById('gate-btn-label').textContent = btnLabel || '';


### PR DESCRIPTION
v3.35.0 replaced the sign-in flash with a spinner, and had `setGate()` reveal the card so a silent failure couldn't spin forever. But the membership check narrates progress through that same function ("Checking your Recruiting Society access…"), so the card flashed on reload again — this time showing a progress line above an empty Discord button.

Now the card is revealed only for terminal messages, which are exactly the ones that pass a button label; progress messages ("Signing you in…", "Checking…", "Re-checking…") stay behind the spinner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)