### PR TITLE
recruiting: one reviewer, three verdicts, optional rejection email (v3.40.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1039,37 +1039,43 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   gap: var(--space-2) var(--space-3);
 }
 .vote-bar__q { font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
-.vote-bar__scores { display: inline-flex; gap: var(--space-2); }
-.vote-bar__score {
-  width: 44px; height: 44px; border-radius: var(--radius-pill);
-  border: 1px solid var(--border); background: var(--bg-surface);
-  font-size: var(--font-size-body); font-weight: var(--fw-semibold);
-  color: var(--fg); cursor: pointer;
+/* Three verdicts, one decides. Each carries its own tint so the destructive
+   one never looks like the neutral one; only the selected chip fills in. */
+.vote-bar__verdicts { display: inline-flex; gap: var(--space-2); flex-wrap: wrap; }
+.vote-bar__verdict {
+  height: 36px; padding: 0 var(--space-3);
+  border-radius: var(--radius-pill); border: 1px solid var(--border);
+  background: var(--bg-surface); color: var(--fg-muted);
+  font-size: var(--font-size-small); font-weight: var(--fw-semibold);
+  cursor: pointer; transition: background 80ms ease, color 80ms ease, box-shadow 80ms ease;
 }
-.vote-bar__score:hover { background: var(--bg-overlay); }
-.vote-bar__score.is-on { background: #9FE870; border-color: #9FE870; color: #163300; }
-.vote-bar__veto {
-  height: 44px; padding: 0 var(--space-3); border-radius: var(--radius-pill);
-  border: 1px solid rgba(168, 32, 13, 0.35); background: none;
-  color: var(--error); font-size: var(--font-size-small); font-weight: var(--fw-semibold);
-  cursor: pointer;
-}
-.vote-bar__veto:hover { background: rgba(168, 32, 13, 0.10); }
-.vote-bar__veto.is-on { background: rgba(168, 32, 13, 0.16); box-shadow: inset 0 0 0 1.5px var(--error); }
+.vote-bar__verdict:hover { background: var(--bg-overlay); color: var(--fg); }
+.vote-bar__verdict.is-on { color: var(--fg); }
+.vote-bar__verdict.is-not-fit.is-on { background: rgba(168, 32, 13, 0.16); box-shadow: inset 0 0 0 1.5px var(--error); }
+.vote-bar__verdict.is-needs-input.is-on { background: var(--bg-overlay); box-shadow: inset 0 0 0 1.5px var(--border-strong); }
+.vote-bar__verdict.is-forward.is-on { background: #9FE870; border-color: #9FE870; color: #163300; }
 .vote-bar__note { flex: 1 1 180px; min-width: 0; height: 44px; }
 .vote-bar__cast { height: 44px; border-radius: var(--radius-pill); }
+.vote-bar__cast[disabled] { opacity: 0.5; cursor: not-allowed; }
+
+/* Verdict label on a past review, in the reviews thread. */
+.verdict-tag {
+  display: inline-block; padding: 0 6px; border-radius: var(--radius-xs);
+  font-size: var(--font-size-tiny, 11px); font-weight: var(--fw-semibold);
+  background: var(--bg-overlay); color: var(--fg-muted);
+}
+.verdict-tag.is-not-fit { background: rgba(168, 32, 13, 0.16); color: var(--error); }
+.verdict-tag.is-forward { background: rgba(159, 232, 112, 0.18); color: #7FC24E; }
 @media (max-width: 720px) {
   .vote-bar__q { flex-basis: 100%; }
-  .vote-bar__scores { flex: 1; justify-content: space-between; }
-  .vote-bar__score { width: 40px; height: 40px; }
+  .vote-bar__verdicts { flex-basis: 100%; }
+  .vote-bar__verdict { flex: 1; }
   .vote-bar__note { flex-basis: 100%; order: 5; }
   .vote-bar__cast { flex: 1; order: 6; }
 }
 
 .decision-chip--vote { background: var(--bg-surface); color: var(--fg-muted); }
 .vote-summary { margin: 0 0 var(--space-3); font-size: var(--font-size-small); font-weight: var(--fw-semibold); color: var(--fg-muted); }
-.vote-score { font-weight: var(--fw-semibold); color: var(--fg); }
-.vote-score--veto { color: var(--error); }
 
 /* --- v3.1: room costs in the drawer --- */
 .occ-drawer__section {

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.39.1">
+  <link rel="stylesheet" href="css/app.css?v=3.40.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.39.1"></script>
+  <script src="js/app.js?v=3.40.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -3,13 +3,14 @@
    the discord-membership edge fn). Applicants, votes, shared decisions, and
    house notes live in Supabase behind RLS (migrations 108 + 120).
 
-   v3 funnel: Inbox (collective 1–5 votes, veto rejects) → Candidates →
+   v4 funnel: Inbox (one reviewer decides: not a fit / needs input /
+   move forward, comment required) → Candidates →
    Openings (listing shortlists) → Screening → Archive. The applicant's
    stage column is recomputed server-side by a trigger on recruit_votes;
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.39.1';
+const VERSION = '3.40.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -95,7 +96,7 @@ const VIEWS = {
 const LEGACY_VIEWS = { review: 'inbox', outreach: 'openings', hold: 'inbox', listings: 'openings' };
 
 let sb = null;                // supabase client (from CtrlAuth)
-let me = null;                // { id, name }
+let me = null;                // { id, name, groupEmail }
 let applicants = [];          // newest first; each carries .stage
 let decisions = {};           // applicant_id -> { d, reason, by, byName, at }
 let votes = {};               // applicant_id -> recruit_votes rows
@@ -105,7 +106,7 @@ let claimPosts = {};          // applicant_id -> { status, posted_at }
 let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
 let houseEvents = {};         // applicant_id -> non-intro_call calendar rows
-let pendingVote = null;       // { score, veto } while the vote bar is open
+let pendingVerdict = null;    // 'not_fit' | 'needs_input' | 'forward' while the review bar is open
 let commentCounts = {};       // applicant_id -> n
 let latestNotes = {};         // applicant_id -> { author, body }
 let comments = [];            // comments for the applicant open in review
@@ -1147,7 +1148,7 @@ async function openUpdateEmail(applicantId) {
   document.getElementById('email-subject').value = '';
   document.getElementById('email-body').value = '';
   document.getElementById('email-send').textContent = 'Send update';
-  document.getElementById('email-status').textContent = 'Drafting the community update…';
+  document.getElementById('email-status').textContent = 'Writing a draft you can edit — sending is optional.';
   document.getElementById('email-modal').hidden = false;
   try {
     const { data } = await sb.auth.getSession();
@@ -1161,7 +1162,8 @@ async function openUpdateEmail(applicantId) {
     if (emailApplicantId !== applicantId) return;
     document.getElementById('email-subject').value = out.subject || 'An update from Agape';
     document.getElementById('email-body').value = out.body || '';
-    document.getElementById('email-status').textContent = 'Edit freely, then send.';
+    document.getElementById('email-status').textContent =
+      'Yours to edit. Close this to leave it unsent — they stay archived either way.';
   } catch (e) {
     document.getElementById('email-status').textContent = `Draft failed: ${e.message}`;
   }
@@ -1229,24 +1231,33 @@ function attachmentLabel(rec) {
   return `${room?.name || 'Room'} — ${l.kind === 'resident' ? 'resident trial' : 'sublet'} from ${fmtDay(l.starts_on)}`;
 }
 
-/* ---------- votes + stage machine ---------- */
-/* Thresholds come from recruit_settings (tunable without a deploy). */
-const voteMin = () => Number(settings.vote_min_count) || 3;
-const votePassAvg = () => Number(settings.vote_pass_avg) || 3.5;
+/* ---------- reviews + stage machine ---------- */
+/* One reviewer decides. Three verdicts, a comment on each, and the DB trigger
+   moves the applicant on the most recent decisive one (migration 140). */
+const VERDICTS = {
+  not_fit: { label: 'Not a fit', title: 'Archives them — an update email is owed', cls: 'is-not-fit' },
+  needs_input: { label: 'Needs input', title: 'Stays in the Inbox, flagged for another housemate to read', cls: 'is-needs-input' },
+  forward: { label: 'Move forward', title: 'Moves them to Candidates and into every listing they qualify for', cls: 'is-forward' },
+};
 
-const myVote = id => (votes[id] || []).find(v => v.voter_id === me?.id) || null;
+const myVote = id => (votes[id] || []).find(v =>
+  (me?.id && v.voter_id === me.id) || (me?.groupEmail && v.voter_email && v.voter_email === me.groupEmail)) || null;
 
+/* Reviews newest-first, plus the one that decided the stage. */
 function voteStats(id) {
-  const list = votes[id] || [];
-  const scored = list.filter(v => !v.veto && v.score != null);
-  const avg = scored.length ? scored.reduce((s, v) => s + v.score, 0) / scored.length : null;
+  const list = [...(votes[id] || [])].sort((x, y) =>
+    new Date(y.updated_at || y.created_at) - new Date(x.updated_at || x.created_at));
+  const decisive = list.find(v => v.verdict === 'not_fit' || v.verdict === 'forward') || null;
   return {
+    list,
     n: list.length,
-    scored: scored.length,
-    avg,
-    veto: list.find(v => v.veto) || null,
+    decisive,
+    notFit: decisive?.verdict === 'not_fit' ? decisive : null,
+    needsInput: list.filter(v => v.verdict === 'needs_input'),
   };
 }
+
+const reviewerName = v => v.voter_name || v.voter_email || 'a housemate';
 
 /* Manual stage moves go through the RPC — recruit_applicants is read-only
    to clients; vote-driven moves happen in the DB trigger. */
@@ -1258,32 +1269,36 @@ async function setStage(id, stage) {
   return true;
 }
 
-/* Upsert my vote, then pick up whatever stage the DB trigger computed. */
+/* Save my review, then pick up whatever stage the DB trigger computed. The
+   comment is required on every verdict — it's the record of why, and for
+   "Not a fit" it becomes the reason on the archived record. */
 async function castVote(applicantId) {
   const a = applicants.find(x => x.id === applicantId);
-  if (!a || !pendingVote) return;
+  if (!a || !pendingVerdict) return;
   const note = (document.getElementById('vote-note')?.value || '').trim();
-  const { score, veto } = pendingVote;
-  if (!veto && !score) { toast('Pick a score — or veto'); return; }
-  if (veto && note.length < 3) { toast('A veto needs a short why'); return; }
+  if (!VERDICTS[pendingVerdict]) { toast('Pick a verdict first'); return; }
+  if (note.length < 3) { toast('Add a comment — every review needs a why'); return; }
   const { data, error } = await sb.from('recruit_votes').upsert({
     applicant_id: applicantId, voter_id: me.id, voter_name: me.name,
-    score: veto ? null : score, veto, note,
+    verdict: pendingVerdict, score: null, veto: false, note,
     updated_at: new Date().toISOString(),
   }, { onConflict: 'applicant_id,voter_id' }).select().single();
-  if (error) { toast(`Vote failed: ${error.message}`); return; }
+  if (error) { toast(`Review failed: ${error.message}`); return; }
   votes[applicantId] = [...(votes[applicantId] || []).filter(v => v.voter_id !== me.id), data];
+  // "Not a fit" is a recruiter decision too, so Archive and the update tray
+  // can show the reason in the reviewer's own words.
+  if (pendingVerdict === 'not_fit') await saveDecision(applicantId, 'pass', 'fit', me.name, note);
   const { data: fresh } = await sb.from('recruit_applicants').select('stage').eq('id', applicantId).single();
   const before = a.stage;
   if (fresh) a.stage = fresh.stage;
-  pendingVote = null;
-  const st = voteStats(applicantId);
-  if (a.stage === 'rejected') toast(`${fullName(a)} vetoed — auto-archived, update email queued`);
+  const verdict = pendingVerdict;
+  pendingVerdict = null;
+  if (verdict === 'not_fit') toast(`${fullName(a)} archived — update email queued`);
   else if (a.stage === 'candidate' && before !== 'candidate') {
     if (!houseLoaded) await loadHouse();
     const added = await syncAutoPlacements();
-    toast(`${fullName(a)} passed review → Candidates${added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : ''}`);
-  } else toast(`Vote saved — ${st.scored}/${voteMin()} votes${st.avg ? ` · avg ${st.avg.toFixed(1)}` : ''}`);
+    toast(`${fullName(a)} moved forward → Candidates${added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : ''}`);
+  } else toast(`Saved — flagged for another housemate to read`);
   renderRailCounts();
   renderReview();
 }
@@ -1361,8 +1376,9 @@ async function render() {
 /* ---------- applicants render ---------- */
 function matchesView(a) {
   const out = a.stage !== 'rejected' && a.stage !== 'archived';
-  // A standing veto means archived — never show them here, whatever the stage says.
-  if (view === 'inbox') return a.stage === 'review' && !voteStats(a.id).veto;
+  // A "not a fit" verdict means archived — never show them here, whatever the
+  // stage column says.
+  if (view === 'inbox') return a.stage === 'review' && !voteStats(a.id).notFit;
   // Saved for future stays a candidate — visible in Candidates with its chip,
   // absent from Openings until the return date brings them back.
   if (view === 'candidates') return a.stage === 'candidate';
@@ -1449,18 +1465,16 @@ function decisionChip(id) {
    call state in Screening, the recruiter decision elsewhere. */
 function voteChip(a) {
   const st = voteStats(a.id);
-  if (st.veto) return `<span class="decision-chip decision-chip--pass" title="Vetoed by ${esc(st.veto.voter_name || 'a housemate')}">Vetoed</span>`;
-  if (!st.scored) return '';
-  // The average stays blind until you've cast your own vote.
-  if (!myVote(a.id)) return `<span class="decision-chip decision-chip--vote" title="${voteMin()} votes needed — tally shows after you vote">${st.scored}/${voteMin()} votes</span>`;
-  const passing = st.scored >= voteMin() && st.avg >= votePassAvg();
-  return `<span class="decision-chip decision-chip--vote ${passing ? 'decision-chip--outreach' : ''}" title="${st.scored} of ${voteMin()} votes needed · passing average is ${votePassAvg()}">${st.scored}/${voteMin()} · avg ${st.avg.toFixed(1)}</span>`;
+  if (st.notFit) return `<span class="decision-chip decision-chip--pass" title="${esc(reviewerName(st.notFit))} marked them not a fit">Not a fit</span>`;
+  if (!st.needsInput.length) return '';
+  const who = st.needsInput.map(reviewerName).join(', ');
+  return `<span class="decision-chip decision-chip--vote" title="${esc(who)} asked for another housemate to read this">Needs input</span>`;
 }
 
 function stageChip(a) {
   if (a.stage === 'rejected') {
     const st = voteStats(a.id);
-    const why = st.veto ? `Vetoed by ${st.veto.voter_name || 'a housemate'}` : (decisions[a.id]?.note || 'Did not pass review');
+    const why = st.notFit ? `Not a fit — ${reviewerName(st.notFit)}: “${st.notFit.note}”` : (decisions[a.id]?.note || 'Did not pass review');
     return `<span class="decision-chip decision-chip--hold" title="${esc(why)}">Update queued</span>`;
   }
   if (decisions[a.id]?.reason === 'dropped-out') return `<span class="decision-chip decision-chip--vote" title="They withdrew — no update email owed">Dropped out</span>`;
@@ -1877,7 +1891,7 @@ function renderApplicants() {
   document.getElementById('page-sub').textContent =
     (filtered ? `${list.length} of ${viewList.length}` : `${viewList.length}`) +
     ` applicant${(filtered ? viewList.length : list.length) === 1 ? '' : 's'}` +
-    (view === 'inbox' ? ` gathering votes · ${voteMin()} needed, one veto rejects` :
+    (view === 'inbox' ? ' waiting on a review · one read decides' :
      view === 'candidates' ? ' passed review — waiting for a room' : '');
 
   const host = document.getElementById('view-root');
@@ -1948,7 +1962,7 @@ function renderApplicants() {
         </div>
         ${pending.map(x => `<div class="update-tray__row">
           <span class="update-tray__who">${esc(fullName(x))}</span>
-          <span class="update-tray__why">${voteStats(x.id).veto ? `vetoed by ${esc(voteStats(x.id).veto.voter_name || 'a housemate')}` : (decisions[x.id]?.note || 'did not pass review')}</span>
+          <span class="update-tray__why">${voteStats(x.id).notFit ? `not a fit — ${esc(reviewerName(voteStats(x.id).notFit))}` : (decisions[x.id]?.note || 'did not pass review')}</span>
           <button type="button" class="cta-link" data-update-edit="${x.id}">Edit email</button>
           <button type="button" class="cta-link" data-update-skip="${x.id}">Skip</button>
         </div>`).join('')}
@@ -2997,7 +3011,7 @@ function openReview(id) {
   }
   qIndex = Math.max(0, queue.indexOf(id));
   reviewTab = 'profile';
-  pendingVote = null;
+  pendingVerdict = null;
   moveinEditing = false;
   if (!viewedIds.has(id)) {
     viewedIds.add(id);
@@ -3026,7 +3040,7 @@ function step(delta) {
   const next = qIndex + delta;
   if (next < 0 || next >= queue.length) { if (delta > 0) closeReview(); return; }
   qIndex = next;
-  pendingVote = null;
+  pendingVerdict = null;
   moveinEditing = false;
   hideHoldSheet();
   renderReview();
@@ -3065,7 +3079,7 @@ function renderReview() {
   const archived = a.stage === 'rejected' || a.stage === 'archived';
   const archiveBanner = () => {
     const st = voteStats(a.id);
-    const why = st.veto ? `Vetoed by ${st.veto.voter_name || 'a housemate'}${st.veto.note ? ` — “${st.veto.note}”` : ''}`
+    const why = st.notFit ? `Not a fit — ${reviewerName(st.notFit)}${st.notFit.note ? `: “${st.notFit.note}”` : ''}`
       : rec?.note || (rec?.reason ? reasonLabel(rec.reason) : 'Did not pass review');
     return `<div class="decision-banner decision-banner--pass">
       <div class="decision-banner__text">
@@ -3185,44 +3199,36 @@ async function saveMoveIn(id, clear = false) {
   renderReview();
 }
 
-/* House votes in the review body. The tally stays hidden until you've cast
-   yours — no anchoring. */
+/* Reviews in the review body. Every review carries its comment, so this reads
+   as a short thread rather than a tally. */
 function voteSectionHtml(a) {
-  if (a.stage !== 'review') {
-    const st = voteStats(a.id);
-    if (!st.n) return '';
-    return `<p class="vote-recap">Review: ${st.scored} vote${st.scored === 1 ? '' : 's'}${st.avg ? ` · avg ${st.avg.toFixed(1)}` : ''}${st.veto ? ' · vetoed' : ''}</p>`;
-  }
-  const list = votes[a.id] || [];
-  const mine = myVote(a.id);
   const st = voteStats(a.id);
-  let body;
-  if (!list.length) {
-    body = `<p class="notes__empty">No votes yet — be the first.</p>`;
-  } else if (!mine && a.stage === 'review') {
-    body = `<p class="notes__empty">${list.length} vote${list.length === 1 ? '' : 's'} cast — the tally appears after you cast yours.</p>`;
-  } else {
-    const summary = st.veto
-      ? `Vetoed — auto-archived, update email queued.`
-      : st.scored
-        ? `${st.scored}/${voteMin()} votes · avg ${st.avg.toFixed(1)} · ${st.scored >= voteMin() && st.avg >= votePassAvg() ? 'passing' : `needs avg ≥ ${votePassAvg()}`}`
-        : '';
-    body = `${summary ? `<p class="vote-summary">${esc(summary)}</p>` : ''}
-      <ul class="notes__list">${list.map(v => `
-        <li class="note">
-          <span class="avatar">${esc((v.voter_name || '?')[0].toUpperCase())}</span>
-          <div class="note__body-wrap">
-            <div class="note__meta">
-              <span class="note__author">${esc(v.voter_name || 'Housemate')}</span>
-              <span class="note__time">${v.veto ? '<span class="vote-score vote-score--veto">Veto</span>' : `<span class="vote-score">${v.score}/5</span>`} · ${relTime(v.updated_at || v.created_at)}</span>
-            </div>
-            ${v.note ? `<p class="note__body">${esc(v.note)}</p>` : ''}
-          </div>
-        </li>`).join('')}</ul>`;
+  if (!st.n) {
+    return a.stage === 'review'
+      ? `<section class="review__section notes">
+           <div class="notes__head"><h3 class="review__section-title">Reviews</h3></div>
+           <p class="notes__empty">No review yet — yours decides.</p>
+         </section>`
+      : '';
   }
+  const rows = st.list.map(v => {
+    const badge = VERDICTS[v.verdict]
+      ? `<span class="verdict-tag ${VERDICTS[v.verdict].cls}">${VERDICTS[v.verdict].label}</span>`
+      : (v.veto ? '<span class="verdict-tag is-not-fit">Not a fit</span>' : '');
+    return `<li class="note">
+      <span class="avatar">${esc(reviewerName(v)[0].toUpperCase())}</span>
+      <div class="note__body-wrap">
+        <div class="note__meta">
+          <span class="note__author">${esc(reviewerName(v))}</span>
+          <span class="note__time">${badge} · ${relTime(v.updated_at || v.created_at)}${v.voter_email && !v.voter_id ? ' · from the application sheet' : ''}</span>
+        </div>
+        ${v.note ? `<p class="note__body">${esc(v.note)}</p>` : ''}
+      </div>
+    </li>`;
+  }).join('');
   return `<section class="review__section notes">
-    <div class="notes__head"><h3 class="review__section-title">House votes</h3></div>
-    ${body}
+    <div class="notes__head"><h3 class="review__section-title">Reviews</h3></div>
+    <ul class="notes__list">${rows}</ul>
   </section>`;
 }
 
@@ -3234,19 +3240,24 @@ function renderReviewFoot(a) {
   const keepNote = document.getElementById('vote-note')?.value ?? null;
   if (a.stage === 'review') {
     const mine = myVote(a.id);
-    const sel = pendingVote || (mine ? { score: mine.score, veto: mine.veto } : { score: null, veto: false });
+    const sel = pendingVerdict || mine?.verdict || null;
+    // Select-then-confirm: picking a verdict arms the bar, the comment is
+    // required, and the confirm button names what will happen.
+    const confirmLabel = sel === 'not_fit' ? 'Archive them'
+      : sel === 'forward' ? 'Move forward'
+      : sel === 'needs_input' ? 'Ask for another read'
+      : 'Save review';
     foot.innerHTML = `
       <div class="vote-bar">
         <span class="vote-bar__q">Would you live with them?</span>
-        <span class="vote-bar__scores">
-          ${[1, 2, 3, 4, 5].map(n =>
-            `<button type="button" class="vote-bar__score ${!sel.veto && sel.score === n ? 'is-on' : ''}" data-vote-score="${n}" aria-label="Vote ${n}">${n}</button>`).join('')}
+        <span class="vote-bar__verdicts">
+          ${Object.entries(VERDICTS).map(([k, v]) =>
+            `<button type="button" class="vote-bar__verdict ${v.cls} ${sel === k ? 'is-on' : ''}" data-verdict="${k}" title="${esc(v.title)}">${v.label}</button>`).join('')}
         </span>
-        <button type="button" class="vote-bar__veto ${sel.veto ? 'is-on' : ''}" data-vote-veto>${sel.veto ? 'Veto — tap to undo' : 'Veto'}</button>
         <input type="text" class="listing-status vote-bar__note" id="vote-note" maxlength="500"
-          placeholder="${sel.veto ? 'Why the veto? (required)' : 'One line on why (optional)'}"
+          placeholder="Your comment (required)"
           value="${esc(keepNote ?? mine?.note ?? '')}">
-        <button type="button" class="btn btn--accent vote-bar__cast" data-cast-vote>${mine ? 'Update vote' : 'Cast vote'}</button>
+        <button type="button" class="btn btn--accent vote-bar__cast" data-cast-vote ${sel ? '' : 'disabled'}>${confirmLabel}</button>
       </div>`;
   } else if (a.stage === 'candidate') {
     const pills = activePlacements(a.id).map(p => {
@@ -3274,25 +3285,37 @@ function renderReviewFoot(a) {
         </span>`;
     }
   } else {
-    foot.innerHTML = `<button class="btn review__btn" data-reopen="${a.id}">Reopen — back to Inbox</button>`;
+    // Archived. The update email is offered here, at the moment it's owed, and
+    // is always optional — skipping archives them with nothing sent.
+    const owed = a.stage === 'rejected' && !a.updateSentAt && !a.updateSkippedAt;
+    foot.innerHTML = `
+      ${owed ? `<span class="foot-cta"><button class="btn btn--accent review__btn" data-update-edit="${a.id}">Write their update</button></span>` : ''}
+      <span class="foot-links">
+        ${owed ? `<button type="button" class="cta-link" data-update-skip="${a.id}">Skip the email</button>` : ''}
+        <button type="button" class="cta-link" data-reopen="${a.id}">Reopen — back to Inbox</button>
+      </span>`;
   }
 }
 
 async function reopenApplicant(id) {
   const a = applicants.find(x => x.id === id);
   if (!a) return;
-  // A veto is archival, so reopening has to clear it — otherwise they'd sit in
-  // the Inbox with a standing veto that can never resolve.
+  // A decisive verdict is what put them here, so reopening has to soften it —
+  // otherwise the trigger sends them straight back. The comment survives: it
+  // becomes a "needs input" note, which is what reopening actually means.
   const st0 = voteStats(id);
-  if (st0.veto) {
-    if (!confirm(`${fullName(a)} was vetoed by ${st0.veto.voter_name || 'a housemate'}. Reopening clears that veto so the house can review them again. Continue?`)) return;
-    const { error } = await sb.from('recruit_votes').delete().eq('applicant_id', id).eq('veto', true);
-    if (error) { toast(`Couldn't clear the veto: ${error.message}`); return; }
-    votes[id] = (votes[id] || []).filter(v => !v.veto);
+  if (st0.decisive) {
+    const { error } = await sb.from('recruit_votes')
+      .update({ verdict: 'needs_input', updated_at: new Date().toISOString() })
+      .eq('applicant_id', id).in('verdict', ['not_fit', 'forward']);
+    if (error) { toast(`Couldn't reopen: ${error.message}`); return; }
+    votes[id] = (votes[id] || []).map(v =>
+      v.verdict === 'not_fit' || v.verdict === 'forward' ? { ...v, verdict: 'needs_input' } : v);
   }
   if (await setStage(id, 'review')) {
-    const st = voteStats(id);
-    toast(st0.veto ? 'Reopened — the veto was cleared' : 'Reopened — back in the Inbox');
+    toast(st0.decisive
+      ? `Reopened — ${reviewerName(st0.decisive)}'s comment is kept as needing input`
+      : 'Reopened — back in the Inbox');
     renderRailCounts();
     if (!document.getElementById('review').hidden) renderReview(); else render();
   }
@@ -3774,14 +3797,16 @@ function stopDictation() {
 /* ---------- export ---------- */
 function exportCsv() {
   const cols = ['first', 'last', 'email', 'ts_iso', 'residency', 'movein', 'budget', 'source'];
-  const head = [...cols, 'stage', 'votes', 'vote_avg', 'vetoed', 'decision', 'reason', 'decision_note', 'decided_by', 'decided_at', 'notes'];
+  const head = [...cols, 'stage', 'reviews', 'verdict', 'reviewed_by', 'review_comment', 'decision', 'reason', 'decision_note', 'decided_by', 'decided_at', 'notes'];
   const q = v => `"${String(v ?? '').replace(/"/g, '""')}"`;
   const lines = [head.join(',')];
   for (const a of applicants) {
     const rec = decisions[a.id] || {};
     const st = voteStats(a.id);
-    lines.push([...cols.map(c => q(a[c])), q(a.stage), q(st.n || 0), q(st.avg ? st.avg.toFixed(2) : ''),
-      q(st.veto ? (st.veto.voter_name || 'yes') : ''), q(DECISION_LABELS[rec.d] || ''),
+    const top = st.decisive || st.list[0];
+    lines.push([...cols.map(c => q(a[c])), q(a.stage), q(st.n || 0),
+      q(top ? (VERDICTS[top.verdict]?.label || '') : ''), q(top ? reviewerName(top) : ''), q(top?.note || ''),
+      q(DECISION_LABELS[rec.d] || ''),
       q(rec.reason ? reasonLabel(rec.reason) : ''), q(rec.note || ''),
       q(rec.byName || ''), q(rec.at || ''), q(commentCounts[a.id] || 0)].join(','));
   }
@@ -4060,9 +4085,15 @@ async function _checkMembershipAndEnter() {
     }
     // in — identify self, load data, render
     const user = window.CtrlAuth.getUser();
-    me = { id: user.id, name: status.discordUsername || user.email || 'Housemate' };
-    sb.from('recruit_profiles').select('display_name').eq('user_id', user.id).maybeSingle()
-      .then(({ data }) => { if (data?.display_name) { me.name = data.display_name; renderRailUser(); } });
+    me = { id: user.id, name: status.discordUsername || user.email || 'Housemate', groupEmail: user.email || null };
+    // group_email ties this account to its roster identity, which is how a
+    // review imported from the sheet becomes yours once you sign in.
+    sb.from('recruit_profiles').select('display_name, group_email').eq('user_id', user.id).maybeSingle()
+      .then(({ data }) => {
+        if (data?.display_name) me.name = data.display_name;
+        if (data?.group_email) me.groupEmail = data.group_email;
+        if (data) renderRailUser();
+      });
     fetch(`${SUPABASE_URL}/functions/v1/recruit-gmail`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${(await sb.auth.getSession()).data?.session?.access_token}` },
@@ -4201,24 +4232,16 @@ function init() {
     if (fclear) { filters = { track: 'all', month: 'any', budget: 'any' }; renderApplicants(); return; }
     const review = e.target.closest('[data-review]');
     if (review) { openReview(review.dataset.review); return; }
-    const vs = e.target.closest('[data-vote-score]');
-    if (vs) {
-      pendingVote = { score: +vs.dataset.voteScore, veto: false };
+    const vd = e.target.closest('[data-verdict]');
+    if (vd) {
+      pendingVerdict = pendingVerdict === vd.dataset.verdict ? null : vd.dataset.verdict;
       renderReviewFoot(applicants.find(x => x.id === queue[qIndex]));
-      return;
-    }
-    const vv = e.target.closest('[data-vote-veto]');
-    if (vv) {
-      pendingVote = { score: pendingVote?.score || null, veto: !(pendingVote?.veto ?? myVote(queue[qIndex])?.veto) };
-      renderReviewFoot(applicants.find(x => x.id === queue[qIndex]));
+      document.getElementById('vote-note')?.focus();
       return;
     }
     const cv = e.target.closest('[data-cast-vote]');
     if (cv) {
-      if (!pendingVote) {
-        const mine = myVote(queue[qIndex]);
-        pendingVote = mine ? { score: mine.score, veto: mine.veto } : null;
-      }
+      if (!pendingVerdict) pendingVerdict = myVote(queue[qIndex])?.verdict || null;
       castVote(queue[qIndex]);
       return;
     }

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -230,3 +230,20 @@ Now exactly one active placement per applicant, enforced by a partial unique ind
 **Every placement is now a move.** `addPlacement()` drops the previous active row before inserting, which turns all four call sites into moves at once without each having to know. Copy follows: *Add* → **Move here** on the accordion when they're already placed, *Add to another listing* → **Move to a different listing** in the review foot.
 
 Reconciling the two existing duplicates preferred a manual placement over an auto one — a recruiter chose it — then fell back to the same date-fit ordering.
+
+## Amendment — v3.40 (one reviewer, three verdicts)
+
+The Inbox is no longer a group vote. One housemate's read decides, and every review requires a comment.
+
+| Verdict | What happens | Row state |
+|---|---|---|
+| **Not a fit** | Archived immediately; an update email is owed | `Not a fit` chip, tooltip names the reviewer |
+| **Needs input** | Stays in the Inbox, explicitly asking for another read | `Needs input` chip, tooltip names who asked |
+| **Move forward** | Candidates, plus auto-placement into every listing they qualify for | leaves the Inbox |
+
+- **The review bar is select-then-confirm.** Picking a verdict arms the bar and focuses the comment; the confirm button then names the consequence ("Archive them", "Ask for another read", "Move forward") rather than saying "Save". It stays disabled until a verdict is picked, and the comment is required — a review with no why is rejected client-side and by a CHECK constraint.
+- **Verdict tints:** not a fit reads in the error tint, move forward in the accent green, needs input in a neutral overlay. Only the selected chip fills in.
+- **No scores, no averages, no veto.** Nothing is hidden until you vote any more, because there is no tally to anchor against; the reviews thread shows each verdict with its comment.
+- **Reopening softens rather than deletes.** A decisive verdict becomes "needs input" and keeps its comment, since the trigger would otherwise send the applicant straight back out.
+- **The rejection email is offered, never forced.** Archiving surfaces "Write their update" with "Skip the email" beside it; the draft is a fixed community template plus one paragraph written from the applicant's own survey answers, and an optional newsletter link. Closing the editor leaves it unsent.
+- **Reviews can arrive from the application sheet.** Comment threads on the sheet import as reviews attributed to their author's roster email, so a review written by someone who has never opened the app still shows under their name — and becomes editable by them the moment their sign-in maps to that email. Imported rows are labelled "from the application sheet".

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.19.0'
+const VERSION = '1.20.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -41,6 +41,7 @@ const SCOPES = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/calendar.events', // screening-call invites
   'https://www.googleapis.com/auth/spreadsheets.readonly', // application-sheet ingest
+  'https://www.googleapis.com/auth/drive.readonly', // review comment threads on the application sheet
 ]
 
 function db() {

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -19,7 +19,7 @@
 // timestamp, and inserts ignore duplicates — so resending the whole sheet is
 // a safe backfill, not a mess of copies.
 
-const VERSION = '1.2.1'
+const VERSION = '1.3.0'
 console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -129,7 +129,10 @@ function deriveId(first: string, last: string, submittedAt: Date): string {
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
   try {
-    const isPull = new URL(req.url).pathname.endsWith('/pull')
+    const path = new URL(req.url).pathname
+    const isPull = path.endsWith('/pull')
+    const isPeek = path.endsWith('/peek')
+    const isReviewImport = path.endsWith('/review-comments')
     const client = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
     const body = await req.json().catch(() => ({}))
     const dryRun = body.dryRun === true
@@ -146,6 +149,157 @@ serve(async (req) => {
       authed = Boolean(burned)
     }
     if (!authed) return json({ error: 'bad or missing x-ingest-secret / x-cron-nonce' }, 401)
+
+    // Column map for the review columns, so the importer can be written
+    // against what the sheet actually holds. Header names and per-column
+    // fill counts only — no applicant content leaves here.
+    if (isPeek) {
+      const at = await sharedAccessToken(client)
+      const meta = await fetch(
+        `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}?fields=sheets.properties.title`,
+        { headers: { Authorization: `Bearer ${at}` } },
+      ).then((r) => r.json())
+      const tabs: string[] = (meta.sheets || []).map((sh: any) => sh.properties?.title).filter(Boolean)
+      const out: Record<string, unknown> = { tabs }
+      for (const tab of tabs) {
+        const resp = await fetch(
+          `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${encodeURIComponent(tab)}`,
+          { headers: { Authorization: `Bearer ${at}` } },
+        )
+        if (!resp.ok) { out[tab] = { error: resp.status }; continue }
+        const values: string[][] = (await resp.json()).values || []
+        const headers = values[0] || []
+        out[tab] = {
+          rows: Math.max(0, values.length - 1),
+          columns: headers.map((h, i) => ({
+            header: h,
+            filled: values.slice(1).filter((r) => String(r[i] ?? '').trim()).length,
+          })).filter((c) => c.header),
+        }
+      }
+        return json(out)
+    }
+
+    /* Import the house's review comments off the application sheet.
+       These are Google comment threads, so each one carries its author — which
+       is how a review written by someone who has never opened /applications
+       still lands under their name. Needs the drive.readonly scope. */
+    if (isReviewImport) {
+      const at = await sharedAccessToken(client)
+      const cResp = await fetch(
+        `https://www.googleapis.com/drive/v3/files/${SHEET_ID}/comments` +
+        '?fields=comments(id,author/displayName,content,anchor,quotedFileContent/value,resolved,createdTime,replies(author/displayName,content,createdTime))&pageSize=100',
+        { headers: { Authorization: `Bearer ${at}` } },
+      )
+      const cText = await cResp.text()
+      if (!cResp.ok) {
+        if (cResp.status === 403 && /scope|insufficient/i.test(cText)) {
+          return json({ error: 'the shared Google account has not granted access to comments yet — reconnect it from the /applications rail footer' }, 502)
+        }
+        return json({ error: `comments unreadable (HTTP ${cResp.status}): ${cText.slice(0, 220)}` }, 502)
+      }
+      // deno-lint-ignore no-explicit-any
+      const threads: any[] = JSON.parse(cText).comments || []
+
+      // Sheet rows in order, so a comment anchored to row N resolves to the
+      // applicant that row produced.
+      const sheetRows = await readSheet(client)
+      const emailOf = (r: Record<string, unknown>) => {
+        const k = Object.keys(r).find((h) => /e-?mail/i.test(h))
+        return k ? String(r[k] || '').trim().toLowerCase() : ''
+      }
+      const { data: appRows } = await client.from('recruit_applicants').select('id, email, first_name, last_name')
+      const byEmail = new Map((appRows || []).map((a: any) => [String(a.email || '').toLowerCase(), a]))
+
+      // Author display name -> roster email. "K Storey-Fisher" and "Kate
+      // Storey-Fisher" are the same person, so match on surname plus first
+      // initial rather than the exact string.
+      const { data: roster } = await client.from('recruit_group_roster').select('email, full_name')
+      const key = (n: string) => {
+        const parts = String(n || '').toLowerCase().replace(/[^a-z\s-]/g, '').trim().split(/\s+/)
+        if (!parts.length) return ''
+        return `${parts[0][0]}|${parts[parts.length - 1]}`
+      }
+      const rosterByKey = new Map((roster || []).map((r: any) => [key(r.full_name), r]))
+
+      const applied: unknown[] = []
+      const unmatched: unknown[] = []
+
+      for (const t of threads) {
+        const authorName = t.author?.displayName || ''
+        const rosterHit = rosterByKey.get(key(authorName))
+        // Every reply is part of the same person's read, but the thread's own
+        // author owns the verdict; replies are appended to the body.
+        const bodyParts = [String(t.content || '').trim(),
+          ...(t.replies || []).map((r: any) => `${r.author?.displayName || 'reply'}: ${String(r.content || '').trim()}`)]
+        const body = bodyParts.filter(Boolean).join('\n').slice(0, 4000)
+        if (!body) continue
+
+        // Resolve the applicant: the anchor's row number first, then the
+        // quoted cell text (an email, or a name).
+        let applicant: any = null
+        const rowNum = Number((String(t.anchor || '').match(/[A-Z]+(\d+)/) || [])[1] || 0)
+        if (rowNum > 1 && sheetRows[rowNum - 2]) applicant = byEmail.get(emailOf(sheetRows[rowNum - 2])) || null
+        if (!applicant) {
+          const quoted = String(t.quotedFileContent?.value || '').trim()
+          const em = quoted.match(/[\w.+-]+@[\w-]+\.[\w.]+/)
+          if (em) applicant = byEmail.get(em[0].toLowerCase()) || null
+          if (!applicant && quoted) {
+            const q = quoted.toLowerCase()
+            applicant = (appRows || []).find((a: any) =>
+              q === `${a.first_name} ${a.last_name}`.toLowerCase().trim() ||
+              q === String(a.email || '').toLowerCase()) || null
+          }
+        }
+        if (!applicant) { unmatched.push({ author: authorName, body: body.slice(0, 120), anchor: t.anchor || null }); continue }
+
+        // Does the comment point at a decision? Only unmistakable language
+        // counts; anything softer stays a comment for a human to read.
+        const low = body.toLowerCase()
+        const verdict =
+          /\b(not a fit|no thanks|hard (no|pass)|pass on|reject|decline|don'?t think .{0,20}fit|not for us)\b/.test(low) ? 'not_fit'
+          : /\b(move forward|move ahead|let'?s (meet|talk|screen|interview)|schedule|yes[!.]?$|would love|great fit|strong (yes|fit))\b/.test(low) ? 'forward'
+          : null
+
+        const row: Record<string, unknown> = {
+          applicant_id: applicant.id,
+          author_name: rosterHit?.full_name || authorName || 'A housemate',
+          author_email: rosterHit?.email || null,
+          body,
+          source: 'sheet',
+          created_at: t.createdTime || new Date().toISOString(),
+        }
+        // Same author, same applicant, same words = already imported. Checked
+        // rather than upserted: the key includes the body, which is too long
+        // to carry a unique index worth maintaining.
+        const { data: dupe } = await client.from('recruit_comments')
+          .select('id').eq('applicant_id', applicant.id).eq('source', 'sheet')
+          .eq('author_name', row.author_name).eq('body', body).maybeSingle()
+        if (!dryRun && !dupe) await client.from('recruit_comments').insert(row)
+        if (verdict && !dryRun) {
+          await client.from('recruit_votes').upsert({
+            applicant_id: applicant.id, voter_id: null,
+            voter_email: rosterHit?.email || null,
+            voter_name: rosterHit?.full_name || authorName || 'A housemate',
+            verdict, note: body.slice(0, 500), score: null, veto: false,
+            updated_at: t.createdTime || new Date().toISOString(),
+          }, { onConflict: 'applicant_id,voter_email' })
+        }
+        applied.push({
+          alreadyImported: Boolean(dupe),
+          applicant: `${applicant.first_name} ${applicant.last_name}`.trim(),
+          author: row.author_name, authorEmail: row.author_email, verdict, body: body.slice(0, 160),
+        })
+      }
+
+      const summary = `${applied.length} review comment${applied.length === 1 ? '' : 's'} from the application sheet`
+      if (!dryRun && applied.length) {
+        await postChannelEmbed(AUTOMATION_CHANNEL_ID,
+          `📝 **${summary}**\n${applied.filter((x: any) => x.verdict).length} pointed to a decision.`,
+          0x378add, summary)
+      }
+      return json({ dryRun, imported: applied.length, withVerdict: applied.filter((x: any) => x.verdict).length, applied, unmatched })
+    }
 
     let rows: Array<Record<string, unknown>>
     if (isPull) {

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.9.0'
+const VERSION = '1.10.0'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -329,29 +329,64 @@ serve(async (req) => {
     }
 
     if (body.action === 'draft_update' && body.applicantId) {
-      // Rejection-queue draft. Unsigned community voice; never discloses
-      // votes, vetoes, or auto-flags.
-      const { data: applicant } = await client.from('recruit_applicants').select('first_name, why_agape').eq('id', String(body.applicantId)).maybeSingle()
+      // Standard rejection note: a fixed community template the reviewer edits
+      // before sending (sending is always optional). Only the middle paragraph
+      // is written per-applicant, grounded in their own survey answers, so the
+      // voice and the promises stay identical for everyone. Never discloses
+      // reviews, verdicts, or auto-flags.
+      const { data: applicant } = await client.from('recruit_applicants')
+        .select('first_name, why_agape, about, gifts, residency')
+        .eq('id', String(body.applicantId)).maybeSingle()
       if (!applicant) return new Response(JSON.stringify({ error: 'Unknown applicant' }), { status: 404, headers: jsonHeaders })
-      const why = (applicant.why_agape || '').replace(/\s+/g, ' ').slice(0, 300)
-      const prompt = `Write a short, kind update email from the Agape community (a 13-bedroom co-op near Dolores Park, SF) to ${applicant.first_name}, who applied to live here and will not be moving forward.
 
-Hard rules:
-- Warm, human, and brief (under 100 words). Thank them genuinely for the care in their application${why ? ` (they wrote: "${why}")` : ''}.
-- Do NOT give reasons, feedback, or specifics about the decision. Do not say "unfortunately" more than once, do not apologize repeatedly.
-- Leave the door open gently (things shift; they're welcome to apply again down the road) without promising anything.
-- Sign off as "the Agape community" — no individual name.
-- Subject: short and neutral, e.g. "An update from Agape".
+      const { data: nl } = await client.from('recruit_settings').select('value').eq('key', 'newsletter_url').maybeSingle()
+      const newsletterUrl = typeof nl?.value === 'string' ? nl.value : (nl?.value as any)?.toString?.() || ''
 
-Return exactly:
-SUBJECT: <subject>
-BODY:
-<body>`
-      const text = await callClaudeRaw('claude-haiku-4-5-20251001', 'You write brief, warm community emails. Follow the format exactly.', prompt, 400)
-      const m = text.match(/SUBJECT:\s*(.+)\n+BODY:\n?([\s\S]+)/)
-      const subject = (m?.[1] || 'An update from Agape').trim().slice(0, 200)
-      const bodyText = (m?.[2] || text).trim().slice(0, 4000)
-      return new Response(JSON.stringify({ subject, body: bodyText }), { headers: jsonHeaders })
+      const survey = [
+        applicant.why_agape && `Why Agape: ${String(applicant.why_agape).replace(/\s+/g, ' ').slice(0, 400)}`,
+        applicant.about && `About them: ${String(applicant.about).replace(/\s+/g, ' ').slice(0, 400)}`,
+        applicant.gifts && `Gifts they offered to share: ${String(applicant.gifts).replace(/\s+/g, ' ').slice(0, 300)}`,
+      ].filter(Boolean).join('\n')
+
+      // One paragraph, their words back to them. If Claude is unavailable the
+      // template still sends — it just loses the personal middle.
+      let personal = ''
+      if (survey) {
+        try {
+          const raw = await callClaudeRaw(
+            'claude-haiku-4-5-20251001',
+            'You write two or three warm, specific sentences. No greeting, no sign-off, no bullet points. Return only the sentences.',
+            `Someone applied to live at Agape, a 13-bedroom co-op near Dolores Park in San Francisco, and is not moving forward. Write TWO OR THREE sentences for the middle of their update email that show we actually read what they wrote.
+
+Their application said:
+${survey}
+
+Rules:
+- Name something specific and true from their answers — an interest, a craft, something they offered to share.
+- Do not evaluate them, rank them, hint at reasons, or explain the decision.
+- Do not promise a future spot, a call, or a reconsideration.
+- No greeting and no sign-off, just the sentences. Under 60 words.`,
+            300,
+          )
+          personal = String(raw || '').trim().replace(/^["']|["']$/g, '').slice(0, 600)
+        } catch (err) {
+          console.error(`[recruit-match] personal paragraph failed: ${(err as Error).message}`)
+        }
+      }
+
+      const cta = newsletterUrl
+        ? `\n\nIf you'd like to hear when we're open again, along with the occasional dinner, workshop, or open house, you can join our list here:\n${newsletterUrl}`
+        : ''
+
+      const subject = 'An update from Agape'
+      const bodyText = `Hi ${applicant.first_name},\n\n` +
+        `Thank you for applying to Agape, and for the care you put into your answers. ` +
+        `We're not able to offer you a room this time.\n` +
+        (personal ? `\n${personal}\n` : '') +
+        `\nOur rooms open up unpredictably, and the house changes with them, so this isn't a closed door — you're welcome to apply again down the road.${cta}\n\n` +
+        `Warmly,\nthe Agape community`
+
+      return new Response(JSON.stringify({ subject, body: bodyText, personalized: Boolean(personal) }), { headers: jsonHeaders })
     }
 
     if (body.action === 'second_opinion' && body.applicantId) {

--- a/supabase/migrations/140_recruit_single_reviewer_verdicts.sql
+++ b/supabase/migrations/140_recruit_single_reviewer_verdicts.sql
@@ -1,0 +1,93 @@
+-- ============================================
+-- Migration 140: one reviewer, three verdicts
+--
+-- Replaces the collective 1-5 score + veto with a single decisive review:
+--   not_fit      -> Archive (an update email is owed, same as the old veto)
+--   needs_input  -> stays in the Inbox, explicitly asking for another read
+--   forward      -> Candidates
+-- One response decides, and every verdict requires a comment.
+--
+-- score/veto stay on the table so old rows keep their meaning in history, but
+-- nothing reads them for stage decisions any more. The CHECK constraints that
+-- forced a score or a veto are dropped: a verdict row has neither.
+--
+-- voter_id becomes nullable alongside a new voter_email, so a review can be
+-- attributed to a housemate who hasn't signed in yet (the Google Sheet import
+-- lands Kate's reviews on kstoreyfisher@gmail.com; they become hers the moment
+-- her Discord sign-in maps to that roster email). Same for comments.
+-- ============================================
+
+ALTER TABLE recruit_votes ADD COLUMN IF NOT EXISTS verdict TEXT;
+ALTER TABLE recruit_votes DROP CONSTRAINT IF EXISTS recruit_votes_verdict_chk;
+ALTER TABLE recruit_votes ADD CONSTRAINT recruit_votes_verdict_chk
+  CHECK (verdict IS NULL OR verdict IN ('not_fit', 'needs_input', 'forward'));
+
+-- A verdict carries no score and needn't be a veto; the old shape constraints
+-- would reject every new row.
+ALTER TABLE recruit_votes DROP CONSTRAINT IF EXISTS recruit_votes_check;   -- veto OR score IS NOT NULL
+ALTER TABLE recruit_votes DROP CONSTRAINT IF EXISTS recruit_votes_check1;  -- veto => note >= 3
+
+-- Every verdict needs a why, whichever verdict it is.
+ALTER TABLE recruit_votes DROP CONSTRAINT IF EXISTS recruit_votes_note_chk;
+ALTER TABLE recruit_votes ADD CONSTRAINT recruit_votes_note_chk
+  CHECK (verdict IS NULL OR char_length(btrim(note)) >= 3);
+
+-- Attribution for reviews written outside the app.
+ALTER TABLE recruit_votes ALTER COLUMN voter_id DROP NOT NULL;
+ALTER TABLE recruit_votes ADD COLUMN IF NOT EXISTS voter_email TEXT;
+ALTER TABLE recruit_comments ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE recruit_comments ADD COLUMN IF NOT EXISTS author_email TEXT;
+ALTER TABLE recruit_comments ADD COLUMN IF NOT EXISTS source TEXT;  -- 'sheet' for imports
+
+-- UNIQUE (applicant_id, voter_id) can't hold an imported row (null voter_id),
+-- so key those on the email too — one review per housemate either way. Not a
+-- partial index: ON CONFLICT can only infer a plain one, and a null
+-- voter_email never collides in Postgres anyway.
+CREATE UNIQUE INDEX IF NOT EXISTS recruit_votes_applicant_email_key
+  ON recruit_votes (applicant_id, voter_email);
+
+-- Legacy rows keep their meaning: a veto was archival, a score of 4-5 was a
+-- pass, anything else was still a question.
+UPDATE recruit_votes SET verdict =
+  CASE WHEN veto THEN 'not_fit'
+       WHEN score >= 4 THEN 'forward'
+       ELSE 'needs_input' END
+  WHERE verdict IS NULL;
+
+-- Service-role imports bypass RLS; the client policies stay as they are (a
+-- housemate may only write their own review, keyed on voter_id = auth.uid()),
+-- so an imported row can't be edited from the app until its owner signs in.
+-- Reads are unchanged: any recruiting member sees every review.
+
+-- ---- Stage machine: the most recent decisive verdict wins ----
+-- Recency, not first-past-the-post: re-reviewing someone is how you change
+-- your mind, and 'needs_input' deliberately decides nothing.
+CREATE OR REPLACE FUNCTION recruit_recompute_stage() RETURNS TRIGGER
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  aid TEXT := COALESCE(NEW.applicant_id, OLD.applicant_id);
+  cur TEXT;
+  decisive TEXT;
+  next_stage TEXT;
+BEGIN
+  SELECT stage INTO cur FROM recruit_applicants WHERE id = aid;
+  IF cur IS NULL OR cur = 'archived' THEN RETURN NULL; END IF;
+
+  SELECT verdict INTO decisive FROM recruit_votes
+    WHERE applicant_id = aid AND verdict IN ('not_fit', 'forward')
+    ORDER BY COALESCE(updated_at, created_at) DESC
+    LIMIT 1;
+
+  IF decisive = 'not_fit' THEN next_stage := 'rejected';
+  ELSIF decisive = 'forward' THEN next_stage := 'candidate';
+  ELSE next_stage := 'review';
+  END IF;
+
+  UPDATE recruit_applicants SET stage = next_stage
+    WHERE id = aid AND stage IS DISTINCT FROM next_stage;
+  RETURN NULL;
+END;
+$$;
+
+-- The thresholds described a group vote that no longer exists.
+DELETE FROM recruit_settings WHERE key IN ('vote_min_count', 'vote_pass_avg');


### PR DESCRIPTION
## The review model

The Inbox was a collective 1–5 vote: three votes needed, a passing average, and any veto rejecting. It is now **one decisive review** with three options and a **required comment**:

| Verdict | Effect |
|---|---|
| Not a fit | Archived, update email owed |
| Needs input | Stays in the Inbox, flagged for another read |
| Move forward | Candidates + auto-placement |

`recruit_recompute_stage` follows the most recent decisive verdict, so re-reviewing someone is how you change your mind and "needs input" deliberately decides nothing. Reopening converts a decisive verdict to `needs_input` and keeps its comment — deleting it would lose the why, and leaving it would have the trigger bounce them straight back out.

## The rejection email is optional

Archiving surfaces **Write their update** with **Skip the email** beside it. The draft is now a fixed community template — same voice and same promises for everyone — plus one Claude-written paragraph grounded in the applicant's own survey answers, and a newsletter link when `recruit_settings.newsletter_url` is set (the CTA is omitted entirely when it isn't).

## Sheet review comments

`recruit-ingest /review-comments` imports the application sheet's Google comment threads as reviews. Authors match `recruit_group_roster` on surname + first initial, so "K Storey-Fisher" resolves to Kate's roster email; `voter_id` is nullable now, and the row becomes editable by her the moment her Discord sign-in maps to that email. Only unmistakable decision language sets a verdict — anything softer imports as a comment for a human to read.

**This last piece needs one consent click**: reading comment threads requires the Drive API, which the shared Google account hasn't granted. `drive.readonly` is now in the scope list, so reconnecting the account from the rail footer covers it. Until then the endpoint returns exactly that instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)