### PR TITLE
fix(recruiting): rejection emails never offer a meeting (v3.40.2)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.40.1">
+  <link rel="stylesheet" href="css/app.css?v=3.40.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.40.1"></script>
+  <script src="js/app.js?v=3.40.2"></script>
 
 </body>
 </html>

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.40.0">
+  <link rel="stylesheet" href="css/app.css?v=3.40.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.40.0"></script>
+  <script src="js/app.js?v=3.40.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.40.0';
+const VERSION = '3.40.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -4565,7 +4565,15 @@ function init() {
     if (id) openSchedulerPreview(id);
   };
   document.getElementById('email-close').onclick = closeEmailModal;
-  document.getElementById('email-regen').onclick = () => emailApplicantId && generateEmail(emailApplicantId);
+  // Regenerate has to respect which editor you're in. In the rejection queue
+  // it must redraft the update — routing it to the outreach drafter produced a
+  // warm invite, complete with a booking link, one click away from being sent
+  // to someone who was just archived.
+  document.getElementById('email-regen').onclick = () => {
+    if (!emailApplicantId) return;
+    if (emailMode === 'update') openUpdateEmail(emailApplicantId);
+    else generateEmail(emailApplicantId);
+  };
   document.getElementById('email-send').onclick = async () => {
     if (!gmailStatus.connected) { toast('Connect the shared Gmail first (Emails tab)'); return; }
     const btn = document.getElementById('email-send');

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.40.1';
+const VERSION = '3.40.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1095,6 +1095,14 @@ let emailKind = null;         // typed draft override, e.g. 'visit'
 async function openEmailModal(applicantId, kind) {
   const a = applicants.find(x => x.id === applicantId);
   if (!a) return;
+  // Outreach is off for anyone who has been archived. Inviting someone to pick
+  // a time right after turning them down is the worst thing this app could
+  // send, so the drafter is unreachable for them rather than merely unused.
+  if (a.stage === 'rejected' || a.stage === 'archived') {
+    toast(`${fullName(a)} is archived — the only email left is their update`);
+    if (a.stage === 'rejected' && !a.updateSentAt && !a.updateSkippedAt) openUpdateEmail(applicantId);
+    return;
+  }
   emailApplicantId = applicantId;
   emailMode = 'outreach';
   emailKind = kind || null;
@@ -1170,6 +1178,11 @@ async function openUpdateEmail(applicantId) {
 }
 
 async function generateEmail(applicantId) {
+  const subject = applicants.find(x => x.id === applicantId);
+  if (subject && (subject.stage === 'rejected' || subject.stage === 'archived')) {
+    document.getElementById('email-status').textContent = 'Archived — no outreach for them.';
+    return;
+  }
   document.getElementById('email-status').textContent = 'Drafting…';
   try {
     const { data } = await sb.auth.getSession();
@@ -3588,6 +3601,11 @@ let availSelected = null;    // ISO of the slot picked in the modal, pre-confirm
 
 async function openAvailModal(applicantId) {
   const a = applicants.find(x => x.id === applicantId);
+  // Scheduling is outreach: off for anyone archived.
+  if (a && (a.stage === 'rejected' || a.stage === 'archived')) {
+    toast(`${fullName(a)} is archived — scheduling is off for them`);
+    return;
+  }
   if (!a) return;
   availApplicantId = applicantId;
   availSelected = null;

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.20.0'
+const VERSION = '1.21.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + Discord claim posts`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -498,6 +498,11 @@ serve(async (req) => {
     if (action === 'send') {
       const { data: applicant } = await client.from('recruit_applicants').select('*').eq('id', String(body.applicantId || '')).maybeSingle()
       if (!applicant?.email?.includes('@')) return json({ error: 'Applicant has no email' }, 400)
+      // Outreach can never reach someone who has been archived. 'send-update'
+      // is the only channel left for them, and it carries no invitation.
+      if (applicant.stage === 'rejected' || applicant.stage === 'archived') {
+        return json({ error: 'They are archived — only their update email can be sent' }, 409)
+      }
       const subject = String(body.subject || '').slice(0, 300)
       const text = String(body.body || '').slice(0, 10000)
       if (!subject || !text) return json({ error: 'Subject and body required' }, 400)

--- a/supabase/functions/recruit-match/index.ts
+++ b/supabase/functions/recruit-match/index.ts
@@ -11,7 +11,7 @@
 //                                    fresh (<7d) suggestion
 // Response: { suggestions: [{ applicantId, listingId, confidence, rationale, flags }] }
 
-const VERSION = '1.10.0'
+const VERSION = '1.10.1'
 console.log(`[recruit-match] v${VERSION} — AI listing match for Agape applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -362,9 +362,10 @@ Their application said:
 ${survey}
 
 Rules:
-- Name something specific and true from their answers — an interest, a craft, something they offered to share.
-- Do not evaluate them, rank them, hint at reasons, or explain the decision.
-- Do not promise a future spot, a call, or a reconsideration.
+- Speak ONLY to what they told us about themselves — an interest, a craft, something they offered to share. Name it specifically.
+- Never mention the decision, the outcome, the room, the house's choice, or "at this time". The sentences around yours already carry that; repeating it makes the email read like a form letter.
+- Do not use the words "application", "applied", "process", "review", or "considered".
+- Do not evaluate them, rank them, hint at reasons, or promise a future spot.
 - No greeting and no sign-off, just the sentences. Under 60 words.`,
             300,
           )


### PR DESCRIPTION
Verifying v3.40.0 in Chrome surfaced a genuinely dangerous path, now closed three ways.

**What happened:** in the rejection editor, **Regenerate** called the outreach drafter. It produced "Hi from Agape! (co-op in the Mission)" with a booking link and "let's do a quick call" — for someone who had just been archived, one click away from **Send update**.

**Fixes**

1. Regenerate now redrafts the update when `emailMode === 'update'`.
2. Outreach is unreachable for archived people, not merely unused: `openEmailModal` and `generateEmail` refuse and point at the update email; `openAvailModal` (availability + scheduling) refuses.
3. Server-side guarantee: `recruit-gmail`'s `send` action returns 409 for any applicant whose stage is `rejected` or `archived`. `send-update` is the only channel left for them, and it never invites.

**Also:** the personal paragraph was restating the decision ("we have decided not to move forward at this time"), duplicating the template sentence above it. The prompt now forbids mentioning the decision or the outcome — it may only speak to what the applicant wrote about themselves.

applications v3.40.2 · recruit-gmail v1.21.0 · recruit-match v1.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)