### PR TITLE
recruiting: import the sheet's review comments (v3.40.3)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.40.2">
+  <link rel="stylesheet" href="css/app.css?v=3.40.3">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -303,7 +303,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.40.2"></script>
+  <script src="js/app.js?v=3.40.3"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.40.2';
+const VERSION = '3.40.3';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -560,7 +560,7 @@ async function loadAll() {
   const [aRes, dRes, cRes, eRes, vRes, scRes, avRes, pRes, vwRes, cpRes, dvRes] = await Promise.all([
     sb.from('recruit_applicants').select('*').order('submitted_at', { ascending: false }),
     sb.from('recruit_decisions').select('*'),
-    sb.from('recruit_comments').select('applicant_id, author_name, body, created_at').order('created_at'),
+    sb.from('recruit_comments').select('applicant_id, author_name, body, created_at, source').order('created_at'),
     // Full rows, not just the state columns: this is also what hydrates
     // emailsCache so a profile can render its thread before any Gmail
     // round-trip. body_text is the one heavy column and stays out — the
@@ -1736,7 +1736,7 @@ function renderWatchNotes() {
       <div class="note__body-wrap">
         <div class="note__meta">
           <span class="note__author">${esc(c.author_name || 'Housemate')}</span>
-          <span class="note__time">${relTime(c.created_at)}</span>
+          <span class="note__time">${relTime(c.created_at)}${c.source === 'sheet' ? ' · from the application sheet' : ''}</span>
         </div>
         <p class="note__body">${esc(c.body)}</p>
       </div>
@@ -3348,7 +3348,7 @@ function renderNotes(applicantId) {
       <div class="note__body-wrap">
         <div class="note__meta">
           <span class="note__author">${esc(c.author_name || 'Housemate')}</span>
-          <span class="note__time">${relTime(c.created_at)}</span>
+          <span class="note__time">${relTime(c.created_at)}${c.source === 'sheet' ? ' · from the application sheet' : ''}</span>
         </div>
         <p class="note__body">${esc(c.body)}</p>
       </div>

--- a/supabase/functions/recruit-ingest/index.ts
+++ b/supabase/functions/recruit-ingest/index.ts
@@ -19,7 +19,7 @@
 // timestamp, and inserts ignore duplicates — so resending the whole sheet is
 // a safe backfill, not a mess of copies.
 
-const VERSION = '1.3.0'
+const VERSION = '1.4.0'
 console.log(`[recruit-ingest] v${VERSION} — application sheet → recruit_applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -208,6 +208,16 @@ serve(async (req) => {
         const k = Object.keys(r).find((h) => /e-?mail/i.test(h))
         return k ? String(r[k] || '').trim().toLowerCase() : ''
       }
+      // A comment's anchor is an opaque range id, but Drive hands back the
+      // quoted cell — which for these threads is the row's Timestamp. That
+      // string identifies the submission exactly, so it's the match key.
+      const stampOf = (r: Record<string, unknown>) => {
+        const k = Object.keys(r).find((h) => /timestamp|submitted/i.test(h))
+        return k ? String(r[k] || '').trim() : ''
+      }
+      const normStamp = (v: string) => v.replace(/\s+/g, ' ').trim()
+      const byStamp = new Map<string, Record<string, unknown>>()
+      for (const r of sheetRows) { const st = normStamp(stampOf(r)); if (st) byStamp.set(st, r) }
       const { data: appRows } = await client.from('recruit_applicants').select('id, email, first_name, last_name')
       const byEmail = new Map((appRows || []).map((a: any) => [String(a.email || '').toLowerCase(), a]))
 
@@ -238,20 +248,20 @@ serve(async (req) => {
         // Resolve the applicant: the anchor's row number first, then the
         // quoted cell text (an email, or a name).
         let applicant: any = null
-        const rowNum = Number((String(t.anchor || '').match(/[A-Z]+(\d+)/) || [])[1] || 0)
-        if (rowNum > 1 && sheetRows[rowNum - 2]) applicant = byEmail.get(emailOf(sheetRows[rowNum - 2])) || null
-        if (!applicant) {
-          const quoted = String(t.quotedFileContent?.value || '').trim()
+        const quoted = normStamp(String(t.quotedFileContent?.value || ''))
+        const stampRow = quoted ? byStamp.get(quoted) : null
+        if (stampRow) applicant = byEmail.get(emailOf(stampRow)) || null
+        if (!applicant && quoted) {
           const em = quoted.match(/[\w.+-]+@[\w-]+\.[\w.]+/)
           if (em) applicant = byEmail.get(em[0].toLowerCase()) || null
-          if (!applicant && quoted) {
+          if (!applicant) {
             const q = quoted.toLowerCase()
             applicant = (appRows || []).find((a: any) =>
               q === `${a.first_name} ${a.last_name}`.toLowerCase().trim() ||
               q === String(a.email || '').toLowerCase()) || null
           }
         }
-        if (!applicant) { unmatched.push({ author: authorName, body: body.slice(0, 120), anchor: t.anchor || null }); continue }
+        if (!applicant) { unmatched.push({ author: authorName, body: body.slice(0, 120), anchor: t.anchor || null, quoted: t.quotedFileContent?.value || null }); continue }
 
         // Does the comment point at a decision? Only unmistakable language
         // counts; anything softer stays a comment for a human to read.


### PR DESCRIPTION
## How the match works

A Google comment thread's `anchor` is an opaque range id (`{"type":"workbook-range","range":"1247360061"}`) — the row can't be read from it. But Drive returns `quotedFileContent`, which for these threads is the row's **Timestamp** cell, and that identifies the submission exactly. Matching on the timestamp resolved **all 13 threads, none unmatched**.

## What it did

Imported 13 review comments across 13 applicants. Exactly one pointed to a decision — Kate's *"interviewed last year, not a fit"* — which archived **Linda Green** with the reason in Kate's own words. The other twelve are notes (fit observations, pros/cons), deliberately not turned into verdicts: only unmistakable decision language counts.

Kate's review carries `voter_email = kstoreyfisher@gmail.com`, so it displays under her name now and becomes editable by her the moment her Discord sign-in maps to that roster email. Author matching is surname + first initial, so "K Storey-Fisher" and "Kate Storey-Fisher" are the same person.

Re-running is a no-op — verified.

## Also

Notes and reviews that came from the sheet are labelled "from the application sheet" wherever they render, so their origin is never ambiguous.

Setup note: this needed the Drive API enabled in GCP project `add-to-calendar-477919` — same gap the Sheets API had. Done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)