### PR TITLE
recruiting: auto-advance after archiving, email checkbox, auto-archive tag (v3.42.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -402,6 +402,17 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   flex-shrink: 0;
 }
 .review__bar-actions { display: inline-flex; align-items: center; gap: var(--space-2); }
+/* Auto-advance banner: what just happened, and the way back. */
+.review__banner {
+  display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  margin: 0 auto var(--space-3); max-width: 720px; padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm); background: var(--bg-surface);
+  border: 1px solid var(--border); color: var(--fg-muted);
+  font-size: var(--font-size-small);
+}
+.review__banner[hidden] { display: none; }
+.review__banner b { color: var(--fg); font-weight: var(--fw-semibold); }
+.review__banner button { margin-left: auto; }
 .review__dots { display: inline-flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; }
 .review__dot {
   width: 8px; height: 8px; border-radius: 999px;
@@ -1054,6 +1065,13 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .vote-bar__verdict.is-not-fit.is-on { background: rgba(168, 32, 13, 0.16); box-shadow: inset 0 0 0 1.5px var(--error); }
 .vote-bar__verdict.is-needs-input.is-on { background: var(--bg-overlay); box-shadow: inset 0 0 0 1.5px var(--border-strong); }
 .vote-bar__verdict.is-forward.is-on { background: #9FE870; border-color: #9FE870; color: #163300; }
+/* "Send them an update" rides with the archive decision, so the choice to
+   email is made once, in the same gesture. Only shown for Not a fit. */
+.vote-bar__email {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: var(--font-size-small); color: var(--fg-muted); cursor: pointer;
+}
+.vote-bar__email input { accent-color: var(--accent); cursor: pointer; }
 .vote-bar__note { flex: 1 1 180px; min-width: 0; height: 44px; }
 .vote-bar__cast { height: 44px; border-radius: var(--radius-pill); }
 .vote-bar__cast[disabled] { opacity: 0.5; cursor: not-allowed; }

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1084,6 +1084,13 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .verdict-tag.is-not-fit { background: rgba(168, 32, 13, 0.16); color: var(--error); }
 .verdict-tag.is-forward { background: rgba(159, 232, 112, 0.18); color: #7FC24E; }
+
+/* Automatic decisions read as the system's, never a housemate's. */
+.decision-chip--auto {
+  background: var(--bg-overlay); color: var(--fg-muted);
+  border: 1px dashed var(--border-strong);
+}
+.decision-banner__label .decision-chip--auto { margin-left: var(--space-2); }
 @media (max-width: 720px) {
   .vote-bar__q { flex-basis: 100%; }
   .vote-bar__verdicts { flex-basis: 100%; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.40.3">
+  <link rel="stylesheet" href="css/app.css?v=3.41.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -88,6 +88,9 @@
       <div id="review-progress"></div>
       <button class="review__close" id="review-close" aria-label="Close">✕</button>
     </div>
+    <!-- Carries the last decision onto the next applicant, so auto-advance
+         never leaves you wondering what just happened. -->
+    <div class="review__banner" id="review-banner" hidden></div>
     <div class="review__scroll"><div class="review__inner" id="review-body"></div></div>
     <!-- Contextual: vote bar while in review, recruiter actions for candidates. -->
     <div class="review__foot" id="review-foot"></div>
@@ -303,7 +306,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.40.3"></script>
+  <script src="js/app.js?v=3.41.0"></script>
 
 </body>
 </html>

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.41.0">
+  <link rel="stylesheet" href="css/app.css?v=3.42.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -306,7 +306,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.41.0"></script>
+  <script src="js/app.js?v=3.42.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.41.0';
+const VERSION = '3.42.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -1344,11 +1344,19 @@ async function castVote(applicantId) {
 /* House rule: a stated budget ceiling under $1,500/mo is an auto-flag —
    straight to Archive (rejected: an update email is owed). Recorded as a
    decision too, for attribution and undo. */
+/* Attribution for decisions the app made on its own. Anything carrying this
+   name is tagged as automatic wherever it's shown, so nobody reads a house
+   rule as a housemate's call. */
+const AUTO_DECIDER = 'House rule';
+const isAutoDecision = rec => rec?.byName === AUTO_DECIDER || /^Auto[\s—-]/.test(rec?.byName || '');
+const fmtMoney = n => n == null ? '' : `$${Number(n).toLocaleString()}`;
+
 async function applyAutoFlags() {
   const auto = applicants.filter(a => a.stage === 'review' && !decisions[a.id]
     && budgetMax(a.budget) !== null && budgetMax(a.budget) < 1500);
   for (const a of auto) {
-    await saveDecision(a.id, 'pass', 'budget', 'Auto — budget under $1,500');
+    await saveDecision(a.id, 'pass', 'budget', AUTO_DECIDER,
+      `Budget tops out at ${fmtMoney(budgetMax(a.budget))}/mo — under the $1,500 house floor.`);
     await setStage(a.id, 'rejected');
   }
   return auto.length;
@@ -1510,6 +1518,12 @@ function voteChip(a) {
 }
 
 function stageChip(a) {
+  const rec = decisions[a.id];
+  if (isAutoDecision(rec)) {
+    const why = rec.note || (rec.reason ? reasonLabel(rec.reason) : 'A house rule archived them');
+    return `<span class="decision-chip decision-chip--auto" title="${esc(why)}">Auto-archived</span>` +
+      (a.stage === 'rejected' ? `<span class="decision-chip decision-chip--hold" title="${esc(why)}">Update queued</span>` : '');
+  }
   if (a.stage === 'rejected') {
     const st = voteStats(a.id);
     const why = st.notFit ? `Not a fit — ${reviewerName(st.notFit)}: “${st.notFit.note}”` : (decisions[a.id]?.note || 'Did not pass review');
@@ -2000,7 +2014,7 @@ function renderApplicants() {
         </div>
         ${pending.map(x => `<div class="update-tray__row">
           <span class="update-tray__who">${esc(fullName(x))}</span>
-          <span class="update-tray__why">${voteStats(x.id).notFit ? `not a fit — ${esc(reviewerName(voteStats(x.id).notFit))}` : (decisions[x.id]?.note || 'did not pass review')}</span>
+          <span class="update-tray__why">${isAutoDecision(decisions[x.id]) ? `auto-archived — ${esc(decisions[x.id].note || reasonLabel(decisions[x.id].reason))}` : voteStats(x.id).notFit ? `not a fit — ${esc(reviewerName(voteStats(x.id).notFit))}` : (decisions[x.id]?.note || 'did not pass review')}</span>
           <button type="button" class="cta-link" data-update-edit="${x.id}">Edit email</button>
           <button type="button" class="cta-link" data-update-skip="${x.id}">Skip</button>
         </div>`).join('')}
@@ -3140,11 +3154,13 @@ function renderReview() {
   const archived = a.stage === 'rejected' || a.stage === 'archived';
   const archiveBanner = () => {
     const st = voteStats(a.id);
-    const why = st.notFit ? `Not a fit — ${reviewerName(st.notFit)}${st.notFit.note ? `: “${st.notFit.note}”` : ''}`
+    const auto = isAutoDecision(rec);
+    const why = auto ? (rec.note || reasonLabel(rec.reason) || 'A house rule archived them')
+      : st.notFit ? `Not a fit — ${reviewerName(st.notFit)}${st.notFit.note ? `: “${st.notFit.note}”` : ''}`
       : rec?.note || (rec?.reason ? reasonLabel(rec.reason) : 'Did not pass review');
     return `<div class="decision-banner decision-banner--pass">
       <div class="decision-banner__text">
-        <span class="decision-banner__label">${a.stage === 'rejected' ? 'Archived — update email queued' : 'Archived'}</span>
+        <span class="decision-banner__label">${auto ? 'Archived by a house rule' : a.stage === 'rejected' ? 'Archived — update email queued' : 'Archived'}${auto ? `<span class="decision-chip decision-chip--auto">Automatic</span>` : ''}</span>
         <span class="decision-banner__meta">${esc(why)}</span>
       </div>
       <span class="decision-banner__actions">
@@ -4199,7 +4215,7 @@ async function _checkMembershipAndEnter() {
     if (!VIEWS[view]) view = 'openings';
     pendingOccRoom = view === 'occupancy' ? +new URLSearchParams(location.search).get('room') || null : null;
     render();
-    if (autoFlagged) toast(`${autoFlagged} applicant${autoFlagged === 1 ? '' : 's'} auto-archived (budget under $1,500) — update emails queued`);
+    if (autoFlagged) toast(`${autoFlagged} applicant${autoFlagged === 1 ? '' : 's'} auto-archived by the $1,500 budget floor — tagged, with update emails queued`);
     const deep = new URLSearchParams(location.search).get('a');
     if (deep && applicants.some(x => x.id === deep)) openReview(deep);
     const linkEv = new URLSearchParams(location.search).get('link');

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.40.3';
+const VERSION = '3.41.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -107,6 +107,7 @@ let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
 let houseEvents = {};         // applicant_id -> non-intro_call calendar rows
 let pendingVerdict = null;    // 'not_fit' | 'needs_input' | 'forward' while the review bar is open
+let sendUpdateWith = true;    // "Send them an update" rides with a Not-a-fit decision
 let commentCounts = {};       // applicant_id -> n
 let latestNotes = {};         // applicant_id -> { author, body }
 let comments = [];            // comments for the applicant open in review
@@ -1305,13 +1306,37 @@ async function castVote(applicantId) {
   const before = a.stage;
   if (fresh) a.stage = fresh.stage;
   const verdict = pendingVerdict;
+  const wantsUpdate = document.getElementById('vote-send-update')?.checked ?? sendUpdateWith;
   pendingVerdict = null;
-  if (verdict === 'not_fit') toast(`${fullName(a)} archived — update email queued`);
-  else if (a.stage === 'candidate' && before !== 'candidate') {
+  if (verdict === 'not_fit') {
+    // The email decision was made on the decision step, so honour it here
+    // rather than asking again.
+    if (!wantsUpdate) {
+      const { error: skipErr } = await sb.rpc('recruit_skip_update', { p_applicant: applicantId });
+      if (skipErr) toast(`Archived, but the email couldn't be marked skipped: ${skipErr.message}`);
+      else { a.updateSkippedAt = new Date().toISOString(); a.stage = 'archived'; }
+    }
+    renderRailCounts();
+    // Auto-advance: their profile has nothing left to do on it. The banner
+    // carries the outcome onto the next applicant.
+    const summary = `${fullName(a)} archived — ${wantsUpdate ? 'update email queued' : 'no email sent'}`;
+    // Last in the queue means step() closes the overlay, taking the banner with
+    // it, so say it in a toast instead.
+    if (qIndex >= queue.length - 1) toast(summary);
+    else {
+      showReviewBanner(`<span><b>${esc(fullName(a))}</b> archived — ${wantsUpdate ? 'update email queued' : 'no email sent'}</span>
+        <button type="button" class="cta-link" data-reopen="${a.id}">Undo</button>`);
+      keepBannerOnce = true;
+    }
+    step(1);
+    if (wantsUpdate) openUpdateEmail(applicantId);
+    return;
+  }
+  if (a.stage === 'candidate' && before !== 'candidate') {
     if (!houseLoaded) await loadHouse();
     const added = await syncAutoPlacements();
     toast(`${fullName(a)} moved forward → Candidates${added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : ''}`);
-  } else toast(`Saved — flagged for another housemate to read`);
+  } else toast('Saved — flagged for another housemate to read');
   renderRailCounts();
   renderReview();
 }
@@ -3043,10 +3068,30 @@ function openReview(id) {
 function closeReview() {
   document.getElementById('review').hidden = true;
   document.body.style.overflow = '';
+  hideReviewBanner();
   gpSyncPlacement(); // a playing call follows you out to the list
   const url = new URL(location); url.searchParams.delete('a');
   history.replaceState(null, '', url);
   render();
+}
+
+/* One line of "what just happened" that survives auto-advance. Carries the way
+   back, since undoing a decision you made a second ago shouldn't mean hunting
+   through Archive for the person. */
+let bannerTimer = null;
+let keepBannerOnce = false;   // set when the banner explains the step we're taking
+function showReviewBanner(html) {
+  const el = document.getElementById('review-banner');
+  if (!el) return;
+  el.innerHTML = html;
+  el.hidden = false;
+  clearTimeout(bannerTimer);
+  bannerTimer = setTimeout(() => { el.hidden = true; }, 12000);
+}
+function hideReviewBanner() {
+  clearTimeout(bannerTimer);
+  const el = document.getElementById('review-banner');
+  if (el) { el.hidden = true; el.innerHTML = ''; }
 }
 
 function step(delta) {
@@ -3054,7 +3099,10 @@ function step(delta) {
   if (next < 0 || next >= queue.length) { if (delta > 0) closeReview(); return; }
   qIndex = next;
   pendingVerdict = null;
+  sendUpdateWith = true;
   moveinEditing = false;
+  if (!keepBannerOnce) hideReviewBanner();
+  keepBannerOnce = false;
   hideHoldSheet();
   renderReview();
   resetScroll();
@@ -3251,6 +3299,8 @@ function renderReviewFoot(a) {
   const foot = document.getElementById('review-foot');
   if (!foot) return;
   const keepNote = document.getElementById('vote-note')?.value ?? null;
+  const liveBox = document.getElementById('vote-send-update');
+  if (liveBox) sendUpdateWith = liveBox.checked;
   if (a.stage === 'review') {
     const mine = myVote(a.id);
     const sel = pendingVerdict || mine?.verdict || null;
@@ -3270,6 +3320,9 @@ function renderReviewFoot(a) {
         <input type="text" class="listing-status vote-bar__note" id="vote-note" maxlength="500"
           placeholder="Your comment (required)"
           value="${esc(keepNote ?? mine?.note ?? '')}">
+        ${sel === 'not_fit' ? `<label class="vote-bar__email" title="Unchecked, they're archived with nothing sent">
+          <input type="checkbox" id="vote-send-update" ${sendUpdateWith ? 'checked' : ''}> Send them an update
+        </label>` : ''}
         <button type="button" class="btn btn--accent vote-bar__cast" data-cast-vote ${sel ? '' : 'disabled'}>${confirmLabel}</button>
       </div>`;
   } else if (a.stage === 'candidate') {
@@ -3326,6 +3379,7 @@ async function reopenApplicant(id) {
       v.verdict === 'not_fit' || v.verdict === 'forward' ? { ...v, verdict: 'needs_input' } : v);
   }
   if (await setStage(id, 'review')) {
+    hideReviewBanner();
     toast(st0.decisive
       ? `Reopened — ${reviewerName(st0.decisive)}'s comment is kept as needing input`
       : 'Reopened — back in the Inbox');


### PR DESCRIPTION
Three changes to the archive path.

## The email choice moved onto the decision step
A **"Send them an update"** checkbox appears with **Not a fit**, checked by default. Unchecked runs `recruit_skip_update` so they're archived owing nothing; checked queues it and opens the editable draft. The separate offer in the archived footer stays for people archived by other paths.

## Archiving auto-advances
An archived profile has nothing left to do on it, so the queue moves to the next applicant and a banner carries the outcome across — "**Linda Green** archived — update email queued" with **Undo** beside it, since undoing a decision you made a second ago shouldn't mean hunting through Archive. The banner clears on the next manual step or when the overlay closes; at the end of the queue the overlay closes, so the same sentence goes to a toast.

Move forward deliberately does *not* auto-advance — that profile gains real follow-on actions (placements, outreach), so staying on it is the point.

## Auto-archived applicants say so, and say why
This was a bug, not a missing feature: `applyAutoFlags` passed its reason into `saveDecision`'s `byName` slot, so the budget floor stored *"Auto — budget under $1,500"* as the **decider** and left the note empty — the reason appeared nowhere. Now the note carries the reason (including the applicant's actual ceiling), attribution reads **House rule**, and anything attributed that way is tagged:

- Archive rows: an `Auto-archived` chip, reason on hover
- Profile banner: "Archived by a house rule" + an `Automatic` chip + the reason
- Update tray: "auto-archived — <reason>"
- Load toast names the rule rather than just counting

The one existing row (Grace Reed) was repaired in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)