### PR TITLE
recruiting: promote a trial candidate to resident (v3.43.0, migration 141)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1015,6 +1015,20 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   padding-top: var(--space-3); border-top: 1px solid var(--border);
 }
 .occ-drawer__trial[hidden] { display: none; }
+/* v3.41: candidate → resident promotion + onboarding checklist */
+.occ-drawer__promote {
+  display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  padding-bottom: var(--space-3); border-bottom: 1px solid var(--border);
+}
+.occ-drawer__promote--open { display: grid; gap: var(--space-2); }
+.occ-drawer__promote-hint { font-size: var(--font-size-caption); color: var(--fg-subtle); flex: 1 1 12rem; }
+.occ-drawer__onboard { padding-top: var(--space-3); border-top: 1px solid var(--border); }
+.onboard-list { list-style: none; margin: var(--space-2) 0 0; padding: 0; display: grid; gap: var(--space-1); }
+.onboard-item label {
+  display: flex; align-items: center; gap: var(--space-2);
+  font-size: var(--font-size-small); color: var(--fg); cursor: pointer;
+}
+.onboard-item.is-done label { color: var(--fg-subtle); text-decoration: line-through; }
 .occ-drawer__facts { margin: 0; display: flex; flex-direction: column; gap: var(--space-2); }
 .occ-drawer__fact { display: flex; justify-content: space-between; gap: var(--space-3); font-size: var(--font-size-small); }
 .occ-drawer__fact dt { color: var(--fg-subtle); }

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.40.3';
+const VERSION = '3.41.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -76,8 +76,27 @@ const REMOVE_OPTIONS = [
     hint: 'our no — queues an update email',
     chip: 'not a fit', stage: 'rejected', danger: true,
   },
+  // The residency decision going the other way. Kept distinct from "not a
+  // fit" so the archive can tell "we lived with them and it didn't work"
+  // apart from "we never got that far".
+  {
+    id: 'trial_ended', label: 'Trial ended — not staying',
+    hint: 'they trialled with us and the house said no',
+    chip: 'trial ended', stage: 'archived', danger: true, trialOnly: true,
+  },
 ];
 const removeOption = id => REMOVE_OPTIONS.find(o => o.id === id) || null;
+
+/* Their live trial stay, if they have one. recruit_stays.applicant_id is the
+   link (migration 141) — before it existed the occupant was a bare name and
+   nothing could join the two sides together. Stays that predate the link
+   stay unmatched, which is why this can be null for a real trial candidate. */
+function trialStayFor(applicantId) {
+  if (!applicantId || !houseLoaded) return null;
+  const today = new Date().toISOString().slice(0, 10);
+  return stays.find(s => s.kind === 'candidate' && s.applicant_id === applicantId
+    && (!s.ends_on || s.ends_on >= today)) || null;
+}
 // Default return date for Save for future: three months out, month start.
 function defaultReturnDate() {
   const d = new Date();
@@ -115,6 +134,7 @@ let filters = { track: 'all', month: 'any', budget: 'any' }; // shared across ap
 let rooms = [];               // recruit_rooms
 let stays = [];               // recruit_stays rows (date-based tenures)
 let listings = [];            // recruit_listings rows
+let onboarding = [];          // recruit_onboarding rows (checklist per resident stay)
 let houseLoaded = false;
 let settings = { open_to_couples: true };
 let gmailStatus = { connected: false };
@@ -974,8 +994,9 @@ function openRemoveSheet(applicantId, listingId = null) {
 
 function renderRemoveOptions() {
   const listingId = removeTarget?.listingId;
+  const onTrial = !!trialStayFor(removeTarget?.applicantId);
   document.getElementById('remove-options').innerHTML = REMOVE_OPTIONS
-    .filter(o => !o.scope || listingId)
+    .filter(o => (!o.scope || listingId) && (!o.trialOnly || onTrial))
     .map(o => `<button type="button" class="remove-sheet__option${removePick === o.id ? ' is-selected' : ''}${o.danger ? ' remove-sheet__option--danger' : ''}" data-remove-pick="${o.id}">
       <span class="remove-sheet__option-label">${esc(o.label)}</span>
       <span class="remove-sheet__option-hint">${esc(o.hint)}</span>
@@ -1337,14 +1358,16 @@ async function loadComments(applicantId) {
 
 /* ---------- house data ---------- */
 async function loadHouse() {
-  const [rRes, sRes, lRes] = await Promise.all([
+  const [rRes, sRes, lRes, oRes] = await Promise.all([
     sb.from('recruit_rooms').select('*').order('sort'),
     sb.from('recruit_stays').select('*').order('starts_on'),
     sb.from('recruit_listings').select('*').order('starts_on'),
+    sb.from('recruit_onboarding').select('*').order('sort'),
   ]);
   rooms = rRes.data || [];
   stays = sRes.data || [];
   listings = lRes.data || [];
+  onboarding = oRes.data || [];
   houseLoaded = true;
 }
 
@@ -1389,6 +1412,10 @@ async function render() {
 /* ---------- applicants render ---------- */
 function matchesView(a) {
   const out = a.stage !== 'rejected' && a.stage !== 'archived';
+  // They moved in. Not archived (that reads as a no) and not in the pipeline
+  // either — they live on the Occupancy calendar now, and every applicant
+  // rail should be quiet about them.
+  if (a.stage === 'resident') return false;
   // A "not a fit" verdict means archived — never show them here, whatever the
   // stage column says.
   if (view === 'inbox') return a.stage === 'review' && !voteStats(a.id).notFit;
@@ -1449,6 +1476,7 @@ function renderFilterBar(viewList) {
 function counts() {
   const c = { inbox: 0, candidates: 0, openings: 0, screening: 0, archive: 0 };
   for (const a of applicants) {
+    if (a.stage === 'resident') continue; // housed — counted nowhere in the funnel
     if (a.stage === 'rejected' || a.stage === 'archived') { c.archive++; continue; }
     if (a.stage === 'review') c.inbox++;
     else if (a.stage === 'candidate') c.candidates++;
@@ -2437,6 +2465,7 @@ function renderOccupancy() {
 
 /* --- right-hand drawer: stay editor, gap actions, or room details --- */
 function openOccDrawer(next) {
+  if (next?.type !== 'stay' || next.id !== promoting) promoting = null;
   occDrawer = next;
   document.querySelectorAll('.cal__event.is-editing, .cal__room-btn.is-editing').forEach(el => el.classList.remove('is-editing'));
   if (next?.type === 'stay') document.querySelector(`[data-stay="${next.id}"]`)?.classList.add('is-editing');
@@ -2479,6 +2508,105 @@ function trialFieldsHtml(s) {
     </div>
     <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. #recruiting-automation gets a reminder a week ahead of each.</p>
   </div>`;
+}
+
+/* --- candidate → resident ---
+   The decision reminder sends the house here. Promotion is a real state
+   change with three moving parts (close the trial, open the residency, move
+   the applicant's stage), so it goes through one RPC rather than the stay
+   form — a half-applied promotion would leave someone in two rooms or in
+   none. The form below still edits the trial itself; this is the door out. */
+let promoting = null;   // stay id currently showing the confirm strip
+
+function promoteBlockHtml(s) {
+  if (!s.id || s.kind !== 'candidate') return '';
+  const trialEnd = s.ends_on;
+  const start = trialEnd ? isoAddDays(trialEnd, 1) : new Date().toISOString().slice(0, 10);
+  if (promoting !== s.id) {
+    return `<div class="occ-drawer__promote">
+      <button type="button" class="btn btn--accent btn--sm" data-promote-open="${s.id}">Welcome them in</button>
+      <span class="occ-drawer__promote-hint">Ends the trial and starts an open-ended residency${trialEnd ? ` on ${fmtShort(start)}` : ''}.</span>
+    </div>`;
+  }
+  return `<form class="occ-drawer__promote occ-drawer__promote--open" data-promote-form="${s.id}">
+    <div class="occ-drawer__section">Welcome ${esc(s.occupant || 'them')} in</div>
+    <div class="occ-drawer__dates">
+      <label class="listing-form__field">Room
+        <select name="room_id" class="listing-status">
+          ${rooms.map(r => `<option value="${r.id}" ${r.id === s.room_id ? 'selected' : ''}>${esc(r.name)}</option>`).join('')}
+        </select>
+      </label>
+      <label class="listing-form__field">Resident from
+        <input type="date" name="starts_on" class="listing-status" value="${start}" required>
+      </label>
+    </div>
+    <p class="occ-drawer__note">The trial closes the day before, so the timeline has no gap. An onboarding checklist gets created for the house to work through.</p>
+    <p class="listing-form__error" data-promote-error></p>
+    <div class="decision-sheet__actions seg-form__actions">
+      <button type="button" class="hold-sheet__cancel" data-promote-cancel>Cancel</button>
+      <button type="submit" class="btn btn--accent btn--sm">Welcome them in</button>
+    </div>
+  </form>`;
+}
+
+/* --- onboarding checklist ---
+   Seeded by the promotion RPC, ticked by hand. Nothing here provisions
+   anything; it's the house's shared memory of what's still owed a new
+   resident. Hidden once every item is done — a finished list is noise. */
+function onboardingHtml(s) {
+  const items = onboarding.filter(o => o.stay_id === s.id)
+    .sort((a, b) => a.sort - b.sort);
+  if (!items.length) return '';
+  const left = items.filter(o => !o.done_at).length;
+  return `<div class="occ-drawer__onboard">
+    <div class="occ-drawer__section">Onboarding ${left ? `· ${left} left` : '· all done'}</div>
+    <ul class="onboard-list">
+      ${items.map(o => `<li class="onboard-item ${o.done_at ? 'is-done' : ''}">
+        <label>
+          <input type="checkbox" data-onboard="${o.id}" ${o.done_at ? 'checked' : ''}>
+          <span>${esc(o.item)}</span>
+        </label>
+      </li>`).join('')}
+    </ul>
+  </div>`;
+}
+
+async function toggleOnboarding(id, done) {
+  const row = onboarding.find(o => o.id === id);
+  if (!row) return;
+  const patch = done
+    ? { done_at: new Date().toISOString(), done_by: (await sb.auth.getUser()).data.user?.id || null }
+    : { done_at: null, done_by: null };
+  const { error } = await sb.from('recruit_onboarding').update(patch).eq('id', id);
+  if (error) { toast(`Could not save: ${error.message}`); return; }
+  Object.assign(row, patch);
+  renderOccDrawer();
+}
+
+async function submitPromote(form) {
+  const stayId = form.dataset.promoteForm;
+  const err = form.querySelector('[data-promote-error]');
+  const fd = new FormData(form);
+  const s = stays.find(x => x.id === stayId);
+  const startsOn = fd.get('starts_on');
+  if (!startsOn) { err.textContent = 'Pick the date their residency starts.'; return; }
+  if (s && startsOn <= s.starts_on) {
+    err.textContent = `Their residency has to start after the trial began (${fmtDay(s.starts_on)}).`;
+    return;
+  }
+  const { error } = await sb.rpc('recruit_promote_stay', {
+    p_stay_id: stayId,
+    p_room_id: +fd.get('room_id'),
+    p_starts_on: startsOn,
+  });
+  if (error) { err.textContent = error.message; return; }
+  promoting = null;
+  occDrawer = null;
+  // The RPC touched stays, onboarding, and possibly an applicant's stage.
+  await Promise.all([loadHouse(), loadAll()]);
+  toast(`${s?.occupant || 'They'} are a resident — onboarding checklist created`);
+  renderRailCounts();
+  renderOccupancy();
 }
 
 function stayFormHtml(s, roomId) {
@@ -2562,7 +2690,7 @@ function renderOccDrawer() {
     const room = rooms.find(r => r.id === s.room_id);
     title = s.occupant || KIND_LABELS[s.kind];
     sub = `${room?.name || 'Room'} · ${KIND_LABELS[s.kind]} · ${fmtShort(s.starts_on)} – ${s.ends_on ? fmtShort(s.ends_on) : 'ongoing'}`;
-    body = stayFormHtml(s, s.room_id);
+    body = promoteBlockHtml(s) + stayFormHtml(s, s.room_id) + onboardingHtml(s);
   } else if (occDrawer.type === 'gap') {
     const room = rooms.find(r => r.id === occDrawer.roomId);
     title = `${room?.name || 'Room'} — open`;
@@ -2590,33 +2718,51 @@ function renderOccDrawer() {
       <div class="occ-drawer__body">${body}</div>
     </aside>`;
   hostWrap.querySelector('[data-stay-form]')?.addEventListener('submit', onStaySave);
-  const ongoing = hostWrap.querySelector('input[name="ongoing"]');
-  if (ongoing) ongoing.addEventListener('change', e => {
-    const ends = hostWrap.querySelector('input[name="ends_on"]');
-    ends.disabled = e.target.checked;
-    if (e.target.checked) ends.value = '';
-    syncTrialFields(hostWrap);
+  hostWrap.querySelector('[data-promote-open]')?.addEventListener('click', e => {
+    promoting = e.currentTarget.dataset.promoteOpen;
+    renderOccDrawer();
   });
+  hostWrap.querySelector('[data-promote-cancel]')?.addEventListener('click', () => {
+    promoting = null;
+    renderOccDrawer();
+  });
+  hostWrap.querySelector('[data-promote-form]')?.addEventListener('submit', e => {
+    e.preventDefault();
+    submitPromote(e.target);
+  });
+  hostWrap.querySelectorAll('[data-onboard]').forEach(box => {
+    box.addEventListener('change', () => toggleOnboarding(box.dataset.onboard, box.checked));
+  });
+  // Scoped to the stay form on purpose: the promote form above it has its own
+  // starts_on, and an unscoped lookup here read that instead — recomputing the
+  // check-in default off the residency date rather than the trial's.
   const form = hostWrap.querySelector('[data-stay-form]');
   if (form) {
+    const ongoing = form.querySelector('input[name="ongoing"]');
+    if (ongoing) ongoing.addEventListener('change', e => {
+      const ends = form.querySelector('input[name="ends_on"]');
+      ends.disabled = e.target.checked;
+      if (e.target.checked) ends.value = '';
+      syncTrialFields(form);
+    });
     for (const sel of ['select[name="kind"]', 'input[name="starts_on"]', 'input[name="ends_on"]']) {
-      form.querySelector(sel)?.addEventListener('change', () => syncTrialFields(hostWrap));
+      form.querySelector(sel)?.addEventListener('change', () => syncTrialFields(form));
     }
-    syncTrialFields(hostWrap);
+    syncTrialFields(form);
   }
 }
 
 /* Show the milestone block only for trial candidates, and keep the suggested
    dates in step with the stay window until someone edits them by hand. */
-function syncTrialFields(hostWrap) {
-  const block = hostWrap.querySelector('[data-trial-fields]');
+function syncTrialFields(form) {
+  const block = form.querySelector('[data-trial-fields]');
   if (!block) return;
-  const kind = hostWrap.querySelector('select[name="kind"]')?.value;
+  const kind = form.querySelector('select[name="kind"]')?.value;
   block.hidden = kind !== 'candidate';
   if (block.hidden) return;
-  const startsOn = hostWrap.querySelector('input[name="starts_on"]')?.value || '';
-  const endsOn = hostWrap.querySelector('input[name="ongoing"]')?.checked
-    ? '' : (hostWrap.querySelector('input[name="ends_on"]')?.value || '');
+  const startsOn = form.querySelector('input[name="starts_on"]')?.value || '';
+  const endsOn = form.querySelector('input[name="ongoing"]')?.checked
+    ? '' : (form.querySelector('input[name="ends_on"]')?.value || '');
   const checkin = block.querySelector('input[name="checkin_on"]');
   const decision = block.querySelector('input[name="decision_on"]');
   if (!checkin.dataset.touched) checkin.value = trialCheckinDefault(startsOn);
@@ -3289,11 +3435,17 @@ function renderReviewFoot(a) {
           <button type="button" class="cta-link cta-link--danger" data-open-remove="${a.id}|">Remove…</button>
         </span>`;
     } else {
+      // Mid-trial, the question stops being "which listing?" and becomes
+      // "do they stay?". Promotion takes over the primary slot; the listing
+      // controls stay available behind it.
+      const trial = trialStayFor(a.id);
       foot.innerHTML = `
         ${pills ? `<span class="foot-pills">${pills}</span>` : ''}
-        <span class="foot-cta">${openingsCta(a)}</span>
+        <span class="foot-cta">${trial
+          ? `<button class="btn btn--accent review__btn" data-promote-applicant="${a.id}">Welcome them in</button>`
+          : openingsCta(a)}</span>
         <span class="foot-links">
-          <button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Move to a different listing' : 'Add to a listing'}</button>
+          ${trial ? '' : `<button type="button" class="cta-link" data-open-decision="outreach">${activePlacements(a.id).length ? 'Move to a different listing' : 'Add to a listing'}</button>`}
           <button type="button" class="cta-link cta-link--danger" data-open-remove="${a.id}|">Remove…</button>
         </span>`;
     }
@@ -4344,6 +4496,22 @@ function init() {
     if (orm) {
       const [aid, lid] = orm.dataset.openRemove.split('|');
       openRemoveSheet(aid, lid || null);
+      return;
+    }
+    // Promotion is confirmed against the stay (room + start date), so the
+    // profile hands off to the occupancy drawer rather than duplicating the
+    // form here. One place decides what a promotion means.
+    const promo = e.target.closest('[data-promote-applicant]');
+    if (promo) {
+      const trial = trialStayFor(promo.dataset.promoteApplicant);
+      if (!trial) { toast("No trial stay on the calendar for them yet — add one in Occupancy first"); return; }
+      closeReview();
+      setView('occupancy');
+      // After setView, not before: renderOccupancy would otherwise open a
+      // room drawer over the top and clear the pending promotion.
+      promoting = trial.id;
+      openOccDrawer({ type: 'stay', id: trial.id });
+      document.querySelector(`[data-stay="${trial.id}"]`)?.scrollIntoView({ block: 'nearest' });
       return;
     }
     const rpick = e.target.closest('[data-remove-pick]');

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -79,5 +79,39 @@ corrected after the fact isn't news.
 Backfilled on the two live trials (Alejandra, Sophia); Andy's finished Jan–Feb
 trial was left alone.
 
+### v3.41.0 (2026-07-29): candidate → resident
+The end of the funnel finally exists. Migration 141:
+
+- **`recruit_stays.applicant_id`** — the missing link. Until now the person in
+  the room was a free-text name with no way back to the application they came
+  from, so nothing could join the two halves of the app together. Nullable:
+  most residents predate the funnel.
+- **`stage = 'resident'`** — a terminal state that isn't a rejection. Drops
+  them out of the auto-placement sweep and every applicant rail for free.
+- **`recruit_onboarding`** — a checklist seeded on promotion, ticked by hand,
+  each row carrying who ticked it. Deliberately **not** a provisioning
+  integration: it's the house's shared memory of what a new resident is still
+  owed (Google Group, Notion, Discord role, buddy, chore rotation, keys).
+- **`recruit_promote_stay` / `recruit_promote_candidate`** — one transaction:
+  close the trial the day before, open an open-ended residency, move the
+  stage, retire their listing placements. Two entry points because two kinds
+  of people get promoted — a candidate the funnel knows, and whoever is in a
+  trial stay. Two of the three trials on the board right now (Sophia, Andy)
+  have no application row at all, so a promotion keyed only on
+  `recruit_applicants` would have been useless for them.
+
+**UX.** The residency-decision reminder links into Occupancy. A trial stay's
+drawer leads with **Welcome them in**, which expands to room + start date
+(defaulting to the trial room and the day after the trial ends) and confirms.
+The candidate profile shows the same action and hands off to the drawer rather
+than duplicating the form. Saying no uses the existing Remove… sheet, which
+gains a **Trial ended — not staying** reason (shown only for someone actually
+on a trial) so the archive can tell "we lived with them and it didn't work"
+apart from "we never got that far".
+
+Not built: a Discord announcement on promotion. It needs an authenticated
+route on `recruit-discord`, and the checklist already gives the house the
+signal. Worth revisiting if promotions start getting missed.
+
 ### Design reference
 Row states, chip taxonomy, and subcopy grammar for Inbox/Candidates/Openings: [docs/ux/recruiting-row-states.md](../../ux/recruiting-row-states.md) (v3.5.0 — response dot, room pills, note bubble, ✕ removal, see-more bar).

--- a/supabase/migrations/141_recruit_promote_resident.sql
+++ b/supabase/migrations/141_recruit_promote_resident.sql
@@ -1,0 +1,252 @@
+-- ============================================
+-- Migration 141: candidate → resident
+--
+-- The trial ends and the house says yes. Until now that had no home in the
+-- data: the applicant stayed a "candidate" forever (or got archived, which
+-- reads as a rejection), and the person in the room was a free-text name with
+-- no link back to the application they came from.
+--
+-- Three pieces:
+--   1. recruit_stays.applicant_id — the missing link. Nullable, because most
+--      stays are founding residents who never applied through the funnel.
+--   2. stage 'resident' — a terminal, non-rejecting end state. Drops them out
+--      of the auto-placement sweep (which filters stage = 'candidate') for
+--      free, and out of the Candidates rail.
+--   3. recruit_onboarding — the post-promotion checklist. Rows, not a JSONB
+--      blob, so each item carries who ticked it and when.
+--
+-- The promotion itself is one RPC, not four client writes: closing the trial
+-- stay, opening the resident stay, moving the stage, and clearing placements
+-- have to happen together or not at all.
+-- ============================================
+
+-- 1. Link a stay to the application it came from.
+ALTER TABLE recruit_stays
+  ADD COLUMN IF NOT EXISTS applicant_id TEXT REFERENCES recruit_applicants(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_recruit_stays_applicant
+  ON recruit_stays (applicant_id) WHERE applicant_id IS NOT NULL;
+
+COMMENT ON COLUMN recruit_stays.applicant_id IS
+  'The application this stay came from. NULL for residents who predate the funnel.';
+
+-- Backfill the live trials by name. Deliberately narrow: candidate stays
+-- only, exact first-name match, and only when that name resolves to exactly
+-- one applicant in the whole table. A wrong link here would be worse than no
+-- link, so ambiguity is left NULL for a human.
+--
+-- Not filtered by stage on purpose. Alejandra is sitting in Priest on a trial
+-- while her application row says 'archived' — the two surfaces drifted apart,
+-- which is precisely the drift applicant_id exists to stop. Identity is what
+-- the match is for; her stage is a separate question.
+UPDATE recruit_stays s SET applicant_id = m.id
+FROM (
+  SELECT a.id, LOWER(TRIM(a.first_name)) AS fn FROM recruit_applicants a
+) m
+WHERE s.kind = 'candidate' AND s.applicant_id IS NULL
+  AND LOWER(TRIM(s.occupant)) = m.fn
+  AND (SELECT COUNT(*) FROM recruit_applicants a2
+       WHERE LOWER(TRIM(a2.first_name)) = m.fn) = 1;
+
+-- 2. 'resident' is an outcome, not an archive.
+ALTER TABLE recruit_applicants DROP CONSTRAINT IF EXISTS recruit_applicants_stage_check;
+ALTER TABLE recruit_applicants ADD CONSTRAINT recruit_applicants_stage_check
+  CHECK (stage IN ('review', 'candidate', 'resident', 'rejected', 'archived'));
+
+CREATE OR REPLACE FUNCTION recruit_set_stage(p_applicant TEXT, p_stage TEXT)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  IF p_stage NOT IN ('review', 'candidate', 'resident', 'rejected', 'archived') THEN
+    RAISE EXCEPTION 'unknown stage %', p_stage;
+  END IF;
+  UPDATE recruit_applicants SET stage = p_stage WHERE id = p_applicant;
+END;
+$$;
+
+-- A trial that ends in "no" is its own exit reason — the archive should not
+-- read the same as someone who never got past the application.
+ALTER TABLE recruit_applicants DROP CONSTRAINT IF EXISTS recruit_applicants_exit_reason_chk;
+ALTER TABLE recruit_applicants ADD CONSTRAINT recruit_applicants_exit_reason_chk
+  CHECK (exit_reason IS NULL OR exit_reason IN ('future', 'opted_out', 'not_a_fit', 'trial_ended'));
+
+-- 3. Onboarding checklist. Seeded on promotion, ticked by hand. Nothing here
+--    provisions anything — it is the house's shared memory of what's left.
+CREATE TABLE IF NOT EXISTS recruit_onboarding (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  stay_id UUID NOT NULL REFERENCES recruit_stays(id) ON DELETE CASCADE,
+  item TEXT NOT NULL,
+  sort INT NOT NULL DEFAULT 0,
+  done_at TIMESTAMPTZ,
+  done_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (stay_id, item)
+);
+CREATE INDEX IF NOT EXISTS idx_recruit_onboarding_stay ON recruit_onboarding (stay_id);
+
+ALTER TABLE recruit_onboarding ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Recruiting members read onboarding" ON recruit_onboarding;
+CREATE POLICY "Recruiting members read onboarding" ON recruit_onboarding
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+DROP POLICY IF EXISTS "Recruiting members write onboarding" ON recruit_onboarding;
+CREATE POLICY "Recruiting members write onboarding" ON recruit_onboarding
+  FOR ALL TO authenticated
+  USING (is_recruiting_member()) WITH CHECK (is_recruiting_member());
+
+-- The default list. Kept in the migration rather than the client so the
+-- checklist a promotion seeds doesn't drift with whatever the browser cached.
+CREATE OR REPLACE FUNCTION recruit_onboarding_items()
+RETURNS TABLE (item TEXT, sort INT)
+LANGUAGE sql IMMUTABLE
+AS $$
+  VALUES
+    ('Add to the Google Group', 1),
+    ('Invite to the Notion workspace', 2),
+    ('Give the resident Discord role', 3),
+    ('Match them with a buddy', 4),
+    ('Add to the chore + dues rotation', 5),
+    ('Keys, door code, and a house walkthrough', 6)
+$$;
+
+-- 4. The promotion itself — all of it, or none of it.
+--
+-- Two doors into one core, because two kinds of people get promoted:
+--   * a candidate the funnel knows (Candidates rail → recruit_promote_candidate)
+--   * whoever is in a trial stay, application or not (occupancy drawer →
+--     recruit_promote_stay). Sophia and Andy are both in this second group:
+--     real trial candidates in real rooms with no application row behind them.
+--     A promotion flow that only worked off recruit_applicants would be
+--     useless for two of the three trials currently on the board.
+--
+-- p_starts_on defaults to the day after the trial ends; p_room_id to the
+-- trial room, so passing a different one is how somebody changes rooms on the
+-- way in. The trial stay is closed, never deleted — it is the record of how
+-- they got here.
+CREATE OR REPLACE FUNCTION recruit_promote_stay(
+  p_stay_id UUID,
+  p_room_id INT DEFAULT NULL,
+  p_starts_on DATE DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $fn$
+DECLARE
+  v_trial recruit_stays%ROWTYPE;
+  v_room INT;
+  v_start DATE;
+  v_stay_id UUID;
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+
+  SELECT * INTO v_trial FROM recruit_stays WHERE id = p_stay_id;
+  IF v_trial.id IS NULL THEN
+    RAISE EXCEPTION 'no such stay %', p_stay_id;
+  END IF;
+  IF v_trial.kind <> 'candidate' THEN
+    RAISE EXCEPTION 'stay % is a % stay, not a trial', p_stay_id, v_trial.kind;
+  END IF;
+
+  v_room := COALESCE(p_room_id, v_trial.room_id);
+  v_start := COALESCE(
+    p_starts_on,
+    CASE WHEN v_trial.ends_on IS NOT NULL THEN v_trial.ends_on + 1 END,
+    CURRENT_DATE);
+
+  -- Close the trial the day before the residency starts: no overlap, no gap.
+  -- A trial that already ended before that date is left as it is.
+  IF v_trial.ends_on IS NULL OR v_trial.ends_on >= v_start THEN
+    UPDATE recruit_stays
+       SET ends_on = v_start - 1, updated_at = NOW()
+     WHERE id = v_trial.id AND v_start - 1 >= starts_on;
+  END IF;
+
+  INSERT INTO recruit_stays (room_id, occupant, kind, starts_on, ends_on, applicant_id)
+  VALUES (v_room, v_trial.occupant, 'resident', v_start, NULL, v_trial.applicant_id)
+  RETURNING id INTO v_stay_id;
+
+  INSERT INTO recruit_onboarding (stay_id, item, sort)
+  SELECT v_stay_id, item, sort FROM recruit_onboarding_items()
+  ON CONFLICT (stay_id, item) DO NOTHING;
+
+  -- Only if the funnel knows them. A trial with no application still gets a
+  -- resident stay and a checklist; there is simply no stage to move.
+  IF v_trial.applicant_id IS NOT NULL THEN
+    UPDATE recruit_applicants
+       SET stage = 'resident', exit_reason = NULL, exit_until = NULL
+     WHERE id = v_trial.applicant_id;
+    -- They're housed; they have no business sitting in open listings. Marked
+    -- removed rather than deleted — this table's tombstones are what stop the
+    -- auto-sweep re-adding people, and they are worth keeping as history.
+    UPDATE recruit_listing_candidates
+       SET status = 'removed', updated_at = NOW()
+     WHERE applicant_id = v_trial.applicant_id AND status = 'active';
+  END IF;
+
+  RETURN v_stay_id;
+END;
+$fn$;
+
+-- Applicant-first door. Finds their trial and delegates; if there is no trial
+-- stay on record (accepted straight off a screening, say), opens the resident
+-- stay directly — p_room_id is required in that case.
+CREATE OR REPLACE FUNCTION recruit_promote_candidate(
+  p_applicant TEXT,
+  p_room_id INT DEFAULT NULL,
+  p_starts_on DATE DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $fn$
+DECLARE
+  v_trial_id UUID;
+  v_name TEXT;
+  v_stay_id UUID;
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+
+  SELECT TRIM(CONCAT(first_name, ' ', COALESCE(last_name, ''))) INTO v_name
+  FROM recruit_applicants WHERE id = p_applicant;
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'no such applicant %', p_applicant;
+  END IF;
+
+  SELECT id INTO v_trial_id FROM recruit_stays
+   WHERE kind = 'candidate' AND applicant_id = p_applicant
+   ORDER BY starts_on DESC LIMIT 1;
+
+  IF v_trial_id IS NOT NULL THEN
+    RETURN recruit_promote_stay(v_trial_id, p_room_id, p_starts_on);
+  END IF;
+
+  IF p_room_id IS NULL THEN
+    RAISE EXCEPTION 'no trial stay on record — pass a room to move them into';
+  END IF;
+
+  INSERT INTO recruit_stays (room_id, occupant, kind, starts_on, ends_on, applicant_id)
+  VALUES (p_room_id, v_name, 'resident', COALESCE(p_starts_on, CURRENT_DATE), NULL, p_applicant)
+  RETURNING id INTO v_stay_id;
+
+  INSERT INTO recruit_onboarding (stay_id, item, sort)
+  SELECT v_stay_id, item, sort FROM recruit_onboarding_items()
+  ON CONFLICT (stay_id, item) DO NOTHING;
+
+  UPDATE recruit_applicants
+     SET stage = 'resident', exit_reason = NULL, exit_until = NULL
+   WHERE id = p_applicant;
+  UPDATE recruit_listing_candidates
+     SET status = 'removed', updated_at = NOW()
+   WHERE applicant_id = p_applicant AND status = 'active';
+
+  RETURN v_stay_id;
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION recruit_promote_stay(UUID, INT, DATE) TO authenticated;
+GRANT EXECUTE ON FUNCTION recruit_promote_candidate(TEXT, INT, DATE) TO authenticated;


### PR DESCRIPTION
Adds the missing end of the funnel: moving a trial candidate to a resident, with a hand-ticked onboarding checklist (no auto-provisioning — that was the explicit call).

## The four things that blocked this
1. **No link between a candidate and their trial stay.** `recruit_stays.occupant` was free text, so the app could not tell that the trial candidate in Priest *is* applicant X. Added `recruit_stays.applicant_id`.
2. **No stage for "they live here."** Added `resident` — terminal, and explicitly not a rejection. Drops them out of the auto-placement sweep and every rail for free.
3. **Two stays, not one edit.** The trial closes the day before the residency opens: no overlap, no gap, and the trial survives as the record of how they got here.
4. **Two kinds of people get promoted.** Sophia and Andy are real trial candidates with no application row at all, so `recruit_promote_candidate(applicant)` alone would have been useless for two of the three live trials. `recruit_promote_stay(stay)` is the core; the applicant version delegates to it.

## UX
- Trial stay drawer leads with **Welcome them in** → room + start date (prefilled from the trial), confirm.
- Resident stay drawer shows the **onboarding checklist** — Google Group, Notion, Discord role, buddy, chore rotation, keys — struck through as they're ticked, hidden when the list is empty.
- Candidate profile shows the same action and routes to the drawer instead of duplicating the confirm form.
- Remove… sheet gains **Trial ended — not staying**, only for someone actually on a trial.

## Verification
- Migration applied to the Boards project. `recruit_promote_stay` tested against Sophia's real row inside a transaction and rolled back: trial held at Nov 1, residency opened Nov 2 open-ended.
- Backfill linked Alejandra's trial stay to her application. Sophia and Andy have no application row to link — the flow handles them via the stay-keyed path.
- Rendered both drawer states in Chrome. **Found and fixed a real bug there:** the promote form's `starts_on` collided with the stay form's, so the check-in default recomputed off the residency date (10/01 instead of 07/01). Milestone lookups are now scoped to the stay form.

## Not built
Discord announcement on promotion — needs an authenticated route on `recruit-discord`, and the checklist already gives the house the signal. Flagged in the PRD.

## One thing to look at
Alejandra is sitting in Priest on a live trial while her application row says `archived`. The two surfaces had drifted apart — exactly the drift `applicant_id` exists to stop — but the stage itself is a separate call I did not want to make silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)