### PR TITLE
recruiting: openings cleanup after the review-model change (v3.43.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1177,6 +1177,12 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .listing-menu__item:hover { background: var(--bg-overlay); }
 .listing-allin { font-weight: var(--fw-semibold); cursor: help; }
+/* The opening date carries the whole listing: it decides who qualifies. Reads
+   at body size in full contrast while the rest of the meta line stays muted. */
+.listing-when {
+  color: var(--fg); font-weight: var(--fw-semibold);
+  font-size: var(--font-size-body);
+}
 .listing-others { margin-top: var(--space-2); }
 .listing-others summary { color: var(--fg-subtle); font-size: var(--font-size-small); cursor: pointer; }
 
@@ -1341,12 +1347,17 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .avail-foot__ask { font-size: var(--font-size-small); color: var(--fg-muted); }
 .cta-pair { display: inline-flex; align-items: center; gap: 6px; }
 .cta-icon { padding: 0 9px; min-width: 0; }
+/* The play control is labelled now — "Watch" reads at a glance where a bare
+   triangle needed a hover. Still the secondary of the pair, so it shrinks
+   first and keeps its own tint. */
+.cta-watch { padding: 0 10px; min-width: 0; gap: 5px; }
+.foot-cta .cta-pair .cta-watch, .inbox-row__actions .cta-pair .cta-watch { width: auto; flex: 0 0 auto; }
 .listing-menu__item--danger { color: var(--error); }
 
 /* --- v3.18.0: aligned CTA column, quiet ⋮, confirm-to-book modal --- */
 .inbox-row__actions .cta-stack { width: 172px; align-items: stretch; }
 .inbox-row__actions .cta-stack .cta-std { width: 100%; justify-content: center; }
-.inbox-row__actions .cta-pair { display: flex; width: 100%; gap: 6px; }
+.inbox-row__actions .cta-pair { display: flex; width: 100%; gap: 6px; flex-wrap: wrap; }
 .inbox-row__actions .cta-pair .cta-std { flex: 1; }
 .inbox-row__actions .cta-context { align-self: flex-end; }
 .listing-menu-btn { border-color: transparent; background: transparent; letter-spacing: 0; font-size: 16px; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.42.2">
+  <link rel="stylesheet" href="css/app.css?v=3.43.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -58,6 +58,7 @@
         <span class="rail-foot__user" id="rail-user"></span>
         <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
         <label class="rail-foot__pref" title="When on, coverage asks post to #recruiting-automation automatically as availability lands"><input type="checkbox" id="pref-autopost"> Auto-post coverage asks</label>
+        <label class="rail-foot__pref" title="Sets how the update-email box starts when someone is marked not a fit — you can still change it per person"><input type="checkbox" id="pref-update-default"> Offer an update email by default</label>
         <button class="rail-foot__link rail-foot__gmail" id="gmail-conn" type="button">Checking shared Gmail…</button>
         <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
         <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
@@ -306,7 +307,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.42.2"></script>
+  <script src="js/app.js?v=3.43.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -126,6 +126,9 @@ let decisionVotes = {};       // applicant_id -> recruit_decision_votes rows
 let screeningState = {};      // applicant_id -> { at?, with?, availability? }
 let houseEvents = {};         // applicant_id -> non-intro_call calendar rows
 let pendingVerdict = null;    // 'not_fit' | 'needs_input' | 'forward' while the review bar is open
+/* How the update-email box starts on a Not-a-fit decision. A house preference
+   rather than a hard default: some houses always write, some rarely do. */
+const updateEmailDefault = () => settings.update_email_default !== false;
 let sendUpdateWith = true;    // "Send them an update" rides with a Not-a-fit decision
 let noteDraft = { id: null, text: '' };  // review comment in progress, scoped to its applicant
 let footFor = null;           // which applicant the review bar in the DOM belongs to
@@ -424,7 +427,7 @@ function avatarHtml(a, large) {
 }
 
 /* The one CTA an Openings row needs right now, from its funnel micro-state:
-   nothing sent yet → Reach out · waiting on them → Follow up · they wrote
+   nothing sent yet → Get started · waiting on them → Follow up · they wrote
    back → Reply · availability in hand → Pick a time · call booked → the
    slot chip (+ Join when there's a Meet link). */
 /* Time-derived call phase — a clock, not a cron, decides these. Stored
@@ -483,7 +486,7 @@ function openingsCta(a) {
       ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours counted`
       : (dv.length ? `${dv.length} decision${dv.length === 1 ? '' : 's'} in — yours isn't` : 'no decisions yet');
     return stack(
-      `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-icon btn--watch" title="Play in the docked player — View opens the Call tab" data-play-mini="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg></button></span>`,
+      `<span class="cta-pair"><button class="btn btn--sm inbox-row__review cta-std cta--blue" data-email="${a.id}" data-email-kind="visit" title="Invite them to a house visit — opens the email draft">Schedule a visit</button><button type="button" class="btn btn--sm cta-watch btn--watch" title="Play in the docked player — View opens the Call tab" data-play-mini="${a.id}"><svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>Watch</button></span>`,
       `${decCtx}${when ? ` · ${when}` : ''}`);
   }
   if (phase === 'done') {
@@ -523,7 +526,7 @@ function openingsCta(a) {
     return stack(`<button class="btn btn--sm inbox-row__review cta-std ${stale ? 'cta--amber' : ''}" data-email="${a.id}">Follow up</button>`,
       `${promised ? 'invite promised · ' : ''}sent ${relTime(st.lastAt)}`);
   }
-  return stack(`<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Reach out</button>`, '');
+  return stack(`<button class="btn btn--sm inbox-row__review cta-std" data-email="${a.id}">Get started</button>`, '');
 }
 
 /* Blue response dot in the row's left gutter — sits beside the avatar,
@@ -669,6 +672,9 @@ async function loadAll() {
     if (box) box.checked = settings.open_to_couples !== false;
     const ap = document.getElementById('pref-autopost');
     if (ap) ap.checked = settings.discord_auto_post === true;
+    const ud = document.getElementById('pref-update-default');
+    if (ud) ud.checked = updateEmailDefault();
+    sendUpdateWith = updateEmailDefault();
   });
   if (aRes.error) throw aRes.error;
   applicants = (aRes.data || []).map(r => ({
@@ -2144,7 +2150,11 @@ function othersAccordion(listingId) {
             </span>
           </button>
           <span class="inbox-row__actions">
-            ${a.stage === 'review' ? (voteChip(a) || '<span class="note-count">gathering votes</span>') : (removed ? '<span class="note-count" title="Removed from this listing by a recruiter">removed</span>' : '')}
+            ${a.stage === 'review'
+              ? '<span class="note-count" title="Nobody has reviewed them yet — one read decides">not reviewed yet</span>'
+              : removed
+                ? '<span class="note-count" title="A recruiter took them off this listing — the auto-sweep won\'t re-add them, but you can">taken off this listing</span>'
+                : '<span class="note-count" title="Reviewed and moved forward — ready to add">moved forward</span>'}
             ${a.stage === 'candidate' ? `<button class="btn btn--sm inbox-row__review" title="${activePlacements(a.id).length ? 'Moves them here from their current listing' : 'Place them on this listing'}" data-add-placement="${a.id}|${esc(listingId)}">${activePlacements(a.id).length ? 'Move here' : 'Add'}</button>` : ''}
           </span>
         </li>`;
@@ -3001,10 +3011,14 @@ function listingPricing(l) {
    hover). Notes live in the edit modal, not the header. */
 function listingMeta(l) {
   const bits = [];
+  // The date is the first thing anyone needs from a listing — it decides who
+  // qualifies — so it leads and it's emphasised.
   if (l.kind === 'resident') {
-    bits.push(`Opens ${fmtDay(l.starts_on)}`);
+    bits.push(`<b class="listing-when">Opens ${fmtDay(l.starts_on)}</b>`);
   } else {
-    bits.push(l.ends_on ? `${fmtDay(l.starts_on)} – ${fmtDay(l.ends_on)}` : `From ${fmtDay(l.starts_on)} · end date TBD`);
+    bits.push(l.ends_on
+      ? `<b class="listing-when">${fmtDay(l.starts_on)} – ${fmtDay(l.ends_on)}</b>`
+      : `<b class="listing-when">From ${fmtDay(l.starts_on)}</b> · end date TBD`);
     const len = windowLength(l.starts_on, l.ends_on);
     if (len) bits.push(len);
   }
@@ -3030,16 +3044,24 @@ function listingMenuHtml(l) {
   </span>`;
 }
 
-/* Everyone who'd qualify for this listing but isn't on the active shortlist:
-   candidates a recruiter removed, plus qualifying applicants still in the
-   Inbox gathering votes. */
+/* Everyone still in play for this listing who isn't on the active shortlist.
+   Two groups, in this order:
+     1. moved forward — reviewed, passed, and a recruiter can add them now
+     2. not reviewed yet — the dates fit, nobody has read them
+   Anyone archived is excluded outright, and so is anyone reviewed but not
+   moved forward: a "needs input" verdict is a question, not a shortlist. */
 function otherQualified(listingId) {
   const l = listings.find(x => x.id === listingId);
   if (!l) return [];
   const placed = new Set(placements.filter(p => p.listing_id === listingId && p.status === 'active').map(p => p.applicant_id));
-  return applicants.filter(a => !placed.has(a.id)
-    && (a.stage === 'review' || a.stage === 'candidate')
-    && qualifiesFor(a, l));
+  const forward = [], unread = [];
+  for (const a of applicants) {
+    if (placed.has(a.id) || a.exitReason) continue;
+    if (!qualifiesFor(a, l)) continue;
+    if (a.stage === 'candidate') forward.push(a);
+    else if (a.stage === 'review' && !voteStats(a.id).n) unread.push(a);
+  }
+  return [...forward, ...unread];
 }
 
 function listingWindow(l) {
@@ -3263,7 +3285,7 @@ function step(delta) {
   if (next < 0 || next >= queue.length) { if (delta > 0) closeReview(); return; }
   qIndex = next;
   pendingVerdict = null;
-  sendUpdateWith = true;
+  sendUpdateWith = updateEmailDefault();
   noteDraft = { id: queue[next], text: '' };
   moveinEditing = false;
   if (!keepBannerOnce) hideReviewBanner();
@@ -4810,6 +4832,16 @@ function init() {
   document.getElementById('gd-close').onclick = () => { document.getElementById('gd-modal').hidden = true; };
   document.getElementById('gd-yes').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'yes');
   document.getElementById('gd-no').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'no');
+  document.getElementById('pref-update-default').onchange = async (e) => {
+    const value = e.target.checked;
+    settings.update_email_default = value;
+    sendUpdateWith = value;
+    const { error } = await sb.from('recruit_settings').upsert({
+      key: 'update_email_default', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
+    });
+    if (error) { toast(`Save failed: ${error.message}`); e.target.checked = !value; settings.update_email_default = !value; }
+    else toast(value ? 'Not a fit will offer an update email' : 'Not a fit will skip the email unless you ask for one');
+  };
   document.getElementById('pref-couples').onchange = async (e) => {
     const value = e.target.checked;
     settings.open_to_couples = value;

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -247,3 +247,12 @@ The Inbox is no longer a group vote. One housemate's read decides, and every rev
 - **Reopening softens rather than deletes.** A decisive verdict becomes "needs input" and keeps its comment, since the trigger would otherwise send the applicant straight back out.
 - **The rejection email is offered, never forced.** Archiving surfaces "Write their update" with "Skip the email" beside it; the draft is a fixed community template plus one paragraph written from the applicant's own survey answers, and an optional newsletter link. Closing the editor leaves it unsent.
 - **Reviews can arrive from the application sheet.** Comment threads on the sheet import as reviews attributed to their author's roster email, so a review written by someone who has never opened the app still shows under their name — and becomes editable by them the moment their sign-in maps to that email. Imported rows are labelled "from the application sheet".
+
+## Amendment — v3.43 (openings cleanup after the review-model change)
+
+- **"See other qualified applicants" only lists people still in play**, in two groups: *moved forward* (reviewed, passed — ready to add) then *not reviewed yet* (dates fit, nobody has read them). Archived applicants are excluded outright — the old filter keyed on stage `review | candidate` without checking for a decisive verdict, so someone archived by a sheet-imported review still appeared. Anyone reviewed but **not** moved forward is excluded too: "needs input" is a question, not a shortlist.
+- **Tags follow the new model.** "gathering votes" is gone — there is no tally to gather. Rows read `not reviewed yet`, `moved forward`, or `taken off this listing` (was the bare "removed", which never said off *what*).
+- **The opening date leads its header**, at body size in full contrast (`.listing-when`) while the rest of the meta stays muted. The date decides who qualifies, so it shouldn't read as fine print.
+- **"Reach out" → "Get started"** — the first-contact CTA on an outreach row.
+- **The play control is labelled "Watch"** rather than a bare triangle. Still the secondary of the pair: it shrinks first and keeps its own tint.
+- **The update email's default is a house preference** (`recruit_settings.update_email_default`, rail footer: "Offer an update email by default"). The checkbox on a Not-a-fit decision starts from it, and can still be changed per person.


### PR DESCRIPTION
1. **Global default for the update-email checkbox** — rail footer, "Offer an update email by default" (`recruit_settings.update_email_default`, defaults on). The checkbox on a Not-a-fit decision starts from it and is still changeable per person.

2. **Archived applicants no longer appear under "See other qualified applicants".** Linda Green was archived by Kate's imported review, but the filter keyed on stage `review | candidate` with no check for a decisive verdict. The list is now two ordered groups — **moved forward** (reviewed, passed, ready to add), then **not reviewed yet** (dates fit, nobody has read them) — with archived people excluded outright and anyone reviewed-but-not-forwarded excluded too: a "needs input" verdict is a question, not a shortlist.

3. **Tags follow the new model.** "gathering votes" described a tally that no longer exists → `not reviewed yet`. The bare "removed" never said removed from *what* → `taken off this listing`. Forwarded candidates read `moved forward`.

4. **The opening date leads the header** at body size in full contrast — it decides who qualifies, so it shouldn't read as fine print.

5. **"Reach out" → "Get started".**

6. **The play control is labelled "Watch"** instead of a bare triangle; still the pair's secondary.

**Your open question — the cut line** — I did not implement, because it's a real design choice and worth your call. Answered in the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)