### PR TITLE
fix(recruiting): the labelled Watch fits beside the primary (v3.43.1)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -569,7 +569,7 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   .inbox-row__review { display: none; } /* whole row is tappable on phones */
   .review__foot { gap: var(--space-2); }
   .review__btn { padding-inline: var(--space-2); font-size: var(--font-size-small); }
-  /* Openings rows: the fixed 172px CTA column (its buttons are hidden here
+  /* Openings rows: the fixed CTA column (its buttons are hidden here
      anyway) starved the name column into one-letter-per-line wraps. */
   .inbox-row__actions .cta-stack { width: auto; }
   .inbox-row__actions .cta-context { display: none; }
@@ -1355,9 +1355,12 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .listing-menu__item--danger { color: var(--error); }
 
 /* --- v3.18.0: aligned CTA column, quiet ⋮, confirm-to-book modal --- */
-.inbox-row__actions .cta-stack { width: 172px; align-items: stretch; }
+/* The CTA column is fixed so every row's buttons line up. 258px is what a
+   labelled secondary needs beside the primary — at 172px the pair wrapped onto
+   two lines, which breaks the one-action-per-line read. */
+.inbox-row__actions .cta-stack { width: 258px; align-items: stretch; }
 .inbox-row__actions .cta-stack .cta-std { width: 100%; justify-content: center; }
-.inbox-row__actions .cta-pair { display: flex; width: 100%; gap: 6px; flex-wrap: wrap; }
+.inbox-row__actions .cta-pair { display: flex; width: 100%; gap: 6px; }
 .inbox-row__actions .cta-pair .cta-std { flex: 1; }
 .inbox-row__actions .cta-context { align-self: flex-end; }
 .listing-menu-btn { border-color: transparent; background: transparent; letter-spacing: 0; font-size: 16px; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.43.0">
+  <link rel="stylesheet" href="css/app.css?v=3.43.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -307,7 +307,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.43.0"></script>
+  <script src="js/app.js?v=3.43.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.43.0';
+const VERSION = '3.43.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';


### PR DESCRIPTION
Caught in Chrome right after v3.43.0: labelling the play control "Watch" pushed the pair past the fixed 172px CTA column, so it wrapped and "Schedule a visit" / "Watch" stacked on two lines — exactly the read the two-tier rail exists to avoid. Column widened to 258px (172 primary + 6 gap + 80 secondary) and the wrap removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)