### PR TITLE
style(recruiting): stay bars get a little breathing room (v3.44.1)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -769,7 +769,7 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .cal__event {
   position: absolute; top: 10px; bottom: 10px;
   display: inline-flex; align-items: center;
-  padding: 0 var(--space-2); margin: 0 2px;
+  padding: 0 var(--space-2); margin: 0 4px;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-caption); font-weight: var(--fw-medium);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.44.0';
+const VERSION = '3.44.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';


### PR DESCRIPTION
Adjacent stays in a room lane were separated by only 4px total, so back-to-back stays read as one continuous run. Bumped `.cal__event` margin from `0 2px` to `0 4px` (8px visual gap).

- [applications/css/app.css](applications/css/app.css) — margin bump
- [applications/js/app.js](applications/js/app.js) — v3.44.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)