### PR TITLE
feat(design-system): name it Sassy; add hierarchical sidebar CTAs (v3.45.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Personal curation platform — collect, organize, and build on everything that m
 2. **Show complete code blocks** with full paths. Don't summarize when exact text is needed.
 3. **End every response** with a "Next Steps" section (numbered steps + commands) or "No action needed."
 4. **Docs travel with code:** when a change affects plans, architecture, or UX docs, update the relevant files under `docs/` directly in the same PR. Plans live in `docs/execution/project-plan/`.
-5. **Design system:** check `design-system/` before any UI work. Document new CSS classes in `design-system/README.md`.
+5. **Design system:** the design system is named **Sassy** (`design-system/`) — check it before any UI work. Document new CSS classes in `design-system/README.md`.
 6. **Announce doc changes:** state file path and what changed.
 7. **Widget work:** check `design-system/widgets.html` stoplight audit before starting (Green=ok, Yellow=needs dev action, Orange=needs review, Red=blocked).
 
@@ -101,4 +101,4 @@ Optional specialized subagent definitions live in `.claude/agents/` (documentati
 - [Brand Positioning](./docs/strategy/brand-positioning.md) | [Personas](./docs/ux/personas.md)
 - [Project Plan](./docs/execution/project-plan/index.md) | [Backlog](./docs/execution/project-plan/backlog.md) | [Bugs](./docs/execution/BUGS.md)
 - [Deployment + Supabase Commands](./docs/infrastructure/deployment.md)
-- [Design System](./design-system/README.md) | [AI Widget Architecture](./docs/infrastructure/technical-design/ai-widget-system.md)
+- [Sassy design system](./design-system/README.md) | [AI Widget Architecture](./docs/infrastructure/technical-design/ai-widget-system.md)

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -736,6 +736,10 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 /* --- Occupancy calendar (v2.4) — lanes, not spreadsheet cells --- */
 .cal {
   --room-col: 200px;
+  /* The break between back-to-back stays. Taken off each bar's right edge
+     only, so a bar's left edge still lands exactly on its start date and the
+     gap reads as a seam between two stays rather than inner padding. */
+  --bar-break: 4px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -760,16 +764,23 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   border-right: 1px solid var(--border);
   display: flex; flex-direction: column; justify-content: center; gap: 1px;
 }
-.cal__lane {
-  position: relative; flex: 1;
-  /* month gridlines */
-  background-image: repeating-linear-gradient(to right,
-    var(--border) 0 1px, transparent 1px calc(100% / var(--occ-months, 12)));
+.cal__lane { position: relative; flex: 1; }
+/* Gridlines live on one overlay behind every lane rather than as a per-lane
+   repeating gradient — the gradient's fractional tile width accumulated
+   rounding error, so by December a month edge sat a couple of pixels off the
+   header label and off any bar starting that month. */
+.cal__grid {
+  position: absolute; top: 0; bottom: 0; left: var(--room-col); right: 0;
+  display: grid; grid-template-columns: repeat(var(--occ-months, 12), 1fr);
+  pointer-events: none; z-index: 0;
 }
+.cal__grid > span { border-left: 1px solid var(--border); }
+/* The room column's own border-right already draws this edge. */
+.cal__grid > span:first-child { border-left: 0; }
 .cal__event {
-  position: absolute; top: 10px; bottom: 10px;
+  position: absolute; top: 10px; bottom: 10px; z-index: 1;
   display: inline-flex; align-items: center;
-  padding: 0 var(--space-2); margin: 0 4px;
+  padding: 0 var(--space-2); margin: 0; min-width: 10px;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-caption); font-weight: var(--fw-medium);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -779,9 +790,10 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .cal__event--sublet { background: var(--hold-tint); color: var(--hold-fg); }
 .cal__event--candidate { background: var(--trial-tint); color: var(--trial-fg); border: 1px solid var(--trial-tint); }
 .cal__event--shared { background: transparent; color: var(--fg-subtle); font-style: italic; }
-.cal__event--vacant { background: rgba(168, 32, 13, 0.10); color: var(--fg-subtle); border: 1px dashed rgba(168, 32, 13, 0.4); }
-.cal__event--vacant.is-listable { cursor: pointer; justify-content: center; font-weight: var(--fw-semibold); }
-.cal__event--vacant.is-listable:hover { background: rgba(168, 32, 13, 0.22); color: var(--fg); }
+/* Unlabelled — the red dashed stretch is the message, and the dates it spans
+   are in the tooltip and the drawer it opens on tap. */
+.cal__event--vacant { background: rgba(168, 32, 13, 0.10); border: 1px dashed rgba(168, 32, 13, 0.4); }
+.cal__event--vacant:hover { background: rgba(168, 32, 13, 0.22); }
 .cal__today {
   position: absolute; top: 0; bottom: 0; width: 2px;
   background: var(--accent); z-index: 2; pointer-events: none;
@@ -831,7 +843,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .cal__event--sublet { border: 1px solid var(--hold-tint); }
 .seg-form { margin-top: var(--space-4); }
 .seg-form__head { display: flex; align-items: baseline; gap: var(--space-2); }
-.seg-form__actions .listing-form__delete { margin-right: auto; }
 .occupants { margin-top: var(--space-6); }
 .occupants__past { margin-top: var(--space-3); }
 .occupants__past summary {
@@ -1027,11 +1038,10 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .occ-drawer__trial[hidden] { display: none; }
 /* v3.43: candidate → resident promotion + onboarding checklist */
 .occ-drawer__promote {
-  display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap;
+  display: flex; flex-direction: column; gap: var(--space-3);
   padding-bottom: var(--space-3); border-bottom: 1px solid var(--border);
 }
 .occ-drawer__promote--open { display: grid; gap: var(--space-2); }
-.occ-drawer__promote-hint { font-size: var(--font-size-caption); color: var(--fg-subtle); flex: 1 1 12rem; }
 .occ-drawer__onboard { padding-top: var(--space-3); border-top: 1px solid var(--border); }
 .onboard-list { list-style: none; margin: var(--space-2) 0 0; padding: 0; display: grid; gap: var(--space-1); }
 .onboard-item label {
@@ -1044,7 +1054,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .occ-drawer__fact dt { color: var(--fg-subtle); }
 .occ-drawer__fact dd { margin: 0; font-weight: var(--fw-medium); }
 .occ-drawer__note { margin: 0; color: var(--fg-muted); font-size: var(--font-size-small); }
-.occ-drawer__list-btn { align-self: flex-start; }
 @media (max-width: 720px) { .occ-drawer { width: 100vw; border-left: 0; } }
 
 /* --- v2.16.1: phone-sized timeline (3 months at a time) --- */
@@ -1559,3 +1568,72 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .gplayer__btn:hover { background: var(--bg-overlay); color: var(--fg); }
 .gplayer.is-mini .vchrome { display: none; }
 @media (max-width: 520px) { .gplayer.is-mini { width: min(250px, 70vw); right: 10px; bottom: 10px; } }
+
+/* --- v3.45.0: sidebar CTA tiers (Sassy `drawer-cta`) ---
+   Drawer footers had four actions fighting inside one right-aligned flex
+   row: two red underlined links (which wrapped onto two lines in a 380px
+   sidebar), a text Cancel, and the primary. A sidebar is too narrow to keep
+   four targets honest side by side, so the footer is now three explicit
+   tiers, ordered by consequence:
+
+     tier 1  .drawer-cta__commit   the one filled primary — right-aligned
+     tier 2  .drawer-cta__quiet    dismiss — no fill, beside the primary
+     tier 3  .drawer-cta__exit     destructive / state changes — full-width
+                                   rows below a rule, one per line
+
+   Rules: exactly one commit per sidebar; anything that removes, ends, or
+   re-routes a record leaves the commit row entirely; exits never underline
+   (see the design system's transparency-not-decoration rule) and carry a
+   hint so a red label is never the only explanation of what it does. */
+.drawer-cta { margin-top: var(--space-4); display: flex; flex-direction: column; }
+.drawer-cta__row {
+  display: flex; align-items: center; justify-content: flex-end; gap: var(--space-2);
+  padding-top: var(--space-3); border-top: 1px solid var(--border);
+}
+.drawer-cta__commit { flex: 0 0 auto; min-width: 104px; }
+.drawer-cta__quiet {
+  flex: 0 0 auto;
+  height: 40px; padding: 0 var(--space-3);
+  background: transparent; border: 0; border-radius: var(--radius-sm);
+  color: var(--fg-muted); font-size: var(--font-size-body); font-weight: var(--fw-medium);
+}
+.drawer-cta__quiet:hover { color: var(--fg); background: var(--bg-overlay); }
+/* The optional fourth slot: a second, non-destructive path the sidebar also
+   offers ("create a listing instead", "welcome them in"). Full-width and
+   outlined, never filled — the filled commit stays unique so the eye can
+   still find the one action that saves what's on screen. */
+.drawer-cta__alt {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
+  width: 100%; padding: var(--space-3);
+  border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  background: transparent; color: var(--fg); text-align: left;
+  font-size: var(--font-size-small); font-weight: var(--fw-semibold);
+}
+.drawer-cta__alt:hover { background: var(--bg-overlay); }
+/* The alt's hint is a full sentence, so it stacks under the label instead of
+   competing with it for the same line. */
+.drawer-cta__alt .drawer-cta__exit-hint { text-align: left; }
+.drawer-cta__exits { display: flex; flex-direction: column; margin-top: var(--space-3); }
+.drawer-cta__exit {
+  display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3);
+  width: 100%; padding: var(--space-3) 0;
+  background: transparent; border: 0; border-top: 1px solid var(--border);
+  color: var(--fg-muted); text-align: left; text-decoration: none;
+  font-size: var(--font-size-small); font-weight: var(--fw-semibold);
+  white-space: nowrap;
+}
+.drawer-cta__exit:hover { color: var(--fg); }
+.drawer-cta__exit--danger { color: var(--error); }
+.drawer-cta__exit--danger:hover { color: var(--error); background: var(--pass-tint); }
+/* The hint yields first: it wraps or ellipsizes so the label — the thing that
+   says what the button does — always reads on one line. */
+.drawer-cta__exit-hint {
+  flex: 0 1 auto; min-width: 0; white-space: normal;
+  color: var(--fg-subtle); font-size: var(--font-size-caption); font-weight: 400; text-align: right;
+}
+/* On a full-width phone drawer the hint gets its own line rather than
+   squeezing the label into an ellipsis. */
+@media (max-width: 480px) {
+  .drawer-cta__exit { flex-direction: column; align-items: flex-start; gap: 2px; }
+  .drawer-cta__exit-hint { text-align: left; }
+}

--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -769,7 +769,7 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .cal__event {
   position: absolute; top: 10px; bottom: 10px;
   display: inline-flex; align-items: center;
-  padding: 0 var(--space-2); margin: 0 2px;
+  padding: 0 var(--space-2); margin: 0 4px;
   border-radius: var(--radius-sm);
   font-size: var(--font-size-caption); font-weight: var(--fw-medium);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.44.0">
+  <link rel="stylesheet" href="css/app.css?v=3.45.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -307,7 +307,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.44.0"></script>
+  <script src="js/app.js?v=3.45.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.44.1';
+const VERSION = '3.45.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2475,16 +2475,19 @@ function renderOccupancy() {
       const range = `${fmtShort(s.starts_on)} – ${s.ends_on ? fmtShort(s.ends_on) : 'ongoing'}`;
       const active = occDrawer?.type === 'stay' && occDrawer.id === s.id;
       bars.push(`<button type="button" class="cal__event cal__event--${s.kind} ${!s.ends_on ? 'is-open-ended' : ''} ${active ? 'is-editing' : ''}"
-        style="left: ${left}%; width: ${Math.max(width, 0.8)}%" title="${esc(`${s.occupant || KIND_LABELS[s.kind]} · ${KIND_LABELS[s.kind]} · ${range}`)}"
+        style="left: ${left}%; width: calc(${Math.max(width, 0.8)}% - var(--bar-break))" title="${esc(`${s.occupant || KIND_LABELS[s.kind]} · ${KIND_LABELS[s.kind]} · ${range}`)}"
         data-stay="${s.id}">${esc(s.occupant || KIND_LABELS[s.kind])}</button>`);
     }
     for (const [a, b] of roomGaps(r.id)) {
       const left = occPos(a) * 100;
       const width = occPos(isoAddDays(b, 1)) * 100 - left;
       const active = occDrawer?.type === 'gap' && occDrawer.roomId === r.id && occDrawer.start === a;
+      // No label: a red stretch already reads as empty, and the dates it
+      // spans are the point. Tapping it opens the drawer, which names them.
       bars.push(`<button type="button" class="cal__event cal__event--vacant ${active ? 'is-editing' : ''}"
-        style="left: ${left}%; width: ${width}%" title="Open ${fmtShort(a)} – ${fmtShort(b)} — click to fill or list"
-        data-gap-room="${r.id}" data-gap-start="${a}" data-gap-end="${b}">Open</button>`);
+        style="left: ${left}%; width: calc(${width}% - var(--bar-break))" title="Open ${fmtShort(a)} – ${fmtShort(b)} — tap to fill or list"
+        aria-label="Open ${fmtShort(a)} – ${fmtShort(b)}"
+        data-gap-room="${r.id}" data-gap-start="${a}" data-gap-end="${b}"></button>`);
     }
     return bars.join('');
   };
@@ -2512,6 +2515,11 @@ function renderOccupancy() {
         </div>
       </div>
       <div class="cal__body">
+        <!-- One gridline overlay for the whole body, on the same
+             repeat(n, 1fr) grid as the header, so a month edge in the header
+             and a month edge behind the bars are the same pixel. Per-lane
+             repeating gradients drifted by a pixel or two per month. -->
+        <div class="cal__grid" aria-hidden="true">${months.map(() => '<span></span>').join('')}</div>
         ${todayPct !== null ? `<span class="cal__today" style="left: calc(var(--room-col) + (100% - var(--room-col)) * ${todayPct / 100})"></span>` : ''}
         ${rooms.map(r => `
           <div class="cal__row">
@@ -2595,8 +2603,10 @@ function promoteBlockHtml(s) {
   const start = trialEnd ? isoAddDays(trialEnd, 1) : new Date().toISOString().slice(0, 10);
   if (promoting !== s.id) {
     return `<div class="occ-drawer__promote">
-      <button type="button" class="btn btn--accent btn--sm" data-promote-open="${s.id}">Welcome them in</button>
-      <span class="occ-drawer__promote-hint">Ends the trial and starts an open-ended residency${trialEnd ? ` on ${fmtShort(start)}` : ''}.</span>
+      <button type="button" class="drawer-cta__alt" data-promote-open="${s.id}">
+        <span>Welcome them in</span>
+        <span class="drawer-cta__exit-hint">Ends the trial and starts an open-ended residency${trialEnd ? ` on ${fmtShort(start)}` : ''}.</span>
+      </button>
     </div>`;
   }
   return `<form class="occ-drawer__promote occ-drawer__promote--open" data-promote-form="${s.id}">
@@ -2613,9 +2623,11 @@ function promoteBlockHtml(s) {
     </div>
     <p class="occ-drawer__note">The trial closes the day before, so the timeline has no gap. An onboarding checklist gets created for the house to work through.</p>
     <p class="listing-form__error" data-promote-error></p>
-    <div class="decision-sheet__actions seg-form__actions">
-      <button type="button" class="hold-sheet__cancel" data-promote-cancel>Cancel</button>
-      <button type="submit" class="btn btn--accent btn--sm">Welcome them in</button>
+    <div class="drawer-cta">
+      <div class="drawer-cta__row">
+        <button type="button" class="drawer-cta__quiet" data-promote-cancel>Cancel</button>
+        <button type="submit" class="btn btn--accent drawer-cta__commit">Welcome them in</button>
+      </div>
     </div>
   </form>`;
 }
@@ -2682,6 +2694,19 @@ async function submitPromote(form) {
 
 function stayFormHtml(s, roomId) {
   const isNew = !s.id;
+  // Tier 3 of the sidebar CTA pattern: the ways out. Each carries a hint so a
+  // red label is never the only thing telling you what it does.
+  const exits = [];
+  if (!isNew && s.kind === 'resident') {
+    exits.push(`<button type="button" class="drawer-cta__exit" data-stay-leaving="${roomId}" data-stay-leaving-date="${s.ends_on || ''}">
+      Mark leaving <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
+    </button>`);
+  }
+  if (!isNew) {
+    exits.push(`<button type="button" class="drawer-cta__exit drawer-cta__exit--danger" data-stay-delete="${s.id}">
+      Remove stay <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
+    </button>`);
+  }
   return `<form class="occ-drawer__form" data-stay-form="${s.id || 'new'}" data-stay-room="${roomId}">
     <label class="listing-form__field">Who
       <input type="text" name="occupant" class="listing-status" value="${esc(s.occupant || '')}" placeholder="Name" autofocus>
@@ -2703,11 +2728,12 @@ function stayFormHtml(s, roomId) {
     <label class="occ-drawer__ongoing"><input type="checkbox" name="ongoing" ${s.id && !s.ends_on ? 'checked' : ''}> Ongoing — no move-out date yet</label>
     ${trialFieldsHtml(s)}
     <p class="listing-form__error" data-form-error></p>
-    <div class="decision-sheet__actions seg-form__actions">
-      ${!isNew ? `<button type="button" class="listing-form__delete" data-stay-delete="${s.id}">Remove stay</button>` : ''}
-      ${!isNew && s.kind === 'resident' ? `<button type="button" class="listing-form__delete" data-stay-leaving="${roomId}" data-stay-leaving-date="${s.ends_on || ''}">Mark leaving — list room</button>` : ''}
-      <button type="button" class="hold-sheet__cancel" data-drawer-close>Cancel</button>
-      <button type="submit" class="btn btn--accent btn--sm">${isNew ? 'Add stay' : 'Save'}</button>
+    <div class="drawer-cta">
+      <div class="drawer-cta__row">
+        <button type="button" class="drawer-cta__quiet" data-drawer-close>Cancel</button>
+        <button type="submit" class="btn btn--accent drawer-cta__commit">${isNew ? 'Add stay' : 'Save'}</button>
+      </div>
+      ${exits.length ? `<div class="drawer-cta__exits">${exits.join('')}</div>` : ''}
     </div>
   </form>`;
 }
@@ -2767,7 +2793,10 @@ function renderOccDrawer() {
     title = `${room?.name || 'Room'} — open`;
     sub = `${fmtShort(occDrawer.start)} – ${fmtShort(occDrawer.end)}`;
     body = `
-      <button class="btn btn--sm occ-drawer__list-btn" data-list-room="${occDrawer.roomId}" data-list-start="${occDrawer.start}">Create listing for this stretch</button>
+      <button class="drawer-cta__alt" data-list-room="${occDrawer.roomId}" data-list-start="${occDrawer.start}">
+        <span>Create a listing for this stretch</span>
+        <span class="drawer-cta__exit-hint">opens the room to candidates</span>
+      </button>
       <p class="occ-drawer__note">…or record who's moving in:</p>
       ${stayFormHtml({ kind: 'sublet', starts_on: occDrawer.start, ends_on: occDrawer.end }, occDrawer.roomId)}`;
   } else if (occDrawer.type === 'room') {

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.44.0';
+const VERSION = '3.44.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -1,6 +1,16 @@
-# Design System - Changelog
+# Sassy — Changelog
 
-> Release history for the ctrl.rodeo design system
+> Release history for Sassy, the ctrl.rodeo design system
+
+---
+
+## [1.3.0] - 2026-07-30
+
+### Added
+- **Sidebar CTAs (`drawer-cta`)** — a hierarchical CTA pattern for sidebars and drawer footers: one filled commit, a quiet dismiss beside it, destructive/state-changing exits as full-width rows below a rule, plus an optional outlined `__alt` for a second forward path. Documented in README and as a story in the recruiting system.
+
+### Changed
+- **The design system is named Sassy.** The umbrella name covers the global CTRL layer and every product system under it. Hub, page titles, and stylesheet headers updated; `CTRL` now names the global layer only.
 
 ---
 

--- a/design-system/FEATURES.md
+++ b/design-system/FEATURES.md
@@ -1,4 +1,4 @@
-# Design System - Features
+# Sassy — Features
 
 > Complete component and token inventory for ctrl.rodeo
 

--- a/design-system/README 2.md
+++ b/design-system/README 2.md
@@ -1,4 +1,4 @@
-# CTRL Design System
+# Sassy: CTRL (global layer)
 
 > Minimal, high-contrast design system powering all ctrl.rodeo products.
 
@@ -9,7 +9,7 @@
 
 ## Product Overview
 
-The CTRL Design System provides a unified visual language across all ctrl.rodeo applications. It emphasizes clarity, speed, and a distinctive code-like aesthetic.
+Sassy's CTRL layer provides a unified visual language across all ctrl.rodeo applications. It emphasizes clarity, speed, and a distinctive code-like aesthetic.
 
 ### Used By
 - **Boards** - Link curation app

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,10 +1,10 @@
-# ctrl.rodeo design systems
+# Sassy — the ctrl.rodeo design system
 
-> Centralized home for every product's design system: **https://ctrl.rodeo/design-system/**
+> Sassy is the name of the whole thing: the global CTRL layer and every product system under it. Home: **https://ctrl.rodeo/design-system/**
 
 | System | Scope | Where |
 |---|---|---|
-| Hub | Landing that indexes all systems | `index.html` |
+| Hub | Sassy's landing page, indexes every layer | `index.html` |
 | CTRL | Global — Boards, Events, Soundscape, Systemic, Favicon | `ctrl.html` |
 | Agape recruiting | Product — /applications (Storybook-style stories) | `recruiting/index.html` · behavior source of truth: `docs/ux/recruiting-row-states.md` |
 | Widget audit | Tooling stoplight | `widgets.html` |
@@ -13,7 +13,7 @@ Product systems override the global system for their product. New products add a
 
 ---
 
-# CTRL Design System
+# Sassy: CTRL (global layer)
 
 > Minimal, high-contrast design system powering ctrl.rodeo products.
 
@@ -24,7 +24,7 @@ Product systems override the global system for their product. New products add a
 
 ## Product Overview
 
-The CTRL Design System provides a unified visual language across all ctrl.rodeo applications. It emphasizes clarity, speed, and a distinctive code-like aesthetic.
+Sassy's CTRL layer provides a unified visual language across all ctrl.rodeo applications. It emphasizes clarity, speed, and a distinctive code-like aesthetic.
 
 ### Used By
 - **Boards** - Link curation app
@@ -641,6 +641,52 @@ A destructive or branching action with **more than two outcomes** opens a sheet,
 - The submit button's label mirrors the chosen option, not a generic "Confirm"
 - `btn--danger` **replaces** `btn--accent` rather than stacking on it — danger is an outline style that fills on hover, so the two together produce an accent fill with a red border
 - The parent menu keeps a single entry (`Remove…`), with a `.listing-menu__rule` separating navigation from destructive items
+
+### Sidebar CTAs (`drawer-cta`)
+
+A sidebar or drawer footer is **three tiers deep, ordered by consequence** — not one right-aligned flex row. A ~380px drawer cannot keep four targets honest side by side; the stay editor proved it, with two red underlined links each wrapping onto two lines.
+
+```html
+<div class="drawer-cta">
+  <!-- tier 1 + 2: commit and dismiss, together -->
+  <div class="drawer-cta__row">
+    <button type="button" class="drawer-cta__quiet" data-drawer-close>Cancel</button>
+    <button type="submit" class="btn btn--accent drawer-cta__commit">Save</button>
+  </div>
+
+  <!-- tier 3: the ways out — full-width rows, one per line -->
+  <div class="drawer-cta__exits">
+    <button type="button" class="drawer-cta__exit">
+      Mark leaving <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
+    </button>
+    <button type="button" class="drawer-cta__exit drawer-cta__exit--danger">
+      Remove stay <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
+    </button>
+  </div>
+
+  <!-- optional: a second, non-destructive forward path -->
+  <button type="button" class="drawer-cta__alt">
+    <span>Welcome them in</span>
+    <span class="drawer-cta__exit-hint">Ends the trial and starts an open-ended residency.</span>
+  </button>
+</div>
+```
+
+| Class | Tier | Rule |
+|---|---|---|
+| `drawer-cta__commit` | 1 | The one filled primary, bottom-right. **Exactly one per sidebar** — it is the only thing that saves what's on screen. |
+| `drawer-cta__quiet` | 2 | Dismiss. No fill, no border, beside the primary. Cancel is not a decision, so it doesn't look like one. |
+| `drawer-cta__exit` | 3 | The ways out. Full-width row below a rule, label left, hint right. `--danger` for destructive (red label, tinted hover); muted for state changes. |
+| `drawer-cta__alt` | — | Optional second forward path. Outlined, never filled, label stacked over hint. |
+
+**Sidebar CTA rules:**
+- Anything that **removes, ends, or re-routes** a record leaves the commit row entirely
+- Exits never underline — weight and color carry them (see [Removed & deferred states](#removed--deferred-states))
+- Every exit and alt carries a hint; a red label is never the only explanation of what a button does
+- Full-width rows mean labels never truncate, so copy stays plain (`Mark leaving`, not `Mark leaving — list room`). The label is `white-space: nowrap`; the **hint** wraps or ellipsizes first
+- Under 480px the hint drops to its own line rather than squeezing the label
+
+*Reference implementation: `applications/css/app.css` — `.drawer-cta`. Story: [Sidebar CTAs](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas).*
 
 ### Drop Target
 

--- a/design-system/components.css
+++ b/design-system/components.css
@@ -1,5 +1,6 @@
 /* ============================================
-   CTRL Design System - Components
+   Sassy — the ctrl.rodeo design system
+   CTRL global layer · components
    Reusable UI components
    ============================================ */
 

--- a/design-system/ctrl.html
+++ b/design-system/ctrl.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CTRL — design system</title>
+  <title>CTRL — a Sassy design system</title>
   <link rel="apple-touch-icon" sizes="180x180" href="/images/icons/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/images/icons/favicons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/images/icons/favicons/favicon-16x16.png">

--- a/design-system/display.css
+++ b/design-system/display.css
@@ -1,5 +1,6 @@
 /* ============================================
-   CTRL Design System — Display Layer
+   Sassy — the ctrl.rodeo design system
+   CTRL global layer · display
    Presentation: portfolios, marketing, decks.
    Swiss minimalism. Type and space do the work.
    ============================================ */

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>ctrl.rodeo — design systems</title>
+<title>Sassy — the ctrl.rodeo design system</title>
 <style>
 :root {
   --bg: #0d1117; --surface: #161b22; --elevated: #1f2630;
@@ -35,11 +35,11 @@ footer { margin-top: 48px; font-size: 12px; color: var(--ink-3); }
 <body>
 <div class="wrap">
   <p class="kicker">ctrl.rodeo</p>
-  <h1>Design systems</h1>
-  <p class="lede">The single home for how ctrl.rodeo products look, speak, and decide. Product systems live here; when a rule appears in a product system, it wins over the global one for that product.</p>
+  <h1>Sassy</h1>
+  <p class="lede">The design system behind ctrl.rodeo — the single home for how these products look, speak, and decide. Sassy is the whole thing: a global layer plus a system per product. When a rule appears in a product system, it wins over the global one for that product.</p>
 
   <a class="sys" href="/design-system/recruiting/">
-    <span><b>Agape recruiting</b> <span class="tag">· product · v3.19</span></span>
+    <span><b>Agape recruiting</b> <span class="tag">· product · v3.28</span></span>
     <span class="d">Principles, tokens, voice, row anatomy, states, and the decision log for /applications. Storybook-style stories.</span>
     <span class="arr">→</span>
   </a>
@@ -56,7 +56,7 @@ footer { margin-top: 48px; font-size: 12px; color: var(--ink-3); }
     <span class="arr">→</span>
   </a>
 
-  <footer>Tokens for CTRL products: tokens.css · components.css. The recruiting system is self-contained.</footer>
+  <footer>Sassy · named Jul 2026. Tokens for CTRL products: tokens.css · components.css. The recruiting system is self-contained.</footer>
 </div>
 </body>
 </html>

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Agape recruiting — design system</title>
+<title>Agape recruiting — a Sassy design system</title>
 <style>
 :root {
   --bg: #0d1117; --surface: #161b22; --elevated: #1f2630;
@@ -146,6 +146,33 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 .co { font-size: 12px; color: var(--ink-2); display: grid; grid-template-columns: 18px 1fr; gap: 8px; }
 .co b { color: var(--ink); font-size: 12px; }
 .co .m { width: 18px; height: 18px; border-radius: 50%; background: var(--tint-blue); color: var(--tint-blue-ink); display: grid; place-items: center; font-size: 10px; font-weight: 700; }
+/* Sidebar CTAs — the drawer footer's three tiers. Mirrors .drawer-cta in
+   applications/css/app.css; keep the two in step. */
+.sidebar { width: 340px; max-width: 100%; background: var(--elevated); border: 1px solid var(--line); border-radius: var(--r-md); padding: 16px; }
+.sidebar .fieldstub { height: 34px; border: 1px solid var(--line); border-radius: var(--r-xs); background: var(--surface); margin-bottom: 10px; }
+.dcta { display: flex; flex-direction: column; margin-top: 16px; }
+.dcta__row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; padding-top: 12px; border-top: 1px solid var(--line); }
+.dcta__commit { min-width: 92px; border-radius: 999px; background: var(--accent); border-color: var(--accent); color: var(--accent-ink); }
+.dcta__quiet { background: transparent; border: 0; color: var(--ink-2); font: 500 12.5px/1 inherit; padding: 9px 12px; border-radius: var(--r-sm); cursor: pointer; }
+.dcta__exits { display: flex; flex-direction: column; margin-top: 12px; }
+.dcta__exit {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
+  width: 100%; padding: 12px 0; border: 0; border-top: 1px solid var(--line);
+  background: transparent; color: var(--ink-2); text-align: left; font: 600 12.5px/1.3 inherit; cursor: pointer; white-space: nowrap;
+}
+.dcta__exit.danger { color: var(--red); }
+.dcta__hint { color: var(--ink-3); font: 400 11px/1.35 inherit; text-align: right; white-space: normal; min-width: 0; }
+.dcta__alt {
+  display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
+  width: 100%; padding: 12px; margin-top: 4px;
+  border: 1px solid var(--line-2); border-radius: var(--r-sm);
+  background: transparent; color: var(--ink); text-align: left; font: 600 12.5px/1.3 inherit; cursor: pointer;
+}
+.dcta__exits + .dcta__alt { margin-top: 14px; }
+.dcta__alt .dcta__hint { text-align: left; }
+.tiers { display: grid; grid-template-columns: 68px 1fr; gap: 10px 14px; font-size: 13px; color: var(--ink-2); max-width: 66ch; }
+.tiers b { color: var(--ink); }
+.tiers code { font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--ink-3); }
 .rule { display: grid; grid-template-columns: 16px 1fr; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--line); }
 .rule:last-child { border-bottom: 0; }
 .rule .n { color: var(--ink-3); padding-top: 2px; }
@@ -166,7 +193,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>design system · v3.27</span><a href="/design-system/">← all design systems</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.28</span><a href="/design-system/">← all of Sassy</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -200,6 +227,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <button type="button">Patterns <span class="tw">▼</span></button>
     <div class="items">
       <a href="#two-tier" data-story="two-tier">Two-tier rail</a>
+      <a href="#sidebar-ctas" data-story="sidebar-ctas">Sidebar CTAs</a>
       <a href="#row-states" data-story="row-states">Row states</a>
       <a href="#schedule-modal" data-story="schedule-modal">Schedule modal</a>
       <a href="#listing-header" data-story="listing-header">Listing header</a>
@@ -251,6 +279,9 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <h1>Decision log</h1>
     <p class="lede">Why it is the way it is — dated, so future arguments have receipts.</p>
     <div class="notes">
+      <div class="dec"><span class="d">Jul 30</span><br><b>The design system got a name: Sassy.</b><p>"The design system" was a description, not a name, so nothing in a review could refer to it without a paragraph of context. Sassy is the whole thing — the global CTRL layer and every product system under it, this one included.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Sidebar CTAs became three tiers instead of one flex row.</b><p>The stay drawer's footer had four actions crammed right-aligned: two red underlined links (both wrapping onto two lines), a text Cancel, and the primary. Commit, dismiss, and the ways out are now separate tiers, and anything destructive leaves the commit row entirely. See <a href="#sidebar-ctas">Sidebar CTAs</a>.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Occupancy bars are exact, and empty stretches are unlabelled.</b><p>The break between back-to-back stays comes off each bar's right edge only, so a left edge still lands on its start date to the pixel. Month gridlines moved to one overlay on the header's own grid — the per-lane repeating gradient drifted a pixel or two per month. Red stretches dropped their "Open" label: the color already says it, and tapping says the dates.</p></div>
       <div class="dec"><span class="d">Jul 29</span><br><b>The single decider came back — with three options and a required comment.</b><p>Quorum stalled: 58 applications sat waiting for a third vote that never came. One read now decides (not a fit / needs input / move forward), and the comment is the accountability that the tally used to pretend to be. "Needs input" is the honest version of a hung vote.</p></div>
       <div class="dec"><span class="d">Jul 22</span><br><b>Collective votes replaced the single decider.</b><p>Culture fit is the house's call; the app's job is quorum, blindness until you've voted, and a hard veto. <em>Superseded Jul 29.</em></p></div>
       <div class="dec"><span class="d">Jul 22</span><br><b>AI suggestions replaced by deterministic placement.</b><p>A candidate is in every listing they qualify for, by rule. Confidence percentages were deleted — dates either line up or they don't.</p></div>
@@ -486,6 +517,45 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <div class="notes"><h3>Notes</h3><p>An icon secondary may split the column with the primary — alignment holds because the pair shares the same 172px. A chip in the top slot means the state is passive: someone else's move. The profile footer reuses this exact component at 200px.</p></div>
   </section>
 
+  <section class="story" id="s-sidebar-ctas">
+    <h1>Sidebar CTAs</h1>
+    <p class="lede">A drawer footer is three tiers deep, ordered by consequence: what saves, what dismisses, and the ways out.</p>
+    <div class="canvas">
+      <div class="sidebar">
+        <div class="fieldstub"></div>
+        <div class="fieldstub"></div>
+        <div class="dcta">
+          <div class="dcta__row">
+            <button class="dcta__quiet">Cancel</button>
+            <button class="btn dcta__commit">Save</button>
+          </div>
+          <div class="dcta__exits">
+            <button class="dcta__exit">Mark leaving <span class="dcta__hint">sets a move-out date and lists the room</span></button>
+            <button class="dcta__exit danger">Remove stay <span class="dcta__hint">deletes it from the timeline</span></button>
+          </div>
+          <button class="dcta__alt"><span>Welcome them in</span><span class="dcta__hint">Ends the trial and starts an open-ended residency on Sep 1, 2026.</span></button>
+        </div>
+      </div>
+    </div>
+    <div class="notes">
+      <h3>The tiers</h3>
+      <div class="tiers">
+        <span><code>__commit</code></span><span><b>One filled primary.</b> Bottom-right, pill, accent. Exactly one per sidebar — it is the only thing that saves what's on screen.</span>
+        <span><code>__quiet</code></span><span><b>Dismiss.</b> No fill, no border, beside the primary. Cancel is not a decision, so it does not look like one.</span>
+        <span><code>__exit</code></span><span><b>The ways out.</b> Full-width rows below a rule, one per line, label left and a hint right. Destructive ones take <code>--danger</code> (red label, tinted hover); state changes stay muted.</span>
+        <span><code>__alt</code></span><span><b>Optional second path.</b> Outlined, never filled, label over hint. Used when the sidebar genuinely offers two forward moves ("create a listing instead", "welcome them in").</span>
+      </div>
+      <h3>Notes</h3>
+      <ul>
+        <li>Anything that removes, ends, or re-routes a record <b>leaves the commit row</b>. A 340px sidebar cannot keep four targets honest side by side — this is exactly how the stay drawer ended up with two red underlined links wrapping onto two lines each.</li>
+        <li>Exits never underline. Weight and color carry them; see <a href="#voice">Voice</a> and the transparency-not-decoration rule.</li>
+        <li>Every exit and alt carries a hint. A red label is never the only explanation of what a button does.</li>
+        <li>Full-width rows mean labels never truncate, so the copy can stay plain ("Mark leaving") instead of compressed ("Mark leaving — list room").</li>
+        <li>Under 480px the hint drops to its own line rather than squeezing the label into an ellipsis.</li>
+      </ul>
+    </div>
+  </section>
+
   <section class="story" id="s-row-states">
     <h1>Row states</h1>
     <p class="lede">Active means your move; passive means the chip tells you whose it is. Every passive state carries its escalation rule.</p>
@@ -608,7 +678,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 <script>
 (function () {
   var stories = document.querySelectorAll('.story');
-  var links = document.querySelectorAll('[data-story]');
+  var links = document.querySelectorAll('.side [data-story]');
   var crumb = document.getElementById('crumb');
   function groupOf(link) {
     var g = link.closest('.grp');

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,5 +1,6 @@
 /* ============================================
-   CTRL Design System
+   Sassy — the ctrl.rodeo design system
+   CTRL global layer · tokens
    A unified design language for ctrl.rodeo projects
    ============================================ */
 

--- a/design-system/widgets.css
+++ b/design-system/widgets.css
@@ -1,5 +1,6 @@
 /* ============================================
-   CTRL Design System - Widget Components
+   Sassy — the ctrl.rodeo design system
+   CTRL global layer · widget components
    w- prefixed component library for AI widgets
    ============================================ */
 

--- a/design-system/widgets.html
+++ b/design-system/widgets.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Widget Design System — ctrl.rodeo</title>
+  <title>Widget audit — Sassy</title>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="components.css">


### PR DESCRIPTION
## Sidebar CTAs

The stay drawer's footer had four actions in one right-aligned flex row — two red underlined links (both wrapping onto two lines), a text Cancel, and the primary. New `drawer-cta` component, three tiers ordered by consequence:

| Class | Tier | Role |
|---|---|---|
| `drawer-cta__commit` | 1 | the one filled primary — exactly one per sidebar |
| `drawer-cta__quiet` | 2 | dismiss, no fill, beside the primary |
| `drawer-cta__exit` | 3 | the ways out — full-width rows below a rule, `--danger` for destructive |
| `drawer-cta__alt` | — | optional outlined second forward path |

Anything that removes, ends, or re-routes a record leaves the commit row. Exits never underline, and each carries a hint so a red label is never the only explanation.

Applied to the stay editor, the promote form, and the gap drawer. Promotion and "create a listing" became `__alt` so Save stays the only filled commit.

## Timeline, from PR #1310 feedback

- **Break, not padding** — the 4px seam comes off each bar's right edge only (`--bar-break`), so a bar's left edge still lands on its start date to the pixel. The symmetric margin shifted every bar right.
- **Exact gridlines** — month lines moved to one `.cal__grid` overlay on the header's own `repeat(n, 1fr)` grid; the per-lane repeating gradient accumulated rounding and drifted a pixel or two per month.
- **No "Open" label** — red stretches render unlabelled; the dates are in the tooltip and the drawer that opens on tap.

## Rename

The design system is named **Sassy** — the umbrella over the global CTRL layer and every product system under it. `CTRL` now names the global layer only.

## Docs
- [design-system/README.md](design-system/README.md) — `drawer-cta` reference + rules
- [design-system/CHANGELOG.md](design-system/CHANGELOG.md) — 1.3.0
- [design-system/recruiting/index.html](design-system/recruiting/index.html) — Sidebar CTAs story, 3 decision-log entries, v3.28
- [design-system/index.html](design-system/index.html), titles, stylesheet headers, [CLAUDE.md](CLAUDE.md) — rename

Verified in Chrome against a local harness of the real stylesheet (timeline alignment, seam, unlabelled vacants) and the rendered design-system pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)