### PR TITLE
feat(recruiting): Inbox is Applicants, Screening leaves the rail (v3.46.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -840,7 +840,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .cal__event { border: 0; cursor: pointer; transition: filter 80ms ease, box-shadow 80ms ease; font: inherit; font-size: var(--font-size-caption); }
 .cal__event:hover { filter: brightness(1.08); box-shadow: 0 0 0 1.5px var(--border-strong); }
 .cal__event.is-editing { box-shadow: 0 0 0 2px var(--accent); }
-.cal__event--sublet { border: 1px solid var(--hold-tint); }
 .seg-form { margin-top: var(--space-4); }
 .seg-form__head { display: flex; align-items: baseline; gap: var(--space-2); }
 .occupants { margin-top: var(--space-6); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.45.0">
+  <link rel="stylesheet" href="css/app.css?v=3.46.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -37,7 +37,7 @@
       <button class="mobile-bar__menu" id="mobile-menu" aria-label="Menu">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
       </button>
-      <span class="mobile-bar__title" id="mobile-title">Inbox</span>
+      <span class="mobile-bar__title" id="mobile-title">Applicants</span>
     </header>
 
     <aside class="app__rail" id="rail">
@@ -49,9 +49,8 @@
         <a class="rail-nav__row" href="?view=openings" data-view-link="openings">Openings <span class="rail-nav__count" id="count-openings"></span></a>
         <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
         <div class="rail-nav__group">Funnel</div>
-        <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Inbox <span class="rail-nav__count" id="count-inbox"></span></a>
+        <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Applicants <span class="rail-nav__count" id="count-inbox"></span></a>
         <a class="rail-nav__row" href="?view=candidates" data-view-link="candidates">Candidates <span class="rail-nav__count" id="count-candidates"></span></a>
-        <a class="rail-nav__row" href="?view=screening" data-view-link="screening">Screening <span class="rail-nav__count" id="count-screening"></span></a>
         <a class="rail-nav__row" href="?view=archive" data-view-link="archive">Archive <span class="rail-nav__count" id="count-archive"></span></a>
       </nav>
       <div class="rail-foot">
@@ -70,7 +69,7 @@
     <main class="app__main">
       <header class="page__head">
         <div class="page__head-text">
-          <h1 class="page__title" id="page-title">Inbox</h1>
+          <h1 class="page__title" id="page-title">Applicants</h1>
           <p class="page__sub" id="page-sub"></p>
         </div>
         <div class="page__head-action" id="page-head-action"></div>
@@ -307,7 +306,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.45.0"></script>
+  <script src="js/app.js?v=3.46.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -3,14 +3,14 @@
    the discord-membership edge fn). Applicants, votes, shared decisions, and
    house notes live in Supabase behind RLS (migrations 108 + 120).
 
-   v4 funnel: Inbox (one reviewer decides: not a fit / needs input /
+   v4 funnel: Applicants (one reviewer decides: not a fit / needs input /
    move forward, comment required) → Candidates →
    Openings (listing shortlists) → Screening → Archive. The applicant's
    stage column is recomputed server-side by a trigger on recruit_votes;
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.45.0';
+const VERSION = '3.46.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -104,7 +104,7 @@ function defaultReturnDate() {
 }
 
 const VIEWS = {
-  inbox: { title: 'Inbox', kind: 'applicants' },
+  inbox: { title: 'Applicants', kind: 'applicants' },
   candidates: { title: 'Candidates', kind: 'applicants' },
   openings: { title: 'Openings', kind: 'applicants' },
   screening: { title: 'Screening', kind: 'applicants' },
@@ -112,7 +112,10 @@ const VIEWS = {
   occupancy: { title: 'Occupancy', kind: 'house' },
 };
 // Old bookmarks and deep links keep working.
-const LEGACY_VIEWS = { review: 'inbox', outreach: 'openings', hold: 'inbox', listings: 'openings' };
+// `inbox` stays the view key and the URL — renaming it would break every
+// bookmark and deep link — but `?view=applicants` resolves too, since that is
+// what the rail now calls it.
+const LEGACY_VIEWS = { review: 'inbox', outreach: 'openings', hold: 'inbox', listings: 'openings', applicants: 'inbox' };
 
 let sb = null;                // supabase client (from CtrlAuth)
 let me = null;                // { id, name, groupEmail }
@@ -536,7 +539,7 @@ function openingsCta(a) {
 /* Blue response dot in the row's left gutter — sits beside the avatar,
    never on top of it. */
 function repliedDot(a) {
-  // Same blue dot, two meanings by context: in the Inbox it marks an
+  // Same blue dot, two meanings by context: in Applicants it marks an
   // application nobody on your account has opened yet; elsewhere it marks
   // their reply waiting on you.
   if (view === 'inbox') {
@@ -1283,7 +1286,7 @@ function attachmentLabel(rec) {
    moves the applicant on the most recent decisive one (migration 140). */
 const VERDICTS = {
   not_fit: { label: 'Not a fit', title: 'Archives them — an update email is owed', cls: 'is-not-fit' },
-  needs_input: { label: 'Needs input', title: 'Stays in the Inbox, flagged for another housemate to read', cls: 'is-needs-input' },
+  needs_input: { label: 'Needs input', title: 'Stays in Applicants, flagged for another housemate to read', cls: 'is-needs-input' },
   forward: { label: 'Move forward', title: 'Moves them to Candidates and into every listing they qualify for', cls: 'is-forward' },
 };
 
@@ -2154,7 +2157,7 @@ function qualifiedTag(a, listingId, removed) {
 }
 
 /* Collapsed rail of everyone else who'd fit this listing — removed
-   candidates can be re-added; Inbox folks link to their review page. */
+   candidates can be re-added; Applicants folks link to their review page. */
 function othersAccordion(listingId) {
   const others = otherQualified(listingId);
   if (!others.length) return '';
@@ -3385,7 +3388,7 @@ function renderReview() {
         <span class="decision-banner__meta">${esc(why)}</span>
       </div>
       <span class="decision-banner__actions">
-        <button class="decision-banner__undo" data-reopen="${a.id}">Reopen — back to Inbox</button>
+        <button class="decision-banner__undo" data-reopen="${a.id}">Reopen — back to Applicants</button>
       </span>
     </div>`;
   };
@@ -3609,7 +3612,7 @@ function renderReviewFoot(a) {
       ${owed ? `<span class="foot-cta"><button class="btn btn--accent review__btn" data-update-edit="${a.id}">Write their update</button></span>` : ''}
       <span class="foot-links">
         ${owed ? `<button type="button" class="cta-link" data-update-skip="${a.id}">Skip the email</button>` : ''}
-        <button type="button" class="cta-link" data-reopen="${a.id}">Reopen — back to Inbox</button>
+        <button type="button" class="cta-link" data-reopen="${a.id}">Reopen — back to Applicants</button>
       </span>`;
   }
 }
@@ -3633,7 +3636,7 @@ async function reopenApplicant(id) {
     hideReviewBanner();
     toast(st0.decisive
       ? `Reopened — ${reviewerName(st0.decisive)}'s comment is kept as needing input`
-      : 'Reopened — back in the Inbox');
+      : 'Reopened — back in Applicants');
     renderRailCounts();
     if (!document.getElementById('review').hidden) renderReview(); else render();
   }


### PR DESCRIPTION
- **Inbox → Applicants** in the rail, the page title, and the mobile bar. The view key and URL stay `?view=inbox` so bookmarks and deep links keep working; `?view=applicants` now resolves to it as well.
- **Screening removed from the rail.** The view itself stays routable (`?view=screening`) so the scheduled-call flow's deep links don't break — only the nav entry is gone. The rail-count loop already guards on a missing element.
- **Sublet bars lose their stroke.** `.cal__event--sublet` had a `1px` border in the same color as its fill, which read as a smudged edge. Tint only now.

Copy referring to the old name updated too ("Reopen — back to Applicants", the `needs_input` verdict tooltip).

Verified in Chrome: rail renders Openings · Occupancy | Applicants · Candidates · Archive, and the sublet bar is flat tint against the resident and trial-candidate bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)