### PR TITLE
docs(recruiting): a Settings concept structured for extensibility

### DIFF
--- a/design-system/index.html
+++ b/design-system/index.html
@@ -39,7 +39,7 @@ footer { margin-top: 48px; font-size: 12px; color: var(--ink-3); }
   <p class="lede">The design system behind ctrl.rodeo — the single home for how these products look, speak, and decide. Sassy is the whole thing: a global layer plus a system per product. When a rule appears in a product system, it wins over the global one for that product.</p>
 
   <a class="sys" href="/design-system/recruiting/">
-    <span><b>Agape recruiting</b> <span class="tag">· product · v3.28</span></span>
+    <span><b>Agape recruiting</b> <span class="tag">· product · v3.29</span></span>
     <span class="d">Principles, tokens, voice, row anatomy, states, and the decision log for /applications. Storybook-style stories.</span>
     <span class="arr">→</span>
   </a>

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -170,6 +170,37 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 }
 .dcta__exits + .dcta__alt { margin-top: 14px; }
 .dcta__alt .dcta__hint { text-align: left; }
+/* Settings (concept) */
+.tag-concept { font-size: 9px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--tint-amber-ink); background: var(--tint-amber); padding: 1px 5px; border-radius: 999px; }
+.setpage { display: grid; grid-template-columns: 150px minmax(0,1fr); gap: 22px; }
+.setnav { display: flex; flex-direction: column; gap: 1px; }
+.setnav a { font-size: 12.5px; color: var(--ink-2); padding: 6px 9px; border-radius: var(--r-xs); }
+.setnav a.on { background: var(--tint-blue); color: var(--ink); font-weight: 600; }
+.setsec { background: var(--elevated); border: 1px solid var(--line); border-radius: var(--r-md); padding: 16px; margin-bottom: 12px; }
+.setsec > h4 { margin: 0; font-size: 13.5px; }
+.setsec > .shint { margin: 2px 0 14px; font-size: 11.5px; color: var(--ink-3); }
+.fld { display: grid; grid-template-columns: 1fr auto; gap: 4px 14px; align-items: center; padding: 11px 0; border-top: 1px solid var(--line); }
+.fld .l { grid-column: 1; grid-row: 1; font-size: 12.5px; font-weight: 600; }
+.fld .h { grid-column: 1; grid-row: 2; font-size: 11px; color: var(--ink-3); }
+.fld .c { grid-column: 2; grid-row: 1 / 3; align-self: center; justify-self: end; }
+.num { display: inline-flex; align-items: baseline; gap: 6px; font-size: 12px; color: var(--ink-3); }
+.num input { width: 54px; background: var(--surface); border: 1px solid var(--line-2); border-radius: var(--r-xs); color: var(--ink); font: 600 12.5px/1 inherit; padding: 7px 8px; text-align: right; }
+.sw2 { width: 34px; height: 20px; border-radius: 999px; background: var(--tint-gray); border: 1px solid var(--line-2); position: relative; display: inline-block; }
+.sw2 i { position: absolute; top: 2px; left: 2px; width: 14px; height: 14px; border-radius: 50%; background: var(--ink-3); transition: left 120ms ease; }
+.sw2.on { background: var(--accent); border-color: var(--accent); }
+.sw2.on i { left: 16px; background: var(--accent-ink); }
+.saved { font-size: 10.5px; color: var(--ok); }
+.autorow { display: grid; grid-template-columns: 1fr auto auto; gap: 4px 14px; align-items: center; padding: 11px 0; border-top: 1px solid var(--line); }
+.autorow .l { grid-column: 1; grid-row: 1; font-size: 12.5px; font-weight: 600; }
+.autorow .h { grid-column: 1; grid-row: 2; font-size: 11px; color: var(--ink-3); }
+.autorow .when { grid-column: 2; grid-row: 1; font-size: 10.5px; color: var(--ink-3); font-variant-numeric: tabular-nums; text-align: right; }
+.autorow .cad { grid-column: 2; grid-row: 2; font-size: 10.5px; color: var(--ink-3); text-align: right; }
+.autorow .c { grid-column: 3; grid-row: 1 / 3; align-self: center; }
+.conn { display: flex; align-items: center; gap: 8px; font-size: 12.5px; padding: 11px 0; border-top: 1px solid var(--line); }
+.conn .who { flex: 1; min-width: 0; font-weight: 600; }
+.conn .st { font-size: 11px; }
+.conn .st.ok { color: var(--ok); }
+.conn .st.warn { color: var(--tint-amber-ink); }
 .tiers { display: grid; grid-template-columns: 68px 1fr; gap: 10px 14px; font-size: 13px; color: var(--ink-2); max-width: 66ch; }
 .tiers b { color: var(--ink); }
 .tiers code { font-family: ui-monospace, Menlo, monospace; font-size: 11px; color: var(--ink-3); }
@@ -193,7 +224,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.28</span><a href="/design-system/">← all of Sassy</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.29</span><a href="/design-system/">← all of Sassy</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -233,6 +264,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
       <a href="#listing-header" data-story="listing-header">Listing header</a>
       <a href="#profile" data-story="profile">Profile</a>
       <a href="#stage-machine" data-story="stage-machine">Stage machine</a>
+      <a href="#settings" data-story="settings">Settings <span class="tag-concept">concept</span></a>
       <a href="#automation-audit" data-story="automation-audit">Automation audit</a>
     </div>
   </div>
@@ -279,6 +311,8 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <h1>Decision log</h1>
     <p class="lede">Why it is the way it is — dated, so future arguments have receipts.</p>
     <div class="notes">
+      <div class="dec"><span class="d">Jul 30</span><br><b>Settings gets the rail's vocabulary, and a schema instead of a page.</b><p>The rail footer was the only place a setting could go, so most settings never became settings — the house's recruiting behavior lives in literals (3 quiet days, ±1 flexible month, +1/−1 trial milestones) that need a deploy to change. The concept: six sections named <code>You · House · Funnel · Automations · Connections · Data</code>, rendered from a field schema where <code>scope</code> picks the store and the schema default <em>is</em> the code default. Concept only — see <a href="#settings">Settings</a>.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Inbox is Applicants, and Screening left the rail.</b><p>"Inbox" described a queue; "Applicants" names what's in it. Screening was a rail entry nobody navigated to — the work happens on a person's row and in Discord — so the view stays routable for deep links and left the rail.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>The design system got a name: Sassy.</b><p>"The design system" was a description, not a name, so nothing in a review could refer to it without a paragraph of context. Sassy is the whole thing — the global CTRL layer and every product system under it, this one included.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Sidebar CTAs became three tiers instead of one flex row.</b><p>The stay drawer's footer had four actions crammed right-aligned: two red underlined links (both wrapping onto two lines), a text Cancel, and the primary. Commit, dismiss, and the ways out are now separate tiers, and anything destructive leaves the commit row entirely. See <a href="#sidebar-ctas">Sidebar CTAs</a>.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Occupancy bars are exact, and empty stretches are unlabelled.</b><p>The break between back-to-back stays comes off each bar's right edge only, so a left edge still lands on its start date to the pixel. Month gridlines moved to one overlay on the header's own grid — the per-lane repeating gradient drifted a pixel or two per month. Red stretches dropped their "Open" label: the color already says it, and tapping says the dates.</p></div>
@@ -636,6 +670,103 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
         <li>The Call tab holds the recording, AI summary, and comments with "comment at current time" stamps.</li>
         <li>Confirmed move-in replaces the parsed date outright — green, ✓, attributed — with the raw answer on hover.</li>
       </ul>
+    </div>
+  </section>
+
+  <section class="story" id="s-settings">
+    <h1>Settings <span class="tag-concept">concept</span></h1>
+    <p class="lede">Six sections that borrow the rail's own vocabulary, rendered from a schema so a new setting is one object literal.</p>
+    <div class="canvas">
+      <div class="setpage">
+        <nav class="setnav">
+          <a>You</a>
+          <a class="on">Funnel</a>
+          <a>House</a>
+          <a>Automations</a>
+          <a>Connections</a>
+          <a>Data</a>
+        </nav>
+        <div>
+          <div class="setsec">
+            <h4>Funnel</h4>
+            <p class="shint">How applicants move. Changes here apply to everyone.</p>
+            <div class="fld">
+              <span class="l">Follow-up goes amber after</span>
+              <span class="c"><span class="num"><input value="3"> days</span></span>
+              <span class="h">A thread this quiet is worth another email.</span>
+            </div>
+            <div class="fld">
+              <span class="l">Flexible move-in stretches by</span>
+              <span class="c"><span class="num"><input value="1"> months</span></span>
+              <span class="h">How far a “flexible” date reaches on each side when matching listings.</span>
+            </div>
+            <div class="fld">
+              <span class="l">Offer an update email by default <span class="saved">✓ saved</span></span>
+              <span class="c"><span class="sw2 on"><i></i></span></span>
+              <span class="h">When someone is marked not a fit — you can still change it per person.</span>
+            </div>
+            <div class="dcta">
+              <div class="dcta__row">
+                <button class="dcta__quiet">Cancel</button>
+                <button class="btn dcta__commit">Save</button>
+              </div>
+              <div class="dcta__exits">
+                <button class="dcta__exit">Reset this section <span class="dcta__hint">back to Sassy defaults</span></button>
+              </div>
+            </div>
+          </div>
+
+          <div class="setsec">
+            <h4>Automations</h4>
+            <p class="shint">Things that run without you.</p>
+            <div class="autorow">
+              <span class="l">Scan the shared inbox</span>
+              <span class="when">ran 4 min ago</span>
+              <span class="c"><span class="sw2 on"><i></i></span></span>
+              <span class="h">Pulls new applications, replies, and availability.</span>
+              <span class="cad">every 20 min</span>
+            </div>
+            <div class="autorow">
+              <span class="l">Remind screeners before a call</span>
+              <span class="when">ran 11 min ago</span>
+              <span class="c"><span class="sw2 on"><i></i></span></span>
+              <span class="h">DMs whoever claimed the call, an hour ahead.</span>
+              <span class="cad">every 15 min</span>
+            </div>
+            <div class="autorow">
+              <span class="l">Auto-post coverage asks</span>
+              <span class="when">off</span>
+              <span class="c"><span class="sw2"><i></i></span></span>
+              <span class="h">Off means a human sees the message before the house does.</span>
+              <span class="cad">on availability</span>
+            </div>
+          </div>
+
+          <div class="setsec">
+            <h4>Connections</h4>
+            <p class="shint">Where recruiting reaches outside the app.</p>
+            <div class="conn"><span class="who">live.at.agapesf@gmail.com</span><span class="st ok">✓ connected</span></div>
+            <div class="conn"><span class="who">House calendar</span><span class="st ok">✓ connected</span></div>
+            <div class="conn"><span class="who">Discord · #recruiting-automation, #recruiting-interviews</span><span class="st ok">✓ connected</span></div>
+            <div class="conn"><span class="who">Agape Notes (call recording)</span><span class="st warn">not set up</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="notes">
+      <h3>Structure</h3>
+      <ul>
+        <li><b>The sections are the rail's words.</b> <code>You · House · Funnel · Automations · Connections · Data</code>. The app already teaches House and Funnel; settings shouldn't teach a second taxonomy. If a new setting has no obvious home, the setting is confused — not the taxonomy.</li>
+        <li><b>Rendered from a schema, not hand-written.</b> Each field declares <code>{ key, label, hint, type, scope, default, min, max, unit }</code>; four types (<code>bool · number · text · enum</code>) cover every knob in the app. Adding a setting is appending an object.</li>
+        <li><b><code>scope</code> picks the store</b> — <code>house</code> → <code>recruit_settings</code>, <code>profile</code> → <code>recruit_profiles</code>, <code>local</code> → localStorage. Callers use <code>setting(key)</code> and never learn where a value lives.</li>
+        <li><b>The schema default is the code default.</b> <code>setting('followup_stale_days')</code> returns 3 until someone changes it, so exposing a knob needs no migration and no seed — and today's magic numbers (3 days, ±1 month, +3 months) become one named thing each.</li>
+        <li><b>Automations and connections are their own row types</b>, not fields: what it does, how often, when it last ran, whether it's on. Those are the four things you want when something didn't happen.</li>
+        <li><b>Save behavior follows the type.</b> Toggles and enums autosave with an inline tick; numbers and text take an explicit commit. The schema knows the type, so the renderer enforces it — no per-field config.</li>
+        <li>Section footers are <a href="#sidebar-ctas">Sidebar CTAs</a> — one commit, and “reset this section” as an exit row with a hint.</li>
+      </ul>
+      <h3>Notes</h3>
+      <p>A full view at <code>?view=settings</code>, not a modal — every section is deep-linkable, so a toast or a Discord audit post can point at the exact knob. The rail footer drops to <b>identity · Settings · Sign out</b>; theme moves to You, Gmail to Connections, CSV export to Data, and food/dues move out of the room drawer (a house-wide cost has no business inside one room) into House.</p>
+      <p>Full write-up, open decisions, and build order: <code>docs/ux/recruiting-settings-concept.md</code>.</p>
     </div>
   </section>
 

--- a/docs/execution/project-plan/backlog.md
+++ b/docs/execution/project-plan/backlog.md
@@ -625,3 +625,12 @@ Improvements flagged while shipping the /ladder product (PRs #633–#645). Track
 | **Rotate GITHUB_PAT to fine-grained PAT** — Currently using the broadly-scoped `gh auth token`. Generate a fine-grained PAT scoped to `fikei/job` only and `supabase secrets set GITHUB_PAT=<token>`. | Pending |
 | **CTRL theme alternate** (Phase 1 milestone i) — Author tokens-ctrl-{light,dark}.css against the abstract token contract; enable in the rail's theme picker. | Pending |
 | **Asset existence detection scaling** — jobs-pipe currently fetches the entire repo tree on every GET to compute hasResume/hasCoverLetter flags. Cache or scope to 03-jobs/. | Pending |
+
+## Agape Recruiting
+
+| Story | Status |
+|-------|--------|
+| **Settings surface** — Concept in `docs/ux/recruiting-settings-concept.md`; mock at [Sassy → Settings](https://ctrl.rodeo/design-system/recruiting/#settings). Six sections (`You · House · Funnel · Automations · Connections · Data`) at `?view=settings`, rendered from a field schema where `scope` picks the store and the schema default is the code default. Step 1 (the `setting()` accessor + schema, no UI) is worth landing on its own — it removes the hardcoded staleness/flexibility/trial-milestone literals. | Pending |
+| **Delete dead vote config** — `recruit_settings.vote_min_count` (3) and `vote_pass_avg` (3.5) survive from the collective-vote model that the single-decider change superseded on Jul 29. Nothing reads them. | Pending |
+| **Move food/dues out of the room drawer** — They're house-wide settings currently edited inside one room's occupancy drawer, next to that room's rent. Belongs in Settings → House. | Pending |
+| **Gmail token expiry is invisible** — The shared-inbox refresh token dies every ~7 days in OAuth Testing mode and the only symptom is no new applications. Settings → Connections should show a real reachable/expired status. Durable fix is publishing the OAuth app to Production. | Pending |

--- a/docs/ux/recruiting-settings-concept.md
+++ b/docs/ux/recruiting-settings-concept.md
@@ -1,0 +1,183 @@
+# Settings — concept & structure
+
+> **Status:** concept, not built. Design system story: [Settings](https://ctrl.rodeo/design-system/recruiting/#settings).
+> **Product:** Agape recruiting (`/applications`) · **Written:** 2026-07-30
+
+---
+
+## The problem
+
+There is no settings surface. There is a rail footer, and everything that didn't fit anywhere else went into it: three unlabelled-group checkboxes, a Gmail connection status line, a theme toggle, a CSV export, and Sign out. Meanwhile the two house-wide money settings — food and dues — are number inputs buried **inside a room's occupancy drawer**, which is where you'd look for that room's rent, not for a global.
+
+The deeper problem is that the footer is the only place a setting *can* go, so most settings never became settings at all. The house's recruiting behavior is currently governed by literals in `applications/js/app.js`:
+
+| Behavior | Today | Where |
+|---|---|---|
+| Follow-up goes amber after quiet | 3 days | `app.js` — `3 * 86400000` |
+| Flexible move-in window padding | ±1 month | `app.js` — `flexPad` |
+| Trial check-in milestone | start + 1 month | migration 139 |
+| Trial decision milestone | end − 1 month | migration 139 |
+| "Save for future" default return | +3 months | `defaultReturnDate()` |
+| Screener slots offered | max 8, 30 min apart | `_shared/discord.ts` |
+| Gap must be this long to list | 7 days | `roomGaps()` |
+| Timezone | `America/Los_Angeles` | `_shared/recruit-schedule.ts` |
+
+Each is a defensible default. None is a law of nature, and every one of them currently requires a PR and a deploy to change. That's the cost this concept is trying to remove.
+
+There is also dead config: `vote_min_count` (3) and `vote_pass_avg` (3.5) still sit in `recruit_settings` from the collective-vote model that the single-decider change superseded on Jul 29. A settings surface makes orphaned config visible instead of quietly load-bearing-looking.
+
+---
+
+## The idea
+
+**Settings mirrors the rail.** The app already teaches a mental model — **House** and **Funnel** — and people navigate by it. Settings should not invent a second taxonomy ("General / Advanced / Preferences"); it should answer "where would I look?" with the same two words, plus three sections for the things the rail has no room for.
+
+```
+Settings
+├── You            per-user, affects nobody else
+├── House          the building and the money
+├── Funnel         how applicants move through it
+├── Automations    the things that run without you
+├── Connections    Gmail, Calendar, Discord, notes bot
+└── Data           export, and the rare destructive stuff
+```
+
+Six sections, and the first three are the app's own vocabulary. A new setting almost always has an obvious home; when it doesn't, that's a signal the setting is confused, not that the taxonomy needs a seventh box.
+
+### Where it lives
+
+A **full view at `?view=settings`**, with a `Settings` entry pinned at the bottom of the rail below the Funnel group. Not a modal, not a drawer.
+
+- Deep-linkable per section (`?view=settings#automations`) — error toasts, Discord audit posts, and docs can point at the exact knob instead of describing where to click.
+- Reuses the existing page chrome (title, sub, scroll) so a new section costs an anchor, not a layout.
+- The rail footer sheds everything except identity and the Settings link. That alone fixes what the footer looks like today.
+
+### What the rail footer becomes
+
+```
+Ian Fike · edit
+Settings
+Sign out
+```
+
+Theme moves to **You**, the Gmail line to **Connections**, CSV export to **Data**, and the three checkboxes to **House** and **Funnel** where they belong.
+
+---
+
+## Structure for extensibility
+
+The point of this section: **adding a setting should be one object literal, not a UI change.**
+
+### 1. A declarative schema, rendered generically
+
+```js
+// applications/js/settings-schema.js
+export const SETTINGS = [
+  { id: 'you', title: 'You', hint: 'Only affects your account.', fields: [
+    { key: 'display_name', scope: 'profile', type: 'text',   label: 'Display name',
+      hint: 'Shown on your reviews and comments.' },
+    { key: 'theme',        scope: 'local',   type: 'enum',   label: 'Theme',
+      options: ['system', 'light', 'dark'], default: 'system' },
+  ]},
+  { id: 'funnel', title: 'Funnel', hint: 'How applicants move.', fields: [
+    { key: 'followup_stale_days', scope: 'house', type: 'number', unit: 'days',
+      label: 'Follow-up goes amber after', default: 3, min: 1, max: 30,
+      hint: 'A thread this quiet is worth another email.' },
+    { key: 'movein_flex_months',  scope: 'house', type: 'number', unit: 'months',
+      label: 'Flexible move-in stretches by', default: 1, min: 0, max: 3,
+      hint: 'How far a "flexible" date reaches on each side when matching listings.' },
+    { key: 'update_email_default', scope: 'house', type: 'bool',
+      label: 'Offer an update email by default',
+      hint: 'When someone is marked not a fit — you can still change it per person.' },
+  ]},
+  // …
+];
+```
+
+The page renders from this array. Four field types cover everything in the inventory: `bool`, `number`, `text`, `enum`. **Adding a setting is appending an object.** No template, no handler, no new markup.
+
+### 2. `scope` decides the store, so nothing else has to know
+
+Every field declares one of three scopes, and a single accessor resolves it:
+
+| Scope | Store | Example |
+|---|---|---|
+| `house` | `recruit_settings` (key/value JSONB) | food cost, staleness window |
+| `profile` | `recruit_profiles` | display name, group email |
+| `local` | `localStorage` | theme, video speed |
+
+```js
+setting('followup_stale_days')            // → house value, or the schema default
+setSetting('followup_stale_days', 5)      // → routes to the right store by scope
+```
+
+The renderer never branches on storage, and callers never learn where a value lives. Moving a setting from `local` to `house` later (theme is a plausible one — a house might want a shared look) is a one-word change in the schema.
+
+### 3. The schema default is the code default
+
+This is the piece that pays for itself. Every literal in the table above becomes:
+
+```js
+const staleDays = setting('followup_stale_days');   // 3 until someone changes it
+```
+
+`setting()` falls back to the schema's `default` when the DB has no row, so **shipping a knob as configurable requires no migration and no seed** — the schema is the source of truth for both the default and the UI. It also means a setting can exist in code *before* it's exposed: omit it from a section's `fields` and it stays a named, documented constant in one place instead of a magic number in three.
+
+### 4. Automations and Connections are row types, not fields
+
+These don't fit the field renderer and shouldn't be forced into it — they have live status, a last-run time, and an action:
+
+```js
+{ id: 'automations', title: 'Automations', rows: [
+  { key: 'gmail_scan',   label: 'Scan the shared inbox',
+    cadence: 'every 20 min', status: () => lastRun('recruit_gmail_scan_tick'),
+    hint: 'Pulls new applications, replies, and availability.' },
+  { key: 'screening_reminders', label: 'Remind screeners before a call',
+    cadence: 'every 15 min', status: () => lastRun('recruit_screening_reminder_tick') },
+]}
+```
+
+Each automation row shows **what it does, how often, when it last ran, and whether it's on** — the four things you want when something didn't happen. Same for connections: Gmail, the house calendar, the Discord server + its two channels, and the optional Recall notes bot, each with a reachable/expired state. The Gmail token expiring every ~7 days is currently invisible until someone notices no new applications; a Connections section with a real status makes that a glance instead of an investigation.
+
+### 5. Reuse the sidebar CTA tiers
+
+Section footers use [`drawer-cta`](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas): one filled commit per section, quiet dismiss, and anything destructive (disconnect Gmail, reset a section to defaults) as a full-width exit row with a hint. Settings is exactly the surface that pattern was built for — the consequences are the whole point.
+
+---
+
+## Open decisions
+
+### 1. Autosave per control, or an explicit Save per section?
+
+- **Autosave** matches the current footer checkboxes (they upsert on change) and suits toggles, but a number field autosaving mid-typing is hostile, and "did that save?" has no answer.
+- **Save per section** gives every change a moment of intent, which is right for things like the staleness window that silently change what everyone else sees — but it's ceremony for flipping a checkbox.
+- **Nuance:** the two behave differently because the *settings* are different. A toggle is a decision; a number is a draft until you stop typing.
+
+**Recommendation:** autosave `bool` and `enum` on change with an inline "saved" tick; require an explicit commit for `number` and `text`. The schema already knows the type, so the renderer can enforce this — no per-field configuration.
+
+### 2. Who can change house-wide settings?
+
+- Today every signed-in Recruiting Society member can flip any of the three footer toggles, and nothing records who did.
+- House-wide settings change what everyone sees. Locking them to an admin list is safer but adds a role concept the app doesn't have yet.
+- **Nuance:** the honest middle is an audit trail — `recruit_settings` gains `updated_by` / `updated_at`, and the section shows "Ian changed this 3 days ago". Accountability without a permissions model, the same bet the single-decider review model already made.
+
+**Recommendation:** no roles. Add `updated_by`/`updated_at` and surface it per setting. Revisit if it's ever abused.
+
+### 3. How far to go on the hardcoded literals in v1?
+
+- **All of them** (8 knobs) is the most complete, but some — the 30-minute screener slot interval, the timezone — nobody will touch this year, and each one exposed is a setting to maintain and document.
+- **None of them**, and Settings is just the footer reorganized, which doesn't earn a new view.
+- **Nuance:** the ones worth exposing are the ones the house has actually argued about.
+
+**Recommendation:** expose four in v1 — follow-up staleness, move-in flexibility, the two trial milestone offsets. Route the rest through `setting()` with schema defaults but leave them out of the UI; they become one-line exposures the day someone asks. Delete `vote_min_count` and `vote_pass_avg`.
+
+---
+
+## Suggested build order
+
+1. `settings-schema.js` + `setting()` / `setSetting()`, and route the four v1 knobs and all existing settings through them. No UI yet — behavior identical, literals gone.
+2. `?view=settings` with the six sections rendering from the schema; rail entry added, footer stripped to identity + Settings + Sign out. Move food/dues out of the room drawer into **House**.
+3. Automations + Connections row types, reading `cron.job_run_details` and the Gmail token state for status.
+4. `updated_by` / `updated_at` on `recruit_settings`, surfaced per setting.
+
+Step 1 is worth doing even if the view never ships.


### PR DESCRIPTION
Concept only — nothing wired. Story: **Sassy → Patterns → Settings**.

## The problem

There is no settings surface, just a rail footer that everything fell into. The consequence is that most settings never became settings — the house's recruiting behavior is literals in `app.js`:

| Behavior | Today |
|---|---|
| Follow-up goes amber after quiet | 3 days |
| Flexible move-in window padding | ±1 month |
| Trial check-in / decision milestones | start +1mo / end −1mo |
| Gap must be this long to list | 7 days |

Each needs a PR and a deploy. Meanwhile food and dues — house-wide costs — are number inputs inside one room's occupancy drawer.

## The structure

Six sections in the rail's own vocabulary, so "where would I look?" has an answer: `You · House · Funnel · Automations · Connections · Data`. Full view at `?view=settings` (deep-linkable per section), and the footer drops to identity · Settings · Sign out.

Extensibility is the real proposal:

- **A declarative field schema, rendered generically.** Adding a setting is appending one object literal. Four types (`bool · number · text · enum`) cover every knob in the inventory.
- **`scope` picks the store** — `house` → `recruit_settings`, `profile` → `recruit_profiles`, `local` → localStorage. The renderer never branches on storage; callers use `setting(key)`.
- **The schema default *is* the code default.** `setting('followup_stale_days')` returns 3 until someone changes it — no migration, no seed, and each magic number becomes one named thing.
- **Automations and Connections are row types, not fields** — what it does, how often, when it last ran, whether it's on.
- **Section footers reuse [`drawer-cta`](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas).**

Three open decisions are written up with recommendations (autosave vs. explicit save; who can change house-wide settings; how many literals to expose in v1), plus a four-step build order where step 1 is worth landing even if the view never ships.

## Files
- [docs/ux/recruiting-settings-concept.md](docs/ux/recruiting-settings-concept.md) — the concept, decisions, build order
- [design-system/recruiting/index.html](design-system/recruiting/index.html) — Settings story + mock, 3 decision-log entries, v3.29
- [docs/execution/project-plan/backlog.md](docs/execution/project-plan/backlog.md) — new Agape Recruiting section with 4 follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)