### PR TITLE
feat(recruiting): notification ledger + activity log (v3.45.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1559,3 +1559,20 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .gplayer__btn:hover { background: var(--bg-overlay); color: var(--fg); }
 .gplayer.is-mini .vchrome { display: none; }
 @media (max-width: 520px) { .gplayer.is-mini { width: min(250px, 70vw); right: 10px; bottom: 10px; } }
+
+/* ---------- activity log (v3.45.0) ----------
+   The running record of every notification. Rows are deliberately quieter than
+   the funnel rails: a log is scanned, not worked, so the icon carries the kind
+   and the third line carries what happened to it. */
+.log-row__icon {
+  flex-shrink: 0; width: 24px; text-align: center;
+  font-size: 14px; line-height: 1;
+}
+.log-row__meta {
+  font-size: var(--font-size-caption); color: var(--fg-subtle);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Resolved entries stay in the log and stop competing for attention. */
+.log-row.is-done .inbox-row__title,
+.log-row.is-done .inbox-row__sub { opacity: 0.5; }
+.log-row.is-done .log-row__meta { opacity: 0.7; }

--- a/applications/index.html
+++ b/applications/index.html
@@ -48,6 +48,7 @@
         <div class="rail-nav__group">House</div>
         <a class="rail-nav__row" href="?view=openings" data-view-link="openings">Openings <span class="rail-nav__count" id="count-openings"></span></a>
         <a class="rail-nav__row" href="?view=occupancy" data-view-link="occupancy">Occupancy</a>
+        <a class="rail-nav__row" href="?view=activity" data-view-link="activity">Activity <span class="rail-nav__count" id="count-activity"></span></a>
         <div class="rail-nav__group">Funnel</div>
         <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Inbox <span class="rail-nav__count" id="count-inbox"></span></a>
         <a class="rail-nav__row" href="?view=candidates" data-view-link="candidates">Candidates <span class="rail-nav__count" id="count-candidates"></span></a>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.44.0';
+const VERSION = '3.45.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -110,6 +110,7 @@ const VIEWS = {
   screening: { title: 'Screening', kind: 'applicants' },
   archive: { title: 'Archive', kind: 'applicants' },
   occupancy: { title: 'Occupancy', kind: 'house' },
+  activity: { title: 'Activity', kind: 'activity' },
 };
 // Old bookmarks and deep links keep working.
 const LEGACY_VIEWS = { review: 'inbox', outreach: 'openings', hold: 'inbox', listings: 'openings' };
@@ -135,6 +136,10 @@ let footFor = null;           // which applicant the review bar in the DOM belon
 let commentCounts = {};       // applicant_id -> n
 let latestNotes = {};         // applicant_id -> { author, body }
 let comments = [];            // comments for the applicant open in review
+let activity = [];            // recruit_notifications, newest first — the running log
+let activityError = null;
+let activityFilter = { kind: 'all', open: false };
+let activityOpenCount = 0;    // unresolved notifications, for the rail badge
 let view = 'inbox';           // current rail view
 let filters = { track: 'all', month: 'any', budget: 'any' }; // shared across applicant views
 let rooms = [];               // recruit_rooms
@@ -1451,8 +1456,162 @@ async function render() {
     await loadHouse();
     if (VIEWS[view].kind !== 'house') return; // navigated away meanwhile
   }
+  if (def.kind === 'activity') {
+    root.innerHTML = `<p class="inbox-empty">Loading…</p>`;
+    await loadActivity();
+    if (view !== 'activity') return;   // navigated away meanwhile
+    renderActivity();
+    return;
+  }
   if (def.kind === 'applicants') renderApplicants();
   else if (view === 'occupancy') renderOccupancy();
+}
+
+/* ---------- activity log ----------
+   The running log of every notification, exactly as recorded — the same rows
+   #recruiting-automation gets, and the same rows the digest draws from. No
+   filtering by default and nothing hidden: muted kinds and DMs are shown with
+   a label saying so, because the point of the log is that it is complete.
+   Migration 142 / recruit_notifications. */
+/* Kind → how it introduces itself. Must stay in step with KINDS in
+   _shared/recruit-notify.ts: the log and Discord should use the same words for
+   the same thing, and neither should ever show the raw kind slug. */
+const ACTIVITY_KINDS = {
+  application_new:   { icon: '📥', label: 'New application' },
+  review_stalled:    { icon: '⏳', label: 'Waiting on a review' },
+  review_backlog:    { icon: '🗄️', label: 'Inbox backlog' },
+  opening_at_risk:   { icon: '🏠', label: 'Opening at risk' },
+  opening_overdue:   { icon: '🔴', label: 'Opening overdue' },
+  room_emptying:     { icon: '📦', label: 'Room emptying' },
+};
+const kindIcon = k => ACTIVITY_KINDS[k]?.icon || '•';
+const kindLabel = k => ACTIVITY_KINDS[k]?.label
+  || (k.charAt(0).toUpperCase() + k.slice(1).replace(/_/g, ' '));
+/* Where each subject type lives, so a log line clicks through to the thing it
+   is about rather than being a dead end. */
+const ACTIVITY_TARGET = {
+  applicant: id => `?a=${encodeURIComponent(id)}`,
+  listing: () => `?view=openings`,
+  stay: () => `?view=occupancy`,
+  house: () => `?view=openings`,
+};
+
+async function loadActivity() {
+  const { data, error } = await sb.from('recruit_notifications')
+    .select('*').order('created_at', { ascending: false }).limit(300);
+  if (error) { activityError = error.message; activity = []; return; }
+  activityError = null;
+  activity = data || [];
+  activityOpenCount = activity.filter(n => !n.acked_at).length;
+  renderRailCounts();
+}
+
+/* Just the badge number, for boot — the rail should show what's outstanding
+   without pulling 300 log rows on every page load. */
+async function loadActivityCount() {
+  const { count, error } = await sb.from('recruit_notifications')
+    .select('id', { count: 'exact', head: true }).is('acked_at', null);
+  if (error) return;
+  activityOpenCount = count || 0;
+  renderRailCounts();
+}
+
+function activityDelivery(n) {
+  // What actually happened to this notification, in the order it happened.
+  const bits = [];
+  if (n.members_at) bits.push('housemates');
+  if (n.escalated_at) bits.push('escalated to on-call');
+  if (n.dm_at) bits.push('DM');
+  if (n.log_at) bits.push('#recruiting-automation');
+  if (n.muted) bits.push('muted — logged only');
+  if (!bits.length) bits.push('not sent yet');
+  return bits.join(' · ');
+}
+
+function renderActivity() {
+  const host = document.getElementById('view-root');
+  if (activityError) {
+    host.innerHTML = `<p class="inbox-empty">Couldn't load the log — ${esc(activityError)}</p>`;
+    return;
+  }
+  if (!activity.length) {
+    host.innerHTML = `<p class="inbox-empty">Nothing logged yet. Every notification the house sends lands here.</p>`;
+    return;
+  }
+  const kinds = [...new Set(activity.map(n => n.kind))].sort();
+  const shown = activity.filter(n =>
+    (activityFilter.kind === 'all' || n.kind === activityFilter.kind) &&
+    (activityFilter.open === false || !n.acked_at));
+
+  // Same chip vocabulary as the applicant filter bar — one kind chip per kind
+  // actually present, plus the unresolved toggle.
+  const filterBar = `<div class="filters">
+    <span class="filters__group">
+      <button class="chip ${activityFilter.open ? 'is-on' : ''}" data-activity-open>Unresolved</button>
+    </span>
+    <span class="filters__sep"></span>
+    <span class="filters__group">
+      <button class="chip ${activityFilter.kind === 'all' ? 'is-on' : ''}" data-activity-kind="all">Everything</button>
+      ${kinds.map(k => `<button class="chip ${activityFilter.kind === k ? 'is-on' : ''}" data-activity-kind="${esc(k)}">${kindIcon(k)} ${esc(kindLabel(k))}</button>`).join('')}
+    </span>
+  </div>`;
+
+  // Grouped by day: a log is read by "what happened on Tuesday", not by row.
+  const days = [];
+  for (const n of shown) {
+    const day = new Date(n.created_at).toLocaleDateString('en-US',
+      { weekday: 'long', month: 'short', day: 'numeric' });
+    if (!days.length || days[days.length - 1].day !== day) days.push({ day, items: [] });
+    days[days.length - 1].items.push(n);
+  }
+
+  host.innerHTML = filterBar + (shown.length ? days.map(g => `
+    <section class="inbox-group">
+      <div class="inbox-group__head">
+        <span class="inbox-group__label">${esc(g.day)}</span>
+        <span class="inbox-group__count">${g.items.length}</span>
+      </div>
+      <ul class="inbox-card">
+        ${g.items.map(n => `<li class="inbox-row log-row${n.acked_at ? ' is-done' : ''}">
+          <span class="log-row__icon" title="${esc(kindLabel(n.kind))}">${kindIcon(n.kind)}</span>
+          <button class="inbox-row__main" data-log-go="${esc(n.subject_type)}|${esc(n.subject_id || '')}">
+            <span class="inbox-row__text">
+              <span class="inbox-row__title">${esc(kindLabel(n.kind))} · ${esc(n.payload?.title || n.subject_label)}</span>
+              <span class="inbox-row__sub">${esc(n.payload?.body || '')}</span>
+              <span class="log-row__meta">${esc(relTime(n.created_at))} · ${esc(activityDelivery(n))}${n.acked_at ? ` · resolved ${esc(relTime(n.acked_at))}` : ''}</span>
+            </span>
+          </button>
+          <span class="inbox-row__actions">
+            ${n.acked_at ? '' : `<button class="btn btn--sm" data-ack="${esc(n.id)}">Resolve</button>`}
+          </span>
+        </li>`).join('')}
+      </ul>
+    </section>`).join('') : `<p class="inbox-empty">Nothing matches these filters.</p>`);
+
+  host.querySelectorAll('[data-activity-kind]').forEach(el =>
+    el.onclick = () => { activityFilter.kind = el.dataset.activityKind; renderActivity(); });
+  host.querySelectorAll('[data-activity-open]').forEach(el =>
+    el.onclick = () => { activityFilter.open = !activityFilter.open; renderActivity(); });
+  host.querySelectorAll('[data-ack]').forEach(el => el.onclick = () => ackNotification(el.dataset.ack));
+  host.querySelectorAll('[data-log-go]').forEach(el => el.onclick = () => {
+    const [type, id] = el.dataset.logGo.split('|');
+    if (type === 'applicant' && id) return openReview(id);
+    const target = ACTIVITY_TARGET[type];
+    if (target) setView(new URLSearchParams(target(id).replace(/^\?/, '')).get('view') || 'openings');
+  });
+}
+
+/* Resolving keeps the entry and adds the fact that it was handled — the log
+   never loses a row, and the next digest stops asking. */
+async function ackNotification(id) {
+  const row = activity.find(n => n.id === id);
+  if (row) { row.acked_at = new Date().toISOString(); renderActivity(); }
+  const { error } = await sb.rpc('recruit_ack_notification', { p_id: id });
+  if (error) {
+    if (row) row.acked_at = null;
+    renderActivity();
+    toast(`Couldn't resolve that — ${error.message}`);
+  }
 }
 
 /* ---------- applicants render ---------- */
@@ -1538,6 +1697,10 @@ function renderRailCounts() {
     const el = document.getElementById(`count-${key}`);
     if (el) el.textContent = c[key] || '';
   }
+  // Activity counts what's still unresolved, not the whole log — a log that
+  // badges its own length would never stop badging.
+  const act = document.getElementById('count-activity');
+  if (act) act.textContent = activityOpenCount || '';
 }
 
 function decisionChip(id) {
@@ -4411,6 +4574,7 @@ async function _checkMembershipAndEnter() {
     resolveAvatars(); // background — server resolves any unchecked profile photos
     scanInbox();      // background — badge replies without opening each thread
     loadRecordingLeads(); // background — unfiled Discord recording links
+    loadActivityCount();  // background — unresolved-notification badge on Activity
     const autoFlagged = await applyAutoFlags();
     document.getElementById('gate').hidden = true;
     document.getElementById('app').hidden = false;

--- a/docs/strategy/prds/agape-recruiting-funnel.md
+++ b/docs/strategy/prds/agape-recruiting-funnel.md
@@ -113,5 +113,8 @@ Not built: a Discord announcement on promotion. It needs an authenticated
 route on `recruit-discord`, and the checklist already gives the house the
 signal. Worth revisiting if promotions start getting missed.
 
+### Notifications
+Every stage change above now has a lifecycle, but the house only hears about four of them. Proposed notification spine (ledger + dispatcher + daily/weekly digests) for applicants, openings, and occupants: [agape-recruiting-notifications.md](./agape-recruiting-notifications.md) — proposed, not built.
+
 ### Design reference
 Row states, chip taxonomy, and subcopy grammar for Inbox/Candidates/Openings: [docs/ux/recruiting-row-states.md](../../ux/recruiting-row-states.md) (v3.5.0 — response dot, room pills, note bubble, ✕ removal, see-more bar).

--- a/docs/strategy/prds/agape-recruiting-notifications.md
+++ b/docs/strategy/prds/agape-recruiting-notifications.md
@@ -1,0 +1,549 @@
+# Agape recruiting notifications — applicants, openings, occupants
+
+**One line:** one ledger records **every** notification as a running in-app log,
+and Discord carries the ones addressed to all housemates on one of three lanes
+(now / daily / weekly) — so the house learns about a stalled review or an
+emptying room before it costs them a month's rent, and can always answer "did
+anyone ever get back to her?"
+
+Status: **Phase 1 shipped** (migration 142, `recruit-discord` v1.16.0,
+`/applications` v3.45.0) — ledger, dispatcher, Activity view, and four detectors
+live and verified against real data. Phases 2–4 planned.
+
+**Currently automation-only.** `notify_house_posts = false`, so every
+notification, escalation, and digest goes to `#recruiting-automation` and nothing
+reaches Recruiting Society. Flipping that one setting is the release.
+
+---
+
+## Why now
+
+The funnel is complete end to end (application → review → opening → screening →
+trial → resident, v3.43.0). Every stage transition exists in the data. But the
+house only hears about **four** of them, and three of those are about a single
+screening call. Everything else is discovered by someone opening
+`/applications` and noticing.
+
+The failures that follow are all the same shape — *nobody was told, so nobody
+acted*:
+
+- An application sits in the Inbox for two weeks because the ping scrolled past.
+- A room empties on Sep 1 and the listing gets created on Aug 20 — three weeks
+  is not enough funnel to fill it.
+- A draft listing generated from an occupancy gap is never opened, so
+  auto-placement (which only sees `open`) never runs.
+
+None of these need new intelligence. They need a dispatcher.
+
+---
+
+## What exists today
+
+| # | Notification | Trigger | Where | Cadence | Dedupe |
+|---|---|---|---|---|---|
+| 1 | New application | `stage='review'`, no votes, no ping, ≤14d old | ping channel (`RECRUITING_PING_CHANNEL_ID`, falls back to `#recruiting-notes`) | 20-min gmail scan | `discord_ping_at` |
+| 2 | Screening claim post | availability submitted | `#recruiting-automation` + notes mirror | on submit | `recruit_claim_posts` |
+| 3 | Claim post stuck | claim post unclaimed | same message, edited | 20-min scan (`remindStuckPosts` / `notifyStuck`) | message state |
+| 4 | Interview in ~1h | `recruit_screenings.status='scheduled'` | DM to claimer | 15-min tick | `reminder_sent_at` |
+| 5 | Call is live / recording + summary | calendar + Recall | notes channel | 15-min tick | `recording_posted_at` |
+| 6 | Trial check-in / decision, 7d ahead | `recruit_stays.checkin_on` / `decision_on` | `#recruiting-automation` | 15-min tick | `*_reminded_at` |
+| 7 | Unmatched call link nudge | calendar event with no applicant | DM | 15-min tick | per-event |
+
+**Infrastructure already in place** — this is the important part; the proposal
+adds almost no new plumbing:
+
+- **Three crons**, all nonce-authenticated (migration 123 pattern):
+  `recruit_screening_reminder_tick` (`*/15`, → `recruit-discord/remind`),
+  `recruit_gmail_scan_tick` (`*/20`, → `recruit-gmail/scan`),
+  `recruit_application_ingest_tick` (hourly, → `recruit-ingest/pull`).
+- **Discord helpers** in `_shared/discord.ts`: `postChannelEmbed`,
+  `postResilient` (cross-channel fallback), `auditMirror`, `dmUser`,
+  channel constants for automation + notes.
+- **The dedupe idiom**, already used four times: a `*_reminded_at` / `*_at`
+  column, cleared when the underlying date moves, plus a
+  "backdated more than 14 days → stamp silently" rule (v3.39.0). Generalising
+  this is most of the work.
+- **Settings as a table** (`recruit_settings`), so cadence and mutes are
+  config, not deploys.
+- **A digest precedent**: the new-application ping already collapses 4+ into
+  one embed.
+
+**What's missing:** any notion of a notification that isn't hard-coded at its
+call site. Six functions each own their own dedupe column, channel choice, and
+volume rule. Adding the eleven notifications below the same way would be
+unmaintainable and would flood the channel.
+
+---
+
+## Lifecycles
+
+### Applicant
+
+```
+submitted → review ─┬─ not_fit ──→ rejected → (update email) → archived
+   (Inbox)          ├─ needs_input → stays in review
+                    └─ forward ───→ candidate
+candidate → auto-placed into every qualifying open listing (Openings)
+   → screening request → availability → claim → call → recording
+   → house decision → trial stay → resident (+ onboarding checklist)
+                                 └─ trial_ended → archived
+```
+
+Signals that exist in data and are currently silent: verdict recorded,
+`needs_input` asked, placement gained/lost, no qualifying listing, update email
+owed, applicant gone cold, and **every inbound reply that isn't availability** —
+a reschedule, a withdrawal, a changed move-in date, and an unanswered question
+are all currently indistinguishable from each other (all four are just a dot on
+a row).
+
+### Opening (`recruit_listings`)
+
+```
+draft (auto from occupancy gap) → open → shortlist fills by placement sweep
+   → screening → filled | closed
+                              └─ start date passes while open = lost rent
+```
+
+Silent today: draft created, draft rotting, open with an empty shortlist,
+shortlist gained its first candidate, move-in date approaching, start date
+passed, filled-but-no-stay-on-the-calendar.
+
+### Occupant (`recruit_stays`)
+
+```
+stay opens (resident | sublet | candidate | shared)
+   candidate: → check-in (+1mo) → decision (−1mo) → promote → resident
+                                                  └─ not staying → exit
+   any: ends_on approaches → room becomes a gap → draft listing
+```
+
+Silent today: any non-trial stay ending, promotion, onboarding items
+outstanding, overlapping or expired stays.
+
+---
+
+## Proposed notifications
+
+Lane key: **Now** = the next 15-min tick. **Daily** = one section of the 8:30am
+PT digest. **Weekly** = Monday roll-up. **Audit** = `#recruiting-automation`
+only, unbatched, never news.
+
+### Applicants
+
+| ID | Notification | Trigger | Lane | Repeat / reset |
+|---|---|---|---|---|
+| A1 | New application | *(exists — #1)* | Now, ≤3 individually; ≥4 as one embed | once per applicant |
+| A2 | **Waiting on a review** | `review`, zero verdicts, 48h since the house could have known | Daily | escalates at 5 days into its own `#recruiting-automation` notification |
+| A3 | **Another read wanted** | verdict `needs_input` written | Now | once per verdict row; names the asker + quotes their comment |
+| A4 | **Passed review — and where they landed** | `stage → candidate` | Now | once; body lists auto-placements, or says *no open room fits*, which is itself the signal |
+| A5 | **Candidate parked** | `candidate` ≥14d, zero active placements, no screening | Weekly | repeats weekly while true |
+| A6 | **Applicant replied** | inbound email, active stages only | *by intent* — see [Reply intents](#reply-intents) | per message |
+| A7 | Availability with no claim | *(exists — #3)* | Now | + new: 72h unclaimed → escalation in `#recruiting-automation` |
+| A8 | Interview reminders / recording | *(exists — #4, #5)* | Now | unchanged |
+| A10 | **Gone cold** | active stage, last outbound >10d, nothing inbound since | Weekly | repeats weekly |
+
+### Reply intents
+
+"An applicant replied" is not a notification — it's a fact with eight different
+consequences. A reschedule request an hour before a call and a question about
+whether the room is furnished do not belong in the same line of the same digest.
+So inbound replies are classified by **intent**, and the intent — not the reply
+— is what routes.
+
+This is nearly free: `recruit-gmail`'s scan already runs Haiku on every inbound
+reply body (`extractAvailability`, which today returns `windows`, `platform`,
+`timezone_note`, `needs_human`). Intent is **three more fields on that same
+call** — no new pass, no new API cost, no new latency.
+
+| Intent | What it looks like | Lane | Routes to |
+|---|---|---|---|
+| `availability` | times offered, "Tue or Wed afternoon works" | **Daily** (+ the claim post fires immediately, as today) | the claim post asks *someone* to take the call; the digest line and log entry tell *the house* she replied. Both. |
+| `reschedule` | move or cancel a booked call | **Now** + DM the claimer | the screening. Most urgent thing in the inbox: the alternative is a no-show on both sides. |
+| `plans_changed` | move-in date, budget, or duration moved | **Now** | the profile's Move-in / budget facts — this changes auto-placement qualification, so it can silently invalidate a shortlist |
+| `withdrawing` | took another place, no longer looking | **Now** | archive with `exit_reason='opted_out'`. They're holding a shortlist slot until someone acts. |
+| `post_acceptance` | lease, keys, move-in day, parking | **Now** | Occupancy / onboarding, not the funnel |
+| `question` | rent, rooms, housemates, process | **Daily**, question quoted verbatim | whoever's on-call; escalates to Now if unanswered 48h |
+| `info_provided` | references, proof of income, socials, the thing we asked for | **Daily** | the profile — read and attach |
+| `nudge` | "just following up", "any update?" | **Daily**, with *how long they've waited* | the stalled thing they're waiting on. A nudge is a reputational clock, and the wait time is the whole message. |
+| `unclear` | can't tell, or confidence below floor | **Daily** | a human reads the thread. Generalises the existing `needs_human` flag. |
+
+**Rules**
+
+1. **One primary intent routes; secondaries annotate.** A reply that offers
+   times *and* asks about parking is `availability` + `question` — the digest
+   says "Maya sent times and asked something", the claim post still fires, and
+   the log records both intents against the message. Store `intent` (primary,
+   drives the lane) and `intents` (array, drives the copy).
+2. **Extraction outranks the classifier on its own turf.** If `windows.length >
+   0`, `availability` is in the array no matter what the classifier said — the
+   parse is ground truth, the label is an opinion.
+3. **Confidence floor 0.6 → `unclear`.** Below that a human reads it. Same
+   discipline as `detectAgreedTime`'s "when in doubt, false": a misrouted
+   withdrawal is worse than an unrouted one.
+4. **Intent routes attention, never action.** No auto-reply, no auto-archive on
+   `withdrawing`, no auto-edit of a move-in window on `plans_changed`. Each
+   Now-lane post carries the *button* for the obvious action; a person presses it.
+5. **Active stages only for routing.** Inbound mail on an `archived` /
+   `resident` applicant is logged and not classified — no LLM cost, and it still
+   appears in the log as a plain reply.
+6. **Dedupe per message, digest per applicant.** `dedupe_key =
+   'reply_<intent>:<email_id>'`, because two questions deserve two answers; but
+   the daily digest collapses to one line per person.
+7. **Each intent is its own `kind`** in the ledger — so each has its own lane
+   and its own entry in `notify_muted`. If `nudge` turns out to be noise, it
+   gets switched off without touching the other eight.
+
+**Schema:** `recruit_emails` gains `intent TEXT`, `intents TEXT[]`,
+`intent_confidence REAL`, `intent_summary TEXT` (one line, the actual ask in the
+applicant's words — this is what the digest prints, not the snippet).
+
+**In-app:** the existing reply dot on Openings/Screening rows gains the intent
+label, so the rail and the digest say the same word. Row-state and chip grammar
+to be added to [recruiting-row-states.md](../../ux/recruiting-row-states.md).
+
+**Digest shape:**
+
+```
+💬 Replies (4)
+  ⏰ Reschedule · Maya wants to move Thu 3pm → DM'd Kate
+  📅 Plans changed · Tom's move-in slipped to Oct 1 — recheck his placements
+  ❓ Question · Priya: "is the room furnished?" · waiting 2 days
+  👋 Nudge · Sam followed up · waiting 9 days on a screening request
+```
+
+### Openings
+
+| ID | Notification | Trigger | Lane | Repeat / reset |
+|---|---|---|---|---|
+| O1 | **Draft listing created** | `status='draft'`, `source` in (`gap`,`leaving`) | Now if <3, else Daily line-list | once per listing; buttons: open it / dismiss |
+| O2 | **Draft still untouched** | `draft` ≥7d | Weekly | weekly while draft |
+| O3 | **Nobody qualifies** | `open` ≥7d, zero qualifying candidates | Weekly | includes *why* — track / budget / date is the blocker |
+| O4 | **Opening at risk** | `open`, `starts_on` ≤21d out | Daily | escalates to Now at 7 days; resets if `starts_on` moves |
+| O5 | **First qualifying candidate** | shortlist 0 → ≥1 | Now | once per listing; this is the cue to send a screening request |
+| O6 | **Start date passed, still open** | `open`, `starts_on` < today | Now | once, then Daily until resolved — this one is literally lost rent |
+| O7 | **Filled but no stay** | `filled` 24h with no `recruit_stays` row covering the window | Audit + Daily | until reconciled |
+| O8 | Rent / window edited on an open listing | update to an `open` row | Audit | every time |
+
+### Occupants
+
+| ID | Notification | Trigger | Lane | Repeat / reset |
+|---|---|---|---|---|
+| C1 | **Room emptying** | current stay `ends_on` ≤45d, no follow-on stay and no listing for that room | Daily | resets if `ends_on` moves; 45d ≈ one full funnel (review → screening → decision → move) |
+| C2 | Trial check-in in 7d | *(exists — #6)* | Now | unchanged |
+| C3 | Trial decision in 7d | *(exists — #6)* | Now | + new: decision date passed, stay still `candidate` → Daily until resolved |
+| C4 | **Welcomed in** | `recruit_promote_stay` / `recruit_promote_candidate` succeeds | Now | once; links the onboarding checklist. *(PRD v3.43.0 flagged this as deliberately not built — the ledger removes the objection, since it no longer needs a bespoke authenticated route.)* |
+| C5 | **Onboarding still owed** | `recruit_onboarding` rows unticked 14d after promotion | Weekly | names the items; weekly while open |
+| C6 | **Occupancy integrity** | overlapping stays in one room; open-ended stay whose room also has a later stay; `ends_on` in the past still treated as current | Audit, Daily | one summary post, not one per conflict |
+
+New, non-existing notifications: **24** (16 above + 8 reply intents). Existing,
+absorbed onto the ledger: **7**.
+
+---
+
+## Surfaces
+
+Three surfaces, and they are not alternatives — a notification can land on all
+three. What decides each one is different:
+
+| Surface | Gets | Decided by |
+|---|---|---|
+| **The log** — in-app Activity view **and** `#recruiting-automation` | **everything, always** — every notification, every kind, in order, retained forever | nothing. There is no filter, no batching, no mute. |
+| **Discord members channel** | anything addressed to **all housemates**, batched | audience. If the house collectively needs to know or act, it goes where the house is. |
+| **DM** | anything owned by **one named person** | ownership — and only real ownership: the claimer of a specific call. |
+
+The log has **two locations, one content**: the Activity view for browsing and
+filtering, `#recruiting-automation` for the same stream arriving live and
+unbatched. Neither is a subset of the other. `#recruiting-automation` is not an
+"audit mirror" as earlier drafted — it is the running log itself, in Discord
+form, and it is where on-call lives (below).
+
+**Double-notify is correct, not a bug.** The same fact reaching a housemate twice
+through two surfaces is two different messages: the claim post asks *someone* to
+pick a call up; the digest line tells *the house* that Maya sent times; the log
+entry is the record that it happened at all. Suppressing the second and third
+because the first fired is how a house ends up unable to answer "did anyone ever
+get back to her?" So the earlier "never double-notify" rule is dropped — every
+notification is logged, and Discord routing is decided on audience alone.
+
+**Muting never loses information.** `notify_muted` suppresses the *Discord*
+post for a kind. The log entry is written regardless. This is what makes it safe
+to switch a noisy kind off — nothing disappears, it just stops shouting.
+
+### The in-app log
+
+A rail view (**Activity**, under the house group next to Occupancy) rendering
+`recruit_notifications` newest-first: timestamp, kind icon, the same one-line
+body Discord got, the subject as a link into its rail, and whether it went to
+Discord, a DM, or nowhere. Filterable by subject type (applicant / opening /
+occupant), by kind, and by subject — so "everything that ever happened to Maya"
+is one filter, and it's also the answer to "what did we send this week".
+
+Because the ledger is written by the detect pass before anything is dispatched,
+the log is complete by construction — it is not a copy of what Discord received,
+it is the source Discord reads from.
+
+### Reaching out to all housemates
+
+Anything the recruiting system asks of the house as a body posts to Discord, at
+the moment of asking — these are the ones where silence is the failure:
+
+| | Ask | Currently |
+|---|---|---|
+| H1 | **New application needs a review** | exists (#1) — keep |
+| H2 | **A screening needs claiming** | exists (#2) — keep |
+| H3 | **A house decision is open** | `recruit_decision_votes` collecting after a screening — **silent today**. Triggered by the clock, not by voting: see below |
+| H4 | **A second read is wanted** | `needs_input` (A3) — the asker is asking the house, not one person |
+| H5 | **A trial decision is due** | exists (#6) — keep |
+| H6 | **Someone was welcomed in** | C4 — the house should meet their new housemate |
+| H7 | **The daily digest** | everything standing, one embed |
+
+#### H3 — the open house decision, on a soft clock
+
+After a screening, `recruit_decision_votes` starts collecting and nothing
+announces it. The obvious fix — post when the first vote lands — is wrong: it
+nags about a decision with a month of runway, then goes quiet exactly when the
+date gets close and someone actually needs to decide.
+
+So H3 is **triggered by the deadline, softly**:
+
+| When | Lane | Copy |
+|---|---|---|
+| **14 days** before the date | Daily digest | "Maya's decision is open — 3 of 8 have weighed in. Moves in 2 weeks." |
+| **7 days** | Daily, moved to the top of the section | names who hasn't voted |
+| **3 days** | escalation in `#recruiting-automation` | the room is at stake, not just the vote |
+| date passes, still open | Daily until resolved | reads as the miss it is |
+
+**The date** is the first of: the applicant's recruiter-confirmed
+`move_in_from`; the `starts_on` of the listing they're placed in; else the
+screening date + 30 days as a fallback so a decision without a room still has a
+clock. Whichever it is, it resets when edited — the standard reset rule.
+
+**Only the clock triggers.** Vote activity never fires a notification; it only
+changes the *copy* (the tally, and who's outstanding). That keeps a lively
+decision quiet and a stalled one loud, which is the correct way round.
+
+---
+
+The general rule: **if the ask has no single owner, it is house-wide and it goes
+to the members channel.** Only genuine ownership converts it to a DM — the claimer of a
+specific call getting their interview reminder. Escalations are *not* DMs; see
+on-call.
+
+### On-call is a channel, not a person
+
+**The members of `#recruiting-automation` are on-call.** The channel's
+membership *is* the roster — nobody maintains a rotation, nobody holds a pager,
+and the roster is self-service: you join the channel to be on-call and leave it
+to stop.
+
+Consequences:
+
+- **No `notify_oncall` setting.** There is no Discord user id to configure, and
+  no stale-owner failure mode when someone travels or leaves the house.
+- **Escalations post to `#recruiting-automation`, not to a DM, and carry no
+  mention.** A2 at 5 days and A7 at 72h unclaimed post there as their own
+  notification. No `@here`: the channel's members are on-call by definition, so
+  the message already reaches exactly the right people, and a channel that
+  buzzes phones gets muted — which costs far more than a late reply.
+- **The escalation is the second post, not a re-post.** The original notification
+  is already in the channel as a log line. The escalation references it and
+  raises the volume; it doesn't repeat it.
+- **DMs are reserved for one case:** the claimer of a scheduled call, who owns
+  something nobody else can do for them. Everything else that would have been a
+  DM is a channel post.
+
+---
+
+## Batching
+
+Batching applies **only to Discord**. The log is never batched — that's the
+point of having it. At current scale — 14 rooms, a handful of applications a
+week — per-event posting would put ~30 messages a week into a channel where the
+house currently sees ~3, and the channel would be muted inside a month. So, for
+Discord:
+
+1. **Three lanes, and the default is Daily.** A notification earns the Now lane
+   only if a human should act *today* and the trigger is genuinely rare
+   (a verdict written, a promotion, a shortlist's first candidate). Anything
+   that's a *standing condition* rather than an *event* — waiting on a review,
+   emails owed, openings at risk — is a digest section by construction.
+2. **The daily digest is one embed with counted sections**, in this order:
+   Needs a review · Update emails owed · Openings at risk · Rooms emptying ·
+   Trials due · Reconcile. Each section is a count plus at most five links, then
+   "+n more" into the matching rail view.
+3. **Zero state posts nothing** *to Discord*. No "all clear" message, ever — a
+   quiet channel must be trustworthy as a quiet channel. The log, of course,
+   simply has nothing new in it that day, which reads correctly on its own.
+4. **Same-lane collapse.** Any lane firing ≥4 notifications of one kind in one
+   pass collapses them to a line-list — the existing new-application rule,
+   generalised.
+5. **Escalation replaces repetition.** A condition doesn't re-post daily on the
+   Now lane; it moves lanes as it gets urgent (A2 at 5 days, O4 at 7 days,
+   O6 immediately). One post per escalation step.
+6. **Silent stamp for backdated facts.** A date corrected after the fact isn't
+   news — the v3.39.0 >14-day rule, applied to every kind.
+7. **Audit gets everything, always.** `#recruiting-automation` is the unbatched
+   firehose, so digesting never loses information. Existing `auditMirror`
+   convention.
+8. **Never notify the applicant from this system.** Every lane here is
+   house-facing. Applicant email stays in `recruit-gmail`, human-triggered.
+
+Projected steady-state volume: **~1–3 Now posts/day, one digest, one weekly
+roll-up** in Discord — against a log that records every one of the ~30 weekly
+events in full.
+
+---
+
+## Mechanism
+
+### `recruit_notifications` — the ledger
+
+One row per notification, written by the detect pass **before** anything is
+dispatched — so the row is the log entry, and every delivery is a stamp on it.
+
+```
+id             uuid pk
+kind           text          -- 'review_stalled', 'reply_reschedule', ...
+subject_type   text          -- 'applicant' | 'listing' | 'stay'
+subject_id     text
+dedupe_key     text unique   -- '<kind>:<subject_id>[:<step>]'
+audience       text          -- 'house' | 'oncall' | 'person'
+recipient_id   uuid          -- set only when audience='person' (a call's claimer)
+lane           text          -- 'now' | 'daily' | 'weekly'  (members-channel timing)
+payload        jsonb         -- title, body, links, digest section
+due_at         timestamptz   -- when it becomes eligible to broadcast
+created_at     timestamptz   -- == when it entered the log
+log_at         timestamptz   -- posted to #recruiting-automation (the log's Discord half)
+members_at     timestamptz   -- posted to the members channel (null = not yet / muted)
+dm_at          timestamptz   -- delivered as a DM
+digest_id      uuid          -- which digest carried it
+muted          boolean       -- suppressed from the members channel; still logged
+acked_at       timestamptz   -- resolved in-app, so the log, rail, and digest agree
+```
+
+`audience='oncall'` is an escalation: it posts to `#recruiting-automation`
+without resolving to any user id and without a mention.
+
+The shape change from a single `sent_at` matters: **the row's existence is the
+notification; the timestamps are only deliveries.** A row with every delivery
+column null is still a complete log entry, which is exactly what a muted kind
+produces. Queries follow from it — the log is `SELECT * ORDER BY created_at`
+with no predicate at all; the digest is `discord_at IS NULL AND NOT muted AND
+lane='daily'`; the rail badge is `acked_at IS NULL`.
+
+`dedupe_key` unique + `ON CONFLICT DO NOTHING` is the whole once-only guarantee
+— it replaces six bespoke `*_at` columns. A reset (date moved) deletes the
+unsent row for that key; an escalation is a new key with a `:step` suffix.
+
+### The dispatcher
+
+A `/notify` route on `recruit-discord`, called from the **existing 15-minute
+tick** — no new cron, same as v3.39.0. Three passes:
+
+1. **Detect** — one SQL query per kind against applicants / listings / stays,
+   inserting into the ledger. Detection is pure and idempotent; running it twice
+   changes nothing. **The log is complete the instant this pass finishes**,
+   whether or not anything is ever broadcast.
+2. **Log** — every row with `log_at IS NULL` posts to `#recruiting-automation`,
+   unbatched, muted or not. This pass runs *first* among the delivery passes, so
+   the channel is never behind the members channel.
+3. **Broadcast Now** — `lane='now'`, `audience='house'`, `members_at IS NULL`,
+   not muted → members channel, collapsing ≥4 of a kind; stamp `members_at`.
+4. **Escalate** — `audience='oncall'` rows → `#recruiting-automation`, stamped
+   `escalated_at` (its own column: an escalation is not a house post, and the log
+   must not claim it was).
+5. **DM** — `audience='person'` rows → the claimer; stamp `dm_at`.
+6. **Digests** — when the tick lands in the 8:30am PT window (or Monday 8:30 for
+   weekly) and no digest was sent today, drain that lane's undelivered rows into
+   one members-channel embed. Clock is read from the tick, not scheduled — the
+   pattern already used for milestone horizons.
+
+Config in `recruit_settings`: `notify_digest_hour` (default 8),
+`notify_members_channel`, `notify_muted` (array of kinds — a bad notification is
+switched off, not redeployed; the log keeps recording it). No on-call setting:
+`#recruiting-automation`'s membership is the roster.
+
+### In-app: the log and the rails
+
+Both read the same ledger, at different altitudes:
+
+- **Activity view** — the complete running log, unfiltered by default. Nothing
+  is hidden from it, including muted kinds and DMs (marked as such).
+- **Rail badges** — `acked_at IS NULL` rows scoped to each view's subject type.
+  Acting in the app stamps `acked_at`, so the next digest doesn't ask for
+  something already handled, and the log shows *when it was resolved* rather
+  than deleting the entry.
+
+This is the [Ladder Updates queue](../../../ladder/DESIGN.md) pattern extended
+by one surface: one source of truth, three readers (log, rail, Discord).
+
+---
+
+## Phasing
+
+- **Phase 1 — spine + log + the four expensive silences.** Migration (ledger +
+  settings), dispatcher, daily digest, **and the Activity view**. Kinds: **A2,
+  A9, O4, C1**, plus the seven existing notifications rewritten to write ledger
+  rows — which is what makes the log a real history rather than a history of the
+  four newest things. Migrate A1's dedupe onto the ledger to prove the pattern
+  against something live.
+
+  The Activity view belongs in Phase 1, not Phase 4: it's a read-only list over
+  a table that already exists by then (~half a day), and it's the only way to
+  debug the dispatcher. Shipping digests before the log means shipping a
+  notification system you can't audit.
+- **Phase 2 — moments of action.** **A3, A4, O1, O5, O6, C4.** Now lane.
+- **Phase 2b — reply intents.** Widen the `extractAvailability` prompt +
+  4 columns on `recruit_emails`, then wire the nine intents to their lanes.
+  Separable from 2 and worth shipping on its own: the three Now-lane intents
+  (`reschedule`, `withdrawing`, `plans_changed`) are each a currently-invisible
+  failure with a real cost — a no-show, a held shortlist slot, and a stale
+  placement. Ship `unclear` + `question` first as the safety net, then the
+  routed ones once the classifier's confidence distribution is visible in the
+  data.
+- **Phase 3 — house-wide asks + the slow rot.** **H3** on its soft clock. Weekly
+  roll-up: **A5, A10, O2, O3, O7, C5, C6.**
+- **Phase 4 — control.** `acked_at` round-trip from every rail action, log
+  filters by subject/kind, per-member mutes.
+
+## Decisions taken (2026-07-29)
+
+| Question | Decision |
+|---|---|
+| Do declined / passed / archived applicants owe an update? | **No.** A closed applicant is closed and the house owes them nothing. The planned "update emails owed" queue (A9) was cut — chasing a debt that doesn't exist just teaches people to ignore the channel. Sending an update stays a choice on the profile. |
+| Mentions on escalations? | **None.** `#recruiting-automation`'s members are on-call, so a post there already reaches them; an `@here` only buzzes phones, and a channel that buzzes gets muted. |
+| Notification copy | **Kind + linked subject, nothing else.** No kind slugs, no lane/audience tags, no clause after an em dash, no buttons. The subject text is the hyperlink; detail lives in the Activity view, which has room for a second line. |
+| Who is on-call? | **The members of `#recruiting-automation`.** Channel membership is the roster; no setting, no rotation, no user id. |
+| Where does the running log live? | **Two places, one content:** the in-app Activity view and `#recruiting-automation`. Not a mirror of the members channel — it is the log. |
+| Double-notify? | **Yes.** The same fact on two surfaces is two messages with two audiences. Nothing is suppressed because something else already fired. |
+| Log retention | **Forever.** A few thousand rows a year, and its value is answering questions about the past. No pruning, no archive tier. |
+| H3 trigger | **The clock, softly** — 14 / 7 / 3 days before the move-in date. Vote activity changes the copy, never fires a post. |
+| Intent classifier rollout | **Shadow mode** (defined below) for two weeks before the Now lane opens. |
+
+### Shadow mode, defined
+
+The classifier runs and records, but is not yet allowed to route anything
+consequential:
+
+- Every inbound reply is classified; `intent`, `intents`, `intent_confidence`,
+  `intent_summary` are written to `recruit_emails`.
+- Ledger rows are created for **all** intents, so the Activity view and
+  `#recruiting-automation` show exactly what the system *would* have broadcast.
+- Only `question` and `unclear` reach the members channel. `reschedule`,
+  `withdrawing`, `plans_changed`, and `post_acceptance` stay log-only —
+  implemented as their default entries in `notify_muted`, so opening the lane is
+  a settings edit, not a deploy.
+- After two weeks: read the confidence distribution and the false-positive rate
+  against real replies, then unmute.
+
+The failure it exists to prevent: a "sorry, still deciding" classified as
+`withdrawing` would, on the Now lane, push someone to archive a live candidate.
+In shadow mode that mistake is a line in a log — free to be wrong, and it
+produces real calibration data instead of a guessed confidence floor.
+
+## Open questions
+
+1. **Does C1 auto-create the draft listing?** Detecting "room emptying, no
+   listing" is one query from generating the draft (Phase C of the funnel PRD,
+   still unbuilt). Recommend keeping them separate: notify in Phase 1,
+   auto-draft later, so a bad gap detector doesn't litter the Openings rail.

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1,0 +1,763 @@
+// Shared: the recruiting notification ledger — detect, log, broadcast.
+//
+// One table (recruit_notifications, migration 142) is both the running log and
+// the dispatch queue. A row is written by detect() before anything is
+// delivered, so the log is complete whether or not the house is ever told, and
+// each surface is a stamp on the row:
+//
+//   log_at       → #recruiting-automation, unbatched, muted or not. This IS the
+//                  log's Discord half, not a mirror of the members channel.
+//   members_at   → the house channel, batched by lane (now / daily / weekly).
+//   escalated_at → posted for audience 'oncall'. Its own column: an escalation
+//                  is not a house post, and the log must not say so.
+//   dm_at        → a DM, only where ownership is real (a call's claimer).
+//
+// Routing is currently automation-only (notify_house_posts = false): the house
+// channel gets nothing while the detectors earn trust. Lanes, audiences, and
+// stamps still behave exactly as designed, so flipping the setting changes only
+// the destination.
+//
+// On-call is a channel, not a person: the members of #recruiting-automation are
+// on-call, so audience 'oncall' just posts there — no mention, no user id to
+// configure, nothing to keep current.
+//
+// Detection is pure and idempotent — every kind's query is "what is true right
+// now", and dedupe_key UNIQUE turns a repeat into a no-op. Running the tick
+// twice in a row changes nothing.
+
+import { AUTOMATION_CHANNEL_ID } from './discord.ts'
+
+const TZ = 'America/Los_Angeles'
+const APP = 'https://ctrl.rodeo/applications/'
+
+/* Where house-wide notifications and digests go.
+
+   For now: nowhere but #recruiting-automation. Everything this module emits —
+   the log, escalations, Now-lane posts, and the digests — lands in that one
+   channel while the system earns trust, so a wrong detector can't spam the
+   channel the whole house reads. Flip `notify_house_posts` to true in
+   recruit_settings to start splitting house-wide traffic out to the members
+   channel; no deploy required.
+
+   Note this is not the same as muting: the rows, lanes, audiences, and stamps
+   all behave exactly as designed, so turning the split on later changes only
+   the destination, not the logic. */
+const houseChannel = (settings: NotifySettings) =>
+  settings.housePosts
+    ? (Deno.env.get('RECRUITING_PING_CHANNEL_ID') || AUTOMATION_CHANNEL_ID)
+    : AUTOMATION_CHANNEL_ID
+
+/* ---- sending -------------------------------------------------------------
+
+   This module does its own Discord posting rather than borrowing
+   postChannelEmbed / postResilient, for two reasons the first live run made
+   obvious:
+
+   1. **Rate limits.** A first tick over a backlog emits a dozen-plus lines to
+      one channel. Discord allows ~5 messages per 5s per channel, so an
+      unpaced burst 429s partway through — on the live test, one log line and
+      all three escalations silently failed. Every send here is paced and
+      retries once on an explicit 429.
+
+   2. **No cross-channel fallback.** postResilient retries a failed post in the
+      *other* recruiting channel, which for a log line means recruiting noise
+      landing in the channel the whole house reads — precisely what
+      notify_house_posts = false exists to prevent. Here a failed send throws,
+      the row keeps its null stamp, and the next tick retries it. A late
+      notification beats one in the wrong room. */
+
+const SEND_GAP_MS = 1200          // ~0.8 msg/s: comfortably inside 5-per-5s
+let lastSendAt = 0
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+let allowedChannel: string = AUTOMATION_CHANNEL_ID
+
+/* The single channel this module may post to on this tick. Set once per tick
+   from settings. While notify_house_posts is false that is
+   #recruiting-automation and nothing else — enforced here rather than trusted
+   at each call site, so no future detector, fallback, or refactor can leak a
+   recruiting notification into the channel the whole house reads. */
+export function setAllowedChannel(settings: NotifySettings): void {
+  allowedChannel = houseChannel(settings)
+}
+
+async function send(channelId: string, payload: Record<string, unknown>): Promise<void> {
+  if (channelId !== allowedChannel) {
+    throw new Error(`[notify] refusing to post to ${channelId}: only ${allowedChannel} is permitted`)
+  }
+  const token = Deno.env.get('DISCORD_BOT_TOKEN')
+  if (!token) throw new Error('DISCORD_BOT_TOKEN not set')
+  const wait = lastSendAt + SEND_GAP_MS - Date.now()
+  if (wait > 0) await sleep(wait)
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    lastSendAt = Date.now()
+    const resp = await fetch(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+      method: 'POST',
+      headers: { Authorization: `Bot ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (resp.ok) { await resp.body?.cancel(); return }
+    const text = await resp.text()
+    if (resp.status === 429 && attempt === 0) {
+      // Discord tells us exactly how long to wait; honour it rather than guess.
+      const retryAfter = Number(JSON.parse(text || '{}').retry_after || 1) * 1000
+      console.warn(`[notify] 429 from Discord, waiting ${Math.round(retryAfter)}ms`)
+      await sleep(retryAfter + 250)
+      continue
+    }
+    throw new Error(`Discord ${resp.status}: ${text.slice(0, 200)}`)
+  }
+}
+
+/* Every message this module sends is an embed, because only embeds render
+   [text](url) — and the whole point is that the relevant words in the
+   notification ARE the link — not a bare URL, and not a button underneath
+   repeating a destination the text already carries.
+
+   No mentions, ever. An escalation posts to #recruiting-automation, whose
+   members are on-call by definition, so the message already reaches exactly the
+   people it is for. A mention on top of that adds nothing but a phone buzz, and
+   a channel that buzzes gets muted — which would cost far more than a late
+   reply. Escalation shows up as a distinct kind and its own log entry, not as a
+   louder noise. */
+const sendEmbed = (channelId: string, description: string) =>
+  send(channelId, { embeds: [{ description: description.slice(0, 3900), color: 0x378add }] })
+
+export interface Notification {
+  kind: string
+  subject_type: 'applicant' | 'listing' | 'stay' | 'house'
+  subject_id: string | null
+  subject_label: string
+  audience?: 'house' | 'oncall' | 'person'
+  recipient_id?: string | null
+  lane?: 'now' | 'daily' | 'weekly'
+  dedupe_key: string
+  payload: {
+    title: string
+    body: string
+    section?: string
+    links?: Array<{ label: string; url: string }>
+  }
+  due_at?: string
+  /* The house was already told by whoever owns this notification's original
+     call site (recruit-gmail's scan posts new applications itself). The ledger
+     row is then purely the log entry, so it is stamped delivered on write and
+     no lane picks it up. */
+  already_broadcast?: boolean
+}
+
+// deno-lint-ignore no-explicit-any
+type DB = any
+
+// ---- settings --------------------------------------------------------------
+
+interface NotifySettings {
+  enabled: boolean
+  digestHour: number
+  muted: Set<string>
+  housePosts: boolean
+}
+
+async function loadSettings(db: DB): Promise<NotifySettings> {
+  const { data } = await db.from('recruit_settings').select('key, value')
+    .in('key', ['notify_enabled', 'notify_digest_hour', 'notify_muted', 'notify_house_posts'])
+  const map = new Map((data || []).map((r: { key: string; value: unknown }) => [r.key, r.value]))
+  return {
+    enabled: map.get('notify_enabled') !== false,
+    digestHour: Number(map.get('notify_digest_hour') ?? 8),
+    muted: new Set(Array.isArray(map.get('notify_muted')) ? map.get('notify_muted') as string[] : []),
+    // Opt-in, not opt-out: silence in the house channel is the safe default.
+    housePosts: map.get('notify_house_posts') === true,
+  }
+}
+
+// ---- dates -----------------------------------------------------------------
+
+// Pacific "today" as YYYY-MM-DD. All the horizons below are date-typed columns
+// compared against house-local days, not UTC instants — a room emptying "in 45
+// days" is a calendar fact.
+export function ptToday(now = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: TZ }).format(now)
+}
+export function ptPlusDays(days: number, now = new Date()): string {
+  return ptToday(new Date(now.getTime() + days * 86400000))
+}
+function ptParts(now = new Date()): { hour: number; weekday: string; date: string } {
+  const p = Object.fromEntries(new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ, hour12: false, hour: '2-digit', weekday: 'short',
+  }).formatToParts(now).map((x) => [x.type, x.value]))
+  return { hour: Number(p.hour) % 24, weekday: String(p.weekday), date: ptToday(now) }
+}
+function daysUntil(isoDate: string, now = new Date()): number {
+  const today = new Date(`${ptToday(now)}T00:00:00Z`).getTime()
+  return Math.round((new Date(`${isoDate}T00:00:00Z`).getTime() - today) / 86400000)
+}
+const applicantLink = (id: string) => `${APP}?a=${encodeURIComponent(id)}`
+const viewLink = (v: string) => `${APP}?view=${v}`
+
+/* "2026-08-01" → "Aug 1". Notifications are read by people, and an ISO date in
+   a sentence makes them read like a database dump. The year appears only when
+   it isn't this one. */
+function fmtDay(isoDate: string, now = new Date()): string {
+  const d = new Date(`${isoDate}T12:00:00Z`)
+  const thisYear = Number(ptToday(now).slice(0, 4))
+  return d.toLocaleDateString('en-US', {
+    month: 'short', day: 'numeric', timeZone: 'UTC',
+    ...(d.getUTCFullYear() === thisYear ? {} : { year: 'numeric' }),
+  })
+}
+
+/* Applicants write their move-in date as prose ("I start my job August 24th but
+   I am flexible on whenever a room opens up"). Truncating that at 60 characters
+   produced "...whenever a r" in the channel. Take the first clause instead, and
+   cut on a word boundary if it's still long — a notification needs the gist,
+   and the profile has the full answer. */
+function shortPhrase(text: string | null | undefined, max = 34): string {
+  const first = String(text || '').replace(/\s+/g, ' ').trim().split(/[,.;(]|\bbut\b|\bthough\b/)[0].trim()
+  if (!first) return ''
+  if (first.length <= max) return first
+  const cut = first.slice(0, max)
+  const space = cut.lastIndexOf(' ')
+  return cut.slice(0, space > max * 0.5 ? space : max).trim() + '…'
+}
+
+/* Move-in answers are prose in the applicant's voice — "asap (august/sept)",
+   "I start my job August 24th", "Flexible". Prefixing any of those with "wants"
+   produces something ungrammatical about half the time, so quote them instead:
+   it always reads correctly and it is honestly their words, not our summary. */
+function moveInQuote(text: string | null | undefined): string {
+  const phrase = shortPhrase(text)
+  return phrase ? `“${phrase.charAt(0).toLowerCase()}${phrase.slice(1)}”` : ''
+}
+
+const plural = (n: number, one: string, many = `${one}s`) => `${n} ${n === 1 ? one : many}`
+
+// ---- write -----------------------------------------------------------------
+
+/* Insert notifications, ignoring any whose dedupe_key already exists. The
+   ledger row is written here — before any delivery — which is what makes the
+   log complete by construction rather than a record of what Discord accepted.
+
+   `muted` is stamped at write time from settings so the log shows what the
+   house's config did to each entry, and so unmuting a kind doesn't retroactively
+   broadcast a fortnight of history. */
+export async function record(db: DB, rows: Notification[]): Promise<number> {
+  if (!rows.length) return 0
+  const { muted } = await loadSettings(db)
+  const payload = rows.map((n) => ({
+    kind: n.kind,
+    subject_type: n.subject_type,
+    subject_id: n.subject_id,
+    subject_label: n.subject_label,
+    audience: n.audience || 'house',
+    recipient_id: n.recipient_id || null,
+    lane: n.lane || 'daily',
+    dedupe_key: n.dedupe_key,
+    payload: n.payload,
+    due_at: n.due_at || new Date().toISOString(),
+    muted: muted.has(n.kind),
+    ...(n.already_broadcast ? { members_at: new Date().toISOString() } : {}),
+  }))
+  const { data, error } = await db.from('recruit_notifications')
+    .upsert(payload, { onConflict: 'dedupe_key', ignoreDuplicates: true })
+    .select('id')
+  if (error) {
+    console.warn(`[notify] record failed: ${error.message}`)
+    return 0
+  }
+  return (data || []).length
+}
+
+/* Clear unsent notifications for a subject+kind. The reset half of the dedupe
+   idiom: when a date moves, the notification it produced is no longer true, so
+   the row is deleted and the new date earns a fresh one. Only ever deletes
+   rows that were never delivered — a notification the house has already seen
+   is history and stays in the log. */
+export async function resetPending(db: DB, kind: string, subjectId: string): Promise<void> {
+  await db.from('recruit_notifications').delete()
+    .eq('kind', kind).eq('subject_id', subjectId)
+    .is('log_at', null).is('members_at', null).is('escalated_at', null).is('dm_at', null)
+}
+
+// ---- detect ----------------------------------------------------------------
+
+/* A1 — new application. Already posted by recruit-gmail's scan; this records
+   the ledger row so the log has it too. Keyed on discord_ping_at, which the
+   scan stamps, so the log picks up exactly what was announced. */
+async function detectNewApplications(db: DB): Promise<Notification[]> {
+  const since = new Date(Date.now() - 3 * 86400000).toISOString()
+  const { data } = await db.from('recruit_applicants')
+    .select('id, first_name, last_name, residency, move_in, discord_ping_at')
+    .not('discord_ping_at', 'is', null).gte('discord_ping_at', since)
+  return (data || []).map((a: Record<string, string>) => ({
+    kind: 'application_new',
+    subject_type: 'applicant' as const,
+    subject_id: a.id,
+    subject_label: a.first_name,
+    lane: 'now' as const,
+    dedupe_key: `application_new:${a.id}`,
+    payload: {
+      // The kind's label already says "New application" — the title is just
+      // who, and the body is the two facts that decide whether to read on.
+      title: `${a.first_name} ${a.last_name || ''}`.trim(),
+      body: [
+        /short/i.test(a.residency || '') ? 'sublet' : 'full-time',
+        moveInQuote(a.move_in),
+      ].filter(Boolean).join(' · '),
+      section: 'New applications',
+      links: [{ label: `Review ${a.first_name}`, url: applicantLink(a.id) }],
+    },
+    // recruit-gmail's scan already posted this one; the row is the log entry.
+    already_broadcast: true,
+  }))
+}
+
+/* A2 — waiting on a review. One read decides under the v3.40 model, so this is
+   never "waiting on a quorum"; it is waiting on one person, any person.
+   Escalates at 5 days into its own notification in #recruiting-automation,
+   whose members are on-call.
+
+   The clock is COALESCE(discord_ping_at, submitted_at), NOT the ping alone.
+   Keying on the ping was wrong in a way only the live data showed: 50 of the 53
+   applications sitting in review were never pinged at all (the ping's 14-day
+   floor exists so switching it on wouldn't dump the backlog), so a
+   ping-keyed detector would have reported "nothing waiting" while 53
+   applications waited. Nobody having been told is worse than having been told
+   and ignored, not better.
+
+   The 30-day window is what keeps that honest without flooding: an application
+   from March is not a notification, it is backlog, and it gets one counted line
+   from detectReviewBacklog instead of fifty rows. */
+const REVIEW_RECENT_DAYS = 30
+
+async function detectReviewStalled(db: DB): Promise<Notification[]> {
+  const { data: pending } = await db.from('recruit_applicants')
+    .select('id, first_name, last_name, submitted_at, discord_ping_at')
+    .eq('stage', 'review')
+    .gte('submitted_at', new Date(Date.now() - REVIEW_RECENT_DAYS * 86400000).toISOString())
+  if (!pending?.length) return []
+  const { data: voted } = await db.from('recruit_votes')
+    .select('applicant_id').in('applicant_id', pending.map((a: { id: string }) => a.id))
+  const hasVote = new Set((voted || []).map((v: { applicant_id: string }) => v.applicant_id))
+
+  const out: Notification[] = []
+  for (const a of pending) {
+    if (hasVote.has(a.id)) continue
+    const knownAt = new Date(a.discord_ping_at || a.submitted_at).getTime()
+    const days = Math.floor((Date.now() - knownAt) / 86400000)
+    if (days < 2) continue   // 48h of grace before it counts as stalled
+    // Two steps, two dedupe keys: the daily digest line, then the escalation.
+    // The escalation is a second notification, not a repeat of the first.
+    const step = days >= 5 ? 'escalated' : 'waiting'
+    out.push({
+      kind: 'review_stalled',
+      subject_type: 'applicant',
+      subject_id: a.id,
+      subject_label: a.first_name,
+      audience: step === 'escalated' ? 'oncall' : 'house',
+      lane: step === 'escalated' ? 'now' : 'daily',
+      dedupe_key: `review_stalled:${a.id}:${step}`,
+      payload: {
+        title: `${a.first_name} ${a.last_name || ''}`.trim(),
+        body: `waiting ${plural(days, 'day')}`,
+        section: 'Needs a review',
+        links: [{ label: `Review ${a.first_name}`, url: applicantLink(a.id) }],
+      },
+    })
+  }
+  return out
+}
+
+/* A2b — the review backlog, as one number. Applications older than the
+   stalled-window that nobody has ever reviewed. Fifty of these exist right now,
+   and fifty notifications would bury everything else in the log on day one — so
+   the backlog is a single weekly line carrying the count, keyed on the ISO week
+   so it says its piece once and waits.
+
+   subject_type 'house': it is not about any one applicant. Clicking through
+   goes to the Inbox, where they already sit. */
+async function detectReviewBacklog(db: DB): Promise<Notification[]> {
+  const floor = new Date(Date.now() - REVIEW_RECENT_DAYS * 86400000).toISOString()
+  const { data: old } = await db.from('recruit_applicants')
+    .select('id').eq('stage', 'review').lt('submitted_at', floor)
+  if (!old?.length) return []
+  const { data: voted } = await db.from('recruit_votes')
+    .select('applicant_id').in('applicant_id', old.map((a: { id: string }) => a.id))
+  const hasVote = new Set((voted || []).map((v: { applicant_id: string }) => v.applicant_id))
+  const n = old.filter((a: { id: string }) => !hasVote.has(a.id)).length
+  if (!n) return []
+
+  // ISO week key: one mention per week however the count moves.
+  const d = new Date()
+  const thursday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - ((d.getUTCDay() + 6) % 7) + 3))
+  const week = Math.ceil(((thursday.getTime() - Date.UTC(thursday.getUTCFullYear(), 0, 1)) / 86400000 + 1) / 7)
+  return [{
+    kind: 'review_backlog',
+    subject_type: 'house',
+    subject_id: null,
+    subject_label: 'Inbox backlog',
+    lane: 'weekly',
+    dedupe_key: `review_backlog:${thursday.getUTCFullYear()}-W${week}`,
+    payload: {
+      title: `${plural(n, 'application')} nobody has reviewed`,
+      body: `all older than ${REVIEW_RECENT_DAYS} days`,
+      section: 'Backlog',
+      links: [{ label: 'Open the inbox', url: viewLink('inbox') }],
+    },
+  }]
+}
+
+/* No "update email owed" detector, deliberately.
+   An earlier draft chased the house for an update email to everyone rejected or
+   archived. That inverted the actual policy: a declined, passed, or archived
+   applicant is *closed*, and the house owes them nothing. Nagging about a debt
+   that doesn't exist is worse than saying nothing — it trains people to ignore
+   the channel. Sending an update stays a choice someone makes on the profile,
+   never a task the system hands out. */
+
+/* O4 / O6 — an opening running out of runway, then past it. Three steps:
+   21 days is a digest line, 7 days is a members-channel post, and a start date
+   that has already passed escalates — by then it is not a reminder, it is rent
+   nobody is collecting. */
+async function detectOpeningsAtRisk(db: DB): Promise<Notification[]> {
+  const { data } = await db.from('recruit_listings')
+    .select('id, room_id, kind, starts_on, status, rent_monthly')
+    .eq('status', 'open').lte('starts_on', ptPlusDays(21))
+  if (!data?.length) return []
+  const { data: rooms } = await db.from('recruit_rooms').select('id, name')
+  const roomName = new Map((rooms || []).map((r: { id: number; name: string }) => [r.id, r.name]))
+
+  return data.map((l: Record<string, string | number>) => {
+    const starts = String(l.starts_on)
+    const left = daysUntil(starts)
+    const room = roomName.get(l.room_id as number) || `room ${l.room_id}`
+    const step = left < 0 ? 'overdue' : left <= 7 ? 'urgent' : 'soon'
+    return {
+      kind: left < 0 ? 'opening_overdue' : 'opening_at_risk',
+      subject_type: 'listing' as const,
+      subject_id: String(l.id),
+      subject_label: String(room),
+      audience: (step === 'overdue' ? 'oncall' : 'house') as 'oncall' | 'house',
+      lane: (step === 'soon' ? 'daily' : 'now') as 'daily' | 'now',
+      dedupe_key: `opening_risk:${l.id}:${step}`,
+      payload: {
+        title: `${room} · ${l.kind === 'sublet' ? 'sublet' : 'resident'}`,
+        body: left < 0
+          ? `should have started ${fmtDay(starts)}, ${plural(Math.abs(left), 'day')} ago`
+          : `starts ${fmtDay(starts)} · ${plural(left, 'day')} out`,
+        section: 'Openings at risk',
+        links: [{ label: 'Open the shortlist', url: viewLink('openings') },
+                { label: 'See the room', url: `${APP}?view=occupancy&room=${l.room_id}` }],
+      },
+    } as Notification
+  })
+}
+
+/* C1 — a room emptying with nothing lined up. 45 days is deliberate: it is
+   roughly one full funnel (review → screening → house decision → move), so a
+   notification at 45 days is the last moment the house can still fill the room
+   without rushing. A stay with a follow-on stay or any listing for the room is
+   already handled and stays quiet. */
+async function detectRoomsEmptying(db: DB): Promise<Notification[]> {
+  const today = ptToday()
+  const horizon = ptPlusDays(45)
+  const { data: ending } = await db.from('recruit_stays')
+    .select('id, room_id, occupant, kind, starts_on, ends_on')
+    .not('ends_on', 'is', null).gte('ends_on', today).lte('ends_on', horizon)
+  if (!ending?.length) return []
+
+  const roomIds = [...new Set(ending.map((s: { room_id: number }) => s.room_id))]
+  const [{ data: rooms }, { data: allStays }, { data: listings }] = await Promise.all([
+    db.from('recruit_rooms').select('id, name').in('id', roomIds),
+    db.from('recruit_stays').select('room_id, starts_on, ends_on').in('room_id', roomIds),
+    db.from('recruit_listings').select('room_id, status, starts_on').in('room_id', roomIds)
+      .in('status', ['draft', 'open', 'filled']),
+  ])
+  const roomName = new Map((rooms || []).map((r: { id: number; name: string }) => [r.id, r.name]))
+
+  const out: Notification[] = []
+  for (const s of ending) {
+    const ends = String(s.ends_on)
+    // Someone already following them into the room? Then it isn't emptying.
+    const followOn = (allStays || []).some((o: Record<string, string | number>) =>
+      o.room_id === s.room_id && String(o.starts_on) > ends && String(o.starts_on) <= ptPlusDays(60))
+    if (followOn) continue
+    // A listing covering the gap counts as handled, draft included — the
+    // Openings rail is then the surface, and O2/O4 chase it from there.
+    const listed = (listings || []).some((l: Record<string, string | number>) =>
+      l.room_id === s.room_id && String(l.starts_on) >= ends)
+    if (listed) continue
+
+    const left = daysUntil(ends)
+    const room = roomName.get(s.room_id) || `room ${s.room_id}`
+    const step = left <= 21 ? 'urgent' : 'soon'
+    out.push({
+      kind: 'room_emptying',
+      subject_type: 'stay',
+      subject_id: String(s.id),
+      subject_label: String(room),
+      audience: step === 'urgent' ? 'oncall' : 'house',
+      lane: step === 'urgent' ? 'now' : 'daily',
+      dedupe_key: `room_emptying:${s.id}:${step}`,
+      payload: {
+        title: room,
+        body: `${s.occupant || 'the occupant'} leaves ${fmtDay(ends)} · no listing`,
+        section: 'Rooms emptying',
+        links: [{ label: 'Open the calendar', url: `${APP}?view=occupancy&room=${s.room_id}` }],
+      },
+    })
+  }
+  return out
+}
+
+/* Detect everything. Each kind is independent: one failing query must not cost
+   the others their tick, so each is caught on its own. */
+export async function detect(db: DB): Promise<number> {
+  const kinds: Array<[string, () => Promise<Notification[]>]> = [
+    ['application_new', () => detectNewApplications(db)],
+    ['review_stalled', () => detectReviewStalled(db)],
+    ['review_backlog', () => detectReviewBacklog(db)],
+    ['opening_at_risk', () => detectOpeningsAtRisk(db)],
+    ['room_emptying', () => detectRoomsEmptying(db)],
+  ]
+  let found = 0
+  for (const [name, fn] of kinds) {
+    try {
+      found += await record(db, await fn())
+    } catch (err) {
+      console.warn(`[notify] detect ${name} failed: ${(err as Error).message}`)
+    }
+  }
+  return found
+}
+
+// ---- deliver ---------------------------------------------------------------
+
+/* How each kind introduces itself to a human. The kind slug is a database
+   value and must never reach a Discord message — "review_stalled" is not a
+   sentence. Every notification reads as: <icon> <label> · <who or what> — <why
+   it matters>. */
+const KINDS: Record<string, { icon: string; label: string }> = {
+  application_new:   { icon: '📥', label: 'New application' },
+  review_stalled:    { icon: '⏳', label: 'Waiting on a review' },
+  review_backlog:    { icon: '🗄️', label: 'Inbox backlog' },
+  opening_at_risk:   { icon: '🏠', label: 'Opening at risk' },
+  opening_overdue:   { icon: '🔴', label: 'Opening overdue' },
+  room_emptying:     { icon: '📦', label: 'Room emptying' },
+}
+const icon = (kind: string) => KINDS[kind]?.icon || '•'
+// Unknown kinds degrade to a de-slugged label rather than leaking the slug.
+const label = (kind: string) =>
+  KINDS[kind]?.label || (kind.charAt(0).toUpperCase() + kind.slice(1).replace(/_/g, ' '))
+
+/* One notification, one line. Deliberately three parts and no more: what kind
+   of thing this is, who it concerns, and the single reason it was worth saying.
+   No lane, no audience, no kind slug — those are how the system thinks, not
+   what a housemate needs at 9am. */
+interface LineRow {
+  kind: string
+  subject_label: string
+  payload?: { title?: string; body?: string; links?: Array<{ label: string; url: string }> }
+}
+
+/* One notification, one line, two parts: what kind of thing this is, and who or
+   what it is about — where the subject itself is the link into the app. That's
+   the whole message.
+
+   No trailing clause after an em dash. The detail (how many days, which date,
+   what they wrote) lives on the payload and shows up in the Activity view,
+   which has room for a second line; in a channel it read as the system
+   explaining itself, and the notification is not the place to argue its case.
+   Anyone who wants the particulars taps the name. */
+function oneLine(n: LineRow): string {
+  const who = n.payload?.title || n.subject_label
+  const url = n.payload?.links?.[0]?.url
+  return `${icon(n.kind)} **${label(n.kind)}** · ${url ? `[${who}](${url})` : who}`
+}
+
+/* The log's Discord half: every row, unbatched, muted or not. Runs before the
+   members-channel passes so #recruiting-automation is never behind the
+   channel the house reads. */
+async function drainLog(db: DB): Promise<number> {
+  const { data } = await db.from('recruit_notifications')
+    .select('id, kind, subject_label, payload, audience, lane, muted')
+    .is('log_at', null).order('created_at').limit(12)
+  if (!data?.length) return 0
+  let sent = 0
+  for (const n of data) {
+    try {
+      await sendEmbed(AUTOMATION_CHANNEL_ID, oneLine(n))
+      await db.from('recruit_notifications').update({ log_at: new Date().toISOString() }).eq('id', n.id)
+      sent++
+    } catch (err) {
+      console.warn(`[notify] log post failed for ${n.id}: ${(err as Error).message}`)
+    }
+  }
+  return sent
+}
+
+/* The Now lane. Two audiences, two destinations, two stamps:
+
+     house   → the members channel, stamped members_at
+     oncall  → #recruiting-automation, stamped escalated_at
+
+   They are drained separately rather than by inspecting each row's audience
+   mid-loop, because a mixed batch would have to pick one channel and one stamp
+   for rows that want different ones — the bug the first live tick exposed, where
+   Chloe's and Soham's escalations were recorded as having gone to the house.
+
+   ≥4 of one kind in a single pass collapse to a line-list — the existing
+   new-application rule, generalised. */
+async function drainLane(db: DB, settings: NotifySettings, audience: 'house' | 'oncall'): Promise<number> {
+  const stampCol = audience === 'oncall' ? 'escalated_at' : 'members_at'
+  const { data } = await db.from('recruit_notifications')
+    .select('id, kind, subject_label, payload')
+    .is(stampCol, null).eq('muted', false)
+    .eq('lane', 'now').eq('audience', audience)
+    .lte('due_at', new Date().toISOString()).is('acked_at', null)
+    .order('created_at').limit(8)
+  if (!data?.length) return 0
+
+  const byKind = new Map<string, typeof data>()
+  for (const n of data) {
+    if (!byKind.has(n.kind)) byKind.set(n.kind, [])
+    byKind.get(n.kind)!.push(n)
+  }
+
+  const channel = audience === 'oncall' ? AUTOMATION_CHANNEL_ID : houseChannel(settings)
+  let sent = 0
+  for (const [kind, rows] of byKind) {
+    try {
+      if (rows.length >= 4) {
+        // A batch names the kind once in its heading, so the rows inside drop
+        // the repeated label and lead with who.
+        const body = `${icon(kind)} **${label(kind)} — ${rows.length}**\n` +
+          rows.map((r: Record<string, any>) => {
+            const who = r.payload?.title || r.subject_label
+            const url = r.payload?.links?.[0]?.url
+            return `• ${url ? `[${who}](${url})` : who}`
+          }).join('\n')
+        await sendEmbed(channel, body)
+      } else {
+        for (const r of rows) {
+          if (audience === 'oncall') {
+            // The log already put this in the channel; the escalation raises
+            // the volume and carries the link, it doesn't repeat the entry.
+            await sendEmbed(channel, oneLine(r))
+          } else {
+            await sendEmbed(channel, oneLine(r))
+          }
+        }
+      }
+      await db.from('recruit_notifications')
+        .update({ [stampCol]: new Date().toISOString() })
+        .in('id', rows.map((r: { id: string }) => r.id))
+      sent += rows.length
+    } catch (err) {
+      console.warn(`[notify] ${audience} now-lane ${kind} failed: ${(err as Error).message}`)
+    }
+  }
+  return sent
+}
+
+/* The digest: one embed, counted sections, five rows each at most. Zero state
+   posts nothing — a quiet channel has to be trustworthy as a quiet channel,
+   and the log is where "nothing happened today" is legible. */
+async function drainDigest(db: DB, settings: NotifySettings, lane: 'daily' | 'weekly'): Promise<number> {
+  const { data } = await db.from('recruit_notifications')
+    .select('id, kind, subject_label, payload')
+    .is('members_at', null).eq('muted', false).eq('lane', lane)
+    .eq('audience', 'house')
+    .is('acked_at', null).lte('due_at', new Date().toISOString())
+    .order('created_at').limit(200)
+  if (!data?.length) return 0
+
+  const SECTION_ORDER = ['Needs a review', 'Openings at risk', 'Rooms emptying', 'New applications', 'Backlog']
+  const sections = new Map<string, typeof data>()
+  for (const n of data) {
+    const s = n.payload?.section || 'Other'
+    if (!sections.has(s)) sections.set(s, [])
+    sections.get(s)!.push(n)
+  }
+  const ordered = [...sections.entries()].sort((a, b) => {
+    const ai = SECTION_ORDER.indexOf(a[0]), bi = SECTION_ORDER.indexOf(b[0])
+    return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi)
+  })
+
+  const digestId = crypto.randomUUID()
+  const blocks = ordered.map(([section, rows]) => {
+    // Inside a named section the kind is already established, so each row is
+    // just the name, linked. The section heading carries everything else.
+    const shown = rows.slice(0, 5).map((r: Record<string, any>) => {
+      const link = r.payload?.links?.[0]?.url
+      const title = r.payload?.title || r.subject_label
+      return `• ${link ? `[${title}](${link})` : title}`
+    }).join('\n')
+    const more = rows.length > 5 ? `\n• _+${rows.length - 5} more_` : ''
+    return `**${section} (${rows.length})**\n${shown}${more}`
+  })
+  const heading = lane === 'daily' ? '☀️ **Recruiting today**' : '🗓️ **Recruiting this week**'
+  await sendEmbed(houseChannel(settings), `${heading}\n\n${blocks.join('\n\n')}`)
+  await db.from('recruit_notifications')
+    .update({ members_at: new Date().toISOString(), digest_id: digestId })
+    .in('id', data.map((r: { id: string }) => r.id))
+  return data.length
+}
+
+/* Has a digest for this lane already gone out in the current period? Read off
+   the ledger itself rather than a separate marker — digest_id is stamped on
+   every row a digest carried, so "did today's digest run" is a query, and a
+   redeploy or a double tick can't produce two. */
+async function digestSentThisPeriod(db: DB, lane: 'daily' | 'weekly'): Promise<boolean> {
+  const since = lane === 'daily'
+    ? new Date(`${ptToday()}T00:00:00-07:00`).toISOString()
+    : new Date(Date.now() - 6 * 86400000).toISOString()
+  const { data } = await db.from('recruit_notifications')
+    .select('id').eq('lane', lane).not('digest_id', 'is', null)
+    .gte('members_at', since).limit(1)
+  return Boolean(data?.length)
+}
+
+export interface TickResult {
+  detected: number
+  logged: number
+  now: number
+  digest: number
+}
+
+/* One tick: detect, then log, then broadcast. Called from recruit-discord's
+   existing 15-minute /remind cron — no new schedule, same as the trial
+   milestone reminders in v3.39. */
+export async function notifyTick(db: DB): Promise<TickResult> {
+  const settings = await loadSettings(db)
+  const out: TickResult = { detected: 0, logged: 0, now: 0, digest: 0 }
+  if (!settings.enabled) return out
+  setAllowedChannel(settings)
+
+  out.detected = await detect(db)
+  // The log first, always: #recruiting-automation must never lag the channel
+  // the house reads.
+  try { out.logged = await drainLog(db) } catch (err) {
+    console.warn(`[notify] log drain failed: ${(err as Error).message}`)
+  }
+  try { out.now = await drainLane(db, settings, 'house') + await drainLane(db, settings, 'oncall') } catch (err) {
+    console.warn(`[notify] now drain failed: ${(err as Error).message}`)
+  }
+
+  // Digests ride the same tick: the clock is read, not scheduled. The window
+  // is the digest hour itself — a 15-minute tick always lands inside it.
+  const { hour, weekday } = ptParts()
+  try {
+    if (hour === settings.digestHour && !(await digestSentThisPeriod(db, 'daily'))) {
+      out.digest += await drainDigest(db, settings, 'daily')
+    }
+    if (weekday === 'Mon' && hour === settings.digestHour && !(await digestSentThisPeriod(db, 'weekly'))) {
+      out.digest += await drainDigest(db, settings, 'weekly')
+    }
+  } catch (err) {
+    console.warn(`[notify] digest failed: ${(err as Error).message}`)
+  }
+  return out
+}

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,13 +13,14 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.15.1'
-console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial milestone reminders`)
+const VERSION = '1.16.0'
+console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial milestones + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { scheduleScreening, sendIntroEmail, sharedAccessToken, sweepCalendars, HOUSE_CALENDAR_ID, SHARED_EMAIL } from '../_shared/recruit-schedule.ts'
 import { editSchedulerSignedUp, editSchedulerFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
+import { notifyTick } from '../_shared/recruit-notify.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
 
@@ -844,8 +845,16 @@ serve(async (req) => {
       const recorded = await processRecordings(client) + await processMeetingRecordings(client)
       const archived = await archiveMissingRecordings(client)
       if (archived) console.log(`[archive] ${archived} recording(s) copied to storage`)
-      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${trials} trial(s), ${recorded} recording(s)`)
-      return json({ bots, live, reminded: sent, trials, recorded })
+      // The notification ledger: detect what's true now, write it to the log,
+      // then broadcast whatever the house is owed. Isolated from everything
+      // above — a failing detector must not cost the screening reminders their
+      // tick.
+      let notify = { detected: 0, logged: 0, now: 0, digest: 0 }
+      try { notify = await notifyTick(client) } catch (err) {
+        console.warn(`[notify] tick failed: ${(err as Error).message}`)
+      }
+      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${trials} trial(s), ${recorded} recording(s), notify ${notify.detected} new / ${notify.logged} logged / ${notify.now} posted / ${notify.digest} digested`)
+      return json({ bots, live, reminded: sent, trials, recorded, notify })
     }
 
     const pathname = new URL(req.url).pathname

--- a/supabase/migrations/142_recruit_notifications.sql
+++ b/supabase/migrations/142_recruit_notifications.sql
@@ -1,0 +1,151 @@
+-- ============================================
+-- Migration 142: the notification ledger
+--
+-- Today six functions each own their own notification: their own dedupe
+-- column, their own hard-coded channel, their own volume rule. Nothing can
+-- answer "what did we send this week" or "did anyone ever get back to her",
+-- because there is no record of a notification anywhere — only the side
+-- effect of having sent one.
+--
+-- recruit_notifications makes the notification itself a row. Written by the
+-- detect pass BEFORE anything is delivered, so:
+--
+--   * the row's existence IS the log entry — the in-app Activity view and
+--     #recruiting-automation both just read this table;
+--   * every delivery is a stamp on it (log_at / members_at / dm_at), so a
+--     muted kind still leaves a complete record with no stamps;
+--   * dedupe_key UNIQUE + ON CONFLICT DO NOTHING replaces six bespoke
+--     *_reminded_at columns with one idiom.
+--
+-- Double-notify is deliberate: the claim post asks someone to take a call,
+-- the digest line tells the house she replied, the log entry is the record it
+-- happened. Suppressing the second because the first fired is how the house
+-- ends up unable to reconstruct what it did.
+--
+-- On-call is not a person: the members of #recruiting-automation are on-call,
+-- so audience 'oncall' resolves to an @here in that channel and there is no
+-- user id to configure or keep current.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS recruit_notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind TEXT NOT NULL,                       -- 'review_stalled', 'reply_reschedule', ...
+  subject_type TEXT NOT NULL CHECK (subject_type IN ('applicant', 'listing', 'stay', 'house')),
+  subject_id TEXT,                          -- applicant id (text) or uuid::text; null for house-wide
+  subject_label TEXT NOT NULL DEFAULT '',   -- "Maya", "Priest", denormalised so the log reads without joins
+
+  -- Who it is for. 'house' = members channel (batched by lane); 'oncall' =
+  -- @here in #recruiting-automation; 'person' = a DM to recipient_id, used
+  -- only where ownership is real (the claimer of a scheduled call).
+  audience TEXT NOT NULL DEFAULT 'house' CHECK (audience IN ('house', 'oncall', 'person')),
+  recipient_id TEXT,                        -- discord user id when audience='person'
+
+  -- Members-channel timing only. The log is never batched or delayed.
+  lane TEXT NOT NULL DEFAULT 'daily' CHECK (lane IN ('now', 'daily', 'weekly')),
+
+  dedupe_key TEXT NOT NULL UNIQUE,          -- '<kind>:<subject_id>[:<step>]'
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,  -- { title, body, section, links: [{label,url}] }
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),   -- == entered the log
+  due_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),       -- eligible to broadcast from
+  log_at TIMESTAMPTZ,                              -- posted to #recruiting-automation
+  members_at TIMESTAMPTZ,                          -- posted to the members channel
+  -- An escalation is NOT a members-channel post: audience='oncall' means an
+  -- @here in #recruiting-automation. Its own column, so the log never claims a
+  -- delivery that didn't happen.
+  escalated_at TIMESTAMPTZ,
+  dm_at TIMESTAMPTZ,                               -- delivered as a DM
+  digest_id UUID,                                  -- which digest embed carried it
+  muted BOOLEAN NOT NULL DEFAULT FALSE,            -- suppressed from the members channel; still logged
+  acked_at TIMESTAMPTZ,                            -- resolved in-app
+  acked_by UUID REFERENCES auth.users(id) ON DELETE SET NULL
+);
+
+-- The log view: newest first, no predicate. This is the Activity view's query.
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_log
+  ON recruit_notifications (created_at DESC);
+-- "everything that ever happened to Maya".
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_subject
+  ON recruit_notifications (subject_type, subject_id, created_at DESC);
+-- The dispatcher's three drain queries.
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_pending_log
+  ON recruit_notifications (created_at) WHERE log_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_pending_members
+  ON recruit_notifications (lane, due_at)
+  WHERE members_at IS NULL AND escalated_at IS NULL AND NOT muted;
+-- Rail badges.
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_open
+  ON recruit_notifications (subject_type, kind) WHERE acked_at IS NULL;
+
+ALTER TABLE recruit_notifications ENABLE ROW LEVEL SECURITY;
+
+-- Members read the whole log — that is the point of it. Writes are
+-- service-role (the dispatcher) except acking, which goes through the RPC
+-- below so a client can never invent or edit a notification.
+CREATE POLICY "Recruiting members read notifications" ON recruit_notifications
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+
+-- Acking resolves a notification without deleting it: the log keeps the entry
+-- and gains the fact that it was handled, and the next digest stops asking.
+CREATE OR REPLACE FUNCTION recruit_ack_notification(p_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  UPDATE recruit_notifications
+    SET acked_at = NOW(), acked_by = auth.uid()
+    WHERE id = p_id AND acked_at IS NULL;
+END;
+$$;
+
+-- Ack every open notification of a kind for a subject. The rails call this
+-- when the underlying thing is dealt with — reviewing an applicant clears
+-- their review_stalled, opening a listing clears its draft nudges — so the
+-- digest never asks for something already done.
+CREATE OR REPLACE FUNCTION recruit_ack_subject(p_subject_type TEXT, p_subject_id TEXT, p_kinds TEXT[] DEFAULT NULL)
+RETURNS INT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE n INT;
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  UPDATE recruit_notifications
+    SET acked_at = NOW(), acked_by = auth.uid()
+    WHERE subject_type = p_subject_type AND subject_id = p_subject_id
+      AND acked_at IS NULL
+      AND (p_kinds IS NULL OR kind = ANY(p_kinds));
+  GET DIAGNOSTICS n = ROW_COUNT;
+  RETURN n;
+END;
+$$;
+
+-- Settings. Cadence and mutes are config, not deploys: a notification that
+-- turns out to be noise is switched off here, and its log entries keep being
+-- written either way.
+INSERT INTO recruit_settings (key, value) VALUES
+  ('notify_digest_hour', '8'::jsonb),
+  ('notify_enabled', 'true'::jsonb),
+  -- Automation-only to start: every notification, escalation, and digest goes
+  -- to #recruiting-automation and nothing reaches the channel the whole house
+  -- reads until the detectors have proven themselves against real data. Lanes
+  -- and audiences still work as designed, so this is a destination switch, not
+  -- a feature flag.
+  ('notify_house_posts', 'false'::jsonb),
+  -- Reply intents ship in shadow mode: classified, logged, and visible in
+  -- #recruiting-automation, but not broadcast to the house until the
+  -- confidence distribution has been read against real replies. Opening the
+  -- lane is an edit here, not a deploy.
+  ('notify_muted', '["reply_reschedule","reply_withdrawing","reply_plans_changed","reply_post_acceptance"]'::jsonb)
+ON CONFLICT (key) DO NOTHING;
+
+COMMENT ON TABLE recruit_notifications IS
+  'Every recruiting notification, as a row. Written before delivery, so the table is the running log and the *_at columns are deliveries. Retained forever.';
+COMMENT ON COLUMN recruit_notifications.muted IS
+  'Suppressed from the members channel by notify_muted. Still logged — muting never loses information.';
+COMMENT ON COLUMN recruit_notifications.audience IS
+  'house = members channel; oncall = @here in #recruiting-automation (its membership IS the on-call roster); person = DM, only where ownership is real.';


### PR DESCRIPTION
## What

Every recruiting notification becomes a row in `recruit_notifications` (migration 142), written by the detect pass **before** anything is delivered. The table *is* the running log — the in-app **Activity** view and `#recruiting-automation` both read it — and each surface is a stamp on the row (`log_at` / `members_at` / `escalated_at` / `dm_at`). A muted kind still leaves a complete entry with no stamps, so **muting never loses information**.

`dedupe_key UNIQUE` + `ON CONFLICT DO NOTHING` replaces six bespoke `*_reminded_at` columns with one idiom.

## Detectors (on the existing 15-min tick — no new cron)

| Kind | Fires when |
|---|---|
| `review_stalled` | in review, no verdict, 48h; escalates at 5 days |
| `review_backlog` | the never-reviewed pile, as one weekly number |
| `opening_at_risk` / `opening_overdue` | a room with no runway left, then past its start date |
| `room_emptying` | a stay ending in ≤45 days with no listing and nobody lined up |
| `application_new` | recorded so the log holds the pings the gmail scan sends |

## Automation-only for now

`notify_house_posts = false`: every notification, escalation, and digest goes to `#recruiting-automation` and **nothing reaches Recruiting Society**. Enforced inside `send()` rather than trusted at call sites, so no future detector or fallback can leak into the channel the whole house reads. Flipping the setting is the release — no deploy.

## Found by testing against real data

- **`review_stalled` keyed on `discord_ping_at` reported zero** while 53 applications sat unreviewed — 50 had never been pinged at all (the ping's 14-day floor). Clock is now `COALESCE(ping, submitted_at)` windowed to 30 days, with the older pile counted once rather than fired 50 times. Now correctly catches Chloe (24d) and Soham (23d).
- **An unpaced burst hit Discord's rate limit**, and `postResilient`'s cross-channel fallback would have spilled log lines into the house channel. This module now does its own paced, retrying, fallback-free sending.
- **Escalations were stamping `members_at`**, making the log claim an on-call post had gone to the house. Own column now.
- `room_emptying` verified by replay against real stays (will fire on Sophia's City trial on 2026-09-17); not driven end-to-end through Discord because that needed a fake occupant in the live Occupancy calendar.

## Decisions folded in

- **No update-email queue.** A declined, passed, or archived applicant is closed and the house owes them nothing.
- **On-call is a channel, not a person** — `#recruiting-automation`'s membership is the roster. No mentions: a post there already reaches them, and a channel that buzzes gets muted.
- **Copy is kind + linked subject, nothing else** — no slugs, no lane tags, no clause after an em dash, no buttons. The subject text is the hyperlink into the app; detail lives in the Activity view.

## Versions

`recruit-discord` v1.16.0 · `/applications` v3.45.0 · migration 142 (+142b) applied · function deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)