### PR TITLE
feat(recruiting): exit tiles, and no Save button unless it earns one (v3.48.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -821,11 +821,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .listing-form__field .listing-status { width: 100%; height: 36px; }
 .listing-form__notes { min-height: 48px; }
 .listing-form__error { margin: 0; color: var(--error); font-size: var(--font-size-small); min-height: 1.2em; }
-.listing-form__delete {
-  margin-right: auto;
-  background: none; border: 0; padding: 0;
-  color: var(--error); font-size: var(--font-size-small); text-decoration: underline; cursor: pointer;
-}
 
 /* --- Outreach ↔ listing attachments --- */
 .inbox-row__attach { color: var(--outreach-fg); }
@@ -1568,26 +1563,31 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .gplayer.is-mini .vchrome { display: none; }
 @media (max-width: 520px) { .gplayer.is-mini { width: min(250px, 70vw); right: 10px; bottom: 10px; } }
 
-/* --- v3.45.0: sidebar CTA tiers (Sassy `drawer-cta`) ---
+/* --- v3.48.0: sidebar CTA tiers (Sassy `drawer-cta`) ---
    Drawer footers had four actions fighting inside one right-aligned flex
    row: two red underlined links (which wrapped onto two lines in a 380px
    sidebar), a text Cancel, and the primary. A sidebar is too narrow to keep
-   four targets honest side by side, so the footer is now three explicit
-   tiers, ordered by consequence:
+   four targets honest side by side, so the footer is three explicit tiers,
+   ordered by consequence:
 
      tier 1  .drawer-cta__commit   the one filled primary — right-aligned
      tier 2  .drawer-cta__quiet    dismiss — no fill, beside the primary
-     tier 3  .drawer-cta__exit     destructive / state changes — full-width
-                                   rows below a rule, one per line
+     tier 3  .drawer-cta__exit     destructive / state changes — inset tiles,
+                                   one per line, separated by space not rules
 
    Rules: exactly one commit per sidebar; anything that removes, ends, or
    re-routes a record leaves the commit row entirely; exits never underline
    (see the design system's transparency-not-decoration rule) and carry a
-   hint so a red label is never the only explanation of what it does. */
-.drawer-cta { margin-top: var(--space-4); display: flex; flex-direction: column; }
+   hint so a red label is never the only explanation of what it does.
+
+   Direction A (Sassy v3.31): no hairlines anywhere in this footer. Each exit
+   is its own inset surface with radius and a gap, so separation comes from
+   the tile edge rather than a rule drawn between two things that belong
+   together. The commit row loses its border-top too — space above it does
+   the same job without a line. */
+.drawer-cta { margin-top: var(--space-5); display: flex; flex-direction: column; }
 .drawer-cta__row {
   display: flex; align-items: center; justify-content: flex-end; gap: var(--space-2);
-  padding-top: var(--space-3); border-top: 1px solid var(--border);
 }
 .drawer-cta__commit { flex: 0 0 auto; min-width: 104px; }
 .drawer-cta__quiet {
@@ -1598,9 +1598,9 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .drawer-cta__quiet:hover { color: var(--fg); background: var(--bg-overlay); }
 /* The optional fourth slot: a second, non-destructive path the sidebar also
-   offers ("create a listing instead", "welcome them in"). Full-width and
-   outlined, never filled — the filled commit stays unique so the eye can
-   still find the one action that saves what's on screen. */
+   offers ("create a listing instead", "welcome them in"). Outlined rather
+   than filled — that's what separates a forward path from a way out, now
+   that the exits are filled tiles. */
 .drawer-cta__alt {
   display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
   width: 100%; padding: var(--space-3);
@@ -1609,30 +1609,32 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   font-size: var(--font-size-small); font-weight: var(--fw-semibold);
 }
 .drawer-cta__alt:hover { background: var(--bg-overlay); }
-/* The alt's hint is a full sentence, so it stacks under the label instead of
-   competing with it for the same line. */
 .drawer-cta__alt .drawer-cta__exit-hint { text-align: left; }
-.drawer-cta__exits { display: flex; flex-direction: column; margin-top: var(--space-3); }
+/* No Save button on an existing record — the fields are the save. This line
+   says so, and briefly says "Saved" when a write lands, so the absence of a
+   button never reads as "nothing happened". */
+.drawer-cta__flag {
+  margin: 0; text-align: right;
+  color: var(--fg-subtle); font-size: var(--font-size-caption);
+  transition: color 120ms ease;
+}
+.drawer-cta__flag.is-on { color: var(--success); font-weight: var(--fw-semibold); }
+.drawer-cta__exits { display: flex; flex-direction: column; gap: 6px; margin-top: var(--space-3); }
 .drawer-cta__exit {
-  display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3);
-  width: 100%; padding: var(--space-3) 0;
-  background: transparent; border: 0; border-top: 1px solid var(--border);
-  color: var(--fg-muted); text-align: left; text-decoration: none;
+  display: grid; grid-template-columns: 1fr auto; gap: 2px var(--space-3);
+  width: 100%; padding: var(--space-3);
+  background: var(--bg-surface); border: 0; border-radius: var(--radius-sm);
+  color: var(--fg); text-align: left; text-decoration: none;
   font-size: var(--font-size-small); font-weight: var(--fw-semibold);
-  white-space: nowrap;
 }
-.drawer-cta__exit:hover { color: var(--fg); }
+/* Explicit placement — an icon spanning both rows would otherwise be placed
+   before the auto-flowed label and take column 1. */
+.drawer-cta__exit-label { grid-column: 1; grid-row: 1; }
+.drawer-cta__exit-hint  { grid-column: 1; grid-row: 2;
+  color: var(--fg-subtle); font-size: var(--font-size-caption); font-weight: 400; }
+.drawer-cta__exit-icon  { grid-column: 2; grid-row: 1 / 3; align-self: center;
+  color: var(--fg-subtle); font-size: var(--font-size-small); }
+.drawer-cta__exit:hover { background: var(--bg-overlay); }
 .drawer-cta__exit--danger { color: var(--error); }
-.drawer-cta__exit--danger:hover { color: var(--error); background: var(--pass-tint); }
-/* The hint yields first: it wraps or ellipsizes so the label — the thing that
-   says what the button does — always reads on one line. */
-.drawer-cta__exit-hint {
-  flex: 0 1 auto; min-width: 0; white-space: normal;
-  color: var(--fg-subtle); font-size: var(--font-size-caption); font-weight: 400; text-align: right;
-}
-/* On a full-width phone drawer the hint gets its own line rather than
-   squeezing the label into an ellipsis. */
-@media (max-width: 480px) {
-  .drawer-cta__exit { flex-direction: column; align-items: flex-start; gap: 2px; }
-  .drawer-cta__exit-hint { text-align: left; }
-}
+.drawer-cta__exit--danger .drawer-cta__exit-icon { color: var(--error); }
+.drawer-cta__exit--danger:hover { background: color-mix(in srgb, var(--error) 14%, transparent); }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.46.0">
+  <link rel="stylesheet" href="css/app.css?v=3.48.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -306,7 +306,7 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.46.0"></script>
+  <script src="js/app.js?v=3.48.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.46.0';
+const VERSION = '3.48.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -2455,6 +2455,37 @@ function roomGaps(roomId) {
   return gaps.filter(([a, b]) => (new Date(b) - new Date(a)) / 86400000 >= 7);
 }
 
+/* One room's bars: stays, then the uncovered stretches between them. Module
+   scope (not a closure inside renderOccupancy) so refreshLane() can repaint a
+   single lane after an autosave without rebuilding the drawer. */
+function laneBarsHtml(r) {
+  const winEndExcl = addMonthsIso(occStart, OCC_WINDOW);
+  const bars = [];
+  for (const s of roomStays(r.id)) {
+    const endExcl = s.ends_on ? isoAddDays(s.ends_on, 1) : winEndExcl;
+    if (s.starts_on >= winEndExcl || endExcl <= occStart) continue;
+    const left = occPos(s.starts_on) * 100;
+    const width = (s.ends_on ? occPos(endExcl) : 1) * 100 - left;
+    const range = `${fmtShort(s.starts_on)} – ${s.ends_on ? fmtShort(s.ends_on) : 'ongoing'}`;
+    const active = occDrawer?.type === 'stay' && occDrawer.id === s.id;
+    bars.push(`<button type="button" class="cal__event cal__event--${s.kind} ${!s.ends_on ? 'is-open-ended' : ''} ${active ? 'is-editing' : ''}"
+      style="left: ${left}%; width: calc(${Math.max(width, 0.8)}% - var(--bar-break))" title="${esc(`${s.occupant || KIND_LABELS[s.kind]} · ${KIND_LABELS[s.kind]} · ${range}`)}"
+      data-stay="${s.id}">${esc(s.occupant || KIND_LABELS[s.kind])}</button>`);
+  }
+  for (const [a, b] of roomGaps(r.id)) {
+    const left = occPos(a) * 100;
+    const width = occPos(isoAddDays(b, 1)) * 100 - left;
+    const active = occDrawer?.type === 'gap' && occDrawer.roomId === r.id && occDrawer.start === a;
+    // No label: a red stretch already reads as empty, and the dates it
+    // spans are the point. Tapping it opens the drawer, which names them.
+    bars.push(`<button type="button" class="cal__event cal__event--vacant ${active ? 'is-editing' : ''}"
+      style="left: ${left}%; width: calc(${width}% - var(--bar-break))" title="Open ${fmtShort(a)} – ${fmtShort(b)} — tap to fill or list"
+      aria-label="Open ${fmtShort(a)} – ${fmtShort(b)}"
+      data-gap-room="${r.id}" data-gap-start="${a}" data-gap-end="${b}"></button>`);
+  }
+  return bars.join('');
+}
+
 function renderOccupancy() {
   OCC_WINDOW = occMq.matches ? 3 : 12;
   if (!occStart) occStart = defaultOccStart();
@@ -2467,33 +2498,6 @@ function renderOccupancy() {
   const todayIso = new Date().toISOString().slice(0, 10);
   const todayPct = todayIso >= occStart && occPos(todayIso) < 1 ? occPos(todayIso) * 100 : null;
 
-  const barsFor = r => {
-    const winEndExcl = addMonthsIso(occStart, OCC_WINDOW);
-    const bars = [];
-    for (const s of roomStays(r.id)) {
-      const endExcl = s.ends_on ? isoAddDays(s.ends_on, 1) : winEndExcl;
-      if (s.starts_on >= winEndExcl || endExcl <= occStart) continue;
-      const left = occPos(s.starts_on) * 100;
-      const width = (s.ends_on ? occPos(endExcl) : 1) * 100 - left;
-      const range = `${fmtShort(s.starts_on)} – ${s.ends_on ? fmtShort(s.ends_on) : 'ongoing'}`;
-      const active = occDrawer?.type === 'stay' && occDrawer.id === s.id;
-      bars.push(`<button type="button" class="cal__event cal__event--${s.kind} ${!s.ends_on ? 'is-open-ended' : ''} ${active ? 'is-editing' : ''}"
-        style="left: ${left}%; width: calc(${Math.max(width, 0.8)}% - var(--bar-break))" title="${esc(`${s.occupant || KIND_LABELS[s.kind]} · ${KIND_LABELS[s.kind]} · ${range}`)}"
-        data-stay="${s.id}">${esc(s.occupant || KIND_LABELS[s.kind])}</button>`);
-    }
-    for (const [a, b] of roomGaps(r.id)) {
-      const left = occPos(a) * 100;
-      const width = occPos(isoAddDays(b, 1)) * 100 - left;
-      const active = occDrawer?.type === 'gap' && occDrawer.roomId === r.id && occDrawer.start === a;
-      // No label: a red stretch already reads as empty, and the dates it
-      // spans are the point. Tapping it opens the drawer, which names them.
-      bars.push(`<button type="button" class="cal__event cal__event--vacant ${active ? 'is-editing' : ''}"
-        style="left: ${left}%; width: calc(${width}% - var(--bar-break))" title="Open ${fmtShort(a)} – ${fmtShort(b)} — tap to fill or list"
-        aria-label="Open ${fmtShort(a)} – ${fmtShort(b)}"
-        data-gap-room="${r.id}" data-gap-start="${a}" data-gap-end="${b}"></button>`);
-    }
-    return bars.join('');
-  };
 
   host.innerHTML = `
     <div class="occ-legend">
@@ -2530,7 +2534,7 @@ function renderOccupancy() {
               <span class="occ__room-name">${esc(r.name)}</span>
               <span class="occ__room-sub">${esc(r.floor)}${r.total_sqft ? ` · ${r.total_sqft} sq ft` : ''}</span>
             </button>
-            <div class="cal__lane">${barsFor(r)}</div>
+            <div class="cal__lane" data-lane-room="${r.id}">${laneBarsHtml(r)}</div>
           </div>`).join('')}
       </div>
     </div>
@@ -2702,12 +2706,16 @@ function stayFormHtml(s, roomId) {
   const exits = [];
   if (!isNew && s.kind === 'resident') {
     exits.push(`<button type="button" class="drawer-cta__exit" data-stay-leaving="${roomId}" data-stay-leaving-date="${s.ends_on || ''}">
-      Mark leaving <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
+      <span class="drawer-cta__exit-label">Mark leaving</span>
+      <span class="drawer-cta__exit-icon" aria-hidden="true">&rarr;</span>
+      <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
     </button>`);
   }
   if (!isNew) {
     exits.push(`<button type="button" class="drawer-cta__exit drawer-cta__exit--danger" data-stay-delete="${s.id}">
-      Remove stay <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
+      <span class="drawer-cta__exit-label">Remove stay</span>
+      <span class="drawer-cta__exit-icon" aria-hidden="true">&times;</span>
+      <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
     </button>`);
   }
   return `<form class="occ-drawer__form" data-stay-form="${s.id || 'new'}" data-stay-room="${roomId}">
@@ -2732,10 +2740,10 @@ function stayFormHtml(s, roomId) {
     ${trialFieldsHtml(s)}
     <p class="listing-form__error" data-form-error></p>
     <div class="drawer-cta">
-      <div class="drawer-cta__row">
+      ${isNew ? `<div class="drawer-cta__row">
         <button type="button" class="drawer-cta__quiet" data-drawer-close>Cancel</button>
-        <button type="submit" class="btn btn--accent drawer-cta__commit">${isNew ? 'Add stay' : 'Save'}</button>
-      </div>
+        <button type="submit" class="btn btn--accent drawer-cta__commit">Add stay</button>
+      </div>` : `<p class="drawer-cta__flag" data-save-flag>Changes save as you go</p>`}
       ${exits.length ? `<div class="drawer-cta__exits">${exits.join('')}</div>` : ''}
     </div>
   </form>`;
@@ -2820,7 +2828,7 @@ function renderOccDrawer() {
       </div>
       <div class="occ-drawer__body">${body}</div>
     </aside>`;
-  hostWrap.querySelector('[data-stay-form]')?.addEventListener('submit', onStaySave);
+  hostWrap.querySelector('[data-stay-form]')?.addEventListener('submit', onStayFormSubmit);
   hostWrap.querySelector('[data-promote-open]')?.addEventListener('click', e => {
     promoting = e.currentTarget.dataset.promoteOpen;
     renderOccDrawer();
@@ -2852,6 +2860,12 @@ function renderOccDrawer() {
       form.querySelector(sel)?.addEventListener('change', () => syncTrialFields(form));
     }
     syncTrialFields(form);
+    // Autosave. `change` is the right moment: text commits on blur, dates and
+    // selects the instant they settle. Delegated, so the trial milestone fields
+    // that appear later are covered without re-binding.
+    if (form.dataset.stayForm !== 'new') {
+      form.addEventListener('change', () => autoSaveStay(form));
+    }
   }
 }
 
@@ -2878,9 +2892,11 @@ function syncTrialFields(form) {
   }
 }
 
-async function onStaySave(e) {
-  e.preventDefault();
-  const form = e.target;
+/* Validate + write, and nothing else — no toast, no navigation, no re-render.
+   Both the autosave path and the create button go through this so an edit and
+   an insert can never drift apart on validation. Returns true on success;
+   on failure the inline error is already set. */
+async function writeStayForm(form) {
   const fd = new FormData(form);
   const id = form.dataset.stayForm;
   const err = form.querySelector('[data-form-error]');
@@ -2925,6 +2941,71 @@ async function onStaySave(e) {
     if (error) { err.textContent = error.message; return; }
     Object.assign(stays.find(s => s.id === id) || {}, rec);
   }
+  err.textContent = '';
+  return true;
+}
+
+/* --- autosave ---
+   A field commits on `change`, which for text fires when it loses focus and
+   for dates/selects the moment the value settles. Nothing is repainted except
+   the one lane and the drawer's own subtitle, so focus and caret survive.
+   Creation is the exception: a record that doesn't exist yet can't autosave,
+   so a new stay keeps an explicit "Add stay". */
+let staySavedTimer = null;
+
+async function autoSaveStay(form) {
+  if (form.dataset.stayForm === 'new') return;
+  const ok = await writeStayForm(form);
+  if (!ok) return;
+  const roomId = +form.dataset.stayRoom;
+  refreshLane(roomId);
+  refreshOccupants();
+  refreshDrawerSub();
+  const flag = form.querySelector('[data-save-flag]');
+  if (flag) {
+    flag.textContent = 'Saved';
+    flag.classList.add('is-on');
+    clearTimeout(staySavedTimer);
+    staySavedTimer = setTimeout(() => {
+      flag.classList.remove('is-on');
+      flag.textContent = 'Changes save as you go';
+    }, 2200);
+  }
+}
+
+/* Repaint one room's bars in place. The whole-view render would rebuild the
+   drawer and throw away whatever the cursor was in. */
+function refreshLane(roomId) {
+  const lane = document.querySelector(`[data-lane-room="${roomId}"]`);
+  const r = rooms.find(x => x.id === roomId);
+  if (lane && r) lane.innerHTML = laneBarsHtml(r);
+}
+
+function refreshOccupants() {
+  const host = document.querySelector('.occupants');
+  if (!host) return;
+  const wrap = document.createElement('div');
+  wrap.innerHTML = occupantsHtml();
+  const next = wrap.firstElementChild;
+  if (next) host.replaceWith(next);
+}
+
+/* The subtitle carries the stay's dates, so it goes stale the moment one changes. */
+function refreshDrawerSub() {
+  if (occDrawer?.type !== 'stay') return;
+  const s = stays.find(x => x.id === occDrawer.id);
+  const el = document.querySelector('.occ-drawer__sub');
+  if (!s || !el) return;
+  const room = rooms.find(r => r.id === s.room_id);
+  el.textContent = `${room?.name || 'Room'} · ${KIND_LABELS[s.kind]} · ${fmtShort(s.starts_on)} – ${s.ends_on ? fmtShort(s.ends_on) : 'ongoing'}`;
+}
+
+/* Submit means "I'm done here": the Add-stay button on a new record, or Enter
+   in a field on an existing one. Either way, write and close. */
+async function onStayFormSubmit(e) {
+  e.preventDefault();
+  const ok = await writeStayForm(e.target);
+  if (!ok) return;
   occDrawer = null;
   toast('Occupancy updated');
   renderOccupancy();
@@ -3163,10 +3244,18 @@ function listingForm(l) {
       <textarea name="notes" class="notes__input listing-form__notes" rows="2" maxlength="1000">${esc(l.notes || '')}</textarea>
     </label>
     <p class="listing-form__error" data-form-error></p>
-    <div class="decision-sheet__actions">
-      ${isNew ? '' : `<button type="button" class="listing-form__delete" data-delete-listing="${l.id}">Delete listing</button>`}
-      <button type="button" class="hold-sheet__cancel" data-cancel-listing>Cancel</button>
-      <button type="submit" class="btn btn--accent btn--sm">${isNew ? 'Create listing' : 'Save changes'}</button>
+    <div class="drawer-cta">
+      ${isNew ? `<div class="drawer-cta__row">
+        <button type="button" class="drawer-cta__quiet" data-cancel-listing>Cancel</button>
+        <button type="submit" class="btn btn--accent drawer-cta__commit">Create listing</button>
+      </div>` : `<p class="drawer-cta__flag" data-save-flag>Changes save as you go</p>
+      <div class="drawer-cta__exits">
+        <button type="button" class="drawer-cta__exit drawer-cta__exit--danger" data-delete-listing="${l.id}">
+          <span class="drawer-cta__exit-label">Delete listing</span>
+          <span class="drawer-cta__exit-icon" aria-hidden="true">&times;</span>
+          <span class="drawer-cta__exit-hint">removes it and unplaces its candidates</span>
+        </button>
+      </div>`}
     </div>
   </form>`;
 }
@@ -3185,7 +3274,11 @@ function openListingModal(idOrNew) {
     <p class="notes__empty">A listing is a sublet (≤ 3 months) of a resident's room, or a 3-month resident trial.</p>
     ${listingForm(l)}`;
   document.getElementById('listing-modal').hidden = false;
-  body.querySelector('[data-listing-form]').addEventListener('submit', onListingSubmit);
+  const lform = body.querySelector('[data-listing-form]');
+  lform.addEventListener('submit', onListingCreate);
+  if (lform.dataset.listingForm !== 'new') {
+    lform.addEventListener('change', e => autoSaveListing(lform, e.target.name));
+  }
 }
 
 function closeListingModal() {
@@ -3204,9 +3297,9 @@ function rerenderAfterListingChange() {
   });
 }
 
-async function onListingSubmit(e) {
-  e.preventDefault();
-  const form = e.target;
+/* Validate + write only. Shared by the autosave path and the create button so
+   the two can't drift apart on validation. */
+async function writeListingForm(form) {
   const id = form.dataset.listingForm;
   const fd = new FormData(form);
   const num = k => { const v = fd.get(k); return v === '' || v === null ? null : Math.round(+v); };
@@ -3235,14 +3328,47 @@ async function onListingSubmit(e) {
     }).select().single();
     if (error) { err.textContent = error.message; return; }
     listings.push(data);
-    toast('Listing created');
   } else {
     const { error } = await sb.from('recruit_listings').update(rec).eq('id', id);
     if (error) { err.textContent = error.message; return; }
     Object.assign(listings.find(l => l.id === id) || {}, rec);
-    toast('Listing updated');
   }
+  err.textContent = '';
+  return true;
+}
+
+async function onListingCreate(e) {
+  e.preventDefault();
+  if (!await writeListingForm(e.target)) return;
   rerenderAfterListingChange();
+}
+
+/* Autosave an existing listing: write, then refresh the views behind the modal
+   without closing it. A status change can pick up or drop auto-placements, so
+   that sync still has to run. */
+let listingSavedTimer = null;
+/* Fields that can change who qualifies for this listing. Editing the notes
+   shouldn't cost an auto-placement round trip. */
+const PLACEMENT_FIELDS = new Set(['room_id', 'kind', 'starts_on', 'ends_on', 'status']);
+async function autoSaveListing(form, changed) {
+  if (form.dataset.listingForm === 'new') return;
+  if (!await writeListingForm(form)) return;
+  const flag = form.querySelector('[data-save-flag]');
+  if (flag) {
+    flag.textContent = 'Saved';
+    flag.classList.add('is-on');
+    clearTimeout(listingSavedTimer);
+    listingSavedTimer = setTimeout(() => {
+      flag.classList.remove('is-on');
+      flag.textContent = 'Changes save as you go';
+    }, 2200);
+  }
+  if (!PLACEMENT_FIELDS.has(changed)) return;
+  const added = await syncAutoPlacements();
+  renderRailCounts();
+  if (view === 'openings') renderApplicants();
+  else if (view === 'occupancy') renderOccupancy();
+  if (added) toast(`${added} candidate${added === 1 ? '' : 's'} auto-placed`);
 }
 
 async function deleteListing(id) {

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [1.4.0] - 2026-07-30
+
+### Changed
+- **Exit rows are inset tiles; footers have no hairlines** (direction A). Each exit is a filled surface with radius and a 6px gap; the commit row dropped its `border-top`. A rule between two things that belong together separates what should be grouped.
+- **No Save button unless it creates, confirms, or destroys.** Editing an existing record autosaves on `change`; `drawer-cta__flag` replaces the commit row with "Changes save as you go" / "Saved". Applied to the stay drawer and the listing editor.
+
+---
+
 ## [1.3.0] - 2026-07-30
 
 ### Added

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -646,21 +646,31 @@ A destructive or branching action with **more than two outcomes** opens a sheet,
 
 A sidebar or drawer footer is **three tiers deep, ordered by consequence** — not one right-aligned flex row. A ~380px drawer cannot keep four targets honest side by side; the stay editor proved it, with two red underlined links each wrapping onto two lines.
 
+**No hairlines.** Exits are inset tiles with radius and a gap; the commit row has no `border-top`. A rule between two things that belong together is separating what should be grouped — surface, radius, and space do that job instead.
+
+**No Save on an existing record.** Fields commit on `change`, and a quiet status line (`drawer-cta__flag`) says "Changes save as you go", flashing "Saved" when a write lands. An explicit commit survives in exactly three cases: **creating** a record (`Add stay`, `Create listing`), **confirming** a state change (`Welcome them in`), and anything **destructive**.
+
 ```html
 <div class="drawer-cta">
-  <!-- tier 1 + 2: commit and dismiss, together -->
+  <!-- tier 1 + 2: only on a NEW record. An existing one autosaves. -->
   <div class="drawer-cta__row">
     <button type="button" class="drawer-cta__quiet" data-drawer-close>Cancel</button>
-    <button type="submit" class="btn btn--accent drawer-cta__commit">Save</button>
+    <button type="submit" class="btn btn--accent drawer-cta__commit">Add stay</button>
   </div>
+  <!-- …or, editing an existing record: -->
+  <p class="drawer-cta__flag" data-save-flag>Changes save as you go</p>
 
-  <!-- tier 3: the ways out — full-width rows, one per line -->
+  <!-- tier 3: the ways out — inset tiles, one per line, no rules -->
   <div class="drawer-cta__exits">
     <button type="button" class="drawer-cta__exit">
-      Mark leaving <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
+      <span class="drawer-cta__exit-label">Mark leaving</span>
+      <span class="drawer-cta__exit-icon" aria-hidden="true">&rarr;</span>
+      <span class="drawer-cta__exit-hint">sets a move-out date and lists the room</span>
     </button>
     <button type="button" class="drawer-cta__exit drawer-cta__exit--danger">
-      Remove stay <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
+      <span class="drawer-cta__exit-label">Remove stay</span>
+      <span class="drawer-cta__exit-icon" aria-hidden="true">&times;</span>
+      <span class="drawer-cta__exit-hint">deletes it from the timeline</span>
     </button>
   </div>
 
@@ -674,17 +684,19 @@ A sidebar or drawer footer is **three tiers deep, ordered by consequence** — n
 
 | Class | Tier | Rule |
 |---|---|---|
-| `drawer-cta__commit` | 1 | The one filled primary, bottom-right. **Exactly one per sidebar** — it is the only thing that saves what's on screen. |
+| `drawer-cta__commit` | 1 | The one filled primary, bottom-right. **Only on a new record, a confirmation, or a destructive act** — never a plain Save. |
 | `drawer-cta__quiet` | 2 | Dismiss. No fill, no border, beside the primary. Cancel is not a decision, so it doesn't look like one. |
-| `drawer-cta__exit` | 3 | The ways out. Full-width row below a rule, label left, hint right. `--danger` for destructive (red label, tinted hover); muted for state changes. |
-| `drawer-cta__alt` | — | Optional second forward path. Outlined, never filled, label stacked over hint. |
+| `drawer-cta__flag` | 2 | Replaces the commit row when editing an existing record: "Changes save as you go", flashing "Saved". |
+| `drawer-cta__exit` | 3 | The ways out. Full-width **inset tile** — filled surface, radius, 6px gap, no rules. Label + hint stacked left, glyph right. `--danger` for destructive. |
+| `drawer-cta__alt` | — | Optional second forward path. **Outlined, never filled** — that's what distinguishes a forward path from a way out now that exits are filled. |
 
 **Sidebar CTA rules:**
 - Anything that **removes, ends, or re-routes** a record leaves the commit row entirely
 - Exits never underline — weight and color carry them (see [Removed & deferred states](#removed--deferred-states))
 - Every exit and alt carries a hint; a red label is never the only explanation of what a button does
-- Full-width rows mean labels never truncate, so copy stays plain (`Mark leaving`, not `Mark leaving — list room`). The label is `white-space: nowrap`; the **hint** wraps or ellipsizes first
-- Under 480px the hint drops to its own line rather than squeezing the label
+- Tiles mean labels never truncate, so copy stays plain (`Mark leaving`, not `Mark leaving — list room`). The label and hint stack; the tile grows
+- Place the icon explicitly (`grid-column: 2; grid-row: 1 / 3`) — an element spanning both rows is auto-placed *before* the label and would otherwise take column 1
+- Autosave writes on `change`, never on `input`: text commits when it loses focus, dates and selects the instant they settle. Repaint only what changed (one lane, the drawer subtitle) — a whole-view render rebuilds the form and throws away the caret
 
 *Reference implementation: `applications/css/app.css` — `.drawer-cta`. Story: [Sidebar CTAs](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas).*
 

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -39,7 +39,7 @@ footer { margin-top: 48px; font-size: 12px; color: var(--ink-3); }
   <p class="lede">The design system behind ctrl.rodeo — the single home for how these products look, speak, and decide. Sassy is the whole thing: a global layer plus a system per product. When a rule appears in a product system, it wins over the global one for that product.</p>
 
   <a class="sys" href="/design-system/recruiting/">
-    <span><b>Agape recruiting</b> <span class="tag">· product · v3.30</span></span>
+    <span><b>Agape recruiting</b> <span class="tag">· product · v3.31</span></span>
     <span class="d">Principles, tokens, voice, row anatomy, states, and the decision log for /applications. Storybook-style stories.</span>
     <span class="arr">→</span>
   </a>

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -151,16 +151,22 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 .sidebar { width: 340px; max-width: 100%; background: var(--elevated); border: 1px solid var(--line); border-radius: var(--r-md); padding: 16px; }
 .sidebar .fieldstub { height: 34px; border: 1px solid var(--line); border-radius: var(--r-xs); background: var(--surface); margin-bottom: 10px; }
 .dcta { display: flex; flex-direction: column; margin-top: 16px; }
-.dcta__row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; padding-top: 12px; border-top: 1px solid var(--line); }
+.dcta__row { display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
 .dcta__commit { min-width: 92px; border-radius: 999px; background: var(--accent); border-color: var(--accent); color: var(--accent-ink); }
 .dcta__quiet { background: transparent; border: 0; color: var(--ink-2); font: 500 12.5px/1 inherit; padding: 9px 12px; border-radius: var(--r-sm); cursor: pointer; }
-.dcta__exits { display: flex; flex-direction: column; margin-top: 12px; }
+.dcta__flag { margin: 0; text-align: right; font-size: 11px; color: var(--ink-3); }
+.dcta__exits { display: flex; flex-direction: column; gap: 6px; margin-top: 12px; }
 .dcta__exit {
-  display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
-  width: 100%; padding: 12px 0; border: 0; border-top: 1px solid var(--line);
-  background: transparent; color: var(--ink-2); text-align: left; font: 600 12.5px/1.3 inherit; cursor: pointer; white-space: nowrap;
+  display: grid; grid-template-columns: 1fr auto; gap: 2px 12px;
+  width: 100%; padding: 11px 12px; border: 0; border-radius: var(--r-sm);
+  background: var(--tint-gray); color: var(--ink); text-align: left; font: 600 12.5px/1.3 inherit; cursor: pointer;
 }
+.dcta__exit .l { grid-column: 1; grid-row: 1; }
+.dcta__exit .h { grid-column: 1; grid-row: 2; font: 400 11px/1.35 inherit; color: var(--ink-3); }
+.dcta__exit .ic { grid-column: 2; grid-row: 1 / 3; align-self: center; color: var(--ink-3); }
+.dcta__exit:hover { background: var(--line); }
 .dcta__exit.danger { color: var(--red); }
+.dcta__exit.danger .ic { color: var(--red); }
 .dcta__hint { color: var(--ink-3); font: 400 11px/1.35 inherit; text-align: right; white-space: normal; min-width: 0; }
 .dcta__alt {
   display: flex; flex-direction: column; align-items: flex-start; gap: 2px;
@@ -312,7 +318,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.30</span><a href="/design-system/">← all of Sassy</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.31</span><a href="/design-system/">← all of Sassy</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -400,7 +406,9 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <h1>Decision log</h1>
     <p class="lede">Why it is the way it is — dated, so future arguments have receipts.</p>
     <div class="notes">
-      <div class="dec"><span class="d">Jul 30</span><br><b>The exit rows' hairlines are up for replacement.</b><p>Full-bleed rules between exits read as a 2015 settings list — the rule was separating things that should have been grouped. Five directions drawn side by side (inset tiles · inset-grouped · space only · danger zone · overflow), with a recommendation: group them in one container with no internal rules, and promote only the genuinely irreversible to a tinted danger block. Undecided — see <a href="#exit-directions">Exit rows — directions</a>.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Nothing has a Save button unless it creates, confirms, or destroys.</b><p>Editing an existing record writes on <code>change</code> — text on blur, dates and selects the instant they settle — and a quiet line says so, flashing "Saved" when a write lands. Save survived only where it means something: <em>Add stay</em> and <em>Create listing</em> (a record that doesn't exist can't autosave), <em>Welcome them in</em> (a confirmation), and the destructive tiles. This also settles the first open question in the Settings concept.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Direction A won: exits are inset tiles, and the footer has no hairlines.</b><p>Each exit is its own filled surface with radius and a 6px gap; the commit row dropped its <code>border-top</code> too. The rules were separating rows that belonged together. The <code>__alt</code> stays outlined — that's now what distinguishes a forward path from a way out.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>The exit rows' hairlines were up for replacement.</b><p>Full-bleed rules between exits read as a 2015 settings list — the rule was separating things that should have been grouped. Five directions drawn side by side (inset tiles · inset-grouped · space only · danger zone · overflow), with a recommendation: group them in one container with no internal rules, and promote only the genuinely irreversible to a tinted danger block. Undecided — see <a href="#exit-directions">Exit rows — directions</a>.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Settings gets the rail's vocabulary, and a schema instead of a page.</b><p>The rail footer was the only place a setting could go, so most settings never became settings — the house's recruiting behavior lives in literals (3 quiet days, ±1 flexible month, +1/−1 trial milestones) that need a deploy to change. The concept: six sections named <code>You · House · Funnel · Automations · Connections · Data</code>, rendered from a field schema where <code>scope</code> picks the store and the schema default <em>is</em> the code default. Concept only — see <a href="#settings">Settings</a>.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Inbox is Applicants, and Screening left the rail.</b><p>"Inbox" described a queue; "Applicants" names what's in it. Screening was a rail entry nobody navigated to — the work happens on a person's row and in Discord — so the view stays routable for deep links and left the rail.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>The design system got a name: Sassy.</b><p>"The design system" was a description, not a name, so nothing in a review could refer to it without a paragraph of context. Sassy is the whole thing — the global CTRL layer and every product system under it, this one included.</p></div>
@@ -643,34 +651,42 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
   <section class="story" id="s-sidebar-ctas">
     <h1>Sidebar CTAs</h1>
-    <p class="lede">A drawer footer is three tiers deep, ordered by consequence: what saves, what dismisses, and the ways out.</p>
+    <p class="lede">A drawer footer is three tiers deep, ordered by consequence — with no hairlines and, on an existing record, no Save at all.</p>
     <div class="canvas">
       <div class="sidebar">
         <div class="fieldstub"></div>
         <div class="fieldstub"></div>
         <div class="dcta">
-          <div class="dcta__row">
-            <button class="dcta__quiet">Cancel</button>
-            <button class="btn dcta__commit">Save</button>
-          </div>
+          <p class="dcta__flag">Changes save as you go</p>
           <div class="dcta__exits">
-            <button class="dcta__exit">Mark leaving <span class="dcta__hint">sets a move-out date and lists the room</span></button>
-            <button class="dcta__exit danger">Remove stay <span class="dcta__hint">deletes it from the timeline</span></button>
+            <button class="dcta__exit"><span class="l">Mark leaving</span><span class="ic">&rarr;</span><span class="h">sets a move-out date and lists the room</span></button>
+            <button class="dcta__exit danger"><span class="l">Remove stay</span><span class="ic">&times;</span><span class="h">deletes it from the timeline</span></button>
           </div>
           <button class="dcta__alt"><span>Welcome them in</span><span class="dcta__hint">Ends the trial and starts an open-ended residency on Sep 1, 2026.</span></button>
+        </div>
+        <p class="shint" style="margin-top:14px">…and on a <b>new</b> record, where autosave has nothing to write to:</p>
+        <div class="dcta">
+          <div class="dcta__row">
+            <button class="dcta__quiet">Cancel</button>
+            <button class="btn dcta__commit">Add stay</button>
+          </div>
         </div>
       </div>
     </div>
     <div class="notes">
       <h3>The tiers</h3>
       <div class="tiers">
-        <span><code>__commit</code></span><span><b>One filled primary.</b> Bottom-right, pill, accent. Exactly one per sidebar — it is the only thing that saves what's on screen.</span>
+        <span><code>__commit</code></span><span><b>One filled primary — and only when it's earned.</b> A new record, a confirmation, or something destructive. Never a plain Save.</span>
         <span><code>__quiet</code></span><span><b>Dismiss.</b> No fill, no border, beside the primary. Cancel is not a decision, so it does not look like one.</span>
-        <span><code>__exit</code></span><span><b>The ways out.</b> Full-width rows below a rule, one per line, label left and a hint right. Destructive ones take <code>--danger</code> (red label, tinted hover); state changes stay muted.</span>
-        <span><code>__alt</code></span><span><b>Optional second path.</b> Outlined, never filled, label over hint. Used when the sidebar genuinely offers two forward moves ("create a listing instead", "welcome them in").</span>
+        <span><code>__flag</code></span><span><b>What replaces Save.</b> On an existing record: "Changes save as you go", flashing "Saved" when a write lands. The absence of a button should never read as "nothing happened".</span>
+        <span><code>__exit</code></span><span><b>The ways out.</b> Inset tiles — filled surface, radius, 6px gap, <em>no rules</em>. Label over hint, glyph right. Destructive ones take <code>--danger</code>.</span>
+        <span><code>__alt</code></span><span><b>Optional second path.</b> Outlined, never filled — that's what separates a forward move from a way out now that exits are filled.</span>
       </div>
       <h3>Notes</h3>
       <ul>
+        <li><b>No hairlines.</b> A rule between two things that belong together separates what should be grouped. Exits are tiles; the commit row lost its <code>border-top</code> too. (Direction A — see <a href="#exit-directions">the five directions</a>.)</li>
+        <li><b>No Save on an existing record.</b> Fields write on <code>change</code>: text on blur, dates and selects the instant they settle. An explicit commit survives only for <b>create</b>, <b>confirm</b>, and <b>destroy</b>.</li>
+        <li>Autosave repaints only what changed — one timeline lane and the drawer subtitle. A whole-view render rebuilds the form and throws away the caret.</li>
         <li>Anything that removes, ends, or re-routes a record <b>leaves the commit row</b>. A 340px sidebar cannot keep four targets honest side by side — this is exactly how the stay drawer ended up with two red underlined links wrapping onto two lines each.</li>
         <li>Exits never underline. Weight and color carry them; see <a href="#voice">Voice</a> and the transparency-not-decoration rule.</li>
         <li>Every exit and alt carries a hint. A red label is never the only explanation of what a button does.</li>

--- a/docs/ux/recruiting-settings-concept.md
+++ b/docs/ux/recruiting-settings-concept.md
@@ -147,13 +147,9 @@ Section footers use [`drawer-cta`](https://ctrl.rodeo/design-system/recruiting/#
 
 ## Open decisions
 
-### 1. Autosave per control, or an explicit Save per section?
+### ~~1. Autosave per control, or an explicit Save per section?~~ — decided Jul 30
 
-- **Autosave** matches the current footer checkboxes (they upsert on change) and suits toggles, but a number field autosaving mid-typing is hostile, and "did that save?" has no answer.
-- **Save per section** gives every change a moment of intent, which is right for things like the staleness window that silently change what everyone else sees — but it's ceremony for flipping a checkbox.
-- **Nuance:** the two behave differently because the *settings* are different. A toggle is a decision; a number is a draft until you stop typing.
-
-**Recommendation:** autosave `bool` and `enum` on change with an inline "saved" tick; require an explicit commit for `number` and `text`. The schema already knows the type, so the renderer can enforce this — no per-field configuration.
+**Autosave, everywhere.** Settled app-wide rather than for Settings alone: nothing in the app gets a Save button unless it **creates**, **confirms**, or **destroys**. Fields write on `change` — text on blur, dates/selects/toggles the instant they settle — and a quiet status line says "Changes save as you go", flashing "Saved" when a write lands. Section footers therefore carry no commit at all; the only button in a Settings section is "Reset this section", which is destructive. See the [Sidebar CTAs](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas) story.
 
 ### 2. Who can change house-wide settings?
 
@@ -176,7 +172,7 @@ Section footers use [`drawer-cta`](https://ctrl.rodeo/design-system/recruiting/#
 ## Suggested build order
 
 1. `settings-schema.js` + `setting()` / `setSetting()`, and route the four v1 knobs and all existing settings through them. No UI yet — behavior identical, literals gone.
-2. `?view=settings` with the six sections rendering from the schema; rail entry added, footer stripped to identity + Settings + Sign out. Move food/dues out of the room drawer into **House**.
+2. `?view=settings` with the six sections rendering from the schema, every field autosaving on `change`; rail entry added, footer stripped to identity + Settings + Sign out. Move food/dues out of the room drawer into **House**.
 3. Automations + Connections row types, reading `cron.job_run_details` and the Gmail token state for status.
 4. `updated_by` / `updated_at` on `recruit_settings`, surfaced per setting.
 


### PR DESCRIPTION
## Direction A

No hairlines anywhere in a drawer footer. Each exit is its own inset surface — filled, radius, 6px gap, label over hint, glyph right. The commit row dropped its `border-top` too; space does the same job. `drawer-cta__alt` stays **outlined**, which is now what distinguishes a forward path from a way out.

## No Save unless it earns one

Editing an existing record autosaves on `change` — text on blur, dates and selects the instant they settle. `drawer-cta__flag` replaces the commit row: *"Changes save as you go"*, flashing *"Saved"* on a write, so a missing button never reads as nothing happening.

An explicit commit survives in exactly three cases:

| Case | Example |
|---|---|
| **Create** | `Add stay`, `Create listing` — a record that doesn't exist can't autosave |
| **Confirm** | `Welcome them in` — a state change with three moving parts |
| **Destroy** | the danger tiles, `Delete listing` |

Applied to the stay drawer and the listing editor. Comment/note composers keep their post button (posting is a create).

## Implementation notes

- Both forms split their submit handler into a pure `writeStayForm()` / `writeListingForm()` shared by the autosave path and the create button, so an edit and an insert can't drift apart on validation.
- Autosave repaints **only what changed** — one timeline lane, the occupants list, the drawer subtitle. `barsFor()` was lifted out of `renderOccupancy()` into module-scope `laneBarsHtml()` to make that possible; a whole-view render rebuilds the form and throws away the caret mid-edit.
- The icon is placed explicitly (`grid-column: 2; grid-row: 1 / 3`) — an element spanning both rows is auto-placed *before* the label and would otherwise take column 1.
- The listing form's auto-placement sync is gated to the fields that can change who qualifies, so editing the notes doesn't cost a round trip.
- Enter in a field on an existing record still submits, which reads as "I'm done" — writes and closes.
- Dead `.listing-form__delete` CSS removed.

## Docs
- [design-system/README.md](design-system/README.md) — `drawer-cta` updated for tiles + the autosave rule
- [design-system/recruiting/index.html](design-system/recruiting/index.html) — Sidebar CTAs story redrawn, 2 decision-log entries, v3.31
- [design-system/CHANGELOG.md](design-system/CHANGELOG.md) — 1.4.0
- [docs/ux/recruiting-settings-concept.md](docs/ux/recruiting-settings-concept.md) — open question 1 marked decided

🤖 Generated with [Claude Code](https://claude.com/claude-code)