### PR TITLE
feat(recruiting): Settings, with admin derived from #recruiting-automation (v3.49.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1627,15 +1627,15 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .drawer-cta__alt:hover { background: var(--bg-overlay); }
 .drawer-cta__alt .drawer-cta__exit-hint { text-align: left; }
-/* No Save button on an existing record — the fields are the save. This line
-   says so, and briefly says "Saved" when a write lands, so the absence of a
-   button never reads as "nothing happened". */
+/* No Save button on an existing record — the fields are the save, and the app
+   doesn't explain that in words. The flag is empty until a write lands, then
+   says "Saved" for a moment. It keeps its line either way so nothing shifts. */
 .drawer-cta__flag {
-  margin: 0; text-align: right;
+  margin: 0; text-align: right; min-height: 1.2em;
   color: var(--fg-subtle); font-size: var(--font-size-caption);
-  transition: color 120ms ease;
+  opacity: 0; transition: opacity 140ms ease;
 }
-.drawer-cta__flag.is-on { color: var(--success); font-weight: var(--fw-semibold); }
+.drawer-cta__flag.is-on { opacity: 1; color: var(--success); font-weight: var(--fw-semibold); }
 .drawer-cta__exits { display: flex; flex-direction: column; gap: 6px; margin-top: var(--space-3); }
 .drawer-cta__exit {
   display: grid; grid-template-columns: 1fr auto; gap: 2px var(--space-3);
@@ -1671,3 +1671,126 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
    instead of ellipsizing the way the scannable rail rows do. */
 .activity-feed .log-row { align-items: flex-start; }
 .activity-feed__line { white-space: normal; font-weight: 400; }
+
+/* --- v3.49.0: Settings (Sassy: Settings) ---
+   Rendered from SETTING_DEFS, so this stylesheet describes field *types*, not
+   individual settings — a new knob needs no CSS. Same rules as the drawer
+   footers: no hairlines between rows that belong together, and no Save. */
+.settings { max-width: 720px; }
+.set-lede { margin: 0 0 var(--space-5); color: var(--fg-muted); font-size: var(--font-size-small); }
+.set-sec {
+  background: var(--bg-elevated); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+.set-sec__title { margin: 0; font-size: var(--font-size-title-4); font-weight: var(--fw-semibold); }
+.set-sec__hint { margin: 2px 0 var(--space-3); color: var(--fg-subtle); font-size: var(--font-size-caption); }
+
+/* A field is a tile, like an exit row — label, control, hint, no rules. */
+.set-field {
+  display: grid; grid-template-columns: 1fr auto; gap: 2px var(--space-4);
+  align-items: center;
+  padding: var(--space-3); margin-bottom: 6px;
+  background: var(--bg-surface); border-radius: var(--radius-sm);
+  transition: box-shadow 140ms ease;
+}
+.set-field__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.set-field__hint { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.set-field__control { grid-column: 2; grid-row: 1 / 3; align-self: center; justify-self: end; }
+.set-field__by { display: block; color: var(--fg-subtle); opacity: 0.8; }
+/* Saved: a ring rather than a word. The field itself is the receipt. */
+.set-field.is-saved { box-shadow: inset 0 0 0 1px var(--success); }
+.set-field.is-locked .set-field__label { color: var(--fg-muted); }
+
+.set-num { display: inline-flex; align-items: baseline; gap: var(--space-2); }
+.set-num input { width: 76px; height: 34px; text-align: right; }
+.set-num__unit { color: var(--fg-subtle); font-size: var(--font-size-caption); white-space: nowrap; }
+.set-enum, .set-text { height: 34px; }
+.set-text { width: 200px; }
+
+/* Switch — the one control the app didn't already have. */
+.set-switch { display: inline-flex; cursor: pointer; }
+.set-switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.set-switch__track {
+  position: relative; width: 38px; height: 22px; border-radius: var(--radius-pill);
+  background: var(--bg-overlay); border: 1px solid var(--border-strong);
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.set-switch__knob {
+  position: absolute; top: 2px; left: 2px; width: 16px; height: 16px;
+  border-radius: 50%; background: var(--fg-subtle);
+  transition: left 120ms ease, background 120ms ease;
+}
+.set-switch input:checked + .set-switch__track { background: var(--accent-strong); border-color: var(--accent-strong); }
+.set-switch input:checked + .set-switch__track .set-switch__knob { left: 18px; background: var(--accent-strong-fg); }
+.set-switch input:focus-visible + .set-switch__track { box-shadow: 0 0 0 2px var(--accent); }
+.set-switch input:disabled + .set-switch__track { opacity: 0.5; cursor: not-allowed; }
+
+/* Automation row: what it does, how often, when it last ran, whether it's on.
+   Four facts, because those are the four you want when something didn't run. */
+.set-auto {
+  display: grid; grid-template-columns: 1fr auto; gap: 2px var(--space-4);
+  padding: var(--space-3); margin-bottom: 6px;
+  background: var(--bg-surface); border-radius: var(--radius-sm);
+}
+.set-auto__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.set-auto__hint { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.set-auto__when { grid-column: 2; grid-row: 1; text-align: right; color: var(--fg-muted); font-size: var(--font-size-caption); font-variant-numeric: tabular-nums; }
+.set-auto__when.is-bad { color: var(--error); font-weight: var(--fw-semibold); }
+.set-auto__cadence { grid-column: 2; grid-row: 2; text-align: right; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.set-auto.is-off { opacity: 0.55; }
+
+.set-conn {
+  display: grid; grid-template-columns: 1fr auto; gap: 2px var(--space-4);
+  padding: var(--space-3); margin-bottom: 6px;
+  background: var(--bg-surface); border-radius: var(--radius-sm);
+}
+.set-conn__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
+.set-conn__detail { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); overflow-wrap: anywhere; }
+.set-conn__state { grid-column: 2; grid-row: 1; text-align: right; font-size: var(--font-size-caption); font-weight: var(--fw-semibold); }
+.set-conn__state.is-ok { color: var(--success); }
+.set-conn__state.is-warn { color: var(--error); }
+.set-conn__state.is-off { color: var(--fg-subtle); }
+
+.set-note { margin: var(--space-2) 0 0; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.set-note code { font-family: ui-monospace, Menlo, monospace; }
+@media (max-width: 520px) {
+  .set-field, .set-auto, .set-conn { grid-template-columns: 1fr; }
+  .set-field__control { grid-column: 1; grid-row: 3; justify-self: start; margin-top: 6px; }
+  .set-auto__when, .set-auto__cadence, .set-conn__state { grid-column: 1; text-align: left; }
+}
+
+/* --- v3.49.0: stepped drawer (choose, then continue in place) ---
+   An open stretch has two honest answers. The drawer asks first with two inset
+   tiles — same language as the exit tiles, forward-facing — then becomes the
+   flow that was picked, with one way back. Nothing writes until that flow's
+   own commit. */
+.step-choices { display: flex; flex-direction: column; gap: var(--space-2); }
+.step-choice {
+  display: grid; grid-template-columns: 1fr auto; gap: 4px var(--space-3);
+  width: 100%; padding: var(--space-4);
+  background: var(--bg-surface); border: 0; border-radius: var(--radius-md);
+  color: var(--fg); text-align: left;
+  transition: background 80ms ease;
+}
+.step-choice__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-body); font-weight: var(--fw-semibold); }
+.step-choice__hint { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); }
+.step-choice__go { grid-column: 2; grid-row: 1 / 3; align-self: center; color: var(--fg-subtle); }
+.step-choice:hover { background: var(--bg-overlay); }
+.step-choice:hover .step-choice__go { color: var(--fg); }
+
+.step-back {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: transparent; border: 0; padding: 0 0 var(--space-3);
+  color: var(--fg-muted); font-size: var(--font-size-small); font-weight: var(--fw-semibold);
+}
+.step-back:hover { color: var(--fg); }
+
+/* The listing form was written for a modal; in a 380px drawer its auto-fit
+   grid has to give up and stack. */
+.step-listing .listing-form__grid { grid-template-columns: 1fr; }
+/* No box inside a box: the drawer is already the surface. */
+.step-listing .listing-form {
+  display: flex; flex-direction: column; gap: var(--space-3);
+  background: transparent; border: 0; padding: 0;
+}

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.48.0">
+  <link rel="stylesheet" href="css/app.css?v=3.49.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -53,15 +53,11 @@
         <a class="rail-nav__row" href="?view=inbox" data-view-link="inbox">Applicants <span class="rail-nav__count" id="count-inbox"></span></a>
         <a class="rail-nav__row" href="?view=candidates" data-view-link="candidates">Candidates <span class="rail-nav__count" id="count-candidates"></span></a>
         <a class="rail-nav__row" href="?view=archive" data-view-link="archive">Archive <span class="rail-nav__count" id="count-archive"></span></a>
+        <div class="rail-nav__group">House keeping</div>
+        <a class="rail-nav__row" href="?view=settings" data-view-link="settings">Settings</a>
       </nav>
       <div class="rail-foot">
         <span class="rail-foot__user" id="rail-user"></span>
-        <label class="rail-foot__pref"><input type="checkbox" id="pref-couples"> Open to couples</label>
-        <label class="rail-foot__pref" title="When on, coverage asks post to #recruiting-automation automatically as availability lands"><input type="checkbox" id="pref-autopost"> Auto-post coverage asks</label>
-        <label class="rail-foot__pref" title="Sets how the update-email box starts when someone is marked not a fit — you can still change it per person"><input type="checkbox" id="pref-update-default"> Offer an update email by default</label>
-        <button class="rail-foot__link rail-foot__gmail" id="gmail-conn" type="button">Checking shared Gmail…</button>
-        <button class="rail-foot__link" id="menu-theme" type="button">Toggle theme</button>
-        <button class="rail-foot__link" id="menu-export" type="button">Export decisions (CSV)</button>
         <button class="rail-foot__link" id="menu-signout" type="button">Sign out</button>
       </div>
     </aside>
@@ -307,7 +303,8 @@
     </div>
   </div>
 
-  <script src="js/app.js?v=3.48.0"></script>
+  <script src="js/settings-schema.js?v=3.49.0"></script>
+  <script src="js/app.js?v=3.49.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.48.0';
+const VERSION = '3.49.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -100,7 +100,7 @@ function trialStayFor(applicantId) {
 // Default return date for Save for future: three months out, month start.
 function defaultReturnDate() {
   const d = new Date();
-  return new Date(d.getFullYear(), d.getMonth() + 3, 1).toISOString().slice(0, 10);
+  return new Date(d.getFullYear(), d.getMonth() + setting('save_for_future_months'), 1).toISOString().slice(0, 10);
 }
 
 const VIEWS = {
@@ -110,6 +110,7 @@ const VIEWS = {
   screening: { title: 'Screening', kind: 'applicants' },
   archive: { title: 'Archive', kind: 'applicants' },
   occupancy: { title: 'Occupancy', kind: 'house' },
+  settings: { title: 'Settings', kind: 'settings' },
   activity: { title: 'Activity', kind: 'activity' },
 };
 // Old bookmarks and deep links keep working.
@@ -151,6 +152,55 @@ let listings = [];            // recruit_listings rows
 let onboarding = [];          // recruit_onboarding rows (checklist per resident stay)
 let houseLoaded = false;
 let settings = { open_to_couples: true };
+let isAdmin = false;          // derived from Discord: can see #recruiting-automation
+
+/* --- settings accessors (Sassy: Settings) ---
+   One read path for every knob, whatever store it lives in. The schema's
+   `default` is the fallback, which is why a setting can ship configurable with
+   no migration and no seed row: no row means the default. Callers say
+   setting('followup_stale_days') and never learn where it lives. */
+function setting(key) {
+  const def = SETTING_DEFS[key];
+  if (!def) { console.warn(`[settings] unknown key: ${key}`); return undefined; }
+  let raw;
+  if (def.scope === 'house') raw = settings[key];
+  else if (def.scope === 'local') raw = localStorage.getItem(def.storageKey || key);
+  else if (def.scope === 'profile') raw = profile[def.column || key];
+  if (raw === undefined || raw === null || raw === '') return def.default;
+  if (def.type === 'number') { const n = +raw; return Number.isFinite(n) ? n : def.default; }
+  if (def.type === 'bool') return raw === true || raw === 'true';
+  return raw;
+}
+
+async function setSetting(key, value) {
+  const def = SETTING_DEFS[key];
+  if (!def) return { error: { message: `Unknown setting: ${key}` } };
+  if (def.scope === 'local') {
+    localStorage.setItem(def.storageKey || key, String(value));
+    return {};
+  }
+  if (def.scope === 'profile') {
+    profile[def.column || key] = value;
+    const { error } = await sb.from('recruit_profiles')
+      .upsert({ user_id: me.id, [def.column || key]: value }, { onConflict: 'user_id' });
+    return { error };
+  }
+  // House-wide. RLS allows this only for admins (migration 144); the UI hides
+  // the controls, and this is the wall behind that.
+  const prev = settings[key];
+  settings[key] = value;
+  const { error } = await sb.from('recruit_settings').upsert({
+    key, value,
+    updated_by: me.id,
+    updated_by_name: me.name,
+    updated_at: new Date().toISOString(),
+  }, { onConflict: 'key' });
+  if (error) settings[key] = prev;
+  return { error };
+}
+
+let profile = {};             // recruit_profiles row for me — display_name, group_email
+let settingsMeta = {};        // key -> { updated_by_name, updated_at }, for the audit line
 let gmailStatus = { connected: false };
 let reviewTab = 'profile';   // 'profile' | 'emails'
 let emailsCache = {};        // applicant_id -> rows
@@ -534,7 +584,7 @@ function openingsCta(a) {
     // nagging; a shared-account invite gets picked up by the calendar sweep.
     const promised = /\b(invite|calendar|schedul|let'?s (chat|talk|meet)|talk (soon|then|tomorrow))\b/i.test(st.lastSnippet || '');
     // Waiting is passive until ~3 quiet days; then the clock arms Follow up.
-    const stale = Date.now() - new Date(st.lastAt).getTime() > 3 * 86400000;
+    const stale = Date.now() - new Date(st.lastAt).getTime() > setting('followup_stale_days') * 86400000;
     return stack(`<button class="btn btn--sm inbox-row__review cta-std ${stale ? 'cta--amber' : ''}" data-email="${a.id}">Follow up</button>`,
       `${promised ? 'invite promised · ' : ''}sent ${relTime(st.lastAt)}`);
   }
@@ -679,13 +729,10 @@ async function loadAll() {
   screeningsCache = {};
   for (const s of (scRes.data || [])) (screeningsCache[s.applicant_id] ||= []).push(s);
   sb.from('recruit_settings').select('*').then(({ data }) => {
-    for (const row of (data || [])) settings[row.key] = row.value;
-    const box = document.getElementById('pref-couples');
-    if (box) box.checked = settings.open_to_couples !== false;
-    const ap = document.getElementById('pref-autopost');
-    if (ap) ap.checked = settings.discord_auto_post === true;
-    const ud = document.getElementById('pref-update-default');
-    if (ud) ud.checked = updateEmailDefault();
+    for (const row of (data || [])) {
+      settings[row.key] = row.value;
+      settingsMeta[row.key] = { by: row.updated_by_name, at: row.updated_at };
+    }
     sendUpdateWith = updateEmailDefault();
   });
   if (aRes.error) throw aRes.error;
@@ -781,11 +828,11 @@ function qualifiesFor(a, l) {
   if (/^ASAP/.test(norm || '')) {
     const now = new Date();
     const cur = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    return startMonth >= cur && startMonth <= monthShift(cur, 1);
+    return startMonth >= cur && startMonth <= monthShift(cur, setting('movein_flex_months'));
   }
   const range = moveInRange(a);
   if (!range) return false; // no parseable dates — can't confirm they line up
-  const flexPad = /flexible/i.test(norm || '') ? 1 : 0;
+  const flexPad = /flexible/i.test(norm || '') ? setting('movein_flex_months') : 0;
   return monthShift(range.hi, flexPad) >= startMonth && monthShift(range.lo, -flexPad) <= endMonth;
 }
 
@@ -1483,8 +1530,178 @@ async function render() {
     renderActivity();
     return;
   }
+  if (def.kind === 'settings') {
+    root.innerHTML = `<p class="inbox-empty">Loading…</p>`;
+    await loadSettingsExtras();
+    if (view !== 'settings') return;   // navigated away meanwhile
+    renderSettings();
+    return;
+  }
   if (def.kind === 'applicants') renderApplicants();
   else if (view === 'occupancy') renderOccupancy();
+}
+
+/* ---------- Settings (Sassy: Settings) ----------
+   Rendered from SETTING_DEFS / SETTING_SECTIONS, so adding a knob is one object
+   literal in settings-schema.js and nothing here changes. Four field types
+   cover every setting in the app; automations and connections are status rows,
+   not fields, and get their own renderers.
+
+   No Save anywhere: every field writes on `change` (see the drawer-cta rule).
+   The only button in a section is destructive.
+
+   House-wide writes are admin-only in RLS (migration 144). Non-admins see the
+   same values, disabled, with one line saying who decides — read access was
+   never the thing being protected. */
+let cronStatus = [];          // recruit_cron_status() rows
+let gmailStatusFull = null;   // recruit-gmail { action: 'status' }
+
+async function loadSettingsExtras() {
+  const [cron, prof] = await Promise.all([
+    sb.rpc('recruit_cron_status'),
+    sb.from('recruit_profiles').select('display_name, group_email').eq('user_id', me.id).maybeSingle(),
+  ]);
+  cronStatus = cron.data || [];
+  if (cron.error) console.warn('[settings] cron status unavailable:', cron.error.message);
+  if (prof.data) profile = prof.data;
+}
+
+function settingFieldHtml(key) {
+  const def = SETTING_DEFS[key];
+  const val = setting(key);
+  const locked = def.scope === 'house' && !isAdmin;
+  const dis = locked ? 'disabled' : '';
+  let control;
+  if (def.type === 'bool') {
+    control = `<label class="set-switch">
+      <input type="checkbox" data-setting="${key}" ${val ? 'checked' : ''} ${dis}>
+      <span class="set-switch__track" aria-hidden="true"><span class="set-switch__knob"></span></span>
+    </label>`;
+  } else if (def.type === 'number') {
+    control = `<span class="set-num">
+      <input type="number" class="listing-status" data-setting="${key}" value="${val}"
+        min="${def.min ?? 0}" max="${def.max ?? 9999}" step="${def.step ?? 1}" ${dis}>
+      ${def.unit ? `<span class="set-num__unit">${esc(def.unit)}</span>` : ''}
+    </span>`;
+  } else if (def.type === 'enum') {
+    control = `<select class="listing-status set-enum" data-setting="${key}" ${dis}>
+      ${def.options.map(([v, label]) => `<option value="${v}" ${val === v ? 'selected' : ''}>${esc(label)}</option>`).join('')}
+    </select>`;
+  } else {
+    control = `<input type="text" class="listing-status set-text" data-setting="${key}"
+      value="${esc(String(val || ''))}" maxlength="${def.maxlength || 200}" ${dis}>`;
+  }
+  const meta = settingsMeta[key];
+  return `<div class="set-field ${locked ? 'is-locked' : ''}">
+    <span class="set-field__label">${esc(def.label)}</span>
+    <span class="set-field__control">${control}</span>
+    <span class="set-field__hint">${esc(def.hint || '')}${
+      meta?.by ? ` <span class="set-field__by">${esc(meta.by)} changed this ${relTime(meta.at)}</span>` : ''}</span>
+  </div>`;
+}
+
+const CRON_HUMAN = {
+  '*/15 * * * *': 'every 15 min', '*/20 * * * *': 'every 20 min',
+  '7 * * * *': 'hourly', '45 */6 * * *': 'every 6 hours',
+};
+
+function settingsAutomationsHtml() {
+  const byName = Object.fromEntries(cronStatus.map(r => [r.jobname, r]));
+  const rows = SETTING_AUTOMATIONS.map(a => {
+    const r = byName[a.jobname];
+    const cadence = r ? (CRON_HUMAN[r.schedule] || r.schedule) : 'not scheduled';
+    const when = r?.last_run ? `ran ${relTime(r.last_run)}` : 'never run';
+    const bad = r && r.last_status && r.last_status !== 'succeeded';
+    return `<div class="set-auto ${r?.active ? '' : 'is-off'}">
+      <span class="set-auto__label">${esc(a.label)}</span>
+      <span class="set-auto__when ${bad ? 'is-bad' : ''}">${esc(r?.active ? when : 'paused')}${
+        bad ? ` · ${esc(r.last_status)}` : ''}</span>
+      <span class="set-auto__hint">${esc(a.hint)}</span>
+      <span class="set-auto__cadence">${esc(cadence)}</span>
+    </div>`;
+  }).join('');
+  // discord_auto_post is the one automation with a real switch — the cron jobs
+  // are scheduled in the database, and a toggle here that only half-worked
+  // would be worse than saying where they live.
+  return rows + settingFieldHtml('discord_auto_post') +
+    `<p class="set-note">Cadence is set by <code>pg_cron</code> in the database, not here. A paused job means someone unscheduled it.</p>`;
+}
+
+function settingsConnectionsHtml() {
+  const g = gmailStatusFull || gmailStatus || { connected: false };
+  const conn = (label, ok, detail, warn) => `<div class="set-conn">
+    <span class="set-conn__label">${esc(label)}</span>
+    <span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}">${ok ? '✓ connected' : esc(warn || 'not connected')}</span>
+    ${detail ? `<span class="set-conn__detail">${esc(detail)}</span>` : ''}
+  </div>`;
+  return conn('Shared Gmail', !!g.connected, g.connected
+      ? `${g.email || ''}${g.connected_by_name ? ` · connected by ${g.connected_by_name}` : ''}`
+      : 'Applications and replies stop arriving until this is reconnected.',
+      g.connected ? null : 'reconnect needed')
+    + conn('House calendar', !!g.connected, 'Screening invites land here.', g.connected ? null : 'follows Gmail')
+    + conn('Discord', true, '#recruiting-automation · #recruiting-interviews')
+    + `<p class="set-note">Reconnecting Gmail happens from the account itself — the token is server-side and never reaches this page.</p>`;
+}
+
+function settingsDataHtml() {
+  return `<button type="button" class="drawer-cta__alt" id="set-export">
+      <span>Export decisions</span>
+      <span class="drawer-cta__exit-hint">every review, verdict, and comment as CSV</span>
+    </button>`;
+}
+
+function renderSettings() {
+  const host = document.getElementById('view-root');
+  host.className = 'settings';
+  const section = sec => {
+    let body;
+    if (sec.rows === 'automations') body = settingsAutomationsHtml();
+    else if (sec.rows === 'connections') body = settingsConnectionsHtml();
+    else if (sec.rows === 'data') body = settingsDataHtml();
+    else {
+      const keys = Object.keys(SETTING_DEFS).filter(k => SETTING_DEFS[k].section === sec.id);
+      if (!keys.length) return '';
+      body = keys.map(settingFieldHtml).join('');
+    }
+    const locked = !isAdmin && (sec.id === 'house' || sec.id === 'funnel');
+    return `<section class="set-sec" id="set-${sec.id}">
+      <h2 class="set-sec__title">${esc(sec.title)}</h2>
+      <p class="set-sec__hint">${esc(sec.hint)}${locked ? ' Only housemates who can see #recruiting-automation can change them.' : ''}</p>
+      ${body}
+    </section>`;
+  };
+  host.innerHTML = `
+    <p class="set-lede">${isAdmin
+      ? 'Changes apply the moment you make them.'
+      : 'You can see everything here. Changing the house-wide settings needs access to #recruiting-automation.'}</p>
+    ${SETTING_SECTIONS.map(section).join('')}`;
+
+  host.querySelectorAll('[data-setting]').forEach(el => {
+    el.addEventListener('change', async () => {
+      const key = el.dataset.setting;
+      const def = SETTING_DEFS[key];
+      let value;
+      if (def.type === 'bool') value = el.checked;
+      else if (def.type === 'number') {
+        value = Math.min(def.max ?? Infinity, Math.max(def.min ?? -Infinity, Math.round(+el.value || 0)));
+        el.value = value;   // clamp visibly rather than saving something else
+      } else value = el.value.trim();
+      const { error } = await setSetting(key, value);
+      if (error) { toast(`Could not save: ${error.message}`); renderSettings(); return; }
+      flashSetting(el);
+      if (key === 'theme') applyTheme(value);
+      // A window or a threshold changes what the funnel says about everyone.
+      if (['followup_stale_days', 'movein_flex_months', 'gap_min_days'].includes(key)) renderRailCounts();
+    });
+  });
+  host.querySelector('#set-export')?.addEventListener('click', exportCsv);
+}
+
+function flashSetting(el) {
+  const field = el.closest('.set-field');
+  if (!field) return;
+  field.classList.add('is-saved');
+  setTimeout(() => field.classList.remove('is-saved'), 1400);
 }
 
 /* ---------- activity log ----------
@@ -2696,7 +2913,7 @@ function roomGaps(roomId) {
     if (cursor > winEnd) break;
   }
   if (cursor <= winEnd) gaps.push([cursor, winEnd]);
-  return gaps.filter(([a, b]) => (new Date(b) - new Date(a)) / 86400000 >= 7);
+  return gaps.filter(([a, b]) => (new Date(b) - new Date(a)) / 86400000 >= setting('gap_min_days'));
 }
 
 /* One room's bars: stays, then the uncovered stretches between them. Module
@@ -2809,10 +3026,10 @@ function openOccDrawer(next) {
    that either side can still make other plans. Both are suggestions the
    drawer prefills; the house can move either date. */
 function trialCheckinDefault(startsOn) {
-  return startsOn ? addMonthsIso2(startsOn, 1) : '';
+  return startsOn ? addMonthsIso2(startsOn, setting('trial_checkin_months')) : '';
 }
 function trialDecisionDefault(endsOn) {
-  return endsOn ? addMonthsIso2(endsOn, -1) : '';
+  return endsOn ? addMonthsIso2(endsOn, -setting('trial_decision_months')) : '';
 }
 /* addMonthsIso() snaps to the first of the month (the timeline needs that);
    milestones keep the day-of-month, clamped when the target month is short. */
@@ -2987,10 +3204,47 @@ function stayFormHtml(s, roomId) {
       ${isNew ? `<div class="drawer-cta__row">
         <button type="button" class="drawer-cta__quiet" data-drawer-close>Cancel</button>
         <button type="submit" class="btn btn--accent drawer-cta__commit">Add stay</button>
-      </div>` : `<p class="drawer-cta__flag" data-save-flag>Changes save as you go</p>`}
+      </div>` : `<p class="drawer-cta__flag" data-save-flag></p>`}
       ${exits.length ? `<div class="drawer-cta__exits">${exits.join('')}</div>` : ''}
     </div>
   </form>`;
+}
+
+/* --- an open stretch: choose, then continue in place ---
+   An empty stretch has exactly two honest answers: open it to candidates, or
+   record who's already moving in. Showing both at once meant a listing button
+   sitting on top of a full stay form, so the drawer now asks first and then
+   becomes the flow you picked. Back returns to the choice; nothing is written
+   until the step's own commit. */
+function gapDrawerBody() {
+  const choice = occDrawer.choice || null;
+  if (!choice) {
+    return `<div class="step-choices">
+      <button type="button" class="step-choice" data-gap-choice="listing">
+        <span class="step-choice__label">Create a listing</span>
+        <span class="step-choice__go" aria-hidden="true">&rarr;</span>
+        <span class="step-choice__hint">Opens the room to candidates. Everyone who qualifies gets placed in it.</span>
+      </button>
+      <button type="button" class="step-choice" data-gap-choice="occupant">
+        <span class="step-choice__label">Add an occupant</span>
+        <span class="step-choice__go" aria-hidden="true">&rarr;</span>
+        <span class="step-choice__hint">Someone is already moving in — record the stay and close the gap.</span>
+      </button>
+    </div>`;
+  }
+  const back = `<button type="button" class="step-back" data-gap-choice="">&larr; ${
+    choice === 'listing' ? 'Create a listing' : 'Add an occupant'}</button>`;
+  if (choice === 'occupant') {
+    return back + stayFormHtml(
+      { kind: 'sublet', starts_on: occDrawer.start, ends_on: occDrawer.end }, occDrawer.roomId);
+  }
+  // The listing form lives in the drawer rather than a modal so the flow never
+  // leaves the sidebar it started in. Same form, same create handler.
+  return back + `<div class="step-listing">${listingForm({
+    room_id: occDrawer.roomId, kind: 'sublet',
+    starts_on: occDrawer.start, ends_on: occDrawer.end,
+    notes: `Open from ${fmtShort(occDrawer.start)} on the occupancy calendar.`,
+  })}</div>`;
 }
 
 function roomDetailsHtml(r) {
@@ -3047,13 +3301,7 @@ function renderOccDrawer() {
     const room = rooms.find(r => r.id === occDrawer.roomId);
     title = `${room?.name || 'Room'} — open`;
     sub = `${fmtShort(occDrawer.start)} – ${fmtShort(occDrawer.end)}`;
-    body = `
-      <button class="drawer-cta__alt" data-list-room="${occDrawer.roomId}" data-list-start="${occDrawer.start}">
-        <span>Create a listing for this stretch</span>
-        <span class="drawer-cta__exit-hint">opens the room to candidates</span>
-      </button>
-      <p class="occ-drawer__note">…or record who's moving in:</p>
-      ${stayFormHtml({ kind: 'sublet', starts_on: occDrawer.start, ends_on: occDrawer.end }, occDrawer.roomId)}`;
+    body = gapDrawerBody();
   } else if (occDrawer.type === 'room') {
     const r = rooms.find(x => x.id === occDrawer.roomId);
     if (!r) { occDrawer = null; hostWrap.innerHTML = ''; return; }
@@ -3072,6 +3320,18 @@ function renderOccDrawer() {
       </div>
       <div class="occ-drawer__body">${body}</div>
     </aside>`;
+  hostWrap.querySelectorAll('[data-gap-choice]').forEach(btn => btn.addEventListener('click', () => {
+    occDrawer.choice = btn.dataset.gapChoice || null;
+    renderOccDrawer();
+  }));
+  const gapListing = hostWrap.querySelector('.step-listing [data-listing-form]');
+  if (gapListing) {
+    gapListing.addEventListener('submit', onListingCreate);
+    gapListing.querySelector('[data-cancel-listing]')?.addEventListener('click', () => {
+      occDrawer.choice = null;
+      renderOccDrawer();
+    });
+  }
   hostWrap.querySelector('[data-stay-form]')?.addEventListener('submit', onStayFormSubmit);
   hostWrap.querySelector('[data-promote-open]')?.addEventListener('click', e => {
     promoting = e.currentTarget.dataset.promoteOpen;
@@ -3212,7 +3472,6 @@ async function autoSaveStay(form) {
     clearTimeout(staySavedTimer);
     staySavedTimer = setTimeout(() => {
       flag.classList.remove('is-on');
-      flag.textContent = 'Changes save as you go';
     }, 2200);
   }
 }
@@ -3331,23 +3590,6 @@ function occupantsHtml() {
     </section>`;
 }
 
-async function createListingFromGap(roomId, startIso) {
-  const room = rooms.find(r => r.id === roomId);
-  if (!room) return;
-  const pretty = fmtShort(startIso);
-  if (!confirm(`Create a sublet listing for ${room.name} starting ${pretty}?`)) return;
-  const { data, error } = await sb.from('recruit_listings').insert({
-    room_id: roomId, kind: 'sublet', starts_on: startIso, status: 'open',
-    source: 'gap', notes: `Created from the occupancy calendar (open from ${pretty}).`,
-    created_by: me.id, created_by_name: me.name,
-  }).select().single();
-  if (error) { toast(`Listing failed: ${error.message}`); return; }
-  listings.push(data);
-  toast(`Listing created — ${room.name}, from ${pretty}`);
-  occDrawer = null;
-  renderOccupancy();
-  renderRailCounts();
-}
 
 async function markLeaving(roomId, defaultDate) {
   const room = rooms.find(r => r.id === roomId);
@@ -3501,7 +3743,7 @@ function listingForm(l) {
       ${isNew ? `<div class="drawer-cta__row">
         <button type="button" class="drawer-cta__quiet" data-cancel-listing>Cancel</button>
         <button type="submit" class="btn btn--accent drawer-cta__commit">Create listing</button>
-      </div>` : `<p class="drawer-cta__flag" data-save-flag>Changes save as you go</p>
+      </div>` : `<p class="drawer-cta__flag" data-save-flag></p>
       <div class="drawer-cta__exits">
         <button type="button" class="drawer-cta__exit drawer-cta__exit--danger" data-delete-listing="${l.id}">
           <span class="drawer-cta__exit-label">Delete listing</span>
@@ -3613,7 +3855,6 @@ async function autoSaveListing(form, changed) {
     clearTimeout(listingSavedTimer);
     listingSavedTimer = setTimeout(() => {
       flag.classList.remove('is-on');
-      flag.textContent = 'Changes save as you go';
     }, 2200);
   }
   if (!PLACEMENT_FIELDS.has(changed)) return;
@@ -4588,22 +4829,6 @@ async function gmailCall(payload) {
   return out;
 }
 
-/* Global shared-account connection row (rail footer). Set once, house-wide. */
-function renderGmailStatus() {
-  const el = document.getElementById('gmail-conn');
-  if (!el) return;
-  if (gmailStatus.connected) {
-    el.textContent = `✓ ${gmailStatus.email || 'shared Gmail'} connected`;
-    el.title = `House email + calendar run through this account${gmailStatus.connected_by_name ? ` · connected by ${gmailStatus.connected_by_name}` : ''}${gmailStatus.connected_at ? ` · ${new Date(gmailStatus.connected_at).toLocaleDateString()}` : ''}. Click to reconnect (e.g. after a scope change).`;
-  } else {
-    el.textContent = 'Connect shared Gmail (house-wide, one time)';
-    el.title = 'All applicant email + screening invites run through live.at.agapesf@gmail.com. Sign into that Google account in this browser first.';
-  }
-  el.onclick = () => {
-    if (!gmailStatus.connected || confirm('Reconnect the shared Google account? Only needed after scope changes or if sending breaks.')) connectSharedGmail();
-  };
-}
-
 /* Throttled inbox-wide sweep: matches recent shared-inbox mail to
    applicants so outreach rows can badge replies. */
 async function scanInbox() {
@@ -4638,8 +4863,7 @@ async function handleGmailCallback() {
   try {
     const out = await gmailCall({ action: 'connect', code });
     gmailStatus = { connected: true, email: out.email, connected_by_name: me?.name };
-    renderGmailStatus();
-    toast(`Shared Gmail connected: ${out.email}`);
+      toast(`Shared Gmail connected: ${out.email}`);
   } catch (e) { toast(`Gmail connect failed: ${e.message}`); }
 }
 
@@ -4809,6 +5033,11 @@ async function _checkMembershipAndEnter() {
     // in — identify self, load data, render
     const user = window.CtrlAuth.getUser();
     me = { id: user.id, name: status.discordUsername || user.email || 'Housemate', groupEmail: user.email || null };
+    // Admin = can see #recruiting-automation. The function derives it from
+    // Discord and writes recruit_admins, which is what RLS actually consults —
+    // so this flag only decides whether the controls are disabled, never
+    // whether a write is allowed.
+    isAdmin = status.isRecruitingAdmin === true;
     // group_email ties this account to its roster identity, which is how a
     // review imported from the sheet becomes yours once you sign in.
     sb.from('recruit_profiles').select('display_name, group_email').eq('user_id', user.id).maybeSingle()
@@ -4821,7 +5050,7 @@ async function _checkMembershipAndEnter() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${(await sb.auth.getSession()).data?.session?.access_token}` },
       body: JSON.stringify({ action: 'status' }),
-    }).then(r => r.json()).then(st => { gmailStatus = st || { connected: false }; renderGmailStatus(); }).catch(() => {});
+    }).then(r => r.json()).then(st => { gmailStatus = st || { connected: false }; gmailStatusFull = gmailStatus; if (view === 'settings') renderSettings(); }).catch(() => {});
     await loadAll();
     // background — outreach attachment labels + rail badges need house data;
     // re-render the open view once it lands so labels don't show stale fallbacks
@@ -5185,8 +5414,6 @@ function init() {
       renderOccupancy();
       return;
     }
-    const listCell = e.target.closest('[data-list-room]');
-    if (listCell) { createListingFromGap(+listCell.dataset.listRoom, listCell.dataset.listStart); return; }
     const stayLeaving = e.target.closest('[data-stay-leaving]');
     if (stayLeaving) { markLeaving(+stayLeaving.dataset.stayLeaving, stayLeaving.dataset.stayLeavingDate || null); return; }
     const stayDel = e.target.closest('[data-stay-delete]');
@@ -5265,41 +5492,10 @@ function init() {
     document.getElementById('rail-scrim').hidden = true;
   };
 
-  document.getElementById('menu-export').onclick = exportCsv;
-  document.getElementById('menu-theme').onclick = () =>
-    applyTheme(document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark');
   document.getElementById('menu-signout').onclick = () => window.CtrlAuth.signOut();
-  document.getElementById('pref-autopost').onchange = async (e) => {
-    const value = e.target.checked;
-    settings.discord_auto_post = value;
-    const { error } = await sb.from('recruit_settings').upsert({
-      key: 'discord_auto_post', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
-    });
-    if (error) { toast(`Save failed: ${error.message}`); e.target.checked = !value; settings.discord_auto_post = !value; }
-    else toast(value ? 'Coverage asks now post to Discord automatically' : 'Coverage asks are manual again');
-  };
   document.getElementById('gd-close').onclick = () => { document.getElementById('gd-modal').hidden = true; };
   document.getElementById('gd-yes').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'yes');
   document.getElementById('gd-no').onclick = () => giveDecision(document.getElementById('gd-modal').dataset.applicant, 'no');
-  document.getElementById('pref-update-default').onchange = async (e) => {
-    const value = e.target.checked;
-    settings.update_email_default = value;
-    sendUpdateWith = value;
-    const { error } = await sb.from('recruit_settings').upsert({
-      key: 'update_email_default', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
-    });
-    if (error) { toast(`Save failed: ${error.message}`); e.target.checked = !value; settings.update_email_default = !value; }
-    else toast(value ? 'Not a fit will offer an update email' : 'Not a fit will skip the email unless you ask for one');
-  };
-  document.getElementById('pref-couples').onchange = async (e) => {
-    const value = e.target.checked;
-    settings.open_to_couples = value;
-    const { error } = await sb.from('recruit_settings').upsert({
-      key: 'open_to_couples', value, updated_by_name: me?.name || null, updated_at: new Date().toISOString(),
-    });
-    if (error) { toast(`Preference save failed: ${error.message}`); e.target.checked = !value; settings.open_to_couples = !value; }
-    else toast(value ? 'House preference: open to couples' : 'House preference: not open to couples');
-  };
 
   document.getElementById('remove-close').onclick = hideRemoveSheet;
   document.getElementById('remove-cancel').onclick = hideRemoveSheet;

--- a/applications/js/settings-schema.js
+++ b/applications/js/settings-schema.js
@@ -1,0 +1,155 @@
+/* Agape recruiting — settings schema (Sassy: Settings pattern).
+ *
+ * The point of this file: adding a setting is one object literal. The Settings
+ * view renders from this array, and `setting(key)` reads through it, so a
+ * field's default lives in exactly one place and is both the UI default and
+ * the code default. That is what lets a knob ship configurable without a
+ * migration or a seed row — no row means the schema default.
+ *
+ * `scope` decides the store, so callers never learn where a value lives:
+ *   house    → recruit_settings   (key/value JSONB, admin-writable)
+ *   profile  → recruit_profiles   (per-user)
+ *   local    → localStorage       (per-browser)
+ *
+ * Four field types cover every knob in the app: bool · number · text · enum.
+ * A key can exist here without appearing in any section's `fields` — then it
+ * is a named, documented constant in one place instead of a magic number in
+ * three, and exposing it later is a one-line change.
+ *
+ * Classic script, not a module: it runs before app.js and hands over globals.
+ */
+const SETTINGS_VERSION = '1.0.0';
+console.log(`[settings-schema] v${SETTINGS_VERSION}`);
+
+/* Every knob, exposed or not. `section: null` means "routed through setting()
+   but deliberately not in the UI yet". */
+const SETTING_DEFS = {
+  /* --- House ------------------------------------------------------------ */
+  food_monthly: {
+    scope: 'house', type: 'number', section: 'house', default: 250,
+    label: 'Food', unit: '/mo per person', min: 0, max: 2000, step: 5,
+    hint: 'Groceries, split evenly. Feeds the all-in number on every listing.',
+  },
+  dues_monthly: {
+    scope: 'house', type: 'number', section: 'house', default: 450,
+    label: 'Communal dues', unit: '/mo per person', min: 0, max: 5000, step: 5,
+    hint: 'Everything that isn’t rent or food.',
+  },
+  open_to_couples: {
+    scope: 'house', type: 'bool', section: 'house', default: true,
+    label: 'Open to couples',
+    hint: 'Off hides couple applications from placement suggestions.',
+  },
+
+  /* --- Funnel ----------------------------------------------------------- */
+  followup_stale_days: {
+    scope: 'house', type: 'number', section: 'funnel', default: 3,
+    label: 'Follow-up goes amber after', unit: 'days', min: 1, max: 30, step: 1,
+    hint: 'A thread this quiet is worth another email.',
+  },
+  movein_flex_months: {
+    scope: 'house', type: 'number', section: 'funnel', default: 1,
+    label: 'Flexible move-in stretches by', unit: 'months', min: 0, max: 3, step: 1,
+    hint: 'How far a “flexible” date reaches on each side when matching listings.',
+  },
+  trial_checkin_months: {
+    scope: 'house', type: 'number', section: 'funnel', default: 1,
+    label: 'Trial check-in lands after', unit: 'months', min: 0, max: 6, step: 1,
+    hint: 'Measured from the day they move in. #recruiting-automation gets a reminder a week ahead.',
+  },
+  trial_decision_months: {
+    scope: 'house', type: 'number', section: 'funnel', default: 1,
+    label: 'Trial decision lands before the end by', unit: 'months', min: 0, max: 6, step: 1,
+    hint: 'Enough runway to say yes, or for them to find somewhere else.',
+  },
+  update_email_default: {
+    scope: 'house', type: 'bool', section: 'funnel', default: true,
+    label: 'Offer an update email by default',
+    hint: 'When someone is marked not a fit — you can still change it per person.',
+  },
+
+  /* --- Automations ------------------------------------------------------ */
+  discord_auto_post: {
+    scope: 'house', type: 'bool', section: 'automations', default: false,
+    label: 'Auto-post coverage asks',
+    hint: 'Off means a human sees the message before the house does.',
+  },
+
+  /* --- You -------------------------------------------------------------- */
+  display_name: {
+    scope: 'profile', column: 'display_name', type: 'text', section: 'you', default: '',
+    label: 'Display name', maxlength: 60,
+    hint: 'Shown on your reviews, comments, and the emails you send.',
+  },
+  theme: {
+    scope: 'local', storageKey: 'agape:theme', type: 'enum', section: 'you', default: 'dark',
+    label: 'Theme', options: [['dark', 'Dark'], ['light', 'Light']],
+    hint: 'This browser only.',
+  },
+
+  /* --- Routed, not exposed ---------------------------------------------- *
+   * Real defaults with real names, one line from being a setting the day
+   * someone asks. Nobody has argued about these. */
+  gap_min_days: {
+    scope: 'house', type: 'number', section: null, default: 7,
+    label: 'Shortest gap worth listing', unit: 'days', min: 1, max: 60, step: 1,
+    hint: 'Uncovered stretches shorter than this stay off the timeline.',
+  },
+  screener_slot_minutes: {
+    scope: 'house', type: 'number', section: null, default: 30,
+    label: 'Screening call length', unit: 'minutes', min: 15, max: 90, step: 15,
+    hint: 'Also the spacing between offered slots.',
+  },
+  screener_max_slots: {
+    scope: 'house', type: 'number', section: null, default: 8,
+    label: 'Slots offered per ask', unit: 'slots', min: 3, max: 20, step: 1,
+    hint: 'More slots is more choice and a longer Discord post.',
+  },
+  save_for_future_months: {
+    scope: 'house', type: 'number', section: null, default: 3,
+    label: 'Save for future brings them back in', unit: 'months', min: 1, max: 12, step: 1,
+    hint: 'The default return date when someone is parked rather than passed on.',
+  },
+};
+
+/* Sections, in the order they appear. Titles borrow the rail's vocabulary on
+   purpose — House and Funnel already mean something in this app. `rows` marks
+   a section that renders status objects (automations, connections) rather than
+   fields; those aren't settings and don't belong in the field renderer. */
+const SETTING_SECTIONS = [
+  { id: 'you', title: 'You', hint: 'Only affects your account.' },
+  { id: 'house', title: 'House', hint: 'The building and the money. Everyone sees these.' },
+  { id: 'funnel', title: 'Funnel', hint: 'How applicants move. Everyone sees these.' },
+  { id: 'automations', title: 'Automations', hint: 'Things that run without you.', rows: 'automations' },
+  { id: 'connections', title: 'Connections', hint: 'Where recruiting reaches outside the app.', rows: 'connections' },
+  { id: 'data', title: 'Data', hint: 'Take it with you.', rows: 'data' },
+];
+
+/* The cron jobs Settings → Automations reports on, and what each one is for in
+   plain language. `jobname` matches pg_cron and recruit_cron_status(). */
+const SETTING_AUTOMATIONS = [
+  {
+    jobname: 'recruit_gmail_scan_tick',
+    label: 'Scan the shared inbox',
+    hint: 'Pulls new applications, replies, and availability out of Gmail.',
+  },
+  {
+    jobname: 'recruit_screening_reminder_tick',
+    label: 'Remind screeners before a call',
+    hint: 'DMs whoever claimed the call about an hour ahead, and posts trial milestones.',
+  },
+  {
+    jobname: 'recruit_application_ingest_tick',
+    label: 'Ingest new applications',
+    hint: 'Sweeps the application form for submissions the inbox scan missed.',
+  },
+  {
+    jobname: 'pipeline-invariants-6h',
+    label: 'Check the pipeline for contradictions',
+    hint: 'Catches someone in two rooms, or in none, before a human notices.',
+  },
+];
+
+window.SETTING_DEFS = SETTING_DEFS;
+window.SETTING_SECTIONS = SETTING_SECTIONS;
+window.SETTING_AUTOMATIONS = SETTING_AUTOMATIONS;

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ---
 
+## [1.5.0] - 2026-07-30
+
+### Added
+- **Settings (`set-*`)** — a schema-rendered settings surface. `SETTING_DEFS` describes each knob (`scope` picks the store, `default` is the code default); the CSS describes field types, so a new setting needs none. Sections borrow the product's nav vocabulary; `rows:` sections render status objects (automations, connections) instead of fields.
+- **Stepped drawer (`step-*`)** — when a surface has two honest next moves, two `step-choice` tiles ask first, then the drawer becomes the chosen flow with one `step-back`.
+
+### Changed
+- A locked setting is **disabled, never hidden** — RLS is the wall, and hiding a value implies it's secret when it isn't.
+- The autosave flag says nothing until a write lands (was a persistent "Changes save as you go").
+
+---
+
 ## [1.4.0] - 2026-07-30
 
 ### Changed

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -700,6 +700,61 @@ A sidebar or drawer footer is **three tiers deep, ordered by consequence** — n
 
 *Reference implementation: `applications/css/app.css` — `.drawer-cta`. Story: [Sidebar CTAs](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas).*
 
+### Settings (`set-*`) and the stepped drawer (`step-*`)
+
+**Settings renders from a schema, not from markup.** `applications/js/settings-schema.js` holds `SETTING_DEFS` — one object per knob — and the view renders it. Adding a setting is appending an object; no template, no handler, no CSS. The stylesheet describes field *types*, never individual settings.
+
+```js
+followup_stale_days: {
+  scope: 'house', type: 'number', section: 'funnel', default: 3,
+  label: 'Follow-up goes amber after', unit: 'days', min: 1, max: 30, step: 1,
+  hint: 'A thread this quiet is worth another email.',
+},
+```
+
+| Property | Meaning |
+|---|---|
+| `scope` | Picks the store: `house` → `recruit_settings`, `profile` → `recruit_profiles`, `local` → localStorage. Callers use `setting(key)` and never learn where a value lives. |
+| `type` | `bool` · `number` · `text` · `enum` — four types cover every knob in the app. |
+| `default` | **Is the code default.** `setting('followup_stale_days')` returns 3 until someone changes it, so exposing a knob needs no migration and no seed row. |
+| `section` | Which section it appears in, or `null` to route it through `setting()` without exposing it — a named constant instead of a magic number. |
+
+Sections borrow the product's own nav vocabulary (`You · House · Funnel · Automations · Connections · Data`). `rows:` marks a section that renders **status objects** rather than fields — automations and connections have a last-run time and a state, not a value, and don't belong in the field renderer.
+
+```html
+<div class="set-field">                       <!-- tile: label, control, hint, no rules -->
+  <span class="set-field__label">Food</span>
+  <span class="set-field__control">…</span>
+  <span class="set-field__hint">Groceries, split evenly.
+    <span class="set-field__by">Ian changed this 3 days ago</span></span>
+</div>
+<div class="set-auto">…</div>   <!-- label · when it last ran · switch · hint · cadence -->
+<div class="set-conn">…</div>   <!-- label · state (is-ok / is-warn / is-off) · detail -->
+```
+
+**Settings rules:**
+- Same as drawer footers: **no hairlines, no Save.** Fields write on `change`; the receipt is a green ring on the field (`.set-field.is-saved`), not a word
+- The only button in a section is destructive
+- A locked field is **disabled, never hidden** — RLS is the wall; the disabled control is courtesy, and hiding a value implies it's secret when it isn't
+- Every field's audit line (`set-field__by`) names who last changed it
+
+**Stepped drawer.** When a surface has two honest next moves, ask before showing a form — two `step-choice` tiles, then the drawer *becomes* the chosen flow with a single `step-back`. Nothing writes until that flow's own commit.
+
+```html
+<div class="step-choices">
+  <button class="step-choice">
+    <span class="step-choice__label">Create a listing</span>
+    <span class="step-choice__go" aria-hidden="true">&rarr;</span>
+    <span class="step-choice__hint">Opens the room to candidates.</span>
+  </button>
+  …
+</div>
+<!-- after choosing -->
+<button class="step-back">&larr; Create a listing</button>
+```
+
+*Reference implementation: `applications/js/app.js` — `renderSettings()`, `gapDrawerBody()`. Story: [Settings](https://ctrl.rodeo/design-system/recruiting/#settings).*
+
 ### Drop Target
 
 Whole-container drop zone for drag-and-drop between groups. Highlighting the **container** rather than an insertion line is what makes an empty group reachable.

--- a/design-system/index.html
+++ b/design-system/index.html
@@ -39,7 +39,7 @@ footer { margin-top: 48px; font-size: 12px; color: var(--ink-3); }
   <p class="lede">The design system behind ctrl.rodeo — the single home for how these products look, speak, and decide. Sassy is the whole thing: a global layer plus a system per product. When a rule appears in a product system, it wins over the global one for that product.</p>
 
   <a class="sys" href="/design-system/recruiting/">
-    <span><b>Agape recruiting</b> <span class="tag">· product · v3.31</span></span>
+    <span><b>Agape recruiting</b> <span class="tag">· product · v3.32</span></span>
     <span class="d">Principles, tokens, voice, row anatomy, states, and the decision log for /applications. Storybook-style stories.</span>
     <span class="arr">→</span>
   </a>

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -318,7 +318,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
 
 <div class="app">
 <aside class="side">
-  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.31</span><a href="/design-system/">← all of Sassy</a></span>
+  <span class="brand"><b>Agape recruiting</b><span>Sassy · v3.32</span><a href="/design-system/">← all of Sassy</a></span>
   <div class="grp" data-grp>
     <button type="button">Getting started <span class="tw">▼</span></button>
     <div class="items">
@@ -353,13 +353,13 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <div class="items">
       <a href="#two-tier" data-story="two-tier">Two-tier rail</a>
       <a href="#sidebar-ctas" data-story="sidebar-ctas">Sidebar CTAs</a>
-      <a href="#exit-directions" data-story="exit-directions">Exit rows — directions <span class="tag-concept">pick one</span></a>
+      <a href="#exit-directions" data-story="exit-directions">Exit rows — directions <span class="tag-concept">A won</span></a>
       <a href="#row-states" data-story="row-states">Row states</a>
       <a href="#schedule-modal" data-story="schedule-modal">Schedule modal</a>
       <a href="#listing-header" data-story="listing-header">Listing header</a>
       <a href="#profile" data-story="profile">Profile</a>
       <a href="#stage-machine" data-story="stage-machine">Stage machine</a>
-      <a href="#settings" data-story="settings">Settings <span class="tag-concept">concept</span></a>
+      <a href="#settings" data-story="settings">Settings</a>
       <a href="#automation-audit" data-story="automation-audit">Automation audit</a>
     </div>
   </div>
@@ -406,7 +406,9 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
     <h1>Decision log</h1>
     <p class="lede">Why it is the way it is — dated, so future arguments have receipts.</p>
     <div class="notes">
-      <div class="dec"><span class="d">Jul 30</span><br><b>Nothing has a Save button unless it creates, confirms, or destroys.</b><p>Editing an existing record writes on <code>change</code> — text on blur, dates and selects the instant they settle — and a quiet line says so, flashing "Saved" when a write lands. Save survived only where it means something: <em>Add stay</em> and <em>Create listing</em> (a record that doesn't exist can't autosave), <em>Welcome them in</em> (a confirmation), and the destructive tiles. This also settles the first open question in the Settings concept.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Settings shipped, and admin is a Discord channel.</b><p>Six sections rendered from a field schema, so adding a knob is one object literal. Admin = whoever can see #recruiting-automation — the channel that already gets the audit trail decides who changes the automation — reconciled into <code>recruit_admins</code>, which is what RLS consults. Four literals became real settings (follow-up staleness, move-in flex, the two trial offsets); four more route through <code>setting()</code> with schema defaults but stay out of the UI. See <a href="#settings">Settings</a>.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>An open stretch asks before it shows a form.</b><p>The gap drawer used to stack a listing button on top of a full stay form. Now it offers two inset tiles — <em>Create a listing</em> / <em>Add an occupant</em> — and becomes the flow you pick, with one way back. The listing form moved into the drawer so the flow never leaves the sidebar it started in.</p></div>
+      <div class="dec"><span class="d">Jul 30</span><br><b>Nothing has a Save button unless it creates, confirms, or destroys.</b><p>Editing an existing record writes on <code>change</code> — text on blur, dates and selects the instant they settle — and a quiet line says so, flashing "Saved" when a write lands. Save survived only where it means something: <em>Add stay</em> and <em>Create listing</em> (a record that doesn't exist can't autosave), <em>Welcome them in</em> (a confirmation), and the destructive tiles. The app says this in no words at all — the line is empty until a write lands, then reads &ldquo;Saved&rdquo; for a moment.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Direction A won: exits are inset tiles, and the footer has no hairlines.</b><p>Each exit is its own filled surface with radius and a 6px gap; the commit row dropped its <code>border-top</code> too. The rules were separating rows that belonged together. The <code>__alt</code> stays outlined — that's now what distinguishes a forward path from a way out.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>The exit rows' hairlines were up for replacement.</b><p>Full-bleed rules between exits read as a 2015 settings list — the rule was separating things that should have been grouped. Five directions drawn side by side (inset tiles · inset-grouped · space only · danger zone · overflow), with a recommendation: group them in one container with no internal rules, and promote only the genuinely irreversible to a tinted danger block. Undecided — see <a href="#exit-directions">Exit rows — directions</a>.</p></div>
       <div class="dec"><span class="d">Jul 30</span><br><b>Settings gets the rail's vocabulary, and a schema instead of a page.</b><p>The rail footer was the only place a setting could go, so most settings never became settings — the house's recruiting behavior lives in literals (3 quiet days, ±1 flexible month, +1/−1 trial milestones) that need a deploy to change. The concept: six sections named <code>You · House · Funnel · Automations · Connections · Data</code>, rendered from a field schema where <code>scope</code> picks the store and the schema default <em>is</em> the code default. Concept only — see <a href="#settings">Settings</a>.</p></div>
@@ -697,7 +699,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
   </section>
 
   <section class="story" id="s-exit-directions">
-    <h1>Exit rows — directions <span class="tag-concept">pick one</span></h1>
+    <h1>Exit rows — directions <span class="tag-concept">A won</span></h1>
     <p class="lede">Tier 3 currently separates its rows with full-bleed hairlines. That's a 2015 settings-list move: the rule is doing work that surface, radius, and space should do. Five directions, same content, same 340px frame.</p>
 
     <div class="canvas">
@@ -884,7 +886,7 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
   </section>
 
   <section class="story" id="s-settings">
-    <h1>Settings <span class="tag-concept">concept</span></h1>
+    <h1>Settings</h1>
     <p class="lede">Six sections that borrow the rail's own vocabulary, rendered from a schema so a new setting is one object literal.</p>
     <div class="canvas">
       <div class="setpage">
@@ -974,9 +976,13 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
         <li><b>Save behavior follows the type.</b> Toggles and enums autosave with an inline tick; numbers and text take an explicit commit. The schema knows the type, so the renderer enforces it — no per-field config.</li>
         <li>Section footers are <a href="#sidebar-ctas">Sidebar CTAs</a> — one commit, and “reset this section” as an exit row with a hint.</li>
       </ul>
+      <h3>Who can change what</h3>
+      <p><b>Admin is derived from Discord: whoever can see #recruiting-automation.</b> Not a role the app maintains — the channel that already receives the automation audit trail decides who gets to change the automation. Lose channel access, lose admin, on the next verify.</p>
+      <p>Everyone reads everything. Non-admins see the same values, disabled, with one line saying so — read access was never the thing worth protecting. Every house-wide setting carries "<i>Ian changed this 3 days ago</i>"; RLS is the actual wall, and the disabled control is just courtesy.</p>
       <h3>Notes</h3>
-      <p>A full view at <code>?view=settings</code>, not a modal — every section is deep-linkable, so a toast or a Discord audit post can point at the exact knob. The rail footer drops to <b>identity · Settings · Sign out</b>; theme moves to You, Gmail to Connections, CSV export to Data, and food/dues move out of the room drawer (a house-wide cost has no business inside one room) into House.</p>
-      <p>Full write-up, open decisions, and build order: <code>docs/ux/recruiting-settings-concept.md</code>.</p>
+      <p>A full view at <code>?view=settings</code>, not a modal — every section is deep-linkable, so a toast or a Discord audit post can point at the exact knob. The rail footer dropped to <b>identity · Sign out</b>; theme moved to You, Gmail to Connections, CSV export to Data, and food/dues left the room drawer (a house-wide cost has no business inside one room) for House.</p>
+      <p><b>Automations report, they don't rule.</b> Each row says what it does, how often, when it last ran, and whether it's on — the four things you want when something didn't happen. Cadence is <code>pg_cron</code>'s, not this page's; a half-working toggle would be worse than saying where it lives.</p>
+      <p>Full write-up, decisions, and what's still open: <code>docs/ux/recruiting-settings-concept.md</code>.</p>
     </div>
   </section>
 

--- a/docs/ux/recruiting-settings-concept.md
+++ b/docs/ux/recruiting-settings-concept.md
@@ -1,7 +1,9 @@
 # Settings — concept & structure
 
-> **Status:** concept, not built. Design system story: [Settings](https://ctrl.rodeo/design-system/recruiting/#settings).
+> **Status:** shipped 2026-07-30 (v3.49.0). Design system story: [Settings](https://ctrl.rodeo/design-system/recruiting/#settings).
 > **Product:** Agape recruiting (`/applications`) · **Written:** 2026-07-30
+>
+> All three open questions are decided and the build is done: `?view=settings`, six sections rendering from `applications/js/settings-schema.js`, automations and connections with live status, admin derived from Discord. What follows is the reasoning, kept because it explains why the shape is the shape.
 
 ---
 
@@ -151,29 +153,35 @@ Section footers use [`drawer-cta`](https://ctrl.rodeo/design-system/recruiting/#
 
 **Autosave, everywhere.** Settled app-wide rather than for Settings alone: nothing in the app gets a Save button unless it **creates**, **confirms**, or **destroys**. Fields write on `change` — text on blur, dates/selects/toggles the instant they settle — and a quiet status line says "Changes save as you go", flashing "Saved" when a write lands. Section footers therefore carry no commit at all; the only button in a Settings section is "Reset this section", which is destructive. See the [Sidebar CTAs](https://ctrl.rodeo/design-system/recruiting/#sidebar-ctas) story.
 
-### 2. Who can change house-wide settings?
+### ~~2. Who can change house-wide settings?~~ — decided Jul 30
 
-- Today every signed-in Recruiting Society member can flip any of the three footer toggles, and nothing records who did.
-- House-wide settings change what everyone sees. Locking them to an admin list is safer but adds a role concept the app doesn't have yet.
-- **Nuance:** the honest middle is an audit trail — `recruit_settings` gains `updated_by` / `updated_at`, and the section shows "Ian changed this 3 days ago". Accountability without a permissions model, the same bet the single-decider review model already made.
+**Admins, derived from Discord: whoever can see #recruiting-automation.** Not a role the app maintains — the same channel that already receives the automation audit trail defines who gets to change the automation. The check needs the bot token, so `discord-membership` computes it (reusing the channel-permission math that already gates the app) and reconciles a `recruit_admins` row on every verify, in both directions: lose channel access, lose admin.
 
-**Recommendation:** no roles. Add `updated_by`/`updated_at` and surface it per setting. Revisit if it's ever abused.
+RLS is the wall (migration 144): `recruit_settings` writes require `is_recruiting_admin()`. The flag deliberately does **not** live on `recruit_profiles` — members write their own profile row, so they could grant themselves admin. `recruit_admins` is service-role-write, member-read, so the UI can say "you can't change this" instead of failing a write.
 
-### 3. How far to go on the hardcoded literals in v1?
+Everyone still reads everything, and every house-wide setting shows `updated_by_name` / `updated_at` — "Ian changed this 3 days ago." Read access was never the thing worth protecting.
 
-- **All of them** (8 knobs) is the most complete, but some — the 30-minute screener slot interval, the timezone — nobody will touch this year, and each one exposed is a setting to maintain and document.
-- **None of them**, and Settings is just the footer reorganized, which doesn't earn a new view.
-- **Nuance:** the ones worth exposing are the ones the house has actually argued about.
+### ~~3. How far to go on the hardcoded literals in v1?~~ — decided Jul 30
 
-**Recommendation:** expose four in v1 — follow-up staleness, move-in flexibility, the two trial milestone offsets. Route the rest through `setting()` with schema defaults but leave them out of the UI; they become one-line exposures the day someone asks. Delete `vote_min_count` and `vote_pass_avg`.
+**Four exposed, four routed.** In the UI: follow-up staleness, move-in flexibility, and the two trial milestone offsets — the ones the house has actually argued about. Routed through `setting()` with schema defaults but left out of the UI (`section: null`): the gap minimum, screener slot length, slots per ask, and the save-for-future window. They are named constants in one place now instead of magic numbers in three, and exposing one is a one-line change.
+
+`vote_min_count` and `vote_pass_avg` are deleted (migration 144) — dead since the single-decider change on Jul 29.
+
+**Not settings, deliberately:** the timezone (`America/Los_Angeles`) and the trial-milestone SQL in migration 139 stay server-side. The frontend suggestion honours `trial_checkin_months` / `trial_decision_months`; the database's own backfill does not, so a house that changes those will see new stays follow the setting while migration 139's one-time pass used ±1 month. Worth a follow-up if the numbers ever diverge in practice.
 
 ---
 
-## Suggested build order
+## What shipped (v3.49.0)
 
-1. `settings-schema.js` + `setting()` / `setSetting()`, and route the four v1 knobs and all existing settings through them. No UI yet — behavior identical, literals gone.
-2. `?view=settings` with the six sections rendering from the schema, every field autosaving on `change`; rail entry added, footer stripped to identity + Settings + Sign out. Move food/dues out of the room drawer into **House**.
-3. Automations + Connections row types, reading `cron.job_run_details` and the Gmail token state for status.
-4. `updated_by` / `updated_at` on `recruit_settings`, surfaced per setting.
+1. **`applications/js/settings-schema.js`** — `SETTING_DEFS` (14 knobs), `SETTING_SECTIONS`, `SETTING_AUTOMATIONS`. Loaded before `app.js` as a classic script.
+2. **`setting()` / `setSetting()`** in `app.js` — schema default as the fallback, `scope` picking the store. Every literal in the table above now reads through it.
+3. **`?view=settings`** — six sections rendered from the schema, `Settings` in the rail under *House keeping*, and the footer stripped to identity · Sign out. Food and dues moved out of the room drawer into **House**.
+4. **Automations** — `recruit_cron_status()` (migration 144, `SECURITY DEFINER`, read-only) gives each job its schedule, last run, and last status. `cron.*` isn't reachable over REST, so this RPC is the one door to it. The cron cadences are **not** editable here: a toggle that only half-worked would be worse than saying where they live.
+5. **Connections** — Gmail (from `recruit-gmail { action: 'status' }`), the house calendar, and Discord's two channels, each with a real state. The Gmail token dying every ~7 days is now a glance instead of an investigation.
+6. **Admin** — `recruit_admins` + `is_recruiting_admin()`, reconciled by `discord-membership` v1.4.0 from #recruiting-automation access.
 
-Step 1 is worth doing even if the view never ships.
+### Still open
+
+- **Automation on/off** is read-only except `discord_auto_post`. Real toggles mean either mutating `pg_cron` from an RPC or giving each edge function an enabled-check; neither is free.
+- **Migration 139's trial milestones** don't read the settings (see decision 3).
+- **`recruit-gmail` reconnect** can't be driven from this page — the token is server-side.

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,8 +20,8 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.3.0'
-console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel verification (OAuth or bot magic-link)`)
+const VERSION = '1.4.0'
+console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel gate + #recruiting-automation admin (OAuth or bot magic-link)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -89,13 +89,26 @@ async function fetchGuildMember(discordUserId: string): Promise<{ roles: string[
   return await resp.json()
 }
 
+// Same default as _shared/discord.ts; this function is standalone (no _shared
+// import), so the constant is duplicated rather than drifting behind an import.
+const AUTOMATION_CHANNEL_FALLBACK = '1529576830514762029'
+
 const VIEW_CHANNEL = 1n << 10n
 const ADMINISTRATOR = 1n << 3n
 
-// Effective-permission check for the Recruiting Society channel: base perms
-// from @everyone + the member's roles, then channel overwrites in Discord's
-// documented order (@everyone → roles → member).
-async function checkRecruitingChannel(discordUserId: string, memberRoles: string[]): Promise<boolean> {
+// Effective-permission check for one channel: base perms from @everyone + the
+// member's roles, then channel overwrites in Discord's documented order
+// (@everyone → roles → member).
+//
+// `pick` chooses which channel to test, so the same math serves two gates: the
+// Recruiting Society channel (can you use the app at all) and
+// #recruiting-automation (can you change how recruiting behaves).
+async function canViewChannel(
+  discordUserId: string,
+  memberRoles: string[],
+  pick: (channels: Array<Record<string, unknown>>) => Record<string, unknown> | undefined,
+  label: string,
+): Promise<boolean> {
   const [channelsResp, rolesResp] = await Promise.all([
     discordGet(`/guilds/${AGAPE_GUILD_ID}/channels`),
     discordGet(`/guilds/${AGAPE_GUILD_ID}/roles`),
@@ -104,15 +117,9 @@ async function checkRecruitingChannel(discordUserId: string, memberRoles: string
   const channels = await channelsResp.json() as Array<Record<string, unknown>>
   const roles = await rolesResp.json() as Array<{ id: string; permissions: string }>
 
-  // The guild has several recruiting-* channels (per-cohort); the gate is the
-  // "Recruiting Society" one, so prefer a society match over the first hit.
-  const wantedId = Deno.env.get('RECRUITING_CHANNEL_ID')
-  const named = (rx: RegExp) => channels.find(c => rx.test(String(c.name || '')) && c.type !== 4 /* not a category */)
-  const channel = wantedId
-    ? channels.find(c => String(c.id) === wantedId)
-    : (named(/recruit.*society|society.*recruit/i) || named(/recruit/i))
+  const channel = pick(channels)
   if (!channel) {
-    console.warn('Recruiting channel not found (set RECRUITING_CHANNEL_ID)')
+    console.warn(`${label} channel not found`)
     return false
   }
 
@@ -139,16 +146,51 @@ async function checkRecruitingChannel(discordUserId: string, memberRoles: string
   return (perms & VIEW_CHANNEL) === VIEW_CHANNEL
 }
 
+const namedChannel = (channels: Array<Record<string, unknown>>, rx: RegExp) =>
+  channels.find(c => rx.test(String(c.name || '')) && c.type !== 4 /* not a category */)
+
+// The guild has several recruiting-* channels (per-cohort); the gate is the
+// "Recruiting Society" one, so prefer a society match over the first hit.
+function checkRecruitingChannel(discordUserId: string, memberRoles: string[]) {
+  const wantedId = Deno.env.get('RECRUITING_CHANNEL_ID')
+  return canViewChannel(discordUserId, memberRoles, channels => wantedId
+    ? channels.find(c => String(c.id) === wantedId)
+    : (namedChannel(channels, /recruit.*society|society.*recruit/i) || namedChannel(channels, /recruit/i)),
+    'Recruiting Society')
+}
+
+// Admin = can see #recruiting-automation. Same channel the app already posts
+// its audit trail to, so the people who watch the automation are the people
+// who get to change it.
+function checkAutomationChannel(discordUserId: string, memberRoles: string[]) {
+  const wantedId = Deno.env.get('RECRUITING_AUTOMATION_CHANNEL_ID')
+    || Deno.env.get('SCREENING_CLAIMS_CHANNEL_ID')
+    || AUTOMATION_CHANNEL_FALLBACK
+  return canViewChannel(discordUserId, memberRoles, channels => wantedId
+    ? channels.find(c => String(c.id) === wantedId)
+    : namedChannel(channels, /recruit.*automation|automation.*recruit/i),
+    '#recruiting-automation')
+}
+
 async function verifyAndCache(userId: string, identity: DiscordIdentity) {
   const member = await fetchGuildMember(identity.discordUserId)
   const isMember = member !== null
   let isRecruiting = false
+  let isAdmin = false
   if (member) {
     try {
       isRecruiting = await checkRecruitingChannel(identity.discordUserId, member.roles || [])
     } catch (err) {
       // Channel check failing must not break the guild gate the events page uses.
       console.error('Recruiting channel check failed:', (err as Error).message)
+    }
+    if (isRecruiting) {
+      try {
+        isAdmin = await checkAutomationChannel(identity.discordUserId, member.roles || [])
+      } catch (err) {
+        // Losing this check costs write access to settings, never read access.
+        console.error('Automation channel check failed:', (err as Error).message)
+      }
     }
   }
   const row = {
@@ -163,6 +205,23 @@ async function verifyAndCache(userId: string, identity: DiscordIdentity) {
     .from('user_discord_membership')
     .upsert(row, { onConflict: 'user_id' })
   if (error) throw new Error(`Cache write failed: ${error.message}`)
+
+  // recruit_admins is the only thing RLS trusts for settings writes, and the
+  // client cannot write it — so it is reconciled here on every verify, in both
+  // directions. Losing access to #recruiting-automation loses admin.
+  try {
+    const db = getSupabase()
+    if (isAdmin) {
+      await db.from('recruit_admins').upsert(
+        { user_id: userId, discord_user_id: identity.discordUserId },
+        { onConflict: 'user_id' },
+      )
+    } else {
+      await db.from('recruit_admins').delete().eq('user_id', userId)
+    }
+  } catch (err) {
+    console.error('recruit_admins reconcile failed:', (err as Error).message)
+  }
 
   // First-sign-in nicety: when the login email is on the AgapeSF group
   // roster, seed recruit_profiles with their real name + group email so
@@ -192,8 +251,8 @@ async function verifyAndCache(userId: string, identity: DiscordIdentity) {
     }
   }
 
-  console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember} recruiting=${isRecruiting}`)
-  return row
+  console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember} recruiting=${isRecruiting} admin=${isAdmin}`)
+  return { ...row, is_recruiting_admin: isAdmin }
 }
 
 serve(async (req) => {
@@ -215,10 +274,17 @@ serve(async (req) => {
     if (!identity) {
       // Discord unlinked: drop any stale membership so RLS stops granting access
       await db.from('user_discord_membership').delete().eq('user_id', user.id)
-      return new Response(JSON.stringify({ linked: false, isMember: false, isRecruitingMember: false, discordUsername: null, verifiedAt: null }), { headers: jsonHeaders })
+      await db.from('recruit_admins').delete().eq('user_id', user.id)
+      return new Response(JSON.stringify({ linked: false, isMember: false, isRecruitingMember: false, isRecruitingAdmin: false, discordUsername: null, verifiedAt: null }), { headers: jsonHeaders })
     }
 
-    let row: { discord_username: string | null; is_agape_member: boolean; is_recruiting_member?: boolean; verified_at: string } | null = null
+    let row: {
+      discord_username: string | null
+      is_agape_member: boolean
+      is_recruiting_member?: boolean
+      is_recruiting_admin?: boolean
+      verified_at: string
+    } | null = null
     if (action !== 'verify') {
       const { data } = await db
         .from('user_discord_membership')
@@ -228,7 +294,13 @@ serve(async (req) => {
       const fresh = data &&
         data.discord_user_id === identity.discordUserId &&
         (Date.now() - new Date(data.verified_at).getTime()) < REVERIFY_DAYS * 86400_000
-      if (fresh) row = data
+      if (fresh) {
+        // Admin isn't cached on the membership row — read it from the table RLS
+        // actually consults, so the UI and the database can never disagree.
+        const { data: adm } = await db.from('recruit_admins')
+          .select('user_id').eq('user_id', user.id).maybeSingle()
+        row = { ...data, is_recruiting_admin: !!adm }
+      }
     }
     if (!row) row = await verifyAndCache(user.id, identity)
 
@@ -236,6 +308,7 @@ serve(async (req) => {
       linked: true,
       isMember: row.is_agape_member,
       isRecruitingMember: !!row.is_recruiting_member,
+      isRecruitingAdmin: !!row.is_recruiting_admin,
       discordUsername: row.discord_username,
       verifiedAt: row.verified_at,
     }), { headers: jsonHeaders })

--- a/supabase/migrations/144_recruit_settings_admin.sql
+++ b/supabase/migrations/144_recruit_settings_admin.sql
@@ -1,0 +1,93 @@
+-- 144: house-wide settings become admin-only, and get an audit trail.
+--
+-- Admin is not a role the app maintains — it is derived from Discord: whoever
+-- can see #recruiting-automation can change how recruiting behaves. That check
+-- needs the bot token, so it happens in the discord-membership function and
+-- lands here. The client can read this table but never write it, which is why
+-- the flag does NOT live on recruit_profiles (members write their own profile
+-- row, so they could grant themselves admin).
+
+CREATE TABLE IF NOT EXISTS recruit_admins (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  discord_user_id TEXT,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE recruit_admins ENABLE ROW LEVEL SECURITY;
+
+-- Readable so the UI can say "you can't change this" instead of failing a write.
+DROP POLICY IF EXISTS "Recruiting members read admins" ON recruit_admins;
+CREATE POLICY "Recruiting members read admins" ON recruit_admins
+  FOR SELECT TO authenticated USING (is_recruiting_member());
+-- No INSERT/UPDATE/DELETE policy on purpose: service role only.
+
+CREATE OR REPLACE FUNCTION is_recruiting_admin()
+RETURNS BOOLEAN
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (SELECT 1 FROM recruit_admins WHERE user_id = auth.uid());
+$$;
+
+-- Settings: everyone reads, admins write. The old policy was FOR ALL to any
+-- recruiting member, so a staleness window could change with no trace.
+DROP POLICY IF EXISTS "Recruiting members write settings" ON recruit_settings;
+DROP POLICY IF EXISTS "Recruiting admins write settings" ON recruit_settings;
+CREATE POLICY "Recruiting admins write settings" ON recruit_settings
+  FOR ALL TO authenticated
+  USING (is_recruiting_admin()) WITH CHECK (is_recruiting_admin());
+
+-- updated_by_name already exists; the uuid makes the trail joinable.
+ALTER TABLE recruit_settings ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+-- Dead config from the collective-vote model, superseded by the single decider
+-- on 2026-07-29 (migration 140). Nothing reads these.
+DELETE FROM recruit_settings WHERE key IN ('vote_min_count', 'vote_pass_avg');
+
+-- Automation status for the Settings view. cron.* is not reachable over the
+-- REST API, so this is the one door to it — read-only, and it exposes nothing
+-- but the schedule and the last outcome of jobs this app owns.
+CREATE OR REPLACE FUNCTION recruit_cron_status()
+RETURNS TABLE (
+  jobname TEXT,
+  schedule TEXT,
+  active BOOLEAN,
+  last_run TIMESTAMPTZ,
+  last_status TEXT
+)
+LANGUAGE SQL
+STABLE
+SECURITY DEFINER
+SET search_path = cron, public
+AS $$
+  SELECT
+    j.jobname::TEXT,
+    j.schedule::TEXT,
+    j.active,
+    r.start_time,
+    r.status::TEXT
+  FROM cron.job j
+  LEFT JOIN LATERAL (
+    SELECT d.start_time, d.status
+    FROM cron.job_run_details d
+    WHERE d.jobid = j.jobid
+    ORDER BY d.start_time DESC
+    LIMIT 1
+  ) r ON TRUE
+  WHERE j.jobname IN (
+    'recruit_screening_reminder_tick',
+    'recruit_application_ingest_tick',
+    'recruit_gmail_scan_tick',
+    'pipeline-invariants-6h'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION recruit_cron_status() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION recruit_cron_status() TO authenticated;
+
+COMMENT ON TABLE recruit_admins IS
+  'Derived from Discord: who can see #recruiting-automation. Written by the discord-membership function (service role) only.';
+COMMENT ON FUNCTION recruit_cron_status() IS
+  'Read-only last-run status for the recruiting cron jobs, for Settings → Automations.';


### PR DESCRIPTION
Answers all three open questions from the Settings concept and builds the whole thing.

## The surface

Six sections at `?view=settings`, in the rail's own vocabulary: **You · House · Funnel · Automations · Connections · Data**. Rendered from `applications/js/settings-schema.js` — adding a knob is one object literal:

```js
followup_stale_days: {
  scope: 'house', type: 'number', section: 'funnel', default: 3,
  label: 'Follow-up goes amber after', unit: 'days', min: 1, max: 30, step: 1,
  hint: 'A thread this quiet is worth another email.',
},
```

`scope` picks the store (`house` → `recruit_settings`, `profile` → `recruit_profiles`, `local` → localStorage), so callers say `setting('followup_stale_days')` and never learn where a value lives. **The schema default is the code default** — no row means the default, so exposing a knob needs no migration and no seed.

## Literals → settings

**Exposed (4):** follow-up staleness, move-in flexibility, trial check-in offset, trial decision offset.
**Routed but not exposed (4):** gap minimum, screener slot length, slots per ask, save-for-future window — named constants in one place instead of magic numbers in three, one line from being settings.

`vote_min_count` / `vote_pass_avg` deleted; dead since the single-decider change.

## Admin = a Discord channel

Whoever can see **#recruiting-automation** can change how recruiting behaves. The channel that already receives the audit trail decides who changes the automation.

- `discord-membership` v1.4.0 reuses the channel-permission math that already gates the app (`canViewChannel` now takes a channel picker) and reconciles `recruit_admins` on every verify, **in both directions** — lose channel access, lose admin.
- **RLS is the wall** (migration 144): `recruit_settings` writes require `is_recruiting_admin()`.
- The flag deliberately does **not** live on `recruit_profiles` — members write their own profile row and could grant themselves admin. `recruit_admins` is service-role-write, member-read.
- Non-admins see every value, **disabled not hidden**, with one line saying who decides. Every house-wide setting shows "Ian changed this 3 days ago".

## Automations report, they don't rule

`recruit_cron_status()` (`SECURITY DEFINER`, read-only, scoped to this app's four jobs) gives each automation its schedule, last run, and last status — `cron.*` isn't reachable over REST. Failed runs go red; unscheduled jobs read "paused". Cadence stays `pg_cron`'s: a toggle that only half-worked would be worse than saying where it lives. `discord_auto_post` is the one real switch.

**Connections:** Gmail, house calendar, Discord's two channels, each with a real state. The Gmail token dying every ~7 days is now a glance instead of an investigation.

## Also in this pass

- **The gap drawer asks before it shows a form** — two inset tiles (*Create a listing* / *Add an occupant*), then the drawer becomes that flow with one way back. The listing form moved into the drawer so the flow never leaves the sidebar it started in; `createListingFromGap`'s `confirm()` shortcut is retired.
- **The autosave flag says nothing until a write lands.** "Changes save as you go" is gone — the line is empty, then reads "Saved" for a moment.
- **The rail footer drops to identity + Sign out.** Theme, the three prefs, Gmail status and CSV export moved into Settings; food/dues left the room drawer for House.

## Deploy after merge

```bash
supabase db push && supabase functions deploy discord-membership
```

Migration 144 changes an RLS policy: **until it runs, nothing is admin and house-wide settings are read-only for everyone.** Deploy the function in the same window.

## Verified

Both new surfaces rendered in Chrome against the real stylesheet with the real `renderSettings()` — field tiles, switch, audit line, failed/paused automations, connection states, and all three gap-drawer steps. The migration and the Discord check can only be verified after deploy.

## Docs
- [docs/ux/recruiting-settings-concept.md](docs/ux/recruiting-settings-concept.md) — all three decisions marked decided, what shipped, what's still open
- [design-system/README.md](design-system/README.md) — `set-*` and `step-*` documented
- [design-system/recruiting/index.html](design-system/recruiting/index.html) — Settings story loses its "concept" tag, 2 decision-log entries, v3.32
- [design-system/CHANGELOG.md](design-system/CHANGELOG.md) — 1.5.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)