### PR TITLE
fix(recruiting): the admin check has to run before it can grant anything

### DIFF
--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,7 +20,7 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.4.0'
+const VERSION = '1.4.1'
 console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel gate + #recruiting-automation admin (OAuth or bot magic-link)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -199,6 +199,9 @@ async function verifyAndCache(userId: string, identity: DiscordIdentity) {
     discord_username: identity.username,
     is_agape_member: isMember,
     is_recruiting_member: isRecruiting,
+    // Cached so a NULL can mean "never checked" — see migration 145. The
+    // authority RLS reads is still recruit_admins, written just below.
+    is_recruiting_admin: isAdmin,
     verified_at: new Date().toISOString(),
   }
   const { error } = await getSupabase()
@@ -252,7 +255,7 @@ async function verifyAndCache(userId: string, identity: DiscordIdentity) {
   }
 
   console.log(`Verified ${identity.discordUserId} (${identity.username || 'unknown'}): member=${isMember} recruiting=${isRecruiting} admin=${isAdmin}`)
-  return { ...row, is_recruiting_admin: isAdmin }
+  return row
 }
 
 serve(async (req) => {
@@ -288,15 +291,18 @@ serve(async (req) => {
     if (action !== 'verify') {
       const { data } = await db
         .from('user_discord_membership')
-        .select('discord_user_id, discord_username, is_agape_member, is_recruiting_member, verified_at')
+        .select('discord_user_id, discord_username, is_agape_member, is_recruiting_member, is_recruiting_admin, verified_at')
         .eq('user_id', user.id)
         .maybeSingle()
       const fresh = data &&
         data.discord_user_id === identity.discordUserId &&
-        (Date.now() - new Date(data.verified_at).getTime()) < REVERIFY_DAYS * 86400_000
+        (Date.now() - new Date(data.verified_at).getTime()) < REVERIFY_DAYS * 86400_000 &&
+        // A null admin verdict means this row predates the admin check, so it
+        // isn't fresh enough to answer the question. One re-verify fixes it.
+        (data.is_recruiting_admin !== null || !data.is_recruiting_member)
       if (fresh) {
-        // Admin isn't cached on the membership row — read it from the table RLS
-        // actually consults, so the UI and the database can never disagree.
+        // Read the verdict from the table RLS actually consults, so the UI and
+        // the database can never disagree about who can write.
         const { data: adm } = await db.from('recruit_admins')
           .select('user_id').eq('user_id', user.id).maybeSingle()
         row = { ...data, is_recruiting_admin: !!adm }

--- a/supabase/migrations/145_recruit_admin_cache.sql
+++ b/supabase/migrations/145_recruit_admin_cache.sql
@@ -1,0 +1,17 @@
+-- 145: cache the admin verdict on the membership row so it can be *absent*.
+--
+-- Migration 144 put admin in recruit_admins, which RLS reads. But the
+-- membership path only re-verifies against Discord when its cache goes stale,
+-- and a missing recruit_admins row is indistinguishable from "checked, not an
+-- admin" — so after 144 nobody became an admin until their cache expired,
+-- which is up to REVERIFY_DAYS of house-wide settings being read-only for
+-- everyone.
+--
+-- A nullable column fixes it: NULL means "never resolved", which the function
+-- treats as stale and re-verifies once. recruit_admins stays the only thing
+-- RLS trusts; this is a freshness marker, not an authority.
+ALTER TABLE user_discord_membership
+  ADD COLUMN IF NOT EXISTS is_recruiting_admin BOOLEAN;
+
+COMMENT ON COLUMN user_discord_membership.is_recruiting_admin IS
+  'Cached #recruiting-automation access. NULL = never checked (forces a re-verify). Authority for RLS is recruit_admins.';


### PR DESCRIPTION
Found by verifying #1319 against production: **the Settings page came up read-only for me, the person who just deployed it.**

Migration 144 put admin in `recruit_admins`, which RLS reads. But `discord-membership` only re-verifies against Discord when its own membership cache goes stale, and a missing `recruit_admins` row is indistinguishable from "checked, not an admin" — so nobody would become an admin until their cache expired. Up to `REVERIFY_DAYS` of house-wide settings being read-only for everyone.

**Fix:** a nullable `user_discord_membership.is_recruiting_admin`. NULL means "never resolved", which the freshness test treats as stale and re-verifies once. `recruit_admins` stays the only thing RLS trusts — this column is a freshness marker, not an authority.

## Verified against production

Migration 145 and `discord-membership` v1.4.1 are **already deployed**. After deploy:

1. One page load re-verified → `recruit_admins` went 0 → 1 row.
2. The lede flipped from "Changing the house-wide settings needs access to #recruiting-automation" to "Changes apply the moment you make them", and the controls went live.
3. A real write to `followup_stale_days` passed RLS, landed the green saved ring, and recorded `updated_by` + `updated_by_name = 'Ian Fike'`. Value restored to 3.
4. `recruit_cron_status()` returns all four jobs with real schedules and last-run times, all `succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)