### PR TITLE
fix(recruiting): candidate names in the listing drawer, and hints stop right-aligning (v3.51.1)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1630,7 +1630,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   font-size: var(--font-size-small); font-weight: var(--fw-semibold);
 }
 .drawer-cta__alt:hover { background: var(--bg-overlay); }
-.drawer-cta__alt .drawer-cta__exit-hint { text-align: left; }
 /* No Save button on an existing record — the fields are the save, and the app
    doesn't explain that in words. The flag is empty until a write lands, then
    says "Saved" for a moment. It keeps its line either way so nothing shifts. */
@@ -1658,18 +1657,6 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .drawer-cta__exit:hover { background: var(--bg-overlay); }
 .drawer-cta__exit--danger { color: var(--error); }
 .drawer-cta__exit--danger:hover { color: var(--error); background: var(--pass-tint); }
-/* The hint yields first: it wraps or ellipsizes so the label — the thing that
-   says what the button does — always reads on one line. */
-.drawer-cta__exit-hint {
-  flex: 0 1 auto; min-width: 0; white-space: normal;
-  color: var(--fg-subtle); font-size: var(--font-size-caption); font-weight: 400; text-align: right;
-}
-/* On a full-width phone drawer the hint gets its own line rather than
-   squeezing the label into an ellipsis. */
-@media (max-width: 480px) {
-  .drawer-cta__exit { flex-direction: column; align-items: flex-start; gap: 2px; }
-  .drawer-cta__exit-hint { text-align: left; }
-}
 
 /* Per-profile activity feed (v3.48.0). Reads as prose, so the line wraps
    instead of ellipsizing the way the scannable rail rows do. */

--- a/applications/index.html
+++ b/applications/index.html
@@ -302,8 +302,8 @@
     </div>
   </div>
 
-  <script src="js/settings-schema.js?v=3.51.0"></script>
-  <script src="js/app.js?v=3.51.0"></script>
+  <script src="js/settings-schema.js?v=3.51.1"></script>
+  <script src="js/app.js?v=3.51.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.51.0';
+const VERSION = '3.51.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -3505,7 +3505,8 @@ function listingDrawerBody(l) {
     </dl>
     <div class="occ-drawer__section">Candidates ${placed.length ? `· ${placed.length}` : ''}</div>
     ${named.length ? `<div class="listing-row__people">
-      ${named.map(a => `<button class="link-chip" data-review="${a.id}">${esc(a.first_name || 'Applicant')}</button>`).join('')}
+      ${named.map(a => `<button class="link-chip" data-review="${a.id}">${
+        esc([a.first, a.last].filter(Boolean).join(' ') || 'Applicant')}</button>`).join('')}
     </div>` : `<p class="occ-drawer__note">Nobody qualifies for it yet. Candidates are placed by rule as their dates line up.</p>`}
     ${l.notes ? `<p class="occ-drawer__note">${esc(l.notes)}</p>` : ''}
     <div class="drawer-cta">


### PR DESCRIPTION
Two things found by opening the drawer on production.

- **Candidate chips all read "Applicant."** The drawer reached for `a.first_name`, but applicants are mapped to `{ first, last }` in memory. Shows the full name now.
- **Every exit hint was pinned to the right edge of its cell.** A leftover flex-era rule sat *after* the grid rule and won on `text-align: right` — which made sense when the hint shared a line with the label, and stopped making sense when direction A stacked them. Rule deleted, along with the now-redundant `__alt` override and a 480px breakpoint that only existed to undo it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)