### PR TITLE
fix(recruiting): the stylesheet was pinned at 3.49.0 for four releases (v3.51.2)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.49.0">
+  <link rel="stylesheet" href="css/app.css?v=3.51.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -302,8 +302,8 @@
     </div>
   </div>
 
-  <script src="js/settings-schema.js?v=3.51.1"></script>
-  <script src="js/app.js?v=3.51.1"></script>
+  <script src="js/settings-schema.js?v=3.51.2"></script>
+  <script src="js/app.js?v=3.51.2"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,8 +10,22 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.51.1';
+const VERSION = '3.51.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
+
+/* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
+   and those are three separate strings that a merge can move independently —
+   which is exactly what happened: the stylesheet sat at 3.49.0 for four
+   releases while the JS advanced, so every CSS change shipped invisible. This
+   says so in the console instead of letting it go quiet again. */
+(() => {
+  const css = [...document.styleSheets].map(s => s.href || '').find(h => h.includes('/css/app.css'));
+  const tag = css && (css.match(/[?&]v=([\d.]+)/) || [])[1];
+  if (tag && tag !== VERSION) {
+    console.warn(`[applications] stale stylesheet: app.css?v=${tag} but app.js is ${VERSION}. `
+      + 'Bump every ?v= in applications/index.html together.');
+  }
+})();
 
 const SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
 const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';


### PR DESCRIPTION
**Every CSS change since v3.49.0 has been shipping invisible.**

`index.html` carries `?v=` on the stylesheet and on two scripts — three independent strings. A merge with another session's branch moved the script tags forward and left the stylesheet at `3.49.0`. The JS was live the whole time, which is why the markup was right and the paint was wrong.

Silently not applied in production:

- the exit tiles (direction A) — footers were still drawing hairlines
- the listed-stretch treatment — `is-listed` bars had no blue tint or solid edge
- all of Settings' `set-*` styles
- the stepped drawer's `step-*` styles
- the empty-until-saved autosave flag

Found by asking the page which rule was right-aligning an exit hint. It answered `app.css?v=3.49.0`.

## Fix

All three tags are `3.51.2`. And `app.js` now compares the loaded stylesheet's `?v=` against its own `VERSION` and warns on a mismatch — so the next drift says so in the console instead of going quiet for four releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)