### PR TITLE
feat(recruiting): availability shows the times; a booked call is a notification

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -1768,7 +1768,7 @@ const ACTIVITY_KINDS = {
   reply_nudge:            { icon: '🔔', label: 'Following up' },
   reply_unclear:          { icon: '🤔', label: 'Reply needs a read' },
   screening_unclaimed:    { icon: '📣', label: 'Call needs a screener' },
-  screening_claimed:      { icon: '🤝', label: 'Call claimed' },
+  screening_booked:       { icon: '🤝', label: 'Call booked' },
   screening_today:        { icon: '📞', label: 'Call today' },
   screening_notes:        { icon: '📝', label: 'Recording ready' },
   screening_followup:     { icon: '⌛', label: 'Owed an answer' },

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -670,59 +670,97 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
   const out: Notification[] = []
   const active = await activeApplicants(db)
 
-  // Claimed — who took it, and when the call is.
-  const { data: claims } = await db.from('recruit_claim_posts')
-    .select('applicant_id, status, claimed_slot, claimed_at, posted_at')
-    .gte('posted_at', new Date(Date.now() - 21 * 86400000).toISOString())
-  for (const c of claims || []) {
-    const who = active.get(c.applicant_id)
+  /* A call got taken. Keyed on the screening rather than the claim post,
+     because a call reaches the calendar three different ways — the Claim button
+     in Discord, a time agreed in the email thread that scheduleFromEmail books,
+     and someone arranging it by hand in the app — and only the first leaves a
+     claim post. Reading recruit_screenings catches all three, which is what
+     "when someone takes a call" actually means. */
+  const { data: booked } = await db.from('recruit_screenings')
+    .select('id, applicant_id, housemate_name, starts_at, status, kind, created_at')
+    .gte('created_at', new Date(Date.now() - 21 * 86400000).toISOString())
+  for (const sc of booked || []) {
+    const who = active.get(sc.applicant_id)
+    if (!who || !sc.starts_at) continue
+    const when = new Date(sc.starts_at)
+    const dayPart = ptToday(when) === ptToday()
+      ? 'today'
+      : when.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric', timeZone: TZ })
+    const at = when.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZone: TZ }).replace(':00', '')
+    /* Who is taking it — when we actually know. Calls swept off the calendar
+       carry the organiser's display name, which for a shared calendar is
+       "Agape Internal Calendar" or "the house": not a person, and reading
+       "Agape Internal Calendar is taking Keerti's call" makes the whole line
+       look machine-generated. When the name isn't a person, the call is the
+       subject of the sentence instead of the screener. */
+    const named = sc.housemate_name && !/calendar|the house|@|^scheduled/i.test(String(sc.housemate_name))
+      ? String(sc.housemate_name) : null
+    out.push({
+      kind: 'screening_booked',
+      subject_type: 'applicant',
+      subject_id: sc.applicant_id,
+      subject_label: who.first_name,
+      lane: 'now',
+      // Re-fires if the call moves, since a rescheduled call is news again.
+      dedupe_key: `screening_booked:${sc.id}:${sc.starts_at}`,
+      payload: {
+        title: fullName(who),
+        sentence: named
+          ? `${named} is taking {}'s intro call ${dayPart} at ${at}.`
+          : `{}'s intro call is booked for ${dayPart} at ${at}.`,
+        body: 'calendar invite sent, on the house calendar',
+        section: 'Screening',
+        links: [{ label: 'Open their profile', url: applicantLink(sc.applicant_id) }],
+      },
+    })
+  }
+
+  /* Times offered, nobody booked. Read from recruit_availability rather than
+     from claim posts: a claim post only exists when discord_auto_post is on
+     (it is off), so keying on it meant this could never fire — while the
+     failure it describes, a candidate who did their part and heard nothing,
+     is the most damaging one in the funnel. */
+  const { data: offers } = await db.from('recruit_availability')
+    .select('applicant_id, windows, updated_at')
+    .lte('updated_at', new Date(Date.now() - 72 * 3600000).toISOString())
+  const bookedFor = new Set((booked || []).map((s2: { applicant_id: string }) => s2.applicant_id))
+  for (const o of offers || []) {
+    const who = active.get(o.applicant_id)
     if (!who) continue
-    if (c.status === 'claimed' && c.claimed_at) {
-      out.push({
-        kind: 'screening_claimed',
-        subject_type: 'applicant',
-        subject_id: c.applicant_id,
-        subject_label: who.first_name,
-        lane: 'now',
-        dedupe_key: `screening_claimed:${c.applicant_id}:${c.claimed_at}`,
-        payload: {
-          title: fullName(who),
-          sentence: `Someone took {}'s intro call.`,
-          section: 'Screening',
-          links: [{ label: 'Open screening', url: applicantLink(c.applicant_id) }],
-        },
-      })
-    }
-    // Still nobody, three days on. This is the one that costs a candidate:
-    // they did their part and the house went quiet.
-    if (c.status === 'open' && new Date(c.posted_at).getTime() < Date.now() - 72 * 3600000) {
-      out.push({
-        kind: 'screening_unclaimed',
-        subject_type: 'applicant',
-        subject_id: c.applicant_id,
-        subject_label: who.first_name,
-        audience: 'oncall',
-        lane: 'now',
-        dedupe_key: `screening_unclaimed:${c.applicant_id}:${Math.floor((Date.now() - new Date(c.posted_at).getTime()) / (72 * 3600000))}`,
-        payload: {
-          title: fullName(who),
-          sentence: `{} sent times ${plural(Math.floor((Date.now() - new Date(c.posted_at).getTime()) / 86400000), 'day')} ago and nobody has taken the call.`,
-          section: 'Screening',
-          links: [{ label: 'Take the call', url: applicantLink(c.applicant_id) }],
-        },
-      })
-    }
+    if (!Array.isArray(o.windows) || !o.windows.length) continue   // nothing was actually offered
+    if (bookedFor.has(o.applicant_id)) continue                    // somebody took it
+    const days = Math.floor((Date.now() - new Date(o.updated_at).getTime()) / 86400000)
+    out.push({
+      kind: 'screening_unclaimed',
+      subject_type: 'applicant',
+      subject_id: o.applicant_id,
+      subject_label: who.first_name,
+      audience: 'oncall',
+      lane: 'now',
+      // One nudge per 3-day block, so it escalates by repetition without
+      // becoming daily noise.
+      dedupe_key: `screening_unclaimed:${o.applicant_id}:${Math.floor(days / 3)}`,
+      payload: {
+        title: fullName(who),
+        sentence: `{} offered times ${plural(days, 'day')} ago and nobody has taken the call.`,
+        section: 'Screening',
+        links: [{ label: 'Take the call', url: applicantLink(o.applicant_id) }],
+      },
+    })
   }
 
   // Today's calls, and calls whose notes have landed.
   const { data: screenings } = await db.from('recruit_screenings')
-    .select('id, applicant_id, housemate_name, starts_at, status, kind, recording_posted_at, share_token')
+    .select('id, applicant_id, housemate_name, starts_at, status, kind, created_at, recording_posted_at, share_token')
     .gte('starts_at', new Date(Date.now() - 14 * 86400000).toISOString())
   for (const sc of screenings || []) {
     const who = active.get(sc.applicant_id)
     if (!who) continue
     const startsPT = ptToday(new Date(sc.starts_at))
-    if (sc.status === 'scheduled' && startsPT === ptToday()) {
+    // Only worth its own line if the booking notification didn't already say
+    // "today" — a call booked this morning for this afternoon says it once.
+    const bookedToday = ptToday(new Date(sc.created_at)) === ptToday()
+    if (sc.status === 'scheduled' && startsPT === ptToday() && !bookedToday) {
       const at = new Date(sc.starts_at).toLocaleTimeString('en-US',
         { hour: 'numeric', minute: '2-digit', timeZone: TZ }).replace(':00', '')
       out.push({
@@ -1367,7 +1405,7 @@ const KINDS: Record<string, { icon: string; label: string }> = {
 
   // The call.
   screening_unclaimed:    { icon: '📣', label: 'Call needs a screener' },
-  screening_claimed:      { icon: '🤝', label: 'Call claimed' },
+  screening_booked:       { icon: '🤝', label: 'Call booked' },
   screening_today:        { icon: '📞', label: 'Call today' },
   screening_notes:        { icon: '📝', label: 'Recording ready' },
   screening_followup:     { icon: '⌛', label: 'Owed an answer' },

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.26.0'
+const VERSION = '1.28.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -455,8 +455,38 @@ function clause(s: string | null): string {
   if (/^(the applicant|asking|confirming|brief|interested|they |he |she )/i.test(t)) return ''
   return t.charAt(0).toLowerCase() + t.slice(1)
 }
+/* The offered times, as a housemate would say them: "Thu Jul 24, 9–11am · Fri
+   2–5pm". A notification that says only "sent times for a call" makes the reader
+   open the thread to learn the one fact they wanted, so the times go in the
+   line.
+
+   The date is dropped from a window that shares a day with the one before it,
+   and the am/pm from a start that shares it with its own end — the same
+   shortenings anyone makes when reading times aloud. */
+function fmtWindows(windows: Array<{ date: string; start: string; end: string }>): string {
+  if (!windows?.length) return ''
+  const hhmm = (t: string, withMeridiem: boolean) => {
+    const [h, m] = t.split(':').map(Number)
+    const h12 = h % 12 === 0 ? 12 : h % 12
+    return `${h12}${m ? `:${String(m).padStart(2, '0')}` : ''}${withMeridiem ? (h < 12 ? 'am' : 'pm') : ''}`
+  }
+  const dayLabel = (d: string) => new Date(`${d}T12:00:00Z`)
+    .toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' })
+
+  const parts: string[] = []
+  let lastDay = ''
+  for (const w of windows.slice(0, 3)) {
+    const sameMeridiem = (Number(w.start.split(':')[0]) < 12) === (Number(w.end.split(':')[0]) < 12)
+    const range = `${hhmm(w.start, !sameMeridiem)}\u2013${hhmm(w.end, true)}`
+    parts.push(w.date === lastDay ? range : `${dayLabel(w.date)} ${range}`)
+    lastDay = w.date
+  }
+  const more = windows.length > 3 ? ` and ${windows.length - 3} more` : ''
+  return parts.join(' \u00b7 ') + more
+}
+
 const INTENT_SENTENCE: Record<string, (s: string | null) => string> = {
-  availability:    () => `{} sent times for a call.`,
+  availability:    (s) => s ? `{} is free ${s}.` : `{} sent times for a call.`,
   reschedule:      () => `{} wants to move their call.`,
   withdrawing:     () => `{} is no longer looking.`,
   post_acceptance: () => `{} is asking about moving in.`,
@@ -485,13 +515,33 @@ async function recordReplyIntents(client: ReturnType<typeof db>): Promise<number
 
   // Only people still in the funnel: mail from an archived applicant is logged
   // as email and is nobody's task.
-  const { data: live } = await client.from('recruit_applicants')
-    .select('id, first_name, last_name, stage')
-    .in('id', [...new Set(rows.map((r) => r.applicant_id))])
-    .in('stage', ['review', 'candidate'])
+  const ids = [...new Set(rows.map((r) => r.applicant_id))]
+  const [{ data: live }, { data: avail }] = await Promise.all([
+    client.from('recruit_applicants').select('id, first_name, last_name, stage')
+      .in('id', ids).in('stage', ['review', 'candidate']),
+    // The windows we parsed out of these very replies — the times themselves are
+    // what the house wants to see, not the fact that times exist.
+    client.from('recruit_availability').select('applicant_id, windows').in('applicant_id', ids),
+  ])
   const byId = new Map((live || []).map((a) => [a.id, a]))
+  const windowsBy = new Map((avail || []).map((r) => [r.applicant_id, r.windows || []]))
 
-  const notes = rows.filter((r) => byId.has(r.applicant_id)).map((r) => {
+  /* Availability gets one notification per person — their latest offer only.
+     recruit_availability stores a single current set of windows per applicant,
+     so an older reply rendered with those windows would advertise times the
+     person never named on that day. Keeping the newest reply means the line and
+     the times always agree; when they send new times, updated_at moves and the
+     next day's key fires with the new ones. */
+  const newestAvailability = new Map<string, string>()
+  for (const r of rows) {
+    if (r.intent !== 'availability') continue
+    const prev = newestAvailability.get(r.applicant_id)
+    if (!prev || String(r.sent_at) > prev) newestAvailability.set(r.applicant_id, String(r.sent_at))
+  }
+
+  const notes = rows.filter((r) => byId.has(r.applicant_id)
+      && (r.intent !== 'availability' || newestAvailability.get(r.applicant_id) === String(r.sent_at)))
+    .map((r) => {
     const a = byId.get(r.applicant_id)!
     const intent = String(r.intent)
     const also = (r.intents || []).filter((x: string) => x !== intent)
@@ -514,7 +564,9 @@ async function recordReplyIntents(client: ReturnType<typeof db>): Promise<number
         : `reply:${r.id}`,
       payload: {
         title: `${a.first_name} ${a.last_name || ''}`.trim(),
-        sentence: (INTENT_SENTENCE[intent] || INTENT_SENTENCE.unclear)(r.intent_summary),
+        sentence: (INTENT_SENTENCE[intent] || INTENT_SENTENCE.unclear)(
+          // Availability speaks in times; every other intent speaks in words.
+          intent === 'availability' ? fmtWindows(windowsBy.get(r.applicant_id)) : r.intent_summary),
         body: [
           // Only repeat the summary where the sentence didn't already use it.
           ['plans_changed', 'question'].includes(intent) && clause(r.intent_summary)


### PR DESCRIPTION
## 1. The times, in the line

`sent times for a call` made the reader open the thread for the one fact they wanted:

> 📅 **Marisa Maccaro** is free Wed, Jul 29 10:15–10:45am · Thu, Jul 30 10–10:30am.
> 📅 **Keerti Nandan** is free Thu, Jul 30 11am–12pm.

`fmtWindows` drops the date from a window sharing a day with the one before it, and the am/pm from a start sharing it with its own end — the shortenings anyone makes reading times aloud.

**Nothing was overwritten**, by the way: `discord_auto_post` is `false` and `recruit_claim_posts` is empty, so the claimable post with slots has never fired. The times were never shown, rather than stopped being shown. Flipping that setting is a separate call — it adds a Claim button, which is a different behaviour from a log line.

Also: one line per person, latest offer only. `recruit_availability` stores a single current set of windows per applicant, so rendering an older reply with those windows advertised times that person never named that day — Marisa's three entries all claimed her Jul 29–30 windows.

## 2. A booked call is now news, however it got booked

A call reaches the calendar three ways — the Claim button, a time agreed in email that `scheduleFromEmail` books, and someone arranging it by hand in the app — and **only the first leaves a claim post**. Keyed on `recruit_screenings` instead:

> 🤝 **Keerti Nandan**'s intro call is booked for today at 11 AM.
> 🤝 **Katie Joseff**'s intro call is booked for Thursday, Jul 23 at 10 AM.

The screener is named only when the name is a person. Swept calendar events carry the organiser's display name — for a shared calendar that's "Agape Internal Calendar" or "the house", and *"Agape Internal Calendar is taking Keerti's call"* makes the line look machine-generated.

**Same class of bug in the unclaimed nudge:** it read claim posts, which only exist when `discord_auto_post` is on — and it's off. So the notification for the most damaging failure in the funnel, a candidate who did their part and heard nothing, could never fire. Now reads `recruit_availability` directly.

## 3. Calendar invites — already correct, no change needed

`scheduleScreening` already invites the applicant **and** the housemate, creates the Meet link, and posts to the house calendar with `sendUpdates=all` (which is what emails the invite).

Verified on live data: the three most recent calls all landed on `knl4pjtdvea5kk80jf1lfuvcpk@group.calendar.google.com` with Meet links, and **none fell back to `primary`** — so the shared account has write access and invites are going out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)