### PR TITLE
fix(recruiting): no auth path may end on a silent spinner (v3.52.0)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.51.2">
+  <link rel="stylesheet" href="css/app.css?v=3.52.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -302,8 +302,8 @@
     </div>
   </div>
 
-  <script src="js/settings-schema.js?v=3.51.2"></script>
-  <script src="js/app.js?v=3.51.2"></script>
+  <script src="js/settings-schema.js?v=3.52.0"></script>
+  <script src="js/app.js?v=3.52.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.51.2';
+const VERSION = '3.52.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -5415,28 +5415,87 @@ function setGate(sub, btnLabel, hint) {
 }
 
 let _entering = false;
+let _watchdog = null;
+
+/* The spinner is shown for authState 'in' and hides the gate card, so any
+   path that stops without calling setGate(..., button) strands the reader on
+   a spinner forever — which is exactly what happened to a housemate whose
+   membership check never returned. Nothing may fail silently behind it. */
+function stall(sub, hint) {
+  setGate(sub, 'Try again', hint);
+  document.getElementById('gate-btn').onclick = () => { _entering = false; checkMembershipAndEnter(); };
+}
+
 async function checkMembershipAndEnter() {
   // CtrlAuth can dispatch signedin twice (fast-restore + auth event); the
   // enter sequence (load + auto-pass + toast) must only run once.
   if (_entering) return;
   _entering = true;
+  // Backstop for anything that hangs rather than throws (a fetch that never
+  // settles, an await that never resolves): after 25s, offer a way out.
+  clearTimeout(_watchdog);
+  _watchdog = setTimeout(() => {
+    if (!document.getElementById('app').hidden) return; // already in
+    if (document.body.dataset.authState === 'out') return; // a gate is showing
+    stall('This is taking longer than it should.',
+      'Sign-in worked, but checking your Recruiting Society access stalled. Try again — if it keeps happening, say so in the Agape server.');
+  }, 25000);
   try { await _checkMembershipAndEnter(); } finally {
+    clearTimeout(_watchdog);
     if (document.getElementById('app').hidden) _entering = false; // gate paths may retry
   }
 }
 
 async function _checkMembershipAndEnter() {
-  const session = await sb.auth.getSession();
-  const token = session?.data?.session?.access_token;
-  if (!token) return;
+  let token = null;
+  try {
+    const session = await sb.auth.getSession();
+    token = session?.data?.session?.access_token || null;
+  } catch (e) {
+    stall('Couldn’t read your sign-in session.', e.message || 'Try again.');
+    return;
+  }
+  // A signedin event can land a beat before the session is persisted. Give it
+  // a moment rather than returning into a permanent spinner.
+  if (!token) {
+    await new Promise(r => setTimeout(r, 1200));
+    token = (await sb.auth.getSession().catch(() => null))?.data?.session?.access_token || null;
+  }
+  if (!token) {
+    // The classic cause: an in-app browser (Instagram, Discord, Messenger)
+    // whose storage is partitioned, so the session written during the OAuth
+    // round-trip is gone by the time we read it. Name it instead of guessing.
+    stall(
+      inAppBrowser()
+        ? 'Sign-in worked, but this in-app browser threw the session away.'
+        : 'You’re signed in, but the session didn’t stick.',
+      inAppBrowser()
+        ? 'Tap ⋯ and choose “Open in browser”, then sign in again — or use “Get sign-in link” in the recruiting channel for a one-tap link that works anywhere.'
+        : 'The browser dropped the sign-in. Try again, or open ctrl.rodeo in a normal browser window.');
+    return;
+  }
   setGate('Checking your Recruiting Society access…', null);
   try {
-    const resp = await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-      body: JSON.stringify({ action: 'status' }),
-    });
-    const status = await resp.json();
+    // No timeout here once cost a housemate a permanent spinner.
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), 20000);
+    let resp;
+    try {
+      resp = await fetch(`${SUPABASE_URL}/functions/v1/discord-membership`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+        body: JSON.stringify({ action: 'status' }),
+        signal: ctl.signal,
+      });
+    } finally { clearTimeout(timer); }
+    const status = await resp.json().catch(() => ({}));
+    // A 500 used to fall through to "no Discord linked", sending people off to
+    // re-link an account that was never the problem. Say what actually broke.
+    if (!resp.ok) {
+      stall('The access check failed.',
+        `${status.error || `Server returned ${resp.status}`} — this is on our side, not your account.`);
+      return;
+    }
     if (!status.linked) {
       setGate('Your account has no Discord linked.', 'Link Discord',
         'Link the Discord account that’s in the Agape server, then try again.');
@@ -5514,8 +5573,9 @@ async function _checkMembershipAndEnter() {
     const linkEv = new URLSearchParams(location.search).get('link');
     if (linkEv) openLinkRecording(linkEv);
   } catch (e) {
-    setGate('Something went wrong checking access.', 'Try again');
-    document.getElementById('gate-btn').onclick = checkMembershipAndEnter;
+    const aborted = e.name === 'AbortError';
+    stall(aborted ? 'The access check timed out.' : 'Something went wrong checking access.',
+      aborted ? 'Discord took too long to answer. Try again — this is usually transient.' : (e.message || ''));
     console.error(e);
   }
 }

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,7 +20,7 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.4.1'
+const VERSION = '1.6.1'
 console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel gate + #recruiting-automation admin (OAuth or bot magic-link)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -75,7 +75,24 @@ function botHeaders() {
 }
 
 async function discordGet(path: string): Promise<Response> {
-  const resp = await fetch(`${DISCORD_API}${path}`, { headers: botHeaders() })
+  // A hung Discord call used to hang the whole request, and the browser had no
+  // timeout either — the caller sat on a spinner indefinitely. Bound it here.
+  const ctl = new AbortController()
+  const timer = setTimeout(() => ctl.abort(), 10_000)
+  let resp: Response
+  try {
+    resp = await fetch(`${DISCORD_API}${path}`, { headers: botHeaders(), signal: ctl.signal })
+  } catch (err) {
+    throw new Error(`Discord API unreachable ${path}: ${(err as Error).name}`)
+  } finally {
+    clearTimeout(timer)
+  }
+  // One retry for the rate limit Discord tells us how to wait out.
+  if (resp.status === 429) {
+    const retryMs = Math.min(Number(resp.headers.get('retry-after') || 1) * 1000, 5_000)
+    await new Promise((r) => setTimeout(r, retryMs))
+    return await discordGet(path)
+  }
   if (resp.status !== 200 && resp.status !== 404) {
     throw new Error(`Discord API ${resp.status} ${path}: ${(await resp.text()).slice(0, 200)}`)
   }
@@ -269,9 +286,113 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Not authenticated' }), { status: 401, headers: jsonHeaders })
     }
     const user = userData.user
-    const action = req.method === 'POST'
-      ? ((await req.json().catch(() => ({})))?.action || 'status')
-      : 'status'
+    // Read the body exactly once — a later req.clone() is too late, the stream
+    // is already consumed ("Body is unusable").
+    const payload = req.method === 'POST' ? (await req.json().catch(() => ({}))) : {}
+    const action = payload?.action || 'status'
+
+    // Admin probe: "why can't <person> get in?" answered from what the bot
+    // actually sees, instead of guessing. Read-only; caches nothing.
+    if (action === 'probe') {
+      const { data: adm } = await db.from('recruit_admins').select('user_id').eq('user_id', user.id).maybeSingle()
+      if (!adm) return new Response(JSON.stringify({ error: 'Admins only' }), { status: 403, headers: jsonHeaders })
+      const target = String(payload?.discordUserId || '')
+      if (!/^[0-9]{5,25}$/.test(target)) {
+        return new Response(JSON.stringify({ error: 'discordUserId required' }), { status: 400, headers: jsonHeaders })
+      }
+      const out: Record<string, unknown> = { discordUserId: target, guildId: AGAPE_GUILD_ID }
+      try {
+        const member = await fetchGuildMember(target)
+        out.inGuild = member !== null
+        if (member) {
+          out.roles = member.roles || []
+          try { out.canSeeRecruiting = await checkRecruitingChannel(target, member.roles || []) }
+          catch (err) { out.recruitingCheckError = (err as Error).message }
+          try { out.canSeeAutomation = await checkAutomationChannel(target, member.roles || []) }
+          catch (err) { out.automationCheckError = (err as Error).message }
+        }
+      } catch (err) {
+        out.error = (err as Error).message
+      }
+      return new Response(JSON.stringify(out), { headers: jsonHeaders })
+    }
+
+    // Admin audit: everyone who can see the Recruiting Society channel, and
+    // whether they have actually managed to sign in. Answers "who is stuck?"
+    // without waiting for each of them to report it.
+    if (action === 'audit') {
+      const { data: adm } = await db.from('recruit_admins').select('user_id').eq('user_id', user.id).maybeSingle()
+      if (!adm) return new Response(JSON.stringify({ error: 'Admins only' }), { status: 403, headers: jsonHeaders })
+      let members: Array<Record<string, any>>
+      try {
+        // Needs the Server Members privileged intent enabled for the bot.
+        const resp = await discordGet(`/guilds/${AGAPE_GUILD_ID}/members?limit=1000`)
+        members = await resp.json()
+        if (!Array.isArray(members)) throw new Error('unexpected member list')
+      } catch (err) {
+        // Listing the roster needs the Server Members privileged intent. Without
+        // it we can still audit in the other direction: everyone who has an
+        // account, and what the bot says their access is right now. That misses
+        // people who have never signed in — which is exactly what the intent
+        // would reveal — so say so rather than implying the list is complete.
+        const { data: known } = await db.from('user_discord_membership')
+          .select('discord_user_id, discord_username, verified_at, is_recruiting_member')
+        const out: Array<Record<string, unknown>> = []
+        for (const r of (known || [])) {
+          const did = String(r.discord_user_id)
+          let inGuild = false, canSee = false, checkError: string | null = null
+          try {
+            const m = await fetchGuildMember(did)
+            inGuild = m !== null
+            if (m) canSee = await checkRecruitingChannel(did, m.roles || [])
+          } catch (e) { checkError = (e as Error).message }
+          out.push({
+            discordUserId: did, name: r.discord_username || did,
+            signedIn: true, inGuild, canSeeRecruiting: canSee,
+            cachedVerdict: Boolean(r.is_recruiting_member), lastVerified: r.verified_at,
+            staleVerdict: Boolean(r.is_recruiting_member) !== canSee,
+            checkError,
+          })
+        }
+        return new Response(JSON.stringify({
+          partial: true,
+          scope: 'accounts-only',
+          note: 'Roster listing needs the Server Members privileged intent; enable it in the Discord developer portal to also see channel members who have never signed in.',
+          reason: (err as Error).message,
+          accounts: out.length,
+          rows: out,
+        }), { headers: jsonHeaders })
+      }
+      const [{ data: cached }, { data: admins }] = await Promise.all([
+        db.from('user_discord_membership').select('discord_user_id, discord_username, verified_at, is_recruiting_member'),
+        db.from('recruit_admins').select('user_id'),
+      ])
+      const byDiscord = new Map((cached || []).map((r: Record<string, unknown>) => [String(r.discord_user_id), r]))
+      const rows: Array<Record<string, unknown>> = []
+      for (const m of members) {
+        const did = String(m.user?.id || '')
+        if (!did || m.user?.bot) continue
+        let canSee = false
+        try { canSee = await checkRecruitingChannel(did, m.roles || []) } catch { canSee = false }
+        if (!canSee) continue
+        const row = byDiscord.get(did)
+        rows.push({
+          discordUserId: did,
+          name: m.user?.global_name || m.nick || m.user?.username || did,
+          signedIn: Boolean(row),
+          lastVerified: row?.verified_at || null,
+          grantedInApp: row ? Boolean(row.is_recruiting_member) : false,
+        })
+      }
+      rows.sort((a, b) => Number(a.signedIn) - Number(b.signedIn))
+      return new Response(JSON.stringify({
+        channelMembers: rows.length,
+        signedIn: rows.filter(r => r.signedIn).length,
+        neverSignedIn: rows.filter(r => !r.signedIn).map(r => r.name),
+        adminCount: (admins || []).length,
+        rows,
+      }), { headers: jsonHeaders })
+    }
 
     const identity = findDiscordIdentity(user as unknown as Record<string, unknown>)
     if (!identity) {


### PR DESCRIPTION
## Why Gavin hung

He is **fully whitelisted** — the new admin probe confirms his Discord id is in the guild and can see both Recruiting Society and the automation channel. Access was never the issue.

His screenshot shows `◀ Instagram`: he opened the link in **Instagram's in-app browser**, whose partitioned storage discards the session written during the OAuth round-trip. `getSession()` then returned no token and `_checkMembershipAndEnter()` hit a bare `return`. Because `authState` was already `'in'`, CSS hides the gate card and shows the spinner — so he got no message, no retry, and no end. His `user_discord_membership` row was never written, confirming the membership call never fired.

## Fixes
Client: retry-then-name the no-token case (in-app browsers called out explicitly), 20s timeout on the membership fetch, non-OK responses no longer masquerade as "no Discord linked", a 25s watchdog behind everything, and `getSession()` failures caught rather than escaping.

Function (v1.6.1): 10s timeout + 429-aware retry on Discord calls; new admin `probe` (what the bot sees for one id) and `audit` (channel members vs who has signed in) actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)