### PR TITLE
fix(recruiting): only announce a call that hasn't happened yet

### DIFF
--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -683,11 +683,20 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
     const who = active.get(sc.applicant_id)
     if (!who || !sc.starts_at) continue
     const when = new Date(sc.starts_at)
-    /* A booking is only news before it happens. Backfilled and swept calls are
-       already in the past, and announcing one as "booked" reads as though it
-       had just been arranged. A day of grace, so a call booked this morning for
-       this afternoon still gets its line. */
-    if (when.getTime() < Date.now() - 86400000) continue
+    /* A booking is only news while the call is still ahead.
+
+       The first version allowed a day of grace, reasoning that a call booked
+       this morning for this afternoon should still get its line. But that grace
+       is about the BOOKING being recent, and the test that matters is whether
+       the CALL has happened — so a call twenty hours past sat inside the window
+       and got announced as "booked", which reads as though it had just been
+       arranged. A call that already happened is covered by its own kinds:
+       screening_notes when the recording lands, screening_followup when nobody
+       follows up. */
+    if (when.getTime() <= Date.now()) continue
+    // And only a live booking. A completed or cancelled screening is not news
+    // about something upcoming, whatever its start time says.
+    if (sc.status !== 'scheduled') continue
 
     /* Never "today" in a stored sentence. The ledger keeps this line forever, so
        a relative word is true on the day it is written and a lie every day


### PR DESCRIPTION
> ❌ 🤝 **Marisa Maccaro**'s intro call is booked for Wednesday, Jul 29 at 10:15 AM.

…posted on the 30th, about a call that had already happened and was marked `completed`.

## The guard was testing the wrong thing

I allowed a day of grace so a call booked *this morning* for *this afternoon* would still get its line. But that grace is about the **booking** being recent, when the test that matters is whether the **call** has happened. Marisa's call was ~20h past — inside the window — so it was announced as though newly arranged.

Now it fires only while `starts_at` is in the future, **and** only for a screening still marked `scheduled`. A completed or cancelled one isn't news about something upcoming, whatever its start time says.

Nothing is lost by this detector going quiet on past calls — they have their own kinds: `screening_notes` when the recording lands, `screening_followup` when nobody follows up.

Verified: `detected: 0` on re-run, and zero genuinely-upcoming calls exist to announce.

## Why they appeared twice

Not the detector. I deleted the rows and re-ran detection to check a copy change, and re-detecting an already-posted row writes a new one, which posts again. **Refreshing copy on delivered rows is a re-send, not an edit** — my mistake, and I've stopped doing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)