### PR TITLE
chore(recruiting): cut the sign-in copy down

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -525,12 +525,9 @@ export async function postSigninMessage(channelId: string): Promise<any> {
     method: 'POST',
     body: JSON.stringify({
       embeds: [{
-        description: '📱 **Applicant inbox — sign in from your phone**\n' +
-          'Tap below for a one-time link — or type `/signin` anywhere in the server ' +
-          'to get one without coming back here.\n' +
-          'No password and no Discord redirect, so it works inside Instagram and ' +
-          'Discord in-app browsers, where normal sign-in fails. ' +
-          'Links last 10 minutes and work once.',
+        description: '**Applicant inbox**\n' +
+          'Tap below, or type `/signin` anywhere in the server.',
+        footer: { text: 'Links work once, for 10 minutes. Fine inside Instagram and Discord browsers.' },
         color: 0x5865f2,
       }],
       components: [{

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -224,11 +224,7 @@ async function handleSigninButton(interaction: Record<string, any>): Promise<Res
   const url = await mintSigninUrl(discordUserId, discordUsername)
   if (!url) return json(ephemeral('Could not mint a link — try again in a minute.'))
 
-  return json(ephemeral(
-    `🔑 Your one-time sign-in link (10 min, single use):\n${url}\n` +
-    `Opens the applicant inbox already signed in — any browser works. ` +
-    `If you are reading this inside another app's browser, open the link in Safari or Chrome.`,
-  ))
+  return json(ephemeral(`🔑 ${url}\nOpens the inbox signed in. Works once, for 10 minutes.`))
 }
 
 /* Registers /signin on the guild so nobody has to hunt for the button.
@@ -951,6 +947,23 @@ serve(async (req) => {
     const pathname = new URL(req.url).pathname
     if (pathname.endsWith('/redeem')) return await handleRedeem(req)
     if (pathname.endsWith('/signin-post')) return await handleSigninPost(req)
+    if (pathname.endsWith('/message-delete')) {
+      const client = db()
+      const tok = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')
+      const { data: u } = await client.auth.getUser(tok)
+      if (!u?.user) return json({ error: 'Not authenticated' }, 401)
+      const { data: adm } = await client.from('recruit_admins').select('user_id').eq('user_id', u.user.id).maybeSingle()
+      if (!adm) return json({ error: 'Admins only' }, 403)
+      const b = await req.json().catch(() => ({}))
+      const ch = String(b.channelId || ''), msg = String(b.messageId || '')
+      if (!/^\d{5,25}$/.test(ch) || !/^\d{5,25}$/.test(msg)) return json({ error: 'channelId and messageId required' }, 400)
+      const resp = await fetch(`https://discord.com/api/v10/channels/${ch}/messages/${msg}`, {
+        method: 'DELETE', headers: { Authorization: `Bot ${Deno.env.get('DISCORD_BOT_TOKEN')}` },
+      })
+      if (!resp.ok && resp.status !== 404) return json({ error: `Discord ${resp.status}` }, 502)
+      return json({ deleted: true, messageId: msg })
+    }
+
     if (pathname.endsWith('/register-commands')) {
       const client = db()
       const tok = (req.headers.get('Authorization') || '').replace(/^Bearer\s+/i, '')


### PR DESCRIPTION
The posted sign-in message was three dense lines of mechanics. Now two, with expiry and the in-app-browser caveat moved to the embed footer where detail belongs. The ephemeral reply loses a sentence that restated what the link obviously does.

Also adds an admin `message-delete` route so a stale posted message can be replaced without hand-editing Discord — used to swap the live message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)