### PR TITLE
feat(recall): signed-in bot via Workspace login group

### DIFF
--- a/supabase/functions/_shared/recall.ts
+++ b/supabase/functions/_shared/recall.ts
@@ -29,12 +29,17 @@ async function recallFetch(path: string, options: RequestInit = {}): Promise<any
 
 // Create a bot that joins the meeting at start time. Returns the bot id.
 export async function createRecordingBot(meetingUrl: string, joinAtISO: string): Promise<string> {
+  // When a Google login group is configured, the bot signs into its own
+  // Workspace account (meet@notes.ctrl.rodeo) and — being invited to every
+  // event — joins Meets directly with no knock.
+  const loginGroup = Deno.env.get('RECALL_LOGIN_GROUP_ID')
   const bot = await recallFetch('/api/v1/bot/', {
     method: 'POST',
     body: JSON.stringify({
       meeting_url: meetingUrl,
       bot_name: 'Agape Notes',
       join_at: joinAtISO,
+      ...(loginGroup ? { google_meet: { google_login_group_id: loginGroup } } : {}),
       recording_config: {
         transcript: { provider: { meeting_captions: {} } },
       },

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.17.0'
+const VERSION = '1.17.1'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial milestones + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.29.0'
+const VERSION = '1.29.1'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
Bots now carry `google_meet.google_login_group_id` (env `RECALL_LOGIN_GROUP_ID`, set) so Recall signs them into **meet@notes.ctrl.rodeo** — invited to every event via `RECALL_BOT_EMAIL` (updated) — for zero-knock joins as "Agape Notes".

Inert until Google-side SSO is enabled (pending the bot user's first sign-in). `deno check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)