### PR TITLE
feat(recruiting): notifications name who owns them (v3.55.0)

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.54.0">
+  <link rel="stylesheet" href="css/app.css?v=3.55.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.54.0';
+const VERSION = '3.55.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1824,6 +1824,15 @@ async function loadActivityCount() {
   renderRailCounts();
 }
 
+/* Who is on the hook. Shown as "you" when it is you, because a log that says
+   "Ian Fike" to Ian reads like it is about somebody else. Notifications with no
+   owner say nothing here — unowned is the common case and often the news. */
+function activityOwner(n) {
+  if (!n.owner_name) return '';
+  const mine = n.owner_user_id && n.owner_user_id === me?.id;
+  return mine ? 'yours' : n.owner_name;
+}
+
 function activityDelivery(n) {
   // What actually happened to this notification, in the order it happened.
   const bits = [];
@@ -1886,7 +1895,7 @@ function renderActivity() {
             <span class="inbox-row__text">
               <span class="inbox-row__title">${esc(kindLabel(n.kind))} · ${esc(n.payload?.title || n.subject_label)}</span>
               <span class="inbox-row__sub">${esc(n.payload?.body || '')}</span>
-              <span class="log-row__meta">${esc(relTime(n.created_at))} · ${esc(activityDelivery(n))}${n.acked_at ? ` · resolved ${esc(relTime(n.acked_at))}` : ''}</span>
+              <span class="log-row__meta">${esc(relTime(n.created_at))}${activityOwner(n) ? ` · ${esc(activityOwner(n))}` : ''} · ${esc(activityDelivery(n))}${n.acked_at ? ` · resolved ${esc(relTime(n.acked_at))}` : ''}</span>
             </span>
           </button>
           <span class="inbox-row__actions">
@@ -2019,7 +2028,8 @@ async function loadProfileActivity(a) {
   // openings they were matched to).
   for (const n of notifs.data || []) {
     const line = (n.payload?.sentence || '').replace('{}', n.payload?.title || fullName(a));
-    add(n.created_at, n.kind, line, n.payload?.body);
+    const owner = n.owner_name ? `${n.owner_user_id === me?.id ? 'yours' : n.owner_name}` : '';
+    add(n.created_at, n.kind, line, [n.payload?.body, owner].filter(Boolean).join(' · '));
   }
 
   feed.sort((x, y) => (x.at < y.at ? 1 : x.at > y.at ? -1 : 0));

--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -66,6 +66,19 @@ release it: `notify_house_posts = true` in `recruit_settings`, and
 No kind slugs, no lane tags, no clause after an em dash, no buttons, no
 mentions. `{}` in a sentence marks where the linked subject goes.
 
+**Owner** — the housemate on the hook, when one is known: the screener who took
+the call, the reviewer who asked for a second read. Stored on the row
+(`owner_name`, `owner_user_id`) as well as named in the sentence, so the log can
+answer *what is Kate on the hook for*. It reads as "yours" in the app when it is
+you. **Unowned is the common case and is often the news itself** — "nobody has
+reviewed this" is precisely a notification with no owner.
+
+A name only counts as an owner if it's a person. Calls swept off the shared
+calendar carry the organiser's display name — "Agape Internal Calendar", "the
+house" — and those resolve to no owner rather than claiming a calendar is taking
+a call. Ownership populates for calls booked through the app; a swept one has
+nobody attached.
+
 **Repeat** — the `dedupe_key` shape. A key fires exactly once; a key with a step
 or date segment re-fires when that segment changes.
 

--- a/supabase/functions/_shared/recruit-copy.ts
+++ b/supabase/functions/_shared/recruit-copy.ts
@@ -92,6 +92,8 @@ export const TEMPLATES: Record<string, string> = {
 
   // --- the call
   'screening_followup.undecided': "{subject} was interviewed {days} ago and the house still hasn't decided.",
+  // Naming who ran the call turns "somebody should" into "you said you would".
+  'screening_followup.undecided_by': "{screener} interviewed {subject} {days} ago and the house still hasn't decided.",
   'screening_followup.silent':    '{subject} was interviewed and has heard nothing for {days}.',
   'screening_followup.waiting':   '{subject} was interviewed {days} ago and is waiting on the house to decide.',
   'screening_unclaimed':          '{subject} offered times {days} ago and nobody has taken the call.',
@@ -100,6 +102,7 @@ export const TEMPLATES: Record<string, string> = {
   'screening_today':              '{subject} has an intro call today at {at}.',
   'screening_today.with':         '{subject} has an intro call today at {at} with {screener}.',
   'screening_notes':              "{subject}'s recording & summary are ready.",
+  'screening_notes.by':           "{screener}'s call with {subject} has its recording & summary ready.",
 
   // --- openings
   'listing_draft':                '{subject} came up as a draft opening from {date}.',

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -138,6 +138,12 @@ export interface Notification {
   subject_id: string | null
   subject_label: string
   audience?: 'house' | 'oncall' | 'person' | 'none'
+  /* The housemate on the hook for this, when one is known — the screener who
+     took the call, the reviewer who asked for a second read, whoever opened the
+     listing. Recorded on the row as well as named in the sentence, so the log
+     can answer "what is Kate on the hook for". Unowned is the common case and
+     is often the news itself. */
+  owner?: { name: string; userId?: string | null } | null
   recipient_id?: string | null
   lane?: 'now' | 'daily' | 'weekly'
   dedupe_key: string
@@ -273,6 +279,20 @@ function moveInClause(text: string | null | undefined): string {
 
 const plural = (n: number, one: string, many = `${one}s`) => `${n} ${n === 1 ? one : many}`
 
+/* A real person's name, or nothing.
+
+   Calls swept off the shared calendar carry the organiser's display name, which
+   is "Agape Internal Calendar" or "the house" — not somebody who can be on the
+   hook for anything. Every detector runs its candidate owner through here, so
+   they all agree on what counts as a person and no sentence ever claims a
+   calendar is taking a call. */
+function personName(raw: unknown): string | null {
+  const name = String(raw || '').trim()
+  if (!name) return null
+  if (/calendar|the house|^scheduled|@/i.test(name)) return null
+  return name
+}
+
 // ---- write -----------------------------------------------------------------
 
 /* Insert notifications, ignoring any whose dedupe_key already exists. The
@@ -298,6 +318,8 @@ export async function record(db: DB, rows: Notification[]): Promise<number> {
     subject_label: n.subject_label,
     audience: n.audience || 'house',
     recipient_id: n.recipient_id || null,
+    owner_name: n.owner?.name || null,
+    owner_user_id: n.owner?.userId || null,
     lane: n.lane || 'daily',
     dedupe_key: n.dedupe_key,
     payload: {
@@ -598,7 +620,7 @@ const fullName = (a: { first_name: string; last_name?: string }) => `${a.first_n
 async function detectNeedsInput(db: DB): Promise<Notification[]> {
   const since = new Date(Date.now() - 14 * 86400000).toISOString()
   const { data } = await db.from('recruit_votes')
-    .select('id, applicant_id, voter_name, note, updated_at, created_at')
+    .select('id, applicant_id, voter_id, voter_name, note, updated_at, created_at')
     .eq('verdict', 'needs_input').gte('created_at', since)
   if (!data?.length) return []
   const active = await activeApplicants(db)
@@ -611,6 +633,7 @@ async function detectNeedsInput(db: DB): Promise<Notification[]> {
       subject_label: active.get(v.applicant_id)!.first_name,
       lane: 'now' as const,
       dedupe_key: `needs_input:${v.id}`,
+      owner: personName(v.voter_name) ? { name: personName(v.voter_name)!, userId: v.voter_id || null } : null,
       payload: {
         title: fullName(active.get(v.applicant_id)!),
         copy: 'needs_input',
@@ -739,8 +762,7 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
        "Agape Internal Calendar is taking Keerti's call" makes the whole line
        look machine-generated. When the name isn't a person, the call is the
        subject of the sentence instead of the screener. */
-    const named = sc.housemate_name && !/calendar|the house|@|^scheduled/i.test(String(sc.housemate_name))
-      ? String(sc.housemate_name) : null
+    const named = personName(sc.housemate_name)
     out.push({
       kind: 'screening_booked',
       subject_type: 'applicant',
@@ -749,6 +771,7 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
       lane: 'now',
       // Re-fires if the call moves, since a rescheduled call is news again.
       dedupe_key: `screening_booked:${sc.id}:${sc.starts_at}`,
+      owner: named ? { name: named, userId: sc.housemate_user_id || null } : null,
       payload: {
         title: fullName(who),
         copy: named ? 'screening_booked.named' : 'screening_booked',
@@ -816,13 +839,14 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
         subject_label: who.first_name,
         lane: 'now',
         dedupe_key: `screening_today:${sc.id}:${startsPT}`,
+        owner: personName(sc.housemate_name)
+          ? { name: personName(sc.housemate_name)!, userId: sc.housemate_user_id || null } : null,
         payload: {
           title: fullName(who),
           // Safe here: this kind only exists on the day of the call, and its
           // dedupe key carries that date, so it is never re-read on another day.
-          copy: /calendar|the house|@/i.test(String(sc.housemate_name || '')) || !sc.housemate_name
-            ? 'screening_today' : 'screening_today.with',
-          vars: { subject: fullName(who), at, screener: String(sc.housemate_name || '') },
+          copy: personName(sc.housemate_name) ? 'screening_today.with' : 'screening_today',
+          vars: { subject: fullName(who), at, screener: personName(sc.housemate_name) || '' },
           section: 'Screening',
           links: [{ label: ACTIONS.profile, url: applicantLink(sc.applicant_id) }],
         },
@@ -836,10 +860,12 @@ async function detectScreeningMoments(db: DB): Promise<Notification[]> {
         subject_label: who.first_name,
         lane: 'now',
         dedupe_key: `screening_notes:${sc.id}`,
+        owner: personName(sc.housemate_name)
+          ? { name: personName(sc.housemate_name)!, userId: sc.housemate_user_id || null } : null,
         payload: {
           title: fullName(who),
-          copy: 'screening_notes',
-          vars: { subject: fullName(who) },
+          copy: personName(sc.housemate_name) ? 'screening_notes.by' : 'screening_notes',
+          vars: { subject: fullName(who), screener: personName(sc.housemate_name) || '' },
           section: 'Screening',
           links: [{ label: ACTIONS.notes, url: applicantLink(sc.applicant_id) }],
         },
@@ -860,7 +886,7 @@ async function detectDecisionOpen(db: DB): Promise<Notification[]> {
   const ids = candidates.map((a: { id: string }) => a.id)
 
   const [{ data: done }, { data: votes }, { data: placements }, { data: listings }] = await Promise.all([
-    db.from('recruit_screenings').select('applicant_id, starts_at, status')
+    db.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, housemate_user_id')
       .in('applicant_id', ids).eq('status', 'completed'),
     db.from('recruit_decision_votes').select('applicant_id, verdict').in('applicant_id', ids),
     db.from('recruit_listing_candidates').select('applicant_id, listing_id')
@@ -958,7 +984,7 @@ async function detectScreeningFollowup(db: DB): Promise<Notification[]> {
   const ids = candidates.map((a: { id: string }) => a.id)
 
   const [{ data: screenings }, { data: emails }, { data: votes }] = await Promise.all([
-    db.from('recruit_screenings').select('applicant_id, starts_at, status')
+    db.from('recruit_screenings').select('applicant_id, starts_at, status, housemate_name, housemate_user_id')
       .in('applicant_id', ids).eq('status', 'completed'),
     // Anything the house has said to them since. One outbound email after the
     // call is the whole point of the nudge, so it stops as soon as one exists.
@@ -970,9 +996,16 @@ async function detectScreeningFollowup(db: DB): Promise<Notification[]> {
 
   // Their most recent completed call.
   const lastCall = new Map<string, string>()
+  // Whoever ran the most recent call is who the house would expect to write.
+  const screener = new Map<string, { name: string; userId: string | null }>()
   for (const sc of screenings) {
     const prev = lastCall.get(sc.applicant_id)
-    if (!prev || sc.starts_at > prev) lastCall.set(sc.applicant_id, sc.starts_at)
+    if (!prev || sc.starts_at > prev) {
+      lastCall.set(sc.applicant_id, sc.starts_at)
+      const name = personName(sc.housemate_name)
+      if (name) screener.set(sc.applicant_id, { name, userId: sc.housemate_user_id || null })
+      else screener.delete(sc.applicant_id)
+    }
   }
   const lastOut = new Map<string, string>()
   for (const e of emails || []) {
@@ -1003,14 +1036,19 @@ async function detectScreeningFollowup(db: DB): Promise<Notification[]> {
       audience: days >= 10 ? 'oncall' : 'house',
       lane: step === FOLLOWUP_FIRST ? 'daily' : 'now',
       dedupe_key: `screening_followup:${a.id}:${step}`,
+      owner: screener.get(a.id) || null,
       payload: {
         title: fullName(a),
         /* One sentence, both facts. The candidate is waiting AND the house
            hasn't decided — reporting those separately meant two notifications a
            word apart about the same person on the same day. */
-        copy: undecided ? 'screening_followup.undecided'
+        copy: undecided
+          ? (screener.has(a.id) ? 'screening_followup.undecided_by' : 'screening_followup.undecided')
           : heard ? 'screening_followup.silent' : 'screening_followup.waiting',
-        vars: { subject: fullName(a), days: plural(days, 'day') },
+        vars: {
+          subject: fullName(a), days: plural(days, 'day'),
+          screener: screener.get(a.id)?.name || '',
+        },
         body: undecided ? undefined : 'the decision is in progress, nobody has told them',
         section: 'Owed an answer',
         links: [{ label: ACTIONS.write, url: applicantLink(a.id) }],

--- a/supabase/migrations/148_recruit_notification_owner.sql
+++ b/supabase/migrations/148_recruit_notification_owner.sql
@@ -1,0 +1,28 @@
+-- ============================================
+-- Migration 148: who owns the thing a notification is about
+--
+-- Most notifications describe something with a person already attached — the
+-- housemate taking a call, the reviewer who asked for a second read, whoever
+-- created a listing. Until now that person appeared only inside the sentence,
+-- if the template happened to mention them, so the log could not answer "what is
+-- Kate on the hook for" and a task with a clear owner read as nobody's.
+--
+-- owner_name is denormalised on purpose: it is what the sentence said at the
+-- time. Resolving it live would rename a past notification when somebody changes
+-- their display name, and the log is a record of what was said.
+--
+-- Unowned stays the common case and is not a defect — "nobody has reviewed this"
+-- is precisely a notification with no owner, and that is the point of it.
+-- ============================================
+
+ALTER TABLE recruit_notifications
+  ADD COLUMN IF NOT EXISTS owner_name TEXT,
+  ADD COLUMN IF NOT EXISTS owner_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN recruit_notifications.owner_name IS
+  'The housemate on the hook for this, when one is known — the screener, the asker, the creator. NULL means nobody owns it yet, which is itself often the news.';
+
+-- "What is on my plate" — the query the column exists for.
+CREATE INDEX IF NOT EXISTS idx_recruit_notifications_owner
+  ON recruit_notifications (owner_user_id, created_at DESC)
+  WHERE owner_user_id IS NOT NULL AND acked_at IS NULL;


### PR DESCRIPTION
Most notifications describe something with a person already attached — the housemate who took the call, the reviewer who asked for a second read. That person only appeared *inside* the sentence, if the template happened to mention them, so the log couldn't answer **"what is Kate on the hook for"** and a task with a clear owner read as nobody's.

## What changed

`owner_name` + `owner_user_id` on the row (migration 148), and the sentence names them where it helps:

> ⌛ **Kate** interviewed **Katie Joseff** 7 days ago and the house still hasn't decided.
> 📝 **Kate**'s call with **Marisa** has its recording & summary ready.

Naming the screener turns *"somebody should follow up"* into *"you said you would"*.

Owners wired where one is genuinely known: the screener on `screening_booked`, `screening_today`, `screening_notes` and `screening_followup`; the asker on `needs_input`.

## Unowned is not a missing field

Where nobody is known the existing wording is used unchanged. **Unowned is the common case** — *"nobody has reviewed this"* is precisely a notification with no owner, and that's the point of it.

`personName()` decides what counts as a person, in one place, for every detector. Calls swept off the shared calendar carry the organiser's display name — "Agape Internal Calendar", "the house" — and those resolve to **no owner** rather than claiming a calendar is taking a call.

⚠️ **All five screenings currently on record are calendar sweeps**, so none has a real person attached. Ownership is wired but won't populate until a call is booked *through the app* (Claim button or manual booking), which sets `housemate_name`/`housemate_user_id` properly.

## Two deliberate choices

- **`owner_name` is denormalised** — it's what the sentence said at the time. Resolving live would rename a past notification when someone changes their display name, and the log is a record of what was said.
- **It reads as "yours" in the app** when it's you. A log that says "Ian Fike" to Ian reads like it's about someone else.

Verified with `?dry=1`: `wouldSend: 0`, nothing written, nothing posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)