### PR TITLE
feat(recruiting): trial votes get a ballot and a nudge ladder

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.55.0';
+const VERSION = '3.56.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -3287,8 +3287,28 @@ function trialFieldsHtml(s) {
         <input type="date" name="decision_on" class="listing-status" value="${s.decision_on || ''}">
       </label>
     </div>
-    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. #recruiting-automation gets a reminder a week ahead of each.</p>
+    <label class="listing-form__field">Check-in ballot
+      <input type="url" name="checkin_form_url" class="listing-status" placeholder="Google Form link"
+             value="${esc(s.checkin_form_url || '')}">
+    </label>
+    <label class="listing-form__field">Decision ballot
+      <input type="url" name="decision_form_url" class="listing-status" placeholder="Google Form link"
+             value="${esc(s.decision_form_url || '')}">
+    </label>
+    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. Each one needs its own copy of the housemate feedback form, named
+      <code>Agape vote · ${esc(s.occupant || 'Name')} · Month 1 · ${voteCloseOn(s.checkin_on) || 'YYYY-MM-DD'}</code> —
+      the date is the Monday meeting the ballot closes at, not the milestone. The house gets nudged a week out, three days before, and on the morning of that meeting.</p>
   </div>`;
+}
+
+/* When a ballot closes: the last Monday house meeting strictly before the
+   milestone, because that meeting is where the house actually decides. Kept
+   in step with lastMondayBefore() in _shared/recruit-notify.ts. */
+function voteCloseOn(iso) {
+  if (!iso) return '';
+  const d = new Date(iso + 'T12:00');
+  d.setDate(d.getDate() - (((d.getDay() + 6) % 7) || 7));
+  return d.toISOString().slice(0, 10);
 }
 
 /* --- candidate → resident ---
@@ -3743,6 +3763,8 @@ async function writeStayForm(form) {
     // Milestones belong to a trial; switching a stay to any other kind clears them.
     checkin_on: fd.get('kind') === 'candidate' ? (fd.get('checkin_on') || null) : null,
     decision_on: fd.get('kind') === 'candidate' ? (fd.get('decision_on') || null) : null,
+    checkin_form_url: fd.get('kind') === 'candidate' ? ((fd.get('checkin_form_url') || '').trim() || null) : null,
+    decision_form_url: fd.get('kind') === 'candidate' ? ((fd.get('decision_form_url') || '').trim() || null) : null,
   };
   if (!rec.starts_on) { err.textContent = 'Start date is required.'; return; }
   if (rec.ends_on && rec.ends_on < rec.starts_on) { err.textContent = '"Through" must be at or after "From".'; return; }
@@ -3761,6 +3783,14 @@ async function writeStayForm(form) {
   }
   if (rec.checkin_on && rec.decision_on && rec.decision_on < rec.checkin_on) {
     err.textContent = 'The decision comes after the check-in.'; return;
+  }
+  // A ballot that isn't a form link is a typo, and the nudges would send the
+  // house somewhere that isn't the ballot.
+  for (const [field, label] of [['checkin_form_url', 'Check-in'], ['decision_form_url', 'Decision']]) {
+    const v = rec[field];
+    if (v && !/^https:\/\/(docs\.google\.com\/forms\/|forms\.gle\/)/.test(v)) {
+      err.textContent = `${label} ballot has to be a Google Form link.`; return;
+    }
   }
   // A moved milestone is a new milestone — let its reminder fire again.
   const prev = stays.find(s => s.id === id);

--- a/applications/js/settings-schema.js
+++ b/applications/js/settings-schema.js
@@ -55,7 +55,7 @@ const SETTING_DEFS = {
   trial_checkin_months: {
     scope: 'house', type: 'number', section: 'funnel', default: 1,
     label: 'Trial check-in lands after', unit: 'months', min: 0, max: 6, step: 1,
-    hint: 'Measured from the day they move in. #recruiting-automation gets a reminder a week ahead.',
+    hint: 'Measured from the day they move in. The ballot closes at the Monday meeting before it, and the house is nudged a week out, three days before, and that morning.',
   },
   trial_decision_months: {
     scope: 'house', type: 'number', section: 'funnel', default: 1,

--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -197,6 +197,72 @@ fires at the last moment the house can still fill the room without rushing.
 
 ---
 
+## Trial votes
+
+The two moments the house weighs in on someone already living here: the
+**month 1 check-in** and the **final decision**. Both dates live on the trial
+stay (`recruit_stays.checkin_on` / `decision_on`, migration 139) and both are
+answered by a copy of the housemate feedback form linked next to the date
+(`checkin_form_url` / `decision_form_url`, migration 152).
+
+**The ballot closes at a Monday meeting, not on the milestone.** The house
+decides out loud, at the last Monday meeting *strictly before* the milestone —
+so responses are only useful if they are in before that meeting, and every
+sentence names it. A milestone that itself falls on a Monday closes at the
+meeting a week earlier: the answers are wanted going into the day, not on it.
+
+| Kind | Fires when | Says | Action | Lane · audience | Repeat |
+|---|---|---|---|---|---|
+| 📮 `trial_vote_open` | 7 days before the closing meeting | *Keerti is up for their month 1 check-in on Sep 3, and the house votes at the meeting on Aug 31.* | Open ballot | Daily · house | once per milestone |
+| 📢 `trial_vote_due` | 3 days before the milestone⁶ | *Keerti's month 1 check-in lands Sep 3, so the ballot has to be in before the meeting on Aug 31.* | Open ballot | Now · house | once per milestone |
+| 🚨 `trial_vote_last_call` | the day of the closing meeting | *The meeting on Aug 31 is the last one before Keerti's month 1 check-in on Sep 3.* | Open ballot | Now · house | once per milestone |
+| 🟥 `trial_vote_overdue` | the milestone passed with nothing settled | *The house still has not settled Keerti's final decision, which was due Sep 3.* | Open ballot | Now · **oncall** | once per milestone |
+
+⁶ Skipped when three days out already falls *after* the closing meeting — a
+milestone early in the week. By then last call is the truer sentence, and two
+lines for one fact is what "one notification per fact" forbids.
+
+**A trial that already turned into a residency owes no vote.** The promotion
+was the answer, so a resident stay for the same person starting at or after the
+trial's start silences both milestones. A milestone more than 14 days past is
+history rather than news and is dropped silently — a date backdated in the app
+is a correction.
+
+**No ballot, no nagging.** With no form link attached, `trial_vote_open` says
+so — *"{} is up for their month 1 check-in on Sep 3 and has no ballot attached
+yet."* — and the three later rungs stay quiet. Chasing people toward a link
+that doesn't exist is worse than silence.
+
+### Naming the form copies
+
+One copy per person per milestone — never a shared form, because answers about
+two people in one response sheet can't be read separately. Copy
+[the housemate feedback form](https://docs.google.com/forms/d/1UpVuMOeSItoSvXpDn2LukBOl6_y0VWfSrrqXs3RWNrk/edit)
+into an Agape-owned `Housemate votes/{year}` folder (the template's own folder
+isn't writable by the house) and name it:
+
+```
+Agape vote · {member} · {Month 1 | Final decision} · {YYYY-MM-DD}
+```
+
+```
+Agape vote · Keerti Sharma · Month 1 · 2026-08-31
+Agape vote · Keerti Sharma · Final decision · 2026-11-30
+```
+
+- **`{member}`** is the name on the stay, so the form and the calendar agree.
+- **The milestone is one of exactly two strings.** They match the two date
+  fields on the stay and the two sentences above; anything else and a person's
+  two ballots stop sorting next to each other.
+- **The date is the closing meeting, not the milestone.** It is the deadline,
+  it is what the nudges say, and ISO keeps the folder in chronological order.
+  The drawer shows the computed date under the milestone fields — copy it.
+
+The responses sheet inherits the name with `(Responses)` appended, so a ballot
+and its answers stay findable as a pair.
+
+---
+
 ## Profile events — `audience: none`
 
 Recorded in the log and on the profile's Activity tab, **never sent anywhere**.
@@ -241,7 +307,7 @@ Batching applies to Discord only; the log is never batched.
 
 These are the rules that keep the catalogue honest. Each is checkable.
 
-- **Every kind has an action.** All 33 payloads carry `links[0]`, which becomes
+- **Every kind has an action.** All 37 payloads carry `links[0]`, which becomes
   the hyperlink on the subject. A notification you can't act on is just news.
 - **Every kind is in `KINDS`.** An unmapped kind renders as `•` with a de-slugged
   label; `icon()`/`label()` warn once when that happens. A merge once dropped two

--- a/supabase/functions/_shared/recruit-copy.ts
+++ b/supabase/functions/_shared/recruit-copy.ts
@@ -68,6 +68,13 @@ export const KINDS: Record<string, { icon: string; label: string }> = {
   // The house.
   onboarding_owed:        { icon: '🎁', label: 'Onboarding owed' },
   occupancy_conflict:     { icon: '❗', label: 'Calendar clash' },
+
+  // Trial votes — the two moments the whole house weighs in on someone
+  // already living here.
+  trial_vote_open:        { icon: '📮', label: 'Ballot open' },
+  trial_vote_due:         { icon: '📢', label: 'Ballot due' },
+  trial_vote_last_call:   { icon: '🚨', label: 'Last call before the meeting' },
+  trial_vote_overdue:     { icon: '🟥', label: 'Ballot overdue' },
 }
 
 /* ---- sentences ----------------------------------------------------------
@@ -113,6 +120,16 @@ export const TEMPLATES: Record<string, string> = {
   'opening_at_risk':              '{subject} opens {date}, {days} away, and is still unfilled.',
   'opening_overdue':              '{subject} should have opened {date}, {days} ago, and is still empty.',
 
+  // --- trial votes. The house votes at a Monday meeting, so every sentence
+  // names the meeting that closes the ballot ({close}) as well as the
+  // milestone it answers ({date}). No "tonight" or "this week" — the ledger
+  // keeps these lines forever.
+  'trial_vote_open':              '{subject} is up for their {milestone} on {date}, and the house votes at the meeting on {close}.',
+  'trial_vote_open.noform':       '{subject} is up for their {milestone} on {date} and has no ballot attached yet.',
+  'trial_vote_due':               "{subject}'s {milestone} lands {date}, so the ballot has to be in before the meeting on {close}.",
+  'trial_vote_last_call':         "The meeting on {close} is the last one before {subject}'s {milestone} on {date}.",
+  'trial_vote_overdue':           "The house still has not settled {subject}'s {milestone}, which was due {date}.",
+
   // --- the house
   'room_emptying':                '{subject} empties {date} when {occupant} leaves, and has no listing yet.',
   'onboarding_owed':              '{subject} moved in {days} ago and is still owed {count}.',
@@ -156,6 +173,7 @@ export const ACTIONS = {
   queue:      'View queue',
   write:      'Write',
   takeCall:   'Take call',
+  ballot:     'Open ballot',
 } as const
 
 // ---- rendering -------------------------------------------------------------

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1442,6 +1442,129 @@ async function detectOccupancyConflicts(db: DB): Promise<Notification[]> {
   }]
 }
 
+/* C7 — the trial votes.
+   A trial candidate has two moments the whole house weighs in on: the check-in
+   a month in, and the final decision before their sublet ends (migration 139).
+   Each one is answered by a copy of the housemate feedback form, linked on the
+   stay (migration 152), and the answers are only useful if they are in before
+   the house talks — which is the Monday meeting. So the ballot closes at the
+   last Monday meeting *before* the milestone, and every sentence names it.
+
+   Four rungs, escalating rather than repeating:
+     open      a week before the closing meeting — the ballot exists, go fill it
+     due       three days before the milestone itself
+     last call the day of the closing meeting
+     overdue   the milestone passed undecided — on-call, not the house
+
+   The T-3 rung is skipped when it would land after the closing meeting (a
+   milestone early in the week), because by then last call is the truer
+   sentence and two lines for one fact is the thing the catalogue forbids. */
+const VOTE_OPEN_LEAD = 7      // days before the closing meeting
+const VOTE_DUE_LEAD = 3       // days before the milestone — the house's ask
+const VOTE_STALE_DAYS = 14    // past this, a milestone is history, not news
+
+/* The house meets on Monday nights, so a ballot closes at the last Monday
+   strictly before the milestone. A milestone that falls on a Monday closes at
+   the meeting a week earlier — the answers are wanted going *into* the day,
+   not on it. */
+export function lastMondayBefore(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() - (((d.getUTCDay() + 6) % 7) || 7))
+  return d.toISOString().slice(0, 10)
+}
+
+const MILESTONES = [
+  ['checkin', 'month 1 check-in'],
+  ['decision', 'final decision'],
+] as const
+
+async function detectTrialVotes(db: DB): Promise<Notification[]> {
+  const { data: stays } = await db.from('recruit_stays')
+    .select('id, kind, occupant, room_id, starts_on, ends_on, checkin_on, decision_on, checkin_form_url, decision_form_url')
+  if (!stays?.length) return []
+
+  const trials = stays.filter((s: { kind: string; checkin_on: string | null; decision_on: string | null }) =>
+    s.kind === 'candidate' && (s.checkin_on || s.decision_on))
+  if (!trials.length) return []
+
+  /* Already decided in. A trial that turned into a residency doesn't owe the
+     house a vote on whether it should — the promotion was the answer. */
+  const settled = new Map<string, string>()
+  for (const s of stays) {
+    if (s.kind !== 'resident') continue
+    const who = String(s.occupant || '').trim().toLowerCase()
+    if (!who) continue
+    const at = String(s.starts_on || '')
+    if (!settled.has(who) || at > settled.get(who)!) settled.set(who, at)
+  }
+
+  const { data: rooms } = await db.from('recruit_rooms').select('id, name')
+  const roomName = new Map((rooms || []).map((r: { id: number; name: string }) => [r.id, r.name]))
+
+  const out: Notification[] = []
+  for (const s of trials) {
+    const who = String(s.occupant || '').trim()
+    if (!who) continue
+    const promotedAt = settled.get(who.toLowerCase())
+    if (promotedAt && promotedAt >= String(s.starts_on || '')) continue
+
+    for (const [which, milestone] of MILESTONES) {
+      const on: string | null = which === 'checkin' ? s.checkin_on : s.decision_on
+      if (!on) continue
+      const form: string | null = which === 'checkin' ? s.checkin_form_url : s.decision_form_url
+      const close = lastMondayBefore(on)
+      const toMilestone = daysUntil(on)
+      const toClose = daysUntil(close)
+
+      // A date corrected after the fact isn't news.
+      if (toMilestone < -VOTE_STALE_DAYS) continue
+
+      let step: 'open' | 'due' | 'last_call' | 'overdue' | null = null
+      if (toMilestone < 0) step = 'overdue'
+      else if (toClose <= 0) step = 'last_call'
+      else if (toMilestone <= VOTE_DUE_LEAD) step = 'due'
+      else if (toClose <= VOTE_OPEN_LEAD) step = 'open'
+      if (!step) continue
+
+      // Without a form there is nothing to fill in, so the opening line says
+      // that instead — and the later rungs would just be nagging about a link
+      // that doesn't exist.
+      if (!form && step !== 'open') continue
+      const copy = step === 'open' && !form ? 'trial_vote_open.noform' : `trial_vote_${step}`
+
+      out.push({
+        kind: `trial_vote_${step}`,
+        subject_type: 'stay',
+        subject_id: String(s.id),
+        subject_label: who,
+        audience: step === 'overdue' ? 'oncall' : 'house',
+        lane: step === 'open' ? 'daily' : 'now',
+        dedupe_key: `trial_vote:${s.id}:${which}:${step}`,
+        payload: {
+          title: who,
+          copy,
+          vars: {
+            subject: who,
+            milestone,
+            date: fmtDay(on),
+            close: fmtDay(close),
+            days: plural(Math.abs(toMilestone), 'day'),
+            room: String(roomName.get(s.room_id) || 'their room'),
+          },
+          section: 'Trial votes',
+          links: form
+            ? [{ label: ACTIONS.ballot, url: form }, { label: ACTIONS.calendar, url: viewLink('occupancy') }]
+            : [{ label: ACTIONS.calendar, url: viewLink('occupancy') }],
+        },
+        // No due_at: dispatch only picks up rows that are already due, and a
+        // rung is due the moment it is detected — the milestone is the thing
+        // being announced, not the time to announce it.
+      })
+    }
+  }
+  return out
+}
+
 /* Detect everything. Each kind is independent: one failing query must not cost
    the others their tick, so each is caught on its own. */
 function detectors(db: DB): Array<[string, () => Promise<Notification[]>]> {
@@ -1467,6 +1590,8 @@ function detectors(db: DB): Array<[string, () => Promise<Notification[]>]> {
     ['gone_cold', () => detectGoneCold(db)],
     ['onboarding_owed', () => detectOnboardingOwed(db)],
     ['occupancy_conflict', () => detectOccupancyConflicts(db)],
+    // The people already living here.
+    ['trial_vote', () => detectTrialVotes(db)],
   ]
 }
 

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,8 +13,8 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.18.1'
-console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial milestones + notification ledger`)
+const VERSION = '1.19.0'
+console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -561,81 +561,11 @@ async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<numb
   return notified
 }
 
-// Trial-candidate milestones (migration 139): a check-in a month into the
-// trial, a house decision a month before the sublet ends. Both post once to
-// #recruiting-automation, a week ahead, and stamp themselves so the 15-minute
-// tick can't repeat them. Moving a date in the app clears the stamp, which is
-// how a rescheduled milestone gets a fresh reminder.
-//
-// LEAD_DAYS of notice, but nothing older than STALE_DAYS: a date backdated in
-// the app is a correction, not a thing to announce, so it's stamped silently.
-const MILESTONE_LEAD_DAYS = 7
-const MILESTONE_STALE_DAYS = 14
-
-async function remindTrialMilestones(client: ReturnType<typeof db>): Promise<number> {
-  const { postResilient, AUTOMATION_CHANNEL_ID } = await import('../_shared/discord.ts')
-  const today = new Date()
-  const iso = (d: Date) => d.toISOString().slice(0, 10)
-  const todayIso = iso(today)
-  const horizon = iso(new Date(today.getTime() + MILESTONE_LEAD_DAYS * 86400000))
-  const floor = iso(new Date(today.getTime() - MILESTONE_STALE_DAYS * 86400000))
-
-  const { data: rows } = await client.from('recruit_stays')
-    .select('id, occupant, room_id, starts_on, ends_on, checkin_on, decision_on, checkin_reminded_at, decision_reminded_at')
-    .eq('kind', 'candidate')
-    .or(`and(checkin_on.lte.${horizon},checkin_reminded_at.is.null),and(decision_on.lte.${horizon},decision_reminded_at.is.null)`)
-  if (!rows?.length) return 0
-
-  const { data: rooms } = await client.from('recruit_rooms').select('id, name')
-  const roomName = new Map((rooms || []).map(r => [r.id, r.name as string]))
-
-  const fmt = (d: string) => new Date(d + 'T12:00Z')
-    .toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'UTC' })
-
-  let posted = 0
-  for (const s of rows) {
-    const kinds: Array<['checkin' | 'decision', string | null, string | null]> = [
-      ['checkin', s.checkin_on, s.checkin_reminded_at],
-      ['decision', s.decision_on, s.decision_reminded_at],
-    ]
-    for (const [which, on, remindedAt] of kinds) {
-      if (!on || remindedAt || on > horizon) continue
-      const stamp = { [`${which}_reminded_at`]: new Date().toISOString() }
-      // Backdated milestone: record it as handled, say nothing.
-      if (on < floor) {
-        await client.from('recruit_stays').update(stamp).eq('id', s.id)
-        continue
-      }
-      const who = s.occupant || 'Trial candidate'
-      const room = roomName.get(s.room_id) || 'their room'
-      const days = Math.round((new Date(on + 'T12:00Z').getTime() - new Date(todayIso + 'T12:00Z').getTime()) / 86400000)
-      const when = days > 1 ? `in ${days} days — ${fmt(on)}`
-        : days === 1 ? `tomorrow — ${fmt(on)}`
-        : days === 0 ? `today — ${fmt(on)}`
-        : `overdue since ${fmt(on)}`
-      const body = which === 'checkin'
-        ? `**${who}** is a month into their trial in ${room}. Time for the check-in: how is it going, both directions, while there's still runway to fix things.`
-        : `**${who}**'s trial in ${room} ends ${s.ends_on ? fmt(s.ends_on) : 'soon'}. The house decides now, so either side can still make other plans.`
-      try {
-        await postResilient(AUTOMATION_CHANNEL_ID, {
-          embeds: [{
-            // "Residency decision", not "trial decision": the question on the
-            // table is whether they become a resident, not how the trial went.
-            title: which === 'checkin' ? `🌱 Trial check-in — ${who}` : `🗳️ Residency decision — ${who}`,
-            description: `${body}\n\nDue ${when}.\nhttps://ctrl.rodeo/applications/?view=occupancy&room=${s.room_id}`,
-            color: which === 'checkin' ? 0x4f8a6b : 0xb8863b,
-          }],
-        }, `Trial ${which} reminder`)
-        await client.from('recruit_stays').update(stamp).eq('id', s.id)
-        posted++
-      } catch (err) {
-        // Leave the stamp unset so the next tick retries rather than losing it.
-        console.warn(`[trial] ${which} reminder for stay ${s.id} failed: ${(err as Error).message}`)
-      }
-    }
-  }
-  return posted
-}
+// Trial-candidate milestones used to post their own one-shot embeds from here.
+// They are now four escalating rungs in the notification ledger
+// (detectTrialVotes in _shared/recruit-notify.ts), so they get copy overrides,
+// dedupe, lanes, and a log entry like every other notification — and the house
+// hears about a milestone once, not from two systems.
 
 // Capability token for a recording's public watch link — 32 random bytes, so
 // links are unguessable. Revoke by nulling share_token.
@@ -935,8 +865,6 @@ serve(async (req) => {
       const live = await announceLiveCalls(client)
       await completePastCalls(client)
       const sent = await remindUpcoming(client)
-      const trials = await remindTrialMilestones(client)
-      if (trials) console.log(`[trial] ${trials} milestone reminder(s) posted`)
       const recorded = await processRecordings(client) + await processMeetingRecordings(client)
       const archived = await archiveMissingRecordings(client)
       if (archived) console.log(`[archive] ${archived} recording(s) copied to storage`)
@@ -948,8 +876,8 @@ serve(async (req) => {
       try { notify = await notifyTick(client) } catch (err) {
         console.warn(`[notify] tick failed: ${(err as Error).message}`)
       }
-      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${trials} trial(s), ${recorded} recording(s), notify ${notify.detected} new / ${notify.logged} logged / ${notify.now} posted / ${notify.digest} digested`)
-      return json({ bots, live, reminded: sent, trials, recorded, notify })
+      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${recorded} recording(s), notify ${notify.detected} new / ${notify.logged} logged / ${notify.now} posted / ${notify.digest} digested`)
+      return json({ bots, live, reminded: sent, recorded, notify })
     }
 
     const pathname = new URL(req.url).pathname

--- a/supabase/migrations/152_recruit_trial_vote_forms.sql
+++ b/supabase/migrations/152_recruit_trial_vote_forms.sql
@@ -1,0 +1,35 @@
+-- ============================================
+-- Migration 152: the ballot behind each trial milestone
+--
+-- Migration 139 gave a trial candidate two dates the house has to remember:
+-- a check-in a month in, and a decision a month before the sublet ends. What
+-- it didn't carry is the thing housemates actually have to *do* on those
+-- dates — fill in the feedback form the house votes with.
+--
+-- One form copy per person per milestone (never a shared form: answers about
+-- two people in one response sheet can't be read separately), so the link
+-- belongs on the stay next to the date it answers.
+--
+-- Naming convention for the copies, so the Drive folder stays legible and the
+-- close date is visible without opening anything:
+--
+--   Agape vote · {member} · {Month 1 | Final decision} · {YYYY-MM-DD}
+--
+-- where the date is the *closing meeting* — the last Monday house meeting
+-- before the milestone — not the milestone itself. Responses have to be in
+-- before that meeting, because that meeting is where the house decides.
+--
+-- The reminders that chase these live in _shared/recruit-notify.ts
+-- (detectTrialVotes) and ride the existing 15-minute /remind tick. They
+-- replace the one-shot embeds migration 139 described; checkin_reminded_at and
+-- decision_reminded_at are left in place but are no longer read.
+-- ============================================
+
+ALTER TABLE recruit_stays
+  ADD COLUMN IF NOT EXISTS checkin_form_url TEXT,
+  ADD COLUMN IF NOT EXISTS decision_form_url TEXT;
+
+COMMENT ON COLUMN recruit_stays.checkin_form_url IS
+  'Trial candidates only: the month-1 feedback form copy the house votes with.';
+COMMENT ON COLUMN recruit_stays.decision_form_url IS
+  'Trial candidates only: the final-decision feedback form copy.';


### PR DESCRIPTION
## What

A trial candidate has two moments the whole house weighs in on — the **month 1 check-in** and the **final decision**. The dates already existed; what was missing is the thing housemates actually have to do on them: fill in a copy of the housemate feedback form.

Each milestone now carries its own ballot link, and the house is chased toward it on a ladder instead of being told once.

## The ladder

Ballots close at the **last Monday house meeting strictly before the milestone** — that meeting is where the house decides, so responses are only useful before it. Every sentence names that meeting.

| Rung | Fires | Lane · audience |
|---|---|---|
| 📮 `trial_vote_open` | 7 days before the closing meeting | Daily · house |
| 📢 `trial_vote_due` | 3 days before the milestone | Now · house |
| 🚨 `trial_vote_last_call` | the day of the closing meeting | Now · house |
| 🟥 `trial_vote_overdue` | milestone passed, nothing settled | Now · **oncall** |

`due` is skipped when three days out already falls after the closing meeting (a milestone early in the week) — last call is the truer sentence, and two lines for one fact is what the catalogue forbids. A trial already promoted to a residency owes no vote. With no form attached, `open` says so and the later rungs stay quiet.

## Naming convention

```
Agape vote · {member} · {Month 1 | Final decision} · {YYYY-MM-DD}
```

The date is the **closing meeting**, not the milestone — it's the deadline, it's what the nudges say, and ISO keeps the Drive folder chronological. The occupancy drawer computes and shows it. Copies go in an Agape-owned `Housemate votes/{year}` folder; the template's own folder isn't writable by the house.

## Changes

- `152_recruit_trial_vote_forms.sql` — `checkin_form_url`, `decision_form_url` on `recruit_stays`
- `_shared/recruit-copy.ts` — 4 kinds, 5 templates, `ACTIONS.ballot`
- `_shared/recruit-notify.ts` — `detectTrialVotes`
- `recruit-discord` v1.19.0 — retires the one-shot milestone embeds into the ledger, so a milestone isn't announced by two systems
- viewer v3.56.0 — ballot fields in the occupancy drawer, Google-Form validation, computed close date
- `docs/ux/recruiting-notifications-catalog.md` — new "Trial votes" section + the naming convention

## Follow-up, not in scope

Nothing counts responses — the nudges never claim *n of m housemates have voted*. That needs the response sheet linked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)