### PR TITLE
fix(recruiting): a missing ballot collapses the vote ladder, not silences it

### DIFF
--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -228,10 +228,13 @@ trial's start silences both milestones. A milestone more than 14 days past is
 history rather than news and is dropped silently — a date backdated in the app
 is a correction.
 
-**No ballot, no nagging.** With no form link attached, `trial_vote_open` says
-so — *"{} is up for their month 1 check-in on Sep 3 and has no ballot attached
-yet."* — and the three later rungs stay quiet. Chasing people toward a link
-that doesn't exist is worse than silence.
+**No ballot collapses the ladder, it doesn't silence it.** With no form link
+attached, every rung becomes the one line that says so — *"{} is up for their
+month 1 check-in on Sep 3 and has no ballot attached yet."* — posted once.
+Chasing people three times toward a link that doesn't exist is noise, but a
+milestone days away with no ballot is worse news than one with an unfilled
+ballot, not better. `trial_vote_overdue` is exempt: it escalates the missed
+decision itself, which no form would have fixed.
 
 ### Naming the form copies
 

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1526,10 +1526,13 @@ async function detectTrialVotes(db: DB): Promise<Notification[]> {
       else if (toClose <= VOTE_OPEN_LEAD) step = 'open'
       if (!step) continue
 
-      // Without a form there is nothing to fill in, so the opening line says
-      // that instead — and the later rungs would just be nagging about a link
-      // that doesn't exist.
-      if (!form && step !== 'open') continue
+      /* Without a form there is nothing to fill in, so the whole ladder
+         collapses to the one line that says so — chasing people three times
+         toward a link that doesn't exist is noise. It collapses rather than
+         going silent: a milestone days away with no ballot is worse news than
+         one with an unfilled ballot, not better. Overdue is exempt because it
+         escalates the missed decision itself, which no form would have fixed. */
+      if (!form && step !== 'overdue') step = 'open'
       const copy = step === 'open' && !form ? 'trial_vote_open.noform' : `trial_vote_${step}`
 
       out.push({


### PR DESCRIPTION
Follow-up to #1341, caught by dry-running the detector against live data: a trial milestone with no form attached produced no notification at all — Alejandra's final decision is tomorrow and would have gone unmentioned.

Every rung now collapses to the single `trial_vote_open.noform` line (posted once), and `trial_vote_overdue` still escalates — it's about the missed decision, which no form would have fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)