### PR TITLE
feat(recruiting): ballots close at the month-end meeting

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1052,6 +1052,11 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .occ-drawer__fact dt { color: var(--fg-subtle); }
 .occ-drawer__fact dd { margin: 0; font-weight: var(--fw-medium); }
 .occ-drawer__note { margin: 0; color: var(--fg-muted); font-size: var(--font-size-small); }
+/* The name a ballot's form copy should carry, under the field that holds it.
+   `code` wraps rather than scrolls: the name is meant to be read and retyped
+   into Drive, not treated as a snippet. */
+.occ-drawer__hint { display: block; margin-top: 4px; color: var(--fg-subtle); font-size: var(--font-size-caption); font-weight: var(--fw-regular); }
+.occ-drawer__hint code { font-family: var(--font-mono, monospace); overflow-wrap: anywhere; }
 @media (max-width: 720px) { .occ-drawer { width: 100vw; border-left: 0; } }
 
 /* --- v2.16.1: phone-sized timeline (3 months at a time) --- */

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.56.0';
+const VERSION = '3.57.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -3287,28 +3287,42 @@ function trialFieldsHtml(s) {
         <input type="date" name="decision_on" class="listing-status" value="${s.decision_on || ''}">
       </label>
     </div>
-    <label class="listing-form__field">Check-in ballot
-      <input type="url" name="checkin_form_url" class="listing-status" placeholder="Google Form link"
-             value="${esc(s.checkin_form_url || '')}">
-    </label>
-    <label class="listing-form__field">Decision ballot
-      <input type="url" name="decision_form_url" class="listing-status" placeholder="Google Form link"
-             value="${esc(s.decision_form_url || '')}">
-    </label>
-    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. Each one needs its own copy of the housemate feedback form, named
-      <code>Agape vote · ${esc(s.occupant || 'Name')} · Month 1 · ${voteCloseOn(s.checkin_on) || 'YYYY-MM-DD'}</code> —
-      the date is the Monday meeting the ballot closes at, not the milestone. The house gets nudged a week out, three days before, and on the morning of that meeting.</p>
+    ${ballotFieldHtml('checkin', 'Month 1', s.occupant, s.checkin_on, s.checkin_form_url)}
+    ${ballotFieldHtml('decision', 'Final decision', s.occupant, s.decision_on, s.decision_form_url)}
+    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. Each needs its own copy of the housemate feedback form, named as shown — the date is the meeting the ballot closes at, not the milestone. The house is nudged a week out, three days out, and on the day of that meeting. Move a milestone into a different month and the ballot closes at a different meeting, so rename the form and the nudges start again.</p>
   </div>`;
 }
 
-/* When a ballot closes: the last Monday house meeting strictly before the
-   milestone, because that meeting is where the house actually decides. Kept
-   in step with lastMondayBefore() in _shared/recruit-notify.ts. */
+/* One ballot field, with the name its form copy should carry underneath it.
+   The name is derived rather than described because the close date is computed
+   — asking someone to work out which Monday it is, for two milestones, per
+   person, is how the folder ends up with four naming schemes in it. */
+function ballotFieldHtml(which, milestone, occupant, on, url) {
+  const close = voteCloseOn(on);
+  return `<label class="listing-form__field">${esc(milestone)} ballot
+      <input type="url" name="${which}_form_url" class="listing-status" placeholder="Google Form link"
+             value="${esc(url || '')}">
+      <span class="occ-drawer__hint">${on
+        ? `Name the copy <code>Agape vote · ${esc(occupant || 'Name')} · ${esc(milestone)} · ${close}</code> — closes at the ${fmtShort(close)} meeting.`
+        : 'Set the date above and this names itself.'}</span>
+    </label>`;
+}
+
+/* When a ballot closes: the house's month-end meeting — the last Monday of a
+   month — that still falls on or before the milestone. Milestones sit on month
+   boundaries and the house settles a month at its last meeting in the month
+   before it, so a Oct 1 decision is taken at the Sep 28 meeting. Kept in step
+   with ballotCloses() in _shared/recruit-notify.ts. */
+function lastMondayOfMonth(year, month) {
+  const d = new Date(Date.UTC(year, month + 1, 0));
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
+  return d.toISOString().slice(0, 10);
+}
 function voteCloseOn(iso) {
   if (!iso) return '';
-  const d = new Date(iso + 'T12:00');
-  d.setDate(d.getDate() - (((d.getDay() + 6) % 7) || 7));
-  return d.toISOString().slice(0, 10);
+  const d = new Date(iso + 'T00:00:00Z');
+  const own = lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth());
+  return own <= iso ? own : lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth() - 1);
 }
 
 /* --- candidate → resident ---

--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -205,22 +205,29 @@ stay (`recruit_stays.checkin_on` / `decision_on`, migration 139) and both are
 answered by a copy of the housemate feedback form linked next to the date
 (`checkin_form_url` / `decision_form_url`, migration 152).
 
-**The ballot closes at a Monday meeting, not on the milestone.** The house
-decides out loud, at the last Monday meeting *strictly before* the milestone —
-so responses are only useful if they are in before that meeting, and every
-sentence names it. A milestone that itself falls on a Monday closes at the
-meeting a week earlier: the answers are wanted going into the day, not on it.
+**The ballot closes at the month-end meeting, not on the milestone.** Trial
+milestones sit on month boundaries — month 1 is the 1st, a decision is a month
+before a sublet ends — and the house settles a month at **its last Monday
+meeting in the month before it**. So the closing meeting is the last Monday of a
+month that still falls on or before the milestone: a decision dated Oct 1 is
+taken on Sep 28, and one dated Sep 15 was taken on Aug 31. Every rung names that
+meeting, and all four are counted from it.
 
 | Kind | Fires when | Says | Action | Lane · audience | Repeat |
 |---|---|---|---|---|---|
-| 📮 `trial_vote_open` | 7 days before the closing meeting | *Keerti is up for their month 1 check-in on Sep 3, and the house votes at the meeting on Aug 31.* | Open ballot | Daily · house | once per milestone |
-| 📢 `trial_vote_due` | 3 days before the milestone⁶ | *Keerti's month 1 check-in lands Sep 3, so the ballot has to be in before the meeting on Aug 31.* | Open ballot | Now · house | once per milestone |
-| 🚨 `trial_vote_last_call` | the day of the closing meeting | *The meeting on Aug 31 is the last one before Keerti's month 1 check-in on Sep 3.* | Open ballot | Now · house | once per milestone |
-| 🟥 `trial_vote_overdue` | the milestone passed with nothing settled | *The house still has not settled Keerti's final decision, which was due Sep 3.* | Open ballot | Now · **oncall** | once per milestone |
+| 📮 `trial_vote_open` | 7 days before the closing meeting | *Keerti is up for their month 1 check-in on Sep 1, and the house votes at the meeting on Aug 31.* | Open ballot | Daily · house | once per meeting |
+| 📢 `trial_vote_due` | 3 days before the closing meeting | *Keerti's month 1 check-in lands Sep 1, so the ballot has to be in before the meeting on Aug 31.* | Open ballot | Now · house | once per meeting |
+| 🚨 `trial_vote_last_call` | the day of the closing meeting | *The meeting on Aug 31 is the last one before Keerti's month 1 check-in on Sep 1.* | Open ballot | Now · house | once per meeting |
+| 🟥 `trial_vote_overdue` | the milestone passed with nothing settled | *The house still has not settled Keerti's final decision, which was due Sep 1.* | Open ballot | Now · **oncall** | once per meeting |
 
-⁶ Skipped when three days out already falls *after* the closing meeting — a
-milestone early in the week. By then last call is the truer sentence, and two
-lines for one fact is what "one notification per fact" forbids.
+**A trial that gets extended re-runs its ladder.** The `dedupe_key` carries the
+closing meeting (`trial_vote:{stay}:{which}:{close}:{step}`), so extending a
+sublet — which moves `decision_on`, which can move the meeting — nudges the
+house again with the new date rather than leaving them holding the deadline from
+before the extension. A milestone that moves *within* the same meeting's window
+is the same deadline and correctly stays quiet. **Rename the form copy when the
+meeting moves**: its name carries the old date, and a stale name is how two
+ballots for one person stop being tellable apart.
 
 **A trial that already turned into a residency owes no vote.** The promotion
 was the answer, so a resident stay for the same person starting at or after the
@@ -252,6 +259,10 @@ Agape vote · {member} · {Month 1 | Final decision} · {YYYY-MM-DD}
 Agape vote · Keerti Sharma · Month 1 · 2026-08-31
 Agape vote · Keerti Sharma · Final decision · 2026-11-30
 ```
+
+The occupancy drawer prints the exact name under each ballot field, close date
+already computed — working out which Monday it is, twice per person, is how a
+folder ends up with four naming schemes in it.
 
 - **`{member}`** is the name on the stay, so the form and the calendar agree.
 - **The milestone is one of exactly two strings.** They match the two date

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1450,27 +1450,35 @@ async function detectOccupancyConflicts(db: DB): Promise<Notification[]> {
    the house talks — which is the Monday meeting. So the ballot closes at the
    last Monday meeting *before* the milestone, and every sentence names it.
 
-   Four rungs, escalating rather than repeating:
-     open      a week before the closing meeting — the ballot exists, go fill it
-     due       three days before the milestone itself
-     last call the day of the closing meeting
-     overdue   the milestone passed undecided — on-call, not the house
-
-   The T-3 rung is skipped when it would land after the closing meeting (a
-   milestone early in the week), because by then last call is the truer
-   sentence and two lines for one fact is the thing the catalogue forbids. */
+   Four rungs, escalating rather than repeating, all anchored on that meeting:
+     open      a week before it — the ballot exists, go fill it
+     due       three days before it — the weekend to do it in
+     last call the day of it
+     overdue   the milestone passed undecided — on-call, not the house */
 const VOTE_OPEN_LEAD = 7      // days before the closing meeting
-const VOTE_DUE_LEAD = 3       // days before the milestone — the house's ask
+const VOTE_DUE_LEAD = 3       // days before the closing meeting
 const VOTE_STALE_DAYS = 14    // past this, a milestone is history, not news
 
-/* The house meets on Monday nights, so a ballot closes at the last Monday
-   strictly before the milestone. A milestone that falls on a Monday closes at
-   the meeting a week earlier — the answers are wanted going *into* the day,
-   not on it. */
-export function lastMondayBefore(isoDate: string): string {
-  const d = new Date(`${isoDate}T00:00:00Z`)
-  d.setUTCDate(d.getUTCDate() - (((d.getUTCDay() + 6) % 7) || 7))
+/* When a ballot closes: the house's *month-end* meeting — the last Monday of a
+   month — that still falls on or before the milestone.
+
+   Trial milestones sit on month boundaries (month 1 is the 1st, a decision is a
+   month before a sublet ends), and the house settles a month at its last
+   meeting in the month before it. So a Oct 1 decision is taken at the Sep 28
+   meeting, not the one on Sep 21: "before the corresponding month" is the rule
+   the house already runs on, and the nearest Monday would have picked the wrong
+   meeting for every mid-month milestone. */
+function lastMondayOfMonth(year: number, month: number): string {
+  const d = new Date(Date.UTC(year, month + 1, 0))       // last day of that month
+  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7))
   return d.toISOString().slice(0, 10)
+}
+export function ballotCloses(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`)
+  const own = lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth())
+  // A milestone before its own month's meeting belongs to the month before —
+  // which is every first-of-the-month milestone, i.e. most of them.
+  return own <= isoDate ? own : lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth() - 1)
 }
 
 const MILESTONES = [
@@ -1512,7 +1520,7 @@ async function detectTrialVotes(db: DB): Promise<Notification[]> {
       const on: string | null = which === 'checkin' ? s.checkin_on : s.decision_on
       if (!on) continue
       const form: string | null = which === 'checkin' ? s.checkin_form_url : s.decision_form_url
-      const close = lastMondayBefore(on)
+      const close = ballotCloses(on)
       const toMilestone = daysUntil(on)
       const toClose = daysUntil(close)
 
@@ -1522,7 +1530,7 @@ async function detectTrialVotes(db: DB): Promise<Notification[]> {
       let step: 'open' | 'due' | 'last_call' | 'overdue' | null = null
       if (toMilestone < 0) step = 'overdue'
       else if (toClose <= 0) step = 'last_call'
-      else if (toMilestone <= VOTE_DUE_LEAD) step = 'due'
+      else if (toClose <= VOTE_DUE_LEAD) step = 'due'
       else if (toClose <= VOTE_OPEN_LEAD) step = 'open'
       if (!step) continue
 
@@ -1542,7 +1550,12 @@ async function detectTrialVotes(db: DB): Promise<Notification[]> {
         subject_label: who,
         audience: step === 'overdue' ? 'oncall' : 'house',
         lane: step === 'open' ? 'daily' : 'now',
-        dedupe_key: `trial_vote:${s.id}:${which}:${step}`,
+        /* Keyed on the closing meeting, not just the step: a trial that gets
+           extended moves its decision date, and a key without the meeting in it
+           would leave the house holding the deadline from before the extension.
+           A milestone that moves *within* the same meeting's month is the same
+           deadline, so that correctly stays quiet. */
+        dedupe_key: `trial_vote:${s.id}:${which}:${close}:${step}`,
         payload: {
           title: who,
           copy,

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.19.0'
+const VERSION = '1.20.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
Follow-up to #1341/#1343, from two things Ian flagged against the real trial stays.

## 1. The closing meeting is the month-end one

Trial milestones sit on month boundaries — month 1 is the 1st, a decision is a month before a sublet ends — and the house settles a month at **its last Monday meeting in the month before it**. So the ballot closes at the last Monday of a month that still falls on or before the milestone.

| Milestone | Closes |
|---|---|
| Thu Oct 1 | Mon **Sep 28** |
| Fri Jul 31 | Mon **Jul 27** |
| Tue Sep 15 | Mon **Aug 31** |

"Nearest Monday before" picked the wrong meeting for every mid-month milestone. All four rungs now count from the meeting: open −7, due −3, last call on the day, overdue once the milestone passes. That also settles the open question from #1341 — the 3-day rung is anchored to the meeting, so it always fires and always lands on the Friday before.

## 2. Sophia's extension — a moved deadline went unannounced

Her term was extended, which moved `decision_on`, which can move the closing meeting. The `dedupe_key` had no date in it, so the ladder would never re-fire and the house would be left holding the deadline from *before* the extension.

The key now carries the meeting — `trial_vote:{stay}:{which}:{close}:{step}` — so a moved deadline re-runs the ladder, and a milestone that moves within the same meeting's window correctly stays quiet.

## Also

The occupancy drawer now prints each ballot's exact form name under its field, close date already computed. Working out which Monday it is, twice per person, is how a Drive folder ends up with four naming schemes in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)