### PR TITLE
feat(recruiting): ballots open 4 days out and get bumped the morning of

### DIFF
--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.57.0';
+const VERSION = '3.58.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -3289,7 +3289,7 @@ function trialFieldsHtml(s) {
     </div>
     ${ballotFieldHtml('checkin', 'Month 1', s.occupant, s.checkin_on, s.checkin_form_url)}
     ${ballotFieldHtml('decision', 'Final decision', s.occupant, s.decision_on, s.decision_form_url)}
-    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. Each needs its own copy of the housemate feedback form, named as shown — the date is the meeting the ballot closes at, not the milestone. The house is nudged a week out, three days out, and on the day of that meeting. Move a milestone into a different month and the ballot closes at a different meeting, so rename the form and the nudges start again.</p>
+    <p class="occ-drawer__note">Check-in lands a month in; the decision a month before they move out. Each needs its own copy of the housemate feedback form, named as shown — the date is the meeting the ballot closes at, not the milestone. The house is nudged four days out and bumped again the morning of that meeting. Move a milestone past a Monday and the ballot closes at a different meeting, so rename the form — the nudges start again on their own.</p>
   </div>`;
 }
 
@@ -3308,21 +3308,14 @@ function ballotFieldHtml(which, milestone, occupant, on, url) {
     </label>`;
 }
 
-/* When a ballot closes: the house's month-end meeting — the last Monday of a
-   month — that still falls on or before the milestone. Milestones sit on month
-   boundaries and the house settles a month at its last meeting in the month
-   before it, so a Oct 1 decision is taken at the Sep 28 meeting. Kept in step
-   with ballotCloses() in _shared/recruit-notify.ts. */
-function lastMondayOfMonth(year, month) {
-  const d = new Date(Date.UTC(year, month + 1, 0));
-  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7));
-  return d.toISOString().slice(0, 10);
-}
+/* When a ballot closes: the Monday house meeting before the milestone, taking
+   the date on the stay as it stands. Kept in step with ballotCloses() in
+   _shared/recruit-notify.ts. */
 function voteCloseOn(iso) {
   if (!iso) return '';
   const d = new Date(iso + 'T00:00:00Z');
-  const own = lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth());
-  return own <= iso ? own : lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth() - 1);
+  d.setUTCDate(d.getUTCDate() - (((d.getUTCDay() + 6) % 7) || 7));
+  return d.toISOString().slice(0, 10);
 }
 
 /* --- candidate → resident ---

--- a/applications/js/settings-schema.js
+++ b/applications/js/settings-schema.js
@@ -55,7 +55,7 @@ const SETTING_DEFS = {
   trial_checkin_months: {
     scope: 'house', type: 'number', section: 'funnel', default: 1,
     label: 'Trial check-in lands after', unit: 'months', min: 0, max: 6, step: 1,
-    hint: 'Measured from the day they move in. The ballot closes at the Monday meeting before it, and the house is nudged a week out, three days before, and that morning.',
+    hint: 'Measured from the day they move in. The ballot closes at the Monday meeting before it — the house is nudged four days out and bumped that morning.',
   },
   trial_decision_months: {
     scope: 'house', type: 'number', section: 'funnel', default: 1,

--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -205,27 +205,28 @@ stay (`recruit_stays.checkin_on` / `decision_on`, migration 139) and both are
 answered by a copy of the housemate feedback form linked next to the date
 (`checkin_form_url` / `decision_form_url`, migration 152).
 
-**The ballot closes at the month-end meeting, not on the milestone.** Trial
-milestones sit on month boundaries — month 1 is the 1st, a decision is a month
-before a sublet ends — and the house settles a month at **its last Monday
-meeting in the month before it**. So the closing meeting is the last Monday of a
-month that still falls on or before the milestone: a decision dated Oct 1 is
-taken on Sep 28, and one dated Sep 15 was taken on Aug 31. Every rung names that
-meeting, and all four are counted from it.
+**The ballot closes at the Monday meeting before the milestone.** The dates on
+the stay are taken as they stand — a trial's dates are set by hand and moved by
+hand — and the meeting is found from whatever they say. A milestone falling on a
+Monday closes at the meeting the week before: answers are wanted going into the
+day, not on it.
+
+**Two nudges, plus a backstop.** Four days out is a Thursday, so the ballot has
+the weekend; then one bump on the morning of the meeting. That is as hard as a
+ballot can be chased before the channel learns to skip these.
 
 | Kind | Fires when | Says | Action | Lane · audience | Repeat |
 |---|---|---|---|---|---|
-| 📮 `trial_vote_open` | 7 days before the closing meeting | *Keerti is up for their month 1 check-in on Sep 1, and the house votes at the meeting on Aug 31.* | Open ballot | Daily · house | once per meeting |
-| 📢 `trial_vote_due` | 3 days before the closing meeting | *Keerti's month 1 check-in lands Sep 1, so the ballot has to be in before the meeting on Aug 31.* | Open ballot | Now · house | once per meeting |
-| 🚨 `trial_vote_last_call` | the day of the closing meeting | *The meeting on Aug 31 is the last one before Keerti's month 1 check-in on Sep 1.* | Open ballot | Now · house | once per meeting |
-| 🟥 `trial_vote_overdue` | the milestone passed with nothing settled | *The house still has not settled Keerti's final decision, which was due Sep 1.* | Open ballot | Now · **oncall** | once per meeting |
+| 📮 `trial_vote_open` | 4 days before the closing meeting | *Keerti is up for their month 1 check-in on Sep 3, and the house votes at the meeting on Aug 31.* | Open ballot | Daily · house | once per meeting |
+| 🚨 `trial_vote_last_call` | the morning of the closing meeting | *The meeting on Aug 31 is where the house votes on Keerti's month 1 check-in, due Sep 3.* | Open ballot | Now · house | once per meeting |
+| 🟥 `trial_vote_overdue` | the milestone passed with nothing settled | *The house still has not settled Keerti's final decision, which was due Sep 3.* | Open ballot | Now · **oncall** | once per meeting |
 
 **A trial that gets extended re-runs its ladder.** The `dedupe_key` carries the
 closing meeting (`trial_vote:{stay}:{which}:{close}:{step}`), so extending a
 sublet — which moves `decision_on`, which can move the meeting — nudges the
 house again with the new date rather than leaving them holding the deadline from
-before the extension. A milestone that moves *within* the same meeting's window
-is the same deadline and correctly stays quiet. **Rename the form copy when the
+before the extension. A milestone that moves but stays on the same side of the
+same Monday is the same deadline and correctly stays quiet. **Rename the form copy when the
 meeting moves**: its name carries the old date, and a stale name is how two
 ballots for one person stop being tellable apart.
 
@@ -238,7 +239,7 @@ is a correction.
 **No ballot collapses the ladder, it doesn't silence it.** With no form link
 attached, every rung becomes the one line that says so — *"{} is up for their
 month 1 check-in on Sep 3 and has no ballot attached yet."* — posted once.
-Chasing people three times toward a link that doesn't exist is noise, but a
+Chasing people twice toward a link that doesn't exist is noise, but a
 milestone days away with no ballot is worse news than one with an unfilled
 ballot, not better. `trial_vote_overdue` is exempt: it escalates the missed
 decision itself, which no form would have fixed.
@@ -321,7 +322,7 @@ Batching applies to Discord only; the log is never batched.
 
 These are the rules that keep the catalogue honest. Each is checkable.
 
-- **Every kind has an action.** All 37 payloads carry `links[0]`, which becomes
+- **Every kind has an action.** All 36 payloads carry `links[0]`, which becomes
   the hyperlink on the subject. A notification you can't act on is just news.
 - **Every kind is in `KINDS`.** An unmapped kind renders as `•` with a de-slugged
   label; `icon()`/`label()` warn once when that happens. A merge once dropped two

--- a/supabase/functions/_shared/recruit-copy.ts
+++ b/supabase/functions/_shared/recruit-copy.ts
@@ -72,7 +72,6 @@ export const KINDS: Record<string, { icon: string; label: string }> = {
   // Trial votes — the two moments the whole house weighs in on someone
   // already living here.
   trial_vote_open:        { icon: '📮', label: 'Ballot open' },
-  trial_vote_due:         { icon: '📢', label: 'Ballot due' },
   trial_vote_last_call:   { icon: '🚨', label: 'Last call before the meeting' },
   trial_vote_overdue:     { icon: '🟥', label: 'Ballot overdue' },
 }
@@ -126,8 +125,9 @@ export const TEMPLATES: Record<string, string> = {
   // keeps these lines forever.
   'trial_vote_open':              '{subject} is up for their {milestone} on {date}, and the house votes at the meeting on {close}.',
   'trial_vote_open.noform':       '{subject} is up for their {milestone} on {date} and has no ballot attached yet.',
-  'trial_vote_due':               "{subject}'s {milestone} lands {date}, so the ballot has to be in before the meeting on {close}.",
-  'trial_vote_last_call':         "The meeting on {close} is the last one before {subject}'s {milestone} on {date}.",
+  // Sent the morning of the meeting — but it says the date, not "tonight".
+  // The ledger keeps the line forever and "tonight" is wrong by tomorrow.
+  'trial_vote_last_call':         "The meeting on {close} is where the house votes on {subject}'s {milestone}, due {date}.",
   'trial_vote_overdue':           "The house still has not settled {subject}'s {milestone}, which was due {date}.",
 
   // --- the house

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1450,35 +1450,27 @@ async function detectOccupancyConflicts(db: DB): Promise<Notification[]> {
    the house talks — which is the Monday meeting. So the ballot closes at the
    last Monday meeting *before* the milestone, and every sentence names it.
 
-   Four rungs, escalating rather than repeating, all anchored on that meeting:
-     open      a week before it — the ballot exists, go fill it
-     due       three days before it — the weekend to do it in
-     last call the day of it
-     overdue   the milestone passed undecided — on-call, not the house */
-const VOTE_OPEN_LEAD = 7      // days before the closing meeting
-const VOTE_DUE_LEAD = 3       // days before the closing meeting
+   Two nudges, plus a backstop:
+     open      four days before the meeting — the Thursday, so the ballot has
+               the weekend to get filled in
+     last call the morning of the meeting
+     overdue   the milestone passed undecided — on-call, not the house
+
+   Two is the whole ladder on purpose. A ballot that is open for four days and
+   bumped once on the day is chased as hard as it can be without the channel
+   learning to skip these. */
+const VOTE_OPEN_LEAD = 4      // days before the closing meeting
 const VOTE_STALE_DAYS = 14    // past this, a milestone is history, not news
 
-/* When a ballot closes: the house's *month-end* meeting — the last Monday of a
-   month — that still falls on or before the milestone.
-
-   Trial milestones sit on month boundaries (month 1 is the 1st, a decision is a
-   month before a sublet ends), and the house settles a month at its last
-   meeting in the month before it. So a Oct 1 decision is taken at the Sep 28
-   meeting, not the one on Sep 21: "before the corresponding month" is the rule
-   the house already runs on, and the nearest Monday would have picked the wrong
-   meeting for every mid-month milestone. */
-function lastMondayOfMonth(year: number, month: number): string {
-  const d = new Date(Date.UTC(year, month + 1, 0))       // last day of that month
-  d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7))
-  return d.toISOString().slice(0, 10)
-}
+/* When a ballot closes: the Monday house meeting before the milestone. The
+   date on the stay is taken as it stands — a trial's dates are set by hand and
+   moved by hand, and the meeting is found from whatever they say rather than
+   rounded to a month boundary first. A milestone falling on a Monday closes at
+   the meeting the week before: answers are wanted going *into* the day. */
 export function ballotCloses(isoDate: string): string {
   const d = new Date(`${isoDate}T00:00:00Z`)
-  const own = lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth())
-  // A milestone before its own month's meeting belongs to the month before —
-  // which is every first-of-the-month milestone, i.e. most of them.
-  return own <= isoDate ? own : lastMondayOfMonth(d.getUTCFullYear(), d.getUTCMonth() - 1)
+  d.setUTCDate(d.getUTCDate() - (((d.getUTCDay() + 6) % 7) || 7))
+  return d.toISOString().slice(0, 10)
 }
 
 const MILESTONES = [
@@ -1527,10 +1519,9 @@ async function detectTrialVotes(db: DB): Promise<Notification[]> {
       // A date corrected after the fact isn't news.
       if (toMilestone < -VOTE_STALE_DAYS) continue
 
-      let step: 'open' | 'due' | 'last_call' | 'overdue' | null = null
+      let step: 'open' | 'last_call' | 'overdue' | null = null
       if (toMilestone < 0) step = 'overdue'
       else if (toClose <= 0) step = 'last_call'
-      else if (toClose <= VOTE_DUE_LEAD) step = 'due'
       else if (toClose <= VOTE_OPEN_LEAD) step = 'open'
       if (!step) continue
 

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.20.0'
+const VERSION = '1.21.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
Per Ian: respect the dates on the Resident trial stay → find the Monday before → open 4 days before that meeting → bump the morning of it.

## What changed

- **The dates are taken as they stand.** No rounding to a month boundary first — a trial's dates are set by hand and moved by hand, so the meeting is found from whatever they say. (Reverts the month-end anchoring from #1344.)
- **Open moved from 7 days to 4** — a Thursday, so the ballot has the weekend.
- **`trial_vote_due` is gone.** Four days plus a bump on the day is as hard as a ballot can be chased before the channel learns to skip these.
- **`trial_vote_last_call` is now the morning-of bump**, and names the meeting date rather than saying "tonight" — the ledger keeps the line forever.
- `trial_vote_overdue` stays as the on-call backstop.

## Against the live stays

| Person | Milestone | Meeting | Opens | Bump |
|---|---|---|---|---|
| Sophia | final decision, Thu Oct 1 | Mon Sep 28 | Thu Sep 24 | Mon Sep 28 |
| Sophia | month 1, Wed Jul 1 | Mon Jun 29 | Thu Jun 25 | Mon Jun 29 |
| Alejandra | final decision, Fri Jul 31 | Mon Jul 27 | Thu Jul 23 | Mon Jul 27 |

A milestone landing on a Monday closes at the meeting the week before — answers are wanted going into the day, not on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)