### PR TITLE
feat(recruiting): ballots make themselves on the cron

### DIFF
--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -244,10 +244,32 @@ milestone days away with no ballot is worse news than one with an unfilled
 ballot, not better. `trial_vote_overdue` is exempt: it escalates the missed
 decision itself, which no form would have fixed.
 
+### Where ballots come from
+
+**The cron makes them.** `ensureBallots` in `_shared/recruit-ballots.ts` runs
+once a day at **PT 8am** off the same 15-minute tick, ahead of the nudge ladder
+so a ballot made this morning is linked before the day's notifications go out.
+For every trial milestone whose meeting is within 14 days and which has no form
+yet, it copies the template into the folder under the name below and writes the
+responder URL onto the stay. It looks for the name before copying, so a save
+that fails can't leave the folder with three ballots for one person.
+
+Three settings, none of which need a deploy to change:
+`ballot_template_file_id`, `ballot_folder_id`, `ballot_lead_days`.
+
+**It needs Drive write, which the shared account does not yet have.** The
+account is consented to `drive.readonly`; every copy 403s, is caught, and the
+house gets the "no ballot attached yet" line — which is exactly what is true.
+Reconnecting the shared Gmail grants `.../auth/drive` and turns provisioning on
+with no code change. `drive.file` would not do: it gives per-file access to what
+the app created, and these copies land in a folder the app didn't make, inside a
+Shared Drive.
+
 ### Naming the form copies
 
 One copy per person per milestone — never a shared form, because answers about
-two people in one response sheet can't be read separately. Copy
+two people in one response sheet can't be read separately. The cron builds this
+name; make it by hand the same way. Copy
 [the housemate feedback form](https://docs.google.com/forms/d/1UpVuMOeSItoSvXpDn2LukBOl6_y0VWfSrrqXs3RWNrk/edit)
 into the **Housemate Feedback** folder it already lives in
 (`14VM4VP1_YpcIenjg-rWn5E_i_laY9_rw`, inside the Agape Shared Drive — the house

--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -249,8 +249,9 @@ decision itself, which no form would have fixed.
 One copy per person per milestone — never a shared form, because answers about
 two people in one response sheet can't be read separately. Copy
 [the housemate feedback form](https://docs.google.com/forms/d/1UpVuMOeSItoSvXpDn2LukBOl6_y0VWfSrrqXs3RWNrk/edit)
-into an Agape-owned `Housemate votes/{year}` folder (the template's own folder
-isn't writable by the house) and name it:
+into the **Housemate Feedback** folder it already lives in
+(`14VM4VP1_YpcIenjg-rWn5E_i_laY9_rw`, inside the Agape Shared Drive — the house
+has write access there, so copies sit next to the template) and name it:
 
 ```
 Agape vote · {member} · {Month 1 | Final decision} · {YYYY-MM-DD}
@@ -274,7 +275,13 @@ folder ends up with four naming schemes in it.
   The drawer shows the computed date under the milestone fields — copy it.
 
 The responses sheet inherits the name with `(Responses)` appended, so a ballot
-and its answers stay findable as a pair.
+and its answers stay findable as a pair. A copy does **not** inherit the
+template's responses — each ballot collects its own, which is the whole point of
+one copy per person per milestone.
+
+The link stored on the stay is the responder URL
+(`.../forms/d/{id}/viewform`), not the `/edit` one Drive hands back on copy: the
+nudges send housemates to fill the form in, not to edit it.
 
 ---
 

--- a/supabase/functions/_shared/recruit-ballots.ts
+++ b/supabase/functions/_shared/recruit-ballots.ts
@@ -1,0 +1,167 @@
+// Shared: provisioning the ballot behind each trial milestone.
+//
+// A trial candidate's month-1 check-in and final decision are each answered by
+// a copy of the housemate feedback form. Making those copies by hand is the one
+// step of the vote that needed a person with a browser, so it is the one step
+// that got skipped — a milestone would arrive with the house told to fill in a
+// form nobody had made. This makes them on the cron instead.
+//
+// Runs once a day off the existing 15-minute recruit-discord tick (PT 8am),
+// ahead of the nudge ladder in recruit-notify.ts, so a ballot created this
+// morning is already linked when the day's notifications go out.
+//
+// SCOPE. Copying needs Drive *write* on the shared account. The account is
+// currently consented to drive.readonly, so every call here 403s and is caught
+// — the house still gets the "no ballot attached yet" line, which is exactly
+// what is true. Re-consenting with the drive scope turns this on with no code
+// change. Nothing here throws into the tick.
+
+// deno-lint-ignore-file no-explicit-any
+
+import { sharedAccessToken } from './recruit-schedule.ts'
+
+type Db = any
+
+const DRIVE = 'https://www.googleapis.com/drive/v3'
+
+/* The template and where copies go. Both live in recruit_settings so a new
+   year's form, or a reorganised Drive, is a settings edit rather than a
+   deploy. Defaults are the form and folder the house uses today. */
+const DEFAULT_TEMPLATE = '1UpVuMOeSItoSvXpDn2LukBOl6_y0VWfSrrqXs3RWNrk'
+const DEFAULT_FOLDER = '14VM4VP1_YpcIenjg-rWn5E_i_laY9_rw'   // "Housemate Feedback"
+const DEFAULT_LEAD_DAYS = 14   // make the ballot this far ahead of the meeting
+
+const MILESTONES = [
+  ['checkin', 'Month 1'],
+  ['decision', 'Final decision'],
+] as const
+
+/* The Monday meeting a ballot closes at. Same rule as ballotCloses() in
+   recruit-notify.ts — the name has to carry the date the nudges say. */
+function closesOn(isoDate: string): string {
+  const d = new Date(`${isoDate}T00:00:00Z`)
+  d.setUTCDate(d.getUTCDate() - (((d.getUTCDay() + 6) % 7) || 7))
+  return d.toISOString().slice(0, 10)
+}
+
+/* The one naming convention, in code, so the folder can't drift into four of
+   them: Agape vote · {member} · {Month 1 | Final decision} · {meeting date}. */
+export function ballotName(occupant: string, milestone: string, close: string): string {
+  return `Agape vote · ${occupant} · ${milestone} · ${close}`
+}
+
+/* What housemates get sent to. Drive hands back an /edit URL on copy; the
+   nudges want the responder form, not the editor. */
+const responderUrl = (fileId: string) => `https://docs.google.com/forms/d/${fileId}/viewform`
+
+async function driveJson(token: string, url: string, init?: RequestInit): Promise<any> {
+  const resp = await fetch(url, {
+    ...init,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', ...(init?.headers || {}) },
+  })
+  const body = await resp.json().catch(() => ({}))
+  if (!resp.ok) {
+    const reason = body?.error?.message || `HTTP ${resp.status}`
+    const err = new Error(reason) as Error & { status?: number }
+    err.status = resp.status
+    throw err
+  }
+  return body
+}
+
+/* Find the copy before making one. The stay's URL column is the record, but a
+   copy that landed and then failed to save would otherwise be remade every
+   morning — one ballot per person per milestone is the whole point, and a
+   folder with three "Final decision" forms in it is worse than none.
+
+   supportsAllDrives / includeItemsFromAllDrives are not optional: the folder
+   lives in the Agape Shared Drive, and without them Drive answers as though it
+   doesn't exist. */
+async function findExisting(token: string, folderId: string, name: string): Promise<string | null> {
+  const q = `'${folderId}' in parents and name = '${name.replace(/'/g, "\\'")}' and trashed = false`
+  const out = await driveJson(token,
+    `${DRIVE}/files?q=${encodeURIComponent(q)}&fields=files(id,name)` +
+    `&supportsAllDrives=true&includeItemsFromAllDrives=true`)
+  return out.files?.[0]?.id || null
+}
+
+async function copyTemplate(token: string, templateId: string, folderId: string, name: string): Promise<string> {
+  const out = await driveJson(token, `${DRIVE}/files/${templateId}/copy?supportsAllDrives=true`, {
+    method: 'POST',
+    body: JSON.stringify({ name, parents: [folderId] }),
+  })
+  if (!out.id) throw new Error('Drive returned no file id')
+  return out.id
+}
+
+async function setting(db: Db, key: string, fallback: string): Promise<string> {
+  const { data } = await db.from('recruit_settings').select('value').eq('key', key).maybeSingle()
+  const v = data?.value
+  return typeof v === 'string' && v.trim() ? v.trim() : fallback
+}
+
+/* Make every ballot a live trial is about to need, and link it to the stay.
+   Returns how many were created. Never throws: a Drive outage, or the missing
+   write scope, must not cost the tick its screening reminders. */
+export async function ensureBallots(db: Db): Promise<number> {
+  const [templateId, folderId, leadRaw] = await Promise.all([
+    setting(db, 'ballot_template_file_id', DEFAULT_TEMPLATE),
+    setting(db, 'ballot_folder_id', DEFAULT_FOLDER),
+    setting(db, 'ballot_lead_days', String(DEFAULT_LEAD_DAYS)),
+  ])
+  const lead = Number(leadRaw) || DEFAULT_LEAD_DAYS
+
+  const { data: stays } = await db.from('recruit_stays')
+    .select('id, kind, occupant, checkin_on, decision_on, checkin_form_url, decision_form_url')
+    .eq('kind', 'candidate')
+  if (!stays?.length) return 0
+
+  const today = new Date().toISOString().slice(0, 10)
+  const horizon = new Date(Date.now() + lead * 86400000).toISOString().slice(0, 10)
+
+  let token: string
+  try {
+    token = await sharedAccessToken(db)
+  } catch (err) {
+    console.warn(`[ballots] no shared-account token: ${(err as Error).message}`)
+    return 0
+  }
+
+  let made = 0
+  for (const s of stays) {
+    const who = String(s.occupant || '').trim()
+    if (!who) continue
+    for (const [which, milestone] of MILESTONES) {
+      const on: string | null = which === 'checkin' ? s.checkin_on : s.decision_on
+      if (!on || (which === 'checkin' ? s.checkin_form_url : s.decision_form_url)) continue
+
+      const close = closesOn(on)
+      // Not yet worth making, or long past being useful. A milestone whose
+      // meeting has already happened still gets one while the milestone itself
+      // is ahead — that ballot is late, but a late ballot beats none.
+      if (close > horizon || on < today) continue
+
+      const name = ballotName(who, milestone, close)
+      try {
+        const fileId = await findExisting(token, folderId, name) ||
+          await copyTemplate(token, templateId, folderId, name)
+        const { error } = await db.from('recruit_stays')
+          .update({ [`${which}_form_url`]: responderUrl(fileId) }).eq('id', s.id)
+        if (error) throw new Error(error.message)
+        console.log(`[ballots] ${name} → ${fileId}`)
+        made++
+      } catch (err) {
+        const e = err as Error & { status?: number }
+        // 403 here is the drive.readonly consent, not a transient fault. Say so
+        // once, plainly, rather than burying it in a generic failure.
+        if (e.status === 403) {
+          console.warn(`[ballots] Drive refused the copy — the shared account is consented to drive.readonly. ` +
+            `Reconnect it with the drive scope to let ballots make themselves. (${e.message})`)
+          return made
+        }
+        console.warn(`[ballots] ${name} failed: ${e.message}`)
+      }
+    }
+  }
+  return made
+}

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.21.0'
+const VERSION = '1.22.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -21,6 +21,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { scheduleScreening, sendIntroEmail, sharedAccessToken, sweepCalendars, HOUSE_CALENDAR_ID, SHARED_EMAIL } from '../_shared/recruit-schedule.ts'
 import { editSchedulerSignedUp, editSchedulerFailed, dmUser, slotLabel, slotWhen } from '../_shared/discord.ts'
 import { notifyTick, previewTick } from '../_shared/recruit-notify.ts'
+import { ensureBallots } from '../_shared/recruit-ballots.ts'
 
 declare const EdgeRuntime: { waitUntil(p: Promise<unknown>): void } | undefined
 
@@ -561,6 +562,15 @@ async function notifyUnmatchedCalls(client: ReturnType<typeof db>): Promise<numb
   return notified
 }
 
+// House-local hour, 0–23. The tick runs every 15 minutes; work that should
+// happen once a day picks its hour with this rather than earning a cron of its
+// own. PT, not UTC — "8am" is a time the house recognises.
+function ptHour(now = new Date()): number {
+  return Number(new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles', hour12: false, hour: '2-digit',
+  }).format(now)) % 24
+}
+
 // Trial-candidate milestones used to post their own one-shot embeds from here.
 // They are now four escalating rungs in the notification ledger
 // (detectTrialVotes in _shared/recruit-notify.ts), so they get copy overrides,
@@ -868,6 +878,18 @@ serve(async (req) => {
       const recorded = await processRecordings(client) + await processMeetingRecordings(client)
       const archived = await archiveMissingRecordings(client)
       if (archived) console.log(`[archive] ${archived} recording(s) copied to storage`)
+      /* Trial ballots, once a day at PT 8am — the copy of the feedback form
+         each milestone is voted with. Ahead of the ledger on purpose: a ballot
+         made this morning is linked by the time the day's nudges go out, so
+         the house never gets told to fill in a form that doesn't exist yet.
+         Idempotent, so the four ticks inside the 8am hour cost one pass. */
+      let ballots = 0
+      if (ptHour() === 8) {
+        try { ballots = await ensureBallots(client) } catch (err) {
+          console.warn(`[ballots] pass failed: ${(err as Error).message}`)
+        }
+        if (ballots) console.log(`[ballots] ${ballots} created`)
+      }
       // The notification ledger: detect what's true now, write it to the log,
       // then broadcast whatever the house is owed. Isolated from everything
       // above — a failing detector must not cost the screening reminders their
@@ -876,8 +898,8 @@ serve(async (req) => {
       try { notify = await notifyTick(client) } catch (err) {
         console.warn(`[notify] tick failed: ${(err as Error).message}`)
       }
-      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${recorded} recording(s), notify ${notify.detected} new / ${notify.logged} logged / ${notify.now} posted / ${notify.digest} digested`)
-      return json({ bots, live, reminded: sent, recorded, notify })
+      console.log(`[recruit-discord] tick: ${bots} bot(s), ${live} live post(s), ${sent} reminder(s), ${recorded} recording(s), ${ballots} ballot(s), notify ${notify.detected} new / ${notify.logged} logged / ${notify.now} posted / ${notify.digest} digested`)
+      return json({ bots, live, reminded: sent, recorded, ballots, notify })
     }
 
     const pathname = new URL(req.url).pathname

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -44,6 +44,16 @@ const SCOPES = [
   'https://www.googleapis.com/auth/calendar.events', // screening-call invites
   'https://www.googleapis.com/auth/spreadsheets.readonly', // application-sheet ingest
   'https://www.googleapis.com/auth/drive.readonly', // review comment threads on the application sheet
+  /* Trial ballots copy the housemate feedback form into the Housemate Feedback
+     folder on the cron (_shared/recruit-ballots.ts). drive.file is not enough:
+     it gives per-file access to what the app itself created, and the copy has
+     to land in a folder the app didn't make, inside a Shared Drive.
+
+     Adding this line changes nothing on its own — the shared account keeps
+     whatever it was consented to until somebody reconnects it. Until then
+     ballot provisioning 403s, is caught, and the house sees "no ballot
+     attached yet", which is true. */
+  'https://www.googleapis.com/auth/drive',
 ]
 
 function db() {


### PR DESCRIPTION
Copying the feedback form was the one step of a trial vote that needed a person with a browser — so it was the step that got skipped, and a milestone would arrive with the house told to fill in a form nobody had made.

## What runs

`ensureBallots()` in `_shared/recruit-ballots.ts`, **once a day at PT 8am** off the existing 15-minute tick — no new schedule to maintain, and it's gated on the hour rather than earning its own cron. It runs *ahead* of the nudge ladder so a ballot made this morning is linked before the day's notifications go out.

For each trial milestone whose meeting is within 14 days and which has no form yet:
1. look for `Agape vote · {member} · {Month 1 | Final decision} · {meeting}` in the folder
2. copy the template under that name if it isn't there
3. write the `/viewform` responder URL onto the stay

Step 1 is what keeps a failed save from leaving three ballots for one person in the folder. Idempotent, so the four ticks inside the 8am hour cost one pass.

Settings, changeable without a deploy: `ballot_template_file_id`, `ballot_folder_id`, `ballot_lead_days`.

## ⚠️ One human step, once

The shared Google account is consented to **`drive.readonly`** — enough to read the template, not to copy it. **Every copy 403s today.** That's caught and logged plainly, and the house still gets the "no ballot attached yet" line, which is exactly what's true. Nothing breaks; the automation is just inert.

Reconnecting the shared Gmail (`live.at.agapesf@gmail.com`) grants `.../auth/drive` and turns provisioning on with **no code change**. `drive.file` won't do — it gives per-file access to what the app itself created, and these copies land in a folder the app didn't make, inside a Shared Drive.

Adding the scope to the list changes nothing on its own: the account keeps whatever it was consented to until someone reconnects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)