### PR TITLE
fix(recruiting): notifications are hyperlinked again

### DIFF
--- a/docs/ux/recruiting-notifications-catalog.md
+++ b/docs/ux/recruiting-notifications-catalog.md
@@ -257,9 +257,15 @@ that fails can't leave the folder with three ballots for one person.
 Three settings, none of which need a deploy to change:
 `ballot_template_file_id`, `ballot_folder_id`, `ballot_lead_days`.
 
-**It needs Drive write, which the shared account does not yet have.** The
-account is consented to `drive.readonly`; every copy 403s, is caught, and the
-house gets the "no ballot attached yet" line — which is exactly what is true.
+`POST /recruit-discord/remind?ballots=1` forces a pass off-schedule, behind the
+same cron auth — for the morning someone reconnects the account and doesn't want
+to wait until 8am to find out whether it worked.
+
+**Only the copy needs Drive write, and the shared account doesn't have it yet.**
+Everything else already works on `drive.readonly`: a pass finds a ballot that
+exists by name and links it to the stay, which is how a form made by hand gets
+picked up without anyone pasting a URL. Only the copy itself 403s — caught, and
+the house gets the "no ballot attached yet" line, which is exactly what is true.
 Reconnecting the shared Gmail grants `.../auth/drive` and turns provisioning on
 with no code change. `drive.file` would not do: it gives per-file access to what
 the app created, and these copies land in a folder the app didn't make, inside a

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -324,8 +324,17 @@ export async function record(db: DB, rows: Notification[]): Promise<number> {
     dedupe_key: n.dedupe_key,
     payload: {
       ...n.payload,
+      /* {subject} renders as the literal slot `{}`, never as the name. The
+         subject is the hyperlink — oneLine() and the app's Activity view both
+         substitute `{}` with the linked name at display time, which is the only
+         moment the URL is known. Rendering the name here produced sentences
+         with nothing to click: correct words, dead line.
+
+         Forced here rather than asked of each detector, because thirty-odd
+         call sites passing `subject: '{}'` by convention is thirty-odd chances
+         to pass the name instead — which is exactly what happened. */
       sentence: n.payload.copy
-        ? renderCopy(n.payload.copy, n.payload.vars || {}, overrides)
+        ? renderCopy(n.payload.copy, { ...(n.payload.vars || {}), subject: '{}' }, overrides)
         : n.payload.sentence,
     },
     due_at: n.due_at || new Date().toISOString(),
@@ -1834,6 +1843,11 @@ export async function previewTick(db: DB): Promise<Array<Record<string, unknown>
     lane: n.lane || 'daily',
     audience: n.audience || 'house',
     copy: n.payload.copy || null,
+    /* The preview renders the real name where a stored row keeps `{}` — a dry
+       run is read by a person, and "{} is up for their final decision" tells
+       them nothing about who. Deliberate divergence from record(): don't
+       "fix" this into matching, and don't trust it to prove a line is linked.
+       It won't show the difference. */
     line: `${icon(n.kind)} ${n.payload.copy
       ? renderCopy(n.payload.copy, n.payload.vars || {}, overrides)
       : (n.payload.sentence || '')}`.replace('{subject}', String(n.payload.vars?.subject ?? n.payload.title)),

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.22.1'
+const VERSION = '1.22.2'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.30.1'
+const VERSION = '1.30.2'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'


### PR DESCRIPTION
Ian spotted it on a trial-vote line: *"The meeting on Jul 27 is where the house votes on Alejandra's final decision, due Jul 31"* with nothing to click.

## The bug is not limited to trial votes

The subject **is** the hyperlink. `oneLine()` and the app's Activity view (`app.js:2030`) both substitute the slot `{}` with the linked name at display time — the only moment the URL is known. Moving all copy into one module (#1339) made `record()` render `{subject}` as the plain name, so the slot never survives to display.

Every notification written since then went out dead. In the ledger:

```
{} has been waiting 24 days for a review.          ← written by the old code, linkable
Alejandra is up for their final decision on...     ← written by the new code, not
```

Trial votes were simply the first kind whose rows were all written after the regression.

## Fix

`record()` renders with `subject: '{}'` forced, rather than asking each detector to pass it. Thirty-odd call sites honouring a convention is thirty-odd chances to pass the name instead — which is what happened.

## Why a dry run didn't catch it

`previewTick` renders the real name on purpose — a preview is read by a person, and *"{} is up for their final decision"* tells them nothing about who. That divergence is now commented, along with a note that the preview can't prove a line is linked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)