### PR TITLE
fix(recruiting): mirror duplicate guard + missing fmtWindows

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -252,11 +252,15 @@ export async function upsertScreenerScheduler(db: any, input: ScreenerSchedulerI
 
   const message = await postOrPatch(CLAIMS_CHANNEL_ID, live?.discord_message_id || null, payload)
   // Mirror copy is best-effort: missing channel perms must not kill the post.
+  // While society posts are held, NOTES resolves to the same channel as the
+  // primary — mirroring then would just duplicate the scheduler post.
   let mirror: any = null
-  try {
-    mirror = await postOrPatch(NOTES_CHANNEL_ID, live?.mirror_message_id || null, payload)
-  } catch (err) {
-    console.warn(`[discord] mirror post failed for ${input.applicantId}: ${(err as Error).message}`)
+  if (NOTES_CHANNEL_ID !== CLAIMS_CHANNEL_ID) {
+    try {
+      mirror = await postOrPatch(NOTES_CHANNEL_ID, live?.mirror_message_id || null, payload)
+    } catch (err) {
+      console.warn(`[discord] mirror post failed for ${input.applicantId}: ${(err as Error).message}`)
+    }
   }
 
   const { data: row, error } = await db.from('recruit_claim_posts').upsert({

--- a/supabase/functions/recruit-availability/index.ts
+++ b/supabase/functions/recruit-availability/index.ts
@@ -7,7 +7,7 @@
 // POST { token }                      → { firstName, windows }
 // POST { token, windows: [...] }      → save; { saved: true, windows }
 
-const VERSION = '1.2.4'
+const VERSION = '1.2.5'
 console.log(`[recruit-availability] v${VERSION} — public applicant availability endpoint + Discord claim post`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.22.0'
+const VERSION = '1.22.1'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.30.2'
+const VERSION = '1.30.3'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, sweepCalendars, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertScreenerScheduler, editSchedulerSignedUp, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID } from '../_shared/discord.ts'
+import { upsertScreenerScheduler, editSchedulerSignedUp, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID, ptToUTC } from '../_shared/discord.ts'
 import { record } from '../_shared/recruit-notify.ts'
 import { ACTIONS } from '../_shared/recruit-copy.ts'
 
@@ -436,6 +436,17 @@ function extractRecordingUrls(text: string): string[] {
     } catch { /* not a URL we can parse */ }
   }
   return [...out]
+}
+
+// "Thu Jul 31 9:00a–12:00p · Fri Aug 1 1:00p–3:00p" — for reply notifications.
+function fmtWindows(windows?: Array<{ date: string; start: string; end: string }>): string {
+  const t = (d: Date) => d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ })
+    .toLowerCase().replace(' am', 'a').replace(' pm', 'p')
+  return (windows || []).slice(0, 4).map((w) => {
+    const s = ptToUTC(w.date, w.start)
+    const e = ptToUTC(w.date, w.end)
+    return `${s.toLocaleString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: TZ })} ${t(s)}–${t(e)}`
+  }).join(' · ')
 }
 
 function header(headers: Array<{ name: string; value: string }>, name: string): string {


### PR DESCRIPTION
Pre-flight fixes found while code-checking the end-to-end test path:

1. With all posts routed to #recruiting-automation, the scheduler's mirror would post a duplicate into the same channel — now skipped when NOTES == CLAIMS.
2. `fmtWindows` was referenced in the availability reply-notification path but never defined — a guaranteed ReferenceError on the exact flow the E2E test exercises. Implemented with the timezone-correct helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)