### PR TITLE
docs: rescue five PRDs from orphaned branches; preview shows the prompt

### DIFF
--- a/docs/infrastructure/archive/openclaw-handoff-protocol.md
+++ b/docs/infrastructure/archive/openclaw-handoff-protocol.md
@@ -1,0 +1,465 @@
+> **Archived from an orphaned branch.** Recovered from `claude/setup-openclaw-context-m1JKS` (last touched 2026-02-15),
+> which shares no history with master after the repository history was rewritten.
+> Kept for the thinking in it; nothing here is current.
+
+# OpenClaw → Claude Code Build Prompt Protocol
+
+> Defines the exact format, fields, and structure that OpenClaw should use when generating build prompts for Claude Code sessions on **ctrl.rodeo**.
+
+---
+
+## 1. Required Fields
+
+Every build prompt must include these fields. Claude Code will ask clarifying questions for anything missing — which is wasted round-trips.
+
+| # | Field | Purpose | Example | Required? |
+|---|-------|---------|---------|-----------|
+| 1 | **Goal** | One sentence: what should be true when done | "Users can share a board via public URL" | **Must** |
+| 2 | **Scope** | Explicit boundaries — what to change and what NOT to touch | "Modify `boards/index.html` and add a new edge function. Do not change the design system." | **Must** |
+| 3 | **Acceptance Criteria** | Testable conditions (see §3) | "Given a board with 3 pins, when I click Share, a public URL is generated and loads in incognito" | **Must** |
+| 4 | **Affected Files** | Files to read/modify (paths from repo root) | `boards/index.html`, `supabase/functions/share-board/index.ts` | **Must** |
+| 5 | **Branch** | Branch name to work on | `claude/share-boards-Xk9mT` | **Must** |
+| 6 | **Context Snippet** | Relevant code excerpts, PRD sections, or architectural constraints | See §4 for format | **Must** |
+| 7 | **Constraints** | Tech stack rules, patterns to follow, things to avoid | "No frameworks. Vanilla JS only. Dark mode first. Must work on mobile." | **Must** |
+| 8 | **Category** | Type of work: `feature`, `bugfix`, `refactor`, `docs`, `infra` | `feature` | *High leverage* |
+| 9 | **Related Docs** | Links to PRDs, tech specs, or design system references | `docs/strategy/prds/boards-mvp.md` | *High leverage* |
+| 10 | **Test Commands** | How to verify the work | "Open `boards/index.html` in browser, add a pin, click Share" | *High leverage* |
+| 11 | **Deploy Steps** | Post-merge actions | `supabase functions deploy share-board --project-ref yfhudwakpgzswiylhfbh` | *High leverage* |
+| 12 | **Dependencies** | Other tasks/PRs this depends on or blocks | "Requires #98 merged first" | *Optional* |
+
+---
+
+## 2. Ideal Prompt Order
+
+The sections should appear in this exact order. The rationale: I parse top-down, and each section narrows the solution space for everything below it.
+
+```
+1. GOAL          — Sets the mental model. Everything else is evaluated against this.
+2. CATEGORY      — Tells me the shape of the work (new code vs. fixing existing).
+3. SCOPE         — Eliminates 90% of the codebase from consideration.
+4. CONSTRAINTS   — Prevents me from reaching for wrong patterns.
+5. CONTEXT       — Now I'm ready to absorb details with the right frame.
+6. AFFECTED FILES — Directs my file reads.
+7. ACCEPTANCE CRITERIA — I now know what "done" looks like.
+8. TEST COMMANDS — How to verify.
+9. DEPLOY STEPS  — What happens after merge.
+10. RELATED DOCS — Background reading, lowest priority but available.
+```
+
+**Why this order reduces errors:**
+- **Goal + Category first** prevents me from solving the wrong problem.
+- **Scope + Constraints before Context** means I don't waste time reading irrelevant code or proposing forbidden patterns.
+- **Acceptance Criteria after Context** means I can cross-reference them against reality.
+- **Deploy Steps last** because they're post-implementation; putting them early creates noise.
+
+---
+
+## 3. Acceptance Criteria Standard
+
+### Format: Given/When/Then checklist
+
+Every criterion must be **independently testable**. Use this format:
+
+```markdown
+## Acceptance Criteria
+- [ ] Given [precondition], when [action], then [observable result]
+- [ ] Given [precondition], when [action], then [observable result]
+- [ ] Build completes without errors
+- [ ] No new lint warnings introduced
+- [ ] Works on mobile viewport (375px)
+- [ ] Dark mode renders correctly
+```
+
+### Standard verification checklist (append to every prompt)
+
+```markdown
+## Verification Checklist
+- [ ] All acceptance criteria met
+- [ ] No hardcoded secrets or API keys in committed code
+- [ ] Mobile responsive (tested at 375px width)
+- [ ] Dark mode first (no light-mode-only styles)
+- [ ] Commit messages are clear and descriptive
+- [ ] PR created and merged to master
+- [ ] Edge functions deployed (if changed)
+```
+
+---
+
+## 4. Repo Context & File Handling
+
+### File paths
+Always use **repo-root-relative paths**. Never absolute paths in prompts.
+
+```
+Good: boards/index.html
+Good: supabase/functions/enrich-link/index.ts
+Bad:  /Users/ian/Documents/GitHub/fikei.github.io/boards/index.html
+```
+
+### File excerpts
+Provide the **function or block** that matters, with line numbers and file path. Keep excerpts under 100 lines — I can read the full file myself.
+
+```markdown
+### Context: `boards/index.html:1842-1870`
+```js
+function addPin(url, category) {
+  const pin = {
+    id: crypto.randomUUID(),
+    url: url,
+    category: category || 'uncategorized',
+    created: new Date().toISOString()
+  };
+  pins.push(pin);
+  saveToLocalStorage();
+  renderBoard();
+}
+`` `
+```
+
+### Referencing existing functions/classes
+Use the format `file_path:function_name` or `file_path:line_number`:
+
+```
+boards/index.html:addPin
+boards/index.html:1842
+supabase/functions/enrich-link/index.ts:enrichUrl
+```
+
+### Minimum repo snapshot needed
+I have full file access, so I don't need a repo dump. Instead provide:
+
+1. **Affected file paths** (I'll read them myself)
+2. **Relevant excerpts** only if they save me from reading a 5000-line file to find the right section
+3. **Architecture constraints** — which Supabase project, which edge function pattern to follow
+
+**Do not** paste entire files into the prompt. Point me to them and I'll read what I need.
+
+---
+
+## 5. Diff / Patch Preference
+
+### Preferred: Stepwise natural-language edits
+
+I work best when told **what to change and why**, not given pre-computed diffs. I generate my own edits using the Edit tool.
+
+```markdown
+## Changes Needed
+1. In `boards/index.html`, add a "Share" button to the board header (after the board title)
+2. Create `supabase/functions/share-board/index.ts` following the pattern in `enrich-link/index.ts`
+3. Add a `shared_boards` table — provide the schema below
+```
+
+### Acceptable: Unified diffs (for precise, surgical changes)
+
+If the change is very specific (e.g., a one-line config fix), a unified diff is fine:
+
+```diff
+--- a/boards/index.html
++++ b/boards/index.html
+@@ -42,7 +42,7 @@
+-  const API_VERSION = 'v5';
++  const API_VERSION = 'v6';
+```
+
+### Avoid
+- File-by-file full replacements (wasteful, error-prone)
+- Pseudo-code descriptions of changes ("make it better", "optimize this")
+
+---
+
+## 6. Resume-Session Method
+
+When resuming work across sessions, provide this state bundle:
+
+```markdown
+## Resume Context
+
+### Branch
+claude/share-boards-Xk9mT
+
+### Last completed step
+3 of 7 — "Created share-board edge function"
+
+### Remaining work
+4. Wire Share button to edge function call
+5. Add clipboard copy feedback
+6. Test on mobile
+7. Create PR and merge
+
+### Key decisions already made
+- Using signed URLs (not public by default)
+- 24-hour expiry on share links
+- No authentication required to view shared board
+
+### Current blockers
+None
+
+### Files modified so far
+- boards/index.html (Share button HTML added)
+- supabase/functions/share-board/index.ts (created)
+- supabase/migrations/20260215_shared_boards.sql (created)
+```
+
+**Minimum fields for resume:**
+1. **Branch name** — so I can check git log and diff
+2. **Last completed step** — so I don't redo work
+3. **Remaining work** — so I know what's next
+4. **Key decisions** — so I don't re-debate settled choices
+
+If the branch exists, I can reconstruct most context from `git log` and `git diff master...HEAD`. But explicit decisions and remaining work save significant time.
+
+---
+
+## 7. Noise to Exclude
+
+### Do not include
+| Noise | Why it hurts |
+|-------|-------------|
+| Product philosophy / brand manifesto | Already in CLAUDE.md; repeating it wastes tokens |
+| Full file dumps | I have file access; point me to paths |
+| Conversation history | Start fresh; use Resume Context (§6) if continuing |
+| Multiple competing approaches | Pick one. If unsure, say "recommend an approach" as the goal |
+| Vague praise/motivation | "Make it awesome" adds nothing |
+| Implementation details I should decide | "Use whatever data structure works best" — just state the constraint |
+
+### Common failure modes in prompts
+
+| Failure Mode | Result | Prevention |
+|-------------|--------|------------|
+| **No acceptance criteria** | I build something, you reject it, repeat 3x | Always include testable criteria (§3) |
+| **Scope too broad** | I touch 20 files, introduce regressions | Limit scope to one feature/fix per prompt |
+| **Contradictory constraints** | I stall asking for clarification | Review constraints for conflicts before sending |
+| **Missing file references** | I search the wrong area of the codebase | List affected files explicitly (§1, field 4) |
+| **Assumed knowledge** | I hallucinate how your auth works | Include relevant excerpts or point to docs |
+| **"Fix everything" goal** | Unfocused work, nothing ships | One goal per prompt, always |
+| **Pre-computed solution** | You paste a diff but it doesn't apply; I waste time debugging your diff | Describe the change; let me implement it |
+
+---
+
+## 8. Example: Perfect Feature Prompt
+
+```markdown
+## Goal
+Users can share a board via a public URL that shows a read-only view of their pins.
+
+## Category
+feature
+
+## Scope
+- Modify: `boards/index.html` (add Share button, share modal, public view mode)
+- Create: `supabase/functions/share-board/index.ts`
+- Create: `supabase/migrations/20260215_shared_boards.sql`
+- Do NOT modify: design system files, other edge functions, events page
+
+## Constraints
+- Vanilla JS only, no frameworks
+- Dark mode first
+- Mobile responsive (must work at 375px)
+- Follow edge function pattern from `supabase/functions/enrich-link/index.ts`
+- Supabase project: Boards (ref: yfhudwakpgzswiylhfbh)
+- Share links expire after 24 hours
+- No authentication required to view a shared board
+
+## Context
+### How pins are stored: `boards/index.html:1842-1860`
+[relevant excerpt here]
+
+### Current board header: `boards/index.html:320-335`
+[relevant excerpt here]
+
+### Edge function pattern: `supabase/functions/enrich-link/index.ts:1-30`
+[relevant excerpt showing the Deno serve pattern, CORS headers, etc.]
+
+## Affected Files
+- boards/index.html
+- supabase/functions/share-board/index.ts (new)
+- supabase/migrations/20260215_shared_boards.sql (new)
+
+## Acceptance Criteria
+- [ ] Given a board with 3+ pins, when I click "Share", a modal appears with a generated URL
+- [ ] Given a share URL, when I open it in incognito, the board renders read-only with all pins visible
+- [ ] Given a share link older than 24 hours, when I open it, I see an "expired" message
+- [ ] Given a mobile viewport (375px), the share modal and public view are usable
+- [ ] Given dark mode, all share UI elements render correctly
+- [ ] Build completes without errors
+- [ ] No hardcoded secrets in committed code
+
+## Test Commands
+1. Open `boards/index.html` locally
+2. Add 3 test pins
+3. Click Share, copy URL
+4. Open URL in incognito — verify read-only view
+5. Verify mobile layout at 375px
+
+## Deploy Steps
+supabase link --project-ref yfhudwakpgzswiylhfbh
+supabase functions deploy share-board
+supabase db push (for migration)
+
+## Related Docs
+- docs/strategy/prds/boards-mvp.md
+- docs/infrastructure/technical-design/ai-widget-system.md (for Supabase patterns)
+```
+
+---
+
+## 9. Example: Bugfix Prompt
+
+```markdown
+## Goal
+Fix: Pins with YouTube URLs show a broken thumbnail instead of the video preview image.
+
+## Category
+bugfix
+
+## Scope
+- Modify: `boards/index.html` (pin rendering logic)
+- Possibly modify: `supabase/functions/enrich-link/index.ts` (if the enrichment response is wrong)
+- Do NOT modify: widget system, design system, other categories
+
+## Constraints
+- YouTube URLs come in multiple formats: youtube.com/watch?v=, youtu.be/, youtube.com/shorts/
+- Must handle all three formats
+- Do not break existing thumbnail rendering for non-YouTube URLs
+
+## Context
+### Bug reproduction
+1. Add pin with URL: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+2. Pin appears with broken image icon instead of thumbnail
+3. Expected: YouTube thumbnail from img.youtube.com/vi/{id}/hqdefault.jpg
+
+### Current thumbnail logic: `boards/index.html:2100-2130`
+```js
+function getThumbnail(pin) {
+  if (pin.enrichment?.image) return pin.enrichment.image;
+  return pin.metadata?.ogImage || '/img/placeholder.png';
+}
+`` `
+
+### Enrich-link response for YouTube URLs
+The `enrich-link` function returns `ogImage` but it's a relative URL without the domain prefix.
+
+## Affected Files
+- boards/index.html (getThumbnail function, ~line 2100)
+- supabase/functions/enrich-link/index.ts (YouTube-specific handling, if needed)
+
+## Acceptance Criteria
+- [ ] Given a youtube.com/watch?v= URL, the correct thumbnail renders
+- [ ] Given a youtu.be/ short URL, the correct thumbnail renders
+- [ ] Given a youtube.com/shorts/ URL, the correct thumbnail renders
+- [ ] Given a non-YouTube URL with a valid ogImage, thumbnails still work as before
+- [ ] Given a URL with no image at all, the placeholder still renders
+
+## Test Commands
+1. Add pins for all 3 YouTube URL formats
+2. Verify thumbnails render for each
+3. Add a non-YouTube pin (e.g., nytimes.com article) — verify it still works
+4. Add a pin with no og:image — verify placeholder appears
+
+## Related Docs
+- docs/infrastructure/technical-design/ai-widget-system.md §Pin Enrichment
+```
+
+---
+
+## 10. ctrl.rodeo Product Context (For OpenClaw Reference)
+
+When generating prompts for ctrl.rodeo, OpenClaw should know these constants — they don't need to be repeated in every prompt because they live in `CLAUDE.md`, but OpenClaw needs them to generate correct prompts.
+
+### Product Identity
+- **Name**: ctrl.rodeo
+- **What it is**: Personal curation platform — collect, organize, build on everything that matters
+- **Primary audience**: Creatives (artists, designers, musicians, DJs)
+- **Tagline**: Your likes. Your saves. Your life — organized.
+
+### Brand Principles (inform every feature decision)
+1. Input shapes output
+2. Organize as you go (AI handles categorization)
+3. One place, whole life (no silos)
+4. Show, don't decorate (minimal UI, content is the design)
+5. Expand with the user (progressive complexity)
+
+### Tech Stack Constants
+- Frontend: HTML/CSS/vanilla JS (no frameworks, ever)
+- Backend: Supabase Edge Functions (TypeScript/Deno)
+- AI: Claude 3 Haiku (primary), GPT-4o mini (fallback)
+- Database: Supabase PostgreSQL
+- Hosting: GitHub Pages at ctrl.rodeo
+- Design: Dark mode first, mobile responsive, black/white aesthetic
+
+### Supabase Projects
+| Project | Ref ID | Purpose |
+|---------|--------|---------|
+| Boards | `yfhudwakpgzswiylhfbh` | Main app |
+| Ops | `ycilriwjnmcelkspmfmg` | Automation |
+| Systemic | `atdqdfpdeytfuvvpsasz` | Design tools |
+
+### Content Categories
+home, wear, watch, listen, use, eat, go, follow, read
+
+### Process Rules
+- Always create feature branch (`claude/<topic>-<random>`)
+- Always create PR to merge to master (never push directly)
+- Always merge the PR when done
+- Deploy edge functions after merge if changed
+- GitHub is source of truth for all documentation
+
+### What CLAUDE.md Already Covers
+OpenClaw should **not** repeat these in prompts — Claude Code reads them automatically:
+- Directory structure
+- Design system rules
+- Commit practices
+- Documentation agent commands
+- Supabase config and deploy commands
+- Widget design audit workflow
+- Autonomous operation permissions
+
+---
+
+## Quick Reference: Prompt Template
+
+Copy and fill in:
+
+```markdown
+## Goal
+[One sentence: what should be true when done]
+
+## Category
+[feature | bugfix | refactor | docs | infra]
+
+## Scope
+- Modify: [file paths]
+- Create: [new file paths]
+- Do NOT modify: [exclusions]
+
+## Constraints
+[Tech rules, patterns to follow, things to avoid]
+
+## Context
+[Relevant code excerpts with file_path:line_numbers]
+
+## Affected Files
+[List of all files to read or modify]
+
+## Acceptance Criteria
+- [ ] Given [precondition], when [action], then [result]
+- [ ] ...
+
+## Verification Checklist
+- [ ] All acceptance criteria met
+- [ ] No hardcoded secrets
+- [ ] Mobile responsive (375px)
+- [ ] Dark mode correct
+- [ ] Commits are clean
+- [ ] PR created and merged
+- [ ] Edge functions deployed (if changed)
+
+## Test Commands
+[Steps to verify manually]
+
+## Deploy Steps
+[Post-merge commands, if any]
+
+## Related Docs
+[Paths to PRDs, specs, design docs]
+```

--- a/docs/strategy/archive/gtm-launch-plan.md
+++ b/docs/strategy/archive/gtm-launch-plan.md
@@ -1,0 +1,332 @@
+> **Archived from an orphaned branch.** Recovered from `claude/gtm-rodeo-echo-launch-TAWEy` (last touched 2026-03-05),
+> which shares no history with master after the repository history was rewritten.
+> Kept for the thinking in it; nothing here is current.
+
+# GTM Launch Plan: Rodeo + Echo
+
+> **Target Launch:** Friday, March 13, 2026
+> **Scale Target:** 2,000 users within 60 days
+> **Status:** DRAFT
+> **Created:** 2026-03-05
+
+---
+
+## Executive Summary
+
+Dual-product launch of **Rodeo** (web — personal curation platform, formerly Boards) and **Echo** (iOS — audio/voice capture app). Both products share the ctrl.rodeo brand and the same core insight: **what you experience informs what you create.** The launch targets creatives and high-volume collectors who need better tools for capturing and organizing their inputs.
+
+---
+
+## Part 1: Rodeo (Web) — Launch-Ready MVP
+
+### What's Already Shipped
+Rodeo is substantially built. The core loop works:
+
+| Capability | Status | Notes |
+|-----------|--------|-------|
+| User auth (signup/login) | SHIPPED | Supabase auth |
+| Link capture (URL input) | SHIPPED | Freeform text, mobile-optimized |
+| AI auto-categorization | SHIPPED | Claude Haiku, 9 categories |
+| Visual grid with hero images | SHIPPED | Swiss design, drag-and-drop |
+| PWA + share target | SHIPPED | Mobile share sheet integration |
+| Quick capture tools | SHIPPED | Bookmarklet, deep links, image scan |
+| AI widgets (21 configs) | SHIPPED | Recommendations, comparisons, etc. |
+| Board sharing (link-only) | SHIPPED | Read-only shared view |
+| Events aggregator | SHIPPED | Multi-source, calendar views |
+| Design system | SHIPPED | Tokens, components, constraints |
+| Analytics (Segment + GTM) | SHIPPED | Already integrated |
+
+### What's Needed for Launch (Must-Have by March 13)
+
+These are the **minimum gaps** to close for a credible public launch:
+
+#### 1. Landing Page (ctrl.rodeo homepage)
+The current homepage is a developer portfolio. It needs to become a product landing page.
+
+- **Hero**: Tagline + 1-sentence value prop + CTA ("Start Curating" → /boards/)
+- **How it works**: 3-step visual (Save → Organize → Discover)
+- **Social proof placeholder**: "Join X creatives organizing their creative life"
+- **Footer**: Links to privacy policy, terms (can be minimal/placeholder)
+- **No signup wall**: Direct link to the app — reduce friction to zero
+
+#### 2. Onboarding Flow (First 60 Seconds)
+Currently users land on an empty board. Fix the cold start:
+
+- **Welcome state**: When board is empty, show 3-step prompt:
+  1. "Paste a URL to get started"
+  2. "Or install the bookmarklet for one-click saving"
+  3. "Share from any app on mobile"
+- **Sample content**: Optional "Try it" button that adds 3 demo links to show categorization
+- **Capture tools surfaced early**: Show bookmarklet/PWA install prompts in onboarding, not buried in a modal
+
+#### 3. Run Blocked Migrations
+6 SQL migrations are pending (019, 020, 016, 017, 018, 007). At minimum, run:
+- `019_board_metadata.sql` — needed for Create a Board
+- `020_link_tags.sql` — needed for tag-based features
+
+#### 4. Deploy Pending Edge Functions
+- Deploy updated `enrich-link` with Tier 2 validation
+- Deploy `validate-image` for image quality
+
+#### 5. Basic Error Handling & Polish
+- Ensure auth flow handles edge cases (password reset, email confirmation)
+- Loading states for AI categorization (users need feedback that something is happening)
+- Mobile viewport fixes if any exist
+
+### What's NOT Needed for Launch (Cut Scope)
+
+| Feature | Why It Can Wait |
+|---------|----------------|
+| Collaborative boards | Solo use is the core loop; collab is Phase 4 |
+| Username system | Not needed until sharing is a growth driver |
+| Bulk import | Nice-to-have; manual adding works for launch |
+| Instagram import | Future growth feature |
+| Lookback/digest emails | Retention feature — add in week 2-3 |
+| Push notifications | Requires FCM/APNs setup — post-launch |
+
+---
+
+## Part 2: Echo (iOS) — Launch-Ready MVP
+
+> **Note:** Echo lives in a separate repo (`echo-ios`). This section defines the GTM requirements; implementation details should be tracked in that repo.
+
+### MVP Definition (Must-Have for Launch)
+
+Echo should launch with the **minimum feature set that delivers a complete, differentiated experience**:
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| Voice/audio capture | P0 | Core differentiator — capture thoughts, sounds, ideas by voice |
+| Auto-transcription | P0 | Whisper or similar — text from voice |
+| AI tagging/categorization | P0 | Match Rodeo's category system — shared taxonomy |
+| Simple feed/timeline | P0 | Chronological view of captures |
+| Share to Rodeo | P1 | Deep link captured items into Rodeo web app |
+| Basic search | P1 | Search transcriptions |
+| iOS share extension | P1 | Capture from any app |
+
+### What Echo Should NOT Do at Launch
+
+- No social features, no public profiles
+- No Android version
+- No complex editing or organization tools
+- No subscription/paywall — free at launch
+
+### Cross-Product Integration
+The key differentiator is that Rodeo + Echo together = **capture everything, everywhere**:
+- **Echo** captures ephemeral moments (audio, voice notes, quick thoughts) on mobile
+- **Rodeo** captures intentional saves (links, articles, products) on web
+- Both feed into the same organized life map
+- Shared user accounts via Supabase auth
+
+---
+
+## Part 3: GTM Strategy
+
+### Positioning
+
+**Rodeo:** "Your likes. Your saves. Your life — organized."
+**Echo:** "Capture what you hear. Remember what matters."
+**Together:** "Everything you find interesting — captured, organized, connected."
+
+### Launch Channels (Ranked by Expected Impact)
+
+#### Tier 1: High-Impact, Low-Cost (Week 1)
+
+| Channel | Action | Expected Impact |
+|---------|--------|-----------------|
+| **Product Hunt** | Launch Rodeo on PH. Echo as "companion app" in description. Schedule for Tuesday or Wednesday (highest traffic). | 300-800 signups day 1 |
+| **Hacker News** | "Show HN: I built an AI-powered curation tool for creatives" — genuine builder story, mention vibe coding approach | 200-500 signups if front page |
+| **Twitter/X** | Thread: "I spent 3 months building the tool I wished existed for organizing my creative life" — demo GIF, link to PH | Amplifier for PH + HN |
+| **Designer communities** | Post in Sidebar.io, Designer News, Dribbble, Behance forums | 50-200 targeted signups |
+
+#### Tier 2: Community Seeding (Week 1-2)
+
+| Channel | Action | Expected Impact |
+|---------|--------|-----------------|
+| **Reddit** | r/InternetIsBeautiful, r/SideProject, r/webdev, r/design — tailored posts per subreddit | 100-300 signups |
+| **Discord communities** | Design, creative, and indie hacker Discords — share as a tool, not spam | 50-100 signups |
+| **IndieHackers** | Product launch post + milestone post | 50-150 signups |
+| **Creative newsletters** | Pitch to Dense Discovery, TLDR Design, Sidebar | 100-500 if featured |
+
+#### Tier 3: Sustained Growth (Week 2-4)
+
+| Channel | Action | Expected Impact |
+|---------|--------|-----------------|
+| **Content marketing** | Blog posts on ctrl.rodeo: "How I organize 500+ links", "The case for intentional curation" | SEO long-tail |
+| **Share-driven virality** | Every shared board is a marketing surface — add "Curated with Rodeo" footer | Organic compound growth |
+| **Bookmarklet/PWA virality** | Users install tools → more captures → more sharing | Retention + word of mouth |
+| **Creator partnerships** | Give 5-10 design influencers early access, ask them to share their public board | 200-1000 per influencer |
+
+### Growth Mechanisms (Built Into the Product)
+
+These are the features that make growth self-sustaining:
+
+#### 1. Shared Boards as Marketing Surfaces
+Every public board at `ctrl.rodeo/boards/share.html?id=X` should include:
+- "Curated with Rodeo" subtle branding
+- "Create your own board →" CTA for non-users
+- Open Graph metadata so shared links look good on social
+
+#### 2. Bookmarklet as Distribution
+The bookmarklet is installed in a user's browser toolbar. Every time they use it:
+- Reinforces the habit
+- Visible to anyone watching them browse (screen shares, pair programming)
+- Can optionally prompt "Share this save?" after capture
+
+#### 3. PWA Share Target as Lock-In
+Once installed as a PWA, Rodeo appears in the mobile share sheet alongside native apps. This makes it:
+- Top-of-mind every time the user shares anything
+- A default habit over time
+- Hard to abandon (behavioral lock-in, not technical)
+
+#### 4. AI Widgets as Content Worth Sharing
+Widget outputs ("Your top picks this week", "Complete the Look") are inherently shareable:
+- Add "Share this widget" button that generates an image/link
+- Each shared widget drives back to the board and to signup
+
+#### 5. Echo → Rodeo Bridge
+Echo captures feed into Rodeo's web view, creating:
+- A reason to use both products
+- Cross-platform stickiness
+- "Capture on phone, organize on desktop" workflow
+
+### Referral Mechanism
+Simple invite system (post-launch week 2):
+- "Invite a friend" — both get early access to upcoming features
+- No complex referral codes — just a share link
+- Track with Segment events
+
+---
+
+## Part 4: Scale Readiness (2,000 Users)
+
+### Infrastructure Assessment
+
+| Component | Current State | Ready for 2K? | Action Needed |
+|-----------|--------------|----------------|---------------|
+| GitHub Pages hosting | Static site | YES | No action — CDN-backed, scales infinitely |
+| Supabase auth | Free tier | MAYBE | Free tier = 50K MAU — fine for 2K |
+| Supabase database | Free tier | WATCH | Free tier = 500MB, 2 CPU. Monitor, upgrade to Pro ($25/mo) if needed |
+| Edge functions | Free tier | WATCH | Free tier = 500K invocations/mo. At ~50 enrichments/user/mo = 100K. Fine. |
+| Claude API (categorization) | Pay-per-use | YES | Haiku is cheap. 2K users × 50 links/mo × $0.001 = ~$100/mo |
+| SERP API (enrichment) | Pay-per-use | WATCH | Check rate limits and budget |
+| Segment analytics | Free tier | YES | Free tier = 1K MTU — will need to upgrade at ~1K users |
+
+### Cost Projection (2,000 Users)
+
+| Item | Monthly Cost |
+|------|-------------|
+| Supabase Pro (if needed) | $25 |
+| Claude API (Haiku) | ~$100 |
+| SERP API | ~$50 |
+| Segment (if over 1K MTU) | $120 |
+| Domain (ctrl.rodeo) | ~$2 |
+| Apple Developer (Echo) | ~$8 |
+| **Total** | **~$305/mo** |
+
+### Performance Checklist Before Launch
+
+- [ ] Load test: Simulate 100 concurrent users hitting /boards/
+- [ ] Edge function cold start: Ensure < 3s for `enrich-link`
+- [ ] Database indexing: Verify GIN indexes on tags, category columns
+- [ ] Image CDN: Ensure hero images aren't served raw from origin
+- [ ] Rate limiting: Add basic rate limits to edge functions to prevent abuse
+- [ ] Error monitoring: Set up basic alerting (Supabase dashboard or Sentry free tier)
+
+---
+
+## Part 5: Launch Timeline
+
+### Week of March 5-9 (This Week — Prep)
+
+| Day | Rodeo | Echo | Marketing |
+|-----|-------|------|-----------|
+| Thu 3/5 | Scope MVP gaps, create landing page plan | Audit current state, define MVP gaps | Draft PH listing, prepare assets |
+| Fri 3/6 | Build landing page, onboarding flow | Close critical MVP gaps | Create demo GIF/video, OG images |
+| Sat 3/7 | Run migrations, deploy functions | TestFlight beta | Write HN post, Twitter thread |
+| Sun 3/8 | Bug bash, mobile testing | Bug bash | Prep PH hunter outreach |
+
+### Week of March 10-13 (Launch Week)
+
+| Day | Rodeo | Echo | Marketing |
+|-----|-------|------|-----------|
+| Mon 3/10 | Final polish, shared board OG tags | Final TestFlight | Schedule PH for Wednesday |
+| Tue 3/11 | Soft launch — share with 10-20 friends/creatives | Submit to App Store | Seed early reviews, prep launch day |
+| Wed 3/12 | **PRODUCT HUNT LAUNCH** | **APP STORE LIVE** | PH, HN, Twitter, Reddit — all channels |
+| Thu 3/13 | Monitor, hotfix, respond to feedback | Monitor crashes, reviews | Follow-up posts, respond to comments |
+
+### Post-Launch (Week 2-4)
+
+| Week | Focus |
+|------|-------|
+| Week 2 | Hotfixes, onboarding iteration based on drop-off data, add referral mechanism |
+| Week 3 | First retention feature (Lookback digest email), creator partnerships |
+| Week 4 | Collaborative boards (if demand signals are strong), content marketing |
+
+---
+
+## Part 6: Success Metrics
+
+### Launch Day (March 12-13)
+- [ ] 200+ signups on day 1
+- [ ] Product Hunt top 10 finish
+- [ ] < 1% error rate on core flows
+- [ ] Average 5+ links saved per new user in first session
+
+### Week 1
+- [ ] 500+ total signups
+- [ ] 30% D1 retention (return next day)
+- [ ] 10+ shared boards created
+- [ ] App Store rating > 4.0 (Echo)
+
+### Month 1
+- [ ] 2,000 total signups
+- [ ] 20% WAU/MAU ratio
+- [ ] 50+ shared boards with external views
+- [ ] 5+ organic mentions (tweets, posts, newsletters)
+
+### Key Tracking Events (Segment)
+```
+user_signed_up        — account creation
+first_link_saved      — activation
+fifth_link_saved      — engagement threshold
+board_shared          — virality trigger
+bookmarklet_installed — power user signal
+pwa_installed         — retention signal
+echo_capture_sent     — cross-product activation
+widget_shared         — content virality
+```
+
+---
+
+## Part 7: Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Echo not App Store approved by 3/12 | Medium | High | Submit by 3/8 at latest; have web fallback |
+| Supabase free tier rate limited | Low | High | Monitor during soft launch; upgrade to Pro preemptively |
+| PH launch underperforms | Medium | Medium | HN + Reddit as backup channels; don't put all eggs in one basket |
+| AI categorization quality issues | Low | Medium | Already battle-tested; monitor edge cases |
+| Cold start problem (empty board) | High | High | Onboarding flow + sample content are P0 |
+| Users confused by two products | Medium | Medium | Clear positioning on landing page: "Rodeo = web saves, Echo = audio capture" |
+
+---
+
+## Immediate Next Steps
+
+### For This Session (Rodeo — ctrl.rodeo repo)
+1. **Build the landing page** — transform ctrl.rodeo homepage into a product landing page
+2. **Add onboarding empty state** — welcome flow for new users in /boards/
+3. **Add OG metadata to shared boards** — make shared links look good on social
+4. **Add "Curated with Rodeo" branding** to share.html
+
+### Requiring Human Action
+1. **Run blocked SQL migrations** (019, 020, 016) via Supabase Dashboard
+2. **Deploy edge functions** (`enrich-link`, `validate-image`)
+3. **Echo iOS:** Audit current state, close MVP gaps, submit TestFlight by 3/7
+4. **Product Hunt:** Create listing draft, find a hunter
+5. **Prepare launch day content:** HN post, Twitter thread, Reddit posts
+
+---
+
+*This is a living document. Update as launch prep progresses.*

--- a/docs/strategy/prds/archive/concept-compression.md
+++ b/docs/strategy/prds/archive/concept-compression.md
@@ -1,0 +1,629 @@
+> **Archived from an orphaned branch.** Recovered from `claude/concept-compression-pins-kvUr1` (last touched 2026-02-23),
+> which shares no history with master after the repository history was rewritten.
+> Kept for the thinking in it; nothing here is current.
+
+# PRD: Concept Compression
+
+**Version:** 1.0
+**Date:** 2026-02-23
+**Status:** Draft
+
+---
+
+## Overview
+
+People save links because the content means something to them — not because of its metadata. But ctrl.rodeo's enrichment pipeline currently understands everything *about* a pin except what it actually *says*. It knows a pin is a video, knows it's from YouTube, knows the image meets visual quality standards, knows it belongs in "watch." It doesn't know it's a documentary about how the Voyager team had 12 seconds to fix the antenna before losing contact forever.
+
+That meaning — the irreducible core idea — is what Concept Compression extracts. It's a new enrichment layer that uses AI to distill each pin into a semantic summary and a set of extracted concepts. This gives every pin a machine-readable representation of *why it matters*, which unlocks capabilities that metadata alone can't support: semantic search, concept-level clustering, cross-category connection discovery, and richer input for Lookback and widgets.
+
+The enrichment stack today:
+
+```
+Layer 0:  Metadata         (exists — enrich-link)      "What is this called?"
+Layer 1:  Classification   (exists — content type)      "What kind of thing is this?"
+Layer 2:  Visual quality   (exists — image scoring)      "Does it look right?"
+Layer 3:  Concept compression  (THIS PRD)                "What does this mean?"
+Layer 4:  Collection synthesis (exists — widgets)         "What do my saves say together?"
+```
+
+Layer 3 is the missing middle. Without it, Layer 4 operates on titles and descriptions — marketing copy written for social cards, not for helping a human remember why they saved something. Concept compression gives downstream systems a semantic backbone.
+
+---
+
+## Goals
+
+1. Give every pin a human-readable, machine-queryable representation of its core meaning
+2. Enable semantic search across the collection (find by concept, not just keyword)
+3. Surface cross-category connections that metadata can't detect (a recipe and an article sharing the same cultural thread)
+4. Provide richer input to Lookback's collection intelligence signals and widget content generation
+5. Build the foundation for concept-level clustering — grouping pins by *what they're about*, not just what category they're in
+
+---
+
+## Who This Serves
+
+### Primary Personas
+
+| Persona | Why Concept Compression Matters | Key Scenario |
+|---------|--------------------------------|--------------|
+| **The Researcher** | They save 40 articles across 6 months. Later, they need the ones about a specific thesis — not a specific domain or category. Concept compression lets them search "supply chain resilience" and find pins from economics blogs, YouTube lectures, and a Reddit thread. | Recall by topic, not by source |
+| **The Visual Collector** | They save hundreds of design references. The difference between two pins in "wear" isn't the category — it's "oversized silhouettes" vs. "monochrome layering." Concepts make the sub-language of their taste searchable. | Precision within large categories |
+| **The Multidisciplinary Maker** | A material science article and a furniture design pin both involve "bent plywood." The connection only emerges at the concept level — categories see "read" and "make," concepts see the shared thread. | Cross-category discovery |
+| **The Cultural Omnivore** | They save across every category. Their collection tells a story — if you can read it. Concept compression is the layer that turns a pile of saves into a legible portrait of someone's interests. | Collection as self-portrait |
+
+### Secondary Personas
+
+| Persona | Why It Matters |
+|---------|---------------|
+| **The DJ** | Genre tags are coarse ("electronic"). Concepts capture finer grain: "UK garage revival," "ambient drone," "Brazilian bass." |
+| **The Deep-Dive Enthusiast** | Their obsession phases have internal structure. Concept compression captures the arc — first "pour-over basics," then "water chemistry," then "grinder calibration." |
+| **The Sound & Scene Curator** | Venues, artists, and albums saved across months share conceptual threads (a city's scene, a label's aesthetic) that categories flatten. |
+
+### Jobs To Be Done
+
+| When I... | I want to... | So I can... |
+|-----------|-------------|-------------|
+| Search my collection | Find pins by what they're about, not just keywords | Retrieve things I vaguely remember by concept |
+| Browse a large category | See sub-groupings by theme | Navigate 50+ pins without scrolling through all of them |
+| Start a creative project | Find everything related to a concept across all categories | Pull references I didn't know I had |
+| Share a board | Have my pins described intelligently | Show others what my collection is actually about |
+| Return after weeks away | Quickly re-orient on what I've collected | Remember my own taste without re-reading everything |
+
+---
+
+## Design Principles
+
+| Brand Principle | Application |
+|-----------------|-------------|
+| **Input shapes output** | Concept compression makes the *meaning* of inputs explicit. It's the literal mechanism by which input becomes searchable, connectable output. |
+| **Organize as you go** | Runs automatically during enrichment. Users never see "extract concepts" — they just find their pins understand them better over time. |
+| **One place, whole life** | Cross-category concept matching is the point. A listen pin and a read pin about the same cultural moment should find each other. |
+| **Show, don't decorate** | The essence is shown only when useful — in search results, expanded cards, and Lookback context labels. Never as visual clutter on the grid. |
+| **Expand with the user** | Simple collections get simple essences. As the collection deepens, concept clustering and cross-category connections emerge naturally. |
+
+---
+
+## Core Concepts
+
+### The Essence
+
+A 1-2 sentence distillation of what the pin is *about* — not what it *is*. Written from the perspective of "why would someone save this?"
+
+**Examples:**
+
+| Pin Title | OG Description (what exists today) | Essence (what this PRD adds) |
+|-----------|-----------------------------------|------------------------------|
+| "The Voyager Golden Record" | "Explore the music, sounds, and images NASA sent into space" | "The 1977 team had to decide what represents all of humanity in a single object — and the constraints they worked under (115 images, 90 minutes of music) forced radical prioritization of what matters." |
+| "Nike Air Max 97 Silver Bullet" | "Shop the Nike Air Max 97 in Metallic Silver" | "The shoe that made visible air a status symbol. The full-length Air unit and the bullet train-inspired ripple lines created the template for every 'futuristic retro' sneaker since." |
+| "How to Make Ramen from Scratch" | "Learn the art of making authentic ramen at home" | "The 48-hour process of building tonkotsu broth — and why the collagen extraction can't be rushed — is basically a meditation on patience as an ingredient." |
+| "Brutalism: An Architecture Overview" | "Explore the history and impact of Brutalist architecture" | "Brutalism as political architecture: the ideology that public buildings should be monumental and honest about their materials, and why that made them loved by designers and hated by occupants." |
+
+The essence is **not** a summary. Summaries compress information. The essence captures the *hook* — the conceptual reason someone would find this worth saving.
+
+### Concepts
+
+A set of 3-7 extracted themes, ideas, or topics. These are the building blocks for clustering, search, and cross-category matching.
+
+**Examples:**
+
+| Pin | Concepts |
+|-----|----------|
+| Voyager Golden Record | `space exploration`, `curation under constraints`, `cultural representation`, `Cold War optimism`, `time capsule` |
+| Nike Air Max 97 | `visible technology as design`, `sneaker culture`, `retro-futurism`, `status signaling`, `industrial design` |
+| Ramen from Scratch | `slow food`, `collagen science`, `Japanese culinary tradition`, `patience as technique`, `broth fundamentals` |
+| Brutalism article | `brutalist architecture`, `political design`, `material honesty`, `public space ideology`, `polarizing aesthetics` |
+
+Concepts are:
+- **Lowercase, natural language phrases** (not hashtags, not single words)
+- **Meaning-bearing** (not generic — "interesting article" is never a concept)
+- **Cross-category capable** — "material honesty" could link a brutalism article, a raw-edge leather jacket, and a no-makeup-makeup tutorial
+- **Hierarchically aware** — "sneaker culture" is broader than "Air Max history"; both can coexist
+
+### Concept Confidence
+
+Each concept extraction includes a confidence score (0-1) reflecting how well the AI could understand the pin's content.
+
+| Score | Meaning | Typical Cause |
+|-------|---------|---------------|
+| 0.9+ | Strong understanding | Rich title + description, clear content type |
+| 0.7-0.9 | Good understanding | Decent metadata, some ambiguity |
+| 0.5-0.7 | Partial understanding | Minimal metadata, generic title |
+| <0.5 | Low understanding | No description, opaque URL, paywall content |
+
+Low-confidence pins are candidates for re-extraction when the page is next visited or when richer metadata becomes available (e.g., after `enrich-link` fills in a better title or description).
+
+---
+
+## How It Works
+
+### Integration into the Enrichment Pipeline
+
+Concept compression runs as **Step 2.7** in the existing `enrich-link` edge function, after content type classification and image resolution, and after any watch/book enrichment has added structured metadata.
+
+```
+URL submitted
+    │
+    ▼
+Step 0: Platform API metadata (YouTube, Vimeo)
+Step 1: Content type classification
+Step 2: Image resolution (3-tier quality gate)
+Step 2.5: Watch enrichment (TMDB, YouTube API)
+Step 2.6: Book enrichment (Open Library)
+Step 2.7: CONCEPT COMPRESSION (NEW)  ◄━━━━━━━━━━━━━━━━━━━
+Step 3: Database update
+```
+
+**Why after everything else?** Because concept compression benefits from all available context. A pin with a title, description, content type, and structured metadata (video genre, book author, music artist) produces a richer essence than a pin with just a URL. By running last, it gets the best possible input.
+
+### The Compression Prompt
+
+The edge function sends available metadata to Claude Haiku:
+
+```
+Given this saved link, extract its conceptual essence.
+
+URL: {url}
+Title: {title}
+Description: {description}
+Content Type: {content_type}
+Category: {category}
+Domain: {domain}
+{if video: Genre: {video.genre}, Creator: {video.creator}, Year: {video.year}}
+{if music: Artist: {music.artist}, Album: {music.albumTitle}, Genre: {music.genre}}
+{if book: Author: {book.author}, Genre: {book.genre}, Year: {book.year}}
+
+Return JSON:
+{
+  "essence": "1-2 sentences capturing WHY someone would save this — the core idea, insight, or hook. Not a summary. Write as if explaining to a friend what makes this interesting.",
+  "concepts": ["3-7 concept phrases that capture the themes, ideas, and topics. Use lowercase natural language. Be specific enough to enable meaningful connections across different content types."],
+  "confidence": 0.0-1.0
+}
+
+Rules:
+- The essence should capture meaning, not metadata. "A YouTube video about architecture" is useless. "How Tadao Ando uses concrete to create silence" is an essence.
+- Concepts should be specific but not so narrow they only match this one pin. "Tadao Ando" is too narrow. "architecture" is too broad. "meditative architecture" or "concrete as emotional material" is right.
+- If the title and description are generic or missing, say what you can infer from the URL/domain and mark confidence low.
+- Never include the content type as a concept (no "article", "video", "product").
+- Never include the domain as a concept (no "YouTube", "Nike.com").
+```
+
+### Client-Side Fallback
+
+For pins that fail server enrichment or when the user is offline, a lightweight client-side extraction runs using only the title and description:
+
+```javascript
+function extractLocalConcepts(pin) {
+  // Simple keyword extraction from title + description
+  // No AI call — uses word frequency, bigrams, and stop-word filtering
+  // Returns concepts only (no essence) with confidence: 0.3
+  // Marked source: 'local' for later server re-extraction
+}
+```
+
+This ensures every pin has *some* concept data, even if degraded. Server-extracted concepts overwrite local ones when they arrive.
+
+---
+
+## Schema Changes
+
+### New Columns on `links` Table
+
+```sql
+-- Migration: 019_concept_compression.sql
+
+ALTER TABLE links ADD COLUMN essence TEXT;
+ALTER TABLE links ADD COLUMN concepts TEXT[];  -- PostgreSQL array of concept phrases
+ALTER TABLE links ADD COLUMN concept_confidence REAL;
+ALTER TABLE links ADD COLUMN concept_source TEXT DEFAULT 'none';
+  -- 'ai' (Claude Haiku), 'local' (client-side fallback), 'user' (manually edited), 'none'
+ALTER TABLE links ADD COLUMN concept_extracted_at TIMESTAMPTZ;
+
+-- Index for concept search
+CREATE INDEX idx_links_concepts ON links USING GIN (concepts);
+
+-- Index for low-confidence re-extraction queue
+CREATE INDEX idx_links_concept_confidence ON links (concept_confidence)
+  WHERE concept_confidence < 0.5 OR concept_confidence IS NULL;
+```
+
+### localStorage Extension
+
+```javascript
+// Each link object in localStorage gains:
+{
+  // ... existing fields ...
+  essence: "string or null",
+  concepts: ["array", "of", "concept", "phrases"],
+  concept_confidence: 0.85,
+  concept_source: "ai",        // 'ai', 'local', 'user', 'none'
+  concept_extracted_at: "ISO"
+}
+```
+
+---
+
+## Surfaces
+
+Concept data is consumed by existing and new surfaces. The concept compression system *produces* data — it doesn't own any UI. Each consumer decides how to display it.
+
+### Surface 1: Expanded Pin Card
+
+**Where:** The existing expanded card detail panel in `renderGrid()`.
+
+```
+┌─────────────────────────────────────────────┐
+│  [Hero Image]                               │
+│                                             │
+│  Pin Title                                  │
+│  domain.com                                 │
+│                                             │
+│  "The 1977 team had to decide what          │
+│   represents all of humanity..."            │  ← essence
+│                                             │
+│  space exploration · curation under         │
+│  constraints · cultural representation      │  ← concepts as tags
+│                                             │
+│  [Visit]  [Notes]  [Share]                  │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+- Essence replaces OG description in the expanded view (falls back to description if no essence)
+- Concepts render as subtle inline tags below the essence
+- Tapping a concept tag filters the collection to all pins sharing that concept (cross-category)
+
+### Surface 2: Search
+
+**Where:** Existing search functionality in Boards.
+
+Current search matches against `title`, `description`, `domain`, and `category`. Concept compression adds:
+
+- **Essence search** — full-text match against the essence field
+- **Concept search** — array containment match against concepts
+- **Semantic ranking** — pins matching on concepts rank higher than pins matching on title keywords
+
+```
+Search: "material honesty"
+
+Results:
+1. Brutalism: An Architecture Overview     [read]    ← concept match: "material honesty"
+2. Raw Edge Leather Wallets — Tanner Goods [wear]    ← concept match: "material honesty"
+3. No-Makeup Makeup Tutorial              [watch]   ← concept match: "material honesty"
+4. Honest Materialworks — Company Page     [make]    ← title keyword match
+```
+
+### Surface 3: Concept Clusters
+
+**Where:** New optional view mode in Boards, accessible from the view toggle.
+
+Instead of organizing by category, concept clusters group pins by shared concepts — regardless of category.
+
+```
+┌─────────────────────────────────────────────┐
+│  View: [Grid] [List] [Concepts]             │
+│                                             │
+│  retro-futurism (4 pins)                    │
+│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐       │
+│  │ AM97 │ │Synth │ │Retro │ │Film  │       │
+│  │ wear │ │listen│ │read  │ │watch │       │
+│  └──────┘ └──────┘ └──────┘ └──────┘       │
+│                                             │
+│  patience as technique (3 pins)             │
+│  ┌──────┐ ┌──────┐ ┌──────┐                │
+│  │Ramen │ │Bread │ │Aging │                │
+│  │ eat  │ │ eat  │ │read  │                │
+│  └──────┘ └──────┘ └──────┘                │
+│                                             │
+│  meditative architecture (3 pins)           │
+│  ┌──────┐ ┌──────┐ ┌──────┐                │
+│  │Ando  │ │Light │ │Quiet │                │
+│  │ read │ │watch │ │ go   │                │
+│  └──────┘ └──────┘ └──────┘                │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+- Clusters are computed client-side by counting concept co-occurrence across pins
+- Minimum 2 pins sharing a concept to form a cluster
+- Clusters sorted by pin count (descending), then alphabetically
+- Pins can appear in multiple clusters (a pin about "brutalist architecture" with concept "material honesty" appears in both)
+- Clusters with only 1 unique concept are shown as-is; clusters with overlapping concepts merge into a named group
+
+### Surface 4: Lookback Enhancement
+
+Concept data enriches Lookback's Signal Layer 4 (Collection Intelligence):
+
+| Existing Signal | Enhancement from Concepts |
+|----------------|--------------------------|
+| **Cross-category connection** | Currently limited to geographic/domain similarity. Concepts enable "this restaurant and that article both involve fermentation culture." |
+| **Emerging theme** | Currently uses title word frequency. Concepts provide actual theme detection: "you've saved 4 pins about 'analog revival' this month." |
+| **Taste drift** | Currently category-level ("you used to save wear, now you save eat"). Concepts detect drift within categories: "your music taste shifted from 'UK garage' to 'ambient drone'." |
+
+New Lookback context labels enabled by concepts:
+
+| Signal | Label |
+|--------|-------|
+| Concept cluster forming | "3 recent saves about 'analog revival'" |
+| Cross-category match | "This connects to your wear pin about 'material honesty'" |
+| Concept drift | "Your interests shifted from X to Y" |
+
+### Surface 5: Widget Input Enhancement
+
+The `generate-widget` edge function currently receives `{ id, title, description, image, url }` per pin. With concept compression:
+
+```json
+{
+  "id": "...",
+  "title": "...",
+  "description": "...",
+  "essence": "The 1977 team had to decide what represents all of humanity...",
+  "concepts": ["space exploration", "curation under constraints", "cultural representation"],
+  "image": "...",
+  "url": "..."
+}
+```
+
+This gives widget prompts dramatically richer context. A "Complete the Look" widget that knows a pin is about "oversized silhouettes" and "monochrome layering" produces far better outfit suggestions than one working from "Shop the Nike ACG Collection."
+
+---
+
+## User Interaction with Concepts
+
+### Viewing
+
+- Essence appears in expanded card view, replacing OG description
+- Concepts appear as subtle tags in expanded card view
+- Concept clusters appear in the new Concepts view mode
+- Search results show concept match indicators
+
+### Editing
+
+Users can edit both essence and concepts:
+
+- **Tap essence** in expanded card → inline edit field
+- **Tap concept tag** + hold → option to remove concept
+- **"+ Add concept"** link at end of concept list → free text input
+- Edits set `concept_source: 'user'` and are never overwritten by AI re-extraction
+
+### Re-extraction
+
+- Concept data can be refreshed via the existing three-dot menu → "Refresh" action
+- Low-confidence pins (< 0.5) are automatically re-queued when the user opens the expanded card
+- Bulk re-extraction available in admin dev tools panel
+
+---
+
+## Technical Architecture
+
+### Compression Function
+
+Added to `enrich-link/index.ts` as a new step:
+
+```typescript
+async function extractConcepts(
+  url: string,
+  title: string,
+  description: string,
+  contentType: string,
+  category: string,
+  richMeta?: { video?: any; music?: any; book?: any }
+): Promise<{
+  essence: string;
+  concepts: string[];
+  confidence: number;
+}> {
+  const prompt = buildCompressionPrompt(url, title, description, contentType, category, richMeta);
+
+  const response = await callClaude(prompt, {
+    model: 'claude-3-haiku-20240307',
+    max_tokens: 300,
+    temperature: 0.3  // Low temp for consistent extraction
+  });
+
+  return parseConceptResponse(response);
+}
+```
+
+### Caching & Deduplication
+
+- **Domain-level concept cache**: Similar to the existing `domain_profiles` cache for content type, store concept patterns per domain. E.g., all YouTube music videos from the same channel share concept templates.
+- **Concept normalization**: Before storing, normalize concepts via lowercasing, trimming, and collapsing synonyms where obvious ("sneaker culture" and "sneaker culture" deduplicate; "shoe culture" and "sneaker culture" do not — that requires Phase 2 embedding-based deduplication).
+- **Batch extraction**: For backfill, process in batches of 20 pins per edge function invocation to minimize cold starts.
+
+### Backfill Strategy
+
+Existing pins need concept extraction. Approach:
+
+1. **Priority queue**: Start with pins that have the richest metadata (high `type_confidence`, non-null `description`, structured `video`/`music`/`book` data)
+2. **Background processing**: Edge function `backfill-concepts` processes 50 pins per run, triggered by cron (every 6 hours)
+3. **Rate limiting**: Max 200 Claude Haiku calls per hour per user during backfill to stay within API budget
+4. **Progress tracking**: `concept_extracted_at IS NULL` identifies unprocessed pins
+
+```typescript
+// POST /functions/v1/backfill-concepts
+// { user_id, batch_size: 50 }
+// Selects pins with richest metadata first, extracts concepts, updates DB
+```
+
+### Re-extraction Triggers
+
+| Trigger | Action |
+|---------|--------|
+| Pin first enriched (new save) | Extract concepts as Step 2.7 |
+| Enrichment refreshed (user clicks Refresh) | Re-extract concepts with latest metadata |
+| Low-confidence pin opened | Re-queue for extraction with any new metadata |
+| Rich metadata added later (watch/book enrichment completes async) | Re-extract with structured metadata included |
+| User edits title or description | Re-extract (preserving user-edited concepts) |
+
+---
+
+## Phasing
+
+### Phase 1: Essence + Concepts (MVP)
+
+**What ships:**
+- `essence` and `concepts` fields on links table
+- Concept extraction as Step 2.7 in `enrich-link`
+- Client-side fallback extraction (keyword-based, no AI)
+- Essence displayed in expanded card view (replaces OG description)
+- Concepts displayed as tags in expanded card view
+- Concept tap → filter collection by concept
+- Basic concept search (array containment + full-text on essence)
+
+**Not included:**
+- Concept clusters view
+- Lookback integration
+- Widget input enhancement
+- User editing of concepts
+- Backfill of existing pins
+
+**Personas served:** All — every pin immediately becomes more understandable
+
+**Cost:** ~$0.001 per pin (Claude Haiku, ~150 input tokens + ~200 output tokens). At 1,000 users with 50 pins/month average: ~$50/month.
+
+### Phase 2: Clusters + Backfill
+
+**What ships:**
+- Concept clusters view mode
+- Backfill edge function for existing pins
+- User editing of essence and concepts
+- Concept normalization and synonym handling
+- Enhanced search ranking (concept matches weighted higher)
+
+**Personas served:** The Researcher (search), The Visual Collector (clusters within categories), The Multidisciplinary Maker (cross-category clusters)
+
+**Cost:** Backfill one-time cost ~$0.001 per existing pin. Ongoing same as Phase 1.
+
+### Phase 3: Intelligence Layer
+
+**What ships:**
+- Lookback Signal Layer 4 enhancement (concept-based cross-category connections, emerging themes, taste drift)
+- Widget input enhancement (essence + concepts in widget prompts)
+- Concept-level analytics ("your top concepts this month")
+- Embedding-based concept similarity (move beyond exact string match to semantic proximity)
+
+**Prerequisites:** Lookback Phase 1 shipped, widget instrumentation
+
+**Personas served:** The Cultural Omnivore (taste analytics), The DJ (concept drift), The Deep-Dive Enthusiast (interest archaeology with concept granularity)
+
+**Cost:** Embedding generation adds ~$0.0001 per pin. Similarity search uses pgvector (Supabase native). Minimal incremental cost.
+
+---
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| Concept extraction latency | < 2s per pin (Claude Haiku) |
+| Client-side fallback latency | < 50ms (keyword extraction, no API call) |
+| Concept search latency | < 100ms (GIN index on PostgreSQL array) |
+| Cluster computation (1,000 pins) | < 500ms client-side |
+| Backfill throughput | 50 pins per 6-hour batch, full backfill in < 7 days for 1,000-pin collection |
+| Concept storage overhead | ~200 bytes per pin (essence + concepts array) |
+
+---
+
+## Privacy & Data Handling
+
+| Data | Storage | Retention | Access |
+|------|---------|-----------|--------|
+| Essence text | `links.essence` column, Supabase | Account lifetime | User only (RLS) |
+| Concept phrases | `links.concepts` column, Supabase | Account lifetime | User only (RLS) |
+| Concept confidence | `links.concept_confidence` column | Account lifetime | User only (RLS) |
+| AI extraction prompts | Not stored — transient in edge function | Request duration | Not persisted |
+| Concept embeddings (Phase 3) | `link_embeddings` table, Supabase | Account lifetime | User only (RLS) |
+
+No pin content is shared across users. Concept extraction happens per-user, per-pin. Concepts are derived from metadata the user already owns (titles, descriptions, enriched fields).
+
+---
+
+## Cost Model
+
+| Component | Per-Pin Cost | At 1,000 Users (50 pins/mo each) |
+|-----------|-------------|-----------------------------------|
+| Claude Haiku extraction | ~$0.001 | ~$50/month |
+| Client-side fallback | $0 | $0 |
+| PostgreSQL GIN index | Negligible | Negligible |
+| Backfill (one-time, per user) | ~$0.001/pin | One-time: ~$0.50/user |
+| Concept embeddings (Phase 3) | ~$0.0001/pin | ~$5/month |
+
+**Total Phase 1:** ~$50/month at 1,000 active users
+**Total Phase 2:** Same + one-time backfill cost
+**Total Phase 3:** ~$55/month at 1,000 active users
+
+This is comparable to the existing content-type classification cost, which also uses Claude Haiku per pin.
+
+---
+
+## Relationship to Existing Systems
+
+### enrich-link Edge Function
+
+Concept compression is added as a step, not a separate function. This avoids an extra HTTP round trip and lets concepts benefit from all metadata gathered in earlier steps.
+
+### AI Categorization
+
+Categories answer "where does this go?" Concepts answer "what is this about?" They're complementary, not competitive. A pin categorized as "wear" might have concepts "oversized silhouettes," "monochrome layering," "Japanese streetwear." The category is organizational; the concepts are semantic.
+
+### Widgets
+
+Widgets currently synthesize across pins using titles and descriptions. Concept data is strictly additive — widgets that want it can include `essence` and `concepts` in their prompts. Widgets that don't need it ignore the fields. No widget changes are required in Phase 1.
+
+### Lookback
+
+Lookback's Signal Layer 4 (Collection Intelligence) currently uses category distribution and title word frequency. Concept data gives it actual semantic understanding. This is a Phase 3 integration — Lookback ships first with temporal and interaction signals, then gains concept-powered intelligence later.
+
+### Search
+
+Current search is keyword-based on titles and descriptions. Concept search is a strict upgrade — it searches additional fields, not different fields. No breaking changes to existing search behavior.
+
+---
+
+## Future Considerations
+
+1. **Concept graph** — Once enough concept data exists, build a navigable graph of concept relationships. "Material honesty" connects to "brutalist architecture" connects to "raw materials" connects to "wabi-sabi." The graph is the user's intellectual fingerprint.
+2. **Concept-driven recommendations** — "You're interested in 'analog revival' — here are things other people with that concept save." Requires cross-user concept aggregation (with privacy controls).
+3. **Concept evolution timeline** — Visualize how concepts enter and leave the collection over time. The Cultural Omnivore persona explicitly wants this kind of reflection.
+4. **Natural language collection queries** — "Show me everything about Japanese design philosophy" → AI interprets the query against concept data, returning pins tagged with related concepts across all categories.
+5. **Concept compression for non-link pins** — When multi-format pins ship (notes, images, files), concept compression extends to those formats. A photo pin gets concepts from EXIF data + visual analysis. A note pin gets concepts from the text itself.
+6. **Shared concept vocabularies** — Collaborative boards could share a concept namespace. Two users saving pins about "brutalist architecture" see their pins clustered together.
+
+---
+
+## Open Questions
+
+1. **Essence tone** — Should the essence be neutral/informational ("This documents the Voyager team's selection process") or opinionated/hook-oriented ("The 1977 team had to decide what represents all of humanity")? The current PRD specifies hook-oriented, but some users may prefer neutral. Should this be a user preference?
+2. **Concept granularity** — How specific should concepts be? "Sneaker culture" is useful for clustering. "Nike Air Max 97 Silver Bullet history" is too specific to match anything else. The prompt instructs mid-level specificity, but this will need tuning based on real extraction results.
+3. **Concept vocabulary drift** — Over time, the AI may use slightly different phrasings for the same concept ("sneaker culture" vs. "sneaker collecting" vs. "kicks culture"). Phase 2 normalization helps, but Phase 3 embeddings are the real solution. How much drift is acceptable before Phase 3?
+4. **Extraction failures** — Some pins have almost no metadata (opaque URLs, paywalled content, deleted pages). Should these get a placeholder essence ("Saved from domain.com — content unavailable for analysis") or no essence at all?
+5. **Backfill priority** — Should backfill process newest pins first (users see the feature on recent content immediately) or oldest pins first (maximizes Lookback value)? Current design says richest-metadata-first, which is neither.
+6. **Widget interaction** — Should widgets be able to *request* specific concept extractions? E.g., the "Complete the Look" widget might want fashion-specific concepts for wear pins. Or should concept extraction be uniform and let widgets filter?
+7. **Concept editing UX** — When a user edits a concept, should it propagate to other pins with the same concept? (Renaming "sneaker culture" to "sneaker collecting" on one pin could update all pins.) This is powerful but potentially surprising.
+
+---
+
+## Success Metrics
+
+| Metric | Target | How Measured |
+|--------|--------|-------------|
+| Concept extraction coverage | 90% of pins with confidence > 0.5 within 30 days of launch | `concept_confidence` distribution |
+| Essence display engagement | 25% of expanded-card views include essence read time > 2s | Scroll/viewport tracking on expanded cards |
+| Concept search usage | 15% of searches use concept-matched results (vs. title-only matches) | Search result click attribution |
+| Cross-category discovery | 10% of concept tag taps lead to discovering a pin in a different category | Concept filter events with category distribution |
+| User concept edits | < 20% of essences manually edited (indicates AI quality is good enough) | `concept_source = 'user'` percentage |
+| Collection with 3+ concept clusters | 60% of collections with 50+ pins form at least 3 meaningful clusters | Cluster computation on active collections |
+| Lookback concept signal quality (Phase 3) | Concept-sourced Lookback pins clicked at 35%+ rate | `pin_interactions` where lookback signal is concept-based |
+
+---
+
+## Related Documents
+
+- [PRD: Boards MVP](./boards-mvp.md) — Core pin data model and enrichment pipeline
+- [PRD: Lookback](./lookback.md) — Signal model and collection intelligence (downstream consumer)
+- [PRD: AI Widgets](./ai-widgets.md) — Widget system (downstream consumer)
+- [PRD: Content Type System](./content-type-system.md) — Classification system (upstream dependency)
+- [TECH: AI Widget System](../../infrastructure/technical-design/ai-widget-system.md) — Widget generation architecture
+- [UX: Pins](../../ux/pins/index.md) — Pin lifecycle and component documentation
+- [UX: AI Categorization](../../ux/pins/ai-categorization.md) — Classification system details
+- [Brand Positioning](../brand-positioning.md) — Brand principles guiding design decisions
+- [User Personas](../../ux/personas.md) — Full persona definitions with JTBD

--- a/docs/strategy/prds/archive/garmin-life-signals-brief.md
+++ b/docs/strategy/prds/archive/garmin-life-signals-brief.md
@@ -1,0 +1,271 @@
+> **Archived from an orphaned branch.** Recovered from `claude/garmin-watch-integration-brief-jhvxsu` (last touched 2026-06-11),
+> which shares no history with master after the repository history was rewritten.
+> Kept for the thinking in it; nothing here is current.
+
+# Garmin Life Signals Brief: A Compliant Health-OS Layer for ctrl.rodeo
+
+**Status:** Draft
+**Date:** 2026-06-11
+**Author:** Claude (autonomous session)
+
+---
+
+## One-Liner
+
+Pull continuous health and activity data from a Garmin watch into ctrl.rodeo, **let the user add their own context conversationally** (e.g. "I've been vaping again this week"), and **associate all of it with the other critical parts of life the platform already curates** — what you read and watch, the work you're chasing, the events on your calendar. Store every data point as a **FHIR-aligned observation from day one** so this becomes a portable, compliant personal health record (a "Health OS"), not a throwaway dashboard.
+
+---
+
+## Context
+
+ctrl.rodeo already collects the *external* inputs of a life: links, content, boards, a Gmail jobs pipeline, events, and a taste profile that finds connections across categories. Its first brand principle is **"input shapes output — surface connections and patterns in what users collect."**
+
+Two inputs are missing, and this brief adds both:
+
+1. **The body (passive).** A Garmin watch produces the richest continuous personal dataset most people own — sleep, stress, HRV, Body Battery, heart rate, training load, workouts — trapped in Garmin Connect, disconnected from everything else.
+2. **Lived context (self-reported).** The things a watch can't sense but that explain everything: nicotine, alcohol, caffeine, medication, mood, symptoms, a stressful meeting. The user must be able to **add these clearly, in natural language, and ask questions back** — *"how did my sleep track with the weeks I was off nicotine?"*
+
+Both must be designed so the data can flow into a real **EHR / Health-OS framework in a compliant way** — structured, coded, provenance-stamped, and exportable to a clinician's system if the user ever chooses, without a rebuild.
+
+**Why now:** Garmin's Connect Developer Program exposes exactly the passive data we need over OAuth 2.0 with push + backfill ([Health API](https://developer.garmin.com/gc-developer-program/health-api/), [Activity API](https://developer.garmin.com/gc-developer-program/activity-api/)), and there is now a published case study mapping **Garmin device data into FHIR** for EHR interoperability ([Frontiers in Digital Health, 2025](https://www.frontiersin.org/journals/digital-health/articles/10.3389/fdgth.2025.1636775/full)). The clinical standards for self-reported data already exist (FHIR social-history observations). We don't have to invent the schema — we have to adopt it.
+
+---
+
+## Two Design Pillars Added in This Revision
+
+> The first draft of this brief covered passive ingestion + cross-domain correlation. This revision adds the two things that turn it from a quantified-self toy into a Health OS: **self-reported context with a conversational interface**, and **a compliant, EHR-portable data model.**
+
+### Pillar A — Conversational input & query (ask + add context)
+
+A single natural-language surface that does two jobs:
+
+- **Add context.** "Add that I quit nicotine on June 1." / "I had 3 drinks last night." / "Started 50mg sertraline this morning." Claude parses the utterance into a **structured, coded observation** (see Pillar B), shows the user exactly what it's about to record, and writes it only on confirmation. Manual context is never free-text mush — it lands as queryable, typed data.
+- **Ask questions.** "How's my resting HR trended since I quit nicotine?" / "Do I sleep worse the night before interviews?" Claude queries the observation store + the existing ctrl.rodeo entities (pins, jobs, events) and answers with honest, hedged correlations.
+
+This reuses ctrl.rodeo's existing AI-narration + connector plumbing — the body/health data simply becomes another thing the connector can read and write, behind the dedicated biometric privacy tier.
+
+### Pillar B — Compliant Health-OS data model (FHIR-native)
+
+Every data point — whether it came from a Garmin sync or from the user saying "I vaped today" — is stored internally as a **FHIR `Observation`**, the same resource EHRs use. This is the single decision that makes everything else (portability, compliance, interoperability) fall out for free. Details below.
+
+---
+
+## Brand Fit
+
+| Principle | How this honors it |
+|-----------|----------------------------|
+| **Input shapes output** | Body data + lived context become first-class inputs the connection engine reasons over. |
+| **Organize as you go** | Garmin pushes automatically; spoken context is parsed and coded automatically. Zero-friction capture. |
+| **One place, whole life** | Stop siloing the body — and the habits that drive it — away from the rest of life. |
+| **Show, don't decorate** | Surface only correlations that mean something. No vanity dashboards. |
+| **Expand with the user** | Start with passive ingestion + a few self-reported types; grow into a full portable health record. |
+
+---
+
+## What Garmin Exposes (Passive Inputs)
+
+The Garmin Connect Developer Program is a suite of OAuth 2.0 APIs. ([overview](https://developer.garmin.com/gc-developer-program/))
+
+### Health API — continuous wellness ([source](https://developer.garmin.com/gc-developer-program/health-api/))
+
+| Data type | Gives us |
+|-----------|------------------|
+| **Daily summaries** | Steps, floors, active/BMR calories, intensity minutes, all-day stress |
+| **Sleep** | Stages, duration, sleep score, restlessness |
+| **Stress** | All-day stress as 3-minute averages |
+| **Body Battery** | Proprietary 0–100 energy reserve (blends HRV, stress, sleep) |
+| **HRV** | Overnight beat-to-beat variation (recovery signal) |
+| **Heart rate / resting HR** | Continuous + daily resting baseline |
+| **Respiration & Pulse Ox (SpO2)** | Breathing rate, blood-oxygen |
+| **User metrics** | VO2 Max, fitness-age estimates |
+| **Epochs** | Minute-level activity rollups |
+
+### Activity API — detailed per-workout data (GPS, splits, HR zones, power, training effect). ([source](https://developer.garmin.com/gc-developer-program/activity-api/))
+
+### Delivery model
+- **Push/Ping** — Garmin POSTs to our callbacks within seconds of a sync; no polling. ([source](https://www.spikeapi.com/blog/why-integrate-garmin-api-directly))
+- **Backfill** — request months of history on connect, so correlations work day one.
+- **Auth** — OAuth 2.0 (PKCE-compatible), same shape as ctrl.rodeo's existing connector OAuth.
+
+### Access constraint
+The Garmin program is **free of fees but gated to "business use"** and requires approval — not a self-serve consumer API ([Program FAQ](https://developer.garmin.com/gc-developer-program/program-faq/)). Aggregators (Terra, Spike, Thryve) offer a faster, paid, multi-wearable path. See Decision #1.
+
+---
+
+## Self-Reported Inputs (Lived Context)
+
+These are entered by the user — typed, spoken, or in conversation — and parsed into the same observation model. Launch vocabulary (extensible):
+
+| Category | Examples | Clinical mapping |
+|----------|----------|------------------|
+| **Substance use** | Nicotine/vaping, alcohol, caffeine, cannabis | FHIR **Social History** observation. Nicotine → LOINC **72166-2** "Tobacco smoking status", value from SNOMED/LOINC answer set (e.g. `LA18976-3` "current every day smoker"). ([LOINC 72166-2](https://loinc.org/72166-2), [US Core Smoking Status](https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-smokingstatus.html)) |
+| **Medication** | "Started 50mg sertraline" | FHIR `MedicationStatement` (self-reported) |
+| **Mood / mental state** | "Anxious all day", energy, focus | Observation, survey category |
+| **Symptoms** | Headache, poor sleep, soreness | Observation / `Condition` |
+| **Life events** | "Big presentation", travel, illness | Observation, social/contextual — also linkable to ctrl.rodeo events |
+
+**Design rule:** self-reported data is *never* second-class. It is coded, timestamped, provenance-stamped as `patient-reported`, and queryable on the same axis as Garmin data — that's what lets "resting HR since I quit nicotine" actually work.
+
+---
+
+## The Health-OS Data Model (FHIR-native)
+
+**One canonical internal resource: `Observation`.** Garmin pushes and user utterances both normalize into it.
+
+```
+ SOURCE                     CANONICAL STORE                 CONSUMERS
+┌──────────────┐
+│ Garmin push  │──┐        ┌────────────────────┐        ┌─ correlation engine
+│ (sleep, HRV, │  │        │  observations       │        │  (time-joins vs.
+│  HR, stress) │  ├───────►│  (FHIR Observation) │───────►│   pins/jobs/events)
+└──────────────┘  │        │  + provenance       │        │
+┌──────────────┐  │        │  + code system map  │        ├─ conversational Q&A
+│ User utterance│ │        │  + privacy tier     │        │  (Claude)
+│ "vaped today"│──┘        └─────────┬──────────┘        │
+└──────────────┘                     │                    └─ FHIR export bundle
+                                      │                       (→ clinician EHR,
+                              ┌───────▼────────┐                Apple Health, etc.)
+                              │  Provenance     │
+                              │  who/what/when/  │
+                              │  source/method   │
+                              └─────────────────┘
+```
+
+### Why FHIR, internally, from the start
+- **It's the EHR lingua franca.** `Observation` is *the* resource EHRs use for vitals, labs, social history, and wearable data — quantitative and qualitative alike ([FHIR Observation](https://hl7.org/fhir/observation.html)). Adopting it now means "incorporate into an EHR framework later" is an *export*, not a migration.
+- **Provenance is built in.** The FHIR **`Provenance`** resource records who/what created each observation and keeps audit reviewers happy; **`derivedFrom`** chains a computed value back to its raw source. This is the backbone of compliant, trustworthy health data — every point can answer "where did this come from?"
+- **Self-reported fits natively.** `performer` = the patient and a `patient-reported` provenance tag distinguish "I said so" from "the device measured it" — without leaving the standard.
+- **Coded, not free-text.** LOINC for vitals/social-history codes, SNOMED for clinical values. The conversational parser's job is text → code, so the store stays queryable and interoperable.
+
+### Pragmatic implementation
+We don't run a full FHIR server on day one. Store a Postgres `observations` table whose columns map 1:1 to the FHIR `Observation` fields (`code`, `category`, `value[x]`, `effectiveDateTime`, `performer`, `derivedFrom`, `provenance`), plus ctrl.rodeo's `user_id` and privacy tier. A thin serializer emits valid FHIR R4 bundles on export. **FHIR-shaped storage, lightweight runtime.**
+
+---
+
+## Compliance Design
+
+The ambition ("EHR framework, compliant") raises the bar past the first draft. Here's the posture.
+
+### Regulatory reality
+- A **direct-to-consumer, self-entered personal health record is generally NOT a HIPAA covered entity or business associate** — HIPAA mostly doesn't apply to a PHR the individual controls and self-populates ([AccountableHQ](https://www.accountablehq.com/post/hipaa-compliance-guide-are-personal-health-records-covered-entities)).
+- **But other regimes do apply:** the **FTC Health Breach Notification Rule** reaches most non-HIPAA health apps; state consumer-health laws (notably **Washington's My Health My Data Act**) and **GDPR special-category data** impose consent, breach, and minimization duties ([Mobile Health Apps Tool, FTC](https://www.ftc.gov/business-guidance/resources/mobile-health-apps-interactive-tool)).
+- **The line moves the moment a provider is involved.** If ctrl.rodeo ever ingests data *from* or pushes *to* a clinician's EHR on their behalf, the covered-entity/business-associate bar engages. Design so that's an explicit, gated step — not an accident.
+
+### What we build to be compliant *and* portable
+| Control | Implementation |
+|---------|---------------|
+| **Provenance + audit** | Every observation carries a FHIR `Provenance` (source, method, device vs. patient-reported, timestamp). Immutable audit log of writes/exports/AI-access. |
+| **Consent & scope** | Dedicated **biometric/health privacy tier, off by default**, never bundled into existing `library`/`full_access` connector scopes. Per-category opt-in (Garmin separate from self-reported). |
+| **Data minimization** | Store only enabled categories. Disconnect = one-tap purge of tokens + observations + derived insights. |
+| **Encryption & isolation** | Health observations encrypted at rest; row-level security in Supabase; never logged in plaintext analytics. |
+| **Right to export / delete** | FHIR R4 bundle export and full delete are first-class user actions — satisfies GDPR/MHMDA and means the data is genuinely *yours* and portable. |
+| **AI access gating** | The connector and conversational agent can only read health observations when the user has explicitly granted the health tier; access is logged. |
+| **Honest framing** | Clear in-product language: this is a personal health record, not a medical/diagnostic device. No clinical claims. |
+
+---
+
+## Proposed Architecture
+
+Reuse the connector pattern from the [Multi-LLM Connector Brief](./multi-llm-connector-brief.md): thin protocol adapter → shared core → Supabase.
+
+| Layer | Implementation |
+|-------|---------------|
+| **OAuth + consent** | Extend `connect/` with a "Connect Garmin" path + health-tier consent; `garmin_tokens` table. |
+| **Garmin ingestion** | `garmin-ingest/index.ts` Edge Function — receives push callbacks, verifies, normalizes Garmin payloads → FHIR `Observation` rows. |
+| **Conversational capture/query** | `health-agent` flow (Claude): NL → structured coded observation (confirm before write); NL question → query over observations + pins/jobs/events. |
+| **Canonical store** | `observations` table (FHIR-Observation-shaped) + `provenance` + immutable `health_audit_log`. |
+| **Correlation core** | `_shared/signals-core.ts` — time-joins observations against pins/jobs/events; computes + thresholds candidate correlations. |
+| **Narration** | Claude Haiku turns flagged correlations + answers into honest connection cards (reuse widget/insight pipeline). |
+| **FHIR export** | Serializer emits an R4 bundle for clinician/Apple Health/Google Health Connect handoff. |
+| **Surface** | A "Health" lens in the UI + connector read/write, all behind the biometric tier. |
+
+---
+
+## Phasing
+
+| Phase | Scope | Size |
+|-------|-------|------|
+| **0. Access** | Decide direct Garmin vs. aggregator; get approved/keyed. | Small (mostly waiting) |
+| **1. Canonical store + ingest** | FHIR-shaped `observations` schema + `provenance` + audit log; Garmin OAuth + `garmin-ingest` webhook + backfill. Land passive data, correctly modeled. | Medium |
+| **2. Self-reported + conversational capture** | NL → coded observation with confirm-before-write; nicotine/alcohol/caffeine/med/mood vocabulary. **The "add context clearly" ask.** | Medium |
+| **3. Conversational query + associate** | Ask questions; time-join body + context against pins/jobs/events; first honest correlation cards. **The actual point.** | Medium–Large |
+| **4. Compliance hardening + FHIR export** | Encryption, purge, consent UX, audit surfacing, R4 export bundle. Makes it a real Health OS. | Medium |
+
+Phases 1–2 de-risk the model and the capture UX; Phase 3 delivers the brand promise; Phase 4 makes it portable and compliant. Don't let scope creep in 1–2 starve 3.
+
+---
+
+## Open Questions (1:3:1)
+
+> Per the connector brief's format requirement: **1 headline / 3 context bullets / 1 recommendation.**
+
+### 1. Direct Garmin integration or a wearable aggregator?
+- **Pro (direct):** No fees, richest first-party data, no third party touching health data.
+- **Con (direct):** "Business use" approval gate, Garmin-only, you own normalization + webhook ops.
+- **Nuance:** Aggregators ship in days, normalize many wearables (Apple Watch/Oura/Whoop later free), but cost money and add a processor to the compliance map.
+- **Recommendation:** **Aggregator for Phase 1 to validate fast and keep multi-wearable open; apply for direct Garmin in parallel since at n=1 it's free.** Revisit if volume makes fees the bottleneck.
+
+### 2. FHIR-native internally now, or normalize later?
+- **Pro (FHIR now):** "Incorporate into an EHR framework" becomes a cheap export, not a migration; provenance/coding designed in from the first row.
+- **Con (FHIR now):** Slightly more modeling effort up front; FHIR has a learning curve.
+- **Nuance:** We adopt the *shape* (FHIR-mapped Postgres + serializer), not a full FHIR server — most of the cost, little of the weight.
+- **Recommendation:** **FHIR-shaped storage from Phase 1.** The user explicitly wants EHR portability; retrofitting a canonical clinical model onto an ad-hoc schema later is the expensive path.
+
+### 3. Conversational capture — how much confirmation friction?
+- **Pro (always confirm):** Health data must be accurate; show the parsed observation ("Tobacco use: quit, 2026-06-01 — save?") before writing.
+- **Con (always confirm):** Adds a tap to every entry; could feel heavy for quick logging.
+- **Nuance:** Tier it — high-stakes types (meds, substances) always confirm; low-stakes (mood, caffeine) can quick-add with easy undo.
+- **Recommendation:** **Confirm-by-default for clinical/substance/med types; quick-add-with-undo for soft signals.** Accuracy where it matters, speed where it doesn't.
+
+### 4. Regulatory posture at launch?
+- **Pro (consumer PHR):** Self-entered + self-controlled keeps us out of HIPAA covered-entity scope; fastest to value.
+- **Con (consumer PHR):** Still bound by FTC Health Breach Notification Rule + state laws (WA MHMDA) + GDPR special-category — real obligations.
+- **Nuance:** The moment we exchange data with a provider's EHR *on their behalf*, the covered-entity/BA bar engages — that must be an explicit gated feature, never implicit.
+- **Recommendation:** **Launch as a self-controlled consumer PHR; build to FHIR/provenance/consent/export standards so a future clinical-integration mode is a gated add-on, not a re-architecture.**
+
+### 5. Personal tool or product feature?
+- **Pro (personal-first):** Fastest value for the one user who asked; free Garmin access at n=1; no support burden.
+- **Con (personal-first):** Multi-tenant consent/compliance differs if generalized.
+- **Nuance:** The connector/shared-core + FHIR model means a personal build is ~80% of the productized build.
+- **Recommendation:** **Personal-first, on the multi-tenant connector + FHIR pattern**, so productizing is wiring, not a rewrite.
+
+---
+
+## Success Criteria
+
+- Garmin data flows into FHIR-shaped `observations` within seconds of a sync, with backfill present day one.
+- The user can **add context in plain language** ("quit nicotine June 1") and have it land as a coded, provenance-stamped observation — and **ask questions** ("HR since I quit nicotine?") with honest answers.
+- At least one **genuinely non-obvious** cross-domain association surfaces in month one (body/context ↔ work/calendar/curation).
+- Health data is opt-in, isolated, auditable, and **exportable as a valid FHIR bundle** — portable into a real EHR if the user chooses.
+- Insights read as honest connection cards, not a quantified-self reskin. No clinical claims.
+
+---
+
+## Out of Scope (for now)
+
+- Pushing structured workouts back to the watch (Garmin Training API).
+- Direct, live two-way EHR integration with a provider (gated future mode — raises the compliance bar deliberately).
+- Medical/diagnostic claims of any kind.
+- Real-time streaming — daily + per-activity + per-entry granularity is plenty.
+- Rebuilding Garmin Connect's native dashboards.
+
+---
+
+## Sources
+
+- [Garmin Connect Developer Program — Overview](https://developer.garmin.com/gc-developer-program/) · [Health API](https://developer.garmin.com/gc-developer-program/health-api/) · [Activity API](https://developer.garmin.com/gc-developer-program/activity-api/) · [Program FAQ](https://developer.garmin.com/gc-developer-program/program-faq/)
+- [Streamlining wearable (Garmin) data integration using FHIR — Frontiers in Digital Health, 2025](https://www.frontiersin.org/journals/digital-health/articles/10.3389/fdgth.2025.1636775/full)
+- [FHIR Observation resource — HL7](https://hl7.org/fhir/observation.html)
+- [US Core Smoking Status Observation](https://build.fhir.org/ig/HL7/US-Core/StructureDefinition-us-core-smokingstatus.html) · [LOINC 72166-2 Tobacco smoking status](https://loinc.org/72166-2)
+- [Are Personal Health Records Covered Entities? — AccountableHQ](https://www.accountablehq.com/post/hipaa-compliance-guide-are-personal-health-records-covered-entities)
+- [Mobile Health Apps Interactive Tool — FTC](https://www.ftc.gov/business-guidance/resources/mobile-health-apps-interactive-tool)
+- [Why Integrate the Garmin API Directly in 2026 — Spike](https://www.spikeapi.com/blog/why-integrate-garmin-api-directly)
+
+---
+
+*Next steps:*
+1. Resolve Decision #1 (direct vs. aggregator) and #4 (regulatory posture) — they gate the build.
+2. Stand up the FHIR-shaped `observations` schema + `provenance` + audit log (Phase 1 foundation).
+3. Build `garmin-ingest` webhook + OAuth connect flow.
+4. Prototype the conversational capture parser (NL → coded observation) on nicotine as the first type.
+5. Run `/plan` to break Phases 0–4 into epics/stories.

--- a/docs/strategy/prds/archive/job-workflow.md
+++ b/docs/strategy/prds/archive/job-workflow.md
@@ -1,0 +1,153 @@
+> **Archived from an orphaned branch.** Recovered from `claude/job-workflow-website-lqmLs` (last touched 2026-04-24),
+> which shares no history with master after the repository history was rewritten.
+> Kept for the thinking in it; nothing here is current.
+
+# Job Workflow Brief
+
+**Date:** 2026-04-24
+**Scope:** Personal tool, not a product.
+
+---
+
+## Context
+
+Job search today runs out of a spreadsheet. It tracks but doesn't work. The move is to a ctrl sub-app at `/jobs` built on the ctrl design system, with Claude Code routines as the execution layer. Storage lives in the existing Boards Supabase project; criteria and rejection lists live as files in this repo so routines can read them without DB roundtrips.
+
+---
+
+## Core use cases
+
+### 1. Declare criteria
+
+**Page:** `/jobs/criteria`
+**Storage:** `docs/job-search/criteria.md` (+ a JSON companion for routines)
+
+A single page (and repo file) that captures what I'm looking for — role titles, seniority, industries, stage/size, comp floor, location/remote, domain preferences, values, deal-breakers, and a free-text "what I'm optimizing for." Every routine below reads from this file. Editing the page commits the file.
+
+### 2. Save companies I like → watch their job boards
+
+**Page:** `/jobs/companies`
+**Routine (scheduled, daily):** `watchlist-scrape`
+
+Mark any company as watched. Each watched company stores its careers URL and detected ATS (Greenhouse, Lever, Ashby, Workday, custom). A daily Claude Code routine polls each source, diffs against last run, matches new postings against criteria, and creates `sourced` jobs for hits.
+
+### 3. Pull saved jobs from LinkedIn
+
+**Trigger:** browser extension button on LinkedIn's saved-jobs page
+**Routine (API-triggered):** `linkedin-saved-import`
+
+Extend the existing ctrl extension with "Import saved jobs." It scrapes the list and POSTs to a routine that dedupes against existing rows and inserts as `sourced`. Email-forward fallback if the extension breaks.
+
+### 4. Recommend 5 jobs a day from my sources
+
+**View:** `/jobs/for-you`
+**Routine (scheduled, daily):** `daily-five`
+
+Aggregates the day's pool (new watchlist postings + LinkedIn saves + any connected feeds), reads criteria, picks 5 with a one-line rationale each. Accept sends it to `sourced`; reject feeds back into the routine's rejection file so the same role never shows up twice.
+
+### 5. Recommend similar companies
+
+**Routine (scheduled, weekly):** `similar-companies`
+
+Reads the saved-companies list, derives attributes (industry, stage, size, product category), proposes N new companies with rationale. Each shows up in `/jobs/companies` as a suggestion — add to watchlist or dismiss.
+
+### 6. Find connections at target companies
+
+**Routine (API-triggered on save):** `connection-sweep`
+
+For any company entering the active pipeline, the routine:
+- Uses the Gmail MCP connector to search for `@company.com` correspondents and surfaces them with last-contact date.
+- Pulls 1st/2nd-degree LinkedIn connections via the extension.
+
+Results land as `job_contacts` tagged `warm_source=gmail|linkedin` and show up on the role detail as "people you already know here."
+
+### 7. Draft cold email, resume, cover letter
+
+**Routines (API-triggered per job):** `draft-cold-email`, `tailor-resume`, `tailor-cover-letter`
+
+- **Cold email** — reads criteria + job + chosen contact + shared context (mutual employers, schools, ctrl pins); writes a short draft to `job_events` for review.
+- **Resume** — pulls resume source from the repo, tailors against JD + criteria, opens a PR on `claude/resume-<company>-<role>`.
+- **Cover letter** — same flow, sibling file on the same PR.
+
+All three read the single criteria file so voice stays consistent.
+
+---
+
+## Data
+
+```
+jobs                 id, company, role, status, source, link,
+                     comp_raw, applied_at, last_touch_at, created_at
+
+job_events           id, job_id, type, payload_jsonb, created_at
+                     -- status_change, note_added, draft_generated,
+                     --   routine_run, contact_added
+
+job_contacts         id, job_id, name, title, email, linkedin,
+                     warm_source, last_evidence_at
+
+companies            id, domain, name, industry, stage, size,
+                     careers_url, ats_vendor, is_watchlisted,
+                     enrichment_jsonb, last_scraped_at
+
+company_postings     id, company_id, external_id, title, link,
+                     first_seen_at, last_seen_at, raw_jsonb
+
+recommendations      id, job_id|posting_id, score_rationale,
+                     surfaced_at, decision  -- accept|reject|snooze
+```
+
+Repo files (routine-readable):
+- `docs/job-search/criteria.md` + `criteria.json`
+- `docs/job-search/rejections.json`
+- `docs/resume/resume.md` (source of truth for tailoring)
+
+---
+
+## Routines at a glance
+
+| Routine | Trigger | Writes |
+|---------|---------|--------|
+| `watchlist-scrape` | Daily | `company_postings`, `jobs` (sourced) |
+| `daily-five` | Daily | `recommendations` |
+| `similar-companies` | Weekly | company suggestions |
+| `linkedin-saved-import` | API (extension) | `jobs` (sourced) |
+| `connection-sweep` | API (on save) | `job_contacts` |
+| `draft-cold-email` | API (per job) | `job_events` |
+| `tailor-resume` | API (per job) | repo PR |
+| `tailor-cover-letter` | API (per job) | repo PR |
+
+---
+
+## Views
+
+- `/jobs` — kanban by status, default view
+- `/jobs/for-you` — daily five
+- `/jobs/companies` — watchlist + similar-company suggestions
+- `/jobs/criteria` — editable criteria
+- `/jobs/:id` — role detail: events, contacts, drafts, linked pins/boards
+
+All styled from `design-system/tokens.css` + `components.css`. Kanban may need `ds-kanban-column` + `ds-kanban-card`; documented in `design-system/README.md` if so.
+
+---
+
+## My choices
+
+- **Storage:** Supabase (Boards project) for rows that power the UI; repo files for criteria, rejections, and resume source.
+- **Execution:** Claude Code routines on my account. No pg_cron, no edge functions.
+- **Views:** kanban + for-you + companies + criteria + detail. No separate table view unless I miss it.
+- **Capture paths:** extension (LinkedIn saved + "Save as job"), watchlist scrape, manual add. No email forwarding at launch.
+
+---
+
+## Build order
+
+1. Criteria file + schema + one-shot spreadsheet import.
+2. `/jobs` kanban + `/jobs/:id` detail reading from Supabase.
+3. `/jobs/companies` watchlist CRUD.
+4. First routine: `watchlist-scrape`.
+5. `/jobs/for-you` + `daily-five` routine.
+6. Extension "Import saved jobs" + `linkedin-saved-import` routine.
+7. `connection-sweep` + `/jobs/:id` "people you know" panel.
+8. Drafters: `draft-cold-email`, `tailor-resume`, `tailor-cover-letter`.
+9. `similar-companies` routine.

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -1860,9 +1860,16 @@ export async function previewTick(db: DB): Promise<Array<Record<string, unknown>
        them nothing about who. Deliberate divergence from record(): don't
        "fix" this into matching, and don't trust it to prove a line is linked.
        It won't show the difference. */
-    line: `${icon(n.kind)} ${n.payload.copy
-      ? renderCopy(n.payload.copy, n.payload.vars || {}, overrides)
-      : (n.payload.sentence || '')}`.replace('{subject}', String(n.payload.vars?.subject ?? n.payload.title)),
+    /* Exactly what would be posted, prompt included. A preview that shows only
+       the sentence is not a preview of the message — the prompt is the half that
+       asks the house for something, and leaving it out is how you end up
+       checking the wrong thing. */
+    line: [
+      `${icon(n.kind)} ${n.payload.copy
+        ? renderCopy(n.payload.copy, n.payload.vars || {}, overrides)
+        : (n.payload.sentence || '')}`,
+      renderPrompt(n.kind, n.payload.links?.[0]?.url),
+    ].filter(Boolean).join('\n').replace('{subject}', String(n.payload.vars?.subject ?? n.payload.title)),
     dedupe_key: n.dedupe_key,
   }))
 }


### PR DESCRIPTION
## The docs

Fifteen old `claude/` branches **share no history with master** — the repo history was rewritten at some point, so they can't be merged, diffed, or rebased. Deleting them destroys the only copy.

Most of what they held is already safe:

- The **4 documents on every orphan branch** (Notion sync guides, bidirectional-sync plan, AI agent system) are in master under `*/archive/` — deliberately archived, not lost.
- `job-product`, `job-onboarding-flow`, `job/DESIGN` are **superseded** by their `ladder-*` equivalents from the rename.

**Five are genuinely absent**, recovered here into the existing `*/archive/` convention (~1,850 lines):

| Document | From |
|---|---|
| `gtm-launch-plan.md` | GTM launch plan, landing page, shared-board virality |
| `concept-compression.md` | pin-level semantic understanding PRD |
| `garmin-life-signals-brief.md` | conversational input + FHIR Health-OS model |
| `job-workflow.md` | job-workflow brief as a personal tool |
| `openclaw-handoff-protocol.md` | OpenClaw → Claude Code handoff |

Each carries a header naming the branch it came from and stating nothing in it is current — an archived doc that reads as live guidance is worse than a deleted one.

With these safe, all 15 orphan branches can be pruned.

## The preview

`previewTick` showed the sentence but not the prompt appended under it, so `?dry=1` couldn't answer *"will the next new-application post ask the house what it knows"*. A preview showing half the message is a preview of the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)