### PR TITLE
feat(recruiting): DM the screener how we run an intro call

### DIFF
--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.22.1'
+const VERSION = '1.23.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -87,6 +87,30 @@ const ephemeral = (content: string) => ({ type: 4, data: { content, flags: 64 } 
 
 // ---- claim background work (runs after the 3s ACK) ----
 
+
+/* The interview guide, as the screener should receive it.
+
+   Lives in recruit_settings so it can be rewritten without a deploy — it is the
+   kind of text that gets edited after every second call for a while. Returns
+   null when it has been deliberately emptied, so the house can turn this off by
+   clearing the setting rather than by us shipping a flag for it.
+
+   Discord caps a message at 2000 characters; the guide is sent as its own
+   message after the confirmation so a long one never truncates the part that
+   says when the call is. */
+async function interviewGuide(client: ReturnType<typeof db>): Promise<string | null> {
+  const { data } = await client.from('recruit_settings').select('key, value')
+    .in('key', ['interview_guide', 'interview_guide_url'])
+  const map = new Map((data || []).map((r) => [r.key, r.value]))
+  const guide = String(map.get('interview_guide') || '').trim()
+  const url = String(map.get('interview_guide_url') || '').trim()
+  if (!guide && !url) return null
+
+  const link = url ? `\n\n[The full version lives here](${url})` : ''
+  const body = guide.slice(0, 1800 - link.length)
+  return `**How we run an intro call**\n\n${body}${link}`
+}
+
 async function finishClaim(client: ReturnType<typeof db>, opts: {
   claimPost: Record<string, any>
   applicantId: string
@@ -122,6 +146,17 @@ async function finishClaim(client: ReturnType<typeof db>, opts: {
     await dmUser(opts.discordUserId,
       `✅ You're screening **${applicantName}** — Agape intro call — ${slotWhen(startsAt)}.\n` +
       `Calendar invites are out to you both. Meet: ${meetLink || '(see calendar invite)'}${platformLine}`)
+
+    /* And what the house wants out of it. Sent separately so a long guide can
+       never push the time and the Meet link out of view, and after the
+       confirmation because the confirmation is the urgent half. A failure here
+       must not mark the claim as failed — the call is booked either way. */
+    try {
+      const guide = await interviewGuide(client)
+      if (guide) await dmUser(opts.discordUserId, guide)
+    } catch (err) {
+      console.warn(`[recruit-discord] could not send the interview guide: ${(err as Error).message}`)
+    }
 
     try {
       await sendIntroEmail(client, applicant, housemateName, housemateEmail, startsAt, meetLink)

--- a/supabase/migrations/154_recruit_interview_guide.sql
+++ b/supabase/migrations/154_recruit_interview_guide.sql
@@ -1,0 +1,42 @@
+-- ============================================
+-- Migration 154: the interview guide, sent to whoever takes the call
+--
+-- A housemate claims a screening and gets a calendar invite and a Meet link —
+-- and no indication of what the house actually wants to learn. So every call is
+-- improvised, the questions differ by screener, and the write-ups are hard to
+-- compare because they answer different things.
+--
+-- The guide lives in settings rather than in the function so it can be rewritten
+-- without a deploy — it is the kind of text that gets edited after every second
+-- call for a while. Same reasoning as recruit_copy.
+--
+-- It is deliberately a starting point, not a script. The house is judging "would
+-- you live with them", which is a conversation, and a screener reading questions
+-- off a list will get worse answers than one who has read the shape of it and
+-- then talks like a person.
+--
+-- interview_guide_url points at the canonical version when one lives elsewhere
+-- (a Notion page, say); the DM links it under the inline text.
+-- ============================================
+
+INSERT INTO recruit_settings (key, value) VALUES
+  ('interview_guide_url', '""'::jsonb),
+  ('interview_guide', to_jsonb($guide$**Before (2 min)** — skim their application and pick one thing to ask about. Referring to something they wrote is the fastest way to make this feel like a conversation rather than a screening.
+
+**Open (5 min)** — who they are, what brought them to SF, what they're looking for in a house. Let them talk; you're listening for whether they're choosing *this* house or any room.
+
+**The core (15 min)** — you're answering one question: would you live with them?
+
+• What does living well with people look like to you?
+• Tell me about a household you loved being part of. What made it work?
+• When something's off with a housemate — dishes, noise, money — how do you handle it?
+• What would you want to start or host here?
+• What's your week actually like? Work hours, travel, guests, sleep.
+• What have you found hard about co-living?
+
+**Their questions (5 min)** — what they ask tells you what they care about. Be honest about the house, including the parts that are work.
+
+**Close (3 min)** — tell them what happens next and roughly when. Nobody should leave a call not knowing whether to expect an answer.
+
+**After** — write it up while it's fresh. Reply to the notification in #recruiting-automation and it lands on their profile as a house note.$guide$::text))
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Claiming a screening got you a calendar invite and a Meet link — and **no indication of what the house wants to learn**. Every call was improvised, questions differed by screener, and write-ups were hard to compare because they answered different things.

## What the screener now gets

A second DM, after the confirmation:

> **How we run an intro call**
>
> **Before (2 min)** — skim their application, pick one thing to ask about…
> **Open (5 min)** — who they are, what brought them to SF…
> **The core (15 min)** — you're answering one question: would you live with them?
> • What does living well with people look like to you?
> • Tell me about a household you loved being part of. What made it work?
> • When something's off with a housemate — dishes, noise, money — how do you handle it?
> • What would you want to start or host here?
> • What's your week actually like? Work hours, travel, guests, sleep.
> • What have you found hard about co-living?
> **Their questions (5 min)** · **Close (3 min)** — tell them what happens next
> **After** — reply to the notification and it lands on their profile as a house note.

Sent as its **own message**, after the confirmation — a long guide must never push the time and Meet link out of view. A failure to send is caught and logged rather than failing the claim: the call is booked either way.

## Editable without a deploy

The text is in `recruit_settings.interview_guide` (migration 154), not in the function — it's the kind of thing that gets rewritten after every second call. Clearing it turns the DM off. `interview_guide_url` links a canonical version elsewhere under the inline text.

It's deliberately a **starting point, not a script**. The house is judging whether it wants to live with someone, which is a conversation; a screener reading questions off a list gets worse answers than one who knows the shape and talks like a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)