### PR TITLE
feat(recruiting): the two stages are always on the profile (v3.60.0)

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1873,3 +1873,40 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
    comment, an email subject, the note someone left. It wraps; the sentence
    above it is the scannable part. */
 .activity-feed__detail { white-space: normal; overflow-wrap: anywhere; }
+
+/* ---------- where they are: the two stages, always present ----------
+   An intro call and a house visit used to appear only once one existed, so
+   "nobody has booked her call" and "the section failed to render" looked
+   identical. Both are permanent rows now, and Not scheduled is a state with its
+   own action rather than an absence. */
+.stages { display: flex; flex-direction: column; gap: var(--space-2); }
+.stage-row {
+  display: grid;
+  grid-template-columns: minmax(84px, auto) auto 1fr auto;
+  align-items: center; gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+}
+.stage-row:last-child { border-bottom: 0; }
+.stage-row__what { font-weight: var(--fw-medium); font-size: var(--font-size-body); color: var(--fg); }
+.stage-row__detail {
+  font-size: var(--font-size-small); color: var(--fg-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.stage-row__muted { font-size: var(--font-size-small); color: var(--fg-subtle); }
+.stage-row__action { flex-shrink: 0; }
+/* The chip carries the state. Not-scheduled is deliberately quiet rather than
+   red — it is the normal starting point for everyone, not a failure. */
+.stage-chip {
+  padding: 2px 8px; border-radius: 999px;
+  font-size: var(--font-size-caption); font-weight: var(--fw-medium);
+  white-space: nowrap;
+}
+.stage-chip--is-none { background: var(--bg-overlay); color: var(--fg-subtle); }
+.stage-chip--is-scheduled { background: var(--outreach-tint, var(--bg-overlay)); color: var(--outreach-fg, var(--fg)); }
+.stage-chip--is-done { background: var(--pass-tint); color: var(--fg-muted); }
+@media (max-width: 560px) {
+  .stage-row { grid-template-columns: 1fr auto; row-gap: 2px; }
+  .stage-row__detail { grid-column: 1 / -1; white-space: normal; }
+  .stage-row__action { grid-column: 1 / -1; }
+}

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.59.0">
+  <link rel="stylesheet" href="css/app.css?v=3.60.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.59.0';
+const VERSION = '3.60.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -4517,6 +4517,7 @@ function renderReview() {
     ${section('About them', a.about)}
     ${section('Why Agape', a.why)}
     ${section('Gifts to share', a.gifts)}
+    ${stagesHtml(a)}
     ${houseEventsHtml(a)}
     <section class="review__section notes" id="notes">
       <div class="notes__head">
@@ -4917,6 +4918,85 @@ function windowSlots(w) {
 /* Visits and house events swept off the house calendar. Read-only context:
    "they came to dinner on the 4th" is exactly the thing that used to live
    only in someone's head. Newest first, past ones included. */
+
+/* The two things that have to happen to a candidate, always on screen.
+
+   Before this, an intro call and a house visit only appeared once one existed —
+   a screening card if booked, a calendar row if visited, nothing at all
+   otherwise. So "has nobody booked her call, or did I just miss it?" could only
+   be answered by reading the whole profile and inferring from absence, and
+   absence looks identical to a rendering bug.
+
+   Now both stages are permanent rows with an explicit state. Not scheduled is a
+   state, and the row says so and offers the way to fix it. */
+const STAGE_STATE = {
+  none:      { label: 'Not scheduled', cls: 'is-none' },
+  scheduled: { label: 'Scheduled',     cls: 'is-scheduled' },
+  done:      { label: 'Completed',     cls: 'is-done' },
+};
+
+function stageRow(kind, opts) {
+  const st = STAGE_STATE[opts.state];
+  return `<div class="stage-row stage-row--${st.cls}">
+    <span class="stage-row__what">${esc(kind)}</span>
+    <span class="stage-chip stage-chip--${st.cls}">${st.label}</span>
+    <span class="stage-row__detail">${opts.detail || ''}</span>
+    <span class="stage-row__action">${opts.action || ''}</span>
+  </div>`;
+}
+
+function stagesHtml(a) {
+  const sc = screeningState[a.id] || {};
+
+  /* The intro call. "Completed" wins over "scheduled" when both exist, because
+     a second call booked after the first is the exception and the first one
+     having happened is the fact that matters most. */
+  let callState = 'none', callDetail = '', callAction = '';
+  if (sc.done) {
+    callState = 'done';
+    callDetail = `${esc(fmtSlot(sc.doneAt))}${sc.with && !/calendar|the house/i.test(sc.with) ? ` · ${esc(sc.with)}` : ''}`;
+    callAction = sc.watch
+      ? `<button type="button" class="cta-link" data-play-mini="${a.id}">Watch</button>`
+      : sc.awaiting ? '<span class="stage-row__muted">recording on the way</span>' : '';
+  } else if (sc.at) {
+    callState = 'scheduled';
+    callDetail = `${esc(fmtSlot(sc.at))}${sc.with && !/calendar|the house/i.test(sc.with) ? ` · ${esc(sc.with)}` : ''}`;
+    callAction = sc.link ? `<a class="cta-link" href="${esc(sc.link)}" target="_blank" rel="noopener">Join</a>` : '';
+  } else {
+    // Availability already in hand is the difference between "ask them" and
+    // "somebody take this" — the two have completely different next actions.
+    const hasTimes = (availCache[a.id]?.windows || []).length > 0;
+    callDetail = hasTimes ? 'they sent times, nobody has taken it' : 'no times offered yet';
+    callAction = `<button type="button" class="cta-link" data-email="${a.id}" data-email-kind="${hasTimes ? 'schedule' : 'availability'}">${hasTimes ? 'Book it' : 'Ask for times'}</button>`;
+  }
+
+  // The house visit. Read from the calendar rather than screenings — a visit is
+  // an event the house holds, not a call somebody claims.
+  const visits = (houseEvents[a.id] || []).filter(e => e.kind === 'visit');
+  const past = visits.filter(e => new Date(e.ends_at || e.starts_at) < new Date());
+  const upcoming = visits.filter(e => new Date(e.ends_at || e.starts_at) >= new Date());
+  let visitState = 'none', visitDetail = '', visitAction = '';
+  if (past.length) {
+    visitState = 'done';
+    visitDetail = esc(fmtSlot(past[past.length - 1].starts_at));
+  } else if (upcoming.length) {
+    visitState = 'scheduled';
+    visitDetail = esc(fmtSlot(upcoming[0].starts_at));
+  } else {
+    // Only worth offering once they have actually been interviewed.
+    visitDetail = sc.done ? 'ready to invite' : 'after the intro call';
+    visitAction = sc.done
+      ? `<button type="button" class="cta-link" data-email="${a.id}" data-email-kind="visit">Invite them</button>`
+      : '';
+  }
+
+  return `<section class="review__section stages">
+    <h3 class="review__section-title">Where they are</h3>
+    ${stageRow('Intro call', { state: callState, detail: callDetail, action: callAction })}
+    ${stageRow('House visit', { state: visitState, detail: visitDetail, action: visitAction })}
+  </section>`;
+}
+
 function houseEventsHtml(a) {
   const evs = (houseEvents[a.id] || []).slice()
     .sort((x, y) => (y.starts_at || '').localeCompare(x.starts_at || ''));


### PR DESCRIPTION
An intro call and a house visit only appeared **once one existed** — a screening card if booked, a calendar row if visited, nothing otherwise. So *"has nobody booked her call, or did I just miss it?"* could only be answered by reading the whole profile and inferring from absence — and absence looks identical to a rendering bug.

## Now

```
Where they are
Intro call     [Not scheduled]  they sent times, nobody has taken it   Book it
House visit    [Not scheduled]  after the intro call
```

```
Intro call     [Completed]      Wed, Jul 29 10:15 AM · Kate            Watch
House visit    [Scheduled]      Sat, Aug 2 4:00 PM
```

**Not scheduled is a state, not a gap.** It distinguishes *nobody has asked them for times* from *they sent times and nobody has picked it up* — completely different next actions — and carries the button that fixes it.

Two judgement calls:
- **Completed beats scheduled** when both exist. A second call booked after the first is the exception; the first having happened is the fact that matters.
- **The visit only offers an invite once the call is done.** Inviting someone to the house before anyone has spoken to them isn't a thing the house does.

The Not-scheduled chip is quiet rather than red — it's where everybody starts, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)