### PR TITLE
feat(recruiting): the call reminder links instead of printing URLs

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -345,6 +345,14 @@ export async function dmUser(
   discordUserId: string,
   content: string,
   buttons: Array<{ label: string; customId: string }> = [],
+  /* Render the text as an embed rather than plain content.
+
+     Discord only resolves [label](url) inside an embed — in plain content it
+     shows the raw URL, which is why a message meant to say "View application"
+     would otherwise print sixty characters of query string. Plain stays the
+     default because most DMs here are one line and an embed would make them
+     look like announcements. */
+  asEmbed = false,
 ): Promise<void> {
   const channel = await discordFetch('/users/@me/channels', {
     method: 'POST', body: JSON.stringify({ recipient_id: discordUserId }),
@@ -359,7 +367,12 @@ export async function dmUser(
     : []
   await discordFetch(`/channels/${channel.id}/messages`, {
     method: 'POST',
-    body: JSON.stringify({ content, ...(components.length ? { components } : {}) }),
+    body: JSON.stringify({
+      ...(asEmbed
+        ? { embeds: [{ description: content.slice(0, 3900), color: 0x378add }] }
+        : { content }),
+      ...(components.length ? { components } : {}),
+    }),
   })
   await auditMirror('Message sent', content.split('\n')[0], { dmTo: discordUserId })
 }

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.29.0'
+const VERSION = '1.30.0'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -458,9 +458,10 @@ async function remindUpcoming(client: ReturnType<typeof db>): Promise<number> {
            have run twenty of these are not made to scroll past it. */
         await dmUser(dm.discord_user_id,
           `⏰ Coming up: you're interviewing **${name}** at ${slotWhen(new Date(s.starts_at))} PT.\n` +
-          `Meet: ${s.meet_link || '(see calendar invite)'}\n` +
-          `Background: https://ctrl.rodeo/applications/?a=${encodeURIComponent(s.applicant_id)}`,
-          [{ label: 'How we run an intro call', customId: `guide|${s.applicant_id}` }])
+          `${s.meet_link ? `[Join the Meet](${s.meet_link})` : 'See the calendar invite for the link'} · ` +
+          `[View application](https://ctrl.rodeo/applications/?a=${encodeURIComponent(s.applicant_id)})`,
+          [{ label: 'How we run an intro call', customId: `guide|${s.applicant_id}` }],
+          true)
         sent++
       }
       // Stamp even without a Discord id so we don't retry forever.
@@ -1021,9 +1022,10 @@ serve(async (req) => {
         const name = who ? `${who.first_name} ${who.last_name || ''}`.trim() : 'an applicant'
         await dmUser(to,
           `⏰ Coming up: you're interviewing **${name}** at 3:00 PM PT.\n` +
-          `Meet: (see calendar invite)\n` +
-          `Background: https://ctrl.rodeo/applications/?a=${encodeURIComponent(applicantId)}`,
-          [{ label: 'How we run an intro call', customId: `guide|${applicantId}` }])
+          `[Join the Meet](https://meet.google.com/) · ` +
+          `[View application](https://ctrl.rodeo/applications/?a=${encodeURIComponent(applicantId)})`,
+          [{ label: 'How we run an intro call', customId: `guide|${applicantId}` }],
+          true)
         return json({ sent: 1, shape: 'reminder' })
       }
 


### PR DESCRIPTION
> ❌ `Background: https://ctrl.rodeo/applications/?a=marisa-maccaro-20260701115658`

Sixty characters of a four-line message spent on a query string nobody reads.

> ✅ ⏰ Coming up: you're interviewing **Marisa Maccaro** at 3:00 PM PT.
> [Join the Meet](…) · [View application](…)
> `[ How we run an intro call ]`

## Why this needed an embed

Discord only resolves `[label](url)` **inside an embed** — in plain content it prints the raw URL, so masking the link in a plain DM would have produced literal markdown in the message.

`dmUser` gains an `asEmbed` flag rather than a second function, and **plain stays the default**: most DMs here are one line, and an embed would make a one-line message look like an announcement.

The preview path sends the same shape — a preview that renders differently from the real thing is worse than none, because it's trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)