### PR TITLE
fix(recruiting): sign-in DM sweep off by default; fix audit fan-out

### DIFF
--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -568,7 +568,57 @@ export async function postSigninMessage(channelId: string): Promise<any> {
 const VIEW_CHANNEL = 1n << 10n
 const ADMINISTRATOR = 1n << 3n
 
+/* Fetch the channel + role table ONCE. Doing this per member turned a roster
+   sweep into two Discord calls per person, which is fine for one lookup and
+   ruinous for a whole guild. */
+export async function recruitingGate(): Promise<{ channel: any; roleById: Map<string, bigint>; guildId: string } | null> {
+  const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
+  const [channels, roles] = await Promise.all([
+    discordFetch(`/guilds/${guildId}/channels`, { method: 'GET' }),
+    discordFetch(`/guilds/${guildId}/roles`, { method: 'GET' }),
+  ])
+  const wantedId = Deno.env.get('RECRUITING_CHANNEL_ID')
+  const named = (rx: RegExp) => channels.find((c: any) => rx.test(String(c.name || '')) && c.type !== 4)
+  const channel = wantedId
+    ? channels.find((c: any) => String(c.id) === wantedId)
+    : (named(/recruit.*society|society.*recruit/i) || named(/recruit/i))
+  if (!channel) return null
+  return { channel, roleById: new Map(roles.map((r: any) => [r.id, BigInt(r.permissions)])), guildId }
+}
+
+/* Pure permission maths against an already-fetched gate. */
+export function canSeeWithGate(
+  gate: { channel: any; roleById: Map<string, bigint>; guildId: string },
+  discordUserId: string,
+  memberRoles: string[],
+): boolean {
+  const { channel, roleById, guildId } = gate
+  let base = (roleById.get(guildId) as bigint) ?? 0n
+  for (const rid of memberRoles) base |= (roleById.get(rid) as bigint) ?? 0n
+  if (base & ADMINISTRATOR) return true
+  const overwrites = (channel.permission_overwrites || []) as Array<any>
+  let perms = base
+  const everyone = overwrites.find((o) => o.id === guildId)
+  if (everyone) { perms &= ~BigInt(everyone.deny); perms |= BigInt(everyone.allow) }
+  let allow = 0n, deny = 0n
+  for (const ow of overwrites) {
+    if (ow.type === 0 && ow.id !== guildId && memberRoles.includes(ow.id)) {
+      allow |= BigInt(ow.allow); deny |= BigInt(ow.deny)
+    }
+  }
+  perms &= ~deny; perms |= allow
+  const mine = overwrites.find((o) => o.type === 1 && o.id === discordUserId)
+  if (mine) { perms &= ~BigInt(mine.deny); perms |= BigInt(mine.allow) }
+  return (perms & VIEW_CHANNEL) === VIEW_CHANNEL
+}
+
 export async function canSeeRecruiting(discordUserId: string, memberRoles: string[]): Promise<boolean> {
+  const gate = await recruitingGate()
+  if (!gate) return false
+  return canSeeWithGate(gate, discordUserId, memberRoles)
+}
+
+export async function _unusedCanSeeRecruiting(discordUserId: string, memberRoles: string[]): Promise<boolean> {
   const guildId = Deno.env.get('AGAPE_GUILD_ID') || '952961396121931838'
   const [channels, roles] = await Promise.all([
     discordFetch(`/guilds/${guildId}/channels`, { method: 'GET' }),

--- a/supabase/functions/discord-membership/index.ts
+++ b/supabase/functions/discord-membership/index.ts
@@ -20,7 +20,7 @@
 // roles + channel permission overwrites. Cached as is_recruiting_member and
 // used by the recruit_* RLS policies (migration 108).
 
-const VERSION = '1.6.1'
+const VERSION = '1.7.0'
 console.log(`[discord-membership] v${VERSION} — Agape guild + recruiting-channel gate + #recruiting-automation admin (OAuth or bot magic-link)`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -368,13 +368,46 @@ serve(async (req) => {
         db.from('recruit_admins').select('user_id'),
       ])
       const byDiscord = new Map((cached || []).map((r: Record<string, unknown>) => [String(r.discord_user_id), r]))
+      // Resolve the channel + role table once. checkRecruitingChannel fetches
+      // both on every call, which is two Discord round trips per member — fine
+      // for one lookup, ruinous across a whole guild (it hung the request).
+      const [chResp, roleResp] = await Promise.all([
+        discordGet(`/guilds/${AGAPE_GUILD_ID}/channels`),
+        discordGet(`/guilds/${AGAPE_GUILD_ID}/roles`),
+      ])
+      const channels = await chResp.json() as Array<Record<string, any>>
+      const allRoles = await roleResp.json() as Array<{ id: string; permissions: string }>
+      const wanted = Deno.env.get('RECRUITING_CHANNEL_ID')
+      const pick = (rx: RegExp) => channels.find(c => rx.test(String(c.name || '')) && c.type !== 4)
+      const chan = wanted ? channels.find(c => String(c.id) === wanted)
+        : (pick(/recruit.*society|society.*recruit/i) || pick(/recruit/i))
+      if (!chan) return new Response(JSON.stringify({ error: 'Recruiting channel not found' }), { status: 502, headers: jsonHeaders })
+      const roleById = new Map(allRoles.map(r => [r.id, BigInt(r.permissions)]))
+      const overwrites = (chan.permission_overwrites || []) as Array<Record<string, any>>
+      const seeChannel = (did: string, memberRoles: string[]): boolean => {
+        let base = roleById.get(AGAPE_GUILD_ID) ?? 0n
+        for (const rid of memberRoles) base |= roleById.get(rid) ?? 0n
+        if (base & ADMINISTRATOR) return true
+        let perms = base
+        const ev = overwrites.find(o => o.id === AGAPE_GUILD_ID)
+        if (ev) { perms &= ~BigInt(ev.deny); perms |= BigInt(ev.allow) }
+        let allow = 0n, deny = 0n
+        for (const ow of overwrites) {
+          if (ow.type === 0 && ow.id !== AGAPE_GUILD_ID && memberRoles.includes(ow.id)) {
+            allow |= BigInt(ow.allow); deny |= BigInt(ow.deny)
+          }
+        }
+        perms &= ~deny; perms |= allow
+        const mine = overwrites.find(o => o.type === 1 && o.id === did)
+        if (mine) { perms &= ~BigInt(mine.deny); perms |= BigInt(mine.allow) }
+        return (perms & VIEW_CHANNEL) === VIEW_CHANNEL
+      }
+
       const rows: Array<Record<string, unknown>> = []
       for (const m of members) {
         const did = String(m.user?.id || '')
         if (!did || m.user?.bot) continue
-        let canSee = false
-        try { canSee = await checkRecruitingChannel(did, m.roles || []) } catch { canSee = false }
-        if (!canSee) continue
+        if (!seeChannel(did, m.roles || [])) continue
         const row = byDiscord.get(did)
         rows.push({
           discordUserId: did,

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -331,7 +331,15 @@ async function registerCommands(): Promise<Record<string, unknown>> {
   })
   const out = await resp.json()
   if (!resp.ok) throw new Error(`Discord ${resp.status}: ${JSON.stringify(out).slice(0, 200)}`)
-  return { registered: Array.isArray(out) ? out.map((c: Record<string, unknown>) => c.name) : out, guildId }
+  // Registering succeeds even when the bot was invited without the
+  // applications.commands scope — in that case Discord accepts the command
+  // but never shows it to anyone. Hand back the URL that grants the scope.
+  const authorizeUrl = `https://discord.com/oauth2/authorize?client_id=${app.id}` +
+    `&scope=applications.commands%20bot&guild_id=${guildId}&disable_guild_select=true`
+  return {
+    registered: Array.isArray(out) ? out.map((c: Record<string, unknown>) => c.name) : out,
+    guildId, appId: app.id, appName: app.name, authorizeUrl,
+  }
 }
 
 // POST /redeem  { token } → { token_hash, email } for supabase-js verifyOtp.
@@ -724,6 +732,12 @@ async function archiveMissingRecordings(client: ReturnType<typeof db>): Promise<
    Listing the roster needs the Server Members privileged intent; without it
    this no-ops quietly rather than pretending to have swept. */
 async function inviteUnsignedMembers(client: ReturnType<typeof db>): Promise<number> {
+  // OFF by default. Unsolicited DMs to the whole house is not a thing to
+  // enable by accident — flip recruit_settings.signin_sweep_enabled to true
+  // deliberately, and only when the house expects it.
+  const { data: flag } = await client.from('recruit_settings')
+    .select('value').eq('key', 'signin_sweep_enabled').maybeSingle()
+  if (flag?.value !== true) return 0
   const { dmUser } = await import('../_shared/discord.ts')
   const botToken = Deno.env.get('DISCORD_BOT_TOKEN')
   if (!botToken) return 0
@@ -746,15 +760,16 @@ async function inviteUnsignedMembers(client: ReturnType<typeof db>): Promise<num
   const hasAccount = new Set((known || []).map((r: Record<string, unknown>) => String(r.discord_user_id)))
   const alreadyAsked = new Set((invited || []).map((r: Record<string, unknown>) => String(r.discord_user_id)))
 
-  // Reuse the membership function's view of the channel rather than
-  // reimplementing permission maths in a second place.
-  const { canSeeRecruiting } = await import('../_shared/discord.ts')
+  // One channel/role fetch for the whole sweep, not one per member.
+  const { recruitingGate, canSeeWithGate } = await import('../_shared/discord.ts')
+  const gate = await recruitingGate()
+  if (!gate) { console.warn('[signin-sweep] recruiting channel not found'); return 0 }
   let sent = 0
   for (const m of members) {
     const did = String(m.user?.id || '')
     if (!did || m.user?.bot || hasAccount.has(did) || alreadyAsked.has(did)) continue
     let allowed = false
-    try { allowed = await canSeeRecruiting(did, m.roles || []) } catch { continue }
+    try { allowed = canSeeWithGate(gate, did, m.roles || []) } catch { continue }
     if (!allowed) continue
     const url = await mintSigninUrl(did, m.user?.global_name || m.user?.username || null)
     if (!url) continue


### PR DESCRIPTION
Two fixes.

**The DM sweep fired unasked.** Enabling the Server Members intent was enough to switch it on, and it DM'd three housemates within seconds. That is not something that should follow from a Discord settings toggle — it now requires `recruit_settings.signin_sweep_enabled = true`, set deliberately.

**The audit hung.** `checkRecruitingChannel` fetches the channel list and role table on every call, so auditing a guild meant two Discord round trips per member. Fine for one lookup, ruinous for a roster — it froze the request. Both the audit and the sweep now resolve the channel/role table once and do the permission maths locally.

Also returns the app id and an `applications.commands` authorize URL from register-commands, for diagnosing why /signin isn't appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)