### PR TITLE
feat(analytics): private site-wide analytics dashboard at /analytics

### DIFF
--- a/account/index.html
+++ b/account/index.html
@@ -357,6 +357,7 @@
   }
 }
   </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
   <!-- Auth mount point -->

--- a/analytics/index.html
+++ b/analytics/index.html
@@ -1,0 +1,420 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Analytics — ctrl.rodeo</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/design-system/tokens.css">
+  <link rel="stylesheet" href="/design-system/components.css">
+  <link rel="stylesheet" href="/auth/ctrl-auth.css">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="/auth/ctrl-auth.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--fg);
+      font-family: var(--font-mono);
+      font-size: var(--text-sm);
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap { max-width: 1080px; margin: 0 auto; padding: var(--space-6) var(--space-4) var(--space-16); }
+
+    /* Gate */
+    .gate {
+      min-height: 100dvh; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: var(--space-4);
+      text-align: center; padding: var(--space-4);
+    }
+    .gate__title { font-family: var(--font-display); font-size: 24px; margin: 0; }
+    .gate__sub { color: var(--fg-muted); margin: 0; max-width: 360px; line-height: 1.6; }
+
+    /* Header */
+    .head { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-4); flex-wrap: wrap; margin-bottom: var(--space-6); }
+    .head__title { font-family: var(--font-display); font-size: 22px; margin: 0; }
+    .head__meta { color: var(--fg-subtle); font-size: var(--text-xs); }
+    .head__actions { display: flex; gap: var(--space-2); align-items: center; }
+
+    /* Filter row */
+    .filters { display: flex; gap: var(--space-2); margin-bottom: var(--space-6); }
+    .range-btn[aria-pressed="true"] { background: var(--fg); color: var(--bg); border-color: var(--fg); }
+
+    /* Stat tiles */
+    .tiles { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: var(--space-2); margin-bottom: var(--space-6); }
+    .tile { border: 1px solid var(--border-subtle); background: var(--bg-surface); padding: var(--space-3) var(--space-4); }
+    .tile__label { color: var(--fg-muted); font-size: var(--text-xs); text-transform: lowercase; letter-spacing: 0.04em; }
+    .tile__value { font-family: var(--font-display); font-size: 26px; line-height: 1.3; margin-top: var(--space-1); font-variant-numeric: tabular-nums; }
+    .tile__value--error { color: var(--color-error); }
+
+    /* Sections */
+    .section { margin-bottom: var(--space-8); }
+    .section__title { font-size: var(--text-sm); color: var(--fg-muted); text-transform: lowercase; letter-spacing: 0.06em; margin: 0 0 var(--space-3); }
+    .panel { border: 1px solid var(--border-subtle); background: var(--bg-surface); padding: var(--space-4); }
+
+    /* Chart */
+    .chart-wrap { position: relative; }
+    .chart-svg { display: block; width: 100%; height: 220px; }
+    .chart-bar { fill: var(--fg); opacity: 0.85; }
+    .chart-bar:hover { opacity: 1; }
+    .chart-hit { fill: transparent; cursor: crosshair; }
+    .chart-axis { fill: var(--fg-subtle); font-size: 10px; font-family: var(--font-mono); }
+    .chart-grid { stroke: var(--border-subtle); stroke-width: 1; }
+    .chart-tip {
+      position: absolute; pointer-events: none; z-index: 5;
+      background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+      padding: var(--space-2) var(--space-3); font-size: var(--text-xs);
+      white-space: nowrap; display: none; line-height: 1.7;
+    }
+    .chart-tip strong { font-weight: 600; }
+    .chart-tip .tip-err { color: var(--color-error); }
+
+    /* Tables */
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-4); }
+    @media (max-width: 760px) { .grid-2 { grid-template-columns: 1fr; } }
+    table { width: 100%; border-collapse: collapse; font-size: var(--text-xs); }
+    th { text-align: left; color: var(--fg-subtle); font-weight: 500; padding: var(--space-1) var(--space-2); border-bottom: 1px solid var(--border-subtle); text-transform: lowercase; }
+    td { padding: var(--space-2); border-bottom: 1px solid var(--border-subtle); vertical-align: top; }
+    tr:last-child td { border-bottom: 0; }
+    td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+    .muted { color: var(--fg-muted); }
+    .subtle { color: var(--fg-subtle); }
+    .cell-path { word-break: break-all; }
+    .err-msg { color: var(--color-error); word-break: break-word; }
+    .err-stack {
+      color: var(--fg-subtle); white-space: pre-wrap; word-break: break-all;
+      font-size: 10px; margin: var(--space-1) 0 0; max-height: 96px; overflow: auto; display: none;
+    }
+    tr.is-open .err-stack { display: block; }
+    .err-row { cursor: pointer; }
+    .table-scroll { overflow-x: auto; }
+
+    .status { color: var(--fg-muted); padding: var(--space-8) 0; text-align: center; }
+    .status--error { color: var(--color-error); }
+  </style>
+</head>
+<body>
+
+  <div class="gate" id="gate">
+    <h1 class="gate__title">Analytics</h1>
+    <p class="gate__sub" id="gate-sub">Sign in to view site analytics. Owner access only.</p>
+    <button class="btn btn--filled" id="gate-btn" type="button">Sign in</button>
+  </div>
+
+  <div class="wrap" id="app" hidden>
+    <header class="head">
+      <h1 class="head__title">Analytics</h1>
+      <div class="head__actions">
+        <span class="head__meta" id="generated-at"></span>
+        <button class="btn btn--sm" id="refresh-btn" type="button">Refresh</button>
+        <button class="btn btn--sm btn--ghost" id="signout-btn" type="button">Sign out</button>
+      </div>
+    </header>
+
+    <div class="filters" id="range-filters" role="group" aria-label="Date range">
+      <button class="btn btn--sm range-btn" data-days="7" aria-pressed="false" type="button">7 days</button>
+      <button class="btn btn--sm range-btn" data-days="30" aria-pressed="true" type="button">30 days</button>
+      <button class="btn btn--sm range-btn" data-days="90" aria-pressed="false" type="button">90 days</button>
+    </div>
+
+    <div class="status" id="loading">Loading…</div>
+    <div class="status status--error" id="load-error" hidden></div>
+
+    <div id="content" hidden>
+      <div class="tiles" id="tiles"></div>
+
+      <section class="section">
+        <h2 class="section__title">views per day</h2>
+        <div class="panel chart-wrap" id="chart-wrap">
+          <svg class="chart-svg" id="chart" role="img" aria-label="Daily pageviews bar chart"></svg>
+          <div class="chart-tip" id="chart-tip"></div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2 class="section__title">projects</h2>
+        <div class="panel table-scroll">
+          <table>
+            <thead><tr><th>app</th><th class="num">views</th><th class="num">sessions</th><th class="num">errors</th><th>last seen</th></tr></thead>
+            <tbody id="by-app"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <div class="grid-2 section">
+        <section>
+          <h2 class="section__title">top pages</h2>
+          <div class="panel table-scroll">
+            <table>
+              <thead><tr><th>path</th><th class="num">views</th></tr></thead>
+              <tbody id="top-paths"></tbody>
+            </table>
+          </div>
+        </section>
+        <section>
+          <h2 class="section__title">top referrers</h2>
+          <div class="panel table-scroll">
+            <table>
+              <thead><tr><th>referrer</th><th class="num">views</th></tr></thead>
+              <tbody id="top-referrers"></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <section class="section">
+        <h2 class="section__title">recent errors</h2>
+        <div class="panel table-scroll">
+          <table>
+            <thead><tr><th>when</th><th>app</th><th>error</th></tr></thead>
+            <tbody id="recent-errors"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2 class="section__title">accounts</h2>
+        <div class="panel table-scroll">
+          <table>
+            <thead><tr><th>email</th><th>providers</th><th>created</th><th>last sign-in</th></tr></thead>
+            <tbody id="accounts"></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+
+  <script>
+  (function () {
+    'use strict';
+    var VERSION = '1.0.0';
+    console.log('[analytics] v' + VERSION + ' - private site analytics dashboard');
+
+    var SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+    var ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+    var FN_URL = SUPABASE_URL + '/functions/v1/analytics-dashboard';
+    var ADMIN_EMAILS = ['fike101@gmail.com'];
+
+    var days = 30;
+    var el = function (id) { return document.getElementById(id); };
+
+    CtrlAuth.init({
+      supabaseUrl: SUPABASE_URL,
+      supabaseAnonKey: ANON_KEY,
+      redirectTo: window.location.origin + '/analytics/',
+      adminEmails: ADMIN_EMAILS,
+      skipUsername: true
+    });
+
+    el('gate-btn').onclick = function () { CtrlAuth.openLoginModal(); };
+    el('signout-btn').onclick = function () { CtrlAuth.signOut(); };
+    el('refresh-btn').onclick = function () { load(); };
+    Array.prototype.forEach.call(document.querySelectorAll('.range-btn'), function (btn) {
+      btn.onclick = function () {
+        days = parseInt(btn.dataset.days, 10);
+        Array.prototype.forEach.call(document.querySelectorAll('.range-btn'), function (b) {
+          b.setAttribute('aria-pressed', String(b === btn));
+        });
+        load();
+      };
+    });
+
+    document.addEventListener('ctrl:auth:signedin', onSignedIn);
+    document.addEventListener('ctrl:auth:signedout', function () {
+      el('app').hidden = true;
+      el('gate').style.display = '';
+      el('gate-sub').textContent = 'Sign in to view site analytics. Owner access only.';
+    });
+
+    function onSignedIn() {
+      if (!CtrlAuth.isAdmin()) {
+        el('gate-sub').textContent = 'This dashboard is owner-only. You are signed in as ' +
+          ((CtrlAuth.getUser() || {}).email || 'an unknown account') + '.';
+        el('gate-btn').textContent = 'Sign out';
+        el('gate-btn').onclick = function () { CtrlAuth.signOut(); };
+        return;
+      }
+      el('gate').style.display = 'none';
+      el('app').hidden = false;
+      load();
+    }
+
+    var data = null;
+
+    function load() {
+      var session = CtrlAuth.getSession();
+      if (!session) return;
+      el('loading').hidden = false;
+      el('load-error').hidden = true;
+      el('content').hidden = true;
+      fetch(FN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: ANON_KEY,
+          Authorization: 'Bearer ' + session.access_token
+        },
+        body: JSON.stringify({ days: days })
+      }).then(function (res) {
+        if (!res.ok) throw new Error(res.status === 403 ? 'This dashboard is owner-only.' : 'Request failed (' + res.status + ')');
+        return res.json();
+      }).then(function (payload) {
+        data = payload;
+        render();
+      }).catch(function (err) {
+        el('loading').hidden = true;
+        el('load-error').hidden = false;
+        el('load-error').textContent = err.message || 'Failed to load analytics.';
+      });
+    }
+
+    // ---------- rendering ----------
+    function esc(s) {
+      return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      });
+    }
+    function fmtNum(n) { return (n == null ? 0 : n).toLocaleString(); }
+    function fmtDate(iso) {
+      if (!iso) return '—';
+      var d = new Date(iso);
+      return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' ' +
+             d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+    }
+    function hostOf(url) {
+      try { return new URL(url).host || url; } catch (e) { return url; }
+    }
+
+    function render() {
+      var s = data.summary || {};
+      var a = data.accounts || {};
+      el('loading').hidden = true;
+      el('content').hidden = false;
+      el('generated-at').textContent = 'updated ' + fmtDate(data.generatedAt);
+
+      var tiles = [
+        ['views today', fmtNum(s.views_today)],
+        ['views · ' + s.days + 'd', fmtNum(s.views_total)],
+        ['sessions · ' + s.days + 'd', fmtNum(s.uniques_total)],
+        ['errors · ' + s.days + 'd', fmtNum(s.errors_total), s.errors_total > 0 ? 'error' : null],
+        ['accounts', fmtNum(a.total)],
+        ['new accounts · 7d', fmtNum(a.new_7d)],
+        ['active accounts · 7d', fmtNum(a.active_7d)]
+      ];
+      el('tiles').innerHTML = tiles.map(function (t) {
+        return '<div class="tile"><div class="tile__label">' + esc(t[0]) + '</div>' +
+          '<div class="tile__value' + (t[2] === 'error' ? ' tile__value--error' : '') + '">' + esc(t[1]) + '</div></div>';
+      }).join('');
+
+      renderChart(s.daily || []);
+
+      el('by-app').innerHTML = (s.by_app || []).map(function (r) {
+        return '<tr><td>' + esc(r.app) + '</td><td class="num">' + fmtNum(r.views) +
+          '</td><td class="num">' + fmtNum(r.uniques) +
+          '</td><td class="num' + (r.errors > 0 ? ' err-msg' : '') + '">' + fmtNum(r.errors) +
+          '</td><td class="subtle">' + esc(fmtDate(r.last_seen)) + '</td></tr>';
+      }).join('') || emptyRow(5, 'no traffic yet');
+
+      el('top-paths').innerHTML = (s.top_paths || []).map(function (r) {
+        return '<tr><td class="cell-path">' + esc(r.path) + '</td><td class="num">' + fmtNum(r.views) + '</td></tr>';
+      }).join('') || emptyRow(2, 'no pageviews yet');
+
+      el('top-referrers').innerHTML = (s.top_referrers || []).map(function (r) {
+        return '<tr><td class="cell-path">' + esc(hostOf(r.referrer)) + '</td><td class="num">' + fmtNum(r.views) + '</td></tr>';
+      }).join('') || emptyRow(2, 'no external referrers yet');
+
+      el('recent-errors').innerHTML = (s.recent_errors || []).map(function (r) {
+        return '<tr class="err-row" onclick="this.classList.toggle(\'is-open\')">' +
+          '<td class="subtle">' + esc(fmtDate(r.occurred_at)) + '</td>' +
+          '<td>' + esc(r.app) + '</td>' +
+          '<td><span class="err-msg">' + esc(r.message) + '</span>' +
+          '<div class="muted">' + esc(r.path) + '</div>' +
+          (r.stack ? '<pre class="err-stack">' + esc(r.stack) + '</pre>' : '') +
+          '</td></tr>';
+      }).join('') || emptyRow(3, 'no errors recorded');
+
+      el('accounts').innerHTML = (a.recent || []).map(function (u) {
+        return '<tr><td>' + esc(u.email || '—') + '</td>' +
+          '<td class="muted">' + esc((u.providers || []).join(', ') || '—') + '</td>' +
+          '<td class="subtle">' + esc(fmtDate(u.created_at)) + '</td>' +
+          '<td class="subtle">' + esc(fmtDate(u.last_sign_in_at)) + '</td></tr>';
+      }).join('') || emptyRow(4, 'no accounts yet');
+    }
+
+    function emptyRow(cols, text) {
+      return '<tr><td colspan="' + cols + '" class="subtle">' + esc(text) + '</td></tr>';
+    }
+
+    // Single-series daily bar chart: rounded data-end bars, hover tooltip.
+    function renderChart(daily) {
+      var svg = el('chart');
+      var tip = el('chart-tip');
+      var W = 1040, H = 220, padL = 36, padB = 20, padT = 8;
+      svg.setAttribute('viewBox', '0 0 ' + W + ' ' + H);
+      // Fill missing days so the x axis is continuous.
+      var byDay = {};
+      daily.forEach(function (d) { byDay[d.day] = d; });
+      var series = [];
+      var now = new Date();
+      for (var i = days - 1; i >= 0; i--) {
+        var dt = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+        var key = dt.getFullYear() + '-' + String(dt.getMonth() + 1).padStart(2, '0') + '-' + String(dt.getDate()).padStart(2, '0');
+        var row = byDay[key] || { day: key, views: 0, uniques: 0, errors: 0 };
+        series.push({ day: key, date: dt, views: row.views || 0, uniques: row.uniques || 0, errors: row.errors || 0 });
+      }
+      var max = Math.max(1, Math.max.apply(null, series.map(function (d) { return d.views; })));
+      var plotW = W - padL - 4, plotH = H - padT - padB;
+      var step = plotW / series.length;
+      var barW = Math.max(2, Math.min(28, step - 2));
+      var html = '';
+      // gridlines: baseline + midline + top, recessive
+      [0, 0.5, 1].forEach(function (f) {
+        var y = padT + plotH - plotH * f;
+        html += '<line class="chart-grid" x1="' + padL + '" y1="' + y + '" x2="' + W + '" y2="' + y + '"/>';
+        html += '<text class="chart-axis" x="' + (padL - 6) + '" y="' + (y + 3) + '" text-anchor="end">' + Math.round(max * f) + '</text>';
+      });
+      series.forEach(function (d, i) {
+        var x = padL + i * step + (step - barW) / 2;
+        var h = Math.round(plotH * (d.views / max));
+        var y = padT + plotH - h;
+        if (d.views > 0) {
+          var r = Math.min(4, barW / 2, h);
+          html += '<path class="chart-bar" d="M' + x + ' ' + (padT + plotH) +
+            ' V' + (y + r) + ' Q' + x + ' ' + y + ' ' + (x + r) + ' ' + y +
+            ' H' + (x + barW - r) + ' Q' + (x + barW) + ' ' + y + ' ' + (x + barW) + ' ' + (y + r) +
+            ' V' + (padT + plotH) + ' Z"/>';
+        }
+        html += '<rect class="chart-hit" data-i="' + i + '" x="' + (padL + i * step) + '" y="' + padT + '" width="' + step + '" height="' + plotH + '"/>';
+      });
+      // x labels: ~6 ticks
+      var tickEvery = Math.max(1, Math.round(series.length / 6));
+      series.forEach(function (d, i) {
+        if (i % tickEvery !== 0) return;
+        var x = padL + i * step + step / 2;
+        html += '<text class="chart-axis" x="' + x + '" y="' + (H - 6) + '" text-anchor="middle">' +
+          d.date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + '</text>';
+      });
+      svg.innerHTML = html;
+
+      svg.onmousemove = function (ev) {
+        var t = ev.target;
+        if (!t.classList || !t.classList.contains('chart-hit')) { tip.style.display = 'none'; return; }
+        var d = series[parseInt(t.dataset.i, 10)];
+        tip.innerHTML = '<strong>' + d.date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' }) + '</strong><br>' +
+          fmtNum(d.views) + ' views · ' + fmtNum(d.uniques) + ' sessions' +
+          (d.errors ? '<br><span class="tip-err">' + fmtNum(d.errors) + ' errors</span>' : '');
+        var wrap = el('chart-wrap').getBoundingClientRect();
+        var left = ev.clientX - wrap.left + 12;
+        if (left > wrap.width - 180) left = ev.clientX - wrap.left - 180;
+        tip.style.left = left + 'px';
+        tip.style.top = (ev.clientY - wrap.top - 10) + 'px';
+        tip.style.display = 'block';
+      };
+      svg.onmouseleave = function () { tip.style.display = 'none'; };
+    }
+  })();
+  </script>
+</body>
+</html>

--- a/analytics/track.js
+++ b/analytics/track.js
@@ -1,0 +1,97 @@
+/**
+ * ctrl.rodeo analytics tracker — pageviews + uncaught JS errors.
+ * Fire-and-forget inserts into Supabase analytics_events (insert-only RLS;
+ * nothing is readable with the anon key). Viewable only on /analytics/.
+ *
+ * Usage: <script defer src="/analytics/track.js"></script>
+ */
+(function () {
+  'use strict';
+  var VERSION = '1.0.0';
+  var SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
+  var ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
+  var ENDPOINT = SUPABASE_URL + '/rest/v1/analytics_events';
+  var MAX_ERRORS_PER_PAGE = 10;
+  var errorCount = 0;
+  var sentErrors = {};
+
+  // Opt out (e.g. your own devices): localStorage.setItem('ctrl-analytics-optout', '1')
+  try {
+    if (localStorage.getItem('ctrl-analytics-optout') === '1') return;
+  } catch (e) { /* storage unavailable — keep tracking */ }
+
+  function sessionId() {
+    try {
+      var id = sessionStorage.getItem('ctrl-analytics-sid');
+      if (!id) {
+        id = Math.random().toString(36).slice(2) + Date.now().toString(36);
+        sessionStorage.setItem('ctrl-analytics-sid', id);
+      }
+      return id;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function appName() {
+    var seg = location.pathname.split('/').filter(Boolean)[0];
+    return seg ? seg.toLowerCase() : 'home';
+  }
+
+  function send(row) {
+    try {
+      fetch(ENDPOINT, {
+        method: 'POST',
+        keepalive: true,
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: ANON_KEY,
+          Authorization: 'Bearer ' + ANON_KEY,
+          Prefer: 'return=minimal'
+        },
+        body: JSON.stringify(row)
+      }).catch(function () { /* never surface tracking failures */ });
+    } catch (e) { /* ignore */ }
+  }
+
+  function base(type) {
+    return {
+      type: type,
+      app: appName(),
+      path: (location.pathname + location.search).slice(0, 512),
+      referrer: (document.referrer || '').slice(0, 512) || null,
+      session_id: sessionId(),
+      viewport: window.innerWidth + 'x' + window.innerHeight,
+      ua: (navigator.userAgent || '').slice(0, 512)
+    };
+  }
+
+  function trackError(message, stack) {
+    if (errorCount >= MAX_ERRORS_PER_PAGE) return;
+    message = String(message || 'Unknown error').slice(0, 1000);
+    var key = message.slice(0, 200);
+    if (sentErrors[key]) return; // dedupe repeats within a page
+    sentErrors[key] = true;
+    errorCount++;
+    var row = base('error');
+    row.message = message;
+    row.stack = stack ? String(stack).slice(0, 4000) : null;
+    send(row);
+  }
+
+  window.addEventListener('error', function (ev) {
+    if (ev.message === 'Script error.' && !ev.filename) return; // opaque cross-origin noise
+    var loc = ev.filename ? ' (' + ev.filename + ':' + ev.lineno + ')' : '';
+    trackError((ev.message || 'Script error') + loc, ev.error && ev.error.stack);
+  });
+
+  window.addEventListener('unhandledrejection', function (ev) {
+    var reason = ev.reason;
+    trackError(
+      'Unhandled rejection: ' + (reason && reason.message ? reason.message : String(reason)),
+      reason && reason.stack
+    );
+  });
+
+  send(base('pageview'));
+})();

--- a/applications/index.html
+++ b/applications/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="css/app.css?v=3.60.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body data-auth-state="loading">
 

--- a/boards/index.html
+++ b/boards/index.html
@@ -6634,6 +6634,7 @@ a:hover { color: var(--accent-cyan); }
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
   <script src="/auth/ctrl-auth.js"></script>
   <script src="../js/image-validation.js"></script>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
 <a href="#grid" class="skip-link">Skip to content</a>

--- a/calendar/index.html
+++ b/calendar/index.html
@@ -646,6 +646,7 @@ body {
   }
 }
   </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
 

--- a/communes/index.html
+++ b/communes/index.html
@@ -216,6 +216,7 @@ header .sub a:hover { text-decoration: underline; }
   #mobile-toggle::before { content: ""; display: block; width: 40px; height: 4px; border-radius: 2px; background: var(--border); margin: 0 auto 8px; }
 }
 </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
 <div id="app">

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -98,6 +98,7 @@ supabase link --project-ref yfhudwakpgzswiylhfbh
 supabase functions deploy enrich-link
 supabase functions deploy generate-widget
 supabase functions deploy categorize
+supabase functions deploy analytics-dashboard   # owner-only aggregates for /analytics
 
 # Recruiting (Agape) functions — Boards project
 supabase functions deploy recruit-gmail

--- a/docs/infrastructure/technical-design/analytics-dashboard.md
+++ b/docs/infrastructure/technical-design/analytics-dashboard.md
@@ -1,0 +1,44 @@
+# Analytics dashboard — technical design
+
+**Status:** Live (v1.0.0) · **Surface:** [ctrl.rodeo/analytics](https://ctrl.rodeo/analytics/) · **Backend:** Supabase Boards project (`yfhudwakpgzswiylhfbh`)
+
+Private, owner-only analytics across every ctrl.rodeo project: pageviews, unique sessions, client-side JS errors, and Supabase account stats.
+
+## Architecture
+
+```
+page (any app) ──▶ /analytics/track.js ──▶ POST /rest/v1/analytics_events  (anon key, insert-only RLS)
+                                                        │
+ctrl.rodeo/analytics ──▶ analytics-dashboard edge fn ──▶ analytics_summary() / analytics_account_stats()
+   (CtrlAuth sign-in)     (403 unless owner email)        (security definer, service_role-only)
+```
+
+### Ingest — `analytics/track.js` (v1.0.0)
+- `<script defer src="/analytics/track.js"></script>` in the `<head>` of: home, boards, events, applications, ladder, calendar, soundscape, account, communes.
+- Sends one `pageview` row per page load, plus `error` rows from `window.onerror` / `unhandledrejection` (deduped per message, max 10/page, cross-origin "Script error." noise dropped).
+- Fields: type, app (first path segment), path, referrer, session_id (per-tab `sessionStorage` id), viewport, ua, message/stack for errors.
+- Fire-and-forget `fetch` with `keepalive`; failures never surface to the page.
+- Opt out on a device: `localStorage.setItem('ctrl-analytics-optout', '1')`.
+
+### Storage — `public.analytics_events` (migration `156_analytics_events.sql`)
+- RLS enabled. One INSERT policy for `anon`/`authenticated` with length-checked columns; **no SELECT policy at all** — the anon key can write telemetry but read nothing back.
+- Reads happen only through two `security definer` functions, `REVOKE`d from public/anon/authenticated and granted to `service_role` only:
+  - `analytics_summary(days)` — totals, daily series, per-app rollup, top paths/referrers, last 50 errors.
+  - `analytics_account_stats()` — counts + 20 most recent accounts from `auth.users` (email, providers, created, last sign-in).
+
+### API — `supabase/functions/analytics-dashboard` (v1.0.0)
+- `verify_jwt` on; additionally checks the caller's email against `ADMIN_EMAILS = ['fike101@gmail.com']` — anyone else gets 403. This is the single access-control gate; the client-side `CtrlAuth.isAdmin()` check is UX only.
+- Accepts `{ days: 1–365 }` (default 30); returns `{ summary, accounts }` from the two RPCs via the service-role client.
+
+### Dashboard — `analytics/index.html` (v1.0.0)
+- CtrlAuth sign-in (magic link / Google / Discord), Sassy tokens/components, dark-first, mobile responsive, `noindex`.
+- Stat tiles, single-series daily views bar chart (SVG, hover tooltip with views/sessions/errors), tables for projects, top pages, referrers, recent errors (click a row to expand the stack), and recent accounts. 7/30/90-day range filter.
+
+## Security model
+- **Only Ian can read anything.** Read path is: owner JWT → edge function email check → service-role RPCs. The table itself is unreadable via PostgREST for every client role, and both SQL functions are non-executable for anon/authenticated.
+- Writes are open to the anon key by design (it's public telemetry), constrained by column length checks and a type whitelist.
+
+## Operations
+- Deploy: `supabase functions deploy analytics-dashboard` (Boards project).
+- Retention: no automatic purge yet; add a cron delete if the table grows past ~1M rows.
+- Adding a page to tracking: drop the one script tag in its `<head>`; `app` is derived from the URL automatically.

--- a/events/index.html
+++ b/events/index.html
@@ -1670,6 +1670,7 @@ body {
   .exhibition-card:active { opacity: 0.6; }
 }
   </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     .process-section { background: transparent; transition: background 0.2s ease; }
     .process-section:hover { background: var(--bg-surface, #1a1a18); }
   </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body class="d-page">
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -62,6 +62,7 @@
       }
     })();
   </script>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body data-auth-state="loading">
 

--- a/soundscape/index.html
+++ b/soundscape/index.html
@@ -1304,6 +1304,7 @@
             }
         }
     </style>
+  <script defer src="/analytics/track.js"></script>
 </head>
 <body>
     <!-- SVG Visualization Container -->

--- a/supabase/functions/analytics-dashboard/index.ts
+++ b/supabase/functions/analytics-dashboard/index.ts
@@ -1,0 +1,76 @@
+// analytics-dashboard — admin-only aggregate feed for ctrl.rodeo/analytics
+// GET/POST /functions/v1/analytics-dashboard   (Authorization: Bearer <user JWT>)
+// Body (optional): { days?: number }
+// Response: { version, generatedAt, summary, accounts }
+// Access: only ADMIN_EMAILS may call; everyone else gets 403.
+
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+
+const VERSION = '1.0.0'
+console.log(`[analytics-dashboard] v${VERSION} - admin-only analytics aggregates`)
+
+const ADMIN_EMAILS = ['fike101@gmail.com']
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  })
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  )
+
+  const authHeader = req.headers.get('Authorization') ?? ''
+  const token = authHeader.replace(/^Bearer\s+/i, '')
+  const { data: userData, error: userError } = await supabase.auth.getUser(token)
+  if (userError || !userData?.user) {
+    return json({ error: 'unauthorized' }, 401)
+  }
+  const email = (userData.user.email ?? '').toLowerCase()
+  if (!ADMIN_EMAILS.includes(email)) {
+    console.log(`[analytics-dashboard] v${VERSION} - forbidden for ${email}`)
+    return json({ error: 'forbidden' }, 403)
+  }
+
+  let days = 30
+  if (req.method === 'POST') {
+    try {
+      const body = await req.json()
+      const n = Number(body?.days)
+      if (Number.isFinite(n)) days = Math.min(Math.max(Math.round(n), 1), 365)
+    } catch (_) { /* empty body is fine */ }
+  }
+
+  const [summaryRes, accountsRes] = await Promise.all([
+    supabase.rpc('analytics_summary', { days }),
+    supabase.rpc('analytics_account_stats'),
+  ])
+  if (summaryRes.error) {
+    console.error(`[analytics-dashboard] v${VERSION} - summary error:`, summaryRes.error)
+    return json({ error: 'summary_failed', details: summaryRes.error.message }, 500)
+  }
+  if (accountsRes.error) {
+    console.error(`[analytics-dashboard] v${VERSION} - accounts error:`, accountsRes.error)
+    return json({ error: 'accounts_failed', details: accountsRes.error.message }, 500)
+  }
+
+  return json({
+    version: VERSION,
+    generatedAt: new Date().toISOString(),
+    summary: summaryRes.data,
+    accounts: accountsRes.data,
+  })
+})

--- a/supabase/migrations/156_analytics_events.sql
+++ b/supabase/migrations/156_analytics_events.sql
@@ -1,0 +1,147 @@
+-- 156_analytics_events.sql
+-- Site-wide analytics: pageview + client error ingest, admin-only read via
+-- security-definer functions called from the analytics-dashboard edge function.
+
+create table if not exists public.analytics_events (
+  id bigint generated always as identity primary key,
+  occurred_at timestamptz not null default now(),
+  type text not null check (type in ('pageview', 'error')),
+  app text not null check (char_length(app) between 1 and 64),
+  path text not null check (char_length(path) between 1 and 512),
+  referrer text check (char_length(referrer) <= 512),
+  session_id text check (char_length(session_id) <= 64),
+  viewport text check (char_length(viewport) <= 32),
+  ua text check (char_length(ua) <= 512),
+  message text check (char_length(message) <= 1000),
+  stack text check (char_length(stack) <= 4000),
+  meta jsonb
+);
+
+create index if not exists analytics_events_occurred_idx
+  on public.analytics_events (occurred_at desc);
+create index if not exists analytics_events_type_occurred_idx
+  on public.analytics_events (type, occurred_at desc);
+create index if not exists analytics_events_app_occurred_idx
+  on public.analytics_events (app, occurred_at desc);
+
+alter table public.analytics_events enable row level security;
+
+-- Anyone may write telemetry; nobody may read it through PostgREST.
+-- Reads happen only via the security-definer functions below, which are
+-- executable by service_role alone (the analytics-dashboard edge function).
+drop policy if exists analytics_events_insert on public.analytics_events;
+create policy analytics_events_insert on public.analytics_events
+  for insert to anon, authenticated
+  with check (type in ('pageview', 'error'));
+
+-- Aggregate rollup for the dashboard.
+create or replace function public.analytics_summary(days int default 30)
+returns jsonb
+language sql
+security definer
+set search_path = ''
+as $$
+  with window_events as (
+    select * from public.analytics_events
+    where occurred_at > now() - make_interval(days => days)
+  )
+  select jsonb_build_object(
+    'days', days,
+    'views_total', (select count(*) from window_events where type = 'pageview'),
+    'views_today', (
+      select count(*) from public.analytics_events
+      where type = 'pageview' and occurred_at >= date_trunc('day', now())
+    ),
+    'uniques_total', (
+      select count(distinct session_id) from window_events
+      where type = 'pageview' and session_id is not null
+    ),
+    'errors_total', (select count(*) from window_events where type = 'error'),
+    'daily', (
+      select coalesce(jsonb_agg(row_to_json(d) order by d.day), '[]'::jsonb)
+      from (
+        select date_trunc('day', occurred_at)::date as day,
+               count(*) filter (where type = 'pageview') as views,
+               count(distinct session_id) filter (where type = 'pageview') as uniques,
+               count(*) filter (where type = 'error') as errors
+        from window_events
+        group by 1
+      ) d
+    ),
+    'by_app', (
+      select coalesce(jsonb_agg(row_to_json(a) order by a.views desc), '[]'::jsonb)
+      from (
+        select app,
+               count(*) filter (where type = 'pageview') as views,
+               count(distinct session_id) filter (where type = 'pageview') as uniques,
+               count(*) filter (where type = 'error') as errors,
+               max(occurred_at) as last_seen
+        from window_events
+        group by app
+      ) a
+    ),
+    'top_paths', (
+      select coalesce(jsonb_agg(row_to_json(p)), '[]'::jsonb)
+      from (
+        select app, path, count(*) as views
+        from window_events
+        where type = 'pageview'
+        group by app, path
+        order by views desc
+        limit 25
+      ) p
+    ),
+    'top_referrers', (
+      select coalesce(jsonb_agg(row_to_json(r)), '[]'::jsonb)
+      from (
+        select referrer, count(*) as views
+        from window_events
+        where type = 'pageview' and referrer is not null and referrer <> ''
+        group by referrer
+        order by views desc
+        limit 15
+      ) r
+    ),
+    'recent_errors', (
+      select coalesce(jsonb_agg(row_to_json(e)), '[]'::jsonb)
+      from (
+        select occurred_at, app, path, message, stack, ua
+        from public.analytics_events
+        where type = 'error'
+        order by occurred_at desc
+        limit 50
+      ) e
+    )
+  );
+$$;
+
+-- Account stats read from auth.users (service_role callers only).
+create or replace function public.analytics_account_stats()
+returns jsonb
+language sql
+security definer
+set search_path = ''
+as $$
+  select jsonb_build_object(
+    'total', (select count(*) from auth.users),
+    'new_7d', (select count(*) from auth.users where created_at > now() - interval '7 days'),
+    'new_30d', (select count(*) from auth.users where created_at > now() - interval '30 days'),
+    'active_7d', (select count(*) from auth.users where last_sign_in_at > now() - interval '7 days'),
+    'active_30d', (select count(*) from auth.users where last_sign_in_at > now() - interval '30 days'),
+    'recent', (
+      select coalesce(jsonb_agg(row_to_json(u)), '[]'::jsonb)
+      from (
+        select email, created_at, last_sign_in_at,
+               (select array_agg(distinct i.provider) from auth.identities i where i.user_id = users.id) as providers
+        from auth.users
+        order by created_at desc
+        limit 20
+      ) u
+    )
+  );
+$$;
+
+revoke execute on function public.analytics_summary(int) from public, anon, authenticated;
+revoke execute on function public.analytics_account_stats() from public, anon, authenticated;
+grant execute on function public.analytics_summary(int) to service_role;
+grant execute on function public.analytics_account_stats() to service_role;


### PR DESCRIPTION
## Summary
- **ctrl.rodeo/analytics** — owner-only dashboard: pageviews, unique sessions, JS errors, and account stats across all projects
- `analytics_events` table in the Boards project: anyone can write telemetry, **nobody** can read it back (insert-only RLS, no select policies; reads only via service_role-only security-definer functions)
- `analytics/track.js` beacon (pageview + window.onerror/unhandledrejection) added to 9 live pages: home, boards, events, applications, ladder, calendar, soundscape, account, communes
- `analytics-dashboard` edge function v1.0.0 — verify_jwt + hard email gate (fike101@gmail.com only), serves `analytics_summary(days)` and `analytics_account_stats()` (auth.users counts + recent signups)
- Dashboard UI on Sassy tokens: stat tiles, daily views SVG bar chart with hover tooltip, projects / top pages / referrers / recent errors (expandable stacks) / recent accounts, 7/30/90d range

## Docs
- New: `docs/infrastructure/technical-design/analytics-dashboard.md`
- Updated: `docs/infrastructure/deployment.md` (deploy command)

## Post-merge
- Apply migration `156_analytics_events.sql` + deploy `analytics-dashboard` (Boards `yfhudwakpgzswiylhfbh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)