### PR TITLE
fix(analytics): dashboard v1.0.1 — dedupe loads, no lingering loading state

### DIFF
--- a/analytics/index.html
+++ b/analytics/index.html
@@ -189,7 +189,7 @@
   <script>
   (function () {
     'use strict';
-    var VERSION = '1.0.0';
+    var VERSION = '1.0.1';
     console.log('[analytics] v' + VERSION + ' - private site analytics dashboard');
 
     var SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -242,13 +242,14 @@
     }
 
     var data = null;
+    var reqId = 0; // latest request wins — signedin can fire twice, ranges can be clicked fast
 
     function load() {
       var session = CtrlAuth.getSession();
       if (!session) return;
-      el('loading').hidden = false;
+      var id = ++reqId;
       el('load-error').hidden = true;
-      el('content').hidden = true;
+      if (!data) { el('loading').hidden = false; el('content').hidden = true; }
       fetch(FN_URL, {
         method: 'POST',
         headers: {
@@ -261,9 +262,11 @@
         if (!res.ok) throw new Error(res.status === 403 ? 'This dashboard is owner-only.' : 'Request failed (' + res.status + ')');
         return res.json();
       }).then(function (payload) {
+        if (id !== reqId) return;
         data = payload;
         render();
       }).catch(function (err) {
+        if (id !== reqId) return;
         el('loading').hidden = true;
         el('load-error').hidden = false;
         el('load-error').textContent = err.message || 'Failed to load analytics.';


### PR DESCRIPTION
Signed-in event can fire twice (init + supabase auth event), causing a duplicate fetch that left the Loading… indicator visible over rendered content. Now latest-request-wins with a request counter; the full-page loading state only shows before first data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)