### PR TITLE
feat(recruiting): expired sign-in links hand back a way to get another

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.60.0">
+  <link rel="stylesheet" href="css/app.css?v=3.61.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.60.0';
+const VERSION = '3.61.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -5520,14 +5520,26 @@ async function redeemSigninToken() {
       body: JSON.stringify({ token }),
     });
     const out = await resp.json();
-    if (!resp.ok) throw new Error(out.error || 'redeem failed');
+    if (!resp.ok) {
+      // An expired link is the common case, not an error to explain — hand
+      // back the button that mints another one.
+      const err = new Error(out.error || 'redeem failed');
+      err.rerequestUrl = out.rerequestUrl;
+      throw err;
+    }
     // token_hash and type ONLY — supabase-js rejects the call if email rides along
     const { error } = await sb.auth.verifyOtp({ type: 'email', token_hash: out.token_hash });
     if (error) throw error;
   } catch (e) {
-    setGate(e.message || 'Sign-in link failed.', 'Continue with Discord',
-      'Get a fresh link from the "Get sign-in link" button on Discord, or sign in with Discord here.');
-    document.getElementById('gate-btn').onclick = signInWithDiscord;
+    if (e.rerequestUrl) {
+      setGate(e.message, 'Get a fresh link',
+        'Opens the sign-in message on Discord. You can also type /signin in the Agape server.');
+      document.getElementById('gate-btn').onclick = () => { location.href = e.rerequestUrl; };
+    } else {
+      setGate(e.message || 'Sign-in link failed.', 'Continue with Discord',
+        'Get a fresh link from the sign-in message on Discord, or sign in with Discord here.');
+      document.getElementById('gate-btn').onclick = signInWithDiscord;
+    }
   }
 }
 

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -262,6 +262,11 @@ const SIGNIN_TTL_MS = 10 * 60_000
 const APP_URL = 'https://ctrl.rodeo/applications/'
 // Shadow email for members who've never OAuth'd on desktop; deterministic so
 // repeat sign-ins land on the same account.
+// Jump link to the pinned sign-in message, so "get another link" is a tap
+// rather than an instruction to go and find something.
+const SIGNIN_MESSAGE_URL = Deno.env.get('SIGNIN_MESSAGE_URL')
+  || 'https://discord.com/channels/952961396121931838/1529576830514762029/1532462592872808539'
+
 const shadowEmail = (discordUserId: string) => `discord-${discordUserId}@signin.ctrl.rodeo`
 
 async function sha256Hex(s: string): Promise<string> {
@@ -353,7 +358,12 @@ async function handleRedeem(req: Request): Promise<Response> {
     .eq('token_hash', await sha256Hex(token)).is('used_at', null)
     .gte('created_at', new Date(Date.now() - SIGNIN_TTL_MS).toISOString())
     .select().maybeSingle()
-  if (!row) return json({ error: 'Link expired or already used — get a fresh one from the Discord button.' }, 401)
+  if (!row) {
+    return json({
+      error: 'This link already expired or was used. Grab a fresh one — it takes a second.',
+      rerequestUrl: SIGNIN_MESSAGE_URL,
+    }, 401)
+  }
 
   // Prefer the member's existing account (from a past desktop OAuth sign-in).
   const { data: membership } = await client.from('user_discord_membership')
@@ -1065,13 +1075,23 @@ serve(async (req) => {
       const b = await req.json().catch(() => ({}))
       const did = String(b.discordUserId || '')
       if (!/^\d{5,25}$/.test(did)) return json({ error: 'discordUserId required' }, 400)
+      const { dmUser } = await import('../_shared/discord.ts')
+      // mode 'pointer' tells someone where to self-serve, without minting a
+      // token that will have expired by the time they read the message.
+      if (b.mode === 'pointer') {
+        await dmUser(did,
+          `Need another sign-in link? Tap here any time: ${SIGNIN_MESSAGE_URL}\n` +
+          `That message has a **Get sign-in link** button — each link works once, for 10 minutes. ` +
+          `Typing \`/signin\` in the server does the same thing.`)
+        return json({ sent: true, mode: 'pointer', discordUserId: did })
+      }
       const url = await mintSigninUrl(did, b.username ? String(b.username) : null)
       if (!url) return json({ error: 'could not mint link' }, 500)
-      const { dmUser } = await import('../_shared/discord.ts')
       await dmUser(did,
         `🔑 Sign-in link for the Agape applicant inbox:\n${url}\n` +
         `Works once, for 10 minutes. Opens signed in — no password, and it works ` +
-        `inside Instagram or Discord's own browser, where the normal sign-in fails.`)
+        `inside Instagram or Discord's own browser, where the normal sign-in fails.\n` +
+        `Expired? Get another here: ${SIGNIN_MESSAGE_URL}`)
       return json({ sent: true, discordUserId: did })
     }
 


### PR DESCRIPTION
Link expiry is the common case, not an error worth explaining. Previously the app said *get a fresh one from the Discord button* — an instruction to go and find something, with no way to act on it.

- `redeem` returns `rerequestUrl`, a jump link straight to the pinned sign-in message
- the gate renders it as a **Get a fresh link** button
- `signin-dm` gains `mode: 'pointer'` — sends that link *without* minting a token, since a token DM'd now is dead by the time a slower reader opens it
- the normal sign-in DM also carries the re-request link as a footer

Verified in prod: the expired-token response returns the jump link, and the pointer DM minted no token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)