### PR TITLE
feat(analytics): visibility build-out — server errors, Discord spike alerts, web vitals

### DIFF
--- a/analytics/index.html
+++ b/analytics/index.html
@@ -243,7 +243,7 @@
   <script>
   (function () {
     'use strict';
-    var VERSION = '1.2.0';
+    var VERSION = '1.3.0';
     console.log('[analytics] v' + VERSION + ' - private site analytics dashboard');
 
     var SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
@@ -395,6 +395,10 @@
         ['errors · ' + s.days + 'd', fmtNum(s.errors_total), s.errors_total > 0 ? 'error' : null],
         ['accounts', fmtNum(a.total)]
       ];
+      var VITAL_FMT = { lcp: function (v) { return (v / 1000).toFixed(2) + 's'; }, inp: function (v) { return Math.round(v) + 'ms'; }, ttfb: function (v) { return Math.round(v) + 'ms'; }, cls: function (v) { return v.toFixed(3); } };
+      (s.vitals || []).forEach(function (v) {
+        if (VITAL_FMT[v.name]) tiles.push([v.name + ' p75', VITAL_FMT[v.name](Number(v.p75))]);
+      });
       el('tiles').innerHTML = tiles.map(tileHtml).join('');
 
       renderChart(s.daily || []);
@@ -419,7 +423,7 @@
       el('recent-errors').innerHTML = (s.recent_errors || []).map(function (r) {
         return '<tr class="err-row" onclick="this.classList.toggle(\'is-open\')">' +
           '<td class="subtle">' + esc(fmtDate(r.occurred_at)) + '</td>' +
-          '<td>' + esc(r.app) + '</td>' +
+          '<td>' + esc(r.app) + (r.type === 'server_error' ? ' <span class="subtle">(server)</span>' : '') + '</td>' +
           '<td><span class="err-msg">' + esc(r.message) + '</span>' +
           '<div class="muted">' + esc(r.path) + '</div>' +
           (r.stack ? '<pre class="err-stack">' + esc(r.stack) + '</pre>' : '') +

--- a/analytics/track.js
+++ b/analytics/track.js
@@ -7,7 +7,7 @@
  */
 (function () {
   'use strict';
-  var VERSION = '1.1.0';
+  var VERSION = '1.2.0';
   var SUPABASE_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co';
   var ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI';
   var ENDPOINT = SUPABASE_URL + '/rest/v1/analytics_events';
@@ -108,4 +108,52 @@
   });
 
   send(base('pageview'));
+
+  // ---- web vitals (hand-rolled: LCP, CLS, INP, TTFB) ----
+  // Collected passively, sent once per page when it first goes hidden.
+  (function vitals() {
+    if (typeof PerformanceObserver === 'undefined') return;
+    var lcp = null, cls = 0, inp = null, sent = false;
+    try {
+      new PerformanceObserver(function (list) {
+        var entries = list.getEntries();
+        if (entries.length) lcp = entries[entries.length - 1].startTime;
+      }).observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch (e) { /* unsupported */ }
+    try {
+      new PerformanceObserver(function (list) {
+        list.getEntries().forEach(function (en) {
+          if (!en.hadRecentInput) cls += en.value;
+        });
+      }).observe({ type: 'layout-shift', buffered: true });
+    } catch (e) { /* unsupported */ }
+    try {
+      new PerformanceObserver(function (list) {
+        list.getEntries().forEach(function (en) {
+          if (en.interactionId && (inp === null || en.duration > inp)) inp = en.duration;
+        });
+      }).observe({ type: 'event', durationThreshold: 40, buffered: true });
+    } catch (e) { /* unsupported */ }
+
+    function flush() {
+      if (sent) return;
+      sent = true;
+      var rows = [];
+      var nav = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];
+      var common = base('vital');
+      function push(name, value) {
+        if (value === null || value === undefined || !isFinite(value)) return;
+        rows.push(Object.assign({}, common, { meta: { name: name, value: Math.round(value * 1000) / 1000 } }));
+      }
+      push('lcp', lcp);
+      push('cls', cls);
+      push('inp', inp);
+      if (nav && nav.responseStart > 0) push('ttfb', nav.responseStart);
+      if (rows.length) send(rows);
+    }
+    document.addEventListener('visibilitychange', function () {
+      if (document.visibilityState === 'hidden') flush();
+    });
+    window.addEventListener('pagehide', flush);
+  })();
 })();

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -99,6 +99,7 @@ supabase functions deploy enrich-link
 supabase functions deploy generate-widget
 supabase functions deploy categorize
 supabase functions deploy analytics-dashboard   # owner-only aggregates for /analytics
+supabase functions deploy analytics-alerts      # error-spike DM watchdog (cron-invoked)
 
 # Recruiting (Agape) functions — Boards project
 supabase functions deploy recruit-gmail

--- a/docs/infrastructure/technical-design/analytics-dashboard.md
+++ b/docs/infrastructure/technical-design/analytics-dashboard.md
@@ -39,6 +39,11 @@ ctrl.rodeo/analytics ──▶ analytics-dashboard edge fn ──▶ analytics_s
 - **Only Ian can read anything.** Read path is: owner JWT → edge function email check → service-role RPCs. The table itself is unreadable via PostgREST for every client role, and both SQL functions are non-executable for anon/authenticated.
 - Writes are open to the anon key by design (it's public telemetry), constrained by column length checks and a type whitelist.
 
+## Visibility build-out (migration `158_analytics_vitals_alerts.sql`)
+- **Server-side errors** — `_shared/telemetry.ts` `logServerError()` writes type `server_error` rows (app `fn:<name>`) from the top-level catch of analytics-dashboard, recruit-watch, recruit-gmail, and recruit-discord. Service-role-only: the anon insert policy excludes `server_error`. They appear on the errors tab labeled "(server)" and count in error totals. Add the same two lines to any function's catch to enroll it.
+- **Web vitals** — track.js v1.2.0 hand-rolls LCP/CLS/INP/TTFB via PerformanceObserver (no external lib), batched as type `vital` rows when the page first goes hidden. `analytics_summary` exposes p75 per metric; the overview shows them as tiles.
+- **Alerts** — `analytics-alerts` fn v1.0.0, pg_cron every 30 min (`analytics_alerts_tick`, nonce handshake per migrations 123/136, no new secrets). DMs Ian via the recruiting bot on ≥3 client errors/hour or ≥1 server error/hour, deduped to one DM per kind per 6h via the `analytics_alerts` ledger.
+
 ## Operations
 - Deploy: `supabase functions deploy analytics-dashboard` (Boards project).
 - Retention: no automatic purge yet; add a cron delete if the table grows past ~1M rows.

--- a/supabase/functions/_shared/telemetry.ts
+++ b/supabase/functions/_shared/telemetry.ts
@@ -1,0 +1,26 @@
+// _shared/telemetry.ts — server-side error breadcrumbs into analytics_events.
+// Call from a function's top-level catch with its service-role client. Rows
+// land as type 'server_error' with app 'fn:<name>', so they surface on the
+// /analytics errors tab next to client errors and feed the spike alerts.
+// The insert path is service-role-only: the anon insert policy deliberately
+// excludes 'server_error', so browsers can't forge one.
+
+// deno-lint-ignore-file no-explicit-any
+
+export async function logServerError(
+  client: any, fn: string, err: unknown, meta?: Record<string, unknown>,
+): Promise<void> {
+  try {
+    const e = err as Error
+    await client.from('analytics_events').insert({
+      type: 'server_error',
+      app: `fn:${fn}`,
+      path: `/functions/v1/${fn}`,
+      message: String(e?.message || err).slice(0, 1000),
+      stack: e?.stack ? String(e.stack).slice(0, 4000) : null,
+      meta: meta ?? null,
+    })
+  } catch {
+    // Telemetry must never take the function down with it.
+  }
+}

--- a/supabase/functions/analytics-alerts/index.ts
+++ b/supabase/functions/analytics-alerts/index.ts
@@ -1,0 +1,104 @@
+// analytics-alerts — error-spike watchdog for ctrl.rodeo analytics.
+// POST /functions/v1/analytics-alerts   (X-Cron-Nonce or X-Cron-Secret)
+// Cron: every 30 min (migration 158). Looks at the last 60 minutes of
+// analytics_events; DMs Ian via the recruiting bot when something is wrong.
+//
+// Alert conditions (deduped via analytics_alerts, one DM per kind per 6h):
+//   error_spike   — ≥3 client errors in the window
+//   server_error  — ≥1 edge-function error in the window
+//
+// No new secrets: nonce handshake from migration 123, DISCORD_BOT_TOKEN and
+// the alert user id already exist for the recruiting automations.
+
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { dmUser } from '../_shared/discord.ts'
+
+const VERSION = '1.0.0'
+console.log(`[analytics-alerts] v${VERSION} - error-spike watchdog`)
+
+const ALERT_DISCORD_USER_ID = Deno.env.get('ALERT_DISCORD_USER_ID') || '853782600082522152' // Ian
+const CLIENT_ERROR_THRESHOLD = 3
+const COOLDOWN_HOURS = 6
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-nonce, x-cron-secret',
+}
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } })
+
+function db() {
+  return createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+  const client = db()
+
+  // Same handshake as recruit-gmail /scan: burn a one-time nonce minted by
+  // the pg_cron tick; X-Cron-Secret honoured if CRON_SECRET is ever set.
+  const secret = Deno.env.get('CRON_SECRET')
+  let authorized = Boolean(secret) && req.headers.get('x-cron-secret') === secret
+  const nonce = req.headers.get('x-cron-nonce')
+  if (!authorized && nonce && /^[0-9a-f-]{36}$/i.test(nonce)) {
+    const { data: burned } = await client.from('recruit_cron_nonce')
+      .delete().eq('nonce', nonce)
+      .gte('created_at', new Date(Date.now() - 10 * 60000).toISOString())
+      .select().maybeSingle()
+    authorized = Boolean(burned)
+  }
+  if (!authorized) return json({ error: 'unauthorized' }, 401)
+
+  try {
+    const since = new Date(Date.now() - 60 * 60000).toISOString()
+    const { data: recent, error } = await client.from('analytics_events')
+      .select('type, app, path, message')
+      .in('type', ['error', 'server_error'])
+      .gte('occurred_at', since)
+    if (error) throw new Error(`query failed: ${error.message}`)
+
+    const clientErrors = (recent || []).filter((r) => r.type === 'error')
+    const serverErrors = (recent || []).filter((r) => r.type === 'server_error')
+
+    const fired: string[] = []
+    const cooldownCutoff = new Date(Date.now() - COOLDOWN_HOURS * 3600_000).toISOString()
+
+    const shouldSend = async (kind: string): Promise<boolean> => {
+      const { data } = await client.from('analytics_alerts')
+        .select('id').eq('kind', kind).gte('sent_at', cooldownCutoff).limit(1)
+      return !data?.length
+    }
+    const topLines = (rows: Array<{ app: string; message: string | null }>): string => {
+      const counts = new Map<string, number>()
+      for (const r of rows) {
+        const key = `${r.app}: ${(r.message || 'unknown').slice(0, 120)}`
+        counts.set(key, (counts.get(key) || 0) + 1)
+      }
+      return [...counts.entries()]
+        .sort((a, b) => b[1] - a[1]).slice(0, 5)
+        .map(([line, n]) => `• ${n}× ${line}`).join('\n')
+    }
+
+    if (clientErrors.length >= CLIENT_ERROR_THRESHOLD && await shouldSend('error_spike')) {
+      await dmUser(ALERT_DISCORD_USER_ID,
+        `⚠️ ctrl.rodeo: ${clientErrors.length} client errors in the last hour.\n` +
+        `${topLines(clientErrors)}\n` +
+        `→ https://ctrl.rodeo/analytics/#errors`)
+      await client.from('analytics_alerts').insert({ kind: 'error_spike', detail: `${clientErrors.length} client errors` })
+      fired.push('error_spike')
+    }
+    if (serverErrors.length >= 1 && await shouldSend('server_error')) {
+      await dmUser(ALERT_DISCORD_USER_ID,
+        `🚨 ctrl.rodeo: ${serverErrors.length} edge-function error(s) in the last hour.\n` +
+        `${topLines(serverErrors)}\n` +
+        `→ https://ctrl.rodeo/analytics/#errors`)
+      await client.from('analytics_alerts').insert({ kind: 'server_error', detail: `${serverErrors.length} server errors` })
+      fired.push('server_error')
+    }
+
+    return json({ version: VERSION, window_minutes: 60, client_errors: clientErrors.length, server_errors: serverErrors.length, fired })
+  } catch (err) {
+    console.error(`[analytics-alerts] v${VERSION} -`, (err as Error).message)
+    return json({ error: (err as Error).message }, 500)
+  }
+})

--- a/supabase/functions/analytics-dashboard/index.ts
+++ b/supabase/functions/analytics-dashboard/index.ts
@@ -5,8 +5,9 @@
 // Access: only ADMIN_EMAILS may call; everyone else gets 403.
 
 import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { logServerError } from '../_shared/telemetry.ts'
 
-const VERSION = '1.2.0'
+const VERSION = '1.3.0'
 console.log(`[analytics-dashboard] v${VERSION} - admin-only analytics aggregates`)
 
 const ADMIN_EMAILS = ['fike101@gmail.com']
@@ -54,6 +55,7 @@ Deno.serve(async (req: Request) => {
     } catch (_) { /* empty body is fine */ }
   }
 
+  try {
   const [summaryRes, accountsRes, peopleRes, authRes] = await Promise.all([
     supabase.rpc('analytics_summary', { days }),
     supabase.rpc('analytics_account_stats'),
@@ -86,4 +88,9 @@ Deno.serve(async (req: Request) => {
     people: peopleRes.data,
     auth: authRes.error ? { error: authRes.error.message, events: [] } : { events: authRes.data || [] },
   })
+  } catch (err) {
+    console.error(`[analytics-dashboard] v${VERSION} - unhandled:`, (err as Error).message)
+    await logServerError(supabase, 'analytics-dashboard', err)
+    return json({ error: 'internal', details: (err as Error).message }, 500)
+  }
 })

--- a/supabase/functions/recruit-discord/index.ts
+++ b/supabase/functions/recruit-discord/index.ts
@@ -13,7 +13,7 @@
 // The app public key is fetched from GET /applications/@me with the bot token
 // (env DISCORD_PUBLIC_KEY overrides), so no extra secret is needed.
 
-const VERSION = '1.30.1'
+const VERSION = '1.30.3'
 console.log(`[recruit-discord] v${VERSION} — screening claims + sign-in + link nudges + trial votes + notification ledger`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -1238,6 +1238,10 @@ serve(async (req) => {
     }
   } catch (err) {
     console.error('[recruit-discord] error:', (err as Error).message)
+    try {
+      const { logServerError } = await import('../_shared/telemetry.ts')
+      await logServerError(db(), 'recruit-discord', err)
+    } catch { /* telemetry is best-effort */ }
     return json({ error: (err as Error).message }, 500)
   }
 })

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,7 +16,7 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.30.4'
+const VERSION = '1.30.5'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -1434,6 +1434,10 @@ serve(async (req) => {
     return json({ error: 'Unknown action' }, 400)
   } catch (err) {
     console.error('recruit-gmail error:', (err as Error).message)
+    try {
+      const { logServerError } = await import('../_shared/telemetry.ts')
+      await logServerError(db(), 'recruit-gmail', err)
+    } catch { /* telemetry is best-effort */ }
     return json({ error: (err as Error).message }, 500)
   }
 })

--- a/supabase/functions/recruit-watch/index.ts
+++ b/supabase/functions/recruit-watch/index.ts
@@ -11,7 +11,7 @@
 // returned beyond what the recording itself shows, and a bad or revoked
 // token is indistinguishable from a missing one (404 either way).
 
-const VERSION = '1.1.0'
+const VERSION = '1.1.1'
 console.log(`[recruit-watch] v${VERSION} — capability-link recording playback, short tokens, nameless titles`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
@@ -83,6 +83,10 @@ serve(async (req) => {
     return json({ title, when, summary, url: signed.signedUrl })
   } catch (err) {
     console.error('[recruit-watch] error:', (err as Error).message)
+    try {
+      const { logServerError } = await import('../_shared/telemetry.ts')
+      await logServerError(db(), 'recruit-watch', err)
+    } catch { /* telemetry is best-effort */ }
     return json({ error: 'Something went wrong' }, 500)
   }
 })

--- a/supabase/migrations/158_analytics_vitals_alerts.sql
+++ b/supabase/migrations/158_analytics_vitals_alerts.sql
@@ -1,0 +1,161 @@
+-- 158_analytics_vitals_alerts.sql
+-- Visibility build-out: web-vitals rows, server-side error rows, and the
+-- error-spike alert cron (analytics-alerts fn, DM via the recruiting bot —
+-- same no-new-secrets nonce handshake as migrations 123/136).
+
+-- 1. Event types: 'vital' (client, via anon insert) and 'server_error'
+--    (edge functions, via service role only — deliberately NOT in the policy).
+do $$
+declare c text;
+begin
+  select conname into c from pg_constraint
+   where conrelid = 'public.analytics_events'::regclass and contype = 'c'
+     and pg_get_constraintdef(oid) like '%pageview%';
+  if c is not null then
+    execute format('alter table public.analytics_events drop constraint %I', c);
+  end if;
+end $$;
+alter table public.analytics_events
+  add constraint analytics_events_type_check
+  check (type in ('pageview', 'error', 'server_error', 'vital'));
+
+drop policy if exists analytics_events_insert on public.analytics_events;
+create policy analytics_events_insert on public.analytics_events
+  for insert to anon, authenticated
+  with check (type in ('pageview', 'error', 'vital'));
+
+-- 2. Alert ledger — dedupes DMs (one per kind per cooldown window).
+create table if not exists public.analytics_alerts (
+  id bigint generated always as identity primary key,
+  sent_at timestamptz not null default now(),
+  kind text not null,
+  detail text
+);
+alter table public.analytics_alerts enable row level security;
+-- No policies on purpose: only the service role (analytics-alerts fn) touches it.
+
+-- 3. analytics_summary v2: server errors count as errors, vitals p75 exposed.
+create or replace function public.analytics_summary(days int default 30)
+returns jsonb
+language sql
+security definer
+set search_path = ''
+as $$
+  with window_events as (
+    select * from public.analytics_events
+    where occurred_at > now() - make_interval(days => days)
+  )
+  select jsonb_build_object(
+    'days', days,
+    'views_total', (select count(*) from window_events where type = 'pageview'),
+    'views_today', (
+      select count(*) from public.analytics_events
+      where type = 'pageview' and occurred_at >= date_trunc('day', now())
+    ),
+    'uniques_total', (
+      select count(distinct session_id) from window_events
+      where type = 'pageview' and session_id is not null
+    ),
+    'errors_total', (select count(*) from window_events where type in ('error', 'server_error')),
+    'daily', (
+      select coalesce(jsonb_agg(row_to_json(d) order by d.day), '[]'::jsonb)
+      from (
+        select date_trunc('day', occurred_at)::date as day,
+               count(*) filter (where type = 'pageview') as views,
+               count(distinct session_id) filter (where type = 'pageview') as uniques,
+               count(*) filter (where type in ('error', 'server_error')) as errors
+        from window_events
+        group by 1
+      ) d
+    ),
+    'by_app', (
+      select coalesce(jsonb_agg(row_to_json(a) order by a.views desc), '[]'::jsonb)
+      from (
+        select app,
+               count(*) filter (where type = 'pageview') as views,
+               count(distinct session_id) filter (where type = 'pageview') as uniques,
+               count(*) filter (where type in ('error', 'server_error')) as errors,
+               max(occurred_at) as last_seen
+        from window_events
+        group by app
+      ) a
+    ),
+    'top_paths', (
+      select coalesce(jsonb_agg(row_to_json(p)), '[]'::jsonb)
+      from (
+        select app, path, count(*) as views
+        from window_events
+        where type = 'pageview'
+        group by app, path
+        order by views desc
+        limit 25
+      ) p
+    ),
+    'top_referrers', (
+      select coalesce(jsonb_agg(row_to_json(r)), '[]'::jsonb)
+      from (
+        select referrer, count(*) as views
+        from window_events
+        where type = 'pageview' and referrer is not null and referrer <> ''
+        group by referrer
+        order by views desc
+        limit 15
+      ) r
+    ),
+    'recent_errors', (
+      select coalesce(jsonb_agg(row_to_json(e)), '[]'::jsonb)
+      from (
+        select occurred_at, type, app, path, message, stack, ua
+        from public.analytics_events
+        where type in ('error', 'server_error')
+        order by occurred_at desc
+        limit 50
+      ) e
+    ),
+    'vitals', (
+      select coalesce(jsonb_agg(row_to_json(v)), '[]'::jsonb)
+      from (
+        select meta->>'name' as name,
+               round((percentile_cont(0.75) within group
+                 (order by (meta->>'value')::numeric))::numeric, 2) as p75,
+               count(*) as samples
+        from window_events
+        where type = 'vital' and meta ? 'name' and meta ? 'value'
+          and (meta->>'value') ~ '^[0-9.]+$'
+        group by 1
+      ) v
+    )
+  );
+$$;
+revoke execute on function public.analytics_summary(int) from public, anon, authenticated;
+grant execute on function public.analytics_summary(int) to service_role;
+
+-- 4. Spike-check cron: every 30 min, nonce handshake (see migration 123 for
+--    why the Authorization header is the public anon key and not the auth).
+do $$
+declare
+  job_id int;
+begin
+  select jobid into job_id from cron.job where jobname = 'analytics_alerts_tick';
+  if job_id is not null then perform cron.unschedule(job_id); end if;
+end $$;
+
+select cron.schedule(
+  'analytics_alerts_tick',
+  '7,37 * * * *',
+  $$
+  with n as (
+    insert into recruit_cron_nonce default values returning nonce
+  )
+  select net.http_post(
+    url := 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/analytics-alerts',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlmaHVkd2FrcGd6c3dpeWxoZmJoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njk4MTE3ODYsImV4cCI6MjA4NTM4Nzc4Nn0.bemC-CPA2vkoM5P4P-tmsPQ1RPr4ifPa5iginUXPKLI',
+      'X-Cron-Nonce', (select nonce::text from n)
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+  $$
+);


### PR DESCRIPTION
Phase 1–3 of the analytics roadmap, first-party, no new vendors or secrets.

## Server-side error logging
- `_shared/telemetry.ts` — `logServerError()` writes `server_error` rows into `analytics_events` (app `fn:<name>`); anon inserts can't forge them
- Wired into top-level catches: analytics-dashboard, recruit-watch, recruit-gmail, recruit-discord (two lines to enroll any other fn)
- Errors tab shows them labeled "(server)"; totals/badges include them

## Discord spike alerts
- New `analytics-alerts` fn: pg_cron every 30 min via the migration-123 nonce handshake; DMs Ian (existing bot + ALERT_DISCORD_USER_ID) on ≥3 client errors/hr or ≥1 server error/hr; one DM per kind per 6h via `analytics_alerts` ledger

## Web vitals
- track.js v1.2.0 hand-rolls LCP/CLS/INP/TTFB with PerformanceObserver (no CDN lib), batched once per page on first hide
- `analytics_summary` v2 exposes p75 per metric; overview gets vitals tiles

## Post-merge
- Apply migration 158; deploy analytics-dashboard, analytics-alerts, recruit-watch/-gmail (--no-verify-jwt for recruit-discord, recruit-watch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)