### PR TITLE
fix(recruiting): restore inline Watch button on rows — v3.64.1

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.64.0">
+  <link rel="stylesheet" href="css/app.css?v=3.64.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -307,7 +307,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.64.0"></script>
-  <script src="js/app.js?v=3.64.0"></script>
+  <script src="js/app.js?v=3.64.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.64.0';
+const VERSION = '3.64.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -571,9 +571,16 @@ function openingsCta(a) {
     return stack(chip('tour ask sent', 'decision-chip--outreach', 'Waiting on their availability — the house poll posts itself when they reply'));
   }
 
-  if (phase === 'watch' || phase === 'done') {
+  if (phase === 'watch') {
+    // Watch earns its inline spot back: the recording is the review artifact,
+    // and burying it made every decision one menu deeper. Still no primary —
+    // it sits beside the status chip, everything else stays in the ⋮.
     const dv = decisionVotes[a.id] || [];
-    return stack(chip(`call done${dv.length ? ` · ${dv.length} weighed in` : ''}`, 'decision-chip--vote', 'Watch, decide, or schedule a house tour from the ⋮ menu'));
+    return stack(`<span class="cta-pair">${chip(`call done${dv.length ? ` · ${dv.length} weighed in` : ''}`, 'decision-chip--vote', 'Decide or schedule a house tour from the ⋮ menu')}${watchBtn(sc, a.id)}</span>`);
+  }
+  if (phase === 'done') {
+    const dv = decisionVotes[a.id] || [];
+    return stack(chip(`call done${dv.length ? ` · ${dv.length} weighed in` : ''}`, 'decision-chip--vote', 'Decide, add a recording, or schedule a house tour from the ⋮ menu'));
   }
   if (phase === 'processing') return stack(processingChip());
   if (phase === 'live') return stack(joinBtn(sc) || processingChip());

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -297,3 +297,6 @@ The ⋮ menu is context-aware and ordered: **suggested next step first** (same f
 5. **Row state** — the tour cycle owns the row chip while active (`tour ask sent` → `house poll open` → `visit <slot>`); the profile's House visit stage row narrates the same states.
 
 New settings: `house_address` (House), `tour_confirm_votes` (House). New table: `recruit_tours` (member-read, service-role write).
+
+### v3.64.1 — Watch returns to the row
+The recording is the review artifact; hiding it made every decision one menu deeper. Rows in the watch state show the small **Watch** button beside the `call done` chip — still no primary CTA, and every other verb stays in the ⋮.


### PR DESCRIPTION
Rows in the watch state show the small Watch button beside the `call done` chip again — the recording is the review artifact and deserved its inline spot. No primary CTA returns; every other verb stays in the ⋮ menu (v3.64 model unchanged). Doc note appended to `docs/ux/recruiting-row-states.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)