### PR TITLE
feat(recruiting): tour polls publish all 5/6/7pm starts + society scheduling posts — v3.65.0

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.64.1">
+  <link rel="stylesheet" href="css/app.css?v=3.65.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -306,8 +306,8 @@
     </div>
   </div>
 
-  <script src="js/settings-schema.js?v=3.64.0"></script>
-  <script src="js/app.js?v=3.64.1"></script>
+  <script src="js/settings-schema.js?v=3.65.0"></script>
+  <script src="js/app.js?v=3.65.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.64.1';
+const VERSION = '3.65.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,

--- a/applications/js/settings-schema.js
+++ b/applications/js/settings-schema.js
@@ -18,7 +18,7 @@
  *
  * Classic script, not a module: it runs before app.js and hands over globals.
  */
-const SETTINGS_VERSION = '1.1.0';
+const SETTINGS_VERSION = '1.2.0';
 console.log(`[settings-schema] v${SETTINGS_VERSION}`);
 
 /* Every knob, exposed or not. `section: null` means "routed through setting()
@@ -83,6 +83,11 @@ const SETTING_DEFS = {
     scope: 'house', type: 'bool', section: 'automations', default: false,
     label: 'Auto-post coverage asks',
     hint: 'Off means a human sees the message before the house does.',
+  },
+  society_scheduling_posts: {
+    scope: 'house', type: 'bool', section: 'automations', default: true,
+    label: 'Scheduling asks reach #recruiting-society',
+    hint: 'House-visit polls and screener schedulers post to the members channel. Test applicants never do — they stay in #recruiting-automation.',
   },
 
   /* --- You -------------------------------------------------------------- */

--- a/docs/ux/recruiting-row-states.md
+++ b/docs/ux/recruiting-row-states.md
@@ -300,3 +300,7 @@ New settings: `house_address` (House), `tour_confirm_votes` (House). New table: 
 
 ### v3.64.1 — Watch returns to the row
 The recording is the review artifact; hiding it made every decision one menu deeper. Rows in the watch state show the small **Watch** button beside the `call done` chip — still no primary CTA, and every other verb stays in the ⋮.
+
+### v3.65 — tour polls publish every recommended start; scheduling asks reach the society channel
+- A qualifying Tue–Thu day publishes **all** recommended starts — 5, 6, and 7pm — as separate emoji slots (up to 10 emojis), so "any evening works" becomes a real choice instead of ratifying the first slot. Slot seeding now paces reaction adds (~350ms apart, 429-retry) so every emoji ships pre-seeded.
+- **Scheduling asks post to #recruiting-society** — house-visit polls and screener schedulers, gated by the new `society_scheduling_posts` setting (Automations, default on). Narrower than the held `RECRUITING_SOCIETY_POSTS` env switch, which still gates notes/recordings. Test applicants (`e2e-*`/`test-*` ids) never post there — they stay in #recruiting-automation.

--- a/supabase/functions/_shared/discord.ts
+++ b/supabase/functions/_shared/discord.ts
@@ -38,7 +38,7 @@ export const CLAIMS_CHANNEL_ID = AUTOMATION_CHANNEL_ID
    ping kept landing there while the ledger's own switch said not to.
 
    Set RECRUITING_SOCIETY_POSTS=true to hand the channel back its traffic. */
-const SOCIETY_CHANNEL_ID = Deno.env.get('SCREENING_NOTES_CHANNEL_ID') || '1503490895469609211'
+export const SOCIETY_CHANNEL_ID = Deno.env.get('SCREENING_NOTES_CHANNEL_ID') || '1503490895469609211'
 const SOCIETY_POSTS_ON = Deno.env.get('RECRUITING_SOCIETY_POSTS') === 'true'
 export const NOTES_CHANNEL_ID = SOCIETY_POSTS_ON ? SOCIETY_CHANNEL_ID : AUTOMATION_CHANNEL_ID
 
@@ -252,12 +252,15 @@ export async function upsertScreenerScheduler(db: any, input: ScreenerSchedulerI
 
   const message = await postOrPatch(CLAIMS_CHANNEL_ID, live?.discord_message_id || null, payload)
   // Mirror copy is best-effort: missing channel perms must not kill the post.
-  // While society posts are held, NOTES resolves to the same channel as the
-  // primary — mirroring then would just duplicate the scheduler post.
+  // Scheduling asks reach the members channel via society_scheduling_posts
+  // (test applicants never do); otherwise fall back to the held NOTES route.
+  // Skipped when it would just duplicate the post into the same channel.
   let mirror: any = null
-  if (NOTES_CHANNEL_ID !== CLAIMS_CHANNEL_ID) {
+  const mirrorChannel = (await schedulingSocietyChannel(db, input.applicantId))
+    || (NOTES_CHANNEL_ID !== CLAIMS_CHANNEL_ID ? NOTES_CHANNEL_ID : null)
+  if (mirrorChannel && mirrorChannel !== CLAIMS_CHANNEL_ID) {
     try {
-      mirror = await postOrPatch(NOTES_CHANNEL_ID, live?.mirror_message_id || null, payload)
+      mirror = await postOrPatch(mirrorChannel, live?.mirror_message_id || null, payload)
     } catch (err) {
       console.warn(`[discord] mirror post failed for ${input.applicantId}: ${(err as Error).message}`)
     }
@@ -698,15 +701,38 @@ export async function _unusedCanSeeRecruiting(discordUserId: string, memberRoles
 // Number emojis for tour poll slots. Reactions, not buttons: a tour is a
 // headcount question ("who can be around?"), and everyone answering is the
 // point — buttons are for the first-taker-wins claim flow.
-export const TOUR_EMOJIS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣']
+export const TOUR_EMOJIS = ['1️⃣', '2️⃣', '3️⃣', '4️⃣', '5️⃣', '6️⃣', '7️⃣', '8️⃣', '9️⃣', '🔟']
 
 export interface TourSlot { start: string; label: string; emoji: string }
+
+// Test records never reach the members channel — the house shouldn't get
+// pinged about a pipeline test.
+export function isTestApplicant(applicantId: string): boolean {
+  return /^(e2e-|test-)/i.test(applicantId)
+}
+
+/* Where scheduling asks (screener schedulers, tour polls) reach the house.
+   recruit_settings.society_scheduling_posts (default ON) routes them to
+   #recruiting-society — deliberately narrower than the held
+   RECRUITING_SOCIETY_POSTS env switch, which still gates notes, recordings,
+   and everything else. Null = keep the ask out of the members channel. */
+// deno-lint-ignore no-explicit-any
+export async function schedulingSocietyChannel(db: any, applicantId: string): Promise<string | null> {
+  if (isTestApplicant(applicantId)) return null
+  try {
+    const { data } = await db.from('recruit_settings')
+      .select('value').eq('key', 'society_scheduling_posts').maybeSingle()
+    if (data?.value === false) return null
+  } catch { /* default on */ }
+  return SOCIETY_CHANNEL_ID
+}
 
 // Post (or refresh) the tour poll and seed each slot's reaction so
 // housemates tap rather than hunt the emoji picker. Returns the message.
 export async function postTourPoll(input: {
   firstName: string; applicantId: string; slots: TourSlot[]
   offHours: boolean; threshold: number
+  channelId?: string
   existing?: { channelId: string; messageId: string } | null
 }): Promise<any> {
   const lines = input.slots.map((s) => `${s.emoji} ${s.label}`).join('\n')
@@ -718,16 +744,30 @@ export async function postTourPoll(input: {
     `See their [application](${appLink(input.applicantId)}).`
   const payload = { embeds: [{ description, color: 0x1abc9c }] }
   const message = await postOrPatch(
-    input.existing?.channelId || NOTES_CHANNEL_ID,
+    input.existing?.channelId || input.channelId || NOTES_CHANNEL_ID,
     input.existing?.messageId || null, payload,
   )
-  const channelId = message.channel_id || input.existing?.channelId || NOTES_CHANNEL_ID
+  const channelId = message.channel_id || input.existing?.channelId || input.channelId || NOTES_CHANNEL_ID
+  /* Seed EVERY slot's reaction. Discord's reaction bucket is ~1 add per
+     300ms per channel — the first version fired PUTs back-to-back and the
+     429s silently ate half the row, so a poll shipped with 1️⃣ and 3️⃣ but
+     no 2️⃣. Space the adds and retry the rate-limited ones. */
   for (const s of input.slots) {
-    try {
-      await discordFetch(`/channels/${channelId}/messages/${message.id}/reactions/${encodeURIComponent(s.emoji)}/@me`, { method: 'PUT' })
-    } catch (err) {
-      console.warn(`[discord] seeding reaction ${s.emoji} failed: ${(err as Error).message}`)
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await discordFetch(`/channels/${channelId}/messages/${message.id}/reactions/${encodeURIComponent(s.emoji)}/@me`, { method: 'PUT' })
+        break
+      } catch (err) {
+        // deno-lint-ignore no-explicit-any
+        if ((err as any).status === 429 && attempt < 2) {
+          await new Promise((r) => setTimeout(r, 800 * (attempt + 1)))
+          continue
+        }
+        console.warn(`[discord] seeding reaction ${s.emoji} failed: ${(err as Error).message}`)
+        break
+      }
     }
+    await new Promise((r) => setTimeout(r, 350))
   }
   await auditMirror('House tour poll', `${input.firstName} — ${input.slots.length} slot(s)`, { channelId })
   return message

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,13 +16,13 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.31.0'
+const VERSION = '1.32.0'
 console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents + tour polls`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { sharedAccessToken as accessToken, b64url, scheduleScreening, sendIntroEmail, sweepCalendars, SHARED_EMAIL, TZ } from '../_shared/recruit-schedule.ts'
-import { upsertScreenerScheduler, editSchedulerSignedUp, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID, ptToUTC, postTourPoll, tourPollCounts, editTourConfirmed, TOUR_EMOJIS } from '../_shared/discord.ts'
+import { upsertScreenerScheduler, editSchedulerSignedUp, notifyStuck, slotLabel, slotWhen, deriveSlots, buildMessage, postChannelEmbed, NOTES_CHANNEL_ID, ptToUTC, postTourPoll, tourPollCounts, editTourConfirmed, TOUR_EMOJIS, schedulingSocietyChannel } from '../_shared/discord.ts'
 import { record } from '../_shared/recruit-notify.ts'
 import { ACTIONS } from '../_shared/recruit-copy.ts'
 
@@ -368,8 +368,12 @@ async function postClaim(client: ReturnType<typeof db>, applicantId: string, ext
    guests never join). That WHY lives here and in Settings, never in any
    email the applicant sees. */
 const TOUR_DAYS = new Set([2, 3, 4]) // Tue, Wed, Thu
-const TOUR_START = '17:00'
-const TOUR_END = '19:00'
+// Every recommended start publishes for a qualifying day — a vague "any
+// evening works" must not collapse to one slot. 7pm is a valid start even
+// though it's the window's edge; the poll is a headcount, not a fence.
+const TOUR_SLOT_STARTS = ['17:00', '18:00', '19:00']
+const TOUR_EVENING_START = '17:00'
+const TOUR_EVENING_END = '20:00'
 
 // Weekday of a PT wall-clock date. Noon UTC on that calendar date is always
 // the same calendar day in Pacific, so getUTCDay is safe here.
@@ -377,28 +381,40 @@ function weekdayPT(date: string): number {
   return new Date(`${date}T12:00:00Z`).getUTCDay()
 }
 
-// Their windows ∩ Tue–Thu 5–7pm → poll slots. When nothing overlaps, fall
-// back to their raw windows and flag the poll off-hours for a human call.
+/* Poll slots from their windows: every Tue–Thu date whose windows touch the
+   evening (5–8pm) publishes ALL recommended starts — 5, 6, and 7pm — so
+   housemates pick the hour, not just ratify the first one. When no day
+   qualifies, fall back to their raw windows and flag the poll off-hours for
+   a human call. */
 function tourSlotsFrom(windows: Array<{ date: string; start: string; end: string }>): { slots: Array<{ start: string; label: string; emoji: string }>; offHours: boolean } {
   const now = Date.now()
-  const hits: Array<{ start: Date; end: Date }> = []
+  const days = new Set<string>()
   for (const w of windows) {
     if (!TOUR_DAYS.has(weekdayPT(w.date))) continue
-    const s = ptToUTC(w.date, w.start > TOUR_START ? w.start : TOUR_START)
-    const e = ptToUTC(w.date, w.end < TOUR_END ? w.end : TOUR_END)
-    if (s.getTime() >= e.getTime() || e.getTime() < now) continue
-    hits.push({ start: s, end: e })
+    if (w.end <= TOUR_EVENING_START || w.start >= TOUR_EVENING_END) continue
+    days.add(w.date)
   }
-  const offHours = !hits.length
-  const source = offHours
-    ? windows.map((w) => ({ start: ptToUTC(w.date, w.start), end: ptToUTC(w.date, w.end) }))
-        .filter((x) => x.end.getTime() > now)
-    : hits
-  const fmtEnd = (d: Date) => d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ })
-    .toLowerCase().replace(' am', 'a').replace(' pm', 'p')
-  const slots = source.sort((a, b) => a.start.getTime() - b.start.getTime())
+  const starts: Date[] = []
+  for (const date of [...days].sort()) {
+    for (const hh of TOUR_SLOT_STARTS) {
+      const d = ptToUTC(date, hh)
+      if (d.getTime() > now) starts.push(d)
+    }
+  }
+  const offHours = !starts.length
+  if (offHours) {
+    const fmtEnd = (d: Date) => d.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, timeZone: TZ })
+      .toLowerCase().replace(' am', 'a').replace(' pm', 'p')
+    const raw = windows.map((w) => ({ start: ptToUTC(w.date, w.start), end: ptToUTC(w.date, w.end) }))
+      .filter((x) => x.end.getTime() > now)
+      .sort((a, b) => a.start.getTime() - b.start.getTime())
+      .slice(0, TOUR_EMOJIS.length)
+      .map((x, i) => ({ start: x.start.toISOString(), label: `${slotLabel(x.start)}–${fmtEnd(x.end)}`, emoji: TOUR_EMOJIS[i] }))
+    return { slots: raw, offHours }
+  }
+  const slots = starts.sort((a, b) => a.getTime() - b.getTime())
     .slice(0, TOUR_EMOJIS.length)
-    .map((x, i) => ({ start: x.start.toISOString(), label: `${slotLabel(x.start)}–${fmtEnd(x.end)}`, emoji: TOUR_EMOJIS[i] }))
+    .map((d, i) => ({ start: d.toISOString(), label: slotLabel(d), emoji: TOUR_EMOJIS[i] }))
   return { slots, offHours }
 }
 
@@ -431,6 +447,9 @@ async function maybePostTourPoll(
     const message = await postTourPoll({
       firstName: applicant?.first_name || 'An applicant', applicantId, slots, offHours,
       threshold: await tourThreshold(client),
+      // Members channel for real applicants (society_scheduling_posts, on by
+      // default); test records and opted-out houses stay in automation.
+      channelId: (await schedulingSocietyChannel(client, applicantId)) || NOTES_CHANNEL_ID,
       existing: tour.discord_message_id
         ? { channelId: tour.discord_channel_id, messageId: tour.discord_message_id }
         : null,


### PR DESCRIPTION
**Poll slots** — a qualifying Tue–Thu day now publishes every recommended start (5, 6, 7pm) as its own emoji slot (up to 10), so a vague "any evening works" reply becomes a real choice. Reaction seeding paces adds and retries 429s, fixing polls shipping with missing emojis (the 1️⃣/3️⃣-but-no-2️⃣ bug).

**Society notifications** — house-visit polls and screener schedulers now reach #recruiting-society, behind the new `society_scheduling_posts` setting (Automations, default on). Test applicants (`e2e-*`/`test-*`) never post there — Indy Tester stays in #recruiting-automation.

Post-merge: deploy `recruit-gmail` and `recruit-availability` (shared discord.ts changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)