### PR TITLE
fix(recruiting): the lane governs the channel, not just the digest

### DIFF
--- a/supabase/functions/_shared/recruit-copy.ts
+++ b/supabase/functions/_shared/recruit-copy.ts
@@ -91,7 +91,7 @@ export const TEMPLATES: Record<string, string> = {
   'review_backlog':               '{subject} are waiting for reviews, {window} days.',
   'needs_input':                  '{asker} wants second opinon on {subject}.',
   'candidate_placed':             '{subject} passed review and fits {rooms}.',
-  'candidate_parked':             '{subject} passed review but no openings fit their move-in dates.',
+  'candidate_parked':             '{subject} passed review but no open room fits their move-in dates.',
   'gone_cold':                    '{subject} never answered the last email, sent {days} ago.',
   'candidate_promoted':           '{subject} moved into {room} on {date} as a resident.',
 
@@ -100,7 +100,7 @@ export const TEMPLATES: Record<string, string> = {
   'decision_open.overdue':        'The house still has not decided on {subject}, who wanted to move in {date}.',
 
   // --- the call
-  'screening_followup.undecided': "{subject} was interviewed {days} ago and waiting on house decision.",
+  'screening_followup.undecided': "{subject} was interviewed {days} ago and waiting on the house to decide.",
   // Naming who ran the call turns "somebody should" into "you said you would".
   'screening_followup.undecided_by': "{screener} interviewed {subject} {days} ago and the house still hasn't decided.",
   'screening_followup.silent':    '{subject} was interviewed and has heard nothing for {days}.',

--- a/supabase/functions/_shared/recruit-notify.ts
+++ b/supabase/functions/_shared/recruit-notify.ts
@@ -705,7 +705,9 @@ async function detectCandidateLanding(db: DB): Promise<Notification[]> {
         subject_type: 'applicant',
         subject_id: a.id,
         subject_label: a.first_name,
-        lane: 'now',
+        // Good news, not urgent news: the sweep places a batch at once and
+        // nobody acts on it the minute it lands.
+        lane: 'daily',
         // Keyed on the set of rooms, so a candidate moving between listings is
         // news again while a candidate sitting still is not.
         dedupe_key: `candidate_placed:${a.id}:${[...rooms].sort().join('+')}`,
@@ -1700,9 +1702,23 @@ function oneLine(n: LineRow): string {
    members-channel passes so #recruiting-automation is never behind the
    channel the house reads. */
 async function drainLog(db: DB): Promise<number> {
+  /* Only what is urgent. Everything else waits for the digest.
+
+     The log was designed to post every notification the moment it appeared,
+     because it was the complete record and the house read a different channel.
+     With everything held to #recruiting-automation that promise turned into the
+     noise: a candidate parked with no room, a shortlist filling up, and a
+     backlog count all arrived as interrupts, each one true and none of them
+     needing anybody to move.
+
+     So the lane now governs the channel. 'now' posts immediately; 'daily' and
+     'weekly' are left unposted here and collected by the digest, which lands in
+     the same channel once a day. Nothing is dropped — the Activity view still
+     holds every notification the instant it is detected, and that is where the
+     complete-record promise lives. */
   const { data } = await db.from('recruit_notifications')
     .select('id, kind, subject_label, payload, audience, lane, muted')
-    .is('log_at', null).neq('audience', 'none')
+    .is('log_at', null).neq('audience', 'none').eq('lane', 'now')
     .order('created_at').limit(12)
   if (!data?.length) return 0
 
@@ -1877,8 +1893,14 @@ async function drainDigest(db: DB, settings: NotifySettings, lane: 'daily' | 'we
   })
   const heading = lane === 'daily' ? '🌞 **Recruiting today**' : '📅 **Recruiting this week**'
   await sendEmbed(houseChannel(settings), `${heading}\n\n${blocks.join('\n\n')}`)
+  /* Stamped as logged as well as digested: the digest IS how these reached the
+     channel, and leaving log_at null would make them look forever unposted. */
   await db.from('recruit_notifications')
-    .update({ members_at: new Date().toISOString(), digest_id: digestId })
+    .update({
+      members_at: new Date().toISOString(),
+      log_at: new Date().toISOString(),
+      digest_id: digestId,
+    })
     .in('id', data.map((r: { id: string }) => r.id))
   return data.length
 }

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -463,13 +463,18 @@ async function maybePostTourPoll(
        this notification exists for. */
     try {
       const name = `${applicant?.first_name || 'An applicant'} ${applicant?.last_name || ''}`.trim()
-      const sig = slots.map((s) => s.start).join(',').slice(0, 120)
+      /* Keyed per person per day, not per set of times. Keying on the slots
+         themselves meant every edit to their availability was a new
+         notification — and produced a 200-character dedupe key made of ISO
+         timestamps. Somebody adjusting their times three times in an afternoon
+         is one piece of news. */
+      const today = new Intl.DateTimeFormat('en-CA', { timeZone: TZ }).format(new Date())
       const times = fmtWindows(windows)
       await record(client, [{
         kind: 'tour_availability',
         subject_type: 'applicant', subject_id: applicantId, subject_label: name,
         lane: refresh ? 'now' : 'daily',
-        dedupe_key: `tour_availability:${applicantId}:${sig}`,
+        dedupe_key: `tour_availability:${applicantId}:${today}`,
         payload: {
           title: name,
           copy: refresh ? (times ? 'tour_availability.updated' : 'tour_availability.updated.plain') : 'tour_availability',


### PR DESCRIPTION
The audit's four cleanups.

## 1. The lane now decides what interrupts

The log posted **every** notification the moment it appeared — correct when it was the complete record and the house read a different channel. Held to one channel, that promise *became* the noise: a candidate parked with no room, a shortlist filling, a backlog count. Each true, none needing anybody to move, all arriving as interrupts.

Now `now` posts immediately; `daily`/`weekly` wait for the digest, which lands in the same channel once a day.

**Nothing is dropped** — the Activity view still holds every notification the instant it's detected, and that's where the complete-record promise belongs.

## 2. `candidate_placed` → daily

Good news, not urgent news: the sweep places a batch at once and nobody acts the minute it lands. **10 of today's 24 immediate notifications.**

Verified: 24 immediate → **14**, with the rest waiting for the digest.

## 3. `tour_availability` keyed per person per day

It was keyed on the **serialized slot list**, so every edit to someone's availability was a fresh notification — with a 200-character dedupe key made of ISO timestamps. Somebody adjusting their times three times in an afternoon is one piece of news.

## 4. Decision vocabulary reconciled

*"hasn't voted"* and *"waiting on house decision"* were both still in the templates after the vote→decision rename landed unevenly across two sessions.

## Not changed — I was wrong in the audit

I flagged "two placeholder conventions" because sentences store the subject as literal `{}`. That's **deliberate**: it lets `oneLine()` and the Activity view substitute the *hyperlinked* name at display time, which is the only moment the URL is known. Baking the name in at record time (my original design) produced correct words with nothing to click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)