### PR TITLE
feat(ladder): track any company by careers URL + Gmail engaged-thread role discovery — v2.39.0

### DIFF
--- a/docs/execution/project-plan/phase-14-gmail-jobs-pipe.md
+++ b/docs/execution/project-plan/phase-14-gmail-jobs-pipe.md
@@ -195,3 +195,12 @@ The following are explicitly excluded from Phase 1. Do not add them here.
 | Verify `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set in Supabase Edge Function secrets | Pending |
 | Manually trigger first scan via `POST /gmail-scan` and confirm roles appear in recommendations widget | Pending |
 | Update `calendar-api` deployment after `_shared/google-tokens.ts` refactor: `supabase functions deploy calendar-api` | Pending |
+
+### Story 5.1 — Watch any company by careers URL (custom adapter, v2.39 / watched-companies v0.2.0)
+
+| Task | Status |
+|------|--------|
+| `watched-companies` POST accepts optional `url`: ATS board URLs (Greenhouse/Lever/Ashby) derive adapter+slug directly; anything else becomes `adapter='custom'` with `config.url` | ✓ |
+| URL-only add derives a display name from the domain (medplum.com → "Medplum") | ✓ |
+| `company-watch` gains `pullCustom`: fetch the careers page, Haiku (claude-haiku-4-5) enumerates openings from page text + link list; budgeted detail fetches populate descriptions so the grade cron can score rows | ✓ |
+| Watched-companies strip: optional "Careers page URL" input beside the company name field; 422 copy now points at the URL fallback | ✓ |

--- a/docs/execution/project-plan/phase-15-gmail-application-tracker.md
+++ b/docs/execution/project-plan/phase-15-gmail-application-tracker.md
@@ -221,3 +221,12 @@ Design pattern documented in `ladder/DESIGN.md` (Updates queue / Signal chips).
 | Migration 107: role_closed event type, liveness source, archived_closed auto_action; backfill legacy 'Closed' roles + last-7d closure events | ✓ |
 | application-events v1.7.0: archived_closed records in the updates feed | ✓ |
 | Client-side closure synthesis removed — dismissals now server-persisted (cross-device) | ✓ |
+
+### Story 5.7 — Engaged-thread discovery (v0.30.0, app-scan pass 3)
+
+| Task | Status |
+|------|--------|
+| Pass 3: `threads.list in:sent newer_than:7d` finds threads the user replied to; unpinned threads (≤8/run) get their latest inbound message queued for the no-match gauntlet | ✓ |
+| New `extractUnmatchedOpportunity` Haiku classifier: is this an active job conversation (recruiter/hiring-manager back-and-forth) → company, title, stage, confidence | ✓ |
+| ≥0.8 confidence + real company + not blocked → auto-create pipeline role at the extracted stage (applied/interviewing/offer) with a stage-mapped event, `auto_action='role_created'` | ✓ |
+| Rejected engaged threads persist to `gmail_skipped` (reason `not_opportunity`) so each thread costs at most one Haiku judgment | ✓ |

--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.38.0");
+@import url("./components.css?v=2.39.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
 
 
 
@@ -82,7 +82,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.38.0";
-console.log(`[ladder] v${VERSION} - Anthropic credit-outage banner w/ billing link; role_created Updates kind`);
+const VERSION = "2.39.0";
+console.log(`[ladder] v${VERSION} - watch any company by careers URL (custom adapter); Gmail engaged-thread role discovery`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-watched-companies.js
+++ b/ladder/js/components/ladder-watched-companies.js
@@ -24,6 +24,7 @@ export class LadderWatchedCompanies extends LitElement {
     state:    { state: true },
     adding:   { state: true },
     newName:  { state: true },
+    newUrl:   { state: true },
     error:    { state: true },
   };
 
@@ -33,6 +34,7 @@ export class LadderWatchedCompanies extends LitElement {
     this.state = 'idle';
     this.adding = false;
     this.newName = '';
+    this.newUrl = '';
     this.error = '';
   }
 
@@ -72,14 +74,16 @@ export class LadderWatchedCompanies extends LitElement {
   async _onAdd(e) {
     e.preventDefault();
     const company = this.newName.trim();
-    if (!company || this.adding) return;
+    const url = this.newUrl.trim();
+    if ((!company && !url) || this.adding) return;
     this.adding = true;
     this.error = '';
     try {
-      await watchCompany({ company });
+      const watch = await watchCompany({ company, url: url || undefined });
       this.newName = '';
+      this.newUrl = '';
       await this._load();
-      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${company} — roles land on the next pull` } }));
+      document.dispatchEvent(new CustomEvent('job:toast', { detail: { msg: `Watching ${watch?.company || company} — roles land on the next pull` } }));
     } catch (err) {
       this.error = err.message || String(err);
     } finally {
@@ -148,7 +152,12 @@ export class LadderWatchedCompanies extends LitElement {
                    .value=${this.newName}
                    @input=${(e) => { this.newName = e.target.value; this.error = ''; }}
                    ?disabled=${this.adding}>
-            <button class="btn btn--sm" type="submit" ?disabled=${this.adding || !this.newName.trim()}>
+            <input type="url" placeholder="Careers page URL (optional)" maxlength="300"
+                   title="For companies off Greenhouse / Lever / Ashby — paste any careers page and we'll track it directly"
+                   .value=${this.newUrl}
+                   @input=${(e) => { this.newUrl = e.target.value; this.error = ''; }}
+                   ?disabled=${this.adding}>
+            <button class="btn btn--sm" type="submit" ?disabled=${this.adding || (!this.newName.trim() && !this.newUrl.trim())}>
               ${this.adding ? 'Resolving…' : '+ Watch'}
             </button>
           </form>

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -346,12 +346,12 @@ export async function fetchWatchedCompanies() {
 // Add a watch. Server resolves the adapter (Google/Amazon/Workday/… or an
 // ATS board probe) when not provided. Throws with the server's message on
 // a 422 so the UI can tell the user the company isn't supported yet.
-export async function watchCompany({ company, adapter, config, filterMode, titleKeywords, locations } = {}) {
+export async function watchCompany({ company, url, adapter, config, filterMode, titleKeywords, locations } = {}) {
   const headers = await authHeader();
   const res = await fetch(WATCHED_URL, {
     method: 'POST',
     headers: { ...headers, 'Content-Type': 'application/json' },
-    body: JSON.stringify({ company, adapter, config, filterMode, titleKeywords, locations }),
+    body: JSON.stringify({ company, url, adapter, config, filterMode, titleKeywords, locations }),
   });
   const j = await res.json().catch(() => ({}));
   if (!res.ok) throw new Error(j.error || `watch-company ${res.status}`);

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.38.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.39.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.38.0">
-  <script src="/ladder/js/theme.js?v=2.38.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <script src="/ladder/js/theme.js?v=2.39.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.38.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/gmail-application-classifier.ts
+++ b/supabase/functions/_shared/gmail-application-classifier.ts
@@ -268,6 +268,96 @@ export async function extractUnmatchedApplication(args: {
   };
 }
 
+// ── Unmatched-opportunity extraction ───────────────────────────────────
+// Third classifier, used ONLY for messages in threads the USER has
+// replied to that matched no pipeline role. Where the receipt extractor
+// asks "is this an application receipt?", this one asks "is this an
+// active job conversation — recruiter outreach the candidate engaged
+// with, a hiring-manager back-and-forth, interview scheduling — for a
+// role Ladder doesn't know about?". The scan uses it to create the
+// pipeline row for opportunities that never had a saved posting.
+
+export interface ExtractedUnmatchedOpportunity {
+  is_job_opportunity: boolean;
+  company: string;
+  title: string;
+  stage: 'applied' | 'interviewing' | 'offer';
+  summary: string;
+  confidence: number;
+}
+
+const EXTRACT_OPPORTUNITY_SYSTEM = `You look at a single Gmail message from a thread the candidate has personally replied to, and decide whether it is part of an ACTIVE job opportunity conversation for the candidate — e.g. a recruiter or hiring manager discussing a specific role with them, scheduling interviews, sharing next steps, or extending an offer.
+
+Return STRICT JSON, no prose:
+{
+  "is_job_opportunity": true | false,
+  "company": "the hiring company's name, exactly as the email presents it",
+  "title": "the role under discussion, exactly as stated ('' if never named)",
+  "stage": "applied" | "interviewing" | "offer",
+  "summary": "one short sentence (≤140 chars) — where this conversation stands",
+  "confidence": 0.0–1.0
+}
+
+Rules:
+- TRUE only for a live, two-way conversation about a specific opportunity FOR the candidate. The thread context (candidate replied) is already established; judge whether the content is about them being hired.
+- FALSE for job alerts, newsletters, cold outreach with no specifics, sales/vendor threads, networking chats with no role, the candidate hiring someone else, and personal email.
+- stage: "interviewing" when calls/interviews are being scheduled or have happened; "offer" only on explicit offer language; otherwise "applied".
+- company/title must come from the email text (sender domain may inform company). If company is not identifiable, use "" and low confidence.
+- NEVER fabricate. Empty / false > guess.
+- The body may be truncated. Trust what you see; do not extrapolate.`;
+
+export async function extractUnmatchedOpportunity(args: {
+  subject: string;
+  sender: string;
+  body: string;
+}): Promise<ExtractedUnmatchedOpportunity | null> {
+  const apiKey = (Deno.env.get('LADDER_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY'));
+  if (!apiKey) {
+    console.warn('[gmail-app-classifier] ANTHROPIC_API_KEY missing');
+    return null;
+  }
+
+  const trimmed = args.body.slice(0, 6000);
+  const userPrompt = [
+    `Subject: ${args.subject}`,
+    `From: ${args.sender}`,
+    `---`,
+    trimmed,
+  ].join('\n');
+
+  const r = await fetch(ANTHROPIC_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 300,
+      system: EXTRACT_OPPORTUNITY_SYSTEM,
+      messages: [{ role: 'user', content: userPrompt }],
+    }),
+  });
+  if (!r.ok) throw new Error(`anthropic ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json() as { content: Array<{ type: string; text: string }> };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('').trim();
+  const parsed = extractFirstJsonObject(text) as Partial<ExtractedUnmatchedOpportunity> | null;
+  if (!parsed) {
+    console.warn(`[gmail-app-classifier] bad JSON (opportunity): ${text.slice(0, 120)}`);
+    return null;
+  }
+  const stage = parsed.stage === 'interviewing' || parsed.stage === 'offer' ? parsed.stage : 'applied';
+  return {
+    is_job_opportunity: parsed.is_job_opportunity === true,
+    company:    String(parsed.company || '').trim().slice(0, 120),
+    title:      String(parsed.title || '').trim().slice(0, 200),
+    stage,
+    summary:    String(parsed.summary || '').trim().slice(0, 180),
+    confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
+  };
+}
+
 // Tolerant JSON extractor — mirrors the pattern in gmail-jobs.ts. Haiku
 // occasionally appends commentary or wraps in fences; this absorbs that.
 function extractFirstJsonObject(text: string): unknown {

--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -28,6 +28,7 @@ const LADDER_LABEL = 'Ladder';
 import {
   classifyApplicationMessage,
   extractUnmatchedApplication,
+  extractUnmatchedOpportunity,
   type ApplicationEventType,
   type ClassifiedApplicationEvent,
   ATS_PLATFORM_DOMAINS,
@@ -75,8 +76,16 @@ export interface ApplicationScanResult {
   autoResolved:  number;        // offers/rejections the scan acted on (undo-able)
   needsReview:   number;        // events flagged for user attention
   skippedNoMatch:number;        // messages where no role could be matched
-  rolesCreated:  number;        // pipeline roles auto-created from unmatched receipts
+  rolesCreated:  number;        // pipeline roles auto-created (receipts + engaged threads)
 }
+
+// Pass 3 (engaged-thread discovery) caps: threads.get calls are the
+// expensive part, and each engaged thread costs at most one Haiku call.
+const MAX_DISCOVERY_THREADS = 8;
+// Senders that never open an opportunity thread — job boards, calendar
+// robots, no-reply automation. The engaged-thread gate already implies
+// the user replied in the thread; this just skips obvious machinery.
+const DISCOVERY_NOISE_SENDER_RE = /\b(no-?reply|notifications?|newsletter|calendar-notification|mailer-daemon|do-?not-?reply)\b|@(linkedin\.com|wellfound\.com|otta\.com|builtin\.com|hnhiring\.com|substack\.com)\b/i;
 
 export async function scanApplicationResponses(args: {
   userEmail: string;
@@ -231,6 +240,56 @@ export async function scanApplicationResponses(args: {
     }
   }
 
+  // Pass 3: engaged-thread discovery. Threads the USER has replied to
+  // recently are the strongest signal for an in-progress conversation —
+  // a hiring-manager back-and-forth at a company Ladder has never seen
+  // won't surface via passes 1/2 (unknown domain, unknown company name).
+  // For each replied thread not already pinned to a role, queue its
+  // latest inbound message; the no-match branch below runs the
+  // opportunity extractor on it. Rejected messages land in gmail_skipped
+  // (reason 'not_opportunity') so we never re-classify them.
+  const engagedThreads = new Set<string>();
+  if (Date.now() < deadline) {
+    try {
+      const skippedRows = await sql<{ gmail_id: string }[]>`
+        select gmail_id from job.gmail_skipped
+         where user_email = ${args.userEmail} and reason = 'not_opportunity'`;
+      const alreadyRejected = new Set(skippedRows.map(r => r.gmail_id));
+
+      const sentThreadIds = await listThreadsByQuery(
+        args.accessToken, `in:sent newer_than:${windowDays}d -in:trash`, 50);
+      let threadBudget = MAX_DISCOVERY_THREADS;
+      for (const threadId of sentThreadIds) {
+        if (threadBudget <= 0 || Date.now() > deadline) break;
+        if (threadToRole.has(threadId)) continue;
+        threadBudget--;
+        try {
+          const r = await fetch(`${GMAIL_BASE}/threads/${threadId}?format=metadata&metadataHeaders=From`, {
+            headers: { Authorization: `Bearer ${args.accessToken}` } });
+          if (!r.ok) continue;
+          const thread = await r.json() as { messages?: GmailMessage[] };
+          // Latest inbound message = the other party's most recent word.
+          const inbound = (thread.messages || []).filter(m => {
+            const from = (getHeader(m, 'From') || '').toLowerCase();
+            return from && !from.includes(args.userEmail.toLowerCase())
+              && !DISCOVERY_NOISE_SENDER_RE.test(from);
+          });
+          const latest = inbound[inbound.length - 1];
+          if (!latest || alreadyRejected.has(latest.id)) continue;
+          engagedThreads.add(threadId);
+          idSet.add(latest.id);
+        } catch (e) {
+          console.warn(`[gmail-app-scan] thread fetch ${threadId} failed: ${(e as Error).message}`);
+        }
+      }
+      if (engagedThreads.size) {
+        console.log(`[gmail-app-scan] discovery: ${engagedThreads.size} engaged thread(s) queued`);
+      }
+    } catch (e) {
+      console.warn(`[gmail-app-scan] discovery pass failed: ${(e as Error).message}`);
+    }
+  }
+
   const ids = [...idSet];
 
   let processed = 0;
@@ -304,14 +363,16 @@ export async function scanApplicationResponses(args: {
       else if (hits.length > 1) matchedRole = pickByTitleOverlap(hits, subject, body);
     }
 
-    // Step 3.5 — no pipeline role matched. If the message looks like an
-    // application receipt (the user applied outside Ladder, directly on
-    // an ATS careers page), auto-create the pipeline role from it.
-    // Everything else is a true no-match.
+    // Step 3.5 — no pipeline role matched. Two auto-create paths:
+    // application receipts (the user applied outside Ladder, directly on
+    // an ATS careers page), and engaged threads (an in-progress
+    // conversation the user is replying to — hiring manager, recruiter —
+    // with no saved posting behind it). Everything else is a true no-match.
     if (!matchedRole) {
-      const created = await maybeCreateRoleFromReceipt(sql, {
+      const created = await maybeCreateRoleFromUnmatched(sql, {
         userEmail: args.userEmail,
         msg, messageId, sender, senderDomain, subject, body,
+        engaged: engagedThreads.has(msg.threadId),
         eventSource: mode === 'backfill' ? 'gmail-backfill' : 'gmail-scan',
       });
       if (created) {
@@ -507,12 +568,16 @@ export async function scanApplicationResponses(args: {
 // regex covers company-domain senders ("careers@acme.com").
 const RECEIPT_SUBJECT_RE = /\b(applicat|thank you for (applying|your interest)|we('|’)?( ha)?ve received|application received)/i;
 
-// Auto-create a pipeline role from an application receipt that matched
-// no existing role. Gate → Haiku extraction → blocked-company check →
-// insert role (stage 'applied') + applied_confirmation event with
-// auto_action='role_created' so it surfaces in the Updates feed.
-// Returns true when a role + event landed.
-async function maybeCreateRoleFromReceipt(
+// Auto-create a pipeline role from an unmatched message. Two paths:
+//   receipt — ATS sender / receipt subject → extractUnmatchedApplication
+//             → role at stage 'applied' + applied_confirmation event.
+//   engaged — the user has replied in this thread (pass-3 discovery) →
+//             extractUnmatchedOpportunity → role at the extracted stage
+//             + stage-mapped event. Rejections persist to gmail_skipped
+//             (reason 'not_opportunity') so the thread is never re-judged.
+// Both land with auto_action='role_created' so they surface in the
+// Updates feed. Returns true when a role + event landed.
+async function maybeCreateRoleFromUnmatched(
   sql: ReturnType<typeof db>,
   args: {
     userEmail: string;
@@ -522,37 +587,84 @@ async function maybeCreateRoleFromReceipt(
     senderDomain: string | null;
     subject: string;
     body: string;
+    engaged: boolean;
     eventSource: string;
   },
 ): Promise<boolean> {
   const atsSender = !!args.senderDomain && isAtsPlatformDomain(args.senderDomain);
-  if (!atsSender && !RECEIPT_SUBJECT_RE.test(args.subject)) return false;
+  const receiptGate = atsSender || RECEIPT_SUBJECT_RE.test(args.subject);
+  if (!receiptGate && !args.engaged) return false;
 
-  let extracted;
-  try {
-    extracted = await extractUnmatchedApplication({
-      subject: args.subject, sender: args.sender, body: args.body,
-    });
-  } catch (e) {
-    console.warn(`[gmail-app-scan] unmatched-extract failed: ${(e as Error).message}`);
-    return false;
+  let company = '';
+  let title = '';
+  let stage: 'applied' | 'interviewing' | 'offer' = 'applied';
+  let summary = '';
+  let confidence = 0;
+  let via: 'receipt' | 'opportunity' | null = null;
+
+  if (receiptGate) {
+    try {
+      const extracted = await extractUnmatchedApplication({
+        subject: args.subject, sender: args.sender, body: args.body,
+      });
+      if (extracted && extracted.is_application_receipt
+          && extracted.confidence >= AUTO_CREATE_CONFIDENCE_FLOOR) {
+        ({ company, title, summary, confidence } = extracted);
+        via = 'receipt';
+      }
+    } catch (e) {
+      console.warn(`[gmail-app-scan] unmatched-extract failed: ${(e as Error).message}`);
+    }
   }
-  if (!extracted || !extracted.is_application_receipt) return false;
-  if (extracted.confidence < AUTO_CREATE_CONFIDENCE_FLOOR) return false;
-  if (!extracted.company || isUnknownCompanyName(extracted.company)) return false;
+
+  if (!via && args.engaged) {
+    try {
+      const opp = await extractUnmatchedOpportunity({
+        subject: args.subject, sender: args.sender, body: args.body,
+      });
+      if (opp && opp.is_job_opportunity && opp.confidence >= AUTO_CREATE_CONFIDENCE_FLOOR
+          && opp.company && !isUnknownCompanyName(opp.company)) {
+        ({ company, title, stage, summary, confidence } = opp);
+        via = 'opportunity';
+      } else {
+        // Remember the verdict — engaged threads resurface every run for
+        // the whole window, and each re-judge is a Haiku call.
+        await sql`
+          insert into job.gmail_skipped (user_email, message_id, gmail_id, sender, subject, reason, details)
+          values (${args.userEmail}, ${args.messageId}, ${args.msg.id}, ${args.sender},
+                  ${args.subject}, 'not_opportunity',
+                  ${sql.json({ confidence: opp?.confidence ?? null, company: opp?.company ?? null })})
+          on conflict (user_email, message_id) do nothing`;
+        return false;
+      }
+    } catch (e) {
+      console.warn(`[gmail-app-scan] opportunity-extract failed: ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  if (!via) return false;
+  if (!company || isUnknownCompanyName(company)) return false;
 
   // Respect the user's block list.
   const blocked = await sql<{ ok: number }[]>`
     select 1 as ok from job.blocked_companies
      where user_email = ${args.userEmail}
-       and company_norm = ${extracted.company.trim().toLowerCase()}
+       and company_norm = ${company.trim().toLowerCase()}
      limit 1`;
   if (blocked.length) return false;
 
-  const slug = buildRoleSlug(extracted.company, extracted.title || 'application');
+  const slug = buildRoleSlug(company, title || 'application');
   const receivedAt = args.msg.internalDate
     ? new Date(Number(args.msg.internalDate)).toISOString()
     : new Date().toISOString();
+
+  const eventType     = via === 'receipt' ? 'applied_confirmation'
+    : stage === 'offer' ? 'offer_received'
+    : stage === 'interviewing' ? 'screen_scheduled'
+    : 'applied_confirmation';
+  const detectedStage = via === 'receipt' ? 'applied' : stage;
+  const appliedAt     = detectedStage === 'applied' ? receivedAt : null;
 
   // Create the role. If the slug already exists (e.g. an Archived row the
   // scan's Active/Saved load didn't see), leave it untouched — the event
@@ -562,9 +674,9 @@ async function maybeCreateRoleFromReceipt(
       slug, company_slug, company_name, title, url, source, status, stage,
       applied_at, last_activity_at, status_changed_at, gmail_thread_ids
     ) values (
-      ${slug}, null, ${extracted.company}, ${extracted.title || '(unknown title)'},
-      null, 'Gmail Auto-detected', 'Active', 'applied',
-      ${receivedAt}, ${receivedAt}, now(), ${[args.msg.threadId]}
+      ${slug}, null, ${company}, ${title || '(unknown title)'},
+      null, 'Gmail Auto-detected', 'Active', ${detectedStage},
+      ${appliedAt}, ${receivedAt}, now(), ${[args.msg.threadId]}
     )
     on conflict (slug) do nothing
     returning slug`;
@@ -577,16 +689,16 @@ async function maybeCreateRoleFromReceipt(
       auto_action, prev_state
     ) values (
       ${slug}, ${args.messageId}, ${args.msg.threadId}, ${args.msg.id},
-      ${args.sender}, ${args.subject}, 'applied_confirmation', 'applied',
-      ${extracted.summary || `Application received at ${extracted.company}`},
-      ${extracted.confidence}, true, false, ${receivedAt}, ${args.eventSource},
+      ${args.sender}, ${args.subject}, ${eventType}, ${detectedStage},
+      ${summary || `${via === 'receipt' ? 'Application received' : 'In-progress conversation detected'} at ${company}`},
+      ${confidence}, true, false, ${receivedAt}, ${args.eventSource},
       'role_created', null
     )
     on conflict (gmail_message_id) do nothing
     returning id`;
   if (!inserted.length) return false;
 
-  console.log(`[gmail-app-scan] auto-created role ${slug} from receipt (${args.sender})${createdRows.length ? '' : ' — slug existed, event attached only'}`);
+  console.log(`[gmail-app-scan] auto-created role ${slug} from ${via} (${args.sender})${createdRows.length ? '' : ' — slug existed, event attached only'}`);
   return true;
 }
 
@@ -626,6 +738,24 @@ async function listMessagesByQuery(accessToken: string, query: string, maxIds: n
     if (!r.ok) throw new Error(`gmail messages.list ${r.status}: ${(await r.text()).slice(0, 200)}`);
     const data = await r.json() as { messages?: Array<{ id: string }>; nextPageToken?: string };
     for (const m of (data.messages || [])) ids.push(m.id);
+    if (ids.length >= maxIds || !data.nextPageToken) break;
+    pageToken = data.nextPageToken;
+  }
+  return ids;
+}
+
+async function listThreadsByQuery(accessToken: string, query: string, maxIds: number): Promise<string[]> {
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+  for (let page = 0; page < 5; page++) {
+    const url = new URL(`${GMAIL_BASE}/threads`);
+    url.searchParams.set('q', query);
+    url.searchParams.set('maxResults', String(Math.min(100, maxIds - ids.length)));
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+    const r = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!r.ok) throw new Error(`gmail threads.list ${r.status}: ${(await r.text()).slice(0, 200)}`);
+    const data = await r.json() as { threads?: Array<{ id: string }>; nextPageToken?: string };
+    for (const t of (data.threads || [])) ids.push(t.id);
     if (ids.length >= maxIds || !data.nextPageToken) break;
     pageToken = data.nextPageToken;
   }

--- a/supabase/functions/_shared/sources/company-watch.ts
+++ b/supabase/functions/_shared/sources/company-watch.ts
@@ -13,6 +13,8 @@
 //                __staticRouterHydrationData (server-rendered).
 //   greenhouse / lever / ashby — public board APIs (same shape tracked-ats
 //                uses), for watched companies on a standard ATS.
+//   custom     — any careers-page URL; Haiku enumerates the openings from
+//                the page text + link list (for companies off every ATS).
 //
 // Config is empty on the user_sources row: the company list + per-company
 // adapter config live in job.watched_companies, so the watch list is a
@@ -299,6 +301,111 @@ async function pullApple(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> 
   }).filter(Boolean) as RecommendedRoleInput[];
 }
 
+// ---------- Custom careers page (any URL, Haiku-extracted) ----------
+// For companies outside the supported ATS/major set (e.g. a static
+// /careers page like medplum.com/careers). We fetch the page, hand the
+// visible text + link list to Haiku, and let it enumerate the openings.
+// Descriptions come from a budgeted follow-up fetch of each job link so
+// the grading cron can score the rows (description > 200 chars gate).
+const CUSTOM_PAGE_TEXT_CAP  = 12_000;
+const CUSTOM_LINKS_CAP      = 120;
+const CUSTOM_EXTRACT_SYSTEM = `You are given the text content of a company careers page plus the list of links on it. Enumerate the OPEN JOB POSTINGS listed on the page.
+
+Return STRICT JSON, no prose:
+{ "jobs": [ { "title": "...", "url": "absolute link to the posting or null", "location": "as stated or null" } ] }
+
+Rules:
+- Only real, currently-listed openings on THIS page. Not nav links, blog posts, values blurbs, or "we're always hiring" boilerplate.
+- url must be chosen from the provided link list (or null when no link maps to the posting). Never invent URLs.
+- If the page lists no openings, return { "jobs": [] }.`;
+
+function extractAnchors(html: string, baseUrl: string): Array<{ href: string; text: string }> {
+  const out: Array<{ href: string; text: string }> = [];
+  const re = /<a\b[^>]*href=["']([^"'#]+)["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) && out.length < CUSTOM_LINKS_CAP) {
+    const text = stripHtml(m[2]).slice(0, 120);
+    if (!text) continue;
+    try {
+      const href = new URL(m[1], baseUrl).toString();
+      if (!/^https?:/.test(href)) continue;
+      out.push({ href, text });
+    } catch { /* skip malformed hrefs */ }
+  }
+  return out;
+}
+
+async function pullCustom(w: WatchedCompanyRow): Promise<RecommendedRoleInput[]> {
+  const cfg = w.adapter_config as { url?: string };
+  if (!cfg.url) throw new Error('custom config needs url');
+  const apiKey = Deno.env.get('LADDER_ANTHROPIC_API_KEY') || Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new Error('custom adapter needs ANTHROPIC_API_KEY');
+
+  const res = await fetch(cfg.url, { headers: { 'user-agent': UA } });
+  if (!res.ok) throw new Error(`${cfg.url} → ${res.status}`);
+  const html = await res.text();
+  const pageText = stripHtml(html).slice(0, CUSTOM_PAGE_TEXT_CAP);
+  const anchors = extractAnchors(html, cfg.url);
+
+  const r = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: 'claude-haiku-4-5',
+      max_tokens: 1500,
+      system: CUSTOM_EXTRACT_SYSTEM,
+      messages: [{ role: 'user', content: [
+        `Careers page: ${cfg.url} (company: ${w.company})`,
+        `--- LINKS ---`,
+        anchors.map(a => `${a.href} :: ${a.text}`).join('\n'),
+        `--- PAGE TEXT ---`,
+        pageText,
+      ].join('\n') }],
+    }),
+  });
+  if (!r.ok) throw new Error(`anthropic ${r.status}: ${(await r.text()).slice(0, 200)}`);
+  const data = await r.json() as { content: Array<{ type: string; text: string }> };
+  const text = (data.content || []).filter(c => c.type === 'text').map(c => c.text).join('');
+  const jsonMatch = text.replace(/```json\s*/gi, '').replace(/```/g, '').match(/\{[\s\S]*\}/);
+  const parsed = jsonMatch ? JSON.parse(jsonMatch[0]) as { jobs?: Array<{ title?: string; url?: string | null; location?: string | null }> } : null;
+  const jobs = (parsed?.jobs || []).filter(j => j.title).slice(0, MAX_ROLES_PER_COMPANY);
+
+  const out: RecommendedRoleInput[] = [];
+  let detailBudget = MAX_DETAIL_FETCHES;
+  for (const j of jobs) {
+    const title = String(j.title).trim();
+    const jobUrl = j.url ? String(j.url) : cfg.url;
+    let description: string | undefined;
+    let salary: string | undefined;
+    if (j.url && detailBudget > 0) {
+      detailBudget--;
+      try {
+        const d = await fetch(jobUrl, { headers: { 'user-agent': UA } });
+        if (d.ok) {
+          const fullJd = stripHtml(await d.text());
+          description = capJd(fullJd);
+          salary = extractCompensation(fullJd) ?? undefined;
+        }
+      } catch { /* JD is best-effort; the row still lands and grades later */ }
+    }
+    out.push({
+      source:      'company-watch',
+      // Keyed on url+title so re-pulls dedup while distinct roles that
+      // share the page URL (no per-job link) still get separate rows.
+      sourceId:    `cw:custom:${w.id}:${slugify(`${title}:${jobUrl}`)}`,
+      sourceLabel: `${w.company} Careers`,
+      url:         jobUrl,
+      company:     w.company,
+      title,
+      location:    j.location ? String(j.location) : undefined,
+      salary,
+      description,
+      payload:     { adapter: 'custom', watchedCompanyId: w.id, careersUrl: cfg.url },
+    });
+  }
+  return out;
+}
+
 // ---------- Standard ATS boards (Greenhouse / Lever / Ashby) ----------
 // For watched companies that run a public board. Same endpoints as
 // tracked-ats but namespaced under company-watch so filter_mode applies.
@@ -355,6 +462,7 @@ const ADAPTERS: Record<string, (w: WatchedCompanyRow) => Promise<RecommendedRole
   greenhouse: pullAtsBoard,
   lever:      pullAtsBoard,
   ashby:      pullAtsBoard,
+  custom:     pullCustom,
 };
 
 // Per-company include filters — cheap substring prefilters the user can

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -51,8 +51,8 @@ import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
 const LADDER_LABEL = 'Ladder';
 
-const VERSION = '1.8.0';
-console.log(`[application-events] v${VERSION} - role_created Updates kind (auto-created roles from unmatched application receipts)`);
+const VERSION = '1.9.0';
+console.log(`[application-events] v${VERSION} - shared scan gains engaged-thread discovery (roles from in-progress Gmail conversations)`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.29.0';
-console.log(`[pull-recommendations] v${VERSION} - app-scan auto-creates pipeline roles from unmatched application receipts`);
+const VERSION = '0.30.0';
+console.log(`[pull-recommendations] v${VERSION} - engaged-thread discovery creates roles from in-progress Gmail conversations; custom careers-page watch adapter`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';

--- a/supabase/functions/watched-companies/index.ts
+++ b/supabase/functions/watched-companies/index.ts
@@ -16,8 +16,8 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 import { db } from '../_shared/job-db.ts';
 
-const VERSION = '0.1.0';
-console.log(`[watched-companies] v${VERSION} - watched company list CRUD + adapter auto-resolution (google/amazon/workday/eightfold/apple/ats)`);
+const VERSION = '0.2.0';
+console.log(`[watched-companies] v${VERSION} - optional careers URL on POST: ATS derivation from board URLs + custom-page fallback adapter`);
 
 const FILTER_MODES = new Set(['all', 'role_level', 'good_fits', 'exceptional']);
 
@@ -64,6 +64,26 @@ async function probeAts(name: string): Promise<{ adapter: string; config: Record
     }));
     const hit = results.find(r => r.status === 'fulfilled');
     if (hit && hit.status === 'fulfilled') return hit.value;
+  }
+  return null;
+}
+
+// Derive an ATS adapter straight from a pasted board URL, so pasting
+// https://jobs.lever.co/acme or a boards.greenhouse.io link watches the
+// board API rather than scraping the page.
+function adapterFromUrl(rawUrl: string): { adapter: string; config: Record<string, unknown> } | null {
+  let u: URL;
+  try { u = new URL(rawUrl); } catch { return null; }
+  const host = u.hostname.toLowerCase();
+  const seg = u.pathname.split('/').filter(Boolean);
+  if (/(?:^|\.)(boards|job-boards)\.greenhouse\.io$/.test(host) && seg[0]) {
+    return { adapter: 'greenhouse', config: { slug: seg[0] } };
+  }
+  if (/(?:^|\.)jobs\.lever\.co$/.test(host) && seg[0]) {
+    return { adapter: 'lever', config: { slug: seg[0] } };
+  }
+  if (/(?:^|\.)jobs\.ashbyhq\.com$/.test(host) && seg[0]) {
+    return { adapter: 'ashby', config: { slug: seg[0] } };
   }
   return null;
 }
@@ -115,17 +135,35 @@ serve(async (req) => {
 
     if (req.method === 'POST') {
       const body = await req.json().catch(() => ({}));
-      const company = String(body.company || '').trim();
-      if (!company) return err('company required', 400);
+      const url = String(body.url || '').trim();
+      let company = String(body.company || '').trim();
+      // URL-only add: derive a display name from the domain ("medplum.com"
+      // → "Medplum") so the user can paste just the careers link.
+      if (!company && url) {
+        try {
+          const host = new URL(url).hostname.replace(/^www\./, '');
+          const base = host.split('.')[0];
+          company = base.charAt(0).toUpperCase() + base.slice(1);
+        } catch { /* fall through to the required check */ }
+      }
+      if (!company) return err('company or url required', 400);
+      if (url && !/^https?:\/\//i.test(url)) return err('url must be http(s)', 400);
       const norm = company.toLowerCase();
 
       let adapter = typeof body.adapter === 'string' ? body.adapter : '';
       let config  = (body.config && typeof body.config === 'object') ? body.config as Record<string, unknown> : {};
+      if (!adapter && url) {
+        // A pasted ATS board URL beats scraping; anything else becomes a
+        // custom careers-page watch (Haiku-extracted at pull time).
+        const fromUrl = adapterFromUrl(url);
+        if (fromUrl) { adapter = fromUrl.adapter; config = { ...fromUrl.config, ...config }; }
+        else { adapter = 'custom'; config = { url, ...config }; }
+      }
       if (!adapter) {
         const resolved = await resolveAdapter(sql, company);
         if (!resolved) {
           return jsonResp({ ok: false, unresolved: true,
-            error: `Couldn't find a careers backend for "${company}". Supported: major tech (Google, Amazon, Apple, Netflix, Nvidia, Salesforce, Adobe) and any company on Greenhouse / Lever / Ashby.` }, 422);
+            error: `Couldn't find a careers backend for "${company}". Paste the careers page URL to track it directly, or use a company on Greenhouse / Lever / Ashby or major tech (Google, Amazon, Apple, Netflix, Nvidia, Salesforce, Adobe).` }, 422);
         }
         adapter = resolved.adapter;
         config  = { ...resolved.config, ...config };


### PR DESCRIPTION
## What

Two Ladder improvements:

### 1. Track companies outside the supported ATS set
- `watched-companies` v0.2.0: POST accepts an optional `url`. Pasted Greenhouse/Lever/Ashby board URLs resolve to the board API; any other careers page (e.g. https://www.medplum.com/careers) becomes the new `custom` adapter.
- `company-watch` gains `pullCustom`: fetches the page, Haiku enumerates the openings from page text + link list, and budgeted follow-up fetches fill descriptions so the grade cron can score the rows.
- Watched-companies strip gets an optional "Careers page URL" input; URL-only adds derive the company name from the domain.

### 2. Gmail detects in-progress opportunities with no saved posting
- App-scan pass 3: `threads.list in:sent` finds threads the user personally replied to (the strongest "back-and-forth with a hiring manager" signal). Latest inbound message of each unpinned thread (≤8/run) enters the no-match gauntlet.
- New `extractUnmatchedOpportunity` Haiku classifier: active job conversation → company / title / stage / confidence. At ≥0.8 confidence the pipeline role is auto-created at the extracted stage (applied / interviewing / offer) with a stage-mapped event and `auto_action='role_created'` — it surfaces in the Updates queue with the existing Undo affordances.
- Rejected threads persist to `gmail_skipped` (reason `not_opportunity`) so each engaged thread costs at most one Haiku judgment, ever.

## Versions
ladder 2.39.0 · pull-recommendations 0.30.0 · application-events 1.9.0 · watched-companies 0.2.0

## Deploy after merge
`supabase functions deploy pull-recommendations application-events watched-companies` (no migrations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)