### PR TITLE
fix(ladder): Gmail engaged-thread discovery was starved by scan budget + message cap

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -179,6 +179,11 @@ export async function scanApplicationResponses(args: {
   // Build the Gmail query set. Three passes — each contributes message
   // IDs that we then dedup, fetch, and try to classify:
   //
+  //   0. Engaged-thread discovery — threads the user replied to, for
+  //      opportunities Ladder has never seen. Runs FIRST: it's cheap
+  //      (one threads.list + ≤8 threads.get) and must not be starved by
+  //      the expensive per-role name search, which can eat the whole
+  //      wall-clock budget on a large pipeline.
   //   1. Sender-domain pass — companies with a known domain in
   //      hiring_companies, plus the ATS-platform allowlist. Cheap, broad.
   //   2. Per-role name pass — for each active role, search the inbox
@@ -189,6 +194,59 @@ export async function scanApplicationResponses(args: {
   //
   // All three streams hit the same matching gauntlet below; Message-ID
   // dedup against application_events ensures we never re-classify.
+
+  // Pass 0: engaged-thread discovery. Threads the USER has replied to
+  // recently are the strongest signal for an in-progress conversation —
+  // a hiring-manager back-and-forth at a company Ladder has never seen
+  // won't surface via passes 1/2 (unknown domain, unknown company name).
+  // For each replied thread not already pinned to a role, queue its
+  // latest inbound message; the no-match branch below runs the
+  // opportunity extractor on it. Rejected messages land in gmail_skipped
+  // (reason 'not_opportunity') so we never re-classify them.
+  const engagedThreads = new Set<string>();
+  const discoveryIds: string[] = [];
+  try {
+    const skippedRows = await sql<{ gmail_id: string }[]>`
+      select gmail_id from job.gmail_skipped
+       where user_email = ${args.userEmail} and reason = 'not_opportunity'`;
+    const alreadyRejected = new Set(skippedRows.map(r => r.gmail_id));
+
+    // Wider window than the live scan's 7d: an active conversation can
+    // lull for a week+ between replies and still be very much alive.
+    const sentWindowDays = Math.max(windowDays, 14);
+    const sentThreadIds = await listThreadsByQuery(
+      args.accessToken, `in:sent newer_than:${sentWindowDays}d -in:trash`, 50);
+    // Cap counts QUEUED messages (the Haiku spend), not thread fetches —
+    // otherwise already-rejected threads eat the budget every run and can
+    // permanently starve newer conversations. Metadata fetches are cheap
+    // and bounded by the 50-thread list + the deadline.
+    for (const threadId of sentThreadIds) {
+      if (discoveryIds.length >= MAX_DISCOVERY_THREADS || Date.now() > deadline) break;
+      if (threadToRole.has(threadId)) continue;
+      try {
+        const r = await fetch(`${GMAIL_BASE}/threads/${threadId}?format=metadata&metadataHeaders=From`, {
+          headers: { Authorization: `Bearer ${args.accessToken}` } });
+        if (!r.ok) continue;
+        const thread = await r.json() as { messages?: GmailMessage[] };
+        // Latest inbound message = the other party's most recent word.
+        const inbound = (thread.messages || []).filter(m => {
+          const from = (getHeader(m, 'From') || '').toLowerCase();
+          return from && !from.includes(args.userEmail.toLowerCase())
+            && !DISCOVERY_NOISE_SENDER_RE.test(from);
+        });
+        const latest = inbound[inbound.length - 1];
+        if (!latest || alreadyRejected.has(latest.id)) continue;
+        engagedThreads.add(threadId);
+        discoveryIds.push(latest.id);
+      } catch (e) {
+        console.warn(`[gmail-app-scan] thread fetch ${threadId} failed: ${(e as Error).message}`);
+      }
+    }
+    console.log(`[gmail-app-scan] discovery: ${discoveryIds.length} engaged thread(s) queued of ${sentThreadIds.length} sent`);
+  } catch (e) {
+    console.warn(`[gmail-app-scan] discovery pass failed: ${(e as Error).message}`);
+  }
+
   const senderDomains = new Set<string>();
   for (const d of domainToRoles.keys()) senderDomains.add(d);
   for (const d of ATS_PLATFORM_DOMAINS) senderDomains.add(d);
@@ -240,57 +298,10 @@ export async function scanApplicationResponses(args: {
     }
   }
 
-  // Pass 3: engaged-thread discovery. Threads the USER has replied to
-  // recently are the strongest signal for an in-progress conversation —
-  // a hiring-manager back-and-forth at a company Ladder has never seen
-  // won't surface via passes 1/2 (unknown domain, unknown company name).
-  // For each replied thread not already pinned to a role, queue its
-  // latest inbound message; the no-match branch below runs the
-  // opportunity extractor on it. Rejected messages land in gmail_skipped
-  // (reason 'not_opportunity') so we never re-classify them.
-  const engagedThreads = new Set<string>();
-  if (Date.now() < deadline) {
-    try {
-      const skippedRows = await sql<{ gmail_id: string }[]>`
-        select gmail_id from job.gmail_skipped
-         where user_email = ${args.userEmail} and reason = 'not_opportunity'`;
-      const alreadyRejected = new Set(skippedRows.map(r => r.gmail_id));
-
-      const sentThreadIds = await listThreadsByQuery(
-        args.accessToken, `in:sent newer_than:${windowDays}d -in:trash`, 50);
-      let threadBudget = MAX_DISCOVERY_THREADS;
-      for (const threadId of sentThreadIds) {
-        if (threadBudget <= 0 || Date.now() > deadline) break;
-        if (threadToRole.has(threadId)) continue;
-        threadBudget--;
-        try {
-          const r = await fetch(`${GMAIL_BASE}/threads/${threadId}?format=metadata&metadataHeaders=From`, {
-            headers: { Authorization: `Bearer ${args.accessToken}` } });
-          if (!r.ok) continue;
-          const thread = await r.json() as { messages?: GmailMessage[] };
-          // Latest inbound message = the other party's most recent word.
-          const inbound = (thread.messages || []).filter(m => {
-            const from = (getHeader(m, 'From') || '').toLowerCase();
-            return from && !from.includes(args.userEmail.toLowerCase())
-              && !DISCOVERY_NOISE_SENDER_RE.test(from);
-          });
-          const latest = inbound[inbound.length - 1];
-          if (!latest || alreadyRejected.has(latest.id)) continue;
-          engagedThreads.add(threadId);
-          idSet.add(latest.id);
-        } catch (e) {
-          console.warn(`[gmail-app-scan] thread fetch ${threadId} failed: ${(e as Error).message}`);
-        }
-      }
-      if (engagedThreads.size) {
-        console.log(`[gmail-app-scan] discovery: ${engagedThreads.size} engaged thread(s) queued`);
-      }
-    } catch (e) {
-      console.warn(`[gmail-app-scan] discovery pass failed: ${(e as Error).message}`);
-    }
-  }
-
-  const ids = [...idSet];
+  // Discovery ids process FIRST — they're few (≤8), high-value, and the
+  // maxMessages cap would otherwise starve them behind hundreds of
+  // pass-1/2 ids.
+  const ids = [...new Set([...discoveryIds, ...idSet])];
 
   let processed = 0;
   for (const id of ids) {

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -51,8 +51,8 @@ import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
 const LADDER_LABEL = 'Ladder';
 
-const VERSION = '1.9.0';
-console.log(`[application-events] v${VERSION} - shared scan gains engaged-thread discovery (roles from in-progress Gmail conversations)`);
+const VERSION = '1.9.1';
+console.log(`[application-events] v${VERSION} - discovery pass runs/processes first in shared scan (starvation fix); 14d sent window`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.30.0';
-console.log(`[pull-recommendations] v${VERSION} - engaged-thread discovery creates roles from in-progress Gmail conversations; custom careers-page watch adapter`);
+const VERSION = '0.30.1';
+console.log(`[pull-recommendations] v${VERSION} - discovery runs first + processes first (was starved by name-search budget/message cap); 14d sent window`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
The v0.30.0 discovery pass never judged a single thread (zero `not_opportunity` rows in `gmail_skipped`). Two starvation bugs:

1. **Budget starvation**: discovery ran *after* the per-role name search, which with 117 pipeline roles spends the entire 40s wall-clock budget — the `Date.now() < deadline` gate then skipped discovery entirely.
2. **Cap starvation**: even when it ran, discovery ids were appended last behind hundreds of pass-1/2 ids, and the 30-message processing cap never reached them.

Fixes: discovery runs first (it's cheap — one `threads.list` + ≤8 metadata gets), its messages are processed first, the thread cap now counts queued (Haiku-bound) messages rather than fetches so already-rejected threads can't eat the budget every run, and the sent-thread window is floored at 14d since active conversations lull past 7d.

Repro case: active SCAN Health conversation absent from active jobs.

pull-recommendations 0.30.1 · application-events 1.9.1 · no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)