### PR TITLE
fix(ladder): auto_action CHECK never allowed 'role_created' — migration 164 + fenced auto-create

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -715,37 +715,45 @@ async function maybeCreateRoleFromUnmatched(
   // Create the role. If the slug already exists (e.g. an Archived row the
   // scan's Active/Saved load didn't see), leave it untouched — the event
   // below still attaches, and the user can resurrect from the role page.
-  const createdRows = await sql<{ slug: string }[]>`
-    insert into job.pipeline_roles (
-      slug, company_slug, company_name, title, url, source, status, stage,
-      applied_at, last_activity_at, status_changed_at, gmail_thread_ids
-    ) values (
-      ${slug}, null, ${company}, ${title || '(unknown title)'},
-      null, 'Gmail Auto-detected', 'Active', ${detectedStage},
-      ${appliedAt}, ${receivedAt}, now(), ${[args.msg.threadId]}
-    )
-    on conflict (slug) do nothing
-    returning slug`;
+  // The whole write is fenced: an insert failure here (a constraint drift
+  // like the pre-164 auto_action CHECK) must cost this message only, not
+  // abort the entire scan run.
+  try {
+    const createdRows = await sql<{ slug: string }[]>`
+      insert into job.pipeline_roles (
+        slug, company_slug, company_name, title, url, source, status, stage,
+        applied_at, last_activity_at, status_changed_at, gmail_thread_ids
+      ) values (
+        ${slug}, null, ${company}, ${title || '(unknown title)'},
+        null, 'Gmail Auto-detected', 'Active', ${detectedStage},
+        ${appliedAt}, ${receivedAt}, now(), ${[args.msg.threadId]}
+      )
+      on conflict (slug) do nothing
+      returning slug`;
 
-  const inserted = await sql<{ id: string }[]>`
-    insert into job.application_events (
-      role_slug, gmail_message_id, gmail_thread_id, gmail_api_id,
-      sender, subject, event_type, detected_stage,
-      summary, confidence, auto_applied, needs_review, received_at, source,
-      auto_action, prev_state
-    ) values (
-      ${slug}, ${args.messageId}, ${args.msg.threadId}, ${args.msg.id},
-      ${args.sender}, ${args.subject}, ${eventType}, ${detectedStage},
-      ${summary || `${via === 'receipt' ? 'Application received' : 'In-progress conversation detected'} at ${company}`},
-      ${confidence}, true, false, ${receivedAt}, ${args.eventSource},
-      'role_created', null
-    )
-    on conflict (gmail_message_id) do nothing
-    returning id`;
-  if (!inserted.length) return false;
+    const inserted = await sql<{ id: string }[]>`
+      insert into job.application_events (
+        role_slug, gmail_message_id, gmail_thread_id, gmail_api_id,
+        sender, subject, event_type, detected_stage,
+        summary, confidence, auto_applied, needs_review, received_at, source,
+        auto_action, prev_state
+      ) values (
+        ${slug}, ${args.messageId}, ${args.msg.threadId}, ${args.msg.id},
+        ${args.sender}, ${args.subject}, ${eventType}, ${detectedStage},
+        ${summary || `${via === 'receipt' ? 'Application received' : 'In-progress conversation detected'} at ${company}`},
+        ${confidence}, true, false, ${receivedAt}, ${args.eventSource},
+        'role_created', null
+      )
+      on conflict (gmail_message_id) do nothing
+      returning id`;
+    if (!inserted.length) return false;
 
-  console.log(`[gmail-app-scan] auto-created role ${slug} from ${via} (${args.sender})${createdRows.length ? '' : ' — slug existed, event attached only'}`);
-  return true;
+    console.log(`[gmail-app-scan] auto-created role ${slug} from ${via} (${args.sender})${createdRows.length ? '' : ' — slug existed, event attached only'}`);
+    return true;
+  } catch (e) {
+    console.warn(`[gmail-app-scan] auto-create ${slug} failed: ${(e as Error).message}`);
+    return false;
+  }
 }
 
 // Rejection → exit_reason mapping for the auto-archive. Where in the

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -51,7 +51,7 @@ import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
 const LADDER_LABEL = 'Ladder';
 
-const VERSION = '1.9.2';
+const VERSION = '1.9.3';
 console.log(`[application-events] v${VERSION} - engaged-message informational fallthrough to opportunity extractor in shared scan`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,7 +24,7 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.30.2';
+const VERSION = '0.30.3';
 console.log(`[pull-recommendations] v${VERSION} - engaged msgs judged 'informational' for a substring-matched role fall through to the opportunity extractor`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';

--- a/supabase/migrations/164_application_events_role_created.sql
+++ b/supabase/migrations/164_application_events_role_created.sql
@@ -1,0 +1,15 @@
+-- 164: allow auto_action='role_created' on application_events.
+-- The auto-create paths (unmatched receipts since v0.29, engaged-thread
+-- discovery since v0.30) insert events with auto_action='role_created',
+-- but migration 103's CHECK never included it — the insert threw, the
+-- role row survived (inserted just before), and the exception aborted
+-- the rest of the scan run.
+
+alter table job.application_events
+  drop constraint application_events_auto_action_check;
+
+alter table job.application_events
+  add constraint application_events_auto_action_check
+  check (auto_action in ('stage_offer', 'archived', 'stage_advance',
+                         'archived_stale', 'archived_closed', 'role_created')
+         or auto_action is null);


### PR DESCRIPTION
Root cause of the missing SCAN role's Updates event (and a latent v0.29 bug): every auto-create event insert uses `auto_action='role_created'`, but migration 103's CHECK constraint never included that value. The insert threw **after** the role row landed, and the uncaught exception aborted the rest of the scan run — this also explains why the discovery drain stalled.

- Migration 164 widens `application_events_auto_action_check` to include `role_created`
- The auto-create write is fenced in try/catch: constraint drift now costs one message, not the whole scan

pull-recommendations 0.30.3 · application-events 1.9.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)