### PR TITLE
feat(ladder): Gmail scan strip on Inbox — last run, found-today counts, Scan now — v2.40.0

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.39.0");
+@import url("./components.css?v=2.40.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/css/components.css
+++ b/ladder/css/components.css
@@ -7235,3 +7235,29 @@ body[data-auth-state="out"] job-chat { display: none; }
 .inbox-more__btn:hover { color: var(--fg); }
 .inbox-more__chevron { font-size: 12px; line-height: 1; }
 .inbox-row--below .inbox-row__title { color: var(--fg-muted); font-weight: var(--fw-medium); }
+
+/* ---------- Gmail scan strip (/ladder/jobs/recommended/) ----------
+   One-line status row under the Updates queue: last run, today's haul,
+   error surface, and a manual "Scan now" force-run. */
+.gmail-scan {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  max-width: 760px;
+  margin: 0 0 var(--space-4);
+  font-size: 13px;
+}
+.gmail-scan strong {
+  font-weight: 600;
+}
+.gmail-scan .btn {
+  margin-left: auto;
+}
+.gmail-scan__err {
+  color: var(--error);
+  max-width: 340px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
 
 
 
@@ -82,7 +82,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.39.0";
-console.log(`[ladder] v${VERSION} - watch any company by careers URL (custom adapter); Gmail engaged-thread role discovery`);
+const VERSION = "2.40.0";
+console.log(`[ladder] v${VERSION} - Gmail scan strip on Inbox: last run, found-today counts, Scan now force-run`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -39,6 +39,7 @@ if (location.pathname.startsWith('/ladder/jobs/drill')) {
 } else if (location.pathname.startsWith('/ladder/jobs/recommended')) {
   import('./components/ladder-recommendations-table.js' + V);
   import('./components/ladder-updates.js' + V);
+  import('./components/ladder-gmail-scan.js' + V);
 } else if (location.pathname.startsWith('/ladder/jobs')) {
   import('./components/ladder-pipeline.js' + V);
 }

--- a/ladder/js/components/ladder-gmail-scan.js
+++ b/ladder/js/components/ladder-gmail-scan.js
@@ -1,0 +1,148 @@
+// ladder-gmail-scan — compact Gmail-scan status strip on the Inbox.
+// Shows when the gmail-jobs source last ran, what the scan found today
+// (recs + activity events + auto-created roles), and a "Scan now" button
+// that force-runs the source and polls until the run completes. Data
+// comes from the recommendations GET (sourceHealth + gmailStats) so the
+// strip stays one cheap limit=1 fetch.
+import { LitElement, html, nothing } from 'https://esm.run/lit@3';
+const V = (new URL(import.meta.url)).search;
+const [{ fetchRecommendations, refreshSources }] = await Promise.all([
+  import('../pipeline.js' + V),
+]);
+
+// A pull run is ~30–90s. Poll on a slow cadence and give up (button
+// re-enables) if the run never reports back — same tuning philosophy as
+// the table's draining loader.
+const SCAN_POLL_MS   = 8 * 1000;
+const SCAN_MAX_MS    = 180 * 1000;
+
+export class LadderGmailScan extends LitElement {
+  createRenderRoot() { return this; }
+
+  static properties = {
+    stats:    { state: true },
+    health:   { state: true },
+    scanning: { state: true },
+    state:    { state: true },
+  };
+
+  constructor() {
+    super();
+    this.stats = null;
+    this.health = null;
+    this.scanning = false;
+    this.state = 'idle';
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._onAuth = () => this._maybeLoad();
+    document.addEventListener('ctrl:auth:signedin', this._onAuth);
+    document.addEventListener('job:auth:ready', this._onAuth);
+    this._maybeLoad();
+  }
+  disconnectedCallback() {
+    document.removeEventListener('ctrl:auth:signedin', this._onAuth);
+    document.removeEventListener('job:auth:ready', this._onAuth);
+    if (this._pollTimer) clearInterval(this._pollTimer);
+    super.disconnectedCallback();
+  }
+
+  _maybeLoad() {
+    if (document.body.dataset.authState !== 'in') return;
+    if (this.state === 'loading' || this.state === 'loaded') return;
+    this._load();
+  }
+
+  async _load() {
+    this.state = 'loading';
+    try {
+      const d = await fetchRecommendations({ view: 'all', limit: 1 });
+      this.health = (d.sourceHealth || []).find(s => s.type === 'gmail-jobs') || null;
+      this.stats  = d.gmailStats || null;
+      this.state = 'loaded';
+    } catch (e) {
+      console.warn('[gmail-scan] load failed', e);
+      this.state = 'error';
+    }
+  }
+
+  _foundToday() {
+    const s = this.stats || {};
+    return (s.recsToday || 0) + (s.eventsToday || 0);
+  }
+
+  _breakdownTitle() {
+    const s = this.stats || {};
+    return [
+      `${s.recsToday || 0} role rec${s.recsToday === 1 ? '' : 's'}`,
+      `${s.eventsToday || 0} activity update${s.eventsToday === 1 ? '' : 's'}`,
+      `${s.rolesCreatedToday || 0} role${s.rolesCreatedToday === 1 ? '' : 's'} auto-created`,
+      `${s.skippedToday || 0} email${s.skippedToday === 1 ? '' : 's'} skipped`,
+    ].join(' · ');
+  }
+
+  _relTime(iso) {
+    if (!iso) return 'never';
+    const m = Math.floor((Date.now() - Date.parse(iso)) / 60000);
+    if (m < 1) return 'just now';
+    if (m < 60) return `${m}m ago`;
+    const h = Math.floor(m / 60); if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+  }
+
+  async _scanNow() {
+    if (this.scanning) return;
+    this.scanning = true;
+    const kickAt = Date.now();
+    try {
+      await refreshSources({ force: true, sourceId: this.health?.id || null });
+    } catch (e) {
+      console.warn('[gmail-scan] kick failed', e);
+    }
+    const before = this._foundToday();
+    // Poll until the source's lastRunAt advances past the kick (a run
+    // completed), then re-read the counts once more.
+    this._pollTimer = setInterval(async () => {
+      try {
+        await this._load();
+        const ranAt = Date.parse(this.health?.lastRunAt || 0);
+        const done = ranAt > kickAt;
+        const timedOut = Date.now() - kickAt > SCAN_MAX_MS;
+        if (done || timedOut) {
+          clearInterval(this._pollTimer);
+          this._pollTimer = null;
+          this.scanning = false;
+          if (done) {
+            const delta = this._foundToday() - before;
+            document.dispatchEvent(new CustomEvent('job:toast', {
+              detail: { msg: delta > 0 ? `Scan complete — ${delta} new from Gmail` : 'Scan complete — nothing new from Gmail' },
+            }));
+            // Fresh recs/events may have landed; let open surfaces re-sync.
+            document.dispatchEvent(new CustomEvent('job:pipeline:refresh'));
+          }
+        }
+      } catch { /* keep polling until the cap */ }
+    }, SCAN_POLL_MS);
+  }
+
+  render() {
+    if (this.state !== 'loaded') return nothing;
+    const lastRun = this.health?.lastRunAt || this.stats?.lastScanAt || null;
+    const err = this.health?.lastError || this.stats?.lastError || null;
+    const found = this._foundToday();
+    return html`
+      <section class="gmail-scan" aria-label="Gmail scan status">
+        <strong>Gmail scan</strong>
+        <span class="muted" title=${lastRun || 'never run'}>last run ${this._relTime(lastRun)}</span>
+        <span class="muted" title=${this._breakdownTitle()}>·&nbsp; ${found} found today</span>
+        ${err ? html`<span class="gmail-scan__err" title=${err}>⚠︎ ${err}</span>` : nothing}
+        <button class="btn btn--sm" ?disabled=${this.scanning} @click=${() => this._scanNow()}>
+          ${this.scanning ? 'Scanning…' : 'Scan now'}
+        </button>
+      </section>
+    `;
+  }
+}
+
+customElements.define('ladder-gmail-scan', LadderGmailScan);

--- a/ladder/js/components/ladder-recommendations-table.js
+++ b/ladder/js/components/ladder-recommendations-table.js
@@ -893,6 +893,7 @@ export class JobRecommendationsTable extends LitElement {
         ${this._renderHeaderMenu()}
       </header>
       <ladder-updates></ladder-updates>
+      <ladder-gmail-scan></ladder-gmail-scan>
       ${this._renderDrainingBanner()}
       ${this._renderHealthBanner()}
       ${rows.length === 0 ? html`

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.39.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.39.0">
-  <script src="/ladder/js/theme.js?v=2.39.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <script src="/ladder/js/theme.js?v=2.40.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.39.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
 </body>
 </html>

--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -8,8 +8,8 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { loadVisionStringArray } from '../_shared/job-vision.ts';
 
-const VERSION = '0.21.1';
-console.log(`[recommendations] v${VERSION} - Inbox gate keyed on fit_score ONLY + default sort fit_score desc; floored Inbox re-applies the role-name universe filter so removing the Strength floor doesn't leak off-universe (engineering/ops) titles from watched-company/gmail sources`);
+const VERSION = '0.22.0';
+console.log(`[recommendations] v${VERSION} - gmailStats block on GET (last scan, PT-today counts) for the Inbox scan strip`);
 
 // Role universe for the below-bar gate when the user hasn't defined their
 // own vision.target_titles. Kept in sync with pull-recommendations'
@@ -383,12 +383,40 @@ serve(async (req) => {
       } catch (e) {
         console.warn(`[recommendations] sourceHealth failed: ${(e as Error).message}`);
       }
+      // Gmail scan stats — powers the Inbox scan strip (last run, what
+      // landed today, manual re-run). "Today" is the user's day (PT).
+      // Never fail the page over stats bookkeeping.
+      let gmailStats: Record<string, unknown> | null = null;
+      try {
+        const [st] = await sql<Array<Record<string, unknown>>>`
+          with day as (
+            select (date_trunc('day', now() at time zone 'America/Los_Angeles')
+                    at time zone 'America/Los_Angeles') as start
+          )
+          select
+            (select g.last_scan_at from job.gmail_scan_state g where g.user_email = ${email}) as "lastScanAt",
+            (select g.last_error   from job.gmail_scan_state g where g.user_email = ${email}) as "lastError",
+            (select count(*)::int from job.recommended_roles r, day
+              where r.user_email = ${email} and r.source = 'gmail-jobs'
+                and r.created_at >= day.start)                                   as "recsToday",
+            (select count(*)::int from job.application_events e, day
+              where e.source in ('gmail-scan', 'gmail-backfill')
+                and e.created_at >= day.start)                                   as "eventsToday",
+            (select count(*)::int from job.application_events e, day
+              where e.auto_action = 'role_created'
+                and e.created_at >= day.start)                                   as "rolesCreatedToday",
+            (select count(*)::int from job.gmail_skipped k, day
+              where k.user_email = ${email} and k.skipped_at >= day.start)       as "skippedToday"`;
+        gmailStats = st ?? null;
+      } catch (e) {
+        console.warn(`[recommendations] gmailStats failed: ${(e as Error).message}`);
+      }
       return jsonResp({
         ok: true, version: VERSION, view,
         count: rows.length, total, recentlyExpired,
         offset, limit,
         hasMore: isAll && offset + rows.length < total,
-        recommendations: rows, sourceHealth,
+        recommendations: rows, sourceHealth, gmailStats,
       });
     }
 


### PR DESCRIPTION
Adds visibility + a manual retry for the Gmail scan, which until today was failing silently (see #1398–#1400).

- **recommendations v0.22.0**: `gmailStats` on GET — last scan time, last error, and PT-today counts (gmail recs, activity events, auto-created roles, skipped emails). Never fails the page.
- **`<ladder-gmail-scan>`** strip under the Updates queue on the Inbox: `Gmail scan · last run 12m ago · 4 found today · [Scan now]`. Tooltip on the count shows the breakdown; source errors surface inline.
- **Scan now** force-runs the gmail-jobs source (bypasses is-due), polls `lastRunAt` until the run completes (8s cadence, 3min cap), then toasts the delta and fires `job:pipeline:refresh`.

ladder 2.40.0 · no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)