### PR TITLE
fix(ladder): gmailStats recsToday column — suggested_at, not created_at

### DIFF
--- a/supabase/functions/recommendations/index.ts
+++ b/supabase/functions/recommendations/index.ts
@@ -8,7 +8,7 @@ import { verifyJobUser, jsonResp, err, corsHeaders } from '../_shared/job-auth.t
 import { db } from '../_shared/job-db.ts';
 import { loadVisionStringArray } from '../_shared/job-vision.ts';
 
-const VERSION = '0.22.0';
+const VERSION = '0.22.1';
 console.log(`[recommendations] v${VERSION} - gmailStats block on GET (last scan, PT-today counts) for the Inbox scan strip`);
 
 // Role universe for the below-bar gate when the user hasn't defined their
@@ -398,7 +398,7 @@ serve(async (req) => {
             (select g.last_error   from job.gmail_scan_state g where g.user_email = ${email}) as "lastError",
             (select count(*)::int from job.recommended_roles r, day
               where r.user_email = ${email} and r.source = 'gmail-jobs'
-                and r.created_at >= day.start)                                   as "recsToday",
+                and r.suggested_at >= day.start)                                 as "recsToday",
             (select count(*)::int from job.application_events e, day
               where e.source in ('gmail-scan', 'gmail-backfill')
                 and e.created_at >= day.start)                                   as "eventsToday",


### PR DESCRIPTION
The v0.22.0 gmailStats block silently returned null (fenced try/catch) because `recommended_roles` has no `created_at` column — the recs count now keys on `suggested_at`. Verified the corrected SQL returns real numbers (31 gmail recs today). recommendations 0.22.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)