### PR TITLE
fix(ladder): gmail-scan strip stays mounted during scan polling — v2.40.1

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.40.0");
+@import url("./components.css?v=2.40.1");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
 
 
 
@@ -82,7 +82,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.40.0";
-console.log(`[ladder] v${VERSION} - Gmail scan strip on Inbox: last run, found-today counts, Scan now force-run`);
+const VERSION = "2.40.1";
+console.log(`[ladder] v${VERSION} - gmail-scan strip stays mounted during scan polling (no unmount blink)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/components/ladder-gmail-scan.js
+++ b/ladder/js/components/ladder-gmail-scan.js
@@ -55,7 +55,11 @@ export class LadderGmailScan extends LitElement {
   }
 
   async _load() {
-    this.state = 'loading';
+    // Only the FIRST load gates rendering — refreshes (scan polling)
+    // must not flip state away from 'loaded' or the strip unmounts for
+    // the whole scan.
+    const first = this.state !== 'loaded';
+    if (first) this.state = 'loading';
     try {
       const d = await fetchRecommendations({ view: 'all', limit: 1 });
       this.health = (d.sourceHealth || []).find(s => s.type === 'gmail-jobs') || null;
@@ -63,7 +67,7 @@ export class LadderGmailScan extends LitElement {
       this.state = 'loaded';
     } catch (e) {
       console.warn('[gmail-scan] load failed', e);
-      this.state = 'error';
+      if (first) this.state = 'error';
     }
   }
 

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.1">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.0">
-  <script src="/ladder/js/theme.js?v=2.40.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <script src="/ladder/js/theme.js?v=2.40.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
 </body>
 </html>


### PR DESCRIPTION
Clicking Scan now unmounted the strip for the whole run: every poll's `_load()` flipped `state` to `'loading'`, and the render gate returns `nothing` for any non-loaded state. Refreshes now keep `state='loaded'`; only the first load gates rendering (and only a first-load failure shows as error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)