### PR TITLE
fix(ladder): Gmail auto-created roles were invisible in Jobs buckets — v2.40.2

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.40.1");
+@import url("./components.css?v=2.40.2");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
 
 
 
@@ -82,7 +82,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.40.1";
-console.log(`[ladder] v${VERSION} - gmail-scan strip stays mounted during scan polling (no unmount blink)`);
+const VERSION = "2.40.2";
+console.log(`[ladder] v${VERSION} - Active roles without a URL stay visible in Jobs buckets (Gmail auto-created roles)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 

--- a/ladder/js/pipeline.js
+++ b/ladder/js/pipeline.js
@@ -92,8 +92,11 @@ export function applyEaseInfo(r) {
 
 // Shared visibility filter — drops rows without a URL and Strava postings.
 // (Was duplicated in the rail and the jobs list.)
+// Exception: Active rows stay visible without a URL — Gmail auto-created
+// roles (receipts, engaged threads) land url-less, and a tracked live
+// application must never vanish from the Jobs buckets over a missing link.
 export function isVisibleRole(r) {
-  if (!r?.url) return false;
+  if (!r?.url && r?.status !== 'Active') return false;
   const company = (r.company || '').toLowerCase();
   if (company === 'strava') return false;
   if (/(^|\.)strava\.com\b/i.test(r.url)) return false;

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.1">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.2">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.1">
-  <script src="/ladder/js/theme.js?v=2.40.1"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.40.2">
+  <script src="/ladder/js/theme.js?v=2.40.2"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.40.1"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.40.2"></script>
 </body>
 </html>

--- a/supabase/functions/_shared/gmail-application-classifier.ts
+++ b/supabase/functions/_shared/gmail-application-classifier.ts
@@ -282,6 +282,7 @@ export interface ExtractedUnmatchedOpportunity {
   company: string;
   title: string;
   stage: 'applied' | 'interviewing' | 'offer';
+  url: string | null;
   summary: string;
   confidence: number;
 }
@@ -294,6 +295,7 @@ Return STRICT JSON, no prose:
   "company": "the hiring company's name, exactly as the email presents it",
   "title": "the role under discussion, exactly as stated ('' if never named)",
   "stage": "applied" | "interviewing" | "offer",
+  "url": "direct link to the job posting if one appears in the email (ATS/careers link), else null",
   "summary": "one short sentence (≤140 chars) — where this conversation stands",
   "confidence": 0.0–1.0
 }
@@ -303,6 +305,7 @@ Rules:
 - FALSE for job alerts, newsletters, cold outreach with no specifics, sales/vendor threads, networking chats with no role, the candidate hiring someone else, and personal email.
 - stage: "interviewing" when calls/interviews are being scheduled or have happened; "offer" only on explicit offer language; otherwise "applied".
 - company/title must come from the email text (sender domain may inform company). If company is not identifiable, use "" and low confidence.
+- url must be copied verbatim from the email (a job-posting/ATS link, not meeting/calendar/tracking links). null when no posting link is present.
 - NEVER fabricate. Empty / false > guess.
 - The body may be truncated. Trust what you see; do not extrapolate.`;
 
@@ -348,11 +351,13 @@ export async function extractUnmatchedOpportunity(args: {
     return null;
   }
   const stage = parsed.stage === 'interviewing' || parsed.stage === 'offer' ? parsed.stage : 'applied';
+  const rawUrl = String(parsed.url || '').trim();
   return {
     is_job_opportunity: parsed.is_job_opportunity === true,
     company:    String(parsed.company || '').trim().slice(0, 120),
     title:      String(parsed.title || '').trim().slice(0, 200),
     stage,
+    url:        /^https?:\/\//i.test(rawUrl) ? rawUrl.slice(0, 500) : null,
     summary:    String(parsed.summary || '').trim().slice(0, 180),
     confidence: typeof parsed.confidence === 'number' ? parsed.confidence : 0,
   };

--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -642,6 +642,7 @@ async function maybeCreateRoleFromUnmatched(
   if (!receiptGate && !args.engaged) return false;
 
   let company = '';
+  let jobUrl: string | null = null;
   let title = '';
   let stage: 'applied' | 'interviewing' | 'offer' = 'applied';
   let summary = '';
@@ -671,6 +672,7 @@ async function maybeCreateRoleFromUnmatched(
       if (opp && opp.is_job_opportunity && opp.confidence >= AUTO_CREATE_CONFIDENCE_FLOOR
           && opp.company && !isUnknownCompanyName(opp.company)) {
         ({ company, title, stage, summary, confidence } = opp);
+        jobUrl = opp.url;
         via = 'opportunity';
       } else {
         // Remember the verdict — engaged threads resurface every run for
@@ -725,7 +727,7 @@ async function maybeCreateRoleFromUnmatched(
         applied_at, last_activity_at, status_changed_at, gmail_thread_ids
       ) values (
         ${slug}, null, ${company}, ${title || '(unknown title)'},
-        null, 'Gmail Auto-detected', 'Active', ${detectedStage},
+        ${jobUrl}, 'Gmail Auto-detected', 'Active', ${detectedStage},
         ${appliedAt}, ${receivedAt}, now(), ${[args.msg.threadId]}
       )
       on conflict (slug) do nothing

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -51,7 +51,7 @@ import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
 const LADDER_LABEL = 'Ladder';
 
-const VERSION = '1.9.3';
+const VERSION = '1.9.4';
 console.log(`[application-events] v${VERSION} - engaged-message informational fallthrough to opportunity extractor in shared scan`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,7 +24,7 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.30.3';
+const VERSION = '0.30.4';
 console.log(`[pull-recommendations] v${VERSION} - engaged msgs judged 'informational' for a substring-matched role fall through to the opportunity extractor`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';


### PR DESCRIPTION
Repro: the auto-created SCAN role was in the data (Active/applied, returned by jobs-pipe) but appeared in no Jobs bucket and no rail count — `isVisibleRole` drops every row without a URL, and Gmail auto-created roles land url-less.

- Active rows now stay visible without a URL (a live tracked application must never vanish over a missing link); url-less Saved junk stays hidden as before.
- `extractUnmatchedOpportunity` now returns the job-posting URL when the email contains one (verbatim-copy rule, http(s)-validated, meeting/tracking links excluded) and the scan writes it on the created role — helps liveness + scoring too.
- SCAN's URL was backfilled directly from Corinne's email (Workday link).

ladder 2.40.2 · pull-recommendations 0.30.4 · application-events 1.9.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)