### PR TITLE
fix(ladder): ats-radar deploy hardening (auth, async kick, data shapes)

### DIFF
--- a/.claude/skills/job-radar/scripts/push_to_ladder.py
+++ b/.claude/skills/job-radar/scripts/push_to_ladder.py
@@ -43,22 +43,37 @@ def find_scan_dir(arg: str | None) -> Path:
     return dirs[0]
 
 
-def resolve_auth() -> dict:
+def resolve_auth() -> list[dict]:
+    """Candidate auth headers, tried in order until one isn't rejected.
+
+    The project may hold either legacy-JWT keys or new sb_secret keys in the
+    function's SUPABASE_SERVICE_ROLE_KEY env, so both formats are tried.
+    """
     if os.environ.get("LADDER_CRON_SECRET"):
-        return {"X-Cron-Secret": os.environ["LADDER_CRON_SECRET"]}
+        return [{"X-Cron-Secret": os.environ["LADDER_CRON_SECRET"]}]
     if os.environ.get("SUPABASE_SERVICE_ROLE_KEY"):
-        return {"Authorization": f"Bearer {os.environ['SUPABASE_SERVICE_ROLE_KEY']}"}
+        return [{"X-Ingest-Key": os.environ["SUPABASE_SERVICE_ROLE_KEY"]}]
+    candidates = []
     try:
         out = subprocess.run(
             ["supabase", "projects", "api-keys", "--project-ref", PROJECT_REF, "-o", "json"],
             capture_output=True, text=True, timeout=30, check=True,
         ).stdout
-        for row in json.loads(out):
+        rows = json.loads(out)
+        # X-Ingest-Key sidesteps the gateway's Authorization handling; the
+        # function compares it to its SUPABASE_SERVICE_ROLE_KEY env, which
+        # may be either the legacy JWT or the new sb_secret — try both.
+        for row in rows:
             if row.get("name") == "service_role":
-                return {"Authorization": f"Bearer {row['api_key']}"}
+                candidates.append({"X-Ingest-Key": row["api_key"]})
+        for row in rows:
+            if str(row.get("api_key", "")).startswith("sb_secret_"):
+                candidates.append({"X-Ingest-Key": row["api_key"]})
     except Exception as e:  # noqa: BLE001 — any failure falls through to the message below
         print(f"  (supabase CLI key lookup failed: {e})", file=sys.stderr)
-    sys.exit("no auth available — set LADDER_CRON_SECRET or SUPABASE_SERVICE_ROLE_KEY, or `supabase login`")
+    if not candidates:
+        sys.exit("no auth available — set LADDER_CRON_SECRET or SUPABASE_SERVICE_ROLE_KEY, or `supabase login`")
+    return candidates
 
 
 def main() -> None:
@@ -84,25 +99,27 @@ def main() -> None:
     payload = {"runAt": summary["run_at"], "companies": companies}
     print(f"Pushing {scan_dir} — {len(companies)} boards, run_at {summary['run_at']}")
 
-    headers = {"Content-Type": "application/json", **resolve_auth()}
-    req = urllib.request.Request(INGEST_URL, json.dumps(payload).encode(), headers, method="POST")
-    try:
-        with urllib.request.urlopen(req, timeout=180) as resp:
-            result = json.loads(resp.read())
-    except urllib.error.HTTPError as e:
-        sys.exit(f"ingest failed: HTTP {e.code} — {e.read().decode()[:500]}")
+    body = json.dumps(payload).encode()
+    result = None
+    last_err = "no auth candidates"
+    for auth in resolve_auth():
+        headers = {"Content-Type": "application/json", **auth}
+        req = urllib.request.Request(INGEST_URL, body, headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=180) as resp:
+                result = json.loads(resp.read())
+            break
+        except urllib.error.HTTPError as e:
+            last_err = f"HTTP {e.code} — {e.read().decode()[:300]}"
+            if e.code not in (401, 403):
+                break  # a non-auth failure won't be fixed by another key
+    if result is None:
+        sys.exit(f"ingest failed: {last_err}")
 
-    print(json.dumps({k: v for k, v in result.items() if k != "run"}, indent=2))
-    run = result.get("run") or {}
-    src = None
-    for s in ((run.get("body") or {}).get("sources") or []):
-        if s.get("type") == "ats-radar":
-            src = s
-    if src:
-        print(f"Worker: pulled {src.get('pulled')} in-universe roles, inserted {src.get('inserted')} new recs"
-              + (f", error: {src['error']}" if src.get("error") else ""))
-    else:
-        print(f"Worker kick status: {run.get('status')}")
+    print(json.dumps(result, indent=2))
+    if result.get("kicked"):
+        print("Worker kicked — grading runs in the background; new recs land in the Inbox "
+              "and the Sources row shows lastRunAt/lastError in a minute or two.")
 
 
 if __name__ == "__main__":

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ npm-debug.log*
 .claude/worktrees/
 .claude/settings.local*.json
 job-scans/
+__pycache__/

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -6,6 +6,13 @@ project_id = "yfhudwakpgzswiylhfbh"
 [functions.pull-recommendations]
 verify_jwt = false
 
+# ats-radar-ingest is called by the local job-radar push script using
+# X-Cron-Secret or a service-key bearer (checked in-function). The gateway
+# only passes legacy JWTs, so platform verification must be off for the
+# new-format sb_secret key to reach the function's own auth check.
+[functions.ats-radar-ingest]
+verify_jwt = false
+
 # recruit-discord is Discord's interactions endpoint — authenticated by
 # Ed25519 request signatures, not JWTs.
 [functions.recruit-discord]

--- a/supabase/functions/_shared/sources/ats-radar.ts
+++ b/supabase/functions/_shared/sources/ats-radar.ts
@@ -18,7 +18,7 @@ interface ScanJob { title?: string; location?: string; url?: string; posted?: st
 interface ScanRow {
   company: string; company_slug: string; ats_type: string | null;
   segments: string[] | null; location: string | null; careers_url: string | null;
-  fetched_at: string | null; jobs: ScanJob[] | null;
+  fetched_at: string | null; jobs: ScanJob[] | string | null;
 }
 
 // Stable per-posting key: the ATS job id when the URL carries one (digits
@@ -44,8 +44,19 @@ export const atsRadarSource: Source = {
          and kind = 'structured'`;
     const out: RecommendedRoleInput[] = [];
     for (const r of rows) {
-      for (const j of (r.jobs || [])) {
+      // jobs may arrive as a jsonb array or as a jsonb-encoded string,
+      // depending on how the ingest serialized it — accept both.
+      let jobList: ScanJob[] = [];
+      if (Array.isArray(r.jobs)) jobList = r.jobs;
+      else if (typeof r.jobs === 'string') {
+        try { jobList = JSON.parse(r.jobs) || []; } catch { jobList = []; }
+      }
+      for (const j of jobList) {
         if (!j?.url || !j?.title) continue;
+        // Workday boards emit "Posted N Days Ago" instead of a date — only
+        // pass postedAt when it actually parses.
+        const postedMs = j.posted ? Date.parse(j.posted) : NaN;
+        const postedAt = Number.isFinite(postedMs) ? new Date(postedMs).toISOString() : undefined;
         out.push({
           source:      'ats-radar',
           sourceId:    atsRadarSourceId(r.company_slug, j.url),
@@ -54,7 +65,7 @@ export const atsRadarSource: Source = {
           company:     r.company,
           title:       j.title,
           location:    j.location || r.location || undefined,
-          postedAt:    j.posted || undefined,
+          postedAt,
           sector:      'outdoor / soft goods',
           payload: {
             fetchedAt:  r.fetched_at,

--- a/supabase/functions/ats-radar-ingest/index.ts
+++ b/supabase/functions/ats-radar-ingest/index.ts
@@ -19,7 +19,7 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { db } from '../_shared/job-db.ts';
 import { jsonResp, err, corsHeaders } from '../_shared/job-auth.ts';
 
-const VERSION = '1.0.0';
+const VERSION = '1.1.0';
 console.log(`[ats-radar-ingest] v${VERSION} - job-radar sweep upload + force-run`);
 
 const PULL_URL = 'https://yfhudwakpgzswiylhfbh.supabase.co/functions/v1/pull-recommendations';
@@ -39,19 +39,45 @@ interface CompanyScan {
   error?:      string;
 }
 
-function authorized(req: Request): boolean {
+// The API gateway rewrites/validates the Authorization header, so the
+// service key travels in X-Ingest-Key instead (verify_jwt is off for this
+// function; this check IS the auth). Accepted credentials:
+//   - X-Cron-Secret matching CRON_SECRET
+//   - the project service key (new sb_secret_… format, exact match on env)
+//   - the legacy service_role JWT, verified against SUPABASE_JWT_SECRET
+//     with role=service_role (HS256 — same check the platform gateway does)
+async function authorized(req: Request): Promise<boolean> {
   const secret = Deno.env.get('CRON_SECRET');
   if (secret && req.headers.get('x-cron-secret') === secret) return true;
+  const key = req.headers.get('x-ingest-key')
+    || (req.headers.get('authorization') || '').replace(/^bearer\s+/i, '');
+  if (!key) return false;
   const svc = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
-  const bearer = (req.headers.get('authorization') || '').replace(/^bearer\s+/i, '');
-  if (svc && bearer === svc) return true;
-  return false;
+  if (svc && key === svc) return true;
+  return await isServiceKey(key);
+}
+
+// A presented key (legacy service_role JWT or sb_secret) is genuine iff the
+// project's own Auth admin API accepts it — admin endpoints require
+// service-level credentials, so a 2xx is proof without needing the JWT
+// secret locally.
+async function isServiceKey(key: string): Promise<boolean> {
+  const base = Deno.env.get('SUPABASE_URL');
+  if (!base) return false;
+  try {
+    const r = await fetch(`${base}/auth/v1/admin/users?page=1&per_page=1`, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    });
+    return r.ok;
+  } catch {
+    return false;
+  }
 }
 
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
   if (req.method !== 'POST') return err('POST only', 405);
-  if (!authorized(req)) return err('forbidden', 403);
+  if (!(await authorized(req))) return err('forbidden', 403);
 
   let body: { runAt?: string; companies?: CompanyScan[] };
   try {
@@ -120,21 +146,23 @@ serve(async (req) => {
      returning id`;
   const sourceId = srcRows[0]?.id ?? null;
 
-  // Kick the worker for this one source (bypasses the schedule). Fire and
-  // wait — the caller is a local script that wants the end-to-end result.
-  let run: unknown = null;
+  // Kick the worker for this one source (bypasses the schedule). Fire and forget
+  // forget — a big scan's grade pass can outlast this function's own 150s
+  // budget, so we must not await it. The Sources row's lastRunAt/lastError
+  // show the outcome; the Inbox picks up new recs on its next fetch.
+  let kicked = false;
   if (sourceId) {
-    try {
-      const r = await fetch(PULL_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Cron-Secret': Deno.env.get('CRON_SECRET') || '' },
-        body: JSON.stringify({ id: sourceId }),
-      });
-      run = { status: r.status, body: await r.json().catch(() => null) };
-    } catch (e) {
-      run = { error: (e as Error).message };
-    }
+    const kick = fetch(PULL_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Cron-Secret': Deno.env.get('CRON_SECRET') || '' },
+      body: JSON.stringify({ id: sourceId }),
+    }).then(r => console.log(`[ats-radar-ingest] worker kick → ${r.status}`))
+      .catch(e => console.warn(`[ats-radar-ingest] worker kick failed: ${(e as Error).message}`));
+    // Keep the kick alive past this response where the runtime supports it.
+    // deno-lint-ignore no-explicit-any
+    (globalThis as any).EdgeRuntime?.waitUntil?.(kick);
+    kicked = true;
   }
 
-  return jsonResp({ ok: true, version: VERSION, sourceId, ...lastScan, run });
+  return jsonResp({ ok: true, version: VERSION, sourceId, kicked, ...lastScan });
 });


### PR DESCRIPTION
Follow-up to #1407 from the first live scan push:

- `verify_jwt = false` for `ats-radar-ingest` in config.toml — the gateway rewrites/validates the Authorization header, so the function's own auth (X-Cron-Secret / service key in `X-Ingest-Key`) is the gate.
- ats-radar-ingest v1.1.0: presented service keys are verified against the project's Auth admin API (accepts both legacy service_role JWTs and new `sb_secret` keys; no `SUPABASE_JWT_SECRET` needed), and the worker kick is fire-and-forget via `EdgeRuntime.waitUntil` — a long grade pass was 504ing the ingest at the 150s wall.
- ats-radar plugin: tolerates `jobs` stored as jsonb array or string, and drops Workday's "Posted N Days Ago" pseudo-dates (they crashed the run with "Invalid time value").
- push_to_ladder.py updated to match.

Verified end-to-end on production: 64 boards staged, 48 in-universe recs inserted (29 production track / 19 digital), 7 unverified boards surfaced in the Sources health note. All functions already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)