### PR TITLE
fix(recruiting): dead Gmail grant surfaces as reconnect-needed — v1.35.1 / v3.69.1

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -336,7 +336,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="js/app.js?v=3.69.0"></script>
+  <script src="js/app.js?v=3.69.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.69.0';
+const VERSION = '3.69.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1702,9 +1702,10 @@ function settingsConnectionsHtml() {
       ? `${g.email || ''}${g.connected_by_name ? ` · connected by ${g.connected_by_name}` : ''}`
       : 'Applications and replies stop arriving until this is reconnected.',
       g.connected ? null : 'reconnect needed')
+    + (g.connected ? '' : `<button type="button" class="btn btn--sm" id="set-gmail-connect">Reconnect Gmail</button>
+      <p class="set-note">You must be signed into live.at.agapesf@gmail.com in this browser.</p>`)
     + conn('House calendar', !!g.connected, 'Screening invites land here.', g.connected ? null : 'follows Gmail')
-    + conn('Discord', true, '#recruiting-automation · #recruiting-interviews')
-    + `<p class="set-note">Reconnecting Gmail happens from the account itself — the token is server-side and never reaches this page.</p>`;
+    + conn('Discord', true, '#recruiting-automation · #recruiting-interviews');
 }
 
 function settingsDataHtml() {
@@ -1759,6 +1760,7 @@ function renderSettings() {
     });
   });
   host.querySelector('#set-export')?.addEventListener('click', exportCsv);
+  host.querySelector('#set-gmail-connect')?.addEventListener('click', connectSharedGmail);
 }
 
 function flashSetting(el) {

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,8 +16,8 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.35.0'
-console.log(`[recruit-gmail] v${VERSION} — shared-account applicant email pipe + claim posts + reply intents + tour polls + manual visit booking`)
+const VERSION = '1.35.1'
+console.log(`[recruit-gmail] v${VERSION} — status probes the refresh token so a dead grant surfaces as reconnect-needed`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -880,7 +880,14 @@ serve(async (req) => {
     if (action === 'status') {
       const { data: acct } = await client.from('recruit_gmail_account')
         .select('email, connected_by_name, connected_at').eq('id', 1).maybeSingle()
-      return json(acct ? { connected: true, ...acct } : { connected: false })
+      if (!acct) return json({ connected: false })
+      // A stored row isn't a live connection — Google can expire or revoke the
+      // refresh token server-side (invalid_grant). Probe it so the app shows
+      // "reconnect needed" instead of a false ✓ while every send/scan fails.
+      try { await accessToken(client) } catch (e) {
+        return json({ connected: false, reconnect: true, ...acct, error: String((e as Error)?.message || e).slice(0, 180) })
+      }
+      return json({ connected: true, ...acct })
     }
 
     if (action === 'send-update') {


### PR DESCRIPTION
## Why
The shared Gmail (live.at.agapesf@gmail.com) refresh token was revoked/expired (`invalid_grant`), so every send/scan fails and Discord alerts fire — yet Settings showed **✓ connected** and offered no way to reconnect, because `status` only checked that a DB row existed.

## What
- **recruit-gmail v1.35.1** — `status` now probes the refresh token; a dead grant returns `connected:false, reconnect:true` (+ short error).
- **app v3.69.1** — Settings → Connections shows a **Reconnect Gmail** button when disconnected (same OAuth flow as the Emails-panel connect card).

## Deploy after merge
- `supabase functions deploy recruit-gmail`

🤖 Generated with [Claude Code](https://claude.com/claude-code)