### PR TITLE
feat(ladder): watch job-radar registry companies + workable/smartrecruiters/rippling adapters

### DIFF
--- a/.claude/skills/job-radar/companies.json
+++ b/.claude/skills/job-radar/companies.json
@@ -1,73 +1,677 @@
 {
-  "_comment": "job-radar company registry. type = ATS fetch strategy in scripts/fetch_boards.py. segments: bag-boutique | outdoor-brand | ultralight | large | bay-area | outdoor-tech. Companies with type=html get their careers page text dumped for Claude to parse; type=none are outreach-only (no board exists). Compiled Aug 2026 — ATS slugs verified against first-party board URLs.",
+  "_comment": "job-radar company registry. type = ATS fetch strategy in scripts/fetch_boards.py. segments: bag-boutique | outdoor-brand | ultralight | large | bay-area | outdoor-tech. Companies with type=html get their careers page text dumped for Claude to parse; type=none are outreach-only (no board exists). Compiled Aug 2026 \u2014 ATS slugs verified against first-party board URLs.",
   "companies": [
-    { "name": "Peak Design", "type": "greenhouse", "slug": "peakdesign", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA", "careers_url": "https://www.peakdesign.com/pages/careers" },
-    { "name": "Db Journey", "type": "html", "segments": ["bag-boutique"], "location": "Oslo, Norway", "careers_url": "https://dbequipment.careers.haileyhr.app/", "notes": "HaileyHR board, no public API. Norwegian brand (ex-Douchebags)." },
-    { "name": "Bellroy", "type": "greenhouse", "slug": "bellroy", "segments": ["bag-boutique"], "location": "Bells Beach / Melbourne, AU", "careers_url": "https://bellroy.com/careers", "notes": "Mostly AU-anchored; eng roles sometimes remote. Softgoods PD/design reqs recur." },
-    { "name": "Aer", "type": "html", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA", "careers_url": "https://www.aersf.com/careers", "notes": "No ATS. Outreach: hello@aersf.com. Top SF speculative target." },
-    { "name": "Evergoods", "type": "html", "segments": ["bag-boutique"], "location": "Bozeman, MT", "careers_url": "https://evergoods.us/pages/careers", "notes": "Apply via careers@evergoods.us. Design-led; PD/materials/sample-tech roles recur." },
-    { "name": "GORUCK", "type": "workable", "slug": "goruck", "segments": ["bag-boutique"], "location": "Jacksonville Beach, FL", "careers_url": "https://www.goruck.com/pages/careers", "notes": "Also posts on JazzHR: https://gorucka1.applytojob.com/" },
-    { "name": "Tom Bihn", "type": "html", "segments": ["bag-boutique"], "location": "Seattle, WA", "careers_url": "https://www.tombihn.com/pages/jobs", "notes": "Rarely hires beyond sewing floor. jobs@tombihn.com" },
-    { "name": "Boundary Supply", "type": "smartrecruiters", "slug": "BoundarySupply", "segments": ["bag-boutique"], "location": "Salt Lake City, UT", "careers_url": "https://careers.smartrecruiters.com/BoundarySupply" },
-    { "name": "Mission Workshop", "type": "html", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA", "careers_url": "https://missionworkshop.com/pages/jobs", "notes": "~20 people, SF Mission. Outreach: jobs@missionworkshop.com" },
-    { "name": "Chrome Industries", "type": "html", "segments": ["bag-boutique"], "location": "Portland, OR", "careers_url": "https://chromeindustries.com/pages/careers", "notes": "Roles surface on LinkedIn; soft-goods pack/bag design reqs appear here." },
-    { "name": "Dagne Dover", "type": "html", "segments": ["bag-boutique"], "location": "New York, NY", "careers_url": "https://careers.dagnedover.com/jobs", "notes": "Teamtailor board." },
-    { "name": "Away", "type": "greenhouse", "slug": "away", "segments": ["bag-boutique"], "location": "New York, NY", "careers_url": "https://www.awaytravel.com/pages/careers", "notes": "If greenhouse slug fails, fall back to careers page." },
-    { "name": "Timbuk2 (Exemplis)", "type": "html", "segments": ["bag-boutique", "bay-area"], "location": "Cypress, CA (brand: SF)", "careers_url": "https://careers.exemplis.com/Timbuk2", "notes": "SuccessFactors. Corporate/digital roles are Cypress; SF is retail only." },
-    { "name": "WANDRD", "type": "html", "segments": ["bag-boutique"], "location": "Utah", "careers_url": "https://www.wandrd.com", "notes": "~18 people, no careers infrastructure. Outreach only." },
-    { "name": "Moment", "type": "html", "segments": ["bag-boutique"], "location": "Remote / Seattle", "careers_url": "https://www.shopmoment.com/careers", "notes": "Remote-first; marketplace + Shopify stack = good digital fit when hiring." },
-    { "name": "Nomatic", "type": "html", "segments": ["bag-boutique"], "location": "Sandy, UT", "careers_url": "https://www.nomatic.com", "notes": "No board found; rarely hires." },
-    { "name": "DSPTCH", "type": "none", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA", "careers_url": "https://www.dsptch.com", "notes": "Micro-team, US manufacturing. Outreach via LinkedIn only." },
-    { "name": "Black Ember", "type": "none", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA", "careers_url": "https://www.blackember.com", "notes": "Micro-team. Outreach via LinkedIn only." },
-    { "name": "Rickshaw Bagworks", "type": "none", "segments": ["bag-boutique", "bay-area"], "location": "San Francisco, CA (Dogpatch)", "careers_url": "https://www.rickshawbags.com", "notes": "~28 people, made-in-SF. Direct approach: info@ / (415) 904-8368." },
-    { "name": "Matador", "type": "html", "segments": ["bag-boutique"], "location": "Boulder, CO", "careers_url": "https://www.matadorequipment.com/pages/careers", "notes": "Apply: careers@matadorup.com" },
-    { "name": "Tortuga", "type": "workable", "slug": "tortuga", "segments": ["bag-boutique"], "location": "Remote (US)", "careers_url": "https://www.tortugabackpacks.com/pages/careers", "notes": "Fully remote, async, e-comm native — best structural fit for remote digital work." },
-    { "name": "Minaal", "type": "workable", "slug": "minaal", "segments": ["bag-boutique"], "location": "Remote / NZ", "careers_url": "https://apply.workable.com/minaal/" },
-    { "name": "Pakt", "type": "html", "segments": ["bag-boutique"], "location": "Bozeman, MT", "careers_url": "https://paktbags.com/pages/jobs" },
-    { "name": "Heimplanet", "type": "html", "segments": ["bag-boutique"], "location": "Hamburg, DE", "careers_url": "https://join.com/companies/heimplanet" },
-    { "name": "Rains", "type": "html", "segments": ["bag-boutique"], "location": "Aarhus, DK (NYC office)", "careers_url": "https://rains.career.emply.com/open-positions", "notes": "Only brand on list with a US (NYC) office; watch for US digital roles." },
-
-    { "name": "Cotopaxi", "type": "html", "segments": ["outdoor-brand"], "location": "Salt Lake City, UT", "careers_url": "https://cotopaxi.applytojob.com/apply", "notes": "JazzHR board (HTML only). Remote-eligible in CA for some roles." },
-    { "name": "Topo Designs", "type": "html", "segments": ["outdoor-brand"], "location": "Denver, CO", "careers_url": "https://topodesigns.com/pages/careers", "notes": "Thin posted list; keeps resumes via careers@topodesigns.com" },
-    { "name": "Osprey (Helen of Troy)", "type": "workday", "host": "helenoftroy.wd1.myworkdayjobs.com", "tenant": "helenoftroy", "site": "Main_HoT", "search": "Osprey", "segments": ["outdoor-brand"], "location": "Cortez, CO", "careers_url": "https://careers.helenoftroy.com/osprey" },
-    { "name": "Hyperlite Mountain Gear", "type": "html", "segments": ["outdoor-brand", "ultralight"], "location": "Biddeford, ME", "careers_url": "https://jobs.gohire.io/hyperlite-mountain-gear-oouvga0i/" },
-    { "name": "YETI / Mystery Ranch", "type": "workday", "host": "yeticoolers.wd5.myworkdayjobs.com", "tenant": "yeticoolers", "site": "YETI", "segments": ["outdoor-brand", "large"], "location": "Austin, TX + Bozeman, MT", "careers_url": "https://www.yeti.com/yeti-careers.html", "notes": "Bozeman = Mystery Ranch bags center of excellence; filter for 'soft goods'/'Bozeman'." },
-    { "name": "Dakine (JR286)", "type": "html", "segments": ["outdoor-brand"], "location": "Torrance, CA", "careers_url": "https://www.jr286.com/careers", "notes": "No first-party board found; Dakine Equipment roles post under parent JR286 on LinkedIn/Indeed. Verify carefully — aggregator-only listings go stale." },
-    { "name": "Gregory / Samsonite / Tumi", "type": "html", "segments": ["outdoor-brand", "large"], "location": "SLC (Gregory) / Mansfield, MA", "careers_url": "https://careers.samsonite.com/jobs" },
-    { "name": "Kelty (Exxel Outdoors)", "type": "html", "segments": ["outdoor-brand", "ultralight"], "location": "Broomfield, CO", "careers_url": "https://theapplicantmanager.com/careers?co=am", "notes": "Also Sierra Designs, Ultimate Direction. hr@exxel.com" },
-    { "name": "Big Agnes", "type": "html", "segments": ["outdoor-brand", "ultralight"], "location": "Steamboat Springs, CO", "careers_url": "https://www.bigagnes.com/pages/careers" },
-    { "name": "Sea to Summit US", "type": "html", "segments": ["outdoor-brand"], "location": "Boulder, CO", "careers_url": "https://seatosummit.com/pages/careers" },
-    { "name": "Eagle Creek", "type": "html", "segments": ["outdoor-brand"], "location": "Steamboat Springs, CO", "careers_url": "https://eaglecreek.com/pages/careers", "notes": "Independent again; historically hybrid-remote ecomm/marketing." },
-    { "name": "Zpacks", "type": "html", "segments": ["ultralight"], "location": "Melbourne, FL", "careers_url": "https://zpacks.com/pages/careers", "notes": "Largest cottage maker (~$24M); serious Shopify DTC funnel, rarely posts non-floor roles." },
-    { "name": "Six Moon Designs", "type": "html", "segments": ["ultralight"], "location": "Beaverton, OR", "careers_url": "https://www.sixmoondesigns.com/pages/jobs", "notes": "jobs@sixmoondesigns.com" },
-    { "name": "Gossamer Gear", "type": "html", "segments": ["ultralight"], "location": "Austin, TX", "careers_url": "https://www.gossamergear.com", "notes": "~5-10 people. marketing@gossamergear.com" },
-    { "name": "ULA Equipment", "type": "html", "segments": ["ultralight"], "location": "Logan, UT", "careers_url": "https://www.ula-equipment.com/careers/" },
-
-    { "name": "Patagonia", "type": "html", "segments": ["large"], "location": "Ventura, CA", "careers_url": "https://careers.patagonia.com/us/en/search", "notes": "Phenom ATS, no public API. Watch: Sr Digital PM reqs + PLM Equipment & Accessories." },
-    { "name": "Arc'teryx", "type": "lever", "slug": "arcteryx.com", "segments": ["large"], "location": "North Vancouver, BC", "careers_url": "https://arcteryx.com/us/en/careers", "notes": "Packs/bags = 'Hardgoods'. PLM Hardgoods + PM eCommerce Technology recur. Visa required." },
-    { "name": "REI", "type": "html", "segments": ["large"], "location": "Issaquah/Seattle, WA", "careers_url": "https://www.rei.jobs/careers-home/jobs", "notes": "Radancy ATS. Digital org hires principal-level design/PM hybrids." },
-    { "name": "The North Face (VF)", "type": "workday", "host": "vfc.wd5.myworkdayjobs.com", "tenant": "vfc", "site": "northface_careers", "segments": ["large"], "location": "Denver, CO", "careers_url": "https://vfc.wd5.myworkdayjobs.com/northface_careers", "notes": "Technical Equipment (packs/tents) design + digital personalization roles recur." },
-    { "name": "Columbia Sportswear", "type": "workday", "host": "columbiasportswearcompany.wd5.myworkdayjobs.com", "tenant": "columbiasportswearcompany", "site": "CSC_Careers", "segments": ["large"], "location": "Portland, OR", "careers_url": "https://columbiasportswearcompany.wd5.myworkdayjobs.com/CSC_Careers" },
-    { "name": "Mountain Hardwear", "type": "workday", "host": "columbiasportswearcompany.wd5.myworkdayjobs.com", "tenant": "columbiasportswearcompany", "site": "Mountain_Hardwear_Careers", "segments": ["large", "bay-area"], "location": "Richmond, CA", "careers_url": "https://columbiasportswearcompany.wd5.myworkdayjobs.com/Mountain_Hardwear_Careers", "notes": "THE Bay Area soft-goods PD target — technical packs developed in Richmond. PD/PLM/materials reqs recur." },
-    { "name": "Herschel Supply", "type": "html", "segments": ["large"], "location": "Vancouver, BC", "careers_url": "https://herschel.ca/pages/careers" },
-    { "name": "Fjällräven NA", "type": "html", "segments": ["large"], "location": "Louisville, CO", "careers_url": "https://career.fjallraven.us/jobs", "notes": "US arm is sales/marketing only; product dev is Sweden (Fenix Outdoor)." },
-    { "name": "Salomon / Amer Sports", "type": "smartrecruiters", "slug": "Salomon", "segments": ["large"], "location": "Ogden, UT / NYC (US)", "careers_url": "https://jobs.smartrecruiters.com/Salomon", "notes": "US roles are ecomm/marketing; pack product creation is Annecy, FR." },
-    { "name": "Marmot (Newell)", "type": "html", "segments": ["large", "bay-area"], "location": "Petaluma, CA (moved from Rohnert Park 2026)", "careers_url": "https://jobs.newellbrands.com/go/AllJobs/9623000/", "notes": "SuccessFactors — search 'Marmot' / Petaluma / Rohnert Park. Brand turnaround, but Newell cutting ~900 jobs through 2026: verify reqs are live." },
-    { "name": "Thule Group", "type": "html", "segments": ["large"], "location": "Seymour, CT (US)", "careers_url": "https://thule.varbi.com", "notes": "US corporate roles rare; most postings Sweden." },
-
-    { "name": "HydraPak", "type": "rippling", "slug": "hydrapak", "segments": ["bay-area"], "location": "Oakland, CA", "careers_url": "https://hydrapak.rippling-ats.com/", "notes": "OEM for Osprey/Salomon/Patagonia reservoirs — production happens in Oakland. #1 Bay Area speculative target for the production pivot." },
-    { "name": "Royal Robbins (Fenix)", "type": "html", "segments": ["bay-area"], "location": "Berkeley, CA", "careers_url": "https://career.royalrobbins.com/jobs" },
-    { "name": "Specialized", "type": "html", "segments": ["bay-area"], "location": "Morgan Hill, CA", "careers_url": "https://www.specialized.com/us/en/careers", "notes": "~70mi from SF. Data/analytics + technical PM roles appear." },
-    { "name": "Marin Bikes", "type": "html", "segments": ["bay-area"], "location": "Petaluma, CA", "careers_url": "https://marinbikes.com/pages/careers" },
-    { "name": "Ibis Cycles", "type": "html", "segments": ["bay-area"], "location": "Santa Cruz, CA", "careers_url": "https://www.ibiscycles.com/our-story/careers", "notes": "jobs@ibiscycles.com" },
-    { "name": "GoPro", "type": "greenhouse", "slug": "gopro", "segments": ["bay-area", "outdoor-tech"], "location": "San Mateo, CA / Remote US", "careers_url": "https://jobs.gopro.com/jobs/category/product-management", "notes": "If greenhouse slug fails, use careers_url. Subscription/growth PM roles recur; subscription biz growing ~20% YoY." },
-
-    { "name": "Strava", "type": "greenhouse", "slug": "strava", "segments": ["outdoor-tech", "bay-area"], "location": "San Francisco, CA (hybrid 3d/wk)", "careers_url": "https://job-boards.greenhouse.io/strava" },
-    { "name": "AllTrails", "type": "lever", "slug": "alltrails", "segments": ["outdoor-tech", "bay-area"], "location": "San Francisco, CA / Remote", "careers_url": "https://www.alltrails.com/careers", "notes": "If lever slug is empty, roles may post via Built In/LinkedIn — check careers page." },
-    { "name": "Oura", "type": "greenhouse", "slug": "oura", "segments": ["outdoor-tech"], "location": "SF office / Remote US", "careers_url": "https://job-boards.greenhouse.io/oura" },
-    { "name": "onX Maps", "type": "greenhouse", "slug": "onxmaps", "segments": ["outdoor-tech"], "location": "Missoula, MT / Remote", "careers_url": "https://job-boards.greenhouse.io/onxmaps" },
-    { "name": "Hipcamp", "type": "rippling", "slug": "join-the-hipcamp-team", "segments": ["outdoor-tech", "bay-area"], "location": "San Francisco, CA / distributed", "careers_url": "https://ats.rippling.com/en-US/join-the-hipcamp-team/jobs" },
-    { "name": "Whoop", "type": "lever", "slug": "whoop", "segments": ["outdoor-tech"], "location": "Boston, MA (strictly — relocation required)", "careers_url": "https://jobs.lever.co/whoop", "notes": "Great-fitting PM roles but Boston-only; include for completeness." },
-    { "name": "The Dyrt", "type": "html", "segments": ["outdoor-tech"], "location": "Portland, OR / Remote", "careers_url": "http://jobs.thedyrt.com/" }
+    {
+      "name": "Peak Design",
+      "type": "greenhouse",
+      "slug": "peakdesign",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA",
+      "careers_url": "https://www.peakdesign.com/pages/careers"
+    },
+    {
+      "name": "Db Journey",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Oslo, Norway",
+      "careers_url": "https://dbequipment.careers.haileyhr.app/",
+      "notes": "HaileyHR board, no public API. Norwegian brand (ex-Douchebags)."
+    },
+    {
+      "name": "Bellroy",
+      "type": "greenhouse",
+      "slug": "bellroy",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Bells Beach / Melbourne, AU",
+      "careers_url": "https://bellroy.com/careers",
+      "notes": "Mostly AU-anchored; eng roles sometimes remote. Softgoods PD/design reqs recur."
+    },
+    {
+      "name": "Aer",
+      "type": "html",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA",
+      "careers_url": "https://www.aersf.com/careers",
+      "notes": "No ATS. Outreach: hello@aersf.com. Top SF speculative target."
+    },
+    {
+      "name": "Evergoods",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Bozeman, MT",
+      "careers_url": "https://evergoods.us/pages/careers",
+      "notes": "Apply via careers@evergoods.us. Design-led; PD/materials/sample-tech roles recur."
+    },
+    {
+      "name": "GORUCK",
+      "type": "workable",
+      "slug": "goruck",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Jacksonville Beach, FL",
+      "careers_url": "https://www.goruck.com/pages/careers",
+      "notes": "Also posts on JazzHR: https://gorucka1.applytojob.com/"
+    },
+    {
+      "name": "Tom Bihn",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Seattle, WA",
+      "careers_url": "https://www.tombihn.com/pages/jobs",
+      "notes": "Rarely hires beyond sewing floor. jobs@tombihn.com"
+    },
+    {
+      "name": "Boundary Supply",
+      "type": "smartrecruiters",
+      "slug": "BoundarySupply",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Salt Lake City, UT",
+      "careers_url": "https://careers.smartrecruiters.com/BoundarySupply"
+    },
+    {
+      "name": "Mission Workshop",
+      "type": "html",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA",
+      "careers_url": "https://missionworkshop.com/pages/jobs",
+      "notes": "~20 people, SF Mission. Outreach: jobs@missionworkshop.com"
+    },
+    {
+      "name": "Chrome Industries",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Portland, OR",
+      "careers_url": "https://chromeindustries.com/pages/careers",
+      "notes": "Roles surface on LinkedIn; soft-goods pack/bag design reqs appear here."
+    },
+    {
+      "name": "Dagne Dover",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "New York, NY",
+      "careers_url": "https://careers.dagnedover.com/jobs",
+      "notes": "Teamtailor board."
+    },
+    {
+      "name": "Away",
+      "type": "ashby",
+      "slug": "away",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "New York, NY",
+      "careers_url": "https://www.awaytravel.com/pages/careers",
+      "notes": "If greenhouse slug fails, fall back to careers page.; moved Greenhouse\u2192Ashby (verified 2026-08-06)"
+    },
+    {
+      "name": "Timbuk2 (Exemplis)",
+      "type": "html",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "Cypress, CA (brand: SF)",
+      "careers_url": "https://careers.exemplis.com/Timbuk2",
+      "notes": "SuccessFactors. Corporate/digital roles are Cypress; SF is retail only."
+    },
+    {
+      "name": "WANDRD",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Utah",
+      "careers_url": "https://www.wandrd.com",
+      "notes": "~18 people, no careers infrastructure. Outreach only."
+    },
+    {
+      "name": "Moment",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Remote / Seattle",
+      "careers_url": "https://www.shopmoment.com/careers",
+      "notes": "Remote-first; marketplace + Shopify stack = good digital fit when hiring."
+    },
+    {
+      "name": "Nomatic",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Sandy, UT",
+      "careers_url": "https://www.nomatic.com",
+      "notes": "No board found; rarely hires."
+    },
+    {
+      "name": "DSPTCH",
+      "type": "none",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA",
+      "careers_url": "https://www.dsptch.com",
+      "notes": "Micro-team, US manufacturing. Outreach via LinkedIn only."
+    },
+    {
+      "name": "Black Ember",
+      "type": "none",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA",
+      "careers_url": "https://www.blackember.com",
+      "notes": "Micro-team. Outreach via LinkedIn only."
+    },
+    {
+      "name": "Rickshaw Bagworks",
+      "type": "none",
+      "segments": [
+        "bag-boutique",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA (Dogpatch)",
+      "careers_url": "https://www.rickshawbags.com",
+      "notes": "~28 people, made-in-SF. Direct approach: info@ / (415) 904-8368."
+    },
+    {
+      "name": "Matador",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Boulder, CO",
+      "careers_url": "https://www.matadorequipment.com/pages/careers",
+      "notes": "Apply: careers@matadorup.com"
+    },
+    {
+      "name": "Tortuga",
+      "type": "workable",
+      "slug": "tortuga",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Remote (US)",
+      "careers_url": "https://www.tortugabackpacks.com/pages/careers",
+      "notes": "Fully remote, async, e-comm native \u2014 best structural fit for remote digital work."
+    },
+    {
+      "name": "Minaal",
+      "type": "workable",
+      "slug": "minaal",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Remote / NZ",
+      "careers_url": "https://apply.workable.com/minaal/"
+    },
+    {
+      "name": "Pakt",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Bozeman, MT",
+      "careers_url": "https://paktbags.com/pages/jobs"
+    },
+    {
+      "name": "Heimplanet",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Hamburg, DE",
+      "careers_url": "https://join.com/companies/heimplanet"
+    },
+    {
+      "name": "Rains",
+      "type": "html",
+      "segments": [
+        "bag-boutique"
+      ],
+      "location": "Aarhus, DK (NYC office)",
+      "careers_url": "https://rains.career.emply.com/open-positions",
+      "notes": "Only brand on list with a US (NYC) office; watch for US digital roles."
+    },
+    {
+      "name": "Cotopaxi",
+      "type": "html",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Salt Lake City, UT",
+      "careers_url": "https://cotopaxi.applytojob.com/apply",
+      "notes": "JazzHR board (HTML only). Remote-eligible in CA for some roles."
+    },
+    {
+      "name": "Topo Designs",
+      "type": "html",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Denver, CO",
+      "careers_url": "https://topodesigns.com/pages/careers",
+      "notes": "Thin posted list; keeps resumes via careers@topodesigns.com"
+    },
+    {
+      "name": "Osprey (Helen of Troy)",
+      "type": "workday",
+      "host": "helenoftroy.wd1.myworkdayjobs.com",
+      "tenant": "helenoftroy",
+      "site": "Main_HoT",
+      "search": "Osprey",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Cortez, CO",
+      "careers_url": "https://careers.helenoftroy.com/osprey"
+    },
+    {
+      "name": "Hyperlite Mountain Gear",
+      "type": "html",
+      "segments": [
+        "outdoor-brand",
+        "ultralight"
+      ],
+      "location": "Biddeford, ME",
+      "careers_url": "https://jobs.gohire.io/hyperlite-mountain-gear-oouvga0i/"
+    },
+    {
+      "name": "YETI / Mystery Ranch",
+      "type": "workday",
+      "host": "yeticoolers.wd5.myworkdayjobs.com",
+      "tenant": "yeticoolers",
+      "site": "YETI",
+      "segments": [
+        "outdoor-brand",
+        "large"
+      ],
+      "location": "Austin, TX + Bozeman, MT",
+      "careers_url": "https://www.yeti.com/yeti-careers.html",
+      "notes": "Bozeman = Mystery Ranch bags center of excellence; filter for 'soft goods'/'Bozeman'."
+    },
+    {
+      "name": "Dakine (JR286)",
+      "type": "html",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Torrance, CA",
+      "careers_url": "https://www.jr286.com/careers",
+      "notes": "No first-party board found; Dakine Equipment roles post under parent JR286 on LinkedIn/Indeed. Verify carefully \u2014 aggregator-only listings go stale."
+    },
+    {
+      "name": "Gregory / Samsonite / Tumi",
+      "type": "html",
+      "segments": [
+        "outdoor-brand",
+        "large"
+      ],
+      "location": "SLC (Gregory) / Mansfield, MA",
+      "careers_url": "https://careers.samsonite.com/jobs"
+    },
+    {
+      "name": "Kelty (Exxel Outdoors)",
+      "type": "html",
+      "segments": [
+        "outdoor-brand",
+        "ultralight"
+      ],
+      "location": "Broomfield, CO",
+      "careers_url": "https://theapplicantmanager.com/careers?co=am",
+      "notes": "Also Sierra Designs, Ultimate Direction. hr@exxel.com"
+    },
+    {
+      "name": "Big Agnes",
+      "type": "html",
+      "segments": [
+        "outdoor-brand",
+        "ultralight"
+      ],
+      "location": "Steamboat Springs, CO",
+      "careers_url": "https://www.bigagnes.com/pages/careers"
+    },
+    {
+      "name": "Sea to Summit US",
+      "type": "html",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Boulder, CO",
+      "careers_url": "https://seatosummit.com/pages/careers"
+    },
+    {
+      "name": "Eagle Creek",
+      "type": "html",
+      "segments": [
+        "outdoor-brand"
+      ],
+      "location": "Steamboat Springs, CO",
+      "careers_url": "https://eaglecreek.com/pages/careers",
+      "notes": "Independent again; historically hybrid-remote ecomm/marketing."
+    },
+    {
+      "name": "Zpacks",
+      "type": "html",
+      "segments": [
+        "ultralight"
+      ],
+      "location": "Melbourne, FL",
+      "careers_url": "https://zpacks.com/pages/careers",
+      "notes": "Largest cottage maker (~$24M); serious Shopify DTC funnel, rarely posts non-floor roles."
+    },
+    {
+      "name": "Six Moon Designs",
+      "type": "html",
+      "segments": [
+        "ultralight"
+      ],
+      "location": "Beaverton, OR",
+      "careers_url": "https://www.sixmoondesigns.com/pages/jobs",
+      "notes": "jobs@sixmoondesigns.com"
+    },
+    {
+      "name": "Gossamer Gear",
+      "type": "html",
+      "segments": [
+        "ultralight"
+      ],
+      "location": "Austin, TX",
+      "careers_url": "https://www.gossamergear.com",
+      "notes": "~5-10 people. marketing@gossamergear.com"
+    },
+    {
+      "name": "ULA Equipment",
+      "type": "html",
+      "segments": [
+        "ultralight"
+      ],
+      "location": "Logan, UT",
+      "careers_url": "https://www.ula-equipment.com/careers/"
+    },
+    {
+      "name": "Patagonia",
+      "type": "html",
+      "segments": [
+        "large"
+      ],
+      "location": "Ventura, CA",
+      "careers_url": "https://careers.patagonia.com/us/en/search",
+      "notes": "Phenom ATS, no public API. Watch: Sr Digital PM reqs + PLM Equipment & Accessories."
+    },
+    {
+      "name": "Arc'teryx",
+      "type": "lever",
+      "slug": "arcteryx.com",
+      "segments": [
+        "large"
+      ],
+      "location": "North Vancouver, BC",
+      "careers_url": "https://arcteryx.com/us/en/careers",
+      "notes": "Packs/bags = 'Hardgoods'. PLM Hardgoods + PM eCommerce Technology recur. Visa required."
+    },
+    {
+      "name": "REI",
+      "type": "html",
+      "segments": [
+        "large"
+      ],
+      "location": "Issaquah/Seattle, WA",
+      "careers_url": "https://www.rei.jobs/careers-home/jobs",
+      "notes": "Radancy ATS. Digital org hires principal-level design/PM hybrids."
+    },
+    {
+      "name": "The North Face (VF)",
+      "type": "workday",
+      "host": "vfc.wd5.myworkdayjobs.com",
+      "tenant": "vfc",
+      "site": "northface_careers",
+      "segments": [
+        "large"
+      ],
+      "location": "Denver, CO",
+      "careers_url": "https://vfc.wd5.myworkdayjobs.com/northface_careers",
+      "notes": "Technical Equipment (packs/tents) design + digital personalization roles recur."
+    },
+    {
+      "name": "Columbia Sportswear",
+      "type": "workday",
+      "host": "columbiasportswearcompany.wd5.myworkdayjobs.com",
+      "tenant": "columbiasportswearcompany",
+      "site": "CSC_Careers",
+      "segments": [
+        "large"
+      ],
+      "location": "Portland, OR",
+      "careers_url": "https://columbiasportswearcompany.wd5.myworkdayjobs.com/CSC_Careers"
+    },
+    {
+      "name": "Mountain Hardwear",
+      "type": "workday",
+      "host": "columbiasportswearcompany.wd5.myworkdayjobs.com",
+      "tenant": "columbiasportswearcompany",
+      "site": "Mountain_Hardwear_Careers",
+      "segments": [
+        "large",
+        "bay-area"
+      ],
+      "location": "Richmond, CA",
+      "careers_url": "https://columbiasportswearcompany.wd5.myworkdayjobs.com/Mountain_Hardwear_Careers",
+      "notes": "THE Bay Area soft-goods PD target \u2014 technical packs developed in Richmond. PD/PLM/materials reqs recur."
+    },
+    {
+      "name": "Herschel Supply",
+      "type": "html",
+      "segments": [
+        "large"
+      ],
+      "location": "Vancouver, BC",
+      "careers_url": "https://herschel.ca/pages/careers"
+    },
+    {
+      "name": "Fj\u00e4llr\u00e4ven NA",
+      "type": "html",
+      "segments": [
+        "large"
+      ],
+      "location": "Louisville, CO",
+      "careers_url": "https://career.fjallraven.us/jobs",
+      "notes": "US arm is sales/marketing only; product dev is Sweden (Fenix Outdoor)."
+    },
+    {
+      "name": "Salomon / Amer Sports",
+      "type": "smartrecruiters",
+      "slug": "Salomon",
+      "segments": [
+        "large"
+      ],
+      "location": "Ogden, UT / NYC (US)",
+      "careers_url": "https://jobs.smartrecruiters.com/Salomon",
+      "notes": "US roles are ecomm/marketing; pack product creation is Annecy, FR."
+    },
+    {
+      "name": "Marmot (Newell)",
+      "type": "html",
+      "segments": [
+        "large",
+        "bay-area"
+      ],
+      "location": "Petaluma, CA (moved from Rohnert Park 2026)",
+      "careers_url": "https://jobs.newellbrands.com/go/AllJobs/9623000/",
+      "notes": "SuccessFactors \u2014 search 'Marmot' / Petaluma / Rohnert Park. Brand turnaround, but Newell cutting ~900 jobs through 2026: verify reqs are live."
+    },
+    {
+      "name": "Thule Group",
+      "type": "html",
+      "segments": [
+        "large"
+      ],
+      "location": "Seymour, CT (US)",
+      "careers_url": "https://thule.varbi.com",
+      "notes": "US corporate roles rare; most postings Sweden."
+    },
+    {
+      "name": "HydraPak",
+      "type": "rippling",
+      "slug": "hydrapak",
+      "segments": [
+        "bay-area"
+      ],
+      "location": "Oakland, CA",
+      "careers_url": "https://hydrapak.rippling-ats.com/",
+      "notes": "OEM for Osprey/Salomon/Patagonia reservoirs \u2014 production happens in Oakland. #1 Bay Area speculative target for the production pivot."
+    },
+    {
+      "name": "Royal Robbins (Fenix)",
+      "type": "html",
+      "segments": [
+        "bay-area"
+      ],
+      "location": "Berkeley, CA",
+      "careers_url": "https://career.royalrobbins.com/jobs"
+    },
+    {
+      "name": "Specialized",
+      "type": "html",
+      "segments": [
+        "bay-area"
+      ],
+      "location": "Morgan Hill, CA",
+      "careers_url": "https://www.specialized.com/us/en/careers",
+      "notes": "~70mi from SF. Data/analytics + technical PM roles appear."
+    },
+    {
+      "name": "Marin Bikes",
+      "type": "html",
+      "segments": [
+        "bay-area"
+      ],
+      "location": "Petaluma, CA",
+      "careers_url": "https://marinbikes.com/pages/careers"
+    },
+    {
+      "name": "Ibis Cycles",
+      "type": "html",
+      "segments": [
+        "bay-area"
+      ],
+      "location": "Santa Cruz, CA",
+      "careers_url": "https://www.ibiscycles.com/our-story/careers",
+      "notes": "jobs@ibiscycles.com"
+    },
+    {
+      "name": "GoPro",
+      "type": "greenhouse",
+      "slug": "goprocareers",
+      "segments": [
+        "bay-area",
+        "outdoor-tech"
+      ],
+      "location": "San Mateo, CA / Remote US",
+      "careers_url": "https://jobs.gopro.com/jobs/category/product-management",
+      "notes": "If greenhouse slug fails, use careers_url. Subscription/growth PM roles recur; subscription biz growing ~20% YoY.; slug gopro\u2192goprocareers (verified 2026-08-06; board live, 0 openings today)"
+    },
+    {
+      "name": "Strava",
+      "type": "ashby",
+      "slug": "strava",
+      "segments": [
+        "outdoor-tech",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA (hybrid 3d/wk)",
+      "careers_url": "https://job-boards.greenhouse.io/strava",
+      "notes": "moved Greenhouse\u2192Ashby (verified 2026-08-06)"
+    },
+    {
+      "name": "AllTrails",
+      "type": "lever",
+      "slug": "alltrails",
+      "segments": [
+        "outdoor-tech",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA / Remote",
+      "careers_url": "https://www.alltrails.com/careers",
+      "notes": "If lever slug is empty, roles may post via Built In/LinkedIn \u2014 check careers page."
+    },
+    {
+      "name": "Oura",
+      "type": "greenhouse",
+      "slug": "oura",
+      "segments": [
+        "outdoor-tech"
+      ],
+      "location": "SF office / Remote US",
+      "careers_url": "https://job-boards.greenhouse.io/oura"
+    },
+    {
+      "name": "onX Maps",
+      "type": "greenhouse",
+      "slug": "onxmaps",
+      "segments": [
+        "outdoor-tech"
+      ],
+      "location": "Missoula, MT / Remote",
+      "careers_url": "https://job-boards.greenhouse.io/onxmaps"
+    },
+    {
+      "name": "Hipcamp",
+      "type": "rippling",
+      "slug": "join-the-hipcamp-team",
+      "segments": [
+        "outdoor-tech",
+        "bay-area"
+      ],
+      "location": "San Francisco, CA / distributed",
+      "careers_url": "https://ats.rippling.com/en-US/join-the-hipcamp-team/jobs"
+    },
+    {
+      "name": "Whoop",
+      "type": "lever",
+      "slug": "whoop",
+      "segments": [
+        "outdoor-tech"
+      ],
+      "location": "Boston, MA (strictly \u2014 relocation required)",
+      "careers_url": "https://jobs.lever.co/whoop",
+      "notes": "Great-fitting PM roles but Boston-only; include for completeness."
+    },
+    {
+      "name": "The Dyrt",
+      "type": "html",
+      "segments": [
+        "outdoor-tech"
+      ],
+      "location": "Portland, OR / Remote",
+      "careers_url": "http://jobs.thedyrt.com/"
+    }
   ]
 }

--- a/supabase/functions/_shared/sources/company-watch.ts
+++ b/supabase/functions/_shared/sources/company-watch.ts
@@ -450,6 +450,59 @@ async function pullAtsBoard(w: WatchedCompanyRow): Promise<RecommendedRoleInput[
       payload: { adapter: 'ashby', watchedCompanyId: w.id, jobId: j.id },
     }));
   }
+  if (w.adapter === 'workable') {
+    const data = await fetchJson<{ jobs?: Array<{ title?: string; city?: string; state?: string; country?: string; telecommuting?: boolean; url?: string; shortlink?: string; published_on?: string }> }>(
+      `https://apply.workable.com/api/v1/widget/accounts/${slug}?details=false`);
+    return (data.jobs || []).slice(0, MAX_ROLES_PER_COMPANY).flatMap(j => {
+      const url = j.url || j.shortlink;
+      if (!url || !j.title) return [];
+      let loc = [j.city, j.state, j.country].filter(Boolean).join(', ');
+      if (j.telecommuting) loc = loc ? `${loc} (remote)` : 'Remote';
+      return [{
+        source: 'company-watch', sourceId: `cw:workable:${cfg.slug}:${url.split('/').pop()}`,
+        sourceLabel: `${w.company} Careers`, url,
+        company: w.company, title: j.title, location: loc || undefined,
+        postedAt: j.published_on && !isNaN(Date.parse(j.published_on)) ? new Date(j.published_on).toISOString() : undefined,
+        payload: { adapter: 'workable', watchedCompanyId: w.id },
+      }];
+    });
+  }
+  if (w.adapter === 'smartrecruiters') {
+    const data = await fetchJson<{ content?: Array<{ id?: string; name?: string; releasedDate?: string; location?: { city?: string; country?: string } }> }>(
+      `https://api.smartrecruiters.com/v1/companies/${slug}/postings`);
+    return (data.content || []).slice(0, MAX_ROLES_PER_COMPANY).flatMap(j => {
+      if (!j.id || !j.name) return [];
+      return [{
+        source: 'company-watch', sourceId: `cw:sr:${cfg.slug}:${j.id}`,
+        sourceLabel: `${w.company} Careers`,
+        url: `https://jobs.smartrecruiters.com/${cfg.slug}/${j.id}`,
+        company: w.company, title: j.name,
+        location: [j.location?.city, j.location?.country].filter(Boolean).join(', ') || undefined,
+        postedAt: j.releasedDate && !isNaN(Date.parse(j.releasedDate)) ? new Date(j.releasedDate).toISOString() : undefined,
+        payload: { adapter: 'smartrecruiters', watchedCompanyId: w.id, jobId: String(j.id) },
+      }];
+    });
+  }
+  if (w.adapter === 'rippling') {
+    // deno-lint-ignore no-explicit-any
+    const data = await fetchJson<any>(`https://api.rippling.com/platform/api/ats/v1/board/${slug}/jobs`);
+    const raw: Array<Record<string, unknown>> = Array.isArray(data) ? data : (data.jobs || data.results || data.items || []);
+    return raw.slice(0, MAX_ROLES_PER_COMPANY).flatMap(j => {
+      const title = String(j.name || j.title || '');
+      const url = j.url ? String(j.url)
+        : j.uuid ? `https://ats.rippling.com/${cfg.slug}/jobs/${j.uuid}` : '';
+      if (!title || !url) return [];
+      let loc: unknown = j.workLocation ?? j.locations ?? '';
+      if (Array.isArray(loc)) loc = loc.map(x => (x && typeof x === 'object') ? ((x as Record<string, unknown>).label || (x as Record<string, unknown>).name || '') : String(x)).filter(Boolean).join(', ');
+      else if (loc && typeof loc === 'object') loc = (loc as Record<string, unknown>).label || (loc as Record<string, unknown>).name || '';
+      return [{
+        source: 'company-watch', sourceId: `cw:rippling:${cfg.slug}:${String(j.uuid || j.id || url.split('/').pop())}`,
+        sourceLabel: `${w.company} Careers`, url,
+        company: w.company, title, location: String(loc || '') || undefined,
+        payload: { adapter: 'rippling', watchedCompanyId: w.id },
+      }];
+    });
+  }
   throw new Error(`unknown ats adapter: ${w.adapter}`);
 }
 
@@ -462,6 +515,9 @@ const ADAPTERS: Record<string, (w: WatchedCompanyRow) => Promise<RecommendedRole
   greenhouse: pullAtsBoard,
   lever:      pullAtsBoard,
   ashby:      pullAtsBoard,
+  workable:        pullAtsBoard,
+  smartrecruiters: pullAtsBoard,
+  rippling:        pullAtsBoard,
   custom:     pullCustom,
 };
 

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.31.0';
-console.log(`[pull-recommendations] v${VERSION} - ats-radar source (job-radar sweeps) + two-track grading (production vs digital)`);
+const VERSION = '0.32.0';
+console.log(`[pull-recommendations] v${VERSION} - company-watch gains workable/smartrecruiters/rippling adapters (job-radar registry watches)`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Adds every API-backed board from the job-radar registry to Ladder's watched companies, each linked to its verified job board.

- **New company-watch adapters**: workable (widget API), smartrecruiters (postings API), rippling (board API) — same endpoints the sweep uses, so any registry company can now be a first-class watch.
- **Board fixes verified live** (also in companies.json): Away → Ashby `away`, Strava → Ashby `strava`, GoPro → Greenhouse `goprocareers`.
- **21 watches created** (greenhouse 7 · workday 5 · lever 3 · workable 3 · smartrecruiters 2 · rippling 2; Strava already existed) with track A + PM title keywords so continuous pulls stay scoped. HydraPak + Osprey inserted **disabled** until their boards are fixed (follow-up task open); the 39 html-only and 3 no-board companies remain covered by the manual ats-radar sweep / outreach list.
- pull-recommendations v0.32.0 deployed; force-run verified: 195 in-keyword roles pulled, zero adapter errors, 9 new recs after dedupe vs the ats-radar batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)