### PR TITLE
style(recruiting): connection-card states use the status-dot vocabulary — v3.69.2

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1768,10 +1768,20 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .set-conn__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
 .set-conn__detail { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); overflow-wrap: anywhere; }
-.set-conn__state { grid-column: 2; grid-row: 1; text-align: right; font-size: var(--font-size-caption); font-weight: var(--fw-semibold); }
+.set-conn__state {
+  grid-column: 2; grid-row: 1; justify-self: end;
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
+}
+/* The dot carries the color (design-system .status vocabulary); a dead
+   connection blinks so the one card needing a click reads at a glance. */
+.set-conn__dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex: none; }
 .set-conn__state.is-ok { color: var(--success); }
 .set-conn__state.is-warn { color: var(--error); }
+.set-conn__state.is-warn .set-conn__dot { animation: set-conn-blink 1s step-start infinite; }
 .set-conn__state.is-off { color: var(--fg-subtle); }
+.set-conn__action { grid-column: 2; grid-row: 2; justify-self: end; align-self: center; }
+@keyframes set-conn-blink { 50% { opacity: 0; } }
 
 .set-note { margin: var(--space-2) 0 0; color: var(--fg-subtle); font-size: var(--font-size-caption); }
 .set-note code { font-family: ui-monospace, Menlo, monospace; }
@@ -1779,6 +1789,8 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   .set-field, .set-auto, .set-conn { grid-template-columns: 1fr; }
   .set-field__control { grid-column: 1; grid-row: 3; justify-self: start; margin-top: 6px; }
   .set-auto__when, .set-auto__cadence, .set-conn__state { grid-column: 1; text-align: left; }
+  .set-conn__state { justify-self: start; }
+  .set-conn__action { grid-column: 1; grid-row: auto; justify-self: start; margin-top: 6px; }
 }
 
 /* --- v3.49.0: stepped drawer (choose, then continue in place) ---

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.69.0">
+  <link rel="stylesheet" href="css/app.css?v=3.69.2">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -336,7 +336,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="js/app.js?v=3.69.1"></script>
+  <script src="js/app.js?v=3.69.2"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.69.1';
+const VERSION = '3.69.2';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1693,17 +1693,20 @@ function settingsAutomationsHtml() {
 
 function settingsConnectionsHtml() {
   const g = gmailStatusFull || gmailStatus || { connected: false };
-  const conn = (label, ok, detail, warn) => `<div class="set-conn">
+  // Same status vocabulary as the design system's .status indicator: a small
+  // dot carries the color, the text stays downstyled. A card that needs a
+  // human action carries its button on the right edge, under the state.
+  const conn = (label, ok, detail, warn, action) => `<div class="set-conn">
     <span class="set-conn__label">${esc(label)}</span>
-    <span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}">${ok ? '✓ connected' : esc(warn || 'not connected')}</span>
+    <span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}"><span class="set-conn__dot" aria-hidden="true"></span>${ok ? 'connected' : esc(warn || 'not connected')}</span>
     ${detail ? `<span class="set-conn__detail">${esc(detail)}</span>` : ''}
+    ${action || ''}
   </div>`;
   return conn('Shared Gmail', !!g.connected, g.connected
       ? `${g.email || ''}${g.connected_by_name ? ` · connected by ${g.connected_by_name}` : ''}`
-      : 'Applications and replies stop arriving until this is reconnected.',
-      g.connected ? null : 'reconnect needed')
-    + (g.connected ? '' : `<button type="button" class="btn btn--sm" id="set-gmail-connect">Reconnect Gmail</button>
-      <p class="set-note">You must be signed into live.at.agapesf@gmail.com in this browser.</p>`)
+      : 'Applications and replies stop arriving until this is reconnected. You must be signed into live.at.agapesf@gmail.com in this browser.',
+      g.connected ? null : 'reconnect needed',
+      g.connected ? '' : `<button type="button" class="btn btn--sm set-conn__action" id="set-gmail-connect">Reconnect</button>`)
     + conn('House calendar', !!g.connected, 'Screening invites land here.', g.connected ? null : 'follows Gmail')
     + conn('Discord', true, '#recruiting-automation · #recruiting-interviews');
 }

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -754,7 +754,11 @@ Sections borrow the product's own nav vocabulary (`You · House · Funnel · Aut
     <span class="set-field__by">Ian changed this 3 days ago</span></span>
 </div>
 <div class="set-auto">…</div>   <!-- label · when it last ran · switch · hint · cadence -->
-<div class="set-conn">…</div>   <!-- label · state (is-ok / is-warn / is-off) · detail -->
+<div class="set-conn">…</div>   <!-- label · state (is-ok / is-warn / is-off) · detail
+                                     state = .set-conn__dot + downstyled text (the .status
+                                     vocabulary; is-warn blinks). A dead connection puts its
+                                     one repair verb in .set-conn__action — right column,
+                                     under the state, never below the card -->
 ```
 
 **Settings rules:**


### PR DESCRIPTION
## What
- Connection cards in Settings → Connections now use the design system's status-indicator vocabulary: a small dot carries the state color (green ok / red warn / muted off), text stays downstyled; `reconnect needed` blinks.
- The **Reconnect** button is condensed into the card's right column, under the state — no longer a stray button below the card. Detail copy absorbed the sign-in hint.
- Mobile (≤520px): state and action fall back to the left column.
- Documented the pattern inline in `design-system/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)