### PR TITLE
style(recruiting): tinted reconnect button replaces the state indicator — v3.69.3

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1780,7 +1780,13 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .set-conn__state.is-warn { color: var(--error); }
 .set-conn__state.is-warn .set-conn__dot { animation: set-conn-blink 1s step-start infinite; }
 .set-conn__state.is-off { color: var(--fg-subtle); }
-.set-conn__action { grid-column: 2; grid-row: 2; justify-self: end; align-self: center; }
+/* The repair button replaces the state entirely — its tint (same treatment
+   as review__btn--notfit) is the disconnected indicator. */
+.set-conn__action {
+  grid-column: 2; grid-row: 1 / span 2; justify-self: end; align-self: center;
+  background: rgba(168, 32, 13, 0.14); border: 0; color: var(--error);
+  font-weight: var(--fw-semibold);
+}
 @keyframes set-conn-blink { 50% { opacity: 0; } }
 
 .set-note { margin: var(--space-2) 0 0; color: var(--fg-subtle); font-size: var(--font-size-caption); }
@@ -1790,7 +1796,7 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   .set-field__control { grid-column: 1; grid-row: 3; justify-self: start; margin-top: 6px; }
   .set-auto__when, .set-auto__cadence, .set-conn__state { grid-column: 1; text-align: left; }
   .set-conn__state { justify-self: start; }
-  .set-conn__action { grid-column: 1; grid-row: auto; justify-self: start; margin-top: 6px; }
+  .set-conn__action { grid-column: 1; grid-row: auto; justify-self: start; margin-top: 6px; align-self: start; }
 }
 
 /* --- v3.49.0: stepped drawer (choose, then continue in place) ---

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.69.2">
+  <link rel="stylesheet" href="css/app.css?v=3.69.3">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -336,7 +336,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="js/app.js?v=3.69.2"></script>
+  <script src="js/app.js?v=3.69.3"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.69.2';
+const VERSION = '3.69.3';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1695,18 +1695,18 @@ function settingsConnectionsHtml() {
   const g = gmailStatusFull || gmailStatus || { connected: false };
   // Same status vocabulary as the design system's .status indicator: a small
   // dot carries the color, the text stays downstyled. A card that needs a
-  // human action carries its button on the right edge, under the state.
+  // human action swaps the state for its one repair verb — the tinted button
+  // IS the indicator, never both.
   const conn = (label, ok, detail, warn, action) => `<div class="set-conn">
     <span class="set-conn__label">${esc(label)}</span>
-    <span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}"><span class="set-conn__dot" aria-hidden="true"></span>${ok ? 'connected' : esc(warn || 'not connected')}</span>
+    ${action || `<span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}"><span class="set-conn__dot" aria-hidden="true"></span>${ok ? 'connected' : esc(warn || 'not connected')}</span>`}
     ${detail ? `<span class="set-conn__detail">${esc(detail)}</span>` : ''}
-    ${action || ''}
   </div>`;
   return conn('Shared Gmail', !!g.connected, g.connected
       ? `${g.email || ''}${g.connected_by_name ? ` · connected by ${g.connected_by_name}` : ''}`
       : 'Applications and replies stop arriving until this is reconnected. You must be signed into live.at.agapesf@gmail.com in this browser.',
-      g.connected ? null : 'reconnect needed',
-      g.connected ? '' : `<button type="button" class="btn btn--sm set-conn__action" id="set-gmail-connect">Reconnect</button>`)
+      null,
+      g.connected ? '' : `<button type="button" class="btn btn--sm set-conn__action" id="set-gmail-connect">${g.reconnect ? 'Reconnect' : 'Connect'}</button>`)
     + conn('House calendar', !!g.connected, 'Screening invites land here.', g.connected ? null : 'follows Gmail')
     + conn('Discord', true, '#recruiting-automation · #recruiting-interviews');
 }

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -756,9 +756,10 @@ Sections borrow the product's own nav vocabulary (`You · House · Funnel · Aut
 <div class="set-auto">…</div>   <!-- label · when it last ran · switch · hint · cadence -->
 <div class="set-conn">…</div>   <!-- label · state (is-ok / is-warn / is-off) · detail
                                      state = .set-conn__dot + downstyled text (the .status
-                                     vocabulary; is-warn blinks). A dead connection puts its
-                                     one repair verb in .set-conn__action — right column,
-                                     under the state, never below the card -->
+                                     vocabulary; is-warn blinks). A dead connection swaps the
+                                     state for its one repair verb: a tinted .set-conn__action
+                                     button in the right column — the button IS the indicator,
+                                     never both, never below the card -->
 ```
 
 **Settings rules:**


### PR DESCRIPTION
## What
- A disconnected connection card no longer shows a "reconnect needed" state **and** a button — the button alone carries the state, sitting in the state's slot (right column, vertically centered) with the app's established danger tint (`rgba(168,32,13,.14)` + `--error`, same as `review__btn--notfit`).
- Label reads **Reconnect** when a dead grant is detected, **Connect** when never connected.
- Healthy cards keep the status-dot vocabulary unchanged.
- design-system/README.md pattern note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)