### PR TITLE
feat(ladder): auto-created Gmail roles resolve their posting — 0.33.0

### DIFF
--- a/supabase/functions/_shared/gmail-application-scan.ts
+++ b/supabase/functions/_shared/gmail-application-scan.ts
@@ -41,6 +41,7 @@ import {
   stageForEventType,
 } from './gmail-application-classifier.ts';
 import { roleSlug as buildRoleSlug } from './job-auth.ts';
+import { fetchJdText } from './job-fit-haiku.ts';
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 
@@ -751,11 +752,119 @@ async function maybeCreateRoleFromUnmatched(
     if (!inserted.length) return false;
 
     console.log(`[gmail-app-scan] auto-created role ${slug} from ${via} (${args.sender})${createdRows.length ? '' : ' — slug existed, event attached only'}`);
+    // Resolve the actual posting — url (when the email had none),
+    // description, location — so the grade cron can score the role
+    // instead of it sitting bare at a floor fit. Best-effort side quest.
+    if (createdRows.length) {
+      try {
+        await resolveCreatedRole(sql, slug, company, title, jobUrl);
+      } catch (e) {
+        console.warn(`[gmail-app-scan] resolve ${slug} failed: ${(e as Error).message}`);
+      }
+    }
     return true;
   } catch (e) {
     console.warn(`[gmail-app-scan] auto-create ${slug} failed: ${(e as Error).message}`);
     return false;
   }
+}
+
+// ---------- posting resolution for auto-created roles ----------
+// With a URL from the email: fetch the JD text (Workday-aware via
+// fetchJdText). Without one: probe the public ATS boards
+// (Greenhouse/Lever/Ashby) under company-derived slugs and match the
+// title — same trio every other resolver in the pipeline uses.
+async function resolveCreatedRole(
+  sql: ReturnType<typeof db>,
+  slug: string,
+  company: string,
+  title: string,
+  jobUrl: string | null,
+): Promise<void> {
+  let url = jobUrl;
+  let description: string | null = null;
+  let location: string | null = null;
+
+  if (url) {
+    description = await fetchJdText(url).catch(() => null);
+  } else if (title) {
+    const found = await findOnAtsBoards(company, title).catch(() => null);
+    if (found) ({ url, description, location } = found);
+  }
+  if (!url && !description) return;
+  if (description && description.length < 200) description = null;
+
+  await sql`
+    update job.pipeline_roles
+       set url         = coalesce(url, ${url}),
+           description = coalesce(description, ${description}),
+           location    = coalesce(location, ${location}),
+           updated_at  = now()
+     where slug = ${slug}`;
+  console.log(`[gmail-app-scan] resolved ${slug}: url=${url ? 'yes' : 'no'} desc=${description?.length ?? 0} chars`);
+}
+
+interface BoardHit { url: string; description: string | null; location: string | null }
+
+function boardSlugCandidates(name: string): string[] {
+  const base = name.toLowerCase().trim();
+  return [...new Set([
+    base.replace(/[^a-z0-9]+/g, ''),
+    base.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
+  ])].filter(Boolean);
+}
+
+function titleMatches(a: string, b: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9 ]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const na = norm(a), nb = norm(b);
+  return !!na && !!nb && (na === nb || na.includes(nb) || nb.includes(na));
+}
+
+function stripBoardHtml(html: string): string {
+  return (html || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&#\d+;/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 8000);
+}
+
+async function findOnAtsBoards(company: string, title: string): Promise<BoardHit | null> {
+  for (const slug of boardSlugCandidates(company)) {
+    // Greenhouse — list, then per-job content fetch.
+    try {
+      const r = await fetch(`https://boards-api.greenhouse.io/v1/boards/${slug}/jobs`);
+      if (r.ok) {
+        const d = await r.json() as { jobs?: Array<{ id: number; title: string; absolute_url: string; location?: { name: string } }> };
+        const hit = (d.jobs || []).find(j => titleMatches(j.title, title));
+        if (hit) {
+          let description: string | null = null;
+          try {
+            const jr = await fetch(`https://boards-api.greenhouse.io/v1/boards/${slug}/jobs/${hit.id}`);
+            if (jr.ok) description = stripBoardHtml(((await jr.json()) as { content?: string }).content || '');
+          } catch { /* listing hit is still useful */ }
+          return { url: hit.absolute_url, description, location: hit.location?.name ?? null };
+        }
+      }
+    } catch { /* next provider */ }
+    // Lever — postings include the plain description inline.
+    try {
+      const r = await fetch(`https://api.lever.co/v0/postings/${slug}?mode=json`);
+      if (r.ok) {
+        const d = await r.json() as Array<{ text: string; hostedUrl: string; descriptionPlain?: string; categories?: { location?: string } }>;
+        const hit = (Array.isArray(d) ? d : []).find(j => titleMatches(j.text, title));
+        if (hit) return { url: hit.hostedUrl, description: (hit.descriptionPlain || '').slice(0, 8000) || null, location: hit.categories?.location ?? null };
+      }
+    } catch { /* next provider */ }
+    // Ashby — board payload carries descriptionPlain.
+    try {
+      const r = await fetch(`https://api.ashbyhq.com/posting-api/job-board/${slug}?includeCompensation=true`);
+      if (r.ok) {
+        const d = await r.json() as { jobs?: Array<{ title: string; jobUrl: string; descriptionPlain?: string; locationName?: string }> };
+        const hit = (d.jobs || []).find(j => titleMatches(j.title, title));
+        if (hit) return { url: hit.jobUrl, description: (hit.descriptionPlain || '').slice(0, 8000) || null, location: hit.locationName ?? null };
+      }
+    } catch { /* next candidate */ }
+  }
+  return null;
 }
 
 // Rejection → exit_reason mapping for the auto-archive. Where in the

--- a/supabase/functions/_shared/job-fit-haiku.ts
+++ b/supabase/functions/_shared/job-fit-haiku.ts
@@ -89,7 +89,38 @@ export async function loadFitContext(sql: any): Promise<FitUserContext> {
   return ctx;
 }
 
+// Workday postings are fully JS-rendered — a plain fetch returns an empty
+// shell. Their CXS API serves the JD as JSON: parse
+// https://<tenant>.wd<N>.myworkdayjobs.com/[<locale>/]<site>/job/[<loc>/]<Req>
+// into /wday/cxs/<tenant>/<site>/job/<Req>.
+async function fetchWorkdayJdText(url: URL): Promise<string | null> {
+  const tenant = url.hostname.split('.')[0];
+  const seg = url.pathname.split('/').filter(Boolean);
+  const jobIdx = seg.indexOf('job');
+  if (jobIdx < 1 || jobIdx === seg.length - 1) return null;
+  // Site = segment before 'job', skipping a leading locale like en-US.
+  const site = seg[jobIdx - 1];
+  const req  = seg[seg.length - 1];
+  const cxs = `https://${url.hostname}/wday/cxs/${tenant}/${site}/job/${encodeURIComponent(req)}`;
+  const r = await fetch(cxs, { headers: { accept: 'application/json' } });
+  if (!r.ok) return null;
+  const data = await r.json() as { jobPostingInfo?: { jobDescription?: string } };
+  const html = data.jobPostingInfo?.jobDescription || '';
+  if (!html) return null;
+  return html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&#\d+;/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 8000) || null;
+}
+
 export async function fetchJdText(url: string): Promise<string> {
+  try {
+    const u = new URL(url);
+    if (/\.myworkdayjobs\.com$/i.test(u.hostname)) {
+      const wd = await fetchWorkdayJdText(u).catch(() => null);
+      if (wd) return wd;
+    }
+  } catch { /* fall through to the generic path */ }
   const resp = await fetch(url, {
     redirect: 'follow',
     headers: {

--- a/supabase/functions/application-events/index.ts
+++ b/supabase/functions/application-events/index.ts
@@ -51,8 +51,8 @@ import { ensureAndApplyLabel } from '../_shared/gmail.ts';
 
 const LADDER_LABEL = 'Ladder';
 
-const VERSION = '1.9.4';
-console.log(`[application-events] v${VERSION} - engaged-message informational fallthrough to opportunity extractor in shared scan`);
+const VERSION = '1.10.0';
+console.log(`[application-events] v${VERSION} - shared scan resolves auto-created roles (posting url + JD + location)`);
 
 const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me';
 const USER_EMAIL_LC = 'fike101@gmail.com';

--- a/supabase/functions/pull-recommendations/index.ts
+++ b/supabase/functions/pull-recommendations/index.ts
@@ -24,8 +24,8 @@ import { extractCompensation, compClears } from '../_shared/comp.ts';
 import { corsHeaders } from '../_shared/job-auth.ts';
 import { loadVisionStringArray, loadVisionField } from '../_shared/job-vision.ts';
 
-const VERSION = '0.32.0';
-console.log(`[pull-recommendations] v${VERSION} - company-watch gains workable/smartrecruiters/rippling adapters (job-radar registry watches)`);
+const VERSION = '0.33.0';
+console.log(`[pull-recommendations] v${VERSION} - auto-created roles resolve their posting (email url -> JD fetch, else GH/Lever/Ashby board title match); Workday CXS-aware fetchJdText`);
 
 const ANTHROPIC_MODEL = 'claude-haiku-4-5';
 const ANTHROPIC_URL   = 'https://api.anthropic.com/v1/messages';


### PR DESCRIPTION
Follow-up to the SCAN saga: when the Gmail scan creates a role from an email (receipt or engaged thread), it now **resolves the posting** instead of leaving the role bare:

- Email had a posting URL → fetch the JD text and stamp description
- No URL → probe Greenhouse/Lever/Ashby boards under company-derived slugs, match the title → url + description + location
- `fetchJdText` is now **Workday-aware**: `myworkdayjobs.com` URLs go through the CXS JSON API (the HTML page is a JS shell that yields 0 chars — exactly why SCAN's description backfill failed). This also fixes `backfillDescriptions` for Workday rows.

Resolution is fenced and best-effort — a failed fetch costs nothing. Once the description lands, the existing 10-min grade cron scores the role (credits are back).

pull-recommendations 0.33.0 · application-events 1.10.0 · no migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)