### PR TITLE
style(recruiting): center connection-card right column, drop 'follows Gmail' — v3.70.1

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1768,8 +1768,10 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 }
 .set-conn__label { grid-column: 1; grid-row: 1; font-size: var(--font-size-small); font-weight: var(--fw-semibold); }
 .set-conn__detail { grid-column: 1; grid-row: 2; color: var(--fg-subtle); font-size: var(--font-size-caption); overflow-wrap: anywhere; }
+/* Whatever sits in the right column — state or repair button — centers on
+   the card's full height, not the first text line. */
 .set-conn__state {
-  grid-column: 2; grid-row: 1; justify-self: end;
+  grid-column: 2; grid-row: 1 / span 2; justify-self: end; align-self: center;
   display: inline-flex; align-items: center; gap: var(--space-2);
   font-size: var(--font-size-caption); font-weight: var(--fw-semibold);
 }
@@ -1798,7 +1800,7 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   .set-field, .set-auto, .set-conn { grid-template-columns: 1fr; }
   .set-field__control { grid-column: 1; grid-row: 3; justify-self: start; margin-top: 6px; }
   .set-auto__when, .set-auto__cadence, .set-conn__state { grid-column: 1; text-align: left; }
-  .set-conn__state { justify-self: start; }
+  .set-conn__state { justify-self: start; grid-row: auto; align-self: start; }
   .set-conn__action { grid-column: 1; grid-row: auto; justify-self: start; margin-top: 6px; align-self: start; }
 }
 

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.70.0">
+  <link rel="stylesheet" href="css/app.css?v=3.70.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -336,7 +336,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="js/app.js?v=3.70.0"></script>
+  <script src="js/app.js?v=3.70.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.70.0';
+const VERSION = '3.70.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1699,7 +1699,7 @@ function settingsConnectionsHtml() {
   // IS the indicator, never both.
   const conn = (label, ok, detail, warn, action, dim) => `<div class="set-conn${dim ? ' is-dim' : ''}">
     <span class="set-conn__label">${esc(label)}</span>
-    ${action || `<span class="set-conn__state ${ok ? 'is-ok' : (warn && !dim ? 'is-warn' : 'is-off')}"><span class="set-conn__dot" aria-hidden="true"></span>${ok ? 'connected' : esc(warn || 'not connected')}</span>`}
+    ${action || (dim ? '' : `<span class="set-conn__state ${ok ? 'is-ok' : (warn ? 'is-warn' : 'is-off')}"><span class="set-conn__dot" aria-hidden="true"></span>${ok ? 'connected' : esc(warn || 'not connected')}</span>`)}
     ${detail ? `<span class="set-conn__detail">${esc(detail)}</span>` : ''}
   </div>`;
   return conn('Shared Gmail', !!g.connected, g.connected
@@ -1708,11 +1708,11 @@ function settingsConnectionsHtml() {
       null,
       g.connected ? '' : `<button type="button" class="btn btn--sm set-conn__action" id="set-gmail-connect">${g.reconnect ? 'Reconnect' : 'Connect'}</button>`)
     // Same rule as the button card, different clothes: no second red flag.
-    // A calendar with nothing to click dims whole — the quiet card is the
-    // state — and says when it comes back.
+    // A calendar with nothing to click dims whole and drops its state text
+    // entirely — the quiet card is the state, the detail says when it wakes.
     + conn('House calendar', !!g.connected,
         g.connected ? 'Screening invites land here.' : 'Wakes back up when Gmail reconnects.',
-        g.connected ? null : 'follows Gmail', '', !g.connected)
+        null, '', !g.connected)
     + conn('Discord', true, '#recruiting-automation · #recruiting-interviews');
 }
 


### PR DESCRIPTION
## What
- The right-column element (status or Reconnect button) now spans both card rows and centers vertically on the card, instead of hugging the label line.
- The dimmed House calendar follower card drops its "follows Gmail" state text entirely — the dim treatment plus "Wakes back up when Gmail reconnects." carry the state.
- Mobile fallback resets the span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)