### PR TITLE
feat(design-system): date picker + date-field context audit — v1.0.0 / app v3.71.0

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.70.1">
+  <link rel="stylesheet" href="css/app.css?v=3.71.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -336,7 +336,8 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="js/app.js?v=3.70.1"></script>
+  <script src="../design-system/datepicker.js?v=1.0.0"></script>
+  <script src="js/app.js?v=3.71.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.70.1';
+const VERSION = '3.71.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -4216,7 +4216,8 @@ function listingForm(l) {
         <input type="date" name="starts_on" class="listing-status" value="${l.starts_on || ''}" required>
       </label>
       <label class="listing-form__field">Sublet ends
-        <input type="date" name="ends_on" class="listing-status" value="${l.ends_on || ''}">
+        <input type="date" name="ends_on" class="listing-status" value="${l.ends_on || ''}"
+          min="${l.starts_on || ''}" ${l.kind === 'resident' ? 'disabled title="Resident trials have no sublet end date"' : ''}>
       </label>
       <label class="listing-form__field">Rent / mo
         <input type="number" name="rent_monthly" class="listing-status" min="0" max="10000" step="5" value="${l.rent_monthly ?? ''}" placeholder="1490">
@@ -4653,7 +4654,9 @@ function moveInFactHtml(a, miNorm) {
     return `<span class="movein-set movein-set--form">
       <input type="date" class="listing-status movein-set__input" id="movein-from" value="${esc(a.moveinFrom || '')}" aria-label="Confirmed move-in">
       <span class="movein-set__sep">→</span>
-      <input type="date" class="listing-status movein-set__input" id="movein-to" value="${esc(a.moveinTo || '')}" aria-label="Through (optional)" title="Through — leave empty for open-ended">
+      <input type="date" class="listing-status movein-set__input" id="movein-to" value="${esc(a.moveinTo || '')}"
+        min="${esc(a.moveinFrom || '')}" ${a.moveinFrom ? '' : 'disabled'}
+        aria-label="Through (optional)" title="Through — leave empty for open-ended. Wakes up once move-in is set.">
       <button type="button" class="btn btn--sm btn--accent" data-movein-save>Save</button>
       ${a.moveinFrom ? `<button type="button" class="btn btn--sm" data-movein-clear>Clear</button>` : ''}
       <button type="button" class="hold-sheet__cancel movein-set__cancel" data-movein-cancel>Cancel</button>
@@ -6389,6 +6392,26 @@ function init() {
   document.addEventListener('change', e => {
     const sel = e.target.closest('[data-listing-status]');
     if (sel) updateListingStatus(sel.dataset.listingStatus, sel.value);
+    // Field-context guardrails, wherever the form came from:
+    // an end date can't precede its start…
+    if (e.target.name === 'starts_on') {
+      const ends = e.target.closest('form')?.querySelector('input[name="ends_on"]');
+      if (ends) ends.min = e.target.value || '';
+    }
+    // "Through" sleeps until a move-in exists to measure it from.
+    if (e.target.id === 'movein-from') {
+      const to = document.getElementById('movein-to');
+      if (to) { to.disabled = !e.target.value; to.min = e.target.value || ''; if (to.disabled) to.value = ''; }
+    }
+    // …and a resident trial has no sublet end — the field sleeps until the
+    // listing is a sublet again.
+    if (e.target.matches('[data-listing-form] select[name="kind"]')) {
+      const ends = e.target.closest('form').querySelector('input[name="ends_on"]');
+      if (ends) {
+        ends.disabled = e.target.value === 'resident';
+        if (ends.disabled) ends.value = '';
+      }
+    }
     const cost = e.target.closest('[data-cost-setting]');
     if (cost) {
       const key = cost.dataset.costSetting;

--- a/design-system/CHANGELOG.md
+++ b/design-system/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ---
 
+## [1.6.0] - 2026-08-06
+
+### Added
+- **Date picker (`datepicker.js` v1.0.0)** — self-attaching calendar dropdown for every `input[type=date]`/`datetime-local`. Typed entry stays first-class; popover on desktop, bottom sheet on mobile; respects `min`/`max`; opt out with `data-no-picker`.
+
+### Changed
+- **Field-context rule** — a date field whose meaning depends on another answer is disabled (not hidden) until that answer exists, with a `title` naming what wakes it; end dates chain `min` to their start.
+
+---
+
 ## [1.5.0] - 2026-07-30
 
 ### Added

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -306,6 +306,39 @@ Form-like display sections for account information.
 </div>
 ```
 
+### Date Picker (`datepicker.js`)
+
+A self-contained calendar dropdown for every date field. Include the script and
+it attaches itself — no markup, no init call:
+
+```html
+<script src="/design-system/datepicker.js?v=1.0.0"></script>
+```
+
+- Targets every `input[type="date"]` and `input[type="datetime-local"]`; opt a
+  field out with `data-no-picker`.
+- **Typing stays first-class** — the input is never readonly, the calendar
+  follows what's typed, and picking a day dispatches real `input` + `change`
+  events so autosave forms hear it.
+- Desktop: popover anchored under the field (flips above when cramped).
+  Mobile (coarse pointer or ≤520px): bottom sheet + backdrop, native wheel
+  suppressed — one picker, never two.
+- Respects the input's `min`/`max`. Month + year are selects (no 40-click
+  scrubbing to a birth year). Footer: **Today**, and **Clear** unless the
+  field is `required`. Esc closes.
+- `datetime-local`: the calendar owns the date half, the typed time is left
+  alone (defaults 12:00).
+- Classes (all injected, themed by app tokens with dark fallbacks): `dp`,
+  `dp--sheet`, `dp-back`, `dp__head`, `dp__nav`, `dp__sel`, `dp__grid`,
+  `dp__dow`, `dp__day` (`is-today`, `is-selected`), `dp__foot`, `dp__quiet`.
+
+**Field-context rule that travels with it:** a date field whose meaning depends
+on another answer is **disabled until that answer exists** (never hidden —
+same rule as locked settings), with a `title` saying what wakes it. An end
+date's `min` follows its start. Examples in recruiting: "Sublet ends" sleeps
+while a listing is a resident trial; move-in "Through" sleeps until move-in
+is set; a stay's "Through" sleeps while "Ongoing" is checked.
+
 ### Progress Bar
 
 ```html

--- a/design-system/datepicker.js
+++ b/design-system/datepicker.js
@@ -1,0 +1,215 @@
+/* Sassy date picker — a calendar dropdown for every date field.
+   Self-contained: include the script and every input[type=date] and
+   input[type=datetime-local] on the page gets a themed calendar on focus.
+   Typing stays first-class — the input is never readonly, the calendar
+   follows what you type, and picking a day writes back through normal
+   'input' + 'change' events so autosave forms hear it.
+
+   Desktop: popover anchored under the field (flips above when cramped).
+   Mobile (coarse pointer or ≤520px): bottom sheet with a backdrop; the
+   native wheel is suppressed so there is one picker, not two.
+
+   Respects min/max on the input. For datetime-local the calendar owns the
+   date half and leaves the typed time alone (defaults 12:00).
+   Opt out per field with data-no-picker. */
+
+(() => {
+  const VERSION = '1.0.0';
+  console.log(`[datepicker] v${VERSION} - Sassy calendar dropdown`);
+
+  const SEL = 'input[type="date"]:not([data-no-picker]), input[type="datetime-local"]:not([data-no-picker])';
+  const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'];
+  const DOW = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+  const coarse = matchMedia('(pointer: coarse)');
+  const narrow = matchMedia('(max-width: 520px)');
+  const sheetMode = () => coarse.matches || narrow.matches;
+
+  const pad = (n) => String(n).padStart(2, '0');
+  const iso = (y, m, d) => `${y}-${pad(m + 1)}-${pad(d)}`;
+  const parseIso = (s) => {
+    const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s || '');
+    return m ? { y: +m[1], mo: +m[2] - 1, d: +m[3] } : null;
+  };
+
+  let pop = null, back = null, anchor = null, vy = 0, vm = 0;
+
+  const STYLE = `
+  .dp { position: absolute; z-index: 1200; min-width: 252px; padding: var(--space-3, 12px);
+    background: var(--bg-elevated, #1f2630); border: 1px solid var(--border, rgba(240,246,252,0.12));
+    border-radius: var(--radius-md, 10px); box-shadow: var(--shadow-md, 0 8px 24px rgba(0,0,0,0.35)); }
+  .dp--sheet { position: fixed; left: 0; right: 0; bottom: 0; min-width: 0;
+    border-radius: var(--radius-md, 10px) var(--radius-md, 10px) 0 0; border-bottom: 0;
+    padding-bottom: max(var(--space-3, 12px), env(safe-area-inset-bottom)); }
+  .dp-back { position: fixed; inset: 0; z-index: 1199; background: rgba(0,0,0,0.4); }
+  .dp__head { display: flex; align-items: center; gap: var(--space-2, 8px); margin-bottom: var(--space-2, 8px); }
+  .dp__nav { flex: none; width: 28px; height: 28px; border: 0; border-radius: var(--radius-sm, 6px);
+    background: transparent; color: var(--fg-muted, #b9c0c9); font-size: 14px; cursor: pointer; }
+  .dp__nav:hover { background: var(--bg-overlay, rgba(255,255,255,0.06)); color: var(--fg, #f0f6fc); }
+  .dp__sel { flex: 1; display: flex; gap: var(--space-1, 4px); justify-content: center; }
+  .dp__sel select { border: 0; background: transparent; color: var(--fg, #f0f6fc);
+    font: inherit; font-size: var(--font-size-small, 13px); font-weight: var(--fw-semibold, 600);
+    text-align: center; cursor: pointer; border-radius: var(--radius-sm, 6px); padding: 2px 2px; }
+  .dp__sel select:hover { background: var(--bg-overlay, rgba(255,255,255,0.06)); }
+  .dp__grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+  .dp__dow { text-align: center; padding: 2px 0; color: var(--fg-subtle, rgba(240,246,252,0.5));
+    font-size: var(--font-size-caption, 11px); font-weight: var(--fw-semibold, 600); }
+  .dp__day { aspect-ratio: 1; min-width: 30px; border: 0; border-radius: var(--radius-sm, 6px);
+    background: transparent; color: var(--fg, #f0f6fc); font-size: var(--font-size-small, 13px);
+    cursor: pointer; font-variant-numeric: tabular-nums; }
+  .dp--sheet .dp__day { min-height: 42px; }
+  .dp__day:hover { background: var(--bg-overlay, rgba(255,255,255,0.06)); }
+  .dp__day.is-today { box-shadow: inset 0 0 0 1px var(--border-strong, rgba(240,246,252,0.28)); }
+  .dp__day.is-selected { background: var(--accent-strong, #5CB2FF); color: var(--accent-strong-fg, #06264D); font-weight: var(--fw-semibold, 600); }
+  .dp__day:disabled { color: var(--fg-subtle, rgba(240,246,252,0.5)); opacity: 0.4; cursor: default; background: transparent; }
+  .dp__blank { pointer-events: none; }
+  .dp__foot { display: flex; justify-content: space-between; margin-top: var(--space-2, 8px); }
+  .dp__quiet { border: 0; background: transparent; color: var(--fg-link, #5CB2FF);
+    font-size: var(--font-size-caption, 11px); cursor: pointer; padding: 4px 6px; border-radius: var(--radius-sm, 6px); }
+  .dp__quiet:hover { background: var(--bg-overlay, rgba(255,255,255,0.06)); }
+  input[type="date"]::-webkit-calendar-picker-indicator,
+  input[type="datetime-local"]::-webkit-calendar-picker-indicator { display: none; }
+  `;
+
+  function ensureBuilt() {
+    if (pop) return;
+    const st = document.createElement('style');
+    st.textContent = STYLE;
+    document.head.appendChild(st);
+    pop = document.createElement('div');
+    pop.className = 'dp';
+    pop.hidden = true;
+    // Keep focus (and the caret) in the input while clicking around the
+    // calendar — click handlers still fire, blur never does.
+    pop.addEventListener('mousedown', (e) => e.preventDefault());
+    document.body.appendChild(pop);
+    back = document.createElement('div');
+    back.className = 'dp-back';
+    back.hidden = true;
+    back.addEventListener('click', close);
+    document.body.appendChild(back);
+  }
+
+  function limits() {
+    return { min: parseIso(anchor.getAttribute('min')), max: parseIso(anchor.getAttribute('max')) };
+  }
+  const before = (y, m, d, l) => l && (y < l.y || (y === l.y && (m < l.mo || (m === l.mo && d < l.d))));
+  const after = (y, m, d, l) => l && (y > l.y || (y === l.y && (m > l.mo || (m === l.mo && d > l.d))));
+
+  function render() {
+    const sel = parseIso(anchor.value);
+    const t = new Date();
+    const { min, max } = limits();
+    const first = new Date(vy, vm, 1).getDay();
+    const days = new Date(vy, vm + 1, 0).getDate();
+    const years = [];
+    const y0 = Math.min(vy, t.getFullYear()) - 5, y1 = Math.max(vy, t.getFullYear()) + 6;
+    for (let y = y0; y <= y1; y++) years.push(y);
+    let cells = DOW.map((d) => `<span class="dp__dow">${d}</span>`).join('');
+    for (let i = 0; i < first; i++) cells += '<span class="dp__day dp__blank"></span>';
+    for (let d = 1; d <= days; d++) {
+      const isSel = sel && sel.y === vy && sel.mo === vm && sel.d === d;
+      const isToday = t.getFullYear() === vy && t.getMonth() === vm && t.getDate() === d;
+      const dis = before(vy, vm, d, min) || after(vy, vm, d, max);
+      cells += `<button type="button" class="dp__day${isSel ? ' is-selected' : ''}${isToday ? ' is-today' : ''}"
+        data-day="${d}" ${dis ? 'disabled' : ''}>${d}</button>`;
+    }
+    pop.innerHTML = `
+      <div class="dp__head">
+        <button type="button" class="dp__nav" data-nav="-1" aria-label="Previous month">‹</button>
+        <span class="dp__sel">
+          <select data-month aria-label="Month">${MONTHS.map((m, i) =>
+            `<option value="${i}" ${i === vm ? 'selected' : ''}>${m}</option>`).join('')}</select>
+          <select data-year aria-label="Year">${years.map((y) =>
+            `<option value="${y}" ${y === vy ? 'selected' : ''}>${y}</option>`).join('')}</select>
+        </span>
+        <button type="button" class="dp__nav" data-nav="1" aria-label="Next month">›</button>
+      </div>
+      <div class="dp__grid">${cells}</div>
+      <div class="dp__foot">
+        <button type="button" class="dp__quiet" data-today>Today</button>
+        ${anchor.required ? '' : '<button type="button" class="dp__quiet" data-clear>Clear</button>'}
+      </div>`;
+  }
+
+  function position() {
+    pop.classList.toggle('dp--sheet', sheetMode());
+    back.hidden = !sheetMode();
+    if (sheetMode()) { pop.style.left = pop.style.top = ''; return; }
+    const r = anchor.getBoundingClientRect();
+    const h = pop.offsetHeight || 300;
+    const below = r.bottom + 4 + h < innerHeight;
+    pop.style.left = `${Math.max(8, Math.min(r.left + scrollX, scrollX + innerWidth - pop.offsetWidth - 8))}px`;
+    pop.style.top = `${(below ? r.bottom + 4 : r.top - h - 4) + scrollY}px`;
+  }
+
+  function open(el) {
+    ensureBuilt();
+    anchor = el;
+    const cur = parseIso(el.value);
+    const now = new Date();
+    vy = cur ? cur.y : now.getFullYear();
+    vm = cur ? cur.mo : now.getMonth();
+    pop.hidden = false;
+    render();
+    position();
+  }
+
+  function close() {
+    if (!pop || pop.hidden) return;
+    pop.hidden = true;
+    back.hidden = true;
+    anchor = null;
+  }
+
+  function write(val) {
+    if (anchor.type === 'datetime-local') {
+      const time = /T(\d{2}:\d{2})/.exec(anchor.value || '');
+      val = val ? `${val}T${time ? time[1] : '12:00'}` : '';
+    }
+    anchor.value = val;
+    anchor.dispatchEvent(new Event('input', { bubbles: true }));
+    anchor.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  document.addEventListener('focusin', (e) => {
+    if (e.target.matches?.(SEL)) { if (anchor !== e.target) open(e.target); }
+    else if (pop && !pop.hidden && !pop.contains(e.target)) close();
+  });
+  // Coarse pointers: one picker, not the native wheel underneath ours.
+  document.addEventListener('touchend', (e) => {
+    const el = e.target.closest?.(SEL);
+    if (el && sheetMode()) { e.preventDefault(); open(el); }
+  }, { passive: false });
+  document.addEventListener('mousedown', (e) => {
+    if (pop && !pop.hidden && !pop.contains(e.target) && e.target !== anchor && e.target !== back) close();
+  });
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+  document.addEventListener('input', (e) => {
+    if (e.target === anchor) {
+      const cur = parseIso(anchor.value);
+      if (cur) { vy = cur.y; vm = cur.mo; }
+      render();
+    }
+  });
+  addEventListener('resize', () => { if (anchor) position(); });
+  addEventListener('scroll', () => { if (anchor && !sheetMode()) position(); }, true);
+
+  document.addEventListener('click', (e) => {
+    if (!pop || pop.hidden || !pop.contains(e.target)) return;
+    const day = e.target.closest('[data-day]');
+    const nav = e.target.closest('[data-nav]');
+    if (day) { write(iso(vy, vm, +day.dataset.day)); if (anchor.type === 'date') close(); else render(); }
+    else if (nav) { vm += +nav.dataset.nav; if (vm < 0) { vm = 11; vy--; } if (vm > 11) { vm = 0; vy++; } render(); }
+    else if (e.target.closest('[data-today]')) {
+      const t = new Date(); vy = t.getFullYear(); vm = t.getMonth();
+      write(iso(vy, vm, t.getDate())); if (anchor.type === 'date') close(); else render();
+    }
+    else if (e.target.closest('[data-clear]')) { write(''); close(); }
+  });
+  document.addEventListener('change', (e) => {
+    if (!pop || pop.hidden || !pop.contains(e.target)) return;
+    if (e.target.matches('[data-month]')) { vm = +e.target.value; render(); }
+    if (e.target.matches('[data-year]')) { vy = +e.target.value; render(); }
+  });
+})();


### PR DESCRIPTION
## What
**`design-system/datepicker.js` v1.0.0** — self-attaching Sassy calendar dropdown for every `input[type=date]` / `datetime-local` (opt out: `data-no-picker`).
- Typing stays first-class: input never readonly, calendar follows typed value, picks dispatch real `input`+`change` so autosave forms hear it.
- Desktop: anchored popover (flips above when cramped). Mobile (coarse pointer or ≤520px): bottom sheet + backdrop, native wheel suppressed.
- Respects `min`/`max`; month+year selects; Today / Clear (hidden when `required`); Esc closes; `datetime-local` keeps the typed time.
- Documented in design-system README + CHANGELOG (Sassy 1.6.0).

**Field-context audit (app v3.71.0)** — rule: a date field that depends on another answer is disabled (not hidden) until that answer exists, with a title naming what wakes it:
- "Sublet ends" sleeps while a listing's Type is Resident trial (live-toggles on Type change; clears on disable).
- Move-in "Through" sleeps until "from" is set; `min` chains to it.
- All `ends_on` fields chain `min` to their form's `starts_on`.
- Already-correct gates verified: Remove-sheet "Bring them back on" only appears for saved-for-future; stay "Through" ↔ Ongoing checkbox; trial milestones hidden unless candidate stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)