### PR TITLE
fix(design-system): datepicker styles inject at load — v1.0.1

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -336,7 +336,7 @@
   </div>
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
-  <script src="../design-system/datepicker.js?v=1.0.0"></script>
+  <script src="../design-system/datepicker.js?v=1.0.1"></script>
   <script src="js/app.js?v=3.71.0"></script>
 
 </body>

--- a/design-system/datepicker.js
+++ b/design-system/datepicker.js
@@ -14,7 +14,7 @@
    Opt out per field with data-no-picker. */
 
 (() => {
-  const VERSION = '1.0.0';
+  const VERSION = '1.0.1';
   console.log(`[datepicker] v${VERSION} - Sassy calendar dropdown`);
 
   const SEL = 'input[type="date"]:not([data-no-picker]), input[type="datetime-local"]:not([data-no-picker])';
@@ -71,11 +71,14 @@
   input[type="datetime-local"]::-webkit-calendar-picker-indicator { display: none; }
   `;
 
+  // Styles land at load — the native calendar icons must be gone before the
+  // first field is ever seen, not after the first open.
+  const st = document.createElement('style');
+  st.textContent = STYLE;
+  (document.head || document.documentElement).appendChild(st);
+
   function ensureBuilt() {
     if (pop) return;
-    const st = document.createElement('style');
-    st.textContent = STYLE;
-    document.head.appendChild(st);
     pop = document.createElement('div');
     pop.className = 'dp';
     pop.hidden = true;


### PR DESCRIPTION
Native calendar-icon hiding (and all dp styles) now land at script load instead of first open, so fields never flash the browser's own icon. Cache-buster bumped in applications/index.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)