### PR TITLE
style(recruiting): reduce corner radius on non-interactive surfaces — v3.71.1

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -82,8 +82,11 @@
   --fw-bold: 700;
   --radius-xs: 6px;
   --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
+  /* md/lg belong to non-interactive surfaces (cards, banners, modals) —
+     kept tighter than the interactive vocabulary (sm/pill), which is why
+     buttons and inputs never borrow them. */
+  --radius-md: 8px;
+  --radius-lg: 12px;
   --radius-pill: 999px;
   --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px;
   --space-5: 20px; --space-6: 24px; --space-7: 32px; --space-8: 40px;
@@ -1813,7 +1816,8 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
 .step-choice {
   display: grid; grid-template-columns: 1fr auto; gap: 4px var(--space-3);
   width: 100%; padding: var(--space-4);
-  background: var(--bg-surface); border: 0; border-radius: var(--radius-md);
+  /* A tile is interactive — it speaks the button radius, not the card one. */
+  background: var(--bg-surface); border: 0; border-radius: var(--radius-sm);
   color: var(--fg); text-align: left;
   transition: background 80ms ease;
 }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.71.0">
+  <link rel="stylesheet" href="css/app.css?v=3.71.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -337,7 +337,7 @@
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
   <script src="../design-system/datepicker.js?v=1.0.1"></script>
-  <script src="js/app.js?v=3.71.0"></script>
+  <script src="js/app.js?v=3.71.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.71.0';
+const VERSION = '3.71.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,


### PR DESCRIPTION
--radius-md 12→8px, --radius-lg 16→12px — both tokens are used only by non-interactive surfaces (cards, banners, trays, modals), so the reduction lands only there. Buttons/chips/inputs untouched; the .step-choice tile pins to --radius-sm (unchanged 8px) to stay in the interactive vocabulary. Datepicker popover follows automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)