### PR TITLE
feat(ladder): nav restructure — Saved top-level, Jobs → In progress — v2.42.0

### DIFF
--- a/ladder/chat/index.html
+++ b/ladder/chat/index.html
@@ -6,8 +6,8 @@
   <title>Chat — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>

--- a/ladder/css/base.css
+++ b/ladder/css/base.css
@@ -5,7 +5,7 @@
 @import url("./tokens-generic-dark.css?v=1.9.0");
 @import url("./tokens-ctrl-light.css?v=1.9.0");
 @import url("./tokens-ctrl-dark.css?v=1.9.0");
-@import url("./components.css?v=2.41.0");
+@import url("./components.css?v=2.42.0");
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@500;600;700&display=swap");
 

--- a/ladder/history/drill/index.html
+++ b/ladder/history/drill/index.html
@@ -6,8 +6,8 @@
   <title>History — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
 
 
 
@@ -33,7 +33,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 
 
 

--- a/ladder/history/index.html
+++ b/ladder/history/index.html
@@ -6,8 +6,8 @@
   <title>Profile — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
 
 
 
@@ -36,7 +36,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 
 
 

--- a/ladder/index.html
+++ b/ladder/index.html
@@ -9,8 +9,8 @@
   <title>/ladder — ctrl.rodeo</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
 
 
 
@@ -82,7 +82,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 
 
 

--- a/ladder/jobs/drill/index.html
+++ b/ladder/jobs/drill/index.html
@@ -7,9 +7,9 @@
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
 
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
   <link rel="stylesheet" href="/ladder/css/apply.css?v=0.6.1">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
 
 
 
@@ -34,7 +34,7 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 
 
 

--- a/ladder/jobs/index.html
+++ b/ladder/jobs/index.html
@@ -6,8 +6,8 @@
   <title>Jobs — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -32,6 +32,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>

--- a/ladder/jobs/recommended/index.html
+++ b/ladder/jobs/recommended/index.html
@@ -6,8 +6,8 @@
   <title>Inbox — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -29,6 +29,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>

--- a/ladder/js/app.js
+++ b/ladder/js/app.js
@@ -2,8 +2,8 @@
 // Bump VERSION on every PR that touches /ladder/js. The HTML loads this file
 // with ?v=VERSION to bypass the 10-min Pages cache, and we append the same
 // query to dynamic imports so the component graph stays consistent.
-const VERSION = "2.41.0";
-console.log(`[ladder] v${VERSION} - ATS boards (job-radar) source + two-track grading (production soft goods vs digital)`);
+const VERSION = "2.42.0";
+console.log(`[ladder] v${VERSION} - nav restructure: Saved top-level; Jobs group renamed In progress (stages + Archive)`);
 window.LADDER_VERSION = `v${VERSION}`;
 const V = `?v=${VERSION}`;
 
@@ -172,12 +172,14 @@ function injectMobileBar() {
 const DRAWER_ITEMS = [
   { href: '/ladder/jobs/recommended/', label: 'Inbox',       countKey: 'recommended', match: /^\/ladder\/jobs\/recommended\/?/,
     icon: '<path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/>' },
-  { href: '/ladder/jobs/',             label: 'Jobs',        match: /^\/ladder\/jobs(?!\/recommended)\/?/,
+  { href: '/ladder/jobs/?bucket=saved', label: 'Saved',      match: /^\/ladder\/jobs(?!\/recommended)\/?/, buckets: ['saved'], countKey: 'saved',
+    icon: '<path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/>' },
+  { href: '/ladder/jobs/?bucket=applied', label: 'In progress', match: /^\/ladder\/jobs(?!\/recommended)\/?/,
+    buckets: ['drafting', 'applied', 'interviewing', 'offer', 'archive'], countKey: 'inprogress',
     icon: '<rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>',
-    // Six pipeline buckets as first-class sub-items (primary nav, no in-page
-    // sub-nav bar). Keep in sync with the Jobs `sub` in components/ladder-rail.js.
+    // Live stages + Archive as first-class sub-items (primary nav, no in-page
+    // sub-nav bar). Keep in sync with the In progress `sub` in components/ladder-rail.js.
     sub: [
-      { href: '/ladder/jobs/?bucket=saved',        label: 'Saved',        bucket: 'saved',        countKey: 'saved' },
       { href: '/ladder/jobs/?bucket=drafting',     label: 'Drafting',     bucket: 'drafting',     countKey: 'drafting' },
       { href: '/ladder/jobs/?bucket=applied',      label: 'Applied',      bucket: 'applied',      countKey: 'applied' },
       { href: '/ladder/jobs/?bucket=interviewing', label: 'Interviewing', bucket: 'interviewing', countKey: 'interviewing' },
@@ -207,7 +209,6 @@ function injectNavDrawer() {
       </a>
       <ul class="nav-drawer__list">
         ${DRAWER_ITEMS.map(i => {
-          const parentActive = i.match.test(here);
           // Normalize the current ?bucket= so legacy links still highlight
           // the right sub-item (leads→saved, active→drafting).
           const curBucket = (() => {
@@ -216,6 +217,9 @@ function injectNavDrawer() {
             if (b === 'active') return 'drafting';
             return b;
           })();
+          // Entries sharing the /jobs path (Saved, In progress)
+          // disambiguate on the current bucket.
+          const parentActive = i.match.test(here) && (!i.buckets || i.buckets.includes(curBucket));
           const sub = (parentActive && i.sub) ? `
             <ul class="nav-drawer__sublist">
               ${i.sub.map(s => `

--- a/ladder/js/components/ladder-pipeline.js
+++ b/ladder/js/components/ladder-pipeline.js
@@ -173,6 +173,7 @@ export class JobPipeline extends LitElement {
       history.replaceState(null, '', `${location.pathname}?${qs}`);
     }
     document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: this.bucket } }));
+    this._syncHeader();
     this.openMenuSlug = null;
     this.livenessChecking = false;
     this.livenessResult = null;            // { checked, closed: [slug…] }
@@ -242,9 +243,25 @@ export class JobPipeline extends LitElement {
       if (b !== this.bucket) {
         this.bucket = b;
         document.dispatchEvent(new CustomEvent('job:jobs:bucket', { detail: { bucket: b } }));
+        this._syncHeader();
       }
     };
     window.addEventListener('popstate', this._onPopState);
+  }
+
+  // Keep the static page h1 (and the browser tab) in step with the nav
+  // taxonomy: Saved and In progress are separate top-level entries, so
+  // the page can't sit under a single "Jobs" heading anymore.
+  _syncHeader() {
+    const label = this.bucket === 'saved' ? 'Saved'
+      : this.bucket === 'archive' ? 'Archive'
+      : 'In progress';
+    const h1 = document.querySelector('.page-header h1');
+    if (h1) h1.textContent = label;
+    // The mobile top bar copies the h1 at inject time — keep it in step.
+    const barTitle = document.querySelector('.mobile-bar__title');
+    if (barTitle) barTitle.textContent = label;
+    document.title = `${label} — Ladder`;
   }
   disconnectedCallback() {
     document.removeEventListener('ctrl:auth:signedin', this._onAuth);

--- a/ladder/js/components/ladder-rail.js
+++ b/ladder/js/components/ladder-rail.js
@@ -15,26 +15,32 @@ const [{ fetchPipeline, fetchRecommendations, BUCKETS, bucketFor, isVisibleRole,
 export const NAV_ICONS = {
   inbox: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>`,
   jobs: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg>`,
+  saved: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>`,
   profile: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>`,
   plan: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="6"/><circle cx="12" cy="12" r="2"/></svg>`,
   settings: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
 };
 
 // Nav taxonomy: Inbox is top-level (the daily loop shouldn't hide under
-// Jobs); Jobs holds the six pipeline buckets — Saved, the four in-progress
-// stages, and Archive — as first-class sub-items (matched by `bucket`). The
-// Search plan sub-items are real sub-pages (matched by `section`). `countKey`
-// says which count to show. Keep in sync with the mobile drawer in app.js.
+// a group); Saved is top-level too (triage output, browsed daily); In
+// progress groups the four live stages + Archive as sub-items (matched by
+// `bucket` — top-level entries that share the /jobs path disambiguate via
+// `buckets`). The Search plan sub-items are real sub-pages (matched by
+// `section`). `countKey` says which count to show. Keep in sync with the
+// mobile drawer in app.js.
 const ROUTES = [
   { href: '/ladder/jobs/recommended/', label: 'Inbox', icon: 'inbox',
     match: /^\/ladder\/jobs\/recommended\/?/, countKey: 'recommended' },
+  { href: '/ladder/jobs/?bucket=saved', label: 'Saved', icon: 'saved',
+    match: /^\/ladder\/jobs(?!\/recommended)\/?/, buckets: ['saved'], countKey: 'saved' },
   {
-    href: '/ladder/jobs/',
-    label: 'Jobs',
+    href: '/ladder/jobs/?bucket=applied',
+    label: 'In progress',
     icon: 'jobs',
     match: /^\/ladder\/jobs(?!\/recommended)\/?/,
+    buckets: ['drafting', 'applied', 'interviewing', 'offer', 'archive'],
+    countKey: 'inprogress',
     sub: [
-      { href: '/ladder/jobs/?bucket=saved',        label: 'Saved',        bucket: 'saved',        countKey: 'saved' },
       { href: '/ladder/jobs/?bucket=drafting',     label: 'Drafting',     bucket: 'drafting',     countKey: 'drafting' },
       { href: '/ladder/jobs/?bucket=applied',      label: 'Applied',      bucket: 'applied',      countKey: 'applied' },
       { href: '/ladder/jobs/?bucket=interviewing', label: 'Interviewing', bucket: 'interviewing', countKey: 'interviewing' },
@@ -127,6 +133,9 @@ export class JobRail extends LitElement {
       // shared bucketFor so the rail never drifts from the list.
       const counts = Object.fromEntries(BUCKETS.map(b => [b, 0]));
       for (const r of roles) counts[bucketFor(r)]++;
+      // "In progress" chip = the four live stages (Archive is terminal,
+      // not in progress — it stays a sub-item count only).
+      counts.inprogress = counts.drafting + counts.applied + counts.interviewing + counts.offer;
       // `total` is the true count of all matching recs; `count` is only the
       // returned page size (caps at the server's page limit, e.g. 100).
       counts.recommended = recs?.total ?? recs?.count ?? (recs?.recommendations?.length ?? 0);
@@ -168,7 +177,11 @@ export class JobRail extends LitElement {
         <nav>
           <ul class="nav-list">
             ${ROUTES.map((r, i) => {
-              const active = r.match.test(this.path) && !(i > 0 && inboxActive);
+              // Entries sharing the /jobs path (Saved, In progress)
+              // disambiguate on the current ?bucket.
+              const active = r.match.test(this.path)
+                && (!r.buckets || r.buckets.includes(this.bucket))
+                && !(i > 0 && inboxActive);
               return html`
                 <li>
                   <a href=${r.href}

--- a/ladder/not-authorized.html
+++ b/ladder/not-authorized.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Not authorized — Ladder</title>
   <meta name="robots" content="noindex">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
 </head>
 <body>
   <section class="gate">

--- a/ladder/onboarding/index.html
+++ b/ladder/onboarding/index.html
@@ -23,8 +23,8 @@
     })();
   </script>
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.41.0">
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.42.0">
   <style>
     /* Full-screen onboarding takeover, pre-auth by default. The sign-in
        modal mounts into #ctrl-auth-root but is only opened by the
@@ -37,7 +37,7 @@
       flex-direction: column;
     }
   </style>
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -49,6 +49,6 @@
     <ladder-onboarding></ladder-onboarding>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>

--- a/ladder/settings/index.html
+++ b/ladder/settings/index.html
@@ -6,9 +6,9 @@
   <title>Settings — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <link rel="stylesheet" href="/ladder/css/components.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <link rel="stylesheet" href="/ladder/css/components.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -34,6 +34,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>

--- a/ladder/vision/index.html
+++ b/ladder/vision/index.html
@@ -6,8 +6,8 @@
   <title>Search plan — Ladder</title>
   <meta name="robots" content="noindex">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="/ladder/css/base.css?v=2.41.0">
-  <script src="/ladder/js/theme.js?v=2.41.0"></script>
+  <link rel="stylesheet" href="/ladder/css/base.css?v=2.42.0">
+  <script src="/ladder/js/theme.js?v=2.42.0"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.97.0"></script>
   <script src="/auth/ctrl-auth.js"></script>
 </head>
@@ -33,6 +33,6 @@
     </main>
   </div>
 
-  <script type="module" src="/ladder/js/app.js?v=2.41.0"></script>
+  <script type="module" src="/ladder/js/app.js?v=2.42.0"></script>
 </body>
 </html>


### PR DESCRIPTION
Left-nav taxonomy change:

- **Saved** is now top-level (bookmark icon, own count) — it's triage output you browse daily, not a pipeline stage.
- **Jobs** group renamed **In progress** (count = drafting + applied + interviewing + offer), holding Drafting / Applied / Interviewing / Offer / Archive.
- Both entries share the /jobs path, so active-state disambiguates on the current `?bucket`.
- Mobile drawer mirrors the rail; the Jobs page h1 / browser tab / mobile-bar title now follow the bucket (Saved · In progress · Archive).

ladder 2.42.0 · frontend only, no function changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)