### PR TITLE
feat(recruiting): reconnecting shared Gmail auto-pulls new sheet applicants

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.71.1">
+  <link rel="stylesheet" href="css/app.css?v=3.72.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -337,7 +337,7 @@
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
   <script src="../design-system/datepicker.js?v=1.0.1"></script>
-  <script src="js/app.js?v=3.71.1"></script>
+  <script src="js/app.js?v=3.72.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.71.1';
+const VERSION = '3.72.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -5650,7 +5650,13 @@ async function handleGmailCallback() {
   try {
     const out = await gmailCall({ action: 'connect', code });
     gmailStatus = { connected: true, email: out.email, connected_by_name: me?.name };
-      toast(`Shared Gmail connected: ${out.email}`);
+    // Reconnecting usually means the hourly sheet pull has been failing —
+    // the server runs a catch-up pull inside connect, so fold its result in.
+    const pulled = out.ingest?.inserted || 0;
+    toast(pulled
+      ? `Shared Gmail connected: ${out.email} — ${pulled} new applicant${pulled === 1 ? '' : 's'} pulled from the sheet`
+      : `Shared Gmail connected: ${out.email}`);
+    if (pulled) { await loadAll(); render(); }
   } catch (e) { toast(`Gmail connect failed: ${e.message}`); }
 }
 

--- a/supabase/functions/recruit-gmail/index.ts
+++ b/supabase/functions/recruit-gmail/index.ts
@@ -16,8 +16,8 @@
 //   sync { applicantId }      → pull recent messages to/from the applicant's
 //                               address into recruit_emails (direction in/out)
 
-const VERSION = '1.35.1'
-console.log(`[recruit-gmail] v${VERSION} — status probes the refresh token so a dead grant surfaces as reconnect-needed`)
+const VERSION = '1.36.0'
+console.log(`[recruit-gmail] v${VERSION} — connect triggers an application-sheet pull so reconnecting catches up new applicants`)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
@@ -874,7 +874,27 @@ serve(async (req) => {
         connected_at: new Date().toISOString(),
       })
       if (error) return json({ error: error.message }, 500)
-      return json({ connected: true, email: SHARED_EMAIL })
+      /* The account usually gets reconnected because something was failing —
+         often the hourly sheet pull. Catch the Inbox up right now rather than
+         waiting for the next cron tick. Same-project call, authed with the
+         ingest secret both functions already share; a pull failure never
+         fails the connect. */
+      let ingest: Record<string, unknown> | null = null
+      const ingestSecret = Deno.env.get('RECRUIT_INGEST_SECRET')
+      if (ingestSecret) {
+        try {
+          const resp = await fetch(`${Deno.env.get('SUPABASE_URL')}/functions/v1/recruit-ingest/pull`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'x-ingest-secret': ingestSecret },
+            body: '{}',
+          })
+          ingest = await resp.json().catch(() => null)
+          if (!resp.ok) console.warn(`[recruit-gmail] post-connect sheet pull failed: ${JSON.stringify(ingest).slice(0, 200)}`)
+        } catch (e) {
+          console.warn(`[recruit-gmail] post-connect sheet pull failed: ${(e as Error).message}`)
+        }
+      }
+      return json({ connected: true, email: SHARED_EMAIL, ingest })
     }
 
     if (action === 'status') {


### PR DESCRIPTION
## Summary
- `recruit-gmail` v1.36.0: a successful `connect` (i.e. any Gmail reconnect from Settings or the Emails panel) now triggers `recruit-ingest/pull` server-side using the shared `RECRUIT_INGEST_SECRET`, so new Applicants-sheet rows land in the Inbox immediately instead of waiting for the next hourly cron. Pull failures never fail the connect; the result rides back on the connect response.
- Applications app v3.72.0: the OAuth callback toast now reports how many new applicants were pulled and reloads the list when any landed.

No new secrets, no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)