### PR TITLE
feat(recruiting): applicant→candidate transition affordance + manual add — v3.73.0

### DIFF
--- a/applications/css/app.css
+++ b/applications/css/app.css
@@ -1962,3 +1962,21 @@ body[data-auth-state="in"] .gate__spinner { display: block; }
   .stage-row__detail { grid-column: 1 / -1; white-space: normal; }
   .stage-row__action { grid-column: 1 / -1; }
 }
+
+/* ---------- applicant → candidate transition (v3.73.0) ----------
+   The vote bar is replaced by the candidate bar the moment a forward verdict
+   lands. The swap announces itself: the bar flashes green once and leads with
+   a "Now a candidate" tag, so the new actions read as a promotion, not a
+   glitch. */
+.review__foot.is-promoted { animation: foot-promoted 1.6s ease-out 1; }
+@keyframes foot-promoted {
+  0% { background: rgba(159, 232, 112, 0.28); }
+  100% { background: var(--bg-elevated); }
+}
+.foot-promoted { align-self: center; padding: 2px 8px; white-space: nowrap; }
+
+/* ---------- add-a-person modal (v3.73.0) ----------
+   Reuses the email-modal shell and listing-form fields; only the two-up rows
+   are new. */
+.add-form__row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-3); }
+@media (max-width: 560px) { .add-form__row { grid-template-columns: 1fr; } }

--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.72.0">
+  <link rel="stylesheet" href="css/app.css?v=3.73.0">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -287,6 +287,61 @@
     </div>
   </div>
 
+  <!-- Add someone by hand — referrals and walk-ins that never touched the
+       application form. Inserts via the recruit_add_applicant RPC. -->
+  <div class="email-modal" id="add-modal" hidden>
+    <div class="email-modal__card">
+      <div class="email-modal__head">
+        <h3 class="hold-sheet__title">Add a person</h3>
+        <button class="review__close email-modal__close" id="add-close" aria-label="Close">✕</button>
+      </div>
+      <p class="email-modal__status" id="add-status"></p>
+      <div class="add-form__row">
+        <label class="listing-form__field">First name
+          <input type="text" class="listing-status" id="add-first" maxlength="80" autocomplete="off">
+        </label>
+        <label class="listing-form__field">Last name
+          <input type="text" class="listing-status" id="add-last" maxlength="80" autocomplete="off">
+        </label>
+      </div>
+      <label class="listing-form__field">Email
+        <input type="email" class="listing-status" id="add-email" maxlength="200" autocomplete="off">
+      </label>
+      <div class="add-form__row">
+        <label class="listing-form__field">Track
+          <select class="listing-status" id="add-track">
+            <option value="Long-term (full-time)">Full-time</option>
+            <option value="Short-term (sublet)">Sublet</option>
+          </select>
+        </label>
+        <label class="listing-form__field">Start them in
+          <select class="listing-status" id="add-stage">
+            <option value="review">Applicants — needs a review</option>
+            <option value="candidate">Candidates — already vouched for</option>
+          </select>
+        </label>
+      </div>
+      <div class="add-form__row">
+        <label class="listing-form__field">Move-in
+          <input type="text" class="listing-status" id="add-movein" maxlength="120" placeholder="e.g. September 2026, flexible">
+        </label>
+        <label class="listing-form__field">Budget
+          <input type="text" class="listing-status" id="add-budget" maxlength="120" placeholder="e.g. $1,800/mo">
+        </label>
+      </div>
+      <label class="listing-form__field">How they reached us
+        <input type="text" class="listing-status" id="add-source" maxlength="200" placeholder="e.g. referred by Sam, met at a house dinner">
+      </label>
+      <label class="listing-form__field">About them (optional)
+        <textarea class="notes__input" id="add-about" rows="3" maxlength="4000" placeholder="Anything the house should know going in."></textarea>
+      </label>
+      <div class="decision-sheet__actions">
+        <button class="hold-sheet__cancel" id="add-cancel" type="button">Cancel</button>
+        <button class="btn btn--accent btn--sm" id="add-submit" type="button">Add them</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Post-screening decision: would you accept them? -->
   <div class="email-modal" id="gd-modal" hidden>
     <div class="email-modal__card">
@@ -337,7 +392,7 @@
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
   <script src="../design-system/datepicker.js?v=1.0.1"></script>
-  <script src="js/app.js?v=3.72.0"></script>
+  <script src="js/app.js?v=3.73.0"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.72.0';
+const VERSION = '3.73.0';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1499,7 +1499,14 @@ async function castVote(applicantId) {
   if (a.stage === 'candidate' && before !== 'candidate') {
     if (!houseLoaded) await loadHouse();
     const added = await syncAutoPlacements();
-    toast(`${fullName(a)} moved forward → Candidates${added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : ''}`);
+    const placed = added ? ` · placed in ${added} listing${added === 1 ? '' : 's'}` : '';
+    toast(`${fullName(a)} moved forward → Candidates${placed}`);
+    // The profile changes shape underneath you — same person, different
+    // questions. Say so where the eye already is (the bar it replaces) and
+    // keep the way back within reach.
+    showReviewBanner(`<span><b>${esc(fullName(a))}</b> is now a candidate${placed}</span>
+      <button type="button" class="cta-link" data-reopen="${a.id}">Undo</button>`);
+    justPromoted = a.id;
   } else toast('Saved — flagged for another housemate to read');
   renderRailCounts();
   renderReview();
@@ -1575,7 +1582,12 @@ async function render() {
   document.getElementById('page-title').textContent = def.title;
   document.getElementById('mobile-title').textContent = def.title;
   const headAction = document.getElementById('page-head-action');
-  if (headAction) headAction.innerHTML = view === 'openings' ? `<button class="btn btn--sm" data-new-listing>New listing</button>` : '';
+  if (headAction) headAction.innerHTML =
+    view === 'openings' ? `<button class="btn btn--sm" data-new-listing>New listing</button>`
+    // Referrals and walk-ins that never touched the application form.
+    : view === 'inbox' || view === 'candidates'
+      ? `<button class="btn btn--sm" data-add-person="${view === 'candidates' ? 'candidate' : 'review'}">Add person</button>`
+    : '';
   document.querySelectorAll('[data-view-link]').forEach(el =>
     el.classList.toggle('is-current', el.dataset.viewLink === view
       && (el.classList.contains('rail-nav__row') || el.classList.contains('rail-foot__settings'))));
@@ -1831,6 +1843,7 @@ const ACTIVITY_KINDS = {
   event_verdict:          { icon: '🔖', label: 'Review written' },
   event_passed:           { icon: '🚪', label: 'Passed on' },
   event_stage:            { icon: '🔀', label: 'Stage changed' },
+  event_added:            { icon: '➕', label: 'Added by hand' },
   event_email:            { icon: '📤', label: 'Email sent' },
   event_placement:        { icon: '📌', label: 'Shortlist changed' },
   event_move_in:          { icon: '🧳', label: 'Move-in confirmed' },
@@ -4461,6 +4474,7 @@ function closeReview() {
    through Archive for the person. */
 let bannerTimer = null;
 let keepBannerOnce = false;   // set when the banner explains the step we're taking
+let justPromoted = null;      // applicant whose foot bar should announce the promotion
 function showReviewBanner(html) {
   const el = document.getElementById('review-banner');
   if (!el) return;
@@ -4746,6 +4760,12 @@ function renderReviewFoot(a) {
   const keepNote = noteDraft.id === a.id ? noteDraft.text : null;
   const liveBox = document.getElementById('vote-send-update');
   if (liveBox) sendUpdateWith = liveBox.checked;
+  // Fresh off a forward verdict: the candidate bar that replaces the vote bar
+  // names the change before offering its new actions, so the swap reads as a
+  // promotion rather than a glitch.
+  const promoted = justPromoted === a.id && a.stage === 'candidate';
+  justPromoted = null;
+  foot.classList.toggle('is-promoted', promoted);
   if (a.stage === 'review') {
     const mine = myVote(a.id);
     const sel = pendingVerdict || mine?.verdict || null;
@@ -4793,6 +4813,7 @@ function renderReviewFoot(a) {
       // controls stay available behind it.
       const trial = trialStayFor(a.id);
       foot.innerHTML = `
+        ${promoted ? `<span class="verdict-tag is-forward foot-promoted">Now a candidate</span>` : ''}
         ${pills ? `<span class="foot-pills">${pills}</span>` : ''}
         <span class="foot-cta">${trial
           ? `<button class="btn btn--accent review__btn" data-promote-applicant="${a.id}">Welcome in</button>`
@@ -4837,6 +4858,62 @@ async function reopenApplicant(id) {
     renderRailCounts();
     if (!document.getElementById('review').hidden) renderReview(); else render();
   }
+}
+
+/* ---------- manual add ----------
+   Referrals, friends of the house, people met at dinners — anyone who never
+   touched the application form. recruit_applicants is client-read-only, so
+   the insert goes through the recruit_add_applicant RPC (migration 166),
+   which also owns id minting and the duplicate-email guard. */
+function openAddPerson(stage) {
+  ['add-first', 'add-last', 'add-email', 'add-movein', 'add-budget', 'add-source', 'add-about']
+    .forEach(id => { const el = document.getElementById(id); if (el) el.value = ''; });
+  document.getElementById('add-stage').value = stage === 'candidate' ? 'candidate' : 'review';
+  document.getElementById('add-status').textContent = '';
+  document.getElementById('add-modal').hidden = false;
+  document.getElementById('add-first').focus();
+}
+
+function closeAddPerson() { document.getElementById('add-modal').hidden = true; }
+
+async function submitAddPerson(btn) {
+  const val = id => (document.getElementById(id)?.value || '').trim();
+  const first = val('add-first'), last = val('add-last'), email = val('add-email');
+  const status = document.getElementById('add-status');
+  if (!first) { status.textContent = 'A first name is required.'; return; }
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { status.textContent = 'A real email is required — it\'s how the funnel reaches them.'; return; }
+  const stage = val('add-stage') === 'candidate' ? 'candidate' : 'review';
+  btn.disabled = true;
+  status.textContent = 'Adding…';
+  const { data: id, error } = await sb.rpc('recruit_add_applicant', {
+    p_first: first, p_email: email, p_last: last, p_stage: stage,
+    p_residency: val('add-track'), p_move_in: val('add-movein'),
+    p_budget: val('add-budget'), p_source: val('add-source'), p_about: val('add-about'),
+  });
+  btn.disabled = false;
+  if (error) { status.textContent = `Couldn't add them: ${error.message}`; return; }
+  const a = {
+    id, ts_iso: new Date().toISOString(), first, last, pronouns: '',
+    email, social: '', about: val('add-about'), why: '', gifts: '',
+    source: val('add-source'), residency: val('add-track'),
+    movein: val('add-movein'), budget: val('add-budget'), avatarUrl: null,
+    stage, moveinFrom: null, moveinTo: null, moveinSetBy: null,
+    updateSentAt: null, updateSkippedAt: null,
+    exitReason: null, exitUntil: null, exitNote: '', exitBy: null,
+  };
+  applicants.unshift(a);
+  logEvent('event_added', id, fullName(a),
+    `${me.name || 'A housemate'} added {} by hand, straight to ${stage === 'candidate' ? 'Candidates' : 'Applicants'}.`,
+    val('add-source') || null);
+  if (stage === 'candidate') {
+    if (!houseLoaded) await loadHouse();
+    await syncAutoPlacements();
+  }
+  closeAddPerson();
+  renderRailCounts();
+  render();
+  toast(`${fullName(a)} added to ${stage === 'candidate' ? 'Candidates' : 'Applicants'}`);
+  openReview(id);
 }
 
 function renderNotes(applicantId) {
@@ -6387,6 +6464,11 @@ function init() {
     if (editL) { openListingModal(editL.dataset.editListing); return; }
     const newL = e.target.closest('[data-new-listing]');
     if (newL) { openListingModal('new'); return; }
+    const addP = e.target.closest('[data-add-person]');
+    if (addP) { openAddPerson(addP.dataset.addPerson); return; }
+    if (e.target.closest('#add-close') || e.target.closest('#add-cancel')) { closeAddPerson(); return; }
+    const addGo = e.target.closest('#add-submit');
+    if (addGo) { submitAddPerson(addGo); return; }
     const cancelL = e.target.closest('[data-cancel-listing]');
     if (cancelL) { closeListingModal(); return; }
     const delL = e.target.closest('[data-delete-listing]');

--- a/design-system/recruiting/index.html
+++ b/design-system/recruiting/index.html
@@ -622,6 +622,8 @@ table.vx th { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.08
         <li>The comment is required on all three, client-side and by a CHECK constraint. A verdict with no why isn't a review.</li>
         <li>Three tints, three meanings: the error tint for not a fit, lime for move forward, a neutral overlay for needs input. Only the selected chip fills in.</li>
         <li>No scores, no averages, no blindness — there's no tally left to anchor against.</li>
+        <li>A forward verdict swaps this bar for the candidate bar in place — the swap announces itself (v3.73.0): the new bar flashes lime once (<code>.review__foot.is-promoted</code>), leads with a "Now a candidate" tag (<code>.foot-promoted</code>, reuses <code>.verdict-tag.is-forward</code>), and a banner at the top of the profile carries the outcome with an Undo. Toast fires too, for the auto-advance case.</li>
+        <li>People can also enter the funnel by hand — "Add person" in the Applicants and Candidates headers opens a modal (email-modal shell, <code>.add-form__row</code> two-up fields) that inserts via the <code>recruit_add_applicant</code> RPC: referrals and walk-ins that never touched the form, starting in Inbox or straight to Candidates.</li>
       </ul>
     </div>
   </section>

--- a/supabase/migrations/166_recruit_add_applicant.sql
+++ b/supabase/migrations/166_recruit_add_applicant.sql
@@ -1,0 +1,74 @@
+-- ============================================
+-- Migration 166: manual applicant entry
+--
+-- Not everyone comes through the application form — referrals, friends of
+-- the house, people met at dinners. recruit_applicants is read-only to
+-- clients (imports use the service role), so adding someone by hand needs
+-- its own RPC, same pattern as recruit_set_stage.
+--
+-- The id follows the ingest scheme: "jane-doe", numbered "-2", "-3" when a
+-- name genuinely repeats. Dedupe is by email — adding an address already in
+-- the funnel raises, naming the existing row, rather than minting a twin.
+-- ============================================
+
+CREATE OR REPLACE FUNCTION recruit_add_applicant(
+  p_first TEXT,
+  p_email TEXT,
+  p_last TEXT DEFAULT '',
+  p_stage TEXT DEFAULT 'review',
+  p_residency TEXT DEFAULT '',
+  p_move_in TEXT DEFAULT '',
+  p_budget TEXT DEFAULT '',
+  p_source TEXT DEFAULT '',
+  p_about TEXT DEFAULT ''
+)
+RETURNS TEXT
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  base TEXT;
+  new_id TEXT;
+  n INT := 1;
+  existing TEXT;
+BEGIN
+  IF NOT is_recruiting_member() THEN
+    RAISE EXCEPTION 'recruiting members only';
+  END IF;
+  -- Manual entries land in the funnel proper: the review inbox, or straight
+  -- to candidate when the house already knows them. Never into an exit stage.
+  IF p_stage NOT IN ('review', 'candidate') THEN
+    RAISE EXCEPTION 'unknown stage %', p_stage;
+  END IF;
+  IF btrim(COALESCE(p_first, '')) = '' THEN
+    RAISE EXCEPTION 'a first name is required';
+  END IF;
+  IF COALESCE(p_email, '') !~ '^[^@[:space:]]+@[^@[:space:]]+\.[^@[:space:]]+$' THEN
+    RAISE EXCEPTION 'a valid email is required';
+  END IF;
+
+  SELECT id INTO existing FROM recruit_applicants
+    WHERE lower(email) = lower(btrim(p_email)) LIMIT 1;
+  IF existing IS NOT NULL THEN
+    RAISE EXCEPTION 'already in the funnel as "%"', existing;
+  END IF;
+
+  base := left(regexp_replace(regexp_replace(
+    lower(btrim(p_first || ' ' || COALESCE(p_last, ''))),
+    '[^a-z0-9[:space:]-]', '', 'g'), '[[:space:]]+', '-', 'g'), 48);
+  IF base = '' THEN base := 'applicant'; END IF;
+  new_id := base;
+  WHILE EXISTS (SELECT 1 FROM recruit_applicants WHERE id = new_id) LOOP
+    n := n + 1;
+    new_id := base || '-' || n;
+  END LOOP;
+
+  INSERT INTO recruit_applicants
+    (id, submitted_at, first_name, last_name, email,
+     residency, move_in, budget, heard_from, about, stage)
+  VALUES
+    (new_id, NOW(), btrim(p_first), btrim(COALESCE(p_last, '')), btrim(p_email),
+     COALESCE(p_residency, ''), COALESCE(p_move_in, ''), COALESCE(p_budget, ''),
+     COALESCE(p_source, ''), COALESCE(p_about, ''), p_stage);
+
+  RETURN new_id;
+END;
+$$;


### PR DESCRIPTION
## What

Two review-flow gaps from triage feedback:

**1. The forward verdict now announces itself.** When a review moves someone from Applicants to Candidates, the profile visibly changes state instead of silently swapping bars:
- A banner at the top of the profile: **"[Name] is now a candidate · placed in N listings"** with an **Undo** (reopen) action.
- The bottom bar swaps to the candidate bar with a one-time lime flash (`.review__foot.is-promoted`) and a leading **Now a candidate** tag.
- The existing toast stays, covering the auto-advance case.

**2. Add a person by hand.** Referrals and walk-ins that never touched the application form can now be added directly: an **Add person** button in the Applicants and Candidates page headers opens a modal (name, email, track, move-in, budget, how they reached us, about) and starts them in the Inbox or straight in Candidates.

## How

- Migration **166**: `recruit_add_applicant` RPC (security definer, `is_recruiting_member()` gated) — `recruit_applicants` stays client-read-only. Ingest-style slug ids (`jane-doe`, `-2`…), dedupe by email (raises naming the existing row), stage restricted to `review`/`candidate`.
- App **v3.73.0**: banner + flash + tag on promotion; add-person modal wired through the existing click delegation; `event_added` activity event; candidate adds run the auto-placement sweep.
- Design-system recruiting page: Review bar story documents both patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)