### PR TITLE
fix(recruiting): castVote crashed before the stage refresh — v3.73.1

### DIFF
--- a/applications/index.html
+++ b/applications/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/auth/ctrl-auth.css">
-  <link rel="stylesheet" href="css/app.css?v=3.73.0">
+  <link rel="stylesheet" href="css/app.css?v=3.73.1">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="/auth/ctrl-auth.js"></script>
   <script defer src="/analytics/track.js"></script>
@@ -392,7 +392,7 @@
 
   <script src="js/settings-schema.js?v=3.69.0"></script>
   <script src="../design-system/datepicker.js?v=1.0.1"></script>
-  <script src="js/app.js?v=3.73.0"></script>
+  <script src="js/app.js?v=3.73.1"></script>
 
 </body>
 </html>

--- a/applications/js/app.js
+++ b/applications/js/app.js
@@ -10,7 +10,7 @@
    manual moves go through the recruit_set_stage RPC. Candidates are
    auto-placed into every open listing they qualify for
    (recruit_listing_candidates, migration 123). */
-const VERSION = '3.73.0';
+const VERSION = '3.73.1';
 console.log(`[applications] v${VERSION} - Agape recruiting viewer`);
 
 /* Cache-bust guard. index.html carries ?v= on the stylesheet and the scripts,
@@ -1459,7 +1459,7 @@ async function castVote(applicantId) {
   if (error) { toast(`Review failed: ${error.message}`); return; }
   votes[applicantId] = [...(votes[applicantId] || []).filter(v => v.voter_id !== me.id), data];
   logEvent('event_verdict', applicantId, fullName(a),
-    `${me.name || 'A housemate'} reviewed {} as ${VERDICTS[pendingVerdict]?.toLowerCase() || pendingVerdict}.`, note);
+    `${me.name || 'A housemate'} reviewed {} as ${VERDICTS[pendingVerdict]?.label.toLowerCase() || pendingVerdict}.`, note);
   // The review IS the answer to both of those asks.
   ackFor('applicant', applicantId, ['review_stalled', 'needs_input', 'application_new']);
   // "Not a fit" is a recruiter decision too, so Archive and the update tray


### PR DESCRIPTION
Follow-up to #1422. Testing the promotion affordance live surfaced the real reason forward verdicts never visibly changed the profile: `castVote` throws a TypeError while composing the activity sentence — `VERDICTS[pendingVerdict]?.toLowerCase()` on what has been a `{label, title, cls}` object since the single-decider model (v3.40). The vote upsert succeeds and the DB trigger promotes the stage, but the crash lands before `ackFor`, the stage refetch, the toast, the banner, and the bar swap — so the UI sits silent on a stale profile.

One-line fix: `.label.toLowerCase()`. Verified live: forward verdict now shows the banner with Undo, the lime flash, the "Now a candidate" tag, and the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)